### PR TITLE
maintainers: remove _0xMRTT

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -144,13 +144,6 @@
     github = "0xMillyByte";
     githubId = 48217459;
   };
-  _0xMRTT = {
-    email = "0xMRTT@proton.me";
-    name = "0xMRTT";
-    github = "0xMRTT";
-    githubId = 105598867;
-    matrix = "@0xmrtt:envs.net";
-  };
   _1000101 = {
     email = "b1000101@pm.me";
     github = "1000101";

--- a/pkgs/by-name/bo/boatswain/package.nix
+++ b/pkgs/by-name/bo/boatswain/package.nix
@@ -72,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/World/boatswain";
     changelog = "https://gitlab.gnome.org/World/boatswain/-/releases/${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ _0xMRTT ];
     teams = [ lib.teams.gnome-circle ];
     mainProgram = "boatswain";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/el/elastic/package.nix
+++ b/pkgs/by-name/el/elastic/package.nix
@@ -57,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "app.drey.Elastic";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ _0xMRTT ];
     teams = [ lib.teams.gnome-circle ];
   };
 })

--- a/pkgs/by-name/sc/schemes/package.nix
+++ b/pkgs/by-name/sc/schemes/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "schemes";
     homepage = "https://gitlab.gnome.org/chergert/schemes";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ _0xMRTT ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [October 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3A0xMRTT)
- Hasn't created any PRs / Issues since [May 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3A0xMRTT)
- About 16 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3A0xMRTT%20-commenter%3A0xMRTT%20-author%3A0xMRTT%20-reviewed-by%3A0xMRTT) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] schemes