### PR TITLE
discord: add Krisp patcher

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -24,6 +24,10 @@
   withMoonlight ? false,
   moonlight,
   commandLineArgs ? "",
+  krispSrc ? null,
+  withKrisp ? withOpenASAR || withVencord || withEquicord || withMoonlight,
+  unzip,
+  darwin,
 }:
 
 let
@@ -41,6 +45,12 @@ let
   moduleSrcs = lib.mapAttrs (_: mod: fetchurl { inherit (mod) url hash; }) source.modules;
 
   moduleVersions = lib.mapAttrs (_: mod: mod.version) source.modules;
+
+  stagedModuleSrcs =
+    if krispSrc != null && withKrisp then
+      lib.removeAttrs moduleSrcs [ "discord_krisp" ]
+    else
+      moduleSrcs;
 
   configDirName = lib.replaceStrings [ " " ] [ "" ] (lib.toLower binaryName);
 
@@ -64,13 +74,27 @@ let
 
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
-    modules_dir="$HOME/Library/Application Support/${configDirName}/${version}/modules"
+    darwin_home="$(${python3.interpreter} -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)')"
+    modules_dir="$darwin_home/Library/Application Support/${configDirName}/${version}/modules"
+
     mkdir -p "$modules_dir"
-    for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-      ln -sfn "$store_modules/$m" "$modules_dir/$m"
+    for m in ${lib.concatStringsSep " " (lib.attrNames moduleVersions)}; do
+      rm -f "$modules_dir/pending/$m"-*.zip 2>/dev/null || true
     done
-    echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
-      > "$modules_dir/installed.json"
+    for m in ${lib.concatStringsSep " " (lib.attrNames stagedModuleSrcs)}; do
+      dest="$modules_dir/$m"
+      if [ -L "$dest" ]; then
+        rm "$dest"
+      elif [ -e "$dest" ]; then
+        chmod -R u+w "$dest" 2>/dev/null || true
+        rm -rf "$dest"
+      fi
+      ln -sfn "$store_modules/$m" "$dest"
+    done
+    cat > "$modules_dir/installed.json.tmp" <<'EOF'
+    ${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}
+    EOF
+    mv "$modules_dir/installed.json.tmp" "$modules_dir/installed.json"
   '';
 
   disableBreakingUpdates =
@@ -87,6 +111,45 @@ let
         substituteAllInPlace $out/bin/disable-breaking-updates.py
         chmod +x $out/bin/disable-breaking-updates.py
       '';
+
+  patchedKrisp = lib.optionalAttrs (krispSrc != null && withKrisp) (
+    runCommand "discord-krisp-patched"
+      {
+        nativeBuildInputs = [
+          brotli
+          unzip
+          (python3.withPackages (ps: [
+            ps.lief
+            ps.capstone
+          ]))
+        ];
+      }
+      ''
+        mkdir -p "$out"
+        brotli -d < ${krispSrc} | tar xf - --strip-components=1 -C "$out"
+        python3 ${./patch-krisp.py} "$out/discord_krisp.node"
+        python3 ${./patch-krisp-module.py} "$out" darwin
+        source ${darwin.signingUtils}
+        sign "$out/discord_krisp.node"
+      ''
+  );
+
+  deployKrisp = lib.optionalAttrs (krispSrc != null && withKrisp) (
+    runCommand "deploy-krisp.py"
+      {
+        pythonInterpreter = "${python3.withPackages (ps: [ ps.watchdog ])}/bin/python3";
+        krispPath = "${patchedKrisp}";
+        discordVersion = version;
+        configDirName = lib.toLower binaryName;
+        meta.mainProgram = "deploy-krisp.py";
+      }
+      ''
+        mkdir -p "$out/bin"
+        cp ${./deploy-krisp.py} "$out/bin/deploy-krisp.py"
+        substituteAllInPlace "$out/bin/deploy-krisp.py"
+        chmod +x "$out/bin/deploy-krisp.py"
+      ''
+  );
 in
 assert lib.assertMsg (
   enabledDiscordModsCount <= 1
@@ -102,6 +165,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     brotli
     makeWrapper
+    python3
   ];
 
   sourceRoot = ".";
@@ -133,21 +197,32 @@ stdenv.mkDerivation {
       lib.mapAttrsToList (name: src: ''
         mkdir -p "$out/Applications/${desktopName}.app/Contents/Resources/modules/${name}"
         extractDistro ${src} "$out/Applications/${desktopName}.app/Contents/Resources/modules/${name}"
-      '') moduleSrcs
+      '') stagedModuleSrcs
     )}
+    ${lib.optionalString (krispSrc != null && withKrisp) ''
+      mkdir -p "$out/Applications/${desktopName}.app/Contents/Resources/modules/discord_krisp"
+      cp -R ${patchedKrisp}/. "$out/Applications/${desktopName}.app/Contents/Resources/modules/discord_krisp/"
+      chmod -R u+w "$out/Applications/${desktopName}.app/Contents/Resources/modules/discord_krisp"
+    ''}
 
     # wrap executable to $out/bin
     mkdir -p $out/bin
     makeWrapper "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" "$out/bin/${binaryName}" \
       --run ${lib.getExe disableBreakingUpdates} \
       --run "${stageModules} \"$out/Applications/${desktopName}.app/Contents/Resources/modules\"" \
