### PR TITLE
nixos/tdarr: add missing options, fix major propagation bug 

### DIFF
--- a/nixos/modules/services/misc/tdarr/apply-node-db-config.sh
+++ b/nixos/modules/services/misc/tdarr/apply-node-db-config.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Apply Tdarr node settings to NodeJSONDB via /api/v2/cruddb.
+# Usage: tdarr-apply-node-db-config <server-url> <node-id> <node-updates-file> [node-config-path]
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: tdarr-apply-node-db-config <server-url> <node-id> <node-updates-file> [node-config-path]" >&2
+  exit 1
+fi
+
+server_url="$1"
+node_id="$2"
+node_updates_file="$3"
+node_config_path="${4:-}"
+
+if [ ! -f "$node_updates_file" ]; then
+  echo "node updates file not found: $node_updates_file" >&2
+  exit 1
+fi
+
+log() {
+  printf '%s\n' "$*"
+}
+
+log "Tdarr node config sync: waiting for server at ${server_url}"
+
+# Wait for Tdarr server API.
+for _ in $(seq 1 60); do
+  if curl -sf --max-time 5 "$server_url/api/v2/status" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+# Wait for node row to appear in NodeJSONDB.
+for _ in $(seq 1 90); do
+  payload_get="$(jq -cn --arg docID "$node_id" \
+    '{data:{collection:"NodeJSONDB",mode:"getById",docID:$docID}}')"
+
+  row="$(curl -sf --max-time 5 \
+    -X POST "$server_url/api/v2/cruddb" \
+    -H 'Content-Type: application/json' \
+    --data "$payload_get" || echo '{}')"
+
+  if [ "$row" != "{}" ] && [ "$row" != "null" ]; then
+    break
+  fi
+  sleep 1
+done
+
+log "Tdarr node config sync: updating NodeJSONDB for ${node_id}"
+
+# Build update payload safely using file
+payload_update="$(jq -cn \
+  --arg docID "$node_id" \
+  --argfile obj "$node_updates_file" \
+  '{data:{collection:"NodeJSONDB",mode:"update",docID:$docID,obj:$obj}}')"
+
+curl -sf --max-time 10 \
+  -X POST "$server_url/api/v2/cruddb" \
+  -H 'Content-Type: application/json' \
+  --data "$payload_update" >/dev/null
+
+# Merge back into on-disk config if present
+if [ -n "$node_config_path" ] && [ -f "$node_config_path" ]; then
+  tmp_file="$(mktemp)"
+
+  jq --argfile obj "$node_updates_file" \
+    '. * $obj' \
+    "$node_config_path" > "$tmp_file"
+
+  mv "$tmp_file" "$node_config_path"
+
+  log "Tdarr node config sync: merged desired values into ${node_config_path}"
+fi

--- a/nixos/modules/services/misc/tdarr/apply-node-db-config.sh
+++ b/nixos/modules/services/misc/tdarr/apply-node-db-config.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Apply Tdarr node settings to NodeJSONDB via /api/v2/cruddb.
+# Usage: tdarr-apply-node-db-config <server-url> <node-id> <node-updates-file> [node-config-path]
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: tdarr-apply-node-db-config <server-url> <node-id> <node-updates-file> [node-config-path]" >&2
+  exit 1
+fi
+
+server_url="$1"
+node_id="$2"
+node_updates_file="$3"
+node_config_path="${4:-}"
+
+if [ ! -f "$node_updates_file" ]; then
+  echo "node updates file not found: $node_updates_file" >&2
+  exit 1
+fi
+
+log() {
+  printf '%s\n' "$*"
+}
+
+log "Tdarr node config sync: waiting for server at ${server_url}"
+
+# Wait for Tdarr server API.
+for _ in $(seq 1 60); do
+  if curl -sf --max-time 5 "$server_url/api/v2/status" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+curl -sf --max-time 5 "$server_url/api/v2/status" >/dev/null || { echo "Tdarr server API did not become ready in time" >&2; exit 1; }
+
+# Wait for node row to appear in NodeJSONDB.
+row='{}'
+for _ in $(seq 1 90); do
+  payload_get="$(jq -cn --arg docID "$node_id" \
+    '{data:{collection:"NodeJSONDB",mode:"getById",docID:$docID}}')"
+
+  row="$(curl -sf --max-time 5 \
+    -X POST "$server_url/api/v2/cruddb" \
+    -H 'Content-Type: application/json' \
+    --data "$payload_get" || echo '{}')"
+
+  if [ "$row" != "{}" ] && [ "$row" != "null" ]; then
+    break
+  fi
+  sleep 1
+done
+[ "$row" != "{}" ] && [ "$row" != "null" ] || { echo "Tdarr node did not appear in NodeJSONDB in time" >&2; exit 1; }
+
+log "Tdarr node config sync: updating NodeJSONDB for ${node_id}"
+
+# Build update payload safely using file
+payload_update="$(jq -cn \
+  --arg docID "$node_id" \
+  --slurpfile obj "$node_updates_file" \
+  '{data:{collection:"NodeJSONDB",mode:"update",docID:$docID,obj:$obj[0]}}')"
+
+log "Tdarr node config sync: update payload ${payload_update}"
+
+curl -sf --max-time 10 \
+  -X POST "$server_url/api/v2/cruddb" \
+  -H 'Content-Type: application/json' \
+  --data "$payload_update" >/dev/null
+
+# Merge back into on-disk config if present
+if [ -n "$node_config_path" ] && [ -f "$node_config_path" ]; then
+  tmp_file="$(mktemp)"
+
+  jq --slurpfile obj "$node_updates_file" \
+    '. * $obj[0]' \
+    "$node_config_path" > "$tmp_file"
+
+  mv "$tmp_file" "$node_config_path"
+
+  log "Tdarr node config sync: merged desired values into ${node_config_path}"
+fi

--- a/nixos/modules/services/misc/tdarr/default.nix
+++ b/nixos/modules/services/misc/tdarr/default.nix
@@ -31,6 +31,17 @@ in
       description = "Base directory for Tdarr data.";
     };
 
