### PR TITLE
meta-package-manager: init at 7.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13981,6 +13981,12 @@
     githubId = 37185887;
     name = "Calvin Kim";
   };
+  kdeldycke = {
+    email = "kevin@deldycke.com";
+    github = "kdeldycke";
+    githubId = 159718;
+    name = "Kevin Deldycke";
+  };
   kedry = {
     name = "Kevin Edry";
     github = "kedry";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14590,6 +14590,12 @@
     githubId = 37185887;
     name = "Calvin Kim";
   };
+  kdeldycke = {
+    email = "kevin@deldycke.com";
+    github = "kdeldycke";
+    githubId = 159718;
+    name = "Kevin Deldycke";
+  };
   kedry = {
     name = "Kevin Edry";
     github = "kedry";

--- a/pkgs/by-name/me/meta-package-manager/package.nix
+++ b/pkgs/by-name/me/meta-package-manager/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "meta-package-manager";
+  version = "6.4.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kdeldycke";
+    repo = "meta-package-manager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-biC8JXGIb3lAuvyGgCtBoUZbSJtNPr7qLvoKLjnXarw=";
+  };
+
+  build-system = with python3Packages; [ uv-build ];
+
+  dependencies = with python3Packages; [
+    boltons
+    click-extra
+    cyclonedx-python-lib
+    extra-platforms
+    packageurl-python
+    spdx-tools
+    tomli-w
+    xmltodict
+  ];
+
+  # mpm's test suite is integration-oriented: it spawns real package
+  # manager binaries (apt, brew, pip, npm and ~30 others), makes network
+  # calls, and assumes a writable ``$HOME``. None of this is reproducible
+  # inside a hermetic builder. mpm's own GitHub Actions CI exercises the
+  # full suite where the appropriate package managers are pre-installed;
+  # the ``pythonImportsCheck`` below is sufficient to validate that the
+  # package imports cleanly and its declared dependencies resolve.
+  doCheck = false;
+
+  pythonImportsCheck = [ "meta_package_manager" ];
+
+  meta = {
+    description = "CLI wrapping all package managers with a unifying interface";
+    homepage = "https://kdeldycke.github.io/meta-package-manager/";
+    changelog = "https://github.com/kdeldycke/meta-package-manager/blob/v${finalAttrs.version}/changelog.md";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kdeldycke ];
+    mainProgram = "mpm";
+  };
+})

--- a/pkgs/by-name/me/meta-package-manager/package.nix
+++ b/pkgs/by-name/me/meta-package-manager/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  zsh,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "meta-package-manager";
+  version = "7.6.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kdeldycke";
+    repo = "meta-package-manager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P/lP9YCekXEzPKYJTsASuxnSbDuFKBw99nVK4p7v+M4=";
+  };
+
+  build-system = with python3Packages; [ uv-build ];
+
+  dependencies = with python3Packages; [
+    boltons
+    click-extra
+    extra-platforms
+    packageurl-python
+    tomli-w
+    xmltodict
+  ];
+
+  nativeCheckInputs =
+    with python3Packages;
+    [
+      pytestCheckHook
+      # tests/test_docs.py parses the GitHub workflow YAML files and loads
+      # docs/docs_update.py, which round-trips pyproject.toml with tomlkit.
+      pyyaml
+      tomlkit
+      # The SBOM unit tests import the CycloneDX renderer and its JSON/XML
+      # schema validators, the SPDX writers, and the mocked HTTP client of
+      # the OSV adapter.
+      cyclonedx-python-lib
+      httpx
+      jsonschema
+      lxml
+      platformdirs
+      respx
+      spdx-tools
+    ]
+    # The Xbar/SwiftBar plugin tests only run on macOS and drive the plugin
+    # through the login shells it targets.
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ zsh ];
+
+  pythonImportsCheck = [ "meta_package_manager" ];
+
+  meta = {
+    description = "Package managers abstraction and unification tool";
+    homepage = "https://mpm.run/";
+    changelog = "https://github.com/kdeldycke/meta-package-manager/blob/v${finalAttrs.version}/changelog.md";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kdeldycke ];
+    mainProgram = "mpm";
+  };
+})

