### PR TITLE
bluetooth: add "auto" option to powerOnBoot for persisting power state

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3544,6 +3544,12 @@
     github = "bitbloxhub";
     githubId = 45184892;
   };
+  bittner = {
+    email = "django@bittner.it";
+    github = "bittner";
+    githubId = 665072;
+    name = "Peter Bittner";
+  };
   bizmyth = {
     email = "andrew.p.council@gmail.com";
     github = "bizmythy";

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -23,11 +23,13 @@ let
     types
     ;
 
+  persistPowerState = cfg.powerOnBoot == "auto";
+
   cfgFmt = pkgs.formats.ini { };
 
   defaults = {
     General.ControllerMode = "dual";
-    Policy.AutoEnable = cfg.powerOnBoot;
+    Policy.AutoEnable = if persistPowerState then true else cfg.powerOnBoot;
   };
 
   hasDisabledPlugins = builtins.length cfg.disabledPlugins > 0;
@@ -55,9 +57,23 @@ in
       hsphfpd.enable = mkEnableOption "support for hsphfpd[-prototype] implementation";
 
       powerOnBoot = mkOption {
-        type = types.bool;
+        type = types.either types.bool (types.enum [ "auto" ]);
         default = true;
-        description = "Whether to power up the default Bluetooth controller on boot.";
+        description = ''
+          Whether to power up the default Bluetooth controller on boot.
+
+          When set to `"auto"`, the power state from the last session is
+          restored on boot: if Bluetooth was on when the system shut down,
+          it will be powered on; if it was off, it will stay off.
+
+          This works by translating a user-initiated power-off (bluez
+          `Powered=false`) into an `rfkill block`, so clients such as
+          PipeWire/WirePlumber cannot auto-power the adapter back on.
+          The off state is recorded in `/var/lib/bluetooth/power-state`
+          and re-applied at next boot, since some platforms (e.g.
+          `thinkpad_acpi` on Lenovo ThinkPads) reset the rfkill state
+          on boot and override systemd-rfkill's restoration.
+        '';
       };
 
       package = mkPackageOption pkgs "bluez" { };
@@ -176,6 +192,55 @@ in
           };
         };
     }
+    // (optionalAttrs persistPowerState {
+      bluetooth-persist-power-state = {
+        description = "Persist Bluetooth power state via rfkill";
+        after = [ "bluetooth.service" ];
+        requires = [ "bluetooth.service" ];
+        partOf = [ "bluetooth.service" ];
+        wantedBy = [ "bluetooth.target" ];
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          RestartSec = "5s";
+          StateDirectory = "bluetooth";
+        };
+        # Translate every user-initiated power-off into an rfkill block,
+        # which keeps the adapter out of bluez's D-Bus tree so that no
+        # client (PipeWire/WirePlumber, gnome-bluetooth, auto-reconnecting
+        # paired devices, ...) can power it back on against the user's
+        # expressed intent. The desired state is recorded in a small file
+        # and re-applied at our service's startup, since some platforms
+        # (e.g. thinkpad_acpi) reset rfkill state on boot and override
+        # systemd-rfkill's restoration. When the user later turns
+        # Bluetooth on (e.g. via GNOME's tile, which lifts the rfkill
+        # block), bluez exposes the adapter again and Policy.AutoEnable
+        # restores the powered state.
+        script = ''
+          state_file=/var/lib/bluetooth/power-state
+
+          # Re-apply the user's last off intent, after thinkpad_acpi (or
+          # similar) has had its say at boot.
+          if [ "$(cat "$state_file" 2>/dev/null)" = "off" ]; then
+            echo "bluetooth-persist: saved state is off, applying rfkill block"
+            ${pkgs.util-linux}/bin/rfkill block bluetooth || true
+          fi
+
+          ${pkgs.glib.bin}/bin/gdbus monitor --system --dest org.bluez \
+          | while IFS= read -r line; do
+              case "$line" in
+                *"PropertiesChanged"*"'Powered': <true>"*)
+                  echo on > "$state_file"; sync "$state_file"
+                  ;;
+                *"PropertiesChanged"*"'Powered': <false>"*)
+                  echo off > "$state_file"; sync "$state_file"
+                  ${pkgs.util-linux}/bin/rfkill block bluetooth || true
+                  ;;
+              esac
+            done
+        '';
+      };
+    })
     // (optionalAttrs cfg.hsphfpd.enable {
       hsphfpd = {
         after = [ "bluetooth.service" ];

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -66,13 +66,14 @@ in
           restored on boot: if Bluetooth was on when the system shut down,
           it will be powered on; if it was off, it will stay off.
 
-          This works by translating a user-initiated power-off (bluez
-          `Powered=false`) into an `rfkill block`, so clients such as
-          PipeWire/WirePlumber cannot auto-power the adapter back on.
-          The off state is recorded in `/var/lib/bluetooth/power-state`
-          and re-applied at next boot, since some platforms (e.g.
-          `thinkpad_acpi` on Lenovo ThinkPads) reset the rfkill state
-          on boot and override systemd-rfkill's restoration.
+          The state is snapshotted at shutdown to
+          `/var/lib/bluetooth/power-state` and re-applied at next boot
+          via `rfkill block`. The rfkill route is needed because some
+          platforms (e.g. `thinkpad_acpi` on Lenovo ThinkPads) reset
+          rfkill state on boot, overriding systemd-rfkill's restoration,
+          and because rfkill hides the adapter from bluez's D-Bus tree
+          so that clients (PipeWire/WirePlumber, gnome-bluetooth, ...)
+          cannot auto-power it back on.
         '';
       };
 