+      ${lib.strings.optionalString (krispSrc != null && withKrisp) "--run ${lib.getExe deployKrisp}"} \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall
   '';
 
   postInstall =
-    lib.strings.optionalString withOpenASAR ''
+    lib.strings.optionalString (krispSrc != null && withKrisp) ''
+      python3 ${./patch-voice-krisp.py} \
+        "$out/Applications/${desktopName}.app/Contents/Resources/modules/discord_voice/index.js" \
+        "require('path').join(require('os').userInfo().homedir, 'Library', 'Application Support', '${configDirName}', '${version}', 'modules', 'discord_krisp')"
+    ''
+    + lib.strings.optionalString withOpenASAR ''
       cp -f ${openasar} "$out/Applications/${desktopName}.app/Contents/Resources/app.asar"
     ''
     + lib.strings.optionalString withVencord ''
@@ -188,6 +263,10 @@ stdenv.mkDerivation {
       withOpenASAR = self.override {
         withOpenASAR = true;
       };
+      withKrisp = self.override {
+        withKrisp = true;
+      };
     };
-  };
+  }
+  // lib.optionalAttrs (krispSrc != null && withKrisp) { inherit patchedKrisp; };
 }

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,5 +1,6 @@
 {
   callPackage,
+  fetchurl,
   lib,
   stdenv,
   discord,
@@ -96,6 +97,13 @@ lib.genAttrs [ "discord" "discord-ptb" "discord-canary" "discord-development" ] 
     args = (variants.${stdenv.hostPlatform.system} or variants.default).${pname};
     platformName = if stdenv.hostPlatform.isDarwin then "osx" else "linux";
     source = sources."${platformName}-${args.branch}";
+    krispSource =
+      if sources ? "${platformName}-${args.branch}-krisp" then
+        sources."${platformName}-${args.branch}-krisp"
+      else if source ? modules && source.modules ? discord_krisp then
+        source.modules.discord_krisp
+      else
+        null;
   in
   callPackage package (
     args
@@ -103,6 +111,11 @@ lib.genAttrs [ "discord" "discord-ptb" "discord-canary" "discord-development" ] 
       inherit pname source;
       meta = meta // {
         mainProgram = args.binaryName;
+      };
+    }
+    // lib.optionalAttrs (krispSource != null) {
+      krispSrc = fetchurl {
+        inherit (krispSource) url hash;
       };
     }
   )

