### PR TITLE
nixos/collectd: allow accessing the final package with applied plugins and minimalPackage

### DIFF
--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -46,6 +46,20 @@ in
 
     package = lib.mkPackageOption pkgs "collectd" { };
 
+    finalPackage = lib.mkOption {
+      readOnly = true;
+      default = minimalPackage;
+      defaultText = lib.literalExpression ''
+        if config.services.collectd.buildMinimalPackage then
+          cfg.package.override {
+            enabledPlugins = [ "syslog" ] ++ builtins.attrNames cfg.plugins;
+          }
+        else
+          cfg.package
+      '';
+      description = "The final package being used after applying plugins and minimalPackage.";
+    };
+
     buildMinimalPackage = lib.mkOption {
       default = false;
       description = ''

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -11,10 +11,10 @@
   flex,
   perl,
   nixosTests,
-  ...
-}@args:
+  enabledPlugins ? null,
+}:
 let
-  plugins = callPackage ./plugins.nix args;
+  plugins = callPackage ./plugins.nix { inherit enabledPlugins; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "collectd";

--- a/pkgs/tools/system/collectd/plugins.nix
+++ b/pkgs/tools/system/collectd/plugins.nix
@@ -45,7 +45,6 @@
   # Defaults to `null` for all supported plugins (except xen, which is marked as
   # insecure), otherwise a list of plugin names for a custom build
   enabledPlugins ? null,
-  ...
 }:
 
 let


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
