### PR TITLE
shotcut: fixed for darwin

### DIFF
--- a/pkgs/by-name/sh/shotcut/package.nix
+++ b/pkgs/by-name/sh/shotcut/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  makeWrapper,
   stdenv,
   replaceVars,
   SDL2,
@@ -18,91 +19,116 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "shotcut";
-  version = "26.2.26";
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    # Override mlt to disable the JACKRACK module. There's a header generation race
+    # that breaks parallel builds on Darwin. LADSPA plugins don't exist on macOS, regardless.
+    mlt =
+      if stdenv.hostPlatform.isDarwin then
+        qt6Packages.mlt.overrideAttrs (old: {
+          cmakeFlags = (old.cmakeFlags or [ ]) ++ [ "-DMOD_JACKRACK=OFF" ];
+        })
+      else
+        qt6Packages.mlt;
+  in
+  {
+    pname = "shotcut";
+    version = "26.2.26";
 
-  src = fetchFromGitHub {
-    owner = "mltframework";
-    repo = "shotcut";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-dOkk2LGFtuCvec8NGoSIjAXQsCZcnx2fB3h6KWFeHj4=";
-  };
+    src = fetchFromGitHub {
+      owner = "mltframework";
+      repo = "shotcut";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-dOkk2LGFtuCvec8NGoSIjAXQsCZcnx2fB3h6KWFeHj4=";
+    };
 
-  nativeBuildInputs = [
-    pkg-config
-    cmake
-    qt6.wrapQtAppsHook
-    wrapGAppsHook3
-  ];
-
-  buildInputs = [
-    SDL2
-    frei0r
-    ladspaPlugins
-    gettext
-    qt6Packages.mlt
-    fftw
-    qt6.qtbase
-    qt6.qttools
-    qt6.qtmultimedia
-    qt6.qtcharts
-    qt6.qtwayland
-    qt6.qtwebsockets
-  ];
-
-  env.NIX_CFLAGS_COMPILE = "-DSHOTCUT_NOUPGRADE";
-
-  cmakeFlags = [ "-DSHOTCUT_VERSION=${finalAttrs.version}" ];
-
-  patches = [
-    (replaceVars ./fix-mlt-ffmpeg-path.patch {
-      inherit ffmpeg;
-      mlt = qt6Packages.mlt;
-    })
-  ];
-
-  dontWrapGApps = true;
-
-  qtWrapperArgs = [
-    "--set FREI0R_PATH ${frei0r}/lib/frei0r-1"
-    "--set LADSPA_PATH ${ladspaPlugins}/lib/ladspa"
-    "--prefix LD_LIBRARY_PATH : ${
-      lib.makeLibraryPath ([ SDL2 ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ jack1 ])
-    }"
-  ];
-
-  preFixup = ''
-    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
-
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir $out/Applications $out/bin
-    mv $out/Shotcut.app $out/Applications/Shotcut.app
-    ln -s $out/Applications/Shotcut.app/Contents/MacOS/Shotcut $out/bin/shotcut
-  '';
-
-  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
-
-  meta = {
-    description = "Free, open source, cross-platform video editor";
-    longDescription = ''
-      An official binary for Shotcut, which includes all the
-      dependencies pinned to specific versions, is provided on
-      http://shotcut.org.
-
-      If you encounter problems with this version, please contact the
-      nixpkgs maintainer(s). If you wish to report any bugs upstream,
-      please use the official build from shotcut.org instead.
-    '';
-    homepage = "https://shotcut.org";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      woffs
-      peti
-      nick-linux
+    nativeBuildInputs = [
+      pkg-config
+      cmake
+      makeWrapper
+      qt6.wrapQtAppsHook
+      wrapGAppsHook3
     ];
-    platforms = lib.platforms.unix;
-    mainProgram = "shotcut";
-  };
-})
+
+    buildInputs = [
+      SDL2
+      frei0r
+      ladspaPlugins
+      gettext
+      mlt
+      fftw
+      qt6.qtbase
+      qt6.qttools
+      qt6.qtmultimedia
+      qt6.qtcharts
+      qt6.qtwebsockets
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      qt6.qtwayland
+    ];
+
+    env.NIX_CFLAGS_COMPILE = "-DSHOTCUT_NOUPGRADE";
+
+    cmakeFlags = [ "-DSHOTCUT_VERSION=${finalAttrs.version}" ];
+
+    patches = [
+      (replaceVars ./fix-mlt-ffmpeg-path.patch {
+        inherit ffmpeg mlt;
+      })
+    ];
+
+    # Prevent wrapGAppsHook from creating its own separate wrapper
+    dontWrapGApps = true;
+
+    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications $out/bin
+      mv $out/Shotcut.app $out/Applications/Shotcut.app
+      ln -s $out/Applications/Shotcut.app/Contents/MacOS/Shotcut $out/bin/shotcut
+    '';
+
+    preFixup = ''
+      qtWrapperArgs+=(
+        "''${gappsWrapperArgs[@]}"
+        --set FREI0R_PATH ${frei0r}/lib/frei0r-1
+        --set LADSPA_PATH ${ladspaPlugins}/lib/ladspa
+      )
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      qtWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath ([ SDL2 ] ++ lib.optionals stdenv.hostPlatform.isLinux [ jack1 ])
+        }
+      )
+    '';
+
+    postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      wrapQtApp "$out/Applications/Shotcut.app/Contents/MacOS/Shotcut"
+    '';
+
+    passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+    meta = {
+      description = "Free, open source, cross-platform video editor";
+      longDescription = ''
+        An official binary for Shotcut, which includes all the
+        dependencies pinned to specific versions, is provided on
+        http://shotcut.org.
+
+        If you encounter problems with this version, please contact the
+        nixpkgs maintainer(s). If you wish to report any bugs upstream,
+        please use the official build from shotcut.org instead.
+      '';
+      homepage = "https://shotcut.org";
+      license = lib.licenses.gpl3Plus;
+      maintainers = with lib.maintainers; [
+        woffs
+        peti
+        nick-linux
+        philocalyst
+      ];
+      platforms = lib.platforms.unix;
+      mainProgram = "shotcut";
+    };
+  }
+)


### PR DESCRIPTION
brings to compilation, but seems to have very inconsistent startup behavior, freqently crashes, but I don't know if this is shotcuts fault.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