@@ -194,51 +195,41 @@ in
     }
     // (optionalAttrs persistPowerState {
       bluetooth-persist-power-state = {
-        description = "Persist Bluetooth power state via rfkill";
+        description = "Persist Bluetooth power state across reboots";
         after = [ "bluetooth.service" ];
         requires = [ "bluetooth.service" ];
         partOf = [ "bluetooth.service" ];
         wantedBy = [ "bluetooth.target" ];
+        # Snapshot the current power state at shutdown and re-apply it at
+        # next boot via rfkill block. rfkill hides the adapter from bluez's
+        # D-Bus tree, so neither bluez's Policy.AutoEnable nor clients
+        # (PipeWire/WirePlumber, gnome-bluetooth, auto-reconnecting paired
+        # devices, ...) can power it back on. Re-applying at boot is
+        # necessary because some platforms (e.g. thinkpad_acpi on Lenovo
+        # ThinkPads) reset rfkill state on boot, overriding systemd-rfkill.
         serviceConfig = {
-          Type = "simple";
-          Restart = "always";
-          RestartSec = "5s";
+          Type = "oneshot";
+          RemainAfterExit = true;
           StateDirectory = "bluetooth";
+          ExecStart = pkgs.writeShellScript "bluetooth-restore-power-state" ''
+            if [ "$(cat /var/lib/bluetooth/power-state 2>/dev/null)" = "off" ]; then
+              ${pkgs.util-linux}/bin/rfkill block bluetooth
+            fi
+          '';
+          # Runs before bluetooth.service stops (After= reverses on stop),
+          # so bluez is still reachable for the Powered query.
+          ExecStop = pkgs.writeShellScript "bluetooth-save-power-state" ''
+            state=on
+            rfkill_state=$(${pkgs.util-linux}/bin/rfkill list bluetooth)
+            bluez_state=$(${package}/bin/bluetoothctl show 2>/dev/null || true)
+            if [[ "$rfkill_state" == *"Soft blocked: yes"* ]]; then
+              state=off
+            elif [[ "$bluez_state" == *"Powered: no"* ]]; then
+              state=off
+            fi
+            echo "$state" > /var/lib/bluetooth/power-state
+          '';
         };
-        # Translate every user-initiated power-off into an rfkill block,
-        # which keeps the adapter out of bluez's D-Bus tree so that no
-        # client (PipeWire/WirePlumber, gnome-bluetooth, auto-reconnecting
-        # paired devices, ...) can power it back on against the user's
-        # expressed intent. The desired state is recorded in a small file
-        # and re-applied at our service's startup, since some platforms
-        # (e.g. thinkpad_acpi) reset rfkill state on boot and override
-        # systemd-rfkill's restoration. When the user later turns
-        # Bluetooth on (e.g. via GNOME's tile, which lifts the rfkill
-        # block), bluez exposes the adapter again and Policy.AutoEnable
-        # restores the powered state.
-        script = ''
-          state_file=/var/lib/bluetooth/power-state
-
-          # Re-apply the user's last off intent, after thinkpad_acpi (or
-          # similar) has had its say at boot.
-          if [ "$(cat "$state_file" 2>/dev/null)" = "off" ]; then
-            echo "bluetooth-persist: saved state is off, applying rfkill block"
-            ${pkgs.util-linux}/bin/rfkill block bluetooth || true
-          fi
-
-          ${pkgs.glib.bin}/bin/gdbus monitor --system --dest org.bluez \
-          | while IFS= read -r line; do
-              case "$line" in
-                *"PropertiesChanged"*"'Powered': <true>"*)
-                  echo on > "$state_file"; sync "$state_file"
-                  ;;
-                *"PropertiesChanged"*"'Powered': <false>"*)
-                  echo off > "$state_file"; sync "$state_file"
-                  ${pkgs.util-linux}/bin/rfkill block bluetooth || true
-                  ;;
-              esac
-            done
-        '';
       };
     })
     // (optionalAttrs cfg.hsphfpd.enable {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -293,6 +293,7 @@ in
   blockbook-frontend = runTest ./blockbook-frontend.nix;
   blocky = runTest ./blocky.nix;
   bluesky-pds = runTest ./bluesky-pds.nix;
+  bluetooth = runTest ./bluetooth.nix;
   bookstack = runTest ./bookstack.nix;
   boot = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./boot.nix { };
   boot-stage1 = runTest ./boot-stage1.nix;