--- a/pkgs/development/python-modules/click-extra/default.nix
+++ b/pkgs/development/python-modules/click-extra/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pytest-httpserver,
+  pygments,
+  pyyaml,
+  hjson,
+  tomlkit,
+  xmltodict,
+  uv-build,
+  boltons,
+  click,
+  cloup,
+  deepmerge,
+  extra-platforms,
+  requests,
+  tabulate,
+  wcmatch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "click-extra";
+  version = "7.15.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kdeldycke";
+    repo = "click-extra";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hof1SFh8XXBoQ9Pr4qI/7jNlBDMpUi7+qs1QcT042tY=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    boltons
+    click
+    cloup
+    deepmerge
+    extra-platforms
+    requests
+    tabulate
+    wcmatch
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    # Optional libraries imported at module-level by various test files:
+    # ``tests/test_table.py`` needs hjson, tomlkit, xmltodict and yaml
+    # (the ``[hjson]``, ``[toml]``, ``[xml]`` and ``[yaml]`` extras
+    # declared in pyproject.toml); ``tests/test_pygments.py`` needs
+    # pygments; ``tests/test_config.py`` uses the ``httpserver`` fixture
+    # from pytest-httpserver to test remote configuration loading.
+    hjson
+    pygments
+    pytest-httpserver
+    pyyaml
+    tomlkit
+    xmltodict
+  ];
+
+  # ``-m "not network"`` skips ``test_ansi_lexers_candidates`` and other
+  # network-tagged tests; the build sandbox has no system TLS CA bundle.
+  pytestFlagsArray = [
+    "-m"
+    "not network"
+  ];
+
+  disabledTestPaths = [
+    # tests/sphinx requires the Sphinx ecosystem (myst-parser, furo,
+    # etc.) not packaged in nixpkgs.
+    "tests/sphinx"
+    # tests/mkdocs requires mkdocs-click.
+    "tests/mkdocs"
+  ];
+
+  disabledTests = [
+    # The four integration tests below assert against debug output that
+    # should not include the test sandbox's ``$HOME``; click-extra logs
+    # the search pattern using the runtime environment HOME instead of
+    # the test fixture's ``tmp_path``.
+    "test_integrated_color_option"
+    "test_required_command"
+    "test_unset_conf_debug_message"
+    "test_integrated_verbosity_options"
+  ];
+
+  pythonImportsCheck = [ "click_extra" ];
+
+  meta = {
+    description = "Drop-in replacement for Click to build colorful CLI";
+    homepage = "https://github.com/kdeldycke/click-extra";
+    changelog = "https://github.com/kdeldycke/click-extra/blob/v${finalAttrs.version}/changelog.md";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kdeldycke ];
+  };
+})

--- a/pkgs/development/python-modules/click-extra/default.nix
+++ b/pkgs/development/python-modules/click-extra/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gitMinimal,
+  pytestCheckHook,
+  hjson,
+  jsonschema,
+  myst-parser,
+  pygments,
+  pytest-httpserver,
+  pyyaml,
+  requests,
+  sphinx,
+  tomlkit,
+  xmltodict,
+  uv-build,
+  boltons,
+  click,
+  cloup,
+  deepmerge,
+  extra-platforms,
+  tabulate,
+  wcmatch,
+  wcwidth,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "click-extra";
+  version = "8.8.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kdeldycke";
+    repo = "click-extra";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-h+FWG6YHWCDDkQ0CxX0h9F8yD2z8H5bMtRAL4Y5WQkQ=";
+  };
+
+  build-system = [ uv-build ];
+
+  # wcwidth backs the ``tabulate[widechars]`` extra pinned in pyproject.toml
+  # and is also a direct runtime dependency since 8.4.
+  dependencies = [
+    boltons
+    click
+    cloup
+    deepmerge
+    extra-platforms
+    tabulate
+    wcmatch
+    wcwidth
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    # Optional libraries imported at module level by the test files.
+    gitMinimal
+    hjson
+    jsonschema
+    myst-parser
+    pygments
+    pytest-httpserver
+    pyyaml
+    requests
+    sphinx
+    tomlkit
+    xmltodict
+  ];
+
+  # Tests marked ``network`` make HTTPS requests; the build sandbox has no
+  # system TLS CA bundle.
+  disabledTestMarks = [ "network" ];
+
+  # The configuration tests are served over HTTP by a local pytest-httpserver
+  # binding to ``localhost``. The Darwin build sandbox cuts the build off from
+  # the resolver, so that bind fails there with a ``gaierror`` unless local
+  # networking is allowed.
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "click_extra" ];
+
+  meta = {
+    description = "Drop-in replacement for Click to build colorful CLI";
+    homepage = "https://github.com/kdeldycke/click-extra";
+    changelog = "https://github.com/kdeldycke/click-extra/blob/v${finalAttrs.version}/changelog.md";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kdeldycke ];
+  };
+})

