### PR TITLE
temporal_capi: fix pkg-config integration

### DIFF
--- a/pkgs/by-name/te/temporal_capi/package.nix
+++ b/pkgs/by-name/te/temporal_capi/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   nix-update-script,
   testers,
+  pkg-config,
   validatePkgConfig,
 }:
 
@@ -53,15 +54,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir $out/lib/pkgconfig
     cat -> $out/lib/pkgconfig/temporal_capi.pc <<EOF
     prefix=$out
-    exec_prefix=''${prefix}
-    libdir=''${exec_prefix}/lib
-    includedir=''${prefix}/include
+    exec_prefix=\''${prefix}
+    libdir=\''${exec_prefix}/lib
+    includedir=\''${prefix}/include
 
     Name: temporal_capi
     Description: C API for temporal_rs
     Version: ${finalAttrs.version}
-    Libs: -L''${libdir} -ltemporal_capi
-    Cflags: -I''${includedir}
+    Libs: -L\''${libdir} -ltemporal_capi
+    Cflags: -I\''${includedir}
     EOF
   '';
   postFixup = lib.optional (stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isStatic) ''
@@ -71,13 +72,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # We don't want to run Rust checks, we only check the resulting lib using C/C++ in the installCheckPhase.
   doCheck = false;
   doInstallCheck = true;
-  nativeInstallCheckInputs = [ stdenv.cc ];
+  nativeInstallCheckInputs = [
+    stdenv.cc
+    pkg-config
+  ];
   installCheckPhase = ''
     runHook preInstallCheck
 
-    cc -L $out/lib -I $out/include temporal_capi/tests/c/simple.c -ltemporal_capi -lm -o c_test
+    FLAGS=$(PKG_CONFIG_PATH="$out/lib/pkgconfig" pkg-config --cflags --libs temporal_capi)
+    cc $FLAGS temporal_capi/tests/c/simple.c -o c_test
     ./c_test
-    c++ -L $out/lib -I $out/include temporal_capi/tests/cpp/simple.cpp -ltemporal_capi -lm -o cpp_test
+    c++ $FLAGS temporal_capi/tests/cpp/simple.cpp -o cpp_test
     ./cpp_test
 
     runHook postInstallCheck


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
