### PR TITLE
mate-wayland-session: 1.28.4 -> 1.28.5

### DIFF
--- a/pkgs/by-name/ma/mate-wayland-session/package.nix
+++ b/pkgs/by-name/ma/mate-wayland-session/package.nix
@@ -14,13 +14,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mate-wayland-session";
-  version = "1.28.4";
+  version = "1.28.5";
 
   src = fetchFromGitHub {
     owner = "mate-desktop";
     repo = "mate-wayland-session";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-jcYkiJOo1k0bMP/LkBW+QIrSyoj6qi8zZMTxqmuNQd0=";
+    hash = "sha256-YWuBAzsLrvnwGgXbcDzIZtQIscIl37Y3wIRCOKidtYo=";
   };
 
   nativeBuildInputs = [
@@ -33,9 +33,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     substituteInPlace session/mate-wayland-components.sh \
       --replace-fail "polkit-mate-authentication-agent-1" "${mate-polkit}/libexec/polkit-mate-authentication-agent-1" \
       --replace-fail "mate-notification-daemon" "${mate-notification-daemon}/libexec/mate-notification-daemon" \
-      --replace-fail "mate-settings-daemon" "${mate-settings-daemon}/libexec/mate-settings-daemon" \
-      --replace-fail "cat /usr/bin/blueman-applet" "command -v blueman-applet" \
-      --replace-fail "cat /usr/bin/gnome-keyring-daemon" "command -v gnome-keyring-daemon"
+      --replace-fail "mate-settings-daemon" "${mate-settings-daemon}/libexec/mate-settings-daemon"
 
     substituteInPlace session/mate-wayland.sh \
       --replace-fail "/usr/share/doc/wayfire/examples/wayfire.ini" "${wayfire.src}/wayfire.ini"
@@ -43,7 +41,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     providedSessions = [ "MATE" ];
-    updateScript = gitUpdater { rev-prefix = "v"; };
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+      odd-unstable = true;
+    };
   };
 
   meta = {


### PR DESCRIPTION
https://github.com/mate-desktop/mate-wayland-session/compare/v1.28.4...v1.28.5



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
