### PR TITLE
lmstudio: 0.4.8.1 -> 0.4.9.1

### DIFF
--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -7,12 +7,12 @@
 let
   pname = "lmstudio";
 
-  version_aarch64-linux = "0.4.8-1";
-  hash_aarch64-linux = "sha256-3Hk67hRlGdL3ODqgL9CaG+WZpKmGW7fLoxxvB3J/gc0=";
-  version_aarch64-darwin = "0.4.8-1";
-  hash_aarch64-darwin = "sha256-14yQI67dv3R1EqyCzoHfprD2+Vuj5YHRn36tb3U/htw=";
-  version_x86_64-linux = "0.4.8-1";
-  hash_x86_64-linux = "sha256-gbLq6nY3Jdo2nZYWbh0XEVojrqkO5noZLV/lw4TaEs8=";
+  version_aarch64-linux = "0.4.9-1";
+  hash_aarch64-linux = "sha256-fQgXmhkbqTjbW/pyPvyZsIxtkQanpgh1DkzyrbFH6t8=";
+  version_aarch64-darwin = "0.4.9-1";
+  hash_aarch64-darwin = "sha256-MuvYJ5mVC6Usz37DF/TG4M8gOHsKG2uN9qzq+dXNa7M=";
+  version_x86_64-linux = "0.4.9-1";
+  hash_x86_64-linux = "sha256-+vn8gExfdfbYUBVzc59kCDlw7nEbFIyGR0fF9sFFodo=";
 
   meta = {
     description = "LM Studio is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog.](https://lmstudio.ai/changelog/lmstudio-v0.4.9)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
