### PR TITLE
hubfetch: init at 1.0.2

### DIFF
--- a/pkgs/by-name/hu/hubfetch/package.nix
+++ b/pkgs/by-name/hu/hubfetch/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "hubfetch";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-L31RCunKz4elsGJL02oR1z8In1ge0LZ5RAA9X4jQhHk=";
+  };
+
+  build-system = [
+    python3.pkgs.hatchling
+  ];
+
+  dependencies = [
+    python3.pkgs.click
+    python3.pkgs.requests
+    python3.pkgs.rich
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "A CLI ricing tool designed to fetch GitHub user stats";
+    homepage = "https://github.com/PranavU-Coder/hubfetch";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "hubfetch";
+  };
+}


### PR DESCRIPTION
Adding `hubfetch` which is a neofetch/fastfetch-style CLI tool that displays GitHub profile stats in the terminal. Built with Python, uses GitHub's REST and GraphQL APIs.

- [PyPI](https://pypi.org/project/hubfetch/)
- [GitHub](https://github.com/PranavU-Coder/hubfetch)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