+    libraryDir = lib.mkOption {
+      type = lib.types.listOf (lib.types.path);
+      description = "Additional directories where your media library is stored";
+      example = lib.literalExpression ''
+        [
+          "/mnt/library1"
+          "/mnt/library2"
+        ]
+      '';
+    };
+
     user = lib.mkOption {
       type = lib.types.str;
       default = "tdarr";

--- a/nixos/modules/services/misc/tdarr/node.nix
+++ b/nixos/modules/services/misc/tdarr/node.nix
@@ -10,10 +10,33 @@ let
   enabledNodes = lib.filterAttrs (_: nodeCfg: nodeCfg.enable) cfg.nodes;
   nodesEnabled = cfg.enable || (enabledNodes != { });
   serverEnabled = cfg.enable || cfg.server.enable;
+  nodeConfigSyncScript = pkgs.writeShellApplication {
+    name = "tdarr-apply-node-db-config";
+    runtimeInputs = with pkgs; [
+      curl
+      jq
+      coreutils
+    ];
+    text = builtins.readFile ./apply-node-db-config.sh;
+  };
   nodeConfigFiles = lib.mapAttrs (
     nodeId: nodeCfg:
     pkgs.writeText "Tdarr_Node_Config_${nodeId}.json" (
-      builtins.toJSON { pathTranslators = nodeCfg.pathTranslators; }
+      builtins.toJSON {
+        nodeName = nodeCfg.name;
+        serverURL = nodeCfg.serverURL;
+        serverIP = nodeCfg.serverIP;
+        serverPort = toString nodeCfg.serverPort;
+        nodeType = nodeCfg.type;
+        priority = nodeCfg.priority;
+        pollInterval = nodeCfg.pollInterval;
+        startPaused = nodeCfg.startPaused;
+        maxLogSizeMB = nodeCfg.maxLogSizeMB;
+        cronPluginUpdate = nodeCfg.cronPluginUpdate;
+        pathTranslators = nodeCfg.pathTranslators;
+        # Required to stop tdarr overwriting the symlink
+        ffprobePath = "";
+      }
     )
   ) enabledNodes;
 in
@@ -60,6 +83,42 @@ in
 
                 This is the recommended way to specify the server location.
                 When running a local server, the default value is correct.
+                For a remote server set this to e.g. `"http://192.168.1.100:8266"`.
+              '';
+            };
+
+            serverIP = lib.mkOption {
+              type = lib.types.str;
+              default = "127.0.0.1";
+              defaultText = lib.literalExpression ''"127.0.0.1"'';
+              description = ''
+                IP address of the Tdarr server.
+
+                Although deprecated in favour of
+                {option}`services.tdarr.nodes.<name>.serverURL`, the node
+                binary still reads this field for internal API calls such as
+                `/api/v2/update-node`.  Without it the node falls back to the
+                compiled-in default of `0.0.0.0` and cannot reach the server.
+
+                Set this to the same host as {option}`serverURL`.  For a remote
+                server this should be the server's IP address, e.g.
+                `"192.168.1.100"`.
+              '';
+              example = "192.168.1.100";
+            };
+
+            serverPort = lib.mkOption {
+              type = lib.types.port;
+              default = cfg.server.serverPort;
+              defaultText = lib.literalExpression "config.services.tdarr.server.serverPort";
+              description = ''
+                Port of the Tdarr server API.
+
+                Although deprecated in favour of
+                {option}`services.tdarr.nodes.<name>.serverURL`, the node
+                binary still reads this field for internal API calls.  Must
+                match the port in {option}`serverURL` and the server's
+                {option}`services.tdarr.server.serverPort`.
               '';
             };
 
@@ -130,6 +189,9 @@ in
               description = ''
                 Path translations between server and node for cross-platform or
                 cross-mount-point file access.
+
+                These are written to the node config JSON file because tdarr does
+                not support setting `pathTranslators` via environment variables.
               '';
               example = lib.literalExpression ''
                 [
@@ -188,57 +250,125 @@ in
       "L+ ${cfg.dataDir}/nodes/${nodeId}/configs/Tdarr_Node_Config.json - - - - ${nodeConfigFiles.${nodeId}}"
     ]) (builtins.attrNames enabledNodes);
 
