### PR TITLE
fmd-server: fix build

### DIFF
--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -5,7 +5,7 @@
   fetchPnpmDeps,
   nix-update-script,
   nodejs,
-  pnpm,
+  pnpm_10,
   pnpmConfigHook,
   stdenv,
   versionCheckHook,
@@ -27,7 +27,7 @@ buildGoModule (
 
     pnpmDeps = fetchPnpmDeps {
       inherit (ui) pname src;
-      inherit pnpm;
+      inherit pnpm_10;
       sourceRoot = "${finalAttrs.src.name}/${ui.pnpmRoot}";
       fetcherVersion = 3;
       hash = "sha256-fgqNaFQ4+uJxXzDJJq+D0+EFaLaYR+WUzi5kGq5ezjs=";
@@ -51,7 +51,7 @@ buildGoModule (
       nativeBuildInputs = [
         nodejs
         pnpmConfigHook
-        pnpm
+        pnpm_10
       ];
 
       buildPhase = ''

--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -26,7 +26,7 @@ buildGoModule (
     };
 
     pnpmDeps = fetchPnpmDeps {
-      inherit (ui) pname;
+      inherit (ui) pname src;
       inherit pnpm;
       sourceRoot = "${finalAttrs.src.name}/${ui.pnpmRoot}";
       fetcherVersion = 3;


### PR DESCRIPTION
Closes: #505992

Fixes the build issue where the unpackPhase failed with: `variable $src or $srcs should point to the source`
See failing Hydra job: https://hydra.nixos.org/job/nixpkgs/unstable/fmd-server.x86_64-linux

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
