### PR TITLE
[Backport release-25.11] thunderbird-esr-bin-unwrapped: 140.8.1esr -> 140.9.0esr

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
@@ -1,1193 +1,1193 @@
 {
-  version = "140.8.1esr";
+  version = "140.9.0esr";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/af/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/af/thunderbird-140.9.0esr.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "a2a6df485c32d95b71ee287593214f6fe93feadf7cf76c04c9f0172652a21cdc";
+      sha256 = "5eb9a9ef1ec665446b1bcc8c0901d531c5bad67ae63f5ce81a517d04c4a56ce2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ar/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ar/thunderbird-140.9.0esr.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "50bfb2f9a1a27ad63732a16a6d313a9444ff4c713b84a2ce242b1c17823d3453";
+      sha256 = "c13827632f7993dc86ee623bc3d3485ff769dcf237ee04b747b621fc3c2f23c7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ast/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ast/thunderbird-140.9.0esr.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "5b423b640a278fdb381e112763e72a5f9707b49e6f009407a0a7a8a0a81f5242";
+      sha256 = "fbbb6510cae937593b185f8689f03da3c1d93edf824cfb2c598c88656aa74410";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/be/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/be/thunderbird-140.9.0esr.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "3e496569f5f7119f3ec6283558e9c789d105148b7dec60b2cf665cdd9fdf9435";
+      sha256 = "ad27d566272d90eff2f650945826c5a71e943ad0f7059057cb8bd8ae1d9a30eb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/bg/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/bg/thunderbird-140.9.0esr.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "31bed156742b5b9262366585854fa272af840f8487b613b13dd86727b2d95390";
+      sha256 = "7510e22126e1e59104f4b6f4aa0c4b27de029e95d530ea1312fd8a419c0eab97";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/br/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/br/thunderbird-140.9.0esr.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "88380e0616d2d7934bf22eba46f19a64ea3bdfedda36a314cbfd5aaa8dbc8729";
+      sha256 = "b99a25b00d0ec92ce74fb172e957a011e1d8076b80700d3219ab3c1b52d18c81";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ca/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ca/thunderbird-140.9.0esr.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7cbea4a762de5432bd2b61825cfe6fab2a942e3dc9ff4e0c814bc2759306cbd5";
+      sha256 = "fb66167fa3c186d81333b46f6af40f95a02030a031caf845295955654f2a2951";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cak/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/cak/thunderbird-140.9.0esr.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3c94e5d17e0368b6abdaa2c0b91dd111c1e2e16af55c7313a9eba8cd4ce2d6d6";
+      sha256 = "ccd60ea654ab4182223e74a3cc03ee82c275a0362e37f4e446a11b97b525077a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cs/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/cs/thunderbird-140.9.0esr.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "7d7c7b6e32c5989199eee307aa0816eec04a5e60e4d9d3129b5adfbde9dc5e75";
+      sha256 = "97d116d5712b02607e19cf65acc90ab9e4845b9596729d141f48a9a8dc6798d0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cy/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/cy/thunderbird-140.9.0esr.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9d7931783730523e3cd194e714fd8daf5fac9cde314785c72951c5cc0b4fa9ec";
+      sha256 = "cd8ac250616e4f31407a1c30f30bf8132731bf934e011b623bf512d32d4c0e52";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/da/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/da/thunderbird-140.9.0esr.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "ca5244d4a282d680d74faf6617af11d78a6f439fc778a7aada985bd704e15292";
+      sha256 = "02dad1cd08244571b8d1c609665cecacc16fe8c37f79b7189c8334bb9ac4231f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/de/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/de/thunderbird-140.9.0esr.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "997467027a0f6285000df0201b3877eb5519423e08d0701517d832321cd2e077";
+      sha256 = "c624bf5d8696cfa224439d739d5eac2f80ed29be309a52b027c7d73eb9cb8ec4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/dsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/dsb/thunderbird-140.9.0esr.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "785c88a25b3b86456e48e605707cdaf8e797560a45e9552c973a5a79ec7cd3cd";
+      sha256 = "c199014f070402516b1106b32e1a2094384ab55205fa533d66fae90adea571b2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/el/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/el/thunderbird-140.9.0esr.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "8c59e36dd60ee10a706a2014ce6e641470fe9860cbb26157d4c25b3bd4933149";
+      sha256 = "ddd4d8cda3c7d8d8c79436a57cd457c35e0707275b429d703c4a106f1851fca3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-CA/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/en-CA/thunderbird-140.9.0esr.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "ac014e1627aec7ac848a858d917e778fcb9909408afbbc06e41bfda22cc74384";
+      sha256 = "a342e46b35116136e2c58f40a065a8292da045726ef078d19bb3f416d98fc22c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-GB/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/en-GB/thunderbird-140.9.0esr.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "620850f83520d09e58926de3b2a706be940eb897df6f750f2d5ce4efbf929f65";
+      sha256 = "de2f8596d903d3f2fdbcf358810080618350979e987e9fd83272b80ea56cf9be";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-US/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/en-US/thunderbird-140.9.0esr.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "d48bbaceb92350534dc609c68c94c202740a1166788fc6b9851ea634e6027cd1";
+      sha256 = "69832e7c311bff97b2b83a393d4c8ac15a0b0823aeb838a510e510a2ddeb6c45";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-AR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/es-AR/thunderbird-140.9.0esr.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e8ff0f9c3dabcf2d9d1721a38d9e7a2c947da4c964cf51ea71258535608e2a5e";
+      sha256 = "f01f5ba14f11f9418ec368ecc3b9cc6b03e5afee67d50eab03428d55a76724f4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-ES/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/es-ES/thunderbird-140.9.0esr.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "694dbae11787f1930552d9dc1c8f4c1075fd92fe5ac4b225d90d5deb5b715563";
+      sha256 = "a6613d38c0e1092fd545b02875cfe2e0189da2e9cbc9d045f228f0546cd70fc4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-MX/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/es-MX/thunderbird-140.9.0esr.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "8a4a9028f85c1798bc8e0a74d4094a5383d8fc433af485202d79852a819f81b7";
+      sha256 = "7acae9583b32a97297a8a9c5dba7244725d1e8035bac7d3c9410e361c1b5b748";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/et/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/et/thunderbird-140.9.0esr.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "1f778eaac6c26b155407d68119d4b8c5b5568a0b7966cc24b1c073fbf3e7944b";
+      sha256 = "7113cf91c0cae1d30413b19e4320460aac226d14b1777b879024d2d9b0fb8fde";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/eu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/eu/thunderbird-140.9.0esr.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "33f9d1cf56652d29402b4142973493c886ba9ce3a18b3dec9f9c01c9c907a276";
+      sha256 = "62403e8fd44872903b1cfea829f011ecee667da09bc211618a49df8a536c626a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/fi/thunderbird-140.9.0esr.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "23d1fe70727aac387e3599d2d87766b0b12ca80c02cf821a443bd4c81496358a";
+      sha256 = "521675713083958b93e3a5dea6e73d94f3ef49354748df1d05e7c0e3fb120c0c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/fr/thunderbird-140.9.0esr.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "986251b06821ca15d7d3902608d8d91f3b83128d1c0ef93e1420c47682f7783d";
+      sha256 = "5ed6df6c32b8beaa221150a970f584ae6a627a5a56f4c871d06562a20e6ff2da";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fy-NL/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/fy-NL/thunderbird-140.9.0esr.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "de17062530629435e748ac48e06c6500712bf430fdee08baa74e3fa63b7f2aab";
+      sha256 = "cb488ddbc7a4638b49900be4a87d36390f1464080bad56f79c9bdf165368e5ed";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ga-IE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ga-IE/thunderbird-140.9.0esr.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "76044251b1260a60dd79c92b74586be48eda9912eceb8c747ba92dc51b94cc44";
+      sha256 = "5883b06e99066b3b772fadfef3db017a0a2db05b69e4c4565845f1ce08db850b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/gd/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/gd/thunderbird-140.9.0esr.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "005605b6fc16111393da1031498d9b90e5ed08e1832dc316f3175bd6b1eb328e";
+      sha256 = "c50b06e7fbb61e8242f396473b8ccbcb10b4c093beb03769da95a1bff75a1ca1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/gl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/gl/thunderbird-140.9.0esr.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b82275a2782b5167d19681c64efa3957a15893490b9e068b0e0d48580ca5b1ac";
+      sha256 = "257ef806883b90be3ce4fc3097a6668c1683b013b35beeb51ec28add8efd62e9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/he/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/he/thunderbird-140.9.0esr.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b19179490601c0acabb179b006e416dec59b0babfff37c9bfa3238ee512e8fb3";
+      sha256 = "9306cac21b22223bcc0545bcd6b60d3d7b9da396ff0775b0aecf723b54916383";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/hr/thunderbird-140.9.0esr.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "7be2a453115375c5e2a4e46b7f6d7f809713df402cced9483958a3a1053d676f";
+      sha256 = "bb753ecd3ec91790a654d846f0abec7065df0c036b5d5e6ebcd4ecf3dec46c96";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/hsb/thunderbird-140.9.0esr.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "c5879ff7416edc616c3bd1362046d0650bdb20444f8b4879c06808467c260432";
+      sha256 = "0a11a947085be1a865f7192c84ddbb3315a307545338e5b42f852cd553367999";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/hu/thunderbird-140.9.0esr.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "0d007b516a9c09a6e48e734843df0093d6d9c92705b348feedfedd54972bd24f";
+      sha256 = "c903657c3dda7e437cff9ecc8374e02209fdca298dbbd7afe842bf57a18747cb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hy-AM/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/hy-AM/thunderbird-140.9.0esr.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "1df90a34bca5232fb18b09fa825ac0b56f83ad61b188a80d0921c697bd04a0f7";
+      sha256 = "19fcd176d832ee44c217100e34f49299070d3abf276700bbc75e49e44627205f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/id/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/id/thunderbird-140.9.0esr.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "4d33d6dfc17dbbc5e0643060e355a5eeab3ada4265f95af260d5449b497fe5d4";
+      sha256 = "c48e5c940363555c5ddc062fcbfd622891ab5b6a22a0693e8be048719aeb950b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/is/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/is/thunderbird-140.9.0esr.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "acfb46eedaf02978d3cfb16c568183e70bc9c82dd662e8aa5783afb00a873c2a";
+      sha256 = "9fe9f07be88091fbbe9aedaf0da2d82b8b2e73bdd487b0f826170a64efd56406";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/it/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/it/thunderbird-140.9.0esr.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "3f09a35bdd66b7606242139d2d34c9815f5abfc6d659c2909361e52ae8bd4dbb";
+      sha256 = "a72bbcddf5306f6282f885e63cb76fe6638926f365f4abeed18d506ca28e7b05";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ja/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ja/thunderbird-140.9.0esr.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "d4d818cc9e73be659770f847ec2f6f3945194e04ea676bd2f8219d19c94bc89f";
+      sha256 = "7d9992eb16abdf035470fa6f6c7cbfcef52ff37ff0e94b491358dbd968b65330";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ka/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ka/thunderbird-140.9.0esr.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "aacdb54a957b455910e2f68f684b8d5725b7232278d178247c7d3489f5fac1f1";
+      sha256 = "219acab4927417d4ebd0b6a0dfda9a19b91ebb6b71b8de77c2d86855dbdb652a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/kab/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/kab/thunderbird-140.9.0esr.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "92d1fd4160f58fdd9130758d85f571047487b5cd78f7e384de98696e894ce831";
+      sha256 = "e087724d93e70498cfca0b167e6407db1890b29eb62f9543faf42525a3085ad2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/kk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/kk/thunderbird-140.9.0esr.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "1170c05c5868a304a9f8e83ff877a7ff467f6c9baa960bc92c259509f8e720df";
+      sha256 = "26f78fde3493db4e8fc7f1f9d0f1d901de984176f684dd3e1405198b1d581297";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ko/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ko/thunderbird-140.9.0esr.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "38cde1a5cb9b073ccd5288d9a3c0bc5215802fe464af82a5ee39aff51ef47c71";
+      sha256 = "05ea218a524485aec96ae6488732e4c8b850066f1f1030d99d51b9c3d0e55eeb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/lt/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/lt/thunderbird-140.9.0esr.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5edb4f92f780df623d0cf38762ca7b95f101fc1024a1d6dd31559fdfa0b9c418";
+      sha256 = "3d09f4ef2e889bc114452388325fe62376cf5c97e856d96a2696d7cdc30f70a2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/lv/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/lv/thunderbird-140.9.0esr.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "958ee3279f68adcaeab5745ea0239b6d37904f6bb94bef4e01369e52d0c360fd";
+      sha256 = "c78182d9b437c5b070f6ba9abfcc0ec0d6e0214d18772c24d9703138fb2f75f1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ms/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ms/thunderbird-140.9.0esr.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "8c5e1f53f4f8c0722999f410f41cada2e349753e314bd751e8a88e3dfa22070a";
+      sha256 = "531845ad39645363799db90331faf612c5ae3313e2418544dce6bd6e0da47cbc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nb-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/nb-NO/thunderbird-140.9.0esr.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "6202a8ec3e33e0256d3031ecc4d4bbbfeb89963a27f33b465ce1ea8c6b76792c";
+      sha256 = "4a0a76f5cac2757ea9429c57d18d77bfa006d35d160938a7d998107d3bf2066f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/nl/thunderbird-140.9.0esr.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "ea348f47896e87077819a7f45c9317ebba61d92f2ef50bfb29c70c5dd740a0f3";
+      sha256 = "b9b408baa807dc5315d0a244a59fb928004de0993feac8ee6b2b4b5e02cc1c48";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nn-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/nn-NO/thunderbird-140.9.0esr.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "c02063b7160e0f8da26bbc45f55e6f4764cd2b07bf513bae234b2626d9a4b3cc";
+      sha256 = "9269a973bb9235f7a67dc35c102ef19d3b76c4eb21e6b971f6f9835dba5c29ac";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pa-IN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/pa-IN/thunderbird-140.9.0esr.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "22e8f5d21ea31b1038a427ca2851bdf9ad4e76d61deeae747920c62497099980";
+      sha256 = "bb42a8d2a127f50e09ec7ababf0344fb40e8185418ef6bd90880cfb802f8e349";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/pl/thunderbird-140.9.0esr.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d6537c1069430250b320fcb4dcb156a3972764b9007600d80726b503a9760306";
+      sha256 = "1b9a3c5cda2dd31df0b84eae6666bb19cd2f47485844339359ff62affb196ced";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pt-BR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/pt-BR/thunderbird-140.9.0esr.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "5214712c72d0039a0284939a9095ef2cf954c3a55ee593389da3448718999ae5";
+      sha256 = "e8464db805b335e931da3dec07e88ba82c8dd6c97ae3a8337c91301e2560542e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pt-PT/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/pt-PT/thunderbird-140.9.0esr.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "b6be8071e73f474f15d1f97bb7eb0d4da8673984b4862faf6aa38ebe78c6421d";
+      sha256 = "150ddd7fa40fb40f86ff5a5605ded4839584c70b936431a275d1f9ea3c688269";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/rm/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/rm/thunderbird-140.9.0esr.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "f8ca0204f1883bfa141d31d6eee01fbadceb5309d186d60de0549e68ddafeff9";
+      sha256 = "fc3e463a5fd106b398bb4a3f15e408cabc265c0b57359053e0c21d375af2b6c9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ro/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ro/thunderbird-140.9.0esr.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "3d17493752007080913a194adcd568718be9caf295d4b7dac0185268f2172ad0";
+      sha256 = "643977c984fa718c8f1455d70909fecf73b35a53ac049e2985c0f60ebc556aa8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ru/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/ru/thunderbird-140.9.0esr.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "e2e9b128d06430cf6154075a0876a0820d6f207dff351383e6c618da7d3b4d81";
+      sha256 = "448ff79983f1711bccd406e8528335b8329edd2beed98272da410cf71dc8c8e5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/sk/thunderbird-140.9.0esr.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ce44fc03b38f31172e5319c6f82283127d122b5d08bf3c2d40ab354d096c9764";
+      sha256 = "84d8a2165f1ceb970fe49f8b0fef833abf340b9fdd000dbcdd74ac3a37cc0298";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/sl/thunderbird-140.9.0esr.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "a924ec6cd3da033146a23705e8e860c53010c0dc41efa2f28156cc38430ba9af";
+      sha256 = "8b8832af203d40f59d68382af7bae5be6b9f870d59a1490af1fc1c39b3d34a1c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sq/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/sq/thunderbird-140.9.0esr.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "4da2f3b2dd7596ccaf7d4b00544110c4d2bc16799bc3a502f7ba916cb28a438b";
+      sha256 = "fef3ec0ebe13508802740809d4c3fe38be476868e19ae795a93ee5cf08053cb9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/sr/thunderbird-140.9.0esr.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c7b5221bdb02be1f054820ffd3775e7a00fc2e60d4bf6c3d3ab9faceaf54ec67";
+      sha256 = "d5af15cd4c34ff9b8a0036a8a8091650113de39941b44a7421aac1e5e3789f20";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sv-SE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/sv-SE/thunderbird-140.9.0esr.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "2acf672155f03b53613f9b2b399b441d92339995036542058c83bebe04b43fb7";
+      sha256 = "75a4514e052b0caa4e0a2ae648230a7477574e30f1b11da7b78cfb2af73e0184";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/th/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/th/thunderbird-140.9.0esr.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "e27b9c5e20f9bcacd12b69973c4d04422c5b4f6334a6d4addfcff24729f1b6ff";
+      sha256 = "db591da8a158734556a05037add7a7c3a8897d8762646fff283da240cae27429";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/tr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/tr/thunderbird-140.9.0esr.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "82074179d975bcff2975bb2c000de6f51cf00a2a603cb1253217f66ca4463055";
+      sha256 = "d580688b7b3a1c41c45c739612ec358d29c512611f907096100cedd0711a6a99";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/uk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/uk/thunderbird-140.9.0esr.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "d0ce5add86c87ef4f97d0dd16a4a29f87eadf1266c225ec9190fd8c61faabe72";
+      sha256 = "3367186b517ea330337dabfc89506d34e39da97db8c1e2ce8c0ecb31edda1cba";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/uz/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/uz/thunderbird-140.9.0esr.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "33c343747528d6f4591f96af4894b1d85d62db6c3a552d691dcf9c2600f6c8b3";
+      sha256 = "e68776e9d92d13a65b1c333d47f173499a3c851a2a0fe01f5b6b4a0119077350";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/vi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/vi/thunderbird-140.9.0esr.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "260ebc557c460796502b16e00789b6f53cdf073adc4f75533873eee2839ebfab";
+      sha256 = "91f00d33556d7317d70be4f2f565531a9359aa7ae761c7f3a396442c47d16025";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/zh-CN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/zh-CN/thunderbird-140.9.0esr.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "6a77b94e6adb10ff4d93c82a75419ce04e14e07c20784d6219080cd7c45dd68d";
+      sha256 = "c9fef874672569ce32f05a852122ed32bd89f834eda1a9b344380e0c77cdae05";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/zh-TW/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-x86_64/zh-TW/thunderbird-140.9.0esr.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "71502937adeb494e2b286b2131c2e113fa15048d3ae4cddf40e58d59af3d5959";
+      sha256 = "656118b3777f805edf38d9b71c4e056543bf0f7d8f80918456fbc98df356b6e5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/af/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/af/thunderbird-140.9.0esr.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "dd2ce21bc9dc5403e12154d3dad21e744854b68aaded45db08c641f7ed5a06bb";
+      sha256 = "6f325a9cf3b98c1ca78d77aec635e91a4502756857edc6fa61a19825da6e5af1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ar/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ar/thunderbird-140.9.0esr.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "02159d0cca4d423f6eed40c9fd14c8e915603da639103dbfe8e4dacc408879d8";
+      sha256 = "73981c7aacb840d4a491ea9d7058b64dc0c3169e40098858a5af22dfa47b1e91";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ast/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ast/thunderbird-140.9.0esr.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "09465b0a97c99b2d87491238de0e1396064ea0ba2781d6ee0a1840b3855f9eeb";
+      sha256 = "119ac734bf984560296d4fc61e9c144fa1effed7830e47fcb93e3814646b2cef";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/be/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/be/thunderbird-140.9.0esr.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "b49a44da05bc8e620c51c24785b25a6fe1c28dbaa1b3721e601fbc295ebd73d2";
+      sha256 = "a3ac94df2520a79eeb9bae624a8a6156a6dada079e9a39ddc98f10abf5439de0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/bg/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/bg/thunderbird-140.9.0esr.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "2a540d4545536672778f8cc59ba05d954689c28a950bf3e815cd245c1f1ddfd1";
+      sha256 = "b2d4016eb85c4f9705cc766502972ae18f1a75c82b3bf3f47c720e26a11c8241";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/br/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/br/thunderbird-140.9.0esr.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "e693e89b822320fc55db17c14fa464b2332c7a017db9008bd30802475de13c4e";
+      sha256 = "da6f483ed3cfcd70d213e3e9ae2e9e2dc0076a438251f6ced9de4a3611449840";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ca/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ca/thunderbird-140.9.0esr.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "e4d6536f3efa260a56188e2552df304feb3cd8668cfe50e580577d44610277a3";
+      sha256 = "7dab9f207fdd9ddc98b54bf6e35d0999a9367b495ea81e895aecf81b20ea4af9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cak/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/cak/thunderbird-140.9.0esr.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "325c6b1cb7730beb044750664a05b205260699631c899e37093d5be866e76a71";
+      sha256 = "4288d9f9d71bf1b4a455aba39a3f98ba50f84e656a7fc5df08a2b76248722449";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cs/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/cs/thunderbird-140.9.0esr.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "1680ae1e599e627ddd7ce4dd9d21eefcb0879390dfc9c7d52c9dce84102d8607";
+      sha256 = "46abfededf97d68521f71c513008a2f560ed084b41e68932df2966250ac33074";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cy/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/cy/thunderbird-140.9.0esr.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "f037c87d327cb5cdf476e977754c671a2b8eda9f895835a399c0c3a43ba4c1fe";
+      sha256 = "9e6a7e534dec3b6d85e51f65d01435023ac74fb42ddb8c8eea845a603728e3d7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/da/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/da/thunderbird-140.9.0esr.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "f6ee6e8d7a8058346894292a3bf4daa59c13ef07be0d875b6f8ed016a3e85f43";
+      sha256 = "f46505566bf62826efb87fb383e2131231293a5cd9963ba53cd1e0210ec74e97";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/de/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/de/thunderbird-140.9.0esr.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "267d4117268074bf5e3c4b8ce2603204c5f22b83e1b6592b0c9acd670fe0f73e";
+      sha256 = "588d6404fdc9133006c261b9e65a983b40135d4b95b11ea933076913bcc66913";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/dsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/dsb/thunderbird-140.9.0esr.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "e886e51b2e4b0659f1093b16fa19710f16895219f1e3ae5cadfb24097f810972";
+      sha256 = "cc28fbc37298809171576b2fc147270d9eb53d936aa13075ffb2156d164fd3ba";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/el/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/el/thunderbird-140.9.0esr.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "a497fb0f4be8ebe738adee3510a74f5c8cefeb6935e7e6a54a049d16eb49991d";
+      sha256 = "82b41b0e01a1e719a09fe278b03f542408f14ae67059a06456614baf5dd6a4b9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-CA/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/en-CA/thunderbird-140.9.0esr.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "ba8ce294c3836d57261192f378869ba03de9a1da08d5d0ce9f598dd15cdad75c";
+      sha256 = "2c7311960aea490919d5623caf615a320119610f44a0d7c6f8c03add99d7ade5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-GB/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/en-GB/thunderbird-140.9.0esr.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "86dc258e8d9b78adcc2c090eb826bf6665415a9715f9f3b735ac0c7870c0c449";
+      sha256 = "aaf25d7d55dbc2ccb8f533c8d004c1665745ea8f1a447736dd41e9bdae0c9fad";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-US/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/en-US/thunderbird-140.9.0esr.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "9a227eae275c99c794d5b47e947f2b50a45de8ff3b236f8849a9c45a7e70201e";
+      sha256 = "00a7d103fde65a1116916a6e0d96f958546e8f22757888c250a0ade91948f956";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-AR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/es-AR/thunderbird-140.9.0esr.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "b390377508a512261901600f8c1e19ed7e3561ba087c8e55f541fe1269aa83b5";
+      sha256 = "6d015123ccc6474ff31d5d28560126c212da322a4886fe548f57a364b307d9de";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-ES/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/es-ES/thunderbird-140.9.0esr.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "208146545b34e6fe4c7b9cb2e1649430b6f2a29be31d9c4d8520c87e518a0d56";
+      sha256 = "05e5ba6aeca6d208c8b1f541dffc50433239c911290baa745de45877ed7710a4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-MX/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/es-MX/thunderbird-140.9.0esr.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "f41948096e01d106629248d491e0db28aab3af5784782f8bb86e5f44f5125e2d";
+      sha256 = "09908059585acd6497df10c480fa0e9bb87ee40c1f02310de6f7ec274a97a3b2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/et/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/et/thunderbird-140.9.0esr.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "ca36fdc6af282939a9739d188299d96fcd260fcf43b1ba4ae00944974272b19f";
+      sha256 = "6f97c18d98b810f7d59787a9651c1bb4f17af8de44d77ca779d9c808092ec15e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/eu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/eu/thunderbird-140.9.0esr.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "f0221f2d636d63514931c9a94c05c34f3e49170941fc61d1c320a4b9563017f0";
+      sha256 = "3f8edbe0c6337e0ddfb081a40b0b55ea6b62c798a343e0209f7a8a835c59da96";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/fi/thunderbird-140.9.0esr.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "d9d6888452b46a64156127909becf22646f8020cf793db4e8bfe420003c21f4f";
+      sha256 = "f58200c0d092b799964dac0422cde055315efc08dc1c68407b7c9e918ef8421b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/fr/thunderbird-140.9.0esr.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "e2aa7355f6b4265daf1928a8e629551361e36c17f420e72092a008f9291a9991";
+      sha256 = "3ef718ff981091c5ba110545d8fd0e0ba48b526daa9ab4390696fa6d8a936894";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fy-NL/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/fy-NL/thunderbird-140.9.0esr.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "50fc5df22a97d0b9e211dc77666464f6f70d50671c3e9fddd5417abb0260a632";
+      sha256 = "08a44970105487b61df5025e02f0c3d5c860af0b3dc12dfbeb79fe3fd6763378";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ga-IE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ga-IE/thunderbird-140.9.0esr.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "c758e488dd58db908e92c414a8a0793c7a9e93ecdd1ba91ee50a97425a9d0667";
+      sha256 = "575b98f3e2bec65bfdc1581870bfc404ec60512cd5755072d86f06b845f39a17";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/gd/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/gd/thunderbird-140.9.0esr.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "4cac68260c2dc303aa256d243991c11470b2d3148e8011d75d93740461a6068a";
+      sha256 = "6a41919c2b1c90376e62d5f50385de64f311607893c096b332c5c4125f1458b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/gl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/gl/thunderbird-140.9.0esr.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "5ef339bb02d8af1d0ed6f57e7f7d4df109cba01721e25640b4aca2834d457137";
+      sha256 = "7781512b491dbb7d3a75e5bf87da486013be909a77c45b79cf14661add24b9d6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/he/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/he/thunderbird-140.9.0esr.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "22e0ffbd1e5b2ef89f7a9d15b5f63aa6417617b416bb1117d66a00061bdd6a12";
+      sha256 = "fd377ac4d1a33a5e96ca696ef19ad54594e930fb279554b65d82900f70f546c6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/hr/thunderbird-140.9.0esr.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "fdd33df5385967689f2236cf35fdd360bb12c81373fe1fef6b0e5332c0f41551";
+      sha256 = "c8f3c66c5acddd3f463e0832d786be22ffc6967270befd56d8bf4773363defe9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/hsb/thunderbird-140.9.0esr.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "79b389658e6dcd527bd814729d2c9924ea9ba03c4fbb98dc8b31812fc039d8fd";
+      sha256 = "06db9fdcc5ba660bcad54faf5c4396ef2819e2335f707aeed3e848ef94041c7d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/hu/thunderbird-140.9.0esr.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "39ee8595f5471924b3f2b7d8e9369d6e3e4e855279236796a47fc6790326f14b";
+      sha256 = "2c79ef974f81d3d7fb0ff91effe65a6a50310b1164f911dd33bc6da454fb022b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hy-AM/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/hy-AM/thunderbird-140.9.0esr.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "801b71c019427b9be7a3f3128f61a834c4c07749b495d9aa39395a5d03201611";
+      sha256 = "aa363fb9a2e488002bb4dd10016d4776f536de29fd12a664af562285ceba01b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/id/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/id/thunderbird-140.9.0esr.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "3e00d95d75feb55a0919aea3566cd683eb9be5bd1fcbf2e906c76fc5e68090d5";
+      sha256 = "5ac4733f419c1629feef0ff1bdc2a0d0940a704258b04b9dcebe20e1d8d069c4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/is/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/is/thunderbird-140.9.0esr.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "8d8c5cd3feb72cb2f902c894ec59e10bfca31b1f7c55692e08f1325a8fafd7e5";
+      sha256 = "b5f4fbce1982c79248a7c6c65ead3684c7da1534b987f27c33ab8bea1fb3ba4e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/it/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/it/thunderbird-140.9.0esr.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "de0705ace7da5a4a0008330b52b609170ba1c19c1724cfcebfad134012fb0311";
+      sha256 = "16c1232f30de7c5763c44e64b0e90b5d8c93ee97a0a27c5e78c81bfc6eb222c3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ja/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ja/thunderbird-140.9.0esr.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "93393d07b9d772f74b0398a7abd6051c8d6bcbba15ea23e47af2bb5e96a80d35";
+      sha256 = "d15c2cf2d0b4678e6c78ac6116226d0be705d6e5c520144ef6dae4e3b9208572";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ka/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ka/thunderbird-140.9.0esr.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "1f445699e183952bc9279d3cf693e0745548d3408be244e72a88cc5f1f3b2582";
+      sha256 = "683d72343ebd8635d36b1264eeceb6b3de6e1dfcf9013804084b1b56658c0a9e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/kab/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/kab/thunderbird-140.9.0esr.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "d734067cd10d77a25c0ace4eae18a207d7c39392e037529060bcaf5a8a385459";
+      sha256 = "d60cc3f324a494f8815c2765266b0512b03f893aff9a8ed2c6f9ca0227c3711f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/kk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/kk/thunderbird-140.9.0esr.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "2154456796c62f69a2605916acbf57936e07e234c8f7d4fa2d09ffb12cf6ded4";
+      sha256 = "2e7377d940521a87d8ed102d6a4d6ccf435df9328aea1c98bb4cc0bb1521702e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ko/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ko/thunderbird-140.9.0esr.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "198c498b0b486a3f482dbccdbe3c70d870d5b38854df08e839e5107db601216f";
+      sha256 = "27fff0b61c881740042fba9ef27cd840bbc42a0c4820db5a1d88bae7d4b7b72a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/lt/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/lt/thunderbird-140.9.0esr.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "a3efc8209a72816e801a899afa45cb2bcd937818c250f8bb6f736487581fff57";
+      sha256 = "823aa56a87470dc3062f031311d4c3dfd2ae096e088c1276bf139fed3dff643b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/lv/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/lv/thunderbird-140.9.0esr.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "3d6158555cade4380eeab77a6d43524dd3ccd69c3e406d9ab4643b0811a941f4";
+      sha256 = "9c54d57f9b85ab6c0f223e7a586872eb6eff91340d2227c681a6ff216032cbfb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ms/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ms/thunderbird-140.9.0esr.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d0702fd04a9aeb69aef103a356116c5d5e6b9ea1f975837c82618bc985f5e080";
+      sha256 = "58377c64a6ca61999bbec8f88946ae95430e7c9502a9386635f57d3879913616";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nb-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/nb-NO/thunderbird-140.9.0esr.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "206ac112df23f8648428781ec15a2a3d52adbab3b5d77e96f561a6e0f8940f50";
+      sha256 = "184be65c63676008c72ea483ab890c6439b17ee788df7167fa46d13babdbec7e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/nl/thunderbird-140.9.0esr.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "7b4e4b489dec23c1b4e28f96f9c4da33420e3889b5b83d3b79ae2425f720ce1c";
+      sha256 = "ecd7fa3b24de74c8d9da7a9c3514a5457c9a5b011d324bdd4791239a63790e0b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nn-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/nn-NO/thunderbird-140.9.0esr.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "3d51d481f1d4fe5d054360f4240065d69f7839b3102f7a702ace47cc84224035";
+      sha256 = "ddbc7de98ae02237e95387daebac814e2cdf6c013dd398ffdb6b3923af4a0f73";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pa-IN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/pa-IN/thunderbird-140.9.0esr.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "18f18aa018e8a4b84ef45164eb6b49b9fff91dc66e96cc6bd1fc75ea54a352a0";
+      sha256 = "244a4cedf25d0a5ed7fbb61e907751296e38f52e4a7a375d607cad89ea00695b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/pl/thunderbird-140.9.0esr.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "64eaafe5466f17cf0de7fa9cdd18dea9aa213dc237f602e95353299429879195";
+      sha256 = "58e4cca14e79266a9b6cda09a3915fc0085dd696882306613e1997bf4660d3c3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pt-BR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/pt-BR/thunderbird-140.9.0esr.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "5a89f60fecc932c4fabbf61dd43d4a8e96687125a779dfd9a8fcc5e58451c751";
+      sha256 = "63d962bcca2b6d97db0be992fb29e803191b947343e0b07f56a04401355f61c6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pt-PT/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/pt-PT/thunderbird-140.9.0esr.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "831a72e09575094b4df9ebc6abc2f5e77d17984a64f0a81ecffb5c37ed7b53d0";
+      sha256 = "0c21d300a72564aecab41ba6ad18af0692ea14467a2e148b0d66572c0c2fdaaa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/rm/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/rm/thunderbird-140.9.0esr.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "b0b6df3c15f1fb111594ee69b0a67e971ffd41e0ebe5633e5c64f1767d1e3ba9";
+      sha256 = "ed8ee13a1e2a5060906b9d4b68e4576916e5c0a97229bac2acfc33badbeb4563";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ro/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ro/thunderbird-140.9.0esr.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "74dd89e782fc4ada8f70837e98171806cf8eb24500ef9d60946d65e6222c7649";
+      sha256 = "2681b757a0f04a0b90943a8cca0e04fd3912ce18eede828c87a3e09564e6b585";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ru/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/ru/thunderbird-140.9.0esr.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "1323e8704c5ad8491c23c8399501dbc67ed545989b83043a1ca232ac03e8fff1";
+      sha256 = "85ac3904e14e385c3dbc39a8a3164172e4d2363c7896bd0f6bf7d56cd06ffea0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/sk/thunderbird-140.9.0esr.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "5b9b506699ac3cbbf6fbb271cd305882c8fa832aa70f52511ebf71bb3d4153dd";
+      sha256 = "3868d5319e126a11e60c5974eed9e909e61e4eafff5ae86385b7dc18116c0311";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/sl/thunderbird-140.9.0esr.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "c00a5812a416d19e7f3afa0db0ec216b10c12a2903b311fee9c0b6213ce3ac59";
+      sha256 = "63333ebe861b7f227a31b4ab4a42a828adabcc3f199369a9c8009af990635629";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sq/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/sq/thunderbird-140.9.0esr.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "f1ee8c8bfcc6fc180f295e7b37363225a1ed596b6c01876d994275286ee835cf";
+      sha256 = "c3d1cb9ad892ac374ef13ea092e212bac05da7fda0c87b6cd97d9cbd1a799988";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/sr/thunderbird-140.9.0esr.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "0b7c3297b005736a0e52c08ccb54f8cf725c4154d5767bd4aca502e88ce1d7b1";
+      sha256 = "e656b140085c7727806f728ed71631fa040e4132db9635d8cf3d150c3f88bb36";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sv-SE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/sv-SE/thunderbird-140.9.0esr.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "28885f0e6a78b85b8acbf2d040bb6405caa6701088a0742cb1197709918c38fb";
+      sha256 = "4b1d12a4c824bde251009c8af8d34bff0d6dde8d586442bc2d2086484a498bd5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/th/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/th/thunderbird-140.9.0esr.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "23645f57987965c5cd2c0128caea047be8495c727c8881a83f222bae4f00ff06";
+      sha256 = "f7e1431d783ef5a8c77d1b7b4ccd17f967ba49d5389be442ea152980efafb7c3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/tr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/tr/thunderbird-140.9.0esr.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "917b63e9193925ba99dffca41b769099af0829b87db23e6c576f4c3c55c3d986";
+      sha256 = "685f5fcae25b69929314391fbcd734d3df6a8d1f7ab7d0c1e01d4224c6a1a8a8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/uk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/uk/thunderbird-140.9.0esr.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "06f7f0d59e2979b215f3d430a9a347b48dfd491c0d68375c6a8a4564a9440f8d";
+      sha256 = "8eb825197956b6a50c044daf1381db33b867c3ede87d9adfcfe7bf6415c67a86";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/uz/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/uz/thunderbird-140.9.0esr.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "62e5bf272ed9b5870d4859368f0b69f76f94699f922b48de3993aee29db4efb0";
+      sha256 = "04dec68b7bd780cb7a2cca74ba746034aeba49fc19e67f83f25a7d22f267340f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/vi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/vi/thunderbird-140.9.0esr.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "efd59dfa5b3647d614decf11dbaf9319aeb3244ced0a5b576b8c8aa9191a14b7";
+      sha256 = "a97661547ec1064af40cae6fd8aeac59445ac4c814eb76713b7d736eae501120";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/zh-CN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/zh-CN/thunderbird-140.9.0esr.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "c832a30626941ed31a539a7271ec40848cffe5434a0bf667e9b86e2ba4658571";
+      sha256 = "6fcc181be58a6979413635d157bfe72048f40f552bb257378ac6c80b80a16866";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/zh-TW/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/linux-i686/zh-TW/thunderbird-140.9.0esr.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "5abce6cbd19e6ebe40f709968f5104b539c503ae71122bff113a3e9f21fee1f6";
+      sha256 = "60f1cc1a25e90f6631e37861bebbe28731518b136888686ada861868bb9c0dcb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/af/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/af/Thunderbird%20140.9.0esr.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "22624183fe0d9583227a4d6c549d96fafdcbc9f3bc3a3f4e5b6ad22629ccfac0";
+      sha256 = "f0004aa0a807219e21019f6069ad3e4e66cdf4698e495489d70791e8420ce864";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ar/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ar/Thunderbird%20140.9.0esr.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "ce73adcba8b5651fec00e1b86f92b111db50d65a5a8306fc5b18b5e9aed965c1";
+      sha256 = "be3d111107c917c536e21808ac45aa9968907b819c6617996fac2a46e42dfee0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ast/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ast/Thunderbird%20140.9.0esr.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "63b51337df4e38cadd6cb1ee4d1bcfaee452a5627f3471d9851365bd4de6bbbd";
+      sha256 = "50f58767fa89f1b08377ff5205ca7f9e97965abbc938f2b1a55eac0f7a26711c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/be/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/be/Thunderbird%20140.9.0esr.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "92934cdfb7562c3dcde41dc1911437db84a22592275fab6db853fbe0d434c7d0";
+      sha256 = "36cc81c97fa1ebb7741a11842b4f6e536314762ba9bf7d1095830f64595f3400";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/bg/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/bg/Thunderbird%20140.9.0esr.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "35aba6bcec1186922b32251661a56fd66b8431ee406169ba107221969d490585";
+      sha256 = "13513e4c776ad721fe7b5204ba7aa6c27376dbd91e0b9919fbeb6e97cebf0b3a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/br/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/br/Thunderbird%20140.9.0esr.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "71c3b7018a6731e86b0c94a1013beb736fa31ef9b5b35bd359d31539d4a7063c";
+      sha256 = "2775f182124d6be0fe70f64dec72b203b030f74b535b320cc14cf1d943579811";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ca/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ca/Thunderbird%20140.9.0esr.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "0be8322568793c296025d4c345382b2ee0f58917fdcfac0aaf3ab8cac13a9e6b";
+      sha256 = "91c1db6abb94c01d85986dabb0a7a6891110fe77be9509634f7e22ce4d31eb3c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cak/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/cak/Thunderbird%20140.9.0esr.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "3fcbe75b6796395784949a514bc3853a1d86a0b6de2be984c3c73550ec4d6dea";
+      sha256 = "67bdf6139cbf9491a96f7a90d4f24536968f6e46b4a963065781e99f0475d813";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cs/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/cs/Thunderbird%20140.9.0esr.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "b9a6022d702c4afa6c665d7690533ed4d9a7e58df86084af7fed49a824e53b79";
+      sha256 = "e7463a16aea636937a72a83ee8cf92a7e7588ddca5732591aeb4cbce395f06dc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cy/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/cy/Thunderbird%20140.9.0esr.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "d7eebea983b2110a91fd74791ab2591255564250a336d72b32b0ec9d71255dc4";
+      sha256 = "ebb796b00dfa4cc0a04e72dd08ee64fc74c33ebf0496a1b2fd7dd839118e54e6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/da/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/da/Thunderbird%20140.9.0esr.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "d75e6dceb07a890ca71229541603320f8c07f4aed11032ba64fe19a0ff2bb4ee";
+      sha256 = "4b00a56583dc4fc1c34d6b4afdae17e22c3d36a0b6d7e8ff76ee9fae7bfc4098";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/de/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/de/Thunderbird%20140.9.0esr.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "97ea7be853fe85d87f8230d4db966a20aa3f570963cc4bdaef088b15f2293906";
+      sha256 = "506688a60636fecaf11d2513fe466a9e9ccf703ca3cfeef8c0b490dc02d66057";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/dsb/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/dsb/Thunderbird%20140.9.0esr.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "b2c9f248dcbaa4b82c0a6fb8367437fce280dc338bfce7441ab1ee295a9ebc1e";
+      sha256 = "f1c93f9af36e2825a34d97d64fcac400f80b8d3165009c339348609706ef1f47";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/el/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/el/Thunderbird%20140.9.0esr.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "e2739ec67f2e088a3bf65916a58fc92686dff4aeec8a7af06af98a8cb06cff29";
+      sha256 = "cb1d5949301699f7ad642a1ef40202c106d8648428b1891a29d47f4255cbd4ad";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-CA/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/en-CA/Thunderbird%20140.9.0esr.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "e4e9e100a5d7cfd17caed84fd76a16817b6776698438c88b0299a7050bb48157";
+      sha256 = "677d31cf97706b6c38c84a212bd9c2540a0a2f86596e1f57aa5b24dce5bac104";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-GB/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/en-GB/Thunderbird%20140.9.0esr.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "99a4f3d1bc162eb98f4d685f1508157a59daab954f8a3103d5b2b2db20f41969";
+      sha256 = "1fea91956744ae218e4acbe36c336528dc3aee503f3e93b56bcff8d72e79cf43";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-US/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/en-US/Thunderbird%20140.9.0esr.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "41eee241cdb2405ead4feb5e676917eb40e54446e3e5db4d090a75d80465c805";
+      sha256 = "b4bbf6c578dcec9e06f2f70267eb80167ed71442d71150751d04551201484df0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-AR/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/es-AR/Thunderbird%20140.9.0esr.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "680f8109aa6728a95e66b3eaf6eb20d17d3d62378d9ac75289aa4bc2935df55c";
+      sha256 = "6b2edd16da211c7c5c0f4dd54a7d031c021abb1e283ac630626c70048a6aa97d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-ES/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/es-ES/Thunderbird%20140.9.0esr.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "7536b48665d16a9ebbb7f687532b97bd08787e0978129923c6a9dd0bf52bd864";
+      sha256 = "0c4a539036a30e4ad636025e4e0249f31b54772cd572e1e639c5be7339f8da63";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-MX/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/es-MX/Thunderbird%20140.9.0esr.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "5c8342b68e8a2afd6f370c9991bc29b6ccb9024e22af638a1fbfb0afd6ed5fd9";
+      sha256 = "af94ad2e280cc875ed211d9d3143dbcd59529f4e70e081e0c1c019bc4031a763";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/et/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/et/Thunderbird%20140.9.0esr.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "ed4beec98b1945c044cadca494f98819298cc533f656a2f4f6116f037cb18e62";
+      sha256 = "f30a0a48a7f3abb76c020d276da0dd929fef43b5e707079efa2cc1e38cd51851";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/eu/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/eu/Thunderbird%20140.9.0esr.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "2d377cac10a089d2fa2dba8452f92f1185d485076e910159b2497c2739d79eb6";
+      sha256 = "0b61c6b290a29e9f8abdba00b7831465e4e84ae86548e9120d8412d70a6e2a9a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fi/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/fi/Thunderbird%20140.9.0esr.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "0f6886d531719c0cb68b318e87435a0b3c67ee2acf239a13ac055ae11c199545";
+      sha256 = "0599e4834b2506133af0dccf005e7dad52f319c4a265c10265eacb236643e289";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/fr/Thunderbird%20140.9.0esr.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "cf27acf21cc6c3e9589de2ad88311643841c4e8ab01f97dceb385e17106b11f0";
+      sha256 = "aaff870e57c22974325bafb1f085bc5bb105c37734a1464136b77224a47f2032";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fy-NL/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/fy-NL/Thunderbird%20140.9.0esr.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "3fe1aa3cd3a0880523f150d7df017edeaabf1725258942aa7fead373e9044173";
+      sha256 = "9fe0b6de90341ed4545495d1938f69e87ba1b052e6c389b437cae40baf14c49c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ga-IE/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ga-IE/Thunderbird%20140.9.0esr.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "2e072cb4b589f7451626f6de5d2fffb4bab34e73d812b94a09be322833c9a0c1";
+      sha256 = "1aeb435f85f19e071adec3c435a2d8ccd84c5e8ccd186526289fc0e842014104";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/gd/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/gd/Thunderbird%20140.9.0esr.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "b78a50e4ab1ed8fd1a46463f304c31307236a123ee8b8c64353358a371ac6f86";
+      sha256 = "2631b994f7777758c9a217f63eb20cad9977ebaa26634aaf6a59b598746ed0ef";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/gl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/gl/Thunderbird%20140.9.0esr.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "3d3034ad6e406318d5cfe7fcf1e46c0cefe0721892761667472ef4920dd7be78";
+      sha256 = "2fb2e540c9a8f895b608ad5d5e2b27ab8e2c1137753e976d40907c22fd5f59a7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/he/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/he/Thunderbird%20140.9.0esr.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "8eb920c4c7c91e7655d9b614e8a710a0d9087229183b96e9c028a93c5df23f83";
+      sha256 = "181b527a9e13486a4347638363b762916b04d7332de11806101bd93d9d59907e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/hr/Thunderbird%20140.9.0esr.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "e4637fb9397b5c642448e43089583add717e8052be3ad7d8d5f07f156b95d41a";
+      sha256 = "6cb415ec2409c99c4dcc49c9e62c5116cbe6dfc942b812b4c6f279b8c1314f14";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hsb/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/hsb/Thunderbird%20140.9.0esr.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "1a752d30f6e0509338bc85b371109cc722e92f7c489c263b31263ab5ac26b8cc";
+      sha256 = "1c4327c78269d1962030976e1c1f40c5b8ca70845a30cf2001c980c8765c2511";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hu/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/hu/Thunderbird%20140.9.0esr.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "ba75bef3a72a04511676be8074c8d00b7c9317418fae22b35455deb1234de904";
+      sha256 = "0ab305f0900b7b80a727de02d31ca4c8de0d429c3b0dbff6ed2c740ac006e06f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hy-AM/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/hy-AM/Thunderbird%20140.9.0esr.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "df202a70c7e6b0d59beb6095f61be4d74e9873b7222946ba3aba8845a991d60c";
+      sha256 = "d3cf3d8d988a3d38925365236f62c2e341689f05dc597ce1bdf42f5cc381c2c7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/id/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/id/Thunderbird%20140.9.0esr.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "94f83da8e9676af52b8711e7cd48575e520d8ce61063c86da27919c504cb6043";
+      sha256 = "4e14f7ffd00d684daf37d0fad3a0fdefdba57b2f16c29e8493379ac4e02ca1ff";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/is/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/is/Thunderbird%20140.9.0esr.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "69b101515450ecb6e50d83c2f9f71f405b28002ad7b64a2c569a798c83bd9468";
+      sha256 = "46a49595ef17517f2bfa213d84e2e6e0f71121e99f6bfdc58fd40303220d9f0e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/it/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/it/Thunderbird%20140.9.0esr.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "cfc5960fc923a483105a0e3e53fc5802853dee61a4a9a392314efc80e0e13360";
+      sha256 = "0c1a1b4742198f70bad5f06b36128d168f093675fdc55e519983bbb0ada21563";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ja-JP-mac/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ja-JP-mac/Thunderbird%20140.9.0esr.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "9eb1f856f59b676e7cf0b7acf243fbf5c3dd29098692d07d0e9eb7bbc89b9110";
+      sha256 = "daad3c5cd8b170b1c81e18451a5c824e04933635781696dc611e9f2b34688aeb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ka/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ka/Thunderbird%20140.9.0esr.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "20c809d40bb46918356ca1e4f7301ae94a6007ea83043830fd23c8b628c73b39";
+      sha256 = "0cd0bd3195d5a50c1f89dc264f9ed9950a5186c13e4aeff7b3fbda3f871def93";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/kab/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/kab/Thunderbird%20140.9.0esr.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "a27545751025fe7835bcbf8759dcb7849b50d2bb783f54543850655602d6fc84";
+      sha256 = "94d482bd397f207c4d43544b41198a00e15c4a458d6c38e37bb6913415788259";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/kk/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/kk/Thunderbird%20140.9.0esr.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "2a74af790469d3da851798b99d2f9f1f31a942f6683e63d148ba8fa9e7397808";
+      sha256 = "b7a16499c976ee02eacade8d5f0729231fa9ed0ea07c5c1d4bdf2a4c8615243b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ko/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ko/Thunderbird%20140.9.0esr.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "0cf9cbe7eb0a365358eb618d41ec234a2ce8a8674ebc6fe3b40a6857a13daba6";
+      sha256 = "74aed9b76f4ea924ee489d8c988644372621a15e9c003739ace0c79a9ee73afd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/lt/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/lt/Thunderbird%20140.9.0esr.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "3ea725b28229d2f07e1fe0daf42b8fcbda860561ca8d1c62433e450a40887db7";
+      sha256 = "2763bf1e55eae72e1677f6adcdc4eddd6393df2bd9712bbccaeaaa142f4bbd76";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/lv/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/lv/Thunderbird%20140.9.0esr.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "01c8d2b9af2dba50b207eb7e62924f5a521a45bafde4e6b6a4110d9d7d28e170";
+      sha256 = "418aa2f935cb3e3ffc9f00ebd47d6d7d78f716b3185abc98a42cfa48ee2ce004";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ms/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ms/Thunderbird%20140.9.0esr.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "aa686dd27733ad308af292a25b141a70174ff2cd09472d29e6280afd0d8533c5";
+      sha256 = "3b443332c6c685a57fec139c388dec9c5ca5b37f17f76d823a51964615337b1a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nb-NO/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/nb-NO/Thunderbird%20140.9.0esr.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "519b5f2075ef5b8f444abb3c0e0e09620299451703c5f549c2b782493e647251";
+      sha256 = "c2b956faa3f6900069b0159012e97f4ab840593cb08628aa77d7029f69a50fe0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/nl/Thunderbird%20140.9.0esr.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "13e3db19da765d62839c72dc2032de1c9e2af2995857df7b5c11128ddc3fdca7";
+      sha256 = "1d3f0ca741abb899cc05a503698959f0764bad151848dc0abc71b12e3911a557";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nn-NO/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/nn-NO/Thunderbird%20140.9.0esr.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "1e0b1965fb8dc9985472a960237492e52d09f9f54b1d9f01f467e2ff3653f764";
+      sha256 = "5541737c316aea93a0859604daf66e5dd1f4cf15a160a354148978108feb2e86";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pa-IN/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/pa-IN/Thunderbird%20140.9.0esr.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "1c1fbdc3a8a58b2983a1e61afde4c1f3c82baace71ba3e34891acbad4d83089c";
+      sha256 = "46bab8449da19ee293d435fba5f45568f55c5f288645f8a6c50dc7a974ca542a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/pl/Thunderbird%20140.9.0esr.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "9a0e1f2a232c20d9ef5abf8b8d081e9173f9b600fdfc80aaef1961c6ce5cb494";
+      sha256 = "1e904b2ec245e8522a85daca37b5d6f521cdcbfecaceb7d36b69fe53d4c1976c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pt-BR/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/pt-BR/Thunderbird%20140.9.0esr.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "bdef886cdf12eeca3a8d12162de97320594abed7c27b26ff4a80232a802c0bb3";
+      sha256 = "efedd2423a32a9b852351a89c1f61b0777d15fa3acdb4e45c89d5247b7391974";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pt-PT/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/pt-PT/Thunderbird%20140.9.0esr.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "05857f22c10c2da4b88e93d1d30e8fc2f8ec6c56a3653e809e9f22fcfb7e206c";
+      sha256 = "18f9f2a0f62421e12bdf2ddc58655242f781870046fd243bfbf342a1303fc690";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/rm/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/rm/Thunderbird%20140.9.0esr.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "1983dd10fc1437b68d3ba347287f889354ed848ceda3374e0c91cb8771bebe19";
+      sha256 = "53ed3c639631ad41f8fecbcc25ce029e36ee3206261e5963ce4c7293704f69a2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ro/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ro/Thunderbird%20140.9.0esr.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "fed16aef5cdc3fe07b90e85a2e988179e1059225b7a4a8a9d514fe80f5970041";
+      sha256 = "d8e512148a3bdbf1c1c6213ed189dd9323e882fd69814afe042672958a4132aa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ru/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/ru/Thunderbird%20140.9.0esr.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "d34428fbe71cf813635490ffa8b06660a485eb4e3e9b28083bdfcca511d21b0a";
+      sha256 = "1615b96d8e430604ce72ddbb3e3698c864a9fd8bb6d86fe1b7315f4ff9841e62";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sk/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/sk/Thunderbird%20140.9.0esr.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "a475eed733592d48adb3287092f58333bf83d0e9ddd8165c0f2bab8b904d3989";
+      sha256 = "3a2c344f7fe47b4a107fbc4d91453e32888b2f1cd19bbeb10edbf269e11f16a3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/sl/Thunderbird%20140.9.0esr.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "42c481c28b5b37ab6b1291804a61c6ba6579d09a405fe38782eb6e38ad67e80a";
+      sha256 = "343b3f3083d90e3af69b868cdeb2838f253eb15620391bcbfd056f1cc8e4abea";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sq/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/sq/Thunderbird%20140.9.0esr.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "b75b09a20c9160c88205d777201ff454ec09725bc184e8e4c44ac3c3db113553";
+      sha256 = "a5bdf5c95daf295a69efc5d10712dfe415fa1789600e8ce5e40293808f0f125b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/sr/Thunderbird%20140.9.0esr.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "6e22260916ff863ec0b4b3ada5ce49e74fda15195c14cc2ac96871b9dbbfdf3a";
+      sha256 = "d55fe916c462d53a487f18e678081a93dae399aee6287e0a71626cbdf63c9830";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sv-SE/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/sv-SE/Thunderbird%20140.9.0esr.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "bdf06df7ba37813e9e5357eeec2b62e21cee79fd5aef34b7766b6a942e629a2d";
+      sha256 = "a3d27f1adc9dd669fcb3d3b723f19a345af724d58313f673909c3f10c15b7dc3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/th/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/th/Thunderbird%20140.9.0esr.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "8a34f2219e3380292760f877f2f8587662b433083bfd0f9d9c23cbdf58c85f7d";
+      sha256 = "6fa301645d35cad9005c89e382cf835ce14e4e16b21a14975ca5ee8bcd5fef7f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/tr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/tr/Thunderbird%20140.9.0esr.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "bd903e7f5d23b77177d6e0f4b76be2f7d9cf96f33c098da44c0a0b703208aa8d";
+      sha256 = "f1e25d069a0abc2739d840e55dedc21381c336f2b33eb79a79162c279535a666";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/uk/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/uk/Thunderbird%20140.9.0esr.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "887f8aad21bd50f6a6e3c8f1a66550a8e8561ba8e92e9ab2933c93cf6bb8be16";
+      sha256 = "64f0437ddaf063b212326f940114ae5c5a93af24126fbf1a85edf9f0c9f81dd5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/uz/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/uz/Thunderbird%20140.9.0esr.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "682a92f644c0bd50b6c614de0539c582faccf74a3052bd7810a2408cb7eecc09";
+      sha256 = "884bfbc9fbf55943ae5756e11eb735a98332f10029eafeb45f569fe16d166217";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/vi/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/vi/Thunderbird%20140.9.0esr.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "9031ccf53c39a3b93ba07a080f864f09884122b0051ed9c0f58f99aa1663d51a";
+      sha256 = "4584b4388ae2030ea59646e65bc5bc622d6184c8ba0276b1e9805cf52f4e56a7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/zh-CN/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/zh-CN/Thunderbird%20140.9.0esr.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "16aabcfbd2351429b509090894798c5fa2f6988acbcdda7cf8fc5de1a8219a82";
+      sha256 = "174172e128bf4bd67e5d01e5e9f6a264f6f4c5bb8b5edb50cc8ccca23629f29e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/zh-TW/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.9.0esr/mac/zh-TW/Thunderbird%20140.9.0esr.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "c6de157bc45d6be2e342ddaadc8a6e24d0c61408db8c4070ff3017d4821c09d2";
+      sha256 = "230780e756d59f2c1b7244d374f83f5f724a77750d1b7edf9c67236a7644003d";
     }
   ];
 }


### PR DESCRIPTION
Backport of #505273. Manual conflict resolution due to https://github.com/NixOS/nixpkgs/pull/496560

(cherry picked from commit b2722bec3ef3c65b48e3dd69a413ffc4f402ae4d)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
