### PR TITLE
ntlm-theft: init at 0-unstable-2025-09-22

### DIFF
--- a/pkgs/by-name/nt/ntlm-theft/package.nix
+++ b/pkgs/by-name/nt/ntlm-theft/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "ntlm-theft";
+  version = "0-unstable-2025-09-22";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Greenwolf";
+    repo = "ntlm-theft";
+    rev = "9750e537444a411e99555155b3a32fad745ae3d4";
+    hash = "sha256-wahjAokAbOa9gpiLO77ZgMaqWCOH34oJBrbEqgoxz8E=";
+  };
+
+  __structuredAttrs = true;
+
+  dependencies = with python3Packages; [
+    xlsxwriter
+  ];
+
+  postPatch = ''
+    # Fix broken shebang
+    substituteInPlace ntlm_theft.py \
+      --replace-fail "#!/usr/bin/env" "#!/usr/bin/env python3"
+
+    # Fix file permissions as copytree normally inherits the ro permissions from the nix store which leads to unwriteable files
+    sed -i '/import shutil/a shutil.copystat = lambda *args, **kwargs: None' ntlm_theft.py
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ntlm_theft.py $out/share/ntlm-theft/ntlm_theft.py
+
+    cp -r templates $out/share/ntlm-theft/
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper "$out/share/ntlm-theft/ntlm_theft.py" "$out/bin/ntlm-theft" \
+      --prefix PATH : "$program_PATH" \
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  preVersionCheck = "export version=0.1.0";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Tool for generating multiple types of NTLMv2 hash theft files";
+    homepage = "https://github.com/Greenwolf/ntlm-theft";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "ntlm-theft";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
This PR adds the ntlm-theft package, which is used for Pentesting Windows Environments and was needed for atleast 1 HTB Machine. See also https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
