### PR TITLE
jetbrains.dataspell: 2025.3.2 -> 2026.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/ides/dataspell.nix
+++ b/pkgs/applications/editors/jetbrains/ides/dataspell.nix
@@ -14,20 +14,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/python/dataspell-2025.3.2.tar.gz";
-      hash = "sha256-rRcGQOEVc7nnqyFDVvkjgZlvoKZfnuSCR5TnqrMFDjo=";
+      url = "https://download.jetbrains.com/python/dataspell-2026.1.tar.gz";
+      hash = "sha256-FcbflBzHsSWvkXVtrlltvb3PjihP91s0gm3wmV3zuRA=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/python/dataspell-2025.3.2-aarch64.tar.gz";
-      hash = "sha256-WQqGvwaBkdJU9AN+LIThnZlW/HDzEpZuS0q+ir/ncfw=";
+      url = "https://download.jetbrains.com/python/dataspell-2026.1-aarch64.tar.gz";
+      hash = "sha256-JKAW0YtwNDjk3Un4e/cWipreAI8pJaJgLNvx7oOw4RQ=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/python/dataspell-2025.3.2.dmg";
-      hash = "sha256-k3GEiAnqst8EB8AFwcVMGaZYJ/jR+MGhQ59ysTP/9uI=";
+      url = "https://download.jetbrains.com/python/dataspell-2026.1.dmg";
+      hash = "sha256-w/nFLddHi/l7VqQKngxhYm/LL49eiawXhK+xGBU6Ej0=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/python/dataspell-2025.3.2-aarch64.dmg";
-      hash = "sha256-R8iT4fDtpOzI6Xcw1mR0rE0Gqhk6r8wl8HoDoaTGzfs=";
+      url = "https://download.jetbrains.com/python/dataspell-2026.1-aarch64.dmg";
+      hash = "sha256-/yZpE2aY07AedubVG6yarO4uObdaIZ4KCtKl9DaRU4c=";
     };
   };
   # update-script-end: urls
@@ -41,8 +41,8 @@ mkJetBrainsProduct {
   product = "DataSpell";
 
   # update-script-start: version
-  version = "2025.3.2";
-  buildNumber = "253.30387.154";
+  version = "2026.1";
+  buildNumber = "261.22158.332";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));


### PR DESCRIPTION
Untested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