-    systemd.services = lib.mapAttrs' (
-      nodeId: nodeCfg:
-      lib.nameValuePair "tdarr-node-${nodeId}" {
-        description = "Tdarr Node - ${nodeCfg.name}";
-        after = [ "network.target" ] ++ lib.optionals serverEnabled [ "tdarr-server.service" ];
-        wants = lib.optionals serverEnabled [ "tdarr-server.service" ];
-        wantedBy = [ "multi-user.target" ];
-        environment = {
-          nodeName = nodeCfg.name;
-          serverURL = nodeCfg.serverURL;
-          nodeType = nodeCfg.type;
-          priority = toString nodeCfg.priority;
-          cronPluginUpdate = nodeCfg.cronPluginUpdate;
-          maxLogSizeMB = toString nodeCfg.maxLogSizeMB;
-          pollInterval = toString nodeCfg.pollInterval;
-          startPaused = lib.boolToString nodeCfg.startPaused;
-          transcodegpuWorkers = toString nodeCfg.workers.transcodeGPU;
-          transcodecpuWorkers = toString nodeCfg.workers.transcodeCPU;
-          healthcheckgpuWorkers = toString nodeCfg.workers.healthcheckGPU;
-          healthcheckcpuWorkers = toString nodeCfg.workers.healthcheckCPU;
-          rootDataPath = toString nodeCfg.dataDir;
-        };
-        serviceConfig = {
-          Type = "simple";
-          User = cfg.user;
-          Group = cfg.group;
-          ExecStart = lib.getExe nodeCfg.package;
-          Restart = "on-failure";
-          RestartSec = 5;
-          WorkingDirectory = toString nodeCfg.dataDir;
+    systemd.services =
+      lib.mapAttrs' (
+        nodeId: nodeCfg:
+        lib.nameValuePair "tdarr-node-${nodeId}" {
+          description = "Tdarr Node - ${nodeCfg.name}";
+          after = [ "network.target" ] ++ lib.optionals serverEnabled [ "tdarr-server.service" ];
+          wants = lib.optionals serverEnabled [ "tdarr-server.service" ];
+          wantedBy = [ "multi-user.target" ];
+          environment = {
+            nodeName = nodeCfg.name;
+            serverURL = nodeCfg.serverURL;
+            # Keep these in sync with the JSON config for the same reason they
+            # exist there: the node binary uses them for internal API calls.
+            serverIP = nodeCfg.serverIP;
+            serverPort = toString nodeCfg.serverPort;
+            nodeType = nodeCfg.type;
+            priority = toString nodeCfg.priority;
+            cronPluginUpdate = nodeCfg.cronPluginUpdate;
+            maxLogSizeMB = toString nodeCfg.maxLogSizeMB;
+            pollInterval = toString nodeCfg.pollInterval;
+            startPaused = lib.boolToString nodeCfg.startPaused;
+            transcodegpuWorkers = toString nodeCfg.workers.transcodeGPU;
+            transcodecpuWorkers = toString nodeCfg.workers.transcodeCPU;
+            healthcheckgpuWorkers = toString nodeCfg.workers.healthcheckGPU;
+            healthcheckcpuWorkers = toString nodeCfg.workers.healthcheckCPU;
+            rootDataPath = toString nodeCfg.dataDir;
+          };
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+            ExecStart = lib.getExe nodeCfg.package;
+            Restart = "on-failure";
+            RestartSec = 5;
+            WorkingDirectory = toString nodeCfg.dataDir;
 
-          # Hardening
-          NoNewPrivileges = true;
-          PrivateTmp = true;
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) (
-            let
-              rel = lib.removePrefix "/var/lib/" (toString nodeCfg.dataDir);
-            in
-            "${rel} ${rel}/configs ${rel}/logs"
-          );
-          StateDirectoryMode = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) "0750";
-          ReadWritePaths = lib.optionals (!lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) [
-            (toString nodeCfg.dataDir)
-          ];
+            # Hardening
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) (
+              let
+                rel = lib.removePrefix "/var/lib/" (toString nodeCfg.dataDir);
+              in
+              "${rel} ${rel}/configs ${rel}/logs"
+            );
+            StateDirectoryMode = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) "0750";
+            ReadWritePaths =
+              lib.optionals (!lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) [
+                (toString nodeCfg.dataDir)
+              ]
+              ++ cfg.libraryDir;
+          }
+          // lib.optionalAttrs (nodeCfg.environmentFile != null) {
+            EnvironmentFile = nodeCfg.environmentFile;
+          };
         }
-        // lib.optionalAttrs (nodeCfg.environmentFile != null) {
-          EnvironmentFile = nodeCfg.environmentFile;
-        };
-      }
-    ) enabledNodes;
+      ) enabledNodes
+      // lib.mapAttrs' (
+        nodeId: nodeCfg:
+        lib.nameValuePair "tdarr-node-config-${nodeId}" {
+          description = "Apply Tdarr node config via API - ${nodeCfg.name}";
+
+          after = [
+            "network-online.target"
+            "tdarr-node-${nodeId}.service"
+          ]
+          ++ lib.optionals serverEnabled [
+            "tdarr-server.service"
+          ];
+
+          wants = [
+            "network-online.target"
+            "tdarr-node-${nodeId}.service"
+          ]
+          ++ lib.optionals serverEnabled [
+            "tdarr-server.service"
+          ];
+
+          partOf = [ "tdarr-node-${nodeId}.service" ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            User = cfg.user;
+            Group = cfg.group;
+
+            Restart = "on-failure";
+            RestartSec = 5;
+            TimeoutStartSec = 180;
+
+            ExecStart =
+              let
+                nodeUpdatesFile = pkgs.writeText "tdarr-node-updates-${nodeId}.json" (
+                  builtins.toJSON {
+                    nodeType = nodeCfg.type;
+                    nodeTags = nodeCfg.type;
+                    serverURL = nodeCfg.serverURL;
+                    serverIP = nodeCfg.serverIP;
+                    serverPort = toString nodeCfg.serverPort;
+                    priority = nodeCfg.priority;
+                    pollInterval = nodeCfg.pollInterval;
+                    startPaused = nodeCfg.startPaused;
+                    nodePaused = nodeCfg.startPaused;
+                    maxLogSizeMB = nodeCfg.maxLogSizeMB;
+                    cronPluginUpdate = nodeCfg.cronPluginUpdate;
+                    pathTranslators = nodeCfg.pathTranslators;
+                  }
+                );
+              in
+              [
+                (lib.getExe nodeConfigSyncScript)
+                nodeCfg.serverURL
+                nodeCfg.name
+                nodeUpdatesFile
+                "${toString nodeCfg.dataDir}/configs/Tdarr_Node_Config.json"
+              ];
+          };
+        }
+      ) enabledNodes;
   };
 }

--- a/nixos/modules/services/misc/tdarr/node.nix
+++ b/nixos/modules/services/misc/tdarr/node.nix
@@ -10,10 +10,37 @@ let
   enabledNodes = lib.filterAttrs (_: nodeCfg: nodeCfg.enable) cfg.nodes;
   nodesEnabled = cfg.enable || (enabledNodes != { });
   serverEnabled = cfg.enable || cfg.server.enable;
+  nodeConfigSyncScript = pkgs.writeShellApplication {
+    name = "tdarr-apply-node-db-config";
+    runtimeInputs = with pkgs; [
+      curl
+      jq
+      coreutils
+    ];
+    text = builtins.readFile ./apply-node-db-config.sh;
+  };
+  nodeCommonConfig = nodeCfg: {
+    serverURL = nodeCfg.serverURL;
+    serverIP = nodeCfg.serverIP;
+    serverPort = toString nodeCfg.serverPort;
+    nodeType = nodeCfg.type;
+    priority = nodeCfg.priority;
+    pollInterval = nodeCfg.pollInterval;
+    startPaused = nodeCfg.startPaused;
+    maxLogSizeMB = nodeCfg.maxLogSizeMB;
+    cronPluginUpdate = nodeCfg.cronPluginUpdate;
+    pathTranslators = nodeCfg.pathTranslators;
+  };
   nodeConfigFiles = lib.mapAttrs (
     nodeId: nodeCfg:
     pkgs.writeText "Tdarr_Node_Config_${nodeId}.json" (
-      builtins.toJSON { pathTranslators = nodeCfg.pathTranslators; }
+      builtins.toJSON (
+        nodeCommonConfig nodeCfg
+        // {
+          nodeName = nodeCfg.name;
+          ffprobePath = "";
+        }
+      )
     )
   ) enabledNodes;
 in
