### PR TITLE
mpm: init at 2026.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6931,6 +6931,11 @@
     githubId = 10913120;
     name = "Dje4321";
   };
+  djmaxus = {
+    name = "djmaxus";
+    github = "djmaxus";
+    githubId = 44438314;
+  };
   djwf = {
     email = "dave@weller-fahy.com";
     github = "djwf";

--- a/pkgs/by-name/mp/mpm-unwrapped/package.nix
+++ b/pkgs/by-name/mp/mpm-unwrapped/package.nix
@@ -21,10 +21,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     };
 
   dontUnpack = true;
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
 
   installPhase = ''
     runHook preInstall
-    install -D "$src" "$out"/bin/mpm
+    install -D "${finalAttrs.src}" "$out"/bin/mpm
     runHook postInstall
   '';
 

--- a/pkgs/by-name/mp/mpm-unwrapped/package.nix
+++ b/pkgs/by-name/mp/mpm-unwrapped/package.nix
@@ -45,6 +45,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   doInstallCheck = stdenvNoCC.hostPlatform.isDarwin;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "MATLAB Package Manager";
     homepage = "https://www.mathworks.com/products/mpm.html";
@@ -54,7 +57,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "mpm";
   };
-
-  strictDeps = true;
-  __structuredAttrs = true;
 })

--- a/pkgs/by-name/mp/mpm-unwrapped/package.nix
+++ b/pkgs/by-name/mp/mpm-unwrapped/package.nix
@@ -8,17 +8,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mpm-unwrapped";
   version = "2026.3";
 
-  passthru.supportedPlatforms = {
-    "aarch64-darwin" = {
-      mathworks_platform = "maca64";
-      hash = "sha256-ESqG7cmVvWfilKN/pM/f6bxPv5Vs8wJ5p2Ne8DD4dI8=";
-    };
-    "x86_64-linux" = {
-      mathworks_platform = "glnxa64";
-      hash = "sha256-lsCa2xT0mXUGunNcs2PsE04ItOOybxlQhmNuKa/qs6M=";
-    };
-  };
-
   src =
     let
       inherit (stdenvNoCC.hostPlatform) system;
@@ -47,6 +36,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   strictDeps = true;
   __structuredAttrs = true;
+
+  passthru.supportedPlatforms = {
+    "aarch64-darwin" = {
+      mathworks_platform = "maca64";
+      hash = "sha256-ESqG7cmVvWfilKN/pM/f6bxPv5Vs8wJ5p2Ne8DD4dI8=";
+    };
+    "x86_64-linux" = {
+      mathworks_platform = "glnxa64";
+      hash = "sha256-lsCa2xT0mXUGunNcs2PsE04ItOOybxlQhmNuKa/qs6M=";
+    };
+  };
 
   meta = {
     description = "MATLAB Package Manager";

--- a/pkgs/by-name/mp/mpm-unwrapped/package.nix
+++ b/pkgs/by-name/mp/mpm-unwrapped/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+  versionCheckHook,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mpm-unwrapped";
+  version = "2026.3";
+
+  passthru.supportedPlatforms = {
+    "aarch64-darwin" = {
+      mathworks_platform = "maca64";
+      hash = "sha256-ESqG7cmVvWfilKN/pM/f6bxPv5Vs8wJ5p2Ne8DD4dI8=";
+    };
+    "x86_64-linux" = {
+      mathworks_platform = "glnxa64";
+      hash = "sha256-lsCa2xT0mXUGunNcs2PsE04ItOOybxlQhmNuKa/qs6M=";
+    };
+  };
+
+  src =
+    let
+      inherit (stdenvNoCC.hostPlatform) system;
+      source =
+        finalAttrs.passthru.supportedPlatforms.${system}
+          or (throw "Platform ${system} is not supported by mpm");
+    in
+    fetchurl {
+      url = "https://ssd.mathworks.com/supportfiles/downloads/mpm/${finalAttrs.version}/${source.mathworks_platform}/mpm";
+      inherit (source) hash;
+    };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D "$src" "$out"/bin/mpm
+    runHook postInstall
+  '';
+
+  # NOTE: Sandboxed binary can't run on Linux hosts during build.
+  # However, it will work on non-NixOS Linux after installation.
+  # Use `pkgs.mpm` on NixOS and/or if you need `versionCheckHook` enabled
+  doInstallCheck = stdenvNoCC.hostPlatform.isDarwin;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "MATLAB Package Manager";
+    homepage = "https://www.mathworks.com/products/mpm.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ djmaxus ];
+    platforms = lib.attrNames finalAttrs.passthru.supportedPlatforms;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "mpm";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+})