--- a/pkgs/applications/networking/instant-messengers/discord/deploy-krisp.py
+++ b/pkgs/applications/networking/instant-messengers/discord/deploy-krisp.py
@@ -1,0 +1,243 @@
+#!@pythonInterpreter@
+"""Deploy pre-patched Krisp module to Discord's user-data directory."""
+
+import hashlib
+import json
+import os
+import pwd
+import shutil
+import sys
+from pathlib import Path
+from shutil import COPY_BUFSIZE
+from threading import Event, Lock
+
+from watchdog.events import (
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    EVENT_TYPE_CLOSED_NO_WRITE,
+    EVENT_TYPE_OPENED,
+    FileClosedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileSystemEventHandler,
+    FileModifiedEvent,
+    FileMovedEvent,
+)
+from watchdog.observers import Observer
+
+KRISP_STORE = Path("@krispPath@")
+VERSION = "@discordVersion@"
+CONFIG_DIR = "@configDirName@"
+
+# Marker file written alongside the deployed krisp to track the patched module
+# contents. A hash mismatch means another Discord install (or the user)
+# overwrote our files, so the caller redeploys from KRISP_STORE.
+MARKER = ".nix-krisp-hash"
+PARENT_CHECK_INTERVAL = 1
+WATCHED_EVENTS = [
+    DirCreatedEvent,
+    DirDeletedEvent,
+    DirModifiedEvent,
+    DirMovedEvent,
+    FileClosedEvent,
+    FileCreatedEvent,
+    FileDeletedEvent,
+    FileModifiedEvent,
+    FileMovedEvent,
+]
+
+
+def modules_dir() -> Path:
+    if sys.platform == "darwin":
+        base = (
+            Path(pwd.getpwuid(os.getuid()).pw_dir) / "Library" / "Application Support"
+        )
+        return base / CONFIG_DIR.replace(" ", "") / VERSION / "modules"
+    home = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+    return home / CONFIG_DIR / VERSION / "modules"
+
+
+def _file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(COPY_BUFSIZE), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+KRISP_HASH = hashlib.sha256(
+    (
+        _file_hash(KRISP_STORE / "discord_krisp.node")
+        + _file_hash(KRISP_STORE / "index.js")
+    ).encode()
+).hexdigest()
+
+
+# True if the deployed krisp is missing, damaged, or has different patched
+# contents. A hash mismatch means another Discord install (or the user)
+# overwrote our files, so the caller redeploys from KRISP_STORE
+def needs_deploy(dest: Path, verify_node: bool = True) -> bool:
+    node = dest / "discord_krisp.node"
+    index = dest / "index.js"
+    marker = dest / MARKER
+    if not node.exists() or not index.exists() or not marker.exists():
+        return True
+    try:
+        stored_hash = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return True
+    if stored_hash != KRISP_HASH:
+        return True
+    if not verify_node:
+        try:
+            return node.stat().st_mtime_ns > marker.stat().st_mtime_ns
+        except OSError:
+            return True
+    return (
+        verify_node
+        and hashlib.sha256((_file_hash(node) + _file_hash(index)).encode()).hexdigest()
+        != KRISP_HASH
+    )
+
+
+def deploy(dest: Path, quiet: bool = False, verify_node: bool = True) -> None:
+    if not needs_deploy(dest, verify_node):
+        if not quiet:
+            print("[Nix] Krisp already deployed")
+        return
+    if not quiet:
+        print("[Nix] Deploying pre-patched Krisp module")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.is_symlink():
+        dest.unlink()
+    elif dest.exists():
+        # Fix read-only permissions inherited from the nix store before removing
+        for p in dest.rglob("*"):
+            if p.is_symlink():
+                p.unlink()
+                continue
+            p.chmod(0o755 if p.is_dir() else 0o644)
+        dest.chmod(0o755)
+        shutil.rmtree(dest)
+    shutil.copytree(KRISP_STORE, dest)
+    dest.chmod(0o755)
+    for p in dest.rglob("*"):
+        p.chmod(0o755 if p.is_dir() or p.suffix == ".node" else 0o644)
+    # Write marker with hash of the deployed files so we can detect overwrites.
+    (dest / MARKER).write_text(KRISP_HASH + "\n", encoding="utf-8")
+
+
+def register(manifest: Path, create: bool) -> None:
+    if not manifest.exists() and not create:
+        return
+    try:
+        data = (
+            json.loads(manifest.read_text(encoding="utf-8"))
+            if manifest.exists()
+            else {}
+        )
+    except (json.JSONDecodeError, OSError):
+        data = {}
+    if data.get("discord_krisp", {}).get("installedVersion") != 1:
+        data["discord_krisp"] = {"installedVersion": 1}
+        tmp = manifest.with_name(f"{manifest.name}.tmp")
+        tmp.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        os.replace(tmp, manifest)
+
+
+def remove_incomplete_manifest(mdir: Path, manifest: Path) -> None:
+    """Recover profiles touched by older deploy scripts.
+
+    If installed.json contains only krisp, Discord thinks bootstrap completed
+    and then fails to require discord_desktop_core. Remove that incomplete
+    manifest so Discord can bootstrap its normal modules.
+    """
+    if not manifest.exists() or (mdir / "discord_desktop_core").exists():
+        return
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    if set(data) == {"discord_krisp"}:
+        manifest.unlink()
+
+
+def process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def watch(parent_pid: int, dest: Path, manifest: Path) -> None:
+    stopped = Event()
+    lock = Lock()
+
+    def repair() -> None:
+        with lock:
+            deploy(dest, quiet=True)
+            register(manifest, create=False)
+
+    class Handler(FileSystemEventHandler):
+        def on_any_event(self, event) -> None:
+            if event.event_type in {EVENT_TYPE_OPENED, EVENT_TYPE_CLOSED_NO_WRITE}:
+                return
+            repair()
+
+    observer = Observer()
+    observer.schedule(
+        Handler(),
+        str(dest.parent),
+        recursive=True,
+        event_filter=WATCHED_EVENTS,
+    )
+    observer.start()
+    try:
+        repair()
+        while process_alive(parent_pid):
+            stopped.wait(PARENT_CHECK_INTERVAL)
+    finally:
+        observer.stop()
+        observer.join()
+
+
+def start_watcher(dest: Path, manifest: Path) -> None:
+    if not hasattr(os, "fork"):
+        return
+    parent_pid = os.getppid()
+    if os.fork() != 0:
+        return
+    try:
+        os.setsid()
+        with open(os.devnull, "w", encoding="utf-8") as devnull:
+            os.dup2(devnull.fileno(), 1)
+            os.dup2(devnull.fileno(), 2)
+        watch(parent_pid, dest, manifest)
+    finally:
+        os._exit(0)
+
+
+def main() -> None:
+    mdir = modules_dir()
+    dest = mdir / "discord_krisp"
+    manifest = mdir / "installed.json"
+
+    remove_incomplete_manifest(mdir, manifest)
+    if not needs_deploy(dest):
+        print("[Nix] Krisp already deployed")
+    else:
+        deploy(dest)
+
+    # Do not create installed.json on fresh legacy installs: Discord needs a
+    # missing manifest to bootstrap discord_desktop_core and friends. A short
+    # watcher repairs krisp if the module updater overwrites it during launch,
+    # then registers it once the real manifest exists.
+    register(manifest, create=False)
+    start_watcher(dest, manifest)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -77,6 +77,9 @@
   # for example if a settings.json is linked declaratively (e.g., with home-manager).
   disableUpdates ? true,
   commandLineArgs ? "",
