### PR TITLE
hyprlandPlugins.imgborders: init at 1.0.1

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -44,6 +44,7 @@ let
     { hyprspace = import ./hyprspace.nix; }
     { hyprsplit = import ./hyprsplit.nix; }
     (import ./hyprland-plugins.nix)
+    { imgborders = import ./imgborders.nix; }
     (lib.optionalAttrs config.allowAliases {
       hycov = throw "hyprlandPlugins.hycov has been removed because it has been marked as broken since September 2024."; # Added 2025-10-12
       hyprscroller = throw "hyprlandPlugins.hyprscroller has been removed as the upstream project is deprecated. Consider using `hyprlandPlugins.hyprscrolling`."; # Added 2025-05-09

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/imgborders.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/imgborders.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromCodeberg,
+  mkHyprlandPlugin,
+  cmake,
+  nix-update-script,
+}:
+mkHyprlandPlugin (finalAttrs: {
+  pluginName = "imgborders";
+  version = "1.0.1";
+
+  src = fetchFromCodeberg {
+    owner = "zacoons";
+    repo = "imgborders";
+    tag = finalAttrs.version;
+    hash = "sha256-fCzz4gh8pd7J6KQJB/avYcS0Z7NYpxjznPMtOwypPSQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    mv imgborders.so $out/lib/libimgborders.so
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://codeberg.org/zacoons/imgborders";
+    description = "Add tiling image borders to windows!";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [
+      mrdev023
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
