### PR TITLE
mcp-server-{*}: init at 2026.1.26

### DIFF
--- a/pkgs/by-name/mc/mcp-server-fetch/package.nix
+++ b/pkgs/by-name/mc/mcp-server-fetch/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mcp-server-fetch";
+  version = "2026.1.26-unstable-2026-05-17";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    rev = "f4244583a6af9425633e433a3eec000d23f4e011";
+    hash = "sha256-bHknioQu8i5RcFlBBdXUQjsV4WN1IScnwohGRxXgGDk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src/fetch/";
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    httpx
+    markdownify
+    mcp
+    protego
+    pydantic
+    readabilipy
+    requests
+  ];
+
+  # Tests require network access
+  doCheck = false;
+
+  pythonImportsCheck = [ "mcp_server_fetch" ];
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${finalAttrs.version}";
+    description = "Model Context Protocol server providing tools to fetch and convert web content for usage by LLMs";
+    homepage = "https://github.com/modelcontextprotocol/servers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "mcp-server-fetch";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/mc/mcp-server-filesystem/package.nix
+++ b/pkgs/by-name/mc/mcp-server-filesystem/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildNpmPackage,
+  typescript,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "mcp-server-filesystem";
+  version = "2026.1.26";
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    tag = finalAttrs.version;
+    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
+  };
+
+  nativeBuildInputs = [
+    typescript
+  ];
+
+  dontNpmPrune = true;
+  npmWorkspace = "src/filesystem";
+  npmDepsHash = "sha256-jmz4JdpeHH07vJQFntBwrENbJaIcOuZMb7+qf497VOE=";
+
+  # TODO: revisit this when https://github.com/NixOS/nixpkgs/pull/333759 has landed
+  postInstall = ''
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-filesystem
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-memory
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-everything
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-sequential-thinking
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/.bin
+  '';
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${finalAttrs.version}";
+    description = "MCP server for filesystem access";
+    homepage = "https://github.com/modelcontextprotocol/servers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "mcp-server-filesystem";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/mc/mcp-server-git/package.nix
+++ b/pkgs/by-name/mc/mcp-server-git/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mcp-server-git";
+  version = "2026.1.26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    tag = finalAttrs.version;
+    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src/git/";
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    gitpython
+    mcp
+    pydantic
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mcp_server_git" ];
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${finalAttrs.version}";
+    description = "Model Context Protocol server providing tools to read, search, and manipulate Git repositories programmatically via LLMs";
+    homepage = "https://github.com/modelcontextprotocol/servers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "mcp-server-git";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/mc/mcp-server-memory/package.nix
+++ b/pkgs/by-name/mc/mcp-server-memory/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildNpmPackage,
+  typescript,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "mcp-server-memory";
+  version = "2026.1.26";
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    tag = finalAttrs.version;
+    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
+  };
+
+  nativeBuildInputs = [
+    typescript
+  ];
+
+  dontNpmPrune = true;
+  npmWorkspace = "src/memory";
+  npmDepsHash = "sha256-jmz4JdpeHH07vJQFntBwrENbJaIcOuZMb7+qf497VOE=";
+
+  # TODO: revisit this when https://github.com/NixOS/nixpkgs/pull/333759 has landed
+  postInstall = ''
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-filesystem
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-memory
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-everything
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-sequential-thinking
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/.bin
+  '';
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${finalAttrs.version}";
+    description = "MCP server for enabling memory for Claude through a knowledge graph";
+    homepage = "https://github.com/modelcontextprotocol/servers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "mcp-server-memory";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/mc/mcp-server-sequential-thinking/package.nix
+++ b/pkgs/by-name/mc/mcp-server-sequential-thinking/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildNpmPackage,
+  typescript,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "mcp-server-sequential-thinking";
+  version = "2026.1.26";
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    tag = finalAttrs.version;
+    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
+  };
+
+  nativeBuildInputs = [
+    typescript
+  ];
+
+  dontNpmPrune = true;
+  npmWorkspace = "src/sequentialthinking";
+  npmDepsHash = "sha256-jmz4JdpeHH07vJQFntBwrENbJaIcOuZMb7+qf497VOE=";
+
+  # TODO: revisit this when https://github.com/NixOS/nixpkgs/pull/333759 has landed
+  postInstall = ''
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-filesystem
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-memory
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-everything
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/@modelcontextprotocol/server-sequential-thinking
+    rm -rf $out/lib/node_modules/@modelcontextprotocol/servers/node_modules/.bin
+  '';
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${finalAttrs.version}";
+    description = "MCP server for sequential thinking and problem solving";
+    homepage = "https://github.com/modelcontextprotocol/servers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "mcp-server-memory";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/mc/mcp-server-time/package.nix
+++ b/pkgs/by-name/mc/mcp-server-time/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mcp-server-time";
+  version = "2026.1.26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    tag = finalAttrs.version;
+    hash = "sha256-uULXUEHFZpYm/fmF6PkOFCxS+B+0q3dMveLG+3JHrhk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src/time/";
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    mcp
+    pydantic
+    tzdata
+    tzlocal
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    freezegun
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "mcp_server_time" ];
+
+  meta = {
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${finalAttrs.version}";
+    description = "Model Context Protocol server providing tools for time queries and timezone conversions for LLMs";
+    homepage = "https://github.com/modelcontextprotocol/servers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "mcp-server-git";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Link: https://github.com/modelcontextprotocol/servers/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