--- a/pkgs/by-name/mp/mpm/package.nix
+++ b/pkgs/by-name/mp/mpm/package.nix
@@ -3,6 +3,8 @@
   lib,
   versionCheckHook,
   buildFHSEnv,
+  pam,
+  zlib,
 }:
 (buildFHSEnv {
   pname = "mpm";
@@ -11,11 +13,10 @@
   executableName = mpm-unwrapped.meta.mainProgram;
   runScript = lib.getExe mpm-unwrapped;
 
-  targetPkgs =
-    pkgs: with pkgs; [
-      pam
-      zlib
-    ];
+  targetPkgs = _: [
+    pam
+    zlib
+  ];
 
   meta = mpm-unwrapped.meta // {
     # Support only Linux platforms for the wrapped binary.

--- a/pkgs/by-name/mp/mpm/package.nix
+++ b/pkgs/by-name/mp/mpm/package.nix
@@ -1,0 +1,33 @@
+{
+  mpm-unwrapped,
+  lib,
+  versionCheckHook,
+  buildFHSEnv,
+}:
+(buildFHSEnv {
+  pname = "mpm";
+  inherit (mpm-unwrapped) version;
+
+  executableName = mpm-unwrapped.meta.mainProgram;
+  runScript = lib.getExe mpm-unwrapped;
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      pam
+      zlib
+    ];
+
+  meta = mpm-unwrapped.meta // {
+    # Support only Linux platforms for the wrapped binary.
+    # List not hardcoded in case other Linux/Darwin platforms become supported.
+    platforms = lib.intersectLists mpm-unwrapped.meta.platforms lib.platforms.linux;
+  };
+}).overrideAttrs # attributes which don't work as intended otherwise
+  {
+    doInstallCheck = true;
+    nativeInstallCheckInputs = [ versionCheckHook ];
+
+    # for nixpkgs-vet
+    strictDeps = true;
+    __structuredAttrs = true;
+  }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduce [MATLAB Package Manager](https://www.mathworks.com/products/mpm.html) to nixpkgs. Apart from Windows, they only support `x86_64-linux` and `aarch64-darwin`.

Further plans after this package is published:

- Create dependent packages with MATLAB installations
- Create Home Manager MATLAB modules

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (NixOS, Ubuntu)
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] versionCheckHook
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## NixOS Nuances

The executable provided by MathWorks for Linux platforms is a self-extracting binary. It contains a ZIP of binaries and many proprietary dynamic libraries that are not available in nixpkgs. On NixOS, it [causes dynamic linking issues](https://nix.dev/guides/faq#how-to-run-non-nix-executables).

I tried to fix it with `autoPatchelfHook` on files extracted manually with `binwalk`, but again, I'd have to work around both the unclear self-extracting logic and who knows how many of their dynamic libraries.

Instead, I decided to package the binary for Linux platforms as is but wrapped with [buildFHSEnv](https://nixos.org/manual/nixpkgs/stable/#sec-fhs-environments).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Context of Previous Reviews

- https://github.com/NixOS/nixpkgs/pull/506150#issuecomment-4231691451
- https://github.com/NixOS/nixpkgs/pull/506150#issuecomment-4232693156
- https://github.com/NixOS/nixpkgs/pull/506150#pullrequestreview-4112510698 (also see my comments below the summary)
- `nixpkgs-review` reports:
  - [macOS](https://github.com/NixOS/nixpkgs/pull/506150#issuecomment-4276080226)
  - [NixOS/Ubuntu](https://github.com/NixOS/nixpkgs/pull/506150#issuecomment-4276082495)