### PR TITLE
odafileconverter: 26.7.0.0 → 27.1.0.0

### DIFF
--- a/pkgs/by-name/od/odafileconverter/package.nix
+++ b/pkgs/by-name/od/odafileconverter/package.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation rec {
       echo "patching $file"
       patchelf --set-rpath '${rpath}' $file
     done
+
+    substituteInPlace $out/share/applications/ODAFileConverter_*.desktop \
+      --replace-fail '/usr/bin/ODAFileConverter' 'ODAFileConverter'
   '';
 
   meta = {

--- a/pkgs/by-name/od/odafileconverter/package.nix
+++ b/pkgs/by-name/od/odafileconverter/package.nix
@@ -22,12 +22,12 @@ stdenv.mkDerivation rec {
   # To obtain the version you will need to run the following command:
   #
   # dpkg-deb -I ${odafileconverter.src} | grep Version
-  version = "26.7.0.0";
+  version = "27.1.0.0";
 
   src = fetchurl {
     # NB: this URL is not stable (i.e. the underlying file and the corresponding version will change over time)
-    url = "https://www.opendesign.com/guestfiles/get?filename=ODAFileConverter_QT6_lnxX64_8.3dll_26.7.deb";
-    hash = "sha256-MqST9Se66OJ+L0IKzuZkkFjCl3nb07gTO17j+lOWrHI=";
+    url = "https://www.opendesign.com/guestfiles/get?filename=ODAFileConverter_QT6_lnxX64_8.3dll_27.1.deb";
+    hash = "sha256-xxNjzVR1gXevR6NlFU8YDcUKHitSoTGZT9pUHBOjZ2Y=";
   };
 
   buildInputs = [


### PR DESCRIPTION
the download link for `26.7.0.0` was broken so `27.1.0.0` is required to be able to build the package again
Edit: the desktop file needed patching too

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