--- a/pkgs/development/python-modules/extra-platforms/default.nix
+++ b/pkgs/development/python-modules/extra-platforms/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  requests,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "extra-platforms";
+  version = "12.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kdeldycke";
+    repo = "extra-platforms";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OJ5ch1dfAnblC+3UCJ9I9P9sw8taGp8yBg//ZraunRo=";
+  };
+
+  build-system = [ uv-build ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    # Used by tests that exercise URL-fetching helpers.
+    requests
+  ];
+
+  # ``-m "not network"`` skips the tests marked ``network`` (e.g.
+  # ``test_pyproject_classifiers``) that reach out to PyPI.
+  pytestFlagsArray = [
+    "-m"
+    "not network"
+  ];
+
+  disabledTestPaths = [
+    # Shells out to ``uv`` to render the docs as a side effect; not
+    # available in the build sandbox.
+    "tests/test_sphinx_crossrefs.py"
+  ];
+
+  pythonImportsCheck = [ "extra_platforms" ];
+
+  meta = {
+    description = "Detect platforms, architectures and OS families";
+    homepage = "https://github.com/kdeldycke/extra-platforms";
+    changelog = "https://github.com/kdeldycke/extra-platforms/blob/v${finalAttrs.version}/changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kdeldycke ];
+  };
+})

--- a/pkgs/development/python-modules/extra-platforms/default.nix
+++ b/pkgs/development/python-modules/extra-platforms/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "extra-platforms";
+  version = "13.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kdeldycke";
+    repo = "extra-platforms";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Sn9x6BChbvIm/66v7cujj/LsD7ObF2stqOz/Yht6K0E=";
+  };
+
+  build-system = [ uv-build ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Tests marked ``network`` reach out to PyPI; the build sandbox has no
+  # system TLS CA bundle.
+  disabledTestMarks = [ "network" ];
+
+  pythonImportsCheck = [ "extra_platforms" ];
+
+  meta = {
+    description = "Detect platforms, architectures and OS families";
+    homepage = "https://github.com/kdeldycke/extra-platforms";
+    changelog = "https://github.com/kdeldycke/extra-platforms/blob/v${finalAttrs.version}/changelog.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kdeldycke ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2823,6 +2823,8 @@ self: super: with self; {
 
   click-didyoumean = callPackage ../development/python-modules/click-didyoumean { };
 
+  click-extra = callPackage ../development/python-modules/click-extra { };
+
   click-help-colors = callPackage ../development/python-modules/click-help-colors { };
 
   click-log = callPackage ../development/python-modules/click-log { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5254,6 +5254,8 @@ self: super: with self; {
 
   extension-helpers = callPackage ../development/python-modules/extension-helpers { };
 
+  extra-platforms = callPackage ../development/python-modules/extra-platforms { };
+
   extra-streamlit-components =
     callPackage ../development/python-modules/extra-streamlit-components
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3188,6 +3188,8 @@ self: super: with self; {
 
   click-didyoumean = callPackage ../development/python-modules/click-didyoumean { };
 
+  click-extra = callPackage ../development/python-modules/click-extra { };
+
   click-help-colors = callPackage ../development/python-modules/click-help-colors { };
 
   click-log = callPackage ../development/python-modules/click-log { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5729,6 +5729,8 @@ self: super: with self; {
 
   extension-helpers = callPackage ../development/python-modules/extension-helpers { };
 
+  extra-platforms = callPackage ../development/python-modules/extra-platforms { };
+
   extra-streamlit-components =
     callPackage ../development/python-modules/extra-streamlit-components
       { };


### PR DESCRIPTION
## Summary

Add [meta-package-manager](https://github.com/kdeldycke/meta-package-manager) (`mpm`), a CLI that wraps multiple package managers (Homebrew, apt, pip, npm, etc.) behind a unified interface.

This PR includes two new dependency packages:
- `python3Packages.extra-platforms` (`13.6.0`): platform and OS detection library
- `python3Packages.click-extra` (`8.8.1`): drop-in replacement for Click with colorful CLI support

Both are used as dependencies by `meta-package-manager` and have no other consumers in nixpkgs yet.

## Checklist

- [x] Package paths follow `pkgs/by-name/` and `pkgs/development/python-modules/` conventions
- [x] `meta.maintainers` set (new maintainer entry in separate commit)
- [x] `meta.mainProgram` set to `mpm`
- [x] `meta.license`, `meta.homepage`, `meta.changelog` set
- [x] `pythonImportsCheck` included
- [x] Source fetched from GitHub release tags
- [x] Library packages bundled with their dependent (per `pkgs/README.md` guidelines)