@@ -130,6 +157,9 @@ in
               description = ''
                 Path translations between server and node for cross-platform or
                 cross-mount-point file access.
+
+                These are written to the node config JSON file because tdarr does
+                not support setting `pathTranslators` via environment variables.
               '';
               example = lib.literalExpression ''
                 [
@@ -188,57 +218,118 @@ in
       "L+ ${cfg.dataDir}/nodes/${nodeId}/configs/Tdarr_Node_Config.json - - - - ${nodeConfigFiles.${nodeId}}"
     ]) (builtins.attrNames enabledNodes);
 
-    systemd.services = lib.mapAttrs' (
-      nodeId: nodeCfg:
-      lib.nameValuePair "tdarr-node-${nodeId}" {
-        description = "Tdarr Node - ${nodeCfg.name}";
-        after = [ "network.target" ] ++ lib.optionals serverEnabled [ "tdarr-server.service" ];
-        wants = lib.optionals serverEnabled [ "tdarr-server.service" ];
-        wantedBy = [ "multi-user.target" ];
-        environment = {
-          nodeName = nodeCfg.name;
-          serverURL = nodeCfg.serverURL;
-          nodeType = nodeCfg.type;
-          priority = toString nodeCfg.priority;
-          cronPluginUpdate = nodeCfg.cronPluginUpdate;
-          maxLogSizeMB = toString nodeCfg.maxLogSizeMB;
-          pollInterval = toString nodeCfg.pollInterval;
-          startPaused = lib.boolToString nodeCfg.startPaused;
-          transcodegpuWorkers = toString nodeCfg.workers.transcodeGPU;
-          transcodecpuWorkers = toString nodeCfg.workers.transcodeCPU;
-          healthcheckgpuWorkers = toString nodeCfg.workers.healthcheckGPU;
-          healthcheckcpuWorkers = toString nodeCfg.workers.healthcheckCPU;
-          rootDataPath = toString nodeCfg.dataDir;
-        };
-        serviceConfig = {
-          Type = "simple";
-          User = cfg.user;
-          Group = cfg.group;
-          ExecStart = lib.getExe nodeCfg.package;
-          Restart = "on-failure";
-          RestartSec = 5;
-          WorkingDirectory = toString nodeCfg.dataDir;
+    systemd.services =
+      lib.mapAttrs' (
+        nodeId: nodeCfg:
+        lib.nameValuePair "tdarr-node-${nodeId}" {
+          description = "Tdarr Node - ${nodeCfg.name}";
+          after = [ "network.target" ] ++ lib.optionals serverEnabled [ "tdarr-server.service" ];
+          wants = lib.optionals serverEnabled [ "tdarr-server.service" ];
+          wantedBy = [ "multi-user.target" ];
+          environment = {
+            nodeName = nodeCfg.name;
+            serverURL = nodeCfg.serverURL;
+            # Keep these in sync with the JSON config for the same reason they
+            # exist there: the node binary uses them for internal API calls.
+            serverIP = nodeCfg.serverIP;
+            serverPort = toString nodeCfg.serverPort;
+            nodeType = nodeCfg.type;
+            priority = toString nodeCfg.priority;
+            cronPluginUpdate = nodeCfg.cronPluginUpdate;
+            maxLogSizeMB = toString nodeCfg.maxLogSizeMB;
+            pollInterval = toString nodeCfg.pollInterval;
+            startPaused = lib.boolToString nodeCfg.startPaused;
+            transcodegpuWorkers = toString nodeCfg.workers.transcodeGPU;
+            transcodecpuWorkers = toString nodeCfg.workers.transcodeCPU;
+            healthcheckgpuWorkers = toString nodeCfg.workers.healthcheckGPU;
+            healthcheckcpuWorkers = toString nodeCfg.workers.healthcheckCPU;
+            rootDataPath = toString nodeCfg.dataDir;
+          };
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+            ExecStart = lib.getExe nodeCfg.package;
+            Restart = "on-failure";
+            RestartSec = 5;
+            WorkingDirectory = toString nodeCfg.dataDir;
 
-          # Hardening
-          NoNewPrivileges = true;
-          PrivateTmp = true;
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) (
-            let
-              rel = lib.removePrefix "/var/lib/" (toString nodeCfg.dataDir);
-            in
-            "${rel} ${rel}/configs ${rel}/logs"
-          );
-          StateDirectoryMode = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) "0750";
-          ReadWritePaths = lib.optionals (!lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) [
-            (toString nodeCfg.dataDir)
-          ];
+            # Hardening
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) (
+              let
+                rel = lib.removePrefix "/var/lib/" (toString nodeCfg.dataDir);
+              in
+              "${rel} ${rel}/configs ${rel}/logs"
+            );
+            StateDirectoryMode = lib.mkIf (lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) "0750";
+            ReadWritePaths =
+              lib.optionals (!lib.hasPrefix "/var/lib/" (toString nodeCfg.dataDir)) [
+                (toString nodeCfg.dataDir)
+              ]
+              ++ cfg.libraryDir;
+          }
+          // lib.optionalAttrs (nodeCfg.environmentFile != null) {
+            EnvironmentFile = nodeCfg.environmentFile;
+          };
         }
