### PR TITLE
qidi-studio: fix 2.05.01.52 hash

### DIFF
--- a/pkgs/by-name/qi/qidi-studio/package.nix
+++ b/pkgs/by-name/qi/qidi-studio/package.nix
@@ -11,7 +11,7 @@ let
 
   src = fetchurl {
     url = "https://github.com/QIDITECH/QIDIStudio/releases/download/v${version}/QIDIStudio_v0${version}_Ubuntu24.AppImage";
-    hash = "sha256-ikLqTei2smj++AbzNOOwW5PGy2zxmdAvXUQJ1YQ4zMU=";
+    hash = "sha256-bjQsLWuBcA9rWwX8UICgh0SKJ3zQe1oZWcqf7buoe6E=";
   };
 
   appimageContents = appimageTools.extract {


### PR DESCRIPTION
## Description

QIDI replaced the  release asset after the original version update landed, while keeping the same release tag and filename.

This updates the fixed-output hash to match the current upstream asset so that it installs again.

## Testing

- Built and tested on a desktop system
- Verified the current upstream AppImage hash matches this update
