### PR TITLE
engauge-digitizer: migrate to by-name, refactor

### DIFF
--- a/pkgs/by-name/en/engauge-digitizer/package.nix
+++ b/pkgs/by-name/en/engauge-digitizer/package.nix
@@ -7,11 +7,8 @@
   log4cpp,
   openjpeg,
   libpng12,
-  poppler,
-  qtbase,
+  libsForQt5,
   qt5,
-  qmake,
-  wrapQtAppsHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -26,14 +23,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
-    wrapQtAppsHook
+    qt5.qmake
+    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
+    qt5.qtbase
     qt5.qttools
-    poppler
+    libsForQt5.poppler
     libpng12
     openjpeg
     openjpeg.dev
@@ -49,9 +46,9 @@ stdenv.mkDerivation rec {
   ];
 
   env = {
-    POPPLER_INCLUDE = "${poppler.dev}/include/poppler/qt5";
+    POPPLER_INCLUDE = "${libsForQt5.poppler.dev}/include/poppler/qt5";
 
-    POPPLER_LIB = "${poppler}/lib";
+    POPPLER_LIB = "${libsForQt5.poppler}/lib";
 
     OPENJPEG_INCLUDE = "${openjpeg.dev}/include/${openjpeg.pname}-${lib.versions.majorMinor openjpeg.version}";
 

--- a/pkgs/by-name/en/engauge-digitizer/package.nix
+++ b/pkgs/by-name/en/engauge-digitizer/package.nix
@@ -11,15 +11,15 @@
   qt5,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "engauge-digitizer";
   version = "12.2.2";
 
   src = fetchFromGitHub {
     owner = "akhuettel";
     repo = "engauge-digitizer";
-    rev = "v${version}";
-    sha256 = "sha256-Wj9o3wWbtHsEi6LFH4xDpwVR9BwcWc472jJ/QFDQZvY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Wj9o3wWbtHsEi6LFH4xDpwVR9BwcWc472jJ/QFDQZvY=";
   };
 
   nativeBuildInputs = [
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
     POPPLER_LIB = "${libsForQt5.poppler}/lib";
 
-    OPENJPEG_INCLUDE = "${openjpeg.dev}/include/${openjpeg.pname}-${lib.versions.majorMinor openjpeg.version}";
+    OPENJPEG_INCLUDE = "${openjpeg.dev}/include/openjpeg-${lib.versions.majorMinor openjpeg.version}";
 
     OPENJPEG_LIB = "${openjpeg}/lib";
   };
@@ -72,4 +72,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.sheepforce ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2225,8 +2225,6 @@ with pkgs;
 
   dvtm-unstable = callPackage ../tools/misc/dvtm/unstable.nix { };
 
-  engauge-digitizer = libsForQt5.callPackage ../applications/science/math/engauge-digitizer { };
-
   rocmPackages = recurseIntoAttrs (callPackage ../development/rocm-modules { });
 
   tsm-client-withGui = callPackage ../by-name/ts/tsm-client/package.nix { enableGui = true; };


### PR DESCRIPTION
This pull request refactors the packaging of `engauge-digitizer` to modernize its Nix packaging and improve maintainability. The package definition is moved to the `by-name` directory and updated to consistently use `libsForQt5` for all Qt5 dependencies, aligning with current best practices.

**Refactoring and Modernization:**

* Moved and renamed the package definition from `pkgs/applications/science/math/engauge-digitizer/default.nix` to `pkgs/by-name/en/engauge-digitizer/package.nix` for better organization and discoverability.
* Updated the package to use `libsForQt5` for all Qt5-related dependencies (`qtbase`, `qttools`, `poppler`, `qmake`, `wrapQtAppsHook`), ensuring consistency and compatibility with other Qt5 packages.
* Adjusted environment variables to reference Qt5 libraries from `libsForQt5`, fixing include and library paths for `poppler` and `openjpeg`.
* Refactored the derivation to use the new function argument style (`stdenv.mkDerivation (finalAttrs: { ... })`).

**Package Set Integration:**

* Removed the legacy `engauge-digitizer` entry from `all-packages.nix`, as the package is now provided via the `by-name` directory.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