-        // lib.optionalAttrs (nodeCfg.environmentFile != null) {
-          EnvironmentFile = nodeCfg.environmentFile;
-        };
-      }
-    ) enabledNodes;
+      ) enabledNodes
+      // lib.mapAttrs' (
+        nodeId: nodeCfg:
+        lib.nameValuePair "tdarr-node-config-${nodeId}" {
+          description = "Apply Tdarr node config via API - ${nodeCfg.name}";
+
+          after = [
+            "network-online.target"
+            "tdarr-node-${nodeId}.service"
+          ]
+          ++ lib.optionals serverEnabled [
+            "tdarr-server.service"
+          ];
+
+          wants = [
+            "network-online.target"
+            "tdarr-node-${nodeId}.service"
+          ]
+          ++ lib.optionals serverEnabled [
+            "tdarr-server.service"
+          ];
+
+          partOf = [ "tdarr-node-${nodeId}.service" ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            User = cfg.user;
+            Group = cfg.group;
+
+            Restart = "on-failure";
+            RestartSec = 5;
+            TimeoutStartSec = 180;
+
+            ExecStart =
+              let
+                nodeUpdatesFile = pkgs.writeText "tdarr-node-updates-${nodeId}.json" (
+                  builtins.toJSON (
+                    nodeCommonConfig nodeCfg
+                    // {
+                      nodeTags = nodeCfg.type;
+                      nodePaused = nodeCfg.startPaused;
+                    }
+                  )
+                );
+              in
+              lib.escapeShellArgs [
+                (lib.getExe nodeConfigSyncScript)
+                nodeCfg.serverURL
+                nodeCfg.name
+                nodeUpdatesFile
+                "${toString nodeCfg.dataDir}/configs/Tdarr_Node_Config.json"
+              ];
+          };
+        }
+      ) enabledNodes;
   };
 }

--- a/nixos/modules/services/misc/tdarr/node.nix
+++ b/nixos/modules/services/misc/tdarr/node.nix
@@ -87,6 +87,42 @@ in
 
                 This is the recommended way to specify the server location.
                 When running a local server, the default value is correct.
+                For a remote server set this to e.g. `"http://192.168.1.100:8266"`.
+              '';
+            };
+
+            serverIP = lib.mkOption {
+              type = lib.types.str;
+              default = "127.0.0.1";
+              defaultText = lib.literalExpression ''"127.0.0.1"'';
+              description = ''
+                IP address of the Tdarr server.
+
+                Although deprecated in favour of
+                {option}`services.tdarr.nodes.<name>.serverURL`, the node
+                binary still reads this field for internal API calls such as
+                `/api/v2/update-node`.  Without it the node falls back to the
+                compiled-in default of `0.0.0.0` and cannot reach the server.
+
+                Set this to the same host as {option}`serverURL`.  For a remote
+                server this should be the server's IP address, e.g.
+                `"192.168.1.100"`.
+              '';
+              example = "192.168.1.100";
+            };
+
+            serverPort = lib.mkOption {
+              type = lib.types.port;
+              default = cfg.server.serverPort;
+              defaultText = lib.literalExpression "config.services.tdarr.server.serverPort";
+              description = ''
+                Port of the Tdarr server API.
+
+                Although deprecated in favour of
+                {option}`services.tdarr.nodes.<name>.serverURL`, the node
+                binary still reads this field for internal API calls.  Must
+                match the port in {option}`serverURL` and the server's
+                {option}`services.tdarr.server.serverPort`.
               '';
             };
 

--- a/nixos/modules/services/misc/tdarr/server.nix
+++ b/nixos/modules/services/misc/tdarr/server.nix
@@ -136,7 +136,7 @@ in
         PrivateTmp = true;
         ProtectSystem = "strict";
         ProtectHome = true;
-        ReadWritePaths = [ cfg.dataDir ];
+        ReadWritePaths = [ cfg.dataDir ] ++ cfg.libraryDir;
       }
       // lib.optionalAttrs (cfg.server.environmentFile != null) {
         EnvironmentFile = cfg.server.environmentFile;

--- a/nixos/modules/services/misc/tdarr/tdarr.md
+++ b/nixos/modules/services/misc/tdarr/tdarr.md
@@ -2,7 +2,7 @@
 
 *Source:* {file}`modules/services/misc/tdarr`
 
-*Upstream documentation:* <https://docs.tdarr.io/\>
+*Upstream documentation:* <https://docs.tdarr.io/>
 
 [Tdarr](https://tdarr.io) is a distributed transcoding system for automating media library transcoding operations using FFmpeg and HandBrake. It provides a web interface for managing transcoding nodes and configuring media processing pipelines.
 
@@ -43,12 +43,21 @@ To run node(s) connecting to a remote server:
 {
   services.tdarr.nodes.worker1 = {
     serverURL = "http://192.168.1.100:8266";
+    serverIP = "192.168.1.100";
+    serverPort = 8266;
     environmentFile = "/run/secrets/tdarr-node-env";
     # /run/secrets/tdarr-node-env contains:
     # apiKey=tapi_your_api_key_here
   };
 }
 ```
+
+::: {.note}
+`serverIP` and `serverPort` must match the host and port in `serverURL`.
+Although these fields are deprecated upstream in favour of `serverURL`, the
+node binary still uses them for internal API calls.  Without them the node
+falls back to `0.0.0.0` and cannot reach the server.
+:::
 
 ## Authentication {#module-services-tdarr-authentication}
 
@@ -167,6 +176,13 @@ Path translators enable cross-mount-point file access by mapping server paths to
 }
 ```
 
+::: {.note}
+`pathTranslators` cannot be set via environment variables (a tdarr upstream
+limitation), so they are written to the node's JSON config file.  The module
+writes all node settings to this file to prevent tdarr from resetting
+`pathTranslators` to its empty default on startup.
+:::
+
 ## Networking {#module-services-tdarr-networking}
 
 ### Firewall Configuration {#module-services-tdarr-networking-firewall}
@@ -188,6 +204,18 @@ Path translators enable cross-mount-point file access by mapping server paths to
     enable = true;
     serverPort = 9266; # default: 8266
     webUIPort = 9265; # default: 8265
+  };
+}
+```
+
+When using a custom server port, update nodes accordingly:
+
+```nix
+{
+  services.tdarr.nodes.main = {
+    serverURL = "http://192.168.1.100:9266";
+    serverIP = "192.168.1.100";
+    serverPort = 9266;
   };
 }
 ```
@@ -266,6 +294,8 @@ Tdarr's distributed architecture allows running nodes on separate machines from 
 {
   services.tdarr.nodes.remote-worker = {
     serverURL = "http://192.168.1.100:8266";
+    serverIP = "192.168.1.100";
+    serverPort = 8266;
     environmentFile = "/run/secrets/tdarr-node-env";
     workers = {
       transcodeCPU = 4;
@@ -276,5 +306,11 @@ Tdarr's distributed architecture allows running nodes on separate machines from 
 ```
 
 ::: {.note}
