### PR TITLE
add launchdarkly python sdk and eventsource

### DIFF
--- a/pkgs/development/python-modules/launchdarkly-eventsource/default.nix
+++ b/pkgs/development/python-modules/launchdarkly-eventsource/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  urllib3,
+
+  # tests
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "launchdarkly-eventsource";
+  version = "1.5.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    pname = "launchdarkly_eventsource";
+    inherit version;
+    hash = "sha256-8SL4CzbbbqGrIK9iyCuLJmhoIlm0FQU8lEAN1sB5Iqc=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ urllib3 ];
+
+  pythonImportsCheck = [ "ld_eventsource" ];
+
+  meta = {
+    description = "LaunchDarkly SSE client for Python";
+    homepage = "https://github.com/launchdarkly/python-eventsource";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/launchdarkly-server-sdk/default.nix
+++ b/pkgs/development/python-modules/launchdarkly-server-sdk/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  certifi,
+  expiringdict,
+  launchdarkly-eventsource,
+  pyrfc3339,
+  semver,
+  urllib3,
+
+  # tests
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "launchdarkly-server-sdk";
+  version = "9.15.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    pname = "launchdarkly_server_sdk";
+    inherit version;
+    hash = "sha256-8xRBt0vBppw4HbV8MxFlCeQHomEmKK1t/wp9uznVAgs=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    certifi
+    expiringdict
+    launchdarkly-eventsource
+    pyrfc3339
+    semver
+    urllib3
+  ];
+
+  pythonImportsCheck = [ "ldclient" ];
+
+  meta = {
+    description = "LaunchDarkly Server-side SDK for Python";
+    homepage = "https://github.com/launchdarkly/python-server-sdk";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8513,6 +8513,10 @@ self: super: with self; {
 
   latexrestricted = callPackage ../development/python-modules/latexrestricted { };
 
+  launchdarkly-eventsource = callPackage ../development/python-modules/launchdarkly-eventsource { };
+
+  launchdarkly-server-sdk = callPackage ../development/python-modules/launchdarkly-server-sdk { };
+
   launchpadlib = callPackage ../development/python-modules/launchpadlib { };
 
   laundrify-aio = callPackage ../development/python-modules/laundrify-aio { };


### PR DESCRIPTION
This PR adds https://github.com/launchdarkly/python-server-sdk and its dependency https://github.com/launchdarkly/python-eventsource, which are used for LaunchDarkly in Python.

LaunchDarkly is yet another product for managing feature flag hell https://launchdarkly.com/docs/home