### PR TITLE
godot: 4.6.1-stable -> 4.6.2-stable

### DIFF
--- a/pkgs/development/tools/godot/4.6/default.nix
+++ b/pkgs/development/tools/godot/4.6/default.nix
@@ -1,11 +1,11 @@
 {
-  version = "4.6.1-stable";
-  hash = "sha256-C3AX+Gl6a3nX/k0TP6FYjYCK9AbKmtku+1ilYBu0R74=";
+  version = "4.6.2-stable";
+  hash = "sha256-alAW8i7wRcOsHvq3flYXgW7DPiIlAXxM1zFL87Kri6Y=";
   default = {
-    exportTemplatesHash = "sha256-5tNyr9T9+q6VceteNWivzZbObbmlaSRANBVPrwrGmHU=";
+    exportTemplatesHash = "sha256-lCNm3E4n52hqmdpNPPsbiujT65RE9tghfu8WJFtZnvI=";
   };
   mono = {
-    exportTemplatesHash = "sha256-V5JmHtCJVQNX4OEJVK9pWEa+CjLtdJT6QKAAnjtaPqk=";
+    exportTemplatesHash = "sha256-Ts9y+vdvluAQ0Wbdu+Pw+459+WMygmZqOpr9TuPgDn0=";
     nugetDeps = ./deps.json;
   };
 }

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -473,14 +473,6 @@ let
           lib.optionals (lib.versionOlder version "4.6") [
             ./Linux-fix-missing-library-with-builtin_glslang-false.patch
           ]
-          ++ lib.optionals (lib.versionAtLeast version "4.6") [
-            # https://github.com/godotengine/godot/pull/115450
-            (fetchpatch {
-              name = "fix-tls-handshake-fail-preventing-assetlib-use.patch";
-              url = "https://github.com/godotengine/godot/commit/29acd734c71f06268d6ef4715d7df70b14731f48.patch";
-              hash = "sha256-wxkr6jPtutUTG+mYrXoxcDcWIIZghlSJ79XqhFh/0P4=";
-            })
-          ]
           ++ lib.optionals (lib.versionOlder version "4.4") [
             (fetchpatch {
               name = "wayland-header-fix.patch";


### PR DESCRIPTION
godot: 4.6.1-stable -> 4.6.2-stable

- https://github.com/godotengine/godot/releases/tag/4.6.2-stable
- https://godotengine.org/article/maintenance-release-godot-4-6-2/ 
- https://godotengine.github.io/godot-interactive-changelog/#4.6.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test