### PR TITLE
fastcap: fix build with gcc15

### DIFF
--- a/pkgs/by-name/fa/fastcap/fastcap-mulglobal-add-ualloc-declaration.patch
+++ b/pkgs/by-name/fa/fastcap/fastcap-mulglobal-add-ualloc-declaration.patch
@@ -1,0 +1,12 @@
+Fix implicit int truncating points in 64 bit systems.
+--- a/src/mulGlobal.h
++++ b/src/mulGlobal.h
+@@ -77,6 +77,8 @@
+ /* #define MALCORE malloc */
+ #define MALCORE ualloc
+ 
++extern char *ualloc(unsigned int);
++
+ /* counts of memory usage by multipole matrix type */
+ extern long memcount;
+ extern long memQ2M;

--- a/pkgs/by-name/fa/fastcap/package.nix
+++ b/pkgs/by-name/fa/fastcap/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./fastcap-mulglobal-drop-conflicting-lib.patch
     ./fastcap-mulsetup-add-forward-declarations.patch
+    ./fastcap-mulglobal-add-ualloc-declaration.patch
   ];
 
   nativeBuildInputs = [
@@ -28,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace ./doc/Makefile \
-      --replace '/bin/rm' 'rm'
+      --replace-fail '/bin/rm' 'rm'
 
     for f in "doc/*.tex" ; do
       sed -i -E $f \
@@ -54,8 +55,14 @@ stdenv.mkDerivation (finalAttrs: {
     "all"
   ];
 
-  # GCC 14 makes these errors by default
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=return-mismatch -Wno-error=implicit-int";
+  env.NIX_CFLAGS_COMPILE = toString [
+    # gcc14
+    "-Wno-error=implicit-function-declaration"
+    "-Wno-error=return-mismatch"
+    "-Wno-error=implicit-int"
+    # gcc15
+    "-std=gnu17"
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/323047185

This program is actually broken even before these new compilation errors with gcc15.
The reason is that implicit int causes the pointer typed return value of `ualloc()` being truncated in 64 bit systems.
Added a small patch to fix this.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