-Ensure the server's firewall allows incoming connections on the configured ports. Both server and nodes must have access to the same media and transcode cache paths (for mapped nodes).
+`serverIP` and `serverPort` must be set alongside `serverURL` for remote nodes.
+Even though these fields are deprecated upstream, the node binary uses them for
+internal API calls and will attempt `0.0.0.0` if they are absent.
+
+Ensure the server's firewall allows incoming connections on the configured
+ports. Both server and nodes must have access to the same media and transcode
+cache paths (for mapped nodes).
 :::

--- a/nixos/modules/services/misc/tdarr/tdarr.md
+++ b/nixos/modules/services/misc/tdarr/tdarr.md
@@ -167,6 +167,13 @@ Path translators enable cross-mount-point file access by mapping server paths to
 }
 ```
 
+::: {.note}
+`pathTranslators` cannot be set via environment variables (a tdarr upstream
+limitation), so they are written to the node's JSON config file.  The module
+writes all node settings to this file to prevent tdarr from resetting
+`pathTranslators` to its empty default on startup.
+:::
+
 ## Networking {#module-services-tdarr-networking}
 
 ### Firewall Configuration {#module-services-tdarr-networking-firewall}

--- a/nixos/modules/services/misc/tdarr/tdarr.md
+++ b/nixos/modules/services/misc/tdarr/tdarr.md
@@ -2,7 +2,7 @@
 
 *Source:* {file}`modules/services/misc/tdarr`
 
-*Upstream documentation:* <https://docs.tdarr.io/\>
+*Upstream documentation:* <https://docs.tdarr.io/>
 
 [Tdarr](https://tdarr.io) is a distributed transcoding system for automating media library transcoding operations using FFmpeg and HandBrake. It provides a web interface for managing transcoding nodes and configuring media processing pipelines.
 
@@ -43,12 +43,20 @@ To run node(s) connecting to a remote server:
 {
   services.tdarr.nodes.worker1 = {
     serverURL = "http://192.168.1.100:8266";
+    serverIP = "192.168.1.100";
+    serverPort = 8266;
     environmentFile = "/run/secrets/tdarr-node-env";
     # /run/secrets/tdarr-node-env contains:
     # apiKey=tapi_your_api_key_here
   };
 }
 ```
+
+::: {.note}
+`serverIP` and `serverPort` must match the host and port in `serverURL`.
+Although these fields are deprecated upstream in favour of `serverURL`, the node binary still uses them for internal API calls.
+Without them the node falls back to `0.0.0.0` and cannot reach the server.
+:::
 
 ## Authentication {#module-services-tdarr-authentication}
 
@@ -168,10 +176,8 @@ Path translators enable cross-mount-point file access by mapping server paths to
 ```
 
 ::: {.note}
-`pathTranslators` cannot be set via environment variables (a tdarr upstream
-limitation), so they are written to the node's JSON config file.  The module
-writes all node settings to this file to prevent tdarr from resetting
-`pathTranslators` to its empty default on startup.
+`pathTranslators` cannot be set via environment variables (a tdarr upstream limitation), so they are written to the node's JSON config file.
+The module writes all node settings to this file to prevent tdarr from resetting `pathTranslators` to its empty default on startup.
 :::
 
 ## Networking {#module-services-tdarr-networking}
@@ -195,6 +201,18 @@ writes all node settings to this file to prevent tdarr from resetting
     enable = true;
     serverPort = 9266; # default: 8266
     webUIPort = 9265; # default: 8265
+  };
+}
+```
+
+When using a custom server port, update nodes accordingly:
+
+```nix
+{
+  services.tdarr.nodes.main = {
+    serverURL = "http://192.168.1.100:9266";
+    serverIP = "192.168.1.100";
+    serverPort = 9266;
   };
 }
 ```
