### PR TITLE
swift-format: add shell completions support

### DIFF
--- a/pkgs/development/compilers/swift/swift-format/default.nix
+++ b/pkgs/development/compilers/swift/swift-format/default.nix
@@ -1,11 +1,11 @@
 {
   lib,
   stdenv,
-  fetchpatch,
   callPackage,
   swift,
   swiftpm,
   swiftpm2nix,
+  installShellFiles,
   Dispatch,
   Foundation,
 }:
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     swift
     swiftpm
+    installShellFiles
   ];
   buildInputs = [ Foundation ];
 
@@ -38,6 +39,16 @@ stdenv.mkDerivation {
     binPath="$(swiftpmBinPath)"
     mkdir -p $out/bin
     cp $binPath/swift-format $out/bin/
+
+    # Generate shell completions
+    for shell in bash zsh fish; do
+      $out/bin/swift-format --generate-completion-script $shell > swift-format.$shell
+    done
+
+    installShellCompletion --cmd swift-format \
+      --bash swift-format.bash \
+      --zsh swift-format.zsh \
+      --fish swift-format.fish
   '';
 
   meta = {


### PR DESCRIPTION
Add shell completions for bash, zsh, and fish using swift-format's built-in --generate-completion-script flag.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