+  krispSrc ? null,
+  withKrisp ? withOpenASAR || withVencord || withEquicord || withMoonlight,
+  unzip,
 }:
 
 let
@@ -94,6 +97,12 @@ let
   moduleSrcs = lib.mapAttrs (_: mod: fetchurl { inherit (mod) url hash; }) source.modules;
 
   moduleVersions = lib.mapAttrs (_: mod: mod.version) source.modules;
+
+  stagedModuleSrcs =
+    if krispSrc != null && withKrisp then
+      lib.removeAttrs moduleSrcs [ "discord_krisp" ]
+    else
+      moduleSrcs;
 
   libPath = lib.makeLibraryPath (
     [
@@ -152,14 +161,25 @@ let
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
     modules_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.toLower binaryName}/${version}/modules"
-    if [ ! -f "$modules_dir/installed.json" ]; then
-      mkdir -p "$modules_dir"
-      for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-        ln -sfn "$store_modules/$m" "$modules_dir/$m"
-      done
-      echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
-        > "$modules_dir/installed.json"
-    fi
+
+    mkdir -p "$modules_dir"
+    for m in ${lib.concatStringsSep " " (lib.attrNames moduleVersions)}; do
+      rm -f "$modules_dir/pending/$m"-*.zip 2>/dev/null || true
+    done
+    for m in ${lib.concatStringsSep " " (lib.attrNames stagedModuleSrcs)}; do
+      dest="$modules_dir/$m"
+      if [ -L "$dest" ]; then
+        rm "$dest"
+      elif [ -e "$dest" ]; then
+        chmod -R u+w "$dest" 2>/dev/null || true
+        rm -rf "$dest"
+      fi
+      ln -sfn "$store_modules/$m" "$dest"
+    done
+    cat > "$modules_dir/installed.json.tmp" <<'EOF'
+    ${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}
+    EOF
+    mv "$modules_dir/installed.json.tmp" "$modules_dir/installed.json"
   '';
 
   disableBreakingUpdates =
@@ -176,6 +196,28 @@ let
         substituteAllInPlace $out/bin/disable-breaking-updates.py
         chmod +x $out/bin/disable-breaking-updates.py
       '';
+
+  deployKrispPython = python3.withPackages (ps: [ ps.watchdog ]);
+
+  patchedKrisp = lib.optionalAttrs (krispSrc != null && withKrisp) (
+    runCommand "discord-krisp-patched"
+      {
+        nativeBuildInputs = [
+          brotli
+          unzip
+          (python3.withPackages (ps: [
+            ps.lief
+            ps.capstone
+          ]))
+        ];
+      }
+      ''
+        mkdir -p "$out"
+        brotli -d < ${krispSrc} | tar xf - --strip-components=1 -C "$out"
+        python3 ${./patch-krisp.py} "$out/discord_krisp.node"
+        python3 ${./patch-krisp-module.py} "$out" linux
+      ''
+  );
 in
 assert lib.assertMsg (
   enabledDiscordModsCount <= 1
@@ -202,6 +244,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
     makeShellWrapper
     brotli
+    python3
   ];
 
   dontWrapGApps = true;
@@ -247,8 +290,13 @@ stdenv.mkDerivation (finalAttrs: {
       lib.mapAttrsToList (name: src: ''
         mkdir -p $out/opt/${binaryName}/modules/${name}
         brotli -d < ${src} | tar xf - --strip-components=1 -C $out/opt/${binaryName}/modules/${name}
-      '') moduleSrcs
+      '') stagedModuleSrcs
     )}
+    ${lib.optionalString (krispSrc != null && withKrisp) ''
+      mkdir -p $out/opt/${binaryName}/modules/discord_krisp
+      cp -R ${patchedKrisp}/. $out/opt/${binaryName}/modules/discord_krisp/
+      chmod -R u+w $out/opt/${binaryName}/modules/discord_krisp
+    ''}
 
     wrapProgramShell $out/opt/${binaryName}/${binaryName} \
         "''${gappsWrapperArgs[@]}" \
@@ -262,11 +310,25 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix LD_LIBRARY_PATH : ${finalAttrs.libPath}:$out/opt/${binaryName} \
         ${lib.strings.optionalString disableUpdates "--run ${lib.getExe disableBreakingUpdates}"} \
         --run "${stageModules} $out/opt/${binaryName}/modules" \
