### PR TITLE
lib.types.submoduleWith: prevent duplication from reimport

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1242,7 +1242,9 @@ rec {
       base = evalModules {
         inherit class specialArgs;
         modules = [
-          {
+          rec {
+            _file = ./types.nix;
+            key = _file;
             # This is a work-around for the fact that some sub-modules,
             # such as the one included in an attribute set, expects an "args"
             # attribute to be given to the sub-module. As the option
@@ -1299,7 +1301,14 @@ rec {
           { loc, defs }:
           let
             configuration = base.extendModules {
-              modules = [ { _module.args.name = last loc; } ] ++ allModules defs;
+              modules = [
+                rec {
+                  _file = ./types.nix;
+                  key = "${_file}:set-name";
+                  _module.args.name = last loc;
+                }
+              ]
+              ++ allModules defs;
               prefix = loc;
             };
           in


### PR DESCRIPTION
Some niche scenarios could see this module being added twice.

The internal module in `lib.modules.evalModules` has `key` set, just in case that happens.

However these do not, and they set values, leading to conflict errors in some niche scenarios such as when people try to export modules used in a submodule type by use of the moduleType argument

Generally, internal modules which set actual values or define options in nixpkgs already do this, and setting key can only de-duplicate the module, so this should have a VERY low chance of breaking anyone's configuration