### PR TITLE
jetbrains.{clion,rust-rover,rider}: 2025.3 -> 2026.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -58,9 +58,9 @@ let
   patchSharedLibs = lib.optionalString stdenv.hostPlatform.isLinux ''
     ls -d \
       $out/*/bin/*/linux/*/lib/liblldb.so \
-      $out/*/bin/*/linux/*/lib/python3.8/lib-dynload/* \
+      $out/*/bin/*/linux/*/lib/python3.*/lib-dynload/* \
       $out/*/plugins/*/bin/*/linux/*/lib/liblldb.so \
-      $out/*/plugins/*/bin/*/linux/*/lib/python3.8/lib-dynload/* |
+      $out/*/plugins/*/bin/*/linux/*/lib/python3.*/lib-dynload/* |
     xargs patchelf \
       --replace-needed libssl.so.10 libssl.so \
       --replace-needed libssl.so.1.1 libssl.so \

--- a/pkgs/applications/editors/jetbrains/ides/clion.nix
+++ b/pkgs/applications/editors/jetbrains/ides/clion.nix
@@ -21,20 +21,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.4.tar.gz";
-      hash = "sha256-Ii6ppV3Hy0DpTj2mo+cUpLrIoNxeHzcAJ7PBSayQcW0=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.1.tar.gz";
+      hash = "sha256-r5flY2u6aCkI8q7ZcGWYLLxxcWWp3gtTkdBdKoacIB0=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.4-aarch64.tar.gz";
-      hash = "sha256-I17oA1RNeITPu1xxvyR1Y2+toHfSWj6BxamA+84cF9g=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.1-aarch64.tar.gz";
+      hash = "sha256-1N1JLpHBAFSDOYLl98KxDBpGmgVMlRFuV49/a2jGHfQ=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.4.dmg";
-      hash = "sha256-pdJXd5Vgn8qiKzC1Q0rVJMpuITWyZU+pl+NLKVsnSA8=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.1.dmg";
+      hash = "sha256-m3AEgpDjUDMJQ7320XuqpEHwe4ItYX8JYq0ZpITaKcs=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/cpp/CLion-2025.3.4-aarch64.dmg";
-      hash = "sha256-WWl2JfK5zJzmrIKFUxHPCkCzRkzVq8IQEWlqDvIxlSg=";
+      url = "https://download.jetbrains.com/cpp/CLion-2026.1-aarch64.dmg";
+      hash = "sha256-Crx63jFbJbCX1/XIZg22Oxd7HxFWmB3iXlJofzv03vA=";
     };
   };
   # update-script-end: urls
@@ -48,8 +48,8 @@ in
   product = "CLion";
 
   # update-script-start: version
-  version = "2025.3.4";
-  buildNumber = "253.32098.68";
+  version = "2026.1";
+  buildNumber = "261.22158.273";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/rider.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rider.nix
@@ -24,20 +24,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.tar.gz";
-      hash = "sha256-srYR8+fLE91G73FY4hqqsTzG1LJbpgDNohlJfR1KDlE=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.0.1.tar.gz";
+      hash = "sha256-moIysTTsq7abpQfNh1Bc5Pk6VQgJIT6erbyHsUXf15Y=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1-aarch64.tar.gz";
-      hash = "sha256-ISUCf/FM6igaAEfZVfL3GBpOa6fMe5cYnaO+ecJvUxA=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.0.1-aarch64.tar.gz";
+      hash = "sha256-0gEmWObwCio3aBqmUh2u5adWO3fFJV8uFwUTT31KsMI=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.dmg";
-      hash = "sha256-Rug+Z/K6pMyxJ9XbVqqZX6al+ix734zwcbYF7M19Yaw=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.0.1.dmg";
+      hash = "sha256-s/lppcf2gfwmFYeHjWtk2NGPAjo/PAEnaGNWhDOkKOM=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1-aarch64.dmg";
-      hash = "sha256-XsFDjH12YNAZXthoOTJnEYlZfcfJDsHycaj8n041EeA=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.0.1-aarch64.dmg";
+      hash = "sha256-BHHrO4DLfw4cdbrJCH1uqX2qdm/ijyFnj32WQ8rpVhI=";
     };
   };
   # update-script-end: urls
@@ -51,8 +51,8 @@ in
   product = "Rider";
 
   # update-script-start: version
-  version = "2026.1";
-  buildNumber = "261.22158.335";
+  version = "2026.1.0.1";
+  buildNumber = "261.22158.394";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/rider.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rider.nix
@@ -24,20 +24,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2025.3.3.tar.gz";
-      hash = "sha256-sBF/XA52oSFD1dEmzhvo7cwf5EGTi0mx1x3PcobQVAs=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.tar.gz";
+      hash = "sha256-srYR8+fLE91G73FY4hqqsTzG1LJbpgDNohlJfR1KDlE=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2025.3.3-aarch64.tar.gz";
-      hash = "sha256-QKBzusZRTOq+2Pte+SEggN/odpJoHKaIwBGpLe9jqmU=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1-aarch64.tar.gz";
+      hash = "sha256-ISUCf/FM6igaAEfZVfL3GBpOa6fMe5cYnaO+ecJvUxA=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2025.3.3.dmg";
-      hash = "sha256-BmKP6puShOwnwa6BzhF5mjDEBZM8gew27szQm6WIdCc=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.dmg";
+      hash = "sha256-Rug+Z/K6pMyxJ9XbVqqZX6al+ix734zwcbYF7M19Yaw=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2025.3.3-aarch64.dmg";
-      hash = "sha256-6AMcnhZH8h3jUz6+goycMY39vkyoWQh/zm2a/9Kgt1E=";
+      url = "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1-aarch64.dmg";
+      hash = "sha256-XsFDjH12YNAZXthoOTJnEYlZfcfJDsHycaj8n041EeA=";
     };
   };
   # update-script-end: urls
@@ -51,8 +51,8 @@ in
   product = "Rider";
 
   # update-script-start: version
-  version = "2025.3.3";
-  buildNumber = "253.31033.136";
+  version = "2026.1";
+  buildNumber = "261.22158.335";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));

--- a/pkgs/applications/editors/jetbrains/ides/rust-rover.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rust-rover.nix
@@ -18,20 +18,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2025.3.5.tar.gz";
-      hash = "sha256-2yEZOWUoD6ELs0WSvdMSZSVAmA/LsoKyfJiR20I86aQ=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1.tar.gz";
+      hash = "sha256-qiOgAHz/tCnyEwljTy1D0sJBhWpOXZCCf5Uq66PZjzk=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2025.3.5-aarch64.tar.gz";
-      hash = "sha256-tl8lxMH6XH+2VGqv6vxGEjjALevaEl7VAzs9LAjwtPQ=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1-aarch64.tar.gz";
+      hash = "sha256-jU61XQ+3zliH3y6nz6o8U/DrRkZ2vs4ff8Fd/RPb0a0=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2025.3.5.dmg";
-      hash = "sha256-8ONWTld29DJjaDH4ubsBRmYYosQ6wTAQInuko76Ucoc=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1.dmg";
+      hash = "sha256-VwVvTSUdFpPhAeWyzkID6TFNE0S1vVeR82FRfU2v3s4=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/rustrover/RustRover-2025.3.5-aarch64.dmg";
-      hash = "sha256-N3D6YE6vV8x+slvphyqzDu2mTp8y2uAeSZTZg0pMABQ=";
+      url = "https://download.jetbrains.com/rustrover/RustRover-2026.1-aarch64.dmg";
+      hash = "sha256-DeLkwKq01M3zmr2yZnOYXCn0CZ+0P9MtWC9bMIzKrVE=";
     };
   };
   # update-script-end: urls
@@ -45,8 +45,8 @@ in
   product = "RustRover";
 
   # update-script-start: version
-  version = "2025.3.5";
-  buildNumber = "253.31033.204";
+  version = "2026.1";
+  buildNumber = "261.22158.331";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));


### PR DESCRIPTION
All these IDEs need the same fix for lldb due to an updated Python version.

Ran RustRover to check.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
