### PR TITLE
awatcher: 0.3.1 -> 0.3.3

### DIFF
--- a/pkgs/by-name/aw/awatcher/package.nix
+++ b/pkgs/by-name/aw/awatcher/package.nix
@@ -4,24 +4,28 @@
   fetchFromGitHub,
   openssl,
   pkg-config,
+  libxkbcommon,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "awatcher";
-  version = "0.3.1";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "2e3s";
     repo = "awatcher";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-bxFc6oM+evIQTjrsWmb7dXOUlSjurjc4CzHpxB+667c=";
+    hash = "sha256-wxnbyWkfRFN+aWa7rrSIv5PdNHNU/D/w7y/VIwzxxaI=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openssl ];
+  buildInputs = [
+    openssl
+    libxkbcommon
+  ];
   doCheck = false;
 
-  cargoHash = "sha256-pUqwg7jblSWRLPcsUDqkir/asSM8zY0jrvrre4OIeZc=";
+  cargoHash = "sha256-/dI0gaTRElAQnZNRo2sKMUc33fphubcG/fXOflPHXWs=";
 
   meta = {
     description = "Activity and idle watchers";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



<details><summary>Needed to add a build dependency due to this compile error:</summary>
<code>
   Compiling bit_field v0.10.2
   Compiling zune-core v0.4.12
   Compiling color_quant v1.1.0
   Compiling cursor-icon v1.2.0
   Compiling rgb v0.8.50
   Compiling bytemuck v1.18.0
   Compiling exr v1.72.0
   Compiling gif v0.13.1
   Compiling anstyle-parse v0.2.5
   Compiling png v0.17.14
   Compiling rustls-pemfile v1.0.4
   Compiling zune-jpeg v0.4.13
   Compiling image-webp v0.2.0
   Compiling url v2.5.2
   Compiling tiff v0.9.1
   Compiling qoi v0.4.1
   Compiling memmap2 v0.9.7
error: failed to run custom build command for `smithay-client-toolkit v0.19.2`
Caused by:
  process didn't exit successfully: `/build/source/target/release/build/smithay-client-toolkit-7a7ffd3cea856bef/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=XKBCOMMON_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=XKBCOMMON_STATIC
  cargo:rerun-if-env-changed=XKBCOMMON_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  --- stderr
  thread 'main' (2810) panicked at /build/awatcher-0.3.3-vendor/source-registry-0/smithay-client-toolkit-0.19.2/build.rs:3:49:
  called `Result::unwrap()` on an `Err` value: "\npkg-config exited with status code 1\n> PKG_CONFIG_PATH=/nix/store/79xszwqidf98ag703b5c82q3pwg9lyzq-openssl-3.6.1-dev/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags xkbcommon\n\nThe system library `xkbcommon` required by crate `smithay-client-toolkit` was not found.\nThe file `xkbcommon.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.\nPKG_CONFIG_PATH contains the following:\n    - /nix/store/79xszwqidf98ag703b5c82q3pwg9lyzq-openssl-3.6.1-dev/lib/pkgconfig\n\nHINT: you may need to install a package such as xkbcommon, xkbcommon-dev or xkbcommon-devel.\n"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
</code>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
