### PR TITLE
livekit-cli: 1.5.1 -> 2.16.0; modernize

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4438,6 +4438,11 @@
     github = "carlthome";
     githubId = 1595907;
   };
+  carschandler = {
+    name = "Cars Chandler";
+    github = "carschandler";
+    githubId = 92899389;
+  };
   casaca = {
     name = "J McNutt";
     email = "jmacasac@hotmail.com";

--- a/pkgs/by-name/li/livekit-cli/package.nix
+++ b/pkgs/by-name/li/livekit-cli/package.nix
@@ -2,28 +2,35 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
+  testers,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "livekit-cli";
-  version = "1.5.1";
+  version = "2.16.0";
 
   src = fetchFromGitHub {
     owner = "livekit";
     repo = "livekit-cli";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-J5tg3nm2pEemEZcIpObcxH+G4ByzvUtoSyy92CcWr6M=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qGxRNsVnrDl8N0hAh8WjumDvaL7Zs90HaRmXORvUWZs=";
   };
 
-  vendorHash = "sha256-ywHTIuiZaoY3p7hTsnImcCpuwMXHQZcnRsWerIlOU4o=";
+  vendorHash = "sha256-6posDd3z2seRvGuWLsmPD5wOz4RVF4ulvmfTqWN29hE=";
 
-  subPackages = [ "cmd/livekit-cli" ];
+  subPackages = [ "cmd/lk" ];
+
+  passthru.updateScript = nix-update-script { };
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
     description = "Command line interface to LiveKit";
     homepage = "https://livekit.io/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ mgdelacroix ];
-    mainProgram = "livekit-cli";
+    maintainers = with lib.maintainers; [
+      mgdelacroix
+    ];
+    mainProgram = "lk";
   };
 })

--- a/pkgs/by-name/li/livekit-cli/package.nix
+++ b/pkgs/by-name/li/livekit-cli/package.nix
@@ -30,6 +30,8 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       mgdelacroix
+      faukah
+      carschandler
     ];
     mainProgram = "lk";
   };


### PR DESCRIPTION
Bumps livekit-cli, cleans up the package and adds me, @carschandler and @faukah to the maintainers.
supersedes https://github.com/NixOS/nixpkgs/pull/483965 which superseded https://github.com/NixOS/nixpkgs/pull/395364

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
