### PR TITLE
nixos/intune: add package options for intune-portal and microsoft-identity-broker

### DIFF
--- a/nixos/modules/services/security/intune.nix
+++ b/nixos/modules/services/security/intune.nix
@@ -10,6 +10,8 @@ in
 {
   options.services.intune = {
     enable = lib.mkEnableOption "Microsoft Intune";
+    intune-portal.package = lib.mkPackageOption pkgs "intune-portal" { };
+    microsoft-identity-broker.package = lib.mkPackageOption pkgs "microsoft-identity-broker" { };
   };
 
   config = lib.mkIf cfg.enable {
@@ -20,16 +22,16 @@ in
 
     users.groups.microsoft-identity-broker = { };
     environment.systemPackages = [
-      pkgs.microsoft-identity-broker
-      pkgs.intune-portal
+      cfg.intune-portal.package
+      cfg.microsoft-identity-broker.package
     ];
     systemd.packages = [
-      pkgs.microsoft-identity-broker
-      pkgs.intune-portal
+      cfg.microsoft-identity-broker.package
+      cfg.intune-portal.package
     ];
 
-    systemd.tmpfiles.packages = [ pkgs.intune-portal ];
-    services.dbus.packages = [ pkgs.microsoft-identity-broker ];
+    systemd.tmpfiles.packages = [ cfg.intune-portal.package ];
+    services.dbus.packages = [ cfg.microsoft-identity-broker.package ];
   };
 
   meta = {

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -80,6 +80,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -a opt/microsoft/intune/bin/* $out/bin/
     cp -a usr/share $out
+    cp -a opt/microsoft/intune/share/* $out/share/
     cp -a lib $out
     mkdir -p $out/lib/security
     cp -a ./usr/lib/x86_64-linux-gnu/security/pam_intune.so $out/lib/security/


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package updates:

* **intune-portal**: ensure i18n files are copied at installPhase.

Module updates:

* Added `intune-portal.package` and `microsoft-identity-broker.package` in nixos module, so users can pin to an older version easier in case future update break things.

Tested locally on NixOS 25.11:

*Note: the operating system being `ubuntu` is due to my local hack changing lsb-release to pass company compliance check, this is not an effect of the intune module*

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6d9e96b5-d291-4c86-acd5-b07adc1aeec3" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
