### PR TITLE
kiorg: init at 1.5.2

### DIFF
--- a/pkgs/by-name/ki/kiorg/package.nix
+++ b/pkgs/by-name/ki/kiorg/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kiorg";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "houqp";
+    repo = "kiorg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gagC6qpWJvNf3aMJyKU5dQLGYk2vZwURi86ISc3JqFU=";
+  };
+
+  cargoHash = "sha256-prZHwCrLzAhwuiENN89MPHO0VHGCkWmMh/qGgzfwwzU=";
+
+  useNextest = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  meta = {
+    description = "A hacker's file manager with VIM inspired keybind";
+    homepage = "https://github.com/houqp/kiorg";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ambroisie ];
+    mainProgram = "kiorg";
+  };
+})


### PR DESCRIPTION
## Things done

I packaged it, but after trying it out I'm not actually that interested in using it -- and therefore maintaining it.

Opening this PR for anyone who's interested to take it over if they want.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
