### PR TITLE
lib.sourceTypes: add obfuscatedCode

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1569,6 +1569,9 @@
   "lib.sourceTypes.binaryBytecode": [
     "index.html#lib.sourceTypes.binaryBytecode"
   ],
+  "lib.sourceTypes.obfuscatedCode": [
+    "index.html#lib.sourceTypes.obfuscatedCode"
+  ],
   "chap-passthru": [
     "index.html#chap-passthru"
   ],

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -258,6 +258,10 @@ Code to be executed on a peripheral device or embedded controller, built by a th
 
 Code to run on a VM interpreter or JIT compiled into bytecode by a third party. This includes packages which download Java `.jar` files from another source.
 
+### `lib.sourceTypes.obfuscatedCode` {#lib.sourceTypes.obfuscatedCode}
+
+Code which is intentionally obfuscated by a third party, for example by using a code obfuscator or by being distributed in an obfuscated form.
+
 ## Software identifiers {#sec-meta-identifiers}
 
 Package's `meta.identifiers` attribute specifies information about software identifiers associated with this package. Software identifiers are used, for example:

--- a/lib/source-types.nix
+++ b/lib/source-types.nix
@@ -17,4 +17,6 @@ lib.mapAttrs (tname: tset: defaultSourceType tname // tset) {
   binaryBytecode = { };
 
   binaryFirmware = { };
+
+  obfuscatedCode = { };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I find it necessary to include obfuscated code as a source type other than the existing ones (from source, binary bytecode, binary native code, binary firmware) because it simply does not fit in any one of them. It would be applicable to some of the unfree Electron apps that I packaged, such as `z-library-desktop`, `pvzge`. I am sure it may also apply to a bunch of other packages currently in nixpkgs. Often npm also pulls packages with minified code, so packages depending on minified code downloaded by npm also should include obfuscated code in their source provenance (although minification does not necessarily mean obfuscation, I think it should be okay to merge those two types of source provenance).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