--- a/nixos/tests/bluetooth.nix
+++ b/nixos/tests/bluetooth.nix
@@ -1,0 +1,52 @@
+{ lib, ... }:
+{
+  name = "bluetooth";
+  meta.maintainers = with lib.maintainers; [
+    bittner
+    rnhmjoj
+  ];
+
+  nodes.machine = {
+    hardware.bluetooth.enable = true;
+
+    specialisation = {
+      powerOn.configuration.hardware.bluetooth.powerOnBoot = true;
+      powerOff.configuration.hardware.bluetooth.powerOnBoot = false;
+      auto.configuration.hardware.bluetooth.powerOnBoot = "auto";
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
+    in
+    ''
+      start_all()
+
+      with subtest("powerOnBoot = true sets AutoEnable = true"):
+          config = machine.succeed("cat ${specialisations}/powerOn/etc/bluetooth/main.conf")
+          assert "AutoEnable=true" in config, f"Expected AutoEnable=true, got: {config}"
+
+      with subtest("powerOnBoot = false sets AutoEnable = false"):
+          config = machine.succeed("cat ${specialisations}/powerOff/etc/bluetooth/main.conf")
+          assert "AutoEnable=false" in config, f"Expected AutoEnable=false, got: {config}"
+
+      with subtest("powerOnBoot = auto sets AutoEnable = true"):
+          config = machine.succeed("cat ${specialisations}/auto/etc/bluetooth/main.conf")
+          assert "AutoEnable=true" in config, f"Expected AutoEnable=true, got: {config}"
+
+      with subtest("powerOnBoot = auto creates persist service"):
+          machine.succeed("test -e ${specialisations}/auto/etc/systemd/system/bluetooth-persist-power-state.service")
+
+      with subtest("persist service uses rfkill to enforce off state"):
+          unit = machine.succeed("cat ${specialisations}/auto/etc/systemd/system/bluetooth-persist-power-state.service")
+          assert "rfkill block bluetooth" in unit, f"Expected 'rfkill block bluetooth' in unit, got: {unit}"
+
+      with subtest("powerOnBoot = true does not create persist service"):
+          machine.fail("test -e ${specialisations}/powerOn/etc/systemd/system/bluetooth-persist-power-state.service")
+
+      with subtest("powerOnBoot = false does not create persist service"):
+          machine.fail("test -e ${specialisations}/powerOff/etc/systemd/system/bluetooth-persist-power-state.service")
+    '';
+}

--- a/nixos/tests/bluetooth.nix
+++ b/nixos/tests/bluetooth.nix
@@ -39,9 +39,20 @@
       with subtest("powerOnBoot = auto creates persist service"):
           machine.succeed("test -e ${specialisations}/auto/etc/systemd/system/bluetooth-persist-power-state.service")
 
-      with subtest("persist service uses rfkill to enforce off state"):
+      with subtest("persist service is a oneshot, not a long-running daemon"):
           unit = machine.succeed("cat ${specialisations}/auto/etc/systemd/system/bluetooth-persist-power-state.service")
-          assert "rfkill block bluetooth" in unit, f"Expected 'rfkill block bluetooth' in unit, got: {unit}"
+          assert "Type=oneshot" in unit, f"Expected Type=oneshot, got: {unit}"
+          assert "RemainAfterExit=true" in unit, f"Expected RemainAfterExit=true, got: {unit}"
+          assert "ExecStart=" in unit, f"Expected ExecStart, got: {unit}"
+          assert "ExecStop=" in unit, f"Expected ExecStop, got: {unit}"
+
+      with subtest("persist service uses rfkill to enforce off state"):
+          import re
+          unit = machine.succeed("cat ${specialisations}/auto/etc/systemd/system/bluetooth-persist-power-state.service")
+          match = re.search(r'ExecStart=(\S+)', unit)
+          assert match, f"Could not find ExecStart in unit: {unit}"
+          script = machine.succeed(f"cat {match.group(1)}")
+          assert "rfkill block bluetooth" in script, f"Expected 'rfkill block bluetooth' in ExecStart script, got: {script}"
 
       with subtest("powerOnBoot = true does not create persist service"):
           machine.fail("test -e ${specialisations}/powerOn/etc/systemd/system/bluetooth-persist-power-state.service")


### PR DESCRIPTION
The current [powerOnBoot](https://mynixos.com/nixpkgs/option/hardware.bluetooth.powerOnBoot) option only accepts true/false, where `false` simply skips powering on the adapter but does not actively power it off if firmware already enabled it, which is arguably confusing.

This change adds an "auto" option that saves the bluetooth power state on shutdown and restores it on boot, using a lightweight systemd oneshot service.

Extending the accepted values follows the `types.either types.bool (types.enum [ "auto" ])` pattern already used in other NixOS modules (e.g. [suricata](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/networking/suricata/settings.nix#L648)), which allows us to stay backward compatible.

Note that the [current default](https://mynixos.com/nixpkgs/option/hardware.bluetooth.powerOnBoot) is `true`. In the long run it may make sense to set it to "auto", which probably reflects user expectations more closely.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
