### PR TITLE
config.silenceAliasWarnings: add nixpkgs config option to silence warnings from aliases

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -223,7 +223,9 @@ let
 
   warnAlias =
     msg: v:
-    if lib.isDerivation v then
+    if super.config.silenceAliasWarnings then
+      v
+    else if lib.isDerivation v then
       lib.warnOnInstantiate msg v
     else if lib.isAttrs v then
       lib.mapAttrs (_: lib.warn msg) v

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -221,6 +221,17 @@ let
       '';
     };
 
+    silenceAliasWarnings = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Silence warnings for aliases such as:
+        > warning: 'foo' has been renamed to/replaced by 'foo2'
+
+        Enabling this will remove all warnings made with `warnAlias` in `pkgs/top-level/aliases.nix`.
+      '';
+    };
+
     allowUnfree = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
solves problem described in and thus resolves #493853

does this need release notes?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