+        ${
+          lib.strings.optionalString (
+            krispSrc != null && withKrisp
+          ) ''--run "$out/bin/.discord-deploy-krisp"''
+        } \
         --add-flags ${lib.escapeShellArg commandLineArgs}
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
     # Without || true the install would fail on case-insensitive filesystems
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/${lib.strings.toLower binaryName} || true
+    ${lib.optionalString (krispSrc != null && withKrisp) ''
+      cp ${./deploy-krisp.py} "$out/bin/.discord-deploy-krisp"
+      substituteInPlace "$out/bin/.discord-deploy-krisp" \
+        --replace-fail '@pythonInterpreter@' '${deployKrispPython}/bin/python3' \
+        --replace-fail '@krispPath@' "$out/opt/${binaryName}/modules/discord_krisp" \
+        --replace-fail '@discordVersion@' '${version}' \
+        --replace-fail '@configDirName@' '${lib.toLower binaryName}'
+      chmod +x "$out/bin/.discord-deploy-krisp"
+    ''}
 
     ln -s $out/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
 
@@ -276,7 +338,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall =
-    lib.strings.optionalString withOpenASAR ''
+    lib.strings.optionalString (krispSrc != null && withKrisp) ''
+      python3 ${./patch-voice-krisp.py} \
+        "$out/opt/${binaryName}/modules/discord_voice/index.js" \
+        "require('path').join(process.env.XDG_CONFIG_HOME || require('path').join(require('os').homedir(), '.config'), '${lib.toLower binaryName}', '${version}', 'modules', 'discord_krisp')" \
+        "$out/opt/${binaryName}/resources/build_info.json" \
+        "$out/opt/${binaryName}/modules"
+    ''
+    + lib.strings.optionalString withOpenASAR ''
       cp -f ${openasar} $out/opt/${binaryName}/resources/app.asar
     ''
     + lib.strings.optionalString withVencord ''
@@ -332,6 +401,10 @@ stdenv.mkDerivation (finalAttrs: {
       withOpenASAR = self.override {
         withOpenASAR = true;
       };
+      withKrisp = self.override {
+        withKrisp = true;
+      };
     };
-  };
+  }
+  // lib.optionalAttrs (krispSrc != null && withKrisp) { inherit patchedKrisp; };
 })