@@ -273,6 +291,8 @@ Tdarr's distributed architecture allows running nodes on separate machines from 
 {
   services.tdarr.nodes.remote-worker = {
     serverURL = "http://192.168.1.100:8266";
+    serverIP = "192.168.1.100";
+    serverPort = 8266;
     environmentFile = "/run/secrets/tdarr-node-env";
     workers = {
       transcodeCPU = 4;
@@ -283,5 +303,11 @@ Tdarr's distributed architecture allows running nodes on separate machines from 
 ```
 
 ::: {.note}
-Ensure the server's firewall allows incoming connections on the configured ports. Both server and nodes must have access to the same media and transcode cache paths (for mapped nodes).
+`serverIP` and `serverPort` must be set alongside `serverURL` for remote nodes.
+Even though these fields are deprecated upstream, the node binary uses them for
+internal API calls and will attempt `0.0.0.0` if they are absent.
+
+Ensure the server's firewall allows incoming connections on the configured
+ports. Both server and nodes must have access to the same media and transcode
+cache paths (for mapped nodes).
 :::

--- a/nixos/tests/tdarr.nix
+++ b/nixos/tests/tdarr.nix
@@ -16,14 +16,34 @@
         };
         nodes = {
           main = {
+            name = "tdarr-main-custom";
+            serverURL = "http://127.0.0.1:9266";
+            serverIP = "127.0.0.1";
+            serverPort = 9266;
+            environmentFile = pkgs.writeText "tdarr-node-env" ''
+              apiKey=tapi_test_node_key
+            '';
             type = "mapped";
-            priority = -1;
-            pollInterval = 2000;
+            priority = 7;
+            pollInterval = 4321;
             startPaused = false;
-            maxLogSizeMB = 10;
+            maxLogSizeMB = 42;
+            cronPluginUpdate = "*/15 * * * *";
+            pathTranslators = [
+              {
+                server = "/mnt/server/cache";
+                node = "/mnt/node/cache";
+              }
+              {
+                server = "/mnt/server/media";
+                node = "/mnt/node/media";
+              }
+            ];
             workers = {
-              transcodeCPU = 1;
-              healthcheckCPU = 1;
+              transcodeGPU = 1;
+              transcodeCPU = 3;
+              healthcheckGPU = 1;
+              healthcheckCPU = 2;
             };
           };
           secondary = {
@@ -35,6 +55,29 @@
 
   testScript = ''
     import json
+    import time
+
+    def assert_any(value, accepted, message):
+        assert value in accepted, f"{message}: expected one of {accepted}, got {value}"
+
+    def get_node_db_rows():
+        return json.loads(machine.succeed(
+            "curl -sf --max-time 5 -X POST http://localhost:9266/api/v2/cruddb "
+            "-H 'Content-Type: application/json' "
+            "--data '{\"data\":{\"collection\":\"NodeJSONDB\",\"mode\":\"getAll\"}}'"
+        ))
+
+    def wait_for_node_row(node_id, attempts=90, delay=1):
+        rows = []
+        node = None
+        for _ in range(attempts):
+            rows = get_node_db_rows()
+            if isinstance(rows, list):
+                node = next((v for v in rows if v.get("_id") == node_id), None)
+            if node is not None:
+                return node
+            time.sleep(delay)
+        raise AssertionError(f"node row not found for _id={node_id}; rows={rows}")
 
     machine.wait_for_unit("tdarr-server.service")
     machine.wait_for_unit("tdarr-node-main.service")
@@ -50,9 +93,7 @@
         machine.fail("test -d /var/lib/tdarr/nodes/secondary")
 
     with subtest("server environment variables are set correctly"):
-        env = machine.succeed(
-            "systemctl show tdarr-server.service --property=Environment"
-        )
+        env = machine.succeed("systemctl show tdarr-server.service --property=Environment")
         assert "serverPort=9266" in env, f"serverPort not found in: {env}"
         assert "webUIPort=9265" in env, f"webUIPort not found in: {env}"
         assert "serverIP=0.0.0.0" in env, f"serverIP not found in: {env}"
@@ -64,26 +105,27 @@
         assert "cronPluginUpdate=" in env, f"cronPluginUpdate not found in: {env}"
 
     with subtest("node environment variables are set correctly"):
-        env = machine.succeed(
-            "systemctl show tdarr-node-main.service --property=Environment"
-        )
+        env = machine.succeed("systemctl show tdarr-node-main.service --property=Environment")
         assert "serverURL=http://127.0.0.1:9266" in env, f"serverURL not found in: {env}"
+        assert "serverIP=127.0.0.1" in env, f"serverIP not found in: {env}"
+        assert "serverPort=9266" in env, f"serverPort not found in: {env}"
         assert "nodeType=mapped" in env, f"nodeType not found in: {env}"
-        assert "priority=-1" in env, f"priority not found in: {env}"
-        assert "pollInterval=2000" in env, f"pollInterval not found in: {env}"
+        assert "priority=7" in env, f"priority not found in: {env}"
+        assert "pollInterval=4321" in env, f"pollInterval not found in: {env}"
         assert "startPaused=false" in env, f"startPaused not found in: {env}"
-        assert "maxLogSizeMB=10" in env, f"maxLogSizeMB not found in: {env}"
-        assert "transcodecpuWorkers=1" in env, f"transcodecpuWorkers not found in: {env}"
-        assert "healthcheckcpuWorkers=1" in env, f"healthcheckcpuWorkers not found in: {env}"
-        assert "transcodegpuWorkers=0" in env, f"transcodegpuWorkers not found in: {env}"
-        assert "healthcheckgpuWorkers=0" in env, f"healthcheckgpuWorkers not found in: {env}"
+        assert "maxLogSizeMB=42" in env, f"maxLogSizeMB not found in: {env}"
+        assert "cronPluginUpdate=*/15 * * * *" in env, f"cronPluginUpdate not found in: {env}"
+        assert "transcodecpuWorkers=3" in env, f"transcodecpuWorkers not found in: {env}"
+        assert "healthcheckcpuWorkers=2" in env, f"healthcheckcpuWorkers not found in: {env}"
+        assert "transcodegpuWorkers=1" in env, f"transcodegpuWorkers not found in: {env}"
+        assert "healthcheckgpuWorkers=1" in env, f"healthcheckgpuWorkers not found in: {env}"
 
     with subtest("custom ports are listening"):
         machine.wait_for_open_port(9265)
         machine.wait_for_open_port(9266)
 
     with subtest("server reports healthy status"):
-        status = json.loads(machine.succeed("curl -sf http://localhost:9266/api/v2/status"))
+        status = json.loads(machine.succeed("curl -sf --max-time 5 http://localhost:9266/api/v2/status"))
         assert "version" in status, f"version missing from status: {status}"
         assert status.get("uptime", -1) >= 0, f"unexpected uptime in status: {status}"
 
@@ -91,34 +133,48 @@
         html = machine.succeed("curl --fail http://localhost:9265/")
         assert "<!DOCTYPE html>" in html or "<html" in html, f"web UI did not return HTML: {html[:200]}"
 
-    with subtest("node registers with server and reports correct config"):
-        machine.wait_until_succeeds(
-            "curl -sf http://localhost:9266/api/v2/get-nodes | grep -q 'main'"
-        )
-        response = machine.succeed("curl -sf http://localhost:9266/api/v2/get-nodes")
-        nodes = json.loads(response)
-        node = next((v for v in nodes.values() if "main" in v.get("nodeName", "")), None)
-        assert node is not None, f"node 'main' not found in: {nodes}"
-        node_config = node["config"]
-        node_worker_limits = node["workerLimits"]
+    with subtest("node reconnect and config-sync service succeed"):
+        machine.succeed("systemctl restart tdarr-node-main.service")
+        machine.succeed("systemctl start tdarr-node-config-main.service")
+        machine.succeed("systemctl show tdarr-node-config-main.service -p Result --value | grep -q '^success$'")
+        machine.succeed("systemctl show tdarr-node-config-main.service -p ExecMainStatus --value | grep -q '^0$'")
+        journal = machine.succeed("journalctl -u tdarr-node-config-main.service --no-pager -o cat")
+        assert "Tdarr node config sync: waiting for server at http://127.0.0.1:9266" in journal, f"missing wait log: {journal}"
+        assert "Tdarr node config sync: updating NodeJSONDB for tdarr-main-custom" in journal, f"missing update log: {journal}"
+        assert "Tdarr node config sync: merged desired values into /var/lib/tdarr/nodes/main/configs/Tdarr_Node_Config.json" in journal, f"missing merge log: {journal}"
+        assert "pathTranslators" in journal, f"missing pathTranslators log key: {journal}"
+        assert "/mnt/server/cache" in journal and "/mnt/node/cache" in journal, f"missing cache path translation log: {journal}"
+        assert "/mnt/server/media" in journal and "/mnt/node/media" in journal, f"missing media path translation log: {journal}"
 
-        # Worker limits
-        assert node_worker_limits.get("transcodecpu") == 1, f"unexpected transcodecpu worker count: {node}"
-        assert node_worker_limits.get("healthcheckcpu") == 1, f"unexpected healthcheckcpu worker count: {node}"
-        assert node_worker_limits.get("transcodegpu") == 0, f"unexpected transcodegpu worker count: {node}"
-        assert node_worker_limits.get("healthcheckgpu") == 0, f"unexpected healthcheckgpu worker count: {node}"
+    with subtest("node JSON config file contains configured values"):
+      cfg = json.loads(machine.succeed("cat /var/lib/tdarr/nodes/main/configs/Tdarr_Node_Config.json"))
+      assert cfg.get("nodeName") == "tdarr-main-custom", f"unexpected nodeName in config JSON: {cfg}"
+      assert cfg.get("nodeType") == "mapped", f"unexpected nodeType in config JSON: {cfg}"
+      assert cfg.get("serverURL") == "http://127.0.0.1:9266", f"unexpected serverURL in config JSON: {cfg}"
+      assert cfg.get("serverIP") == "127.0.0.1", f"unexpected serverIP in config JSON: {cfg}"
+      assert_any(cfg.get("serverPort"), [9266, "9266"], f"unexpected serverPort in config JSON: {cfg}")
+      assert cfg.get("priority") == 7, f"unexpected priority in config JSON: {cfg}"
+      assert cfg.get("pollInterval") == 4321, f"unexpected pollInterval in config JSON: {cfg}"
+      assert cfg.get("startPaused") == False, f"unexpected startPaused in config JSON: {cfg}"
+      assert_any(cfg.get("maxLogSizeMB"), [42, "42"], f"unexpected maxLogSizeMB in config JSON: {cfg}")
+      assert cfg.get("cronPluginUpdate") == "*/15 * * * *", f"unexpected cronPluginUpdate in config JSON: {cfg}"
+      assert cfg.get("pathTranslators") == [
+        {"server": "/mnt/server/cache", "node": "/mnt/node/cache"},
+        {"server": "/mnt/server/media", "node": "/mnt/node/media"},
+      ], f"unexpected pathTranslators in config JSON: {cfg}"
 
-        # Node config as registered with the server
-        assert "pathTranslators" in node_config, f"pathTranslators missing from node config: {node_config}"
-        assert node_config.get("nodeType") == "mapped", f"unexpected nodeType: {node_config}"
-        assert node_config.get("priority") == -1, f"unexpected priority: {node_config}"
-        assert node_config.get("pollInterval") == 2000, f"unexpected pollInterval: {node_config}"
-        assert node_config.get("startPaused") == False, f"unexpected startPaused: {node_config}"
-        assert node_config.get("maxLogSizeMB") == "10", f"unexpected maxLogSizeMB: {node_config}"
-        assert node_config.get("cronPluginUpdate") == "", f"unexpected cronPluginUpdate: {node_config}"
+    with subtest("node config is persisted via API in NodeJSONDB"):
+        node = wait_for_node_row("tdarr-main-custom")
 
-        # Top-level node state
-        assert node.get("nodePaused") == False, f"unexpected nodePaused: {node}"
+        node_worker_limits = node.get("workerLimits", {})
+        assert node_worker_limits.get("transcodecpu") == 3, f"unexpected transcodecpu worker count: {node}"
+        assert node_worker_limits.get("healthcheckcpu") == 2, f"unexpected healthcheckcpu worker count: {node}"
+        assert node_worker_limits.get("transcodegpu") == 1, f"unexpected transcodegpu worker count: {node}"
+        assert node_worker_limits.get("healthcheckgpu") == 1, f"unexpected healthcheckgpu worker count: {node}"
+
+        assert node.get("_id") == "tdarr-main-custom", f"unexpected node _id: {node}"
         assert node.get("nodeTags") == "mapped", f"unexpected nodeTags: {node}"
+        assert node.get("priority") == 7, f"unexpected priority: {node}"
+        assert node.get("nodePaused") == False, f"unexpected nodePaused: {node}"
   '';
 }


### PR DESCRIPTION
The node config JSON previously only contained `pathTranslators`, leaving all other fields absent. On startup tdarr rewrites its config file with built-in defaults, which resets `pathTranslators` to an empty array and sets `serverIP`/`serverPort` to `0.0.0.0`/`8266`. This caused two bugs:

- `pathTranslators` set via NixOS options had no effect after first start
- Nodes connecting to a remote server would always attempt `http://0.0.0.0:8266` for internal API calls (e.g. /api/v2/update-node) regardless of the configured `serverURL`

Add explicit `serverIP` and `serverPort` options to the node submodule. Although deprecated upstream in favour of `serverURL`, the node binary still reads these fields for internal API calls. Without them the node cannot reach a remote server.

Add a script and one time systemd service to apply the node's configured config to Tdarr's db. This is required due to Tdarr overwriting the json config file at runtime, replacing all values with values declared in the environment, and setting all other values to their default. Using the API these settings can be forced.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
