### PR TITLE
systemd: point meson's ukify pefile probe at the runtime python

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -5,6 +5,7 @@
   pkgsCross,
   testers,
   fetchFromGitHub,
+  writeText,
   buildPackages,
   makeBinaryWrapper,
   ninja,
@@ -192,6 +193,25 @@ assert withBootloader -> withEfi;
 let
   wantCurl = withRemote || withImportd;
 
+  # The python env that ends up in the installed ukify's shebang via
+  # patchShebangsAuto (HOST_PATH). meson's pefile probe must validate this
+  # interpreter, not the build-time templating python from nativeBuildInputs.
+  ukifyPython = python3Packages.python.withPackages (ps: with ps; [ pefile ]);
+
+  # When cross-compiling the host python is not executable on the build machine,
+  # so meson cannot probe it; substitute a build-runnable env with the same
+  # module set so the check still validates that pefile is packageable.
+  ukifyPythonForMeson =
+    if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+      ukifyPython
+    else
+      buildPackages.python3Packages.python.withPackages (ps: with ps; [ pefile ]);
+
+  ukifyNativeFile = writeText "ukify-native-file.ini" ''
+    [binaries]
+    python3-ukify = '${ukifyPythonForMeson.interpreter}'
+  '';
+
   # Use the command below to update `releaseTimestamp` on every (major) version
   # change. More details in the commentary at mesonFlags.
   # command:
@@ -257,6 +277,17 @@ stdenv.mkDerivation (finalAttrs: {
       --replace \
       "/usr/lib/systemd/boot/efi" \
       "$out/lib/systemd/boot/efi"
+    # Since v260 meson hard-requires the pefile module in the python3 it finds
+    # on PATH (systemd/systemd@582d499e32e7). That is the build-time templating
+    # python. Look up the runtime interpreter via a dedicated find_program()
+    # name supplied through a native machine file, then pass its path to
+    # find_installation() so the pefile probe runs against the interpreter
+    # that actually ships in ukify's shebang (or, when cross-compiling, a
+    # build-runnable env with the same module set).
+    substituteInPlace meson.build \
+      --replace-fail \
+      "want_ukify = pymod.find_installation('python3', required: get_option('ukify'), modules : ['pefile']).found()" \
+      "want_ukify = pymod.find_installation(find_program('python3-ukify', native : true, required : get_option('ukify')).full_path(), required : get_option('ukify'), modules : ['pefile']).found()"
   ''
   # Finally, patch shebangs in scripts used at build time. This must not patch
   # scripts that will end up in the output, to avoid build platform references
@@ -359,7 +390,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (withHomed || withCryptsetup) [ libfido2 ]
   ++ lib.optionals withLibBPF [ libbpf ]
   ++ lib.optional withTpm2Tss tpm2-tss
-  ++ lib.optional withUkify (python3Packages.python.withPackages (ps: with ps; [ pefile ]))
+  ++ lib.optional withUkify ukifyPython
   ++ lib.optionals withPasswordQuality [ libpwquality ]
   ++ lib.optionals withQrencode [ qrencode ]
   ++ lib.optionals withLibarchive [ libarchive ]
@@ -373,6 +404,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     # Options
+  ]
+  ++ lib.optionals withUkify [
+    "--native-file=${ukifyNativeFile}"
+  ]
+  ++ [
 
     # We bump this attribute on every (major) version change to ensure that we
     # have known-good value for a timestamp that is in the (not so distant)


### PR DESCRIPTION
Since systemd/systemd@582d499e32e7 (v260), meson hard-requires the
pefile module when ukify is enabled. The probe runs against whatever
python3 meson finds on PATH, which is the one from nativeBuildInputs
that only carries jinja2/lxml/pyelftools.

The interpreter that actually runs the installed ukify is a separate
buildInputs python env (pefile only) that patchShebangs wires into
the shebang. Expose that interpreter to meson under a
dedicated binary name in a native machine file and patch the probe to
chain find_program('python3-ukify', native: true) into
find_installation, so the check validates the interpreter that
actually ships.

When cross-compiling the host python is not executable on the build
machine, so a build-runnable env with the same module set is supplied
to the probe instead; the installed shebang still points at the host
python via patchShebangs.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
