### PR TITLE
museeks: 0.23.1 -> 0.23.4

### DIFF
--- a/pkgs/by-name/mu/museeks/package.nix
+++ b/pkgs/by-name/mu/museeks/package.nix
@@ -12,20 +12,23 @@
   dbus,
   gdk-pixbuf,
   nix-update-script,
+  wrapGAppsHook3,
+  gst_all_1,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "museeks";
-  version = "0.23.1";
+  version = "0.23.4";
 
   src = fetchurl {
     url = "https://github.com/martpie/museeks/releases/download/${finalAttrs.version}/Museeks_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-bji49ncJriDGrYoC0VYfblcGPDU66Ep+c/z9FNEXnkI=";
+    hash = "sha256-2WkWBd4opWpCcjE+uWRbDC8RPQoVvflpxbWuuNF2Z54=";
   };
 
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -37,6 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     glib
     (lib.getLib stdenv.cc.cc)
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
   ];
 
   installPhase = ''


### PR DESCRIPTION
update version and fix:
```
[stream_server] Audio stream server started on port 34475
[2026-04-02][14:45:40][INFO][museeks::plugins::db] Run possible migrations
[2026-04-02][14:45:40][INFO][museeks] Main window built
[2026-04-02][14:45:40][INFO][museeks::plugins::default_view] Navigating to '/library'
[2026-04-02][14:45:40][INFO][webview] [DatabaseBridge] getAllTracks (5ms)
[2026-04-02][14:45:40][INFO][webview] [DatabaseBridge] getAllPlaylists (5ms)
[2026-04-02][14:45:40][INFO][webview:o@tauri://localhost/assets/index-DshpMyt9.js:74:1629] Navigated to: /library
[2026-04-02][14:45:40][INFO][webview] [DatabaseBridge] getAllTracks (24ms)
[2026-04-02][14:45:40][INFO][webview:qL@tauri://localhost/assets/index-DshpMyt9.js:24:41198] UI is ready!
[2026-04-02][14:45:41][INFO][webview] [DatabaseBridge] getAllTracks (74ms)
[2026-04-02][14:45:41][INFO][webview] [DatabaseBridge] getAllPlaylists (74ms)
GStreamer element appsink not found. Please install it.
GStreamer element autoaudiosink not found. Please install it

(WebKitWebProcess:62274): GLib-GObject-CRITICAL **: 22:45:46.272: invalid (NULL) pointer instance
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
