### PR TITLE
mpvScripts.playlist-dir-conf: init at 0-unstable-2026-04-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30206,6 +30206,12 @@
     github = "zazedd";
     githubId = 93401987;
   };
+  zeal = {
+    name = "Mads Jensen";
+    github = "zzzealed";
+    githubId = 108904280;
+    email = "zzzealed@proton.me";
+  };
   zebradil = {
     email = "german.lashevich+nixpkgs@gmail.com";
     github = "zebradil";

--- a/pkgs/by-name/mp/mpv/scripts/playlist-dir-conf.nix
+++ b/pkgs/by-name/mp/mpv/scripts/playlist-dir-conf.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+
+buildLua {
+  pname = "playlist-dir-conf";
+  version = "0-unstable-2026-04-02";
+
+  src = fetchFromGitHub {
+    owner = "zzzealed";
+    repo = "mpv-playlist-dir-conf";
+    rev = "aac34c612a1ded93abf9234cf78be05acbce9b95";
+    hash = "sha256-lbaJ3WsEPxigrUFzS/ip6d6cfGT5bMDOFdYF+yIxIWE=";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "MPV script that loads a config from a playlists directory";
+    longDescription = "MPV script that loads a mpv.conf from the directory of the playlist, extending `--use-filedir-conf` behavior to work with playlists";
+    homepage = "https://github.com/zzzealed/mpv-playlist-dir-conf";
+    maintainers = with lib.maintainers; [ zeal ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added `playlist-dir-conf.lua` which is really pretty neat little script that I have been using for a while (even though the repo is new).
Also added myself as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
