### PR TITLE
thunderbird-mcp: init at 0.4.0

### DIFF
--- a/pkgs/by-name/th/thunderbird-mcp/package-lock.json
+++ b/pkgs/by-name/th/thunderbird-mcp/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "thunderbird-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thunderbird-mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "thunderbird-mcp": "mcp-bridge.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/pkgs/by-name/th/thunderbird-mcp/package.nix
+++ b/pkgs/by-name/th/thunderbird-mcp/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "thunderbird-mcp";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "TKasperczyk";
+    repo = "thunderbird-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+m54jF39SoViHxDI18ewtVjeVUdRximJ6Ozcv1HVdiU=";
+  };
+
+  postPatch = ''
+    cp ${./package-lock.json} package-lock.json
+  '';
+
+  preInstall = "mkdir node_modules/";
+  forceEmptyCache = true;
+  dontNpmBuild = true;
+
+  npmDepsHash = "sha256-LbEnmABmAoTCTPNNbocl+n2TtFC3FOFwwTnyATxvM3k=";
+
+  meta = {
+    description = "MCP server for Thunderbird - enables AI assistants to access email, contacts, and calendars";
+    homepage = "https://github.com/TKasperczyk/thunderbird-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "thunderbird-mcp";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
