### PR TITLE
[Backport release-25.11] glances: 4.3.3 -> 4.5.2

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -7,18 +7,19 @@
   defusedxml,
   packaging,
   psutil,
+  pyinstrument,
   setuptools,
   nixosTests,
   pytestCheckHook,
   which,
   podman,
   selenium,
+  python-jose,
   # Optional dependencies:
   fastapi,
   jinja2,
   pysnmp,
   hddtemp,
-  netifaces2, # IP module
   uvicorn,
   requests,
   prometheus-client,
@@ -27,7 +28,7 @@
 
 buildPythonApplication rec {
   pname = "glances";
-  version = "4.3.3";
+  version = "4.5.0.5";
   pyproject = true;
 
   disabled = isPyPy;
@@ -36,7 +37,7 @@ buildPythonApplication rec {
     owner = "nicolargo";
     repo = "glances";
     tag = "v${version}";
-    hash = "sha256-RmGbd8Aa2jJ2DMrBUUoa8mPBa6bGnQd0s0y3p/zP0ng=";
+    hash = "sha256-IHgMZw+X7C/72w4vXaP37GgnhLVg7EF5/sd9QlmE0NM=";
   };
 
   build-system = [ setuptools ];
@@ -56,14 +57,15 @@ buildPythonApplication rec {
 
   dependencies = [
     defusedxml
-    netifaces2
     packaging
     psutil
+    pyinstrument
     pysnmp
     fastapi
     uvicorn
     requests
     jinja2
+    python-jose
     which
     prometheus-client
     shtab
@@ -84,6 +86,20 @@ buildPythonApplication rec {
   disabledTestPaths = [
     # Message: Unable to obtain driver for chrome
     "tests/test_webui.py"
+  ];
+
+  disabledTests = [
+    # Upstream bug: diskio plugin doesn't check if args is None before accessing attributes
+    # Bug report: https://github.com/nicolargo/glances/issues/3429
+    "test_msg_curse_returns_list"
+    "test_msg_curse_with_max_width"
+    # Network test expects visible network interfaces
+    # Default config hides loopback and interfaces without IP (glances.conf)
+    # In Nix sandbox environment, this results in zero visible interfaces
+    "test_glances_api_plugin_network"
+    # Test always returns 3 plugin updates, but needs >=5 to not fail
+    # May be an upstream bug, see: https://github.com/nicolargo/glances/issues/3430
+    "test_perf_update"
   ];
 
   meta = {

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -3,7 +3,6 @@
   buildPythonApplication,
   fetchFromGitHub,
   isPyPy,
-  pythonOlder,
   lib,
   defusedxml,
   packaging,
@@ -31,7 +30,7 @@ buildPythonApplication rec {
   version = "4.3.3";
   pyproject = true;
 
-  disabled = isPyPy || pythonOlder "3.9";
+  disabled = isPyPy;
 
   src = fetchFromGitHub {
     owner = "nicolargo";

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -26,7 +26,7 @@
   shtab,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "glances";
   version = "4.5.0.5";
   pyproject = true;
@@ -36,7 +36,7 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "nicolargo";
     repo = "glances";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-IHgMZw+X7C/72w4vXaP37GgnhLVg7EF5/sd9QlmE0NM=";
   };
 
@@ -106,10 +106,10 @@ buildPythonApplication rec {
     homepage = "https://nicolargo.github.io/glances/";
     description = "Cross-platform curses-based monitoring tool";
     mainProgram = "glances";
-    changelog = "https://github.com/nicolargo/glances/blob/${src.tag}/NEWS.rst";
+    changelog = "https://github.com/nicolargo/glances/blob/${finalAttrs.src.tag}/NEWS.rst";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [
       koral
     ];
   };
-}
+})

--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   isPyPy,
   lib,
+  chevron,
   defusedxml,
   packaging,
   psutil,
@@ -28,7 +29,7 @@
 
 buildPythonApplication (finalAttrs: {
   pname = "glances";
-  version = "4.5.0.5";
+  version = "4.5.2";
   pyproject = true;
 
   disabled = isPyPy;
@@ -37,7 +38,7 @@ buildPythonApplication (finalAttrs: {
     owner = "nicolargo";
     repo = "glances";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IHgMZw+X7C/72w4vXaP37GgnhLVg7EF5/sd9QlmE0NM=";
+    hash = "sha256-o/q/zW7lRKQg+u4XblwNIswCVIroMdeUaPTNkN8QKwo=";
   };
 
   build-system = [ setuptools ];
@@ -77,6 +78,7 @@ buildPythonApplication (finalAttrs: {
   };
 
   nativeCheckInputs = [
+    chevron
     which
     pytestCheckHook
     selenium
@@ -100,6 +102,8 @@ buildPythonApplication (finalAttrs: {
     # Test always returns 3 plugin updates, but needs >=5 to not fail
     # May be an upstream bug, see: https://github.com/nicolargo/glances/issues/3430
     "test_perf_update"
+    # Upstream pipe handling currently fails under the new 4.5.2 sanitization coverage
+    "test_pipe"
   ];
 
   meta = {
@@ -110,6 +114,7 @@ buildPythonApplication (finalAttrs: {
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [
       koral
+      miniharinn
     ];
   };
 })


### PR DESCRIPTION
Manual backport of 
  - https://github.com/NixOS/nixpkgs/pull/489172
  - https://github.com/NixOS/nixpkgs/pull/503276
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
