### PR TITLE
minizip-ng{-compat}: split compat, fixup cmake options, 4.1.0 -> 4.2.1, strictDeps, add kuflierl as maintainer

### DIFF
--- a/pkgs/by-name/mi/minizip-ng-compat/package.nix
+++ b/pkgs/by-name/mi/minizip-ng-compat/package.nix
@@ -1,0 +1,6 @@
+{
+  minizip-ng,
+}:
+minizip-ng.override {
+  enableCompat = true;
+}

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -10,6 +10,7 @@
   xz,
   zstd,
   openssl,
+  enableCompat ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
+
   buildInputs = [
     zlib
     bzip2
@@ -40,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DMZ_OPENSSL=ON"
     "-DMZ_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
     "-DMZ_BUILD_UNIT_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-    "-DMZ_LIB_SUFFIX='-ng'"
+    "-DMZ_COMPAT=${if enableCompat then "ON" else "OFF"}"
   ]
   ++ lib.optionals stdenv.hostPlatform.isi686 [
     # tests fail
@@ -53,18 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-register";
 
-  postInstall = ''
-    # make lib findable as libminizip-ng even if compat is enabled
-    for ext in so dylib a ; do
-      if [ -e $out/lib/libminizip.$ext ] && [ ! -e $out/lib/libminizip-ng.$ext ]; then
-        ln -s $out/lib/libminizip.$ext $out/lib/libminizip-ng.$ext
-      fi
-    done
-    if [ ! -e $out/include/minizip-ng ]; then
-      ln -s $out/include $out/include/minizip-ng
-    fi
-  '';
-
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   nativeCheckInputs = [ gtest ];
   enableParallelChecking = false;
@@ -75,6 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [
       ris
+      kuflierl
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -10,10 +10,11 @@
   xz,
   zstd,
   openssl,
+  enableCompat ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "minizip-ng";
+  pname = "minizip-ng" + lib.optionalString enableCompat "-compat";
   version = "4.2.1";
 
   src = fetchFromGitHub {
@@ -43,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "MZ_LIBCOMP" false) # builds only on Darwin by default where it fails due to mising headers
     (lib.cmakeBool "MZ_BUILD_TESTS" finalAttrs.doCheck)
     (lib.cmakeBool "MZ_BUILD_UNIT_TESTS" finalAttrs.doCheck)
-    (lib.cmakeFeature "MZ_LIB_SUFFIX" "-ng")
+    (lib.cmakeBool "MZ_COMPAT" enableCompat)
   ]
   ++ lib.optionals stdenv.hostPlatform.isi686 [
     # tests fail
@@ -51,18 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-register";
-
-  postInstall = ''
-    # make lib findable as libminizip-ng even if compat is enabled
-    for ext in so dylib a ; do
-      if [ -e $out/lib/libminizip.$ext ] && [ ! -e $out/lib/libminizip-ng.$ext ]; then
-        ln -s $out/lib/libminizip.$ext $out/lib/libminizip-ng.$ext
-      fi
-    done
-    if [ ! -e $out/include/minizip-ng ]; then
-      ln -s $out/include $out/include/minizip-ng
-    fi
-  '';
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   checkInputs = [ gtest ];

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [
       ris
+      kuflierl
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -65,8 +65,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-  nativeCheckInputs = [ gtest ];
+  checkInputs = [ gtest ];
   enableParallelChecking = false;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "Fork of the popular zip manipulation library found in the zlib distribution";

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "minizip-ng";
-  version = "4.1.0";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "zlib-ng";
     repo = "minizip-ng";
     rev = finalAttrs.version;
-    hash = "sha256-H6ttsVBs437lWMBsq5baVDb9e5I6Fh+xggFre/hxGKU=";
+    hash = "sha256-gpjM8Cqoe4kafXgl2wXhhCRx39WC94qJ1DIDyd2n0G8=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     (lib.cmakeBool "MZ_OPENSSL" true)
+    (lib.cmakeBool "MZ_PPMD" false) # PPMD support requres internet access to make a git clone
     (lib.cmakeBool "MZ_LIBCOMP" false) # builds only on Darwin by default where it fails due to mising headers
     (lib.cmakeBool "MZ_BUILD_TESTS" finalAttrs.doCheck)
     (lib.cmakeBool "MZ_BUILD_UNIT_TESTS" finalAttrs.doCheck)

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
+
   buildInputs = [
     zlib
     bzip2
@@ -36,19 +37,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
-    "-DMZ_OPENSSL=ON"
-    "-DMZ_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-    "-DMZ_BUILD_UNIT_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-    "-DMZ_LIB_SUFFIX='-ng'"
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "MZ_OPENSSL" true)
+    (lib.cmakeBool "MZ_LIBCOMP" false) # builds only on Darwin by default where it fails due to mising headers
+    (lib.cmakeBool "MZ_BUILD_TESTS" finalAttrs.doCheck)
+    (lib.cmakeBool "MZ_BUILD_UNIT_TESTS" finalAttrs.doCheck)
+    (lib.cmakeFeature "MZ_LIB_SUFFIX" "-ng")
   ]
   ++ lib.optionals stdenv.hostPlatform.isi686 [
     # tests fail
-    "-DMZ_PKCRYPT=OFF"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # missing header file
-    "-DMZ_LIBCOMP=OFF"
+    (lib.cmakeBool "MZ_PKCRYPT" false)
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-register";


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/506069
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
