### PR TITLE
tree-sitter: 0.25.10 -> 0.26.8

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -112,17 +112,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tree-sitter";
-  version = "0.25.10";
+  version = "0.26.8";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "tree-sitter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aHszbvLCLqCwAS4F4UmM3wbSb81QuG9FM7BDHTu1ZvM=";
+    hash = "sha256-fcFEfoALrbpBD6rWogxJ7FNVlvDQgswoX9ylRgko+8Q=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-4R5Y9yancbg/w3PhACtsWq0+gieUd2j8YnmEj/5eqkg=";
+  cargoHash = "sha256-9FeWnWWPUWmMF15Psmul8GxGv2JceHWc2WZPmOr81gw=";
 
   buildInputs = [
     installShellFiles
@@ -131,6 +131,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
   nativeBuildInputs = [
+    rustPlatform.bindgenHook
     which
   ]
   ++ lib.optionals webUISupport [

--- a/pkgs/development/tools/parsing/tree-sitter/remove-web-interface.patch
+++ b/pkgs/development/tools/parsing/tree-sitter/remove-web-interface.patch
@@ -1,9 +1,39 @@
-diff --git a/cli/src/lib.rs b/cli/src/lib.rs
-index 4a00747e..e17d253b 100644
---- a/cli/src/lib.rs
-+++ b/cli/src/lib.rs
-@@ -6,7 +6,6 @@ pub mod highlight;
- pub mod init;
+diff --git a/crates/cli/src/main.rs b/crates/cli/src/main.rs
+index c6d845fc..d1aa1b1c 100644
+--- a/crates/cli/src/main.rs
++++ b/crates/cli/src/main.rs
+@@ -24,7 +24,6 @@ use tree_sitter_cli::{
+     input::{get_input, get_tmp_source_file, CliInput},
+     logger,
+     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
+-    playground,
+     query::{self, QueryFileOptions},
+     tags::{self, TagsOptions},
+     test::{self, TestOptions, TestStats, TestSummary},
+@@ -1933,16 +1932,8 @@ impl Tags {
+ 
+ impl Playground {
+     fn run(self, current_dir: &Path) -> Result<()> {
+-        let grammar_path = self.grammar_path.as_deref().map_or(current_dir, Path::new);
+-
+-        if let Some(export_path) = self.export {
+-            playground::export(grammar_path, &export_path)?;
+-        } else {
+-            let open_in_browser = !self.quiet;
+-            playground::serve(grammar_path, open_in_browser)?;
+-        }
+-
+-        Ok(())
++        println!("ERROR: web-ui is not available in this nixpkgs build; enable the webUISupport");
++        std::process::exit(1);
+     }
+ }
+ 
+diff --git a/crates/cli/src/tree_sitter_cli.rs b/crates/cli/src/tree_sitter_cli.rs
+index 3960d961..55f8e2e4 100644
+--- a/crates/cli/src/tree_sitter_cli.rs
++++ b/crates/cli/src/tree_sitter_cli.rs
+@@ -6,7 +6,6 @@ pub mod init;
  pub mod input;
  pub mod logger;
  pub mod parse;
@@ -11,29 +41,3 @@ index 4a00747e..e17d253b 100644
  pub mod query;
  pub mod query_testing;
  pub mod tags;
-diff --git a/cli/src/main.rs b/cli/src/main.rs
-index 1758fada..4bc56cc2 100644
---- a/cli/src/main.rs
-+++ b/cli/src/main.rs
-@@ -23,7 +23,7 @@ use tree_sitter_cli::{
-     input::{get_input, get_tmp_source_file, CliInput},
-     logger,
-     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
--    playground, query,
-+    query,
-     tags::{self, TagsOptions},
-     test::{self, TestOptions, TestStats},
-     test_highlight, test_tags, util, version, wasm,
-@@ -1614,10 +1614,8 @@ impl Tags {
- 
- impl Playground {
-     fn run(self, current_dir: &Path) -> Result<()> {
--        let open_in_browser = !self.quiet;
--        let grammar_path = self.grammar_path.as_deref().map_or(current_dir, Path::new);
--        playground::serve(grammar_path, open_in_browser)?;
--        Ok(())
-+        println!("ERROR: web-ui is not available in this nixpkgs build; enable the webUISupport");
-+        std::process::exit(1);
-     }
- }
- 


### PR DESCRIPTION
Closes #505982

changelog: https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.8
diff: https://github.com/tree-sitter/tree-sitter/compare/v0.25.10...v0.26.8

Neovim also builds fine with this update.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