--- a/pkgs/applications/networking/instant-messengers/discord/patch-krisp-module.py
+++ b/pkgs/applications/networking/instant-messengers/discord/patch-krisp-module.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Post-process Discord's Krisp module for use from Nix builds."""
+
+import sys
+from pathlib import Path
+
+import lief
+
+
+INIT_CALL = "KrispModule._initialize(initializationParams);"
+INIT_GUARD = "process.env.NIXPKGS_KRISP_INITIALIZED"
+INIT_PATCH = f"""if ({INIT_GUARD} !== "1") {{
+    {INIT_CALL}
+    {INIT_GUARD} = "1";
+}}"""
+
+# KrispInitializeExternal returns 0 on success. The module is initialized from
+# index.js above, so the Linux external init hook can report success without
+# running the native initializer a second time.
+LINUX_EXTERNAL_INIT_PATCH = b"\x31\xc0\xc3"  # xor eax, eax; ret
+
+
+def patch_index(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    if INIT_GUARD in text:
+        return
+    if INIT_CALL not in text:
+        raise RuntimeError(f"could not find Krisp initialize call in {path}")
+    path.write_text(text.replace(INIT_CALL, INIT_PATCH), encoding="utf-8")
+
+
+def patch_linux_external_init(path: Path) -> None:
+    elf = lief.parse(str(path))
+    symbol = elf.get_dynamic_symbol("KrispInitializeExternal")
+    if symbol is None:
+        raise RuntimeError("could not find KrispInitializeExternal")
+    offset = elf.virtual_address_to_offset(symbol.value)
+    data = bytearray(path.read_bytes())
+    end = offset + len(LINUX_EXTERNAL_INIT_PATCH)
+    if end > len(data):
+        raise RuntimeError("KrispInitializeExternal patch is outside the binary")
+    data[offset:end] = LINUX_EXTERNAL_INIT_PATCH
+    path.write_bytes(data)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit(f"Usage: {sys.argv[0]} <module-dir> <linux|darwin>")
+
+    module_dir = Path(sys.argv[1])
+    platform = sys.argv[2]
+    patch_index(module_dir / "index.js")
+
+    if platform == "linux":
+        patch_linux_external_init(module_dir / "discord_krisp.node")
+    elif platform != "darwin":
+        raise SystemExit(f"unsupported platform: {platform}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/applications/networking/instant-messengers/discord/patch-krisp.py
+++ b/pkgs/applications/networking/instant-messengers/discord/patch-krisp.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p "python3.withPackages (ps: [ ps.lief ps.capstone ])"
+"""
+Patch discord_krisp.node to bypass its signature verification
+
+Krisp checks its own code signature on load. Since Nix modifies the binary (e.g.
+patchelf), the signature no longer matches and the module refuses to start. We
+patch the verification function to always return true
+
+ELF (Linux)
+-----------
+The check lives in discord::util::IsSignedByDiscord(). It MD5-hashes the file
+and compares the result with SSE2. Discord ships stripped ELFs, but .eh_frame
+(DWARF unwind info) still gives us every function's start address. We scan .text
+for the unique MD5-compare byte sequence (pmovmskb + cmp $0xffff), find the
+function whose range contains it, and overwrite the entry with "mov eax, 1; ret"
+
+  # before:                                    # after:
+  #   pmovmskb %xmm0, %eax  ; 66 0f d7 c0      #   mov $0x1, %eax  ; b8 01 00 00 00
+  #   cmp $0xffff, %eax     ; 3d ff ff 00 00   #   ret             ; c3
+  #   sete %bpl             ; 40 0f 94 c5      #
+
+Mach-O (macOS, fat binary: x86_64 + arm64)
+------------------------------------------
+On macOS the check uses Apple's Security framework. We anchor on the
+_SecStaticCodeCreateWithPath import stub, disassemble __text once with capstone,
+and build a ``branch target -> containing function`` index. We hop up through
+unique callers until the chain fans out (0 or 2+ callers)
+
+  # the call chain (from nm + c++filt, addresses vary per build):
+  #   _SecStaticCodeCreateWithPath   [stub]
+  #     <- GetSigningInformation()   hop 1 (only caller of the stub)
+  #       <- IsSignedBy()            hop 2 (only caller of hop 1)
+  #         <- IsSignedByDiscord()   hop 3 (only caller of hop 2) <- PATCH HERE
+  #           <- DoKrispInitialize() hop 4 (only caller of hop 3)
+  #              ^^^ has multiple callers, so the chain fans out
+
+Useful commands for poking at a binary yourself:
+  otool -f discord_krisp.node                                     # fat header
+  otool -arch x86_64 -l discord_krisp.node                        # load commands
+  otool -arch x86_64 -Iv discord_krisp.node | grep SecStaticCode  # stub lookup
+  nm -arch x86_64 discord_krisp.node | c++filt | grep -i sign     # signing symbols
+  objdump -d --start-address=0x4754c0 --stop-address=0x475580 discord_krisp.node
+"""
+
+import mmap
+import sys
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import Iterator, TypeVar
+
+import capstone
+import lief
+
+T = TypeVar("T")
+
+
+def _first(gen: Iterator[T], err: str) -> T:
+    """Return first item from gen, or raise SystemExit with err."""
+    if (result := next(gen, None)) is None:
+        raise SystemExit(err)
+    return result
+
+
+@dataclass(frozen=True)
+class Arch:
+    """Per-CPU disassembler settings and the "return true" patch bytes."""
+
+    name: str
+    cs_args: tuple
+    return_true: bytes
+
+
+_X86_64 = lief.MachO.Header.CPU_TYPE.X86_64
+_ARM64 = lief.MachO.Header.CPU_TYPE.ARM64
+
+ARCHS: dict = {
+    _X86_64: Arch(
+        name="x86_64",
+        cs_args=(capstone.CS_ARCH_X86, capstone.CS_MODE_64),
+        return_true=b"\xb8\x01\x00\x00\x00\xc3",  # mov eax, 1; ret
+    ),
+    _ARM64: Arch(
+        name="arm64",
+        cs_args=(capstone.CS_ARCH_ARM64, capstone.CS_MODE_LITTLE_ENDIAN),
+        return_true=b"\x20\x00\x80\x52\xc0\x03\x5f\xd6",  # mov w0, #1; ret
+    ),
+}
+
+# Direct-branch mnemonics we follow when building the caller index. We skip
+# conditional branches (b.eq, jne, cbz, ...) since those encode intra-function
+# control flow rather than call edges
+DIRECT_BRANCHES = frozenset({"b", "bl", "call", "jmp"})
+
+# MD5-hash comparison idiom inside IsSignedByDiscord (ELF path):
+#   pmovmskb %xmm0,%eax ; cmp $0xffff,%eax
+ELF_SIG = b"\x66\x0f\xd7\xc0\x3d\xff\xff\x00\x00"
+
+# Apple Security framework import used as the Mach-O call-chain anchor
+ANCHOR_IMPORT = "_SecStaticCodeCreateWithPath"
+
+
+@dataclass(frozen=True)
+class FunctionStarts:
+    """Sorted function starts with a helper for address-to-function lookup."""
+
+    addrs: tuple[int, ...]
+
+    @classmethod
+    def from_lief(
+        cls,
+        binary,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> "FunctionStarts":
+        addrs = tuple(
+            sorted(
+                f.address
+                for f in binary.functions
+                if (start is None or start <= f.address)
+                and (end is None or f.address < end)
+            )
+        )
+        if not addrs:
+            raise SystemExit("Error: no function starts found")
+        return cls(addrs)
+
+    def containing(self, addr: int) -> int | None:
+        idx = bisect_right(self.addrs, addr) - 1
+        if idx < 0:
+            return None
+        return self.addrs[idx]
+
+    def require_containing(self, addr: int) -> int:
+        if (fn := self.containing(addr)) is None:
+            raise SystemExit(f"Error: no function contains address 0x{addr:x}")
+        return fn
+
+
+def _apply_patch(mm: mmap.mmap, off: int, patch: bytes, label: str) -> None:
+    state = (
+        "already patched"
+        if mm[off : off + len(patch)] == patch
+        else "patched -> return true"
+    )
+    mm[off : off + len(patch)] = patch
+    print(f"[krisp-patcher] {label}: {state}")
+
+
+def _build_xrefs(
+    data: bytes,
+    text_vm: int,
+    arch: Arch,
+    functions: FunctionStarts,
+) -> dict[int, set[int]]:
+    """Disassemble ``data`` (the __text section) once and index direct-branch
+    targets by the function containing the branch
+
+    Returns ``{target_vaddr: {start addresses of calling functions}}``. The
+    containing function for a branch comes from ``functions``.
+    """
+    md = capstone.Cs(*arch.cs_args)
+    md.detail = True
+    # __text contains jump tables and other data interleaved with code on x86
+    # (ARM64 is fixed-width so the sweep stays aligned regardless). Without
+    # skipdata, capstone's linear sweep stops at the first undecodable byte,
+    # often within a few KB. Skipdata resyncs one byte at a time
+    md.skipdata = True
+    xrefs: dict[int, set[int]] = {}
+    for insn in md.disasm(data, text_vm):
+        if insn.mnemonic not in DIRECT_BRANCHES:
+            continue
+        op = insn.operands[0] if insn.operands else None
+        if op is None or op.type != capstone.CS_OP_IMM:
+            continue
+        if (fn := functions.containing(insn.address)) is None:
+            continue
+        xrefs.setdefault(op.imm, set()).add(fn)
+    return xrefs
+
+
+def _unique_match(
+    mm: mmap.mmap, needle: bytes, start: int, end: int, label: str
+) -> int:
+    idx = mm.find(needle, start, end)
+    if idx == -1 or mm.find(needle, idx + 1, end) != -1:
+        raise SystemExit(f"Error: expected exactly 1 {label} match")
+    return idx
+
+
+def _macho_import_stub(binary, section, name: str) -> int:
+    """Return the vaddr of an imported symbol's lazy-bind stub."""
+    stub_size = section.reserved2
+    n_stubs = section.size // stub_size if stub_size else 0
+    indirect = list(binary.dynamic_symbol_command.indirect_symbols)
+    return _first(
+        (
+            section.virtual_address + i * stub_size
+            for i in range(n_stubs)
+            if section.reserved1 + i < len(indirect)
+            and name in indirect[section.reserved1 + i].name
+        ),
+        f"Error: {name} stub not found",
+    )
+
+
+def _walk_unique_callers(
+    xrefs: dict[int, set[int]],
+    target: int,
+    label: str,
+) -> int:
+    """Follow the single-caller chain and return the last unique caller."""
+    hop, previous = 0, target
+    while len(callers := xrefs.get(target, ())) == 1:
+        previous, target, hop = target, next(iter(callers)), hop + 1
+        print(f"[krisp-patcher] {label}: hop {hop} -> 0x{target:x}")
+    if hop < 2:
+        raise SystemExit("Error: call chain too short (expected >= 2 hops)")
+    return previous
+
+
+def patch_elf(mm: mmap.mmap, path: str) -> None:
+    binary = lief.ELF.parse(path)
+    text = binary.get_section(".text")
+    if text is None:
+        raise SystemExit("Error: .text not found")
+    text_off, text_sz = text.file_offset, text.size
+    # Offset between file offset and vaddr within .text (constant across the section)
+    text_delta = text.virtual_address - text_off
+
+    idx = _unique_match(mm, ELF_SIG, text_off, text_off + text_sz, "signature")
+
+    # binary.functions is populated from .eh_frame unwind info, which is
+    # present even in stripped binaries. Bisect picks the containing function
+    functions = FunctionStarts.from_lief(binary)
+    func_vaddr = functions.require_containing(idx + text_delta)
+    func_off = func_vaddr - text_delta
+
+    print(f"[krisp-patcher] ELF: signature at 0x{idx:x}, function at 0x{func_off:x}")
+    _apply_patch(mm, func_off, ARCHS[_X86_64].return_true, "ELF")
+
+
+def patch_macho_slice(mm: mmap.mmap, binary: "lief.MachO.Binary") -> None:
+    """Trace _SecStaticCodeCreateWithPath up the call chain and patch the
+    last uniquely-reachable function."""
+    arch = ARCHS[binary.header.cpu_type]
+    base = binary.fat_offset
+
+    text = binary.get_section("__text")
+    text_vm, text_sz, text_off = text.virtual_address, text.size, text.offset
+    fstart = base + text_off
+
+    stubs = binary.get_section("__stubs")
+
+    target = _macho_import_stub(binary, stubs, ANCHOR_IMPORT)
+
+    # Sorted function starts; bisect maps any __text address to its function.
+    # binary.functions merges symbols + __unwind_info so it covers stripped
+    # functions too
+    functions = FunctionStarts.from_lief(binary, text_vm, text_vm + text_sz)
+
+    # One disassembly pass; each hop up the chain is an O(1) dict lookup
+    xrefs = _build_xrefs(bytes(mm[fstart : fstart + text_sz]), text_vm, arch, functions)
+
+    patch_addr = _walk_unique_callers(xrefs, target, f"Mach-O {arch.name}")
+    _apply_patch(mm, fstart + (patch_addr - text_vm), arch.return_true, arch.name)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit(f"Usage: {sys.argv[0]} <discord_krisp.node>")
+    path = sys.argv[1]
+    with open(path, "r+b") as f, mmap.mmap(f.fileno(), 0) as mm:
+        if mm[:4] == b"\x7fELF":
+            patch_elf(mm, path)
+        else:
+            fat = lief.MachO.parse(path)
+            for binary in fat:
+                patch_macho_slice(mm, binary)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/applications/networking/instant-messengers/discord/patch-voice-krisp.py
+++ b/pkgs/applications/networking/instant-messengers/discord/patch-voice-krisp.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Point Discord's voice module at the Nix-managed Krisp module."""
+
+import json
+import sys
+from pathlib import Path
+
+
+SETUP_KRISP = """VoiceEngine.setupKrispPath = function () {
+    const krispPath = discordNative?.nativeModules?.getModulePath('discord_krisp');
+    if (krispPath != null) {
+        VoiceEngine.setKrispPath(krispPath);
+    }
+};"""
+
+
+def patch_build_info(path: Path, modules_root: str) -> None:
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    data["localModulesRoot"] = modules_root
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def patch_voice(path: Path, runtime_path_js: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    replacement = f"""const nixKrispPath = {runtime_path_js};
+try {{
+    require(nixKrispPath);
+}}
+catch (e) {{
+    console.warn('Failed to initialize Krisp via Node module before voice engine setup:', e);
+}}
+VoiceEngine.setKrispPath(nixKrispPath);
+VoiceEngine.setupKrispPath = function () {{
+    VoiceEngine.setKrispPath(nixKrispPath);
+}};"""
+    if SETUP_KRISP not in text:
+        raise RuntimeError(f"could not find Krisp setup hook in {path}")
+    path.write_text(text.replace(SETUP_KRISP, replacement), encoding="utf-8")
+
+
+def main() -> None:
+    if len(sys.argv) not in {3, 5}:
+        raise SystemExit(
+            f"Usage: {sys.argv[0]} <voice-index.js> <runtime-path-js> "
+            "[<build-info.json> <modules-root>]"
+        )
+
+    patch_voice(Path(sys.argv[1]), sys.argv[2])
+
+    if len(sys.argv) == 5:
+        patch_build_info(Path(sys.argv[3]), sys.argv[4])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Krisp is Discord's proprietary noise cancellation feature. On nixpkgs it fails to load because patchelf/code signing changes cause the module's built-in signature verification to fail (see #195512)

This PR binary-patches `discord_krisp.node` to bypass the signature check, deploys the patched module to the user's Discord config dir at runtime, and handles macOS ad-hoc re-signing

There was a prior attempt (and this was inspired by it):

- #290077 Binary-patched Krisp using hardcoded mangled C++ symbol names looked up via `objdump`. This approach _technically works_. Locating `IsSignedByDiscord` by its mangled symbol and patching it is functionally equivalent to what we do here. 

The problem is maintenance: If the symbol gets stripped/renamed entirely (which Discord could do at any time), the approach breaks with no fallback. Also see https://github.com/NixOS/nixpkgs/pull/290077#pullrequestreview-1891626076

Here is how my patch works (conceptually):

On ELF, the patcher finds a unique byte pattern in `.text` that corresponds to the MD5 comparison in the signature check (`pmovmskb` + `cmp $0xffff`), walks back to the function start, and overwrites it with `mov eax, 1; ret`

On Mach-O (macOS), it starts from the `_SecStaticCodeCreateWithPath` import stub and walks callers upward, each hop is the single unique caller of the previous target. When the chain fans out (multiple callers), we've found `IsSignedByDiscord()` and patch it to return true. Then re-sign with `darwin.signingUtils`

At runtime, `deploy-krisp.py` copies the patched module into the user's config dir before Discord starts. It uses a SHA-256 marker to skip redeployment on subsequent launches and to catch cases where vanilla Discord overwrites our files (macOS APFS case-insensitivity). On fresh installs it waits for Discord to bootstrap its core modules before writing to `installed.json`

I'm keeping it off by default tho, using Krisp with a modified Discord client _probably_ violates Discord's ToS. _But_, using Vencord/Equicord/Moonlight already violates those same terms, so enabling Krisp alongside them doesn't introduce any new ToS risk

Closes #195512

Tested on NixOS and Nix-Darwin

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
