### PR TITLE
python3Packages.pycasperglow: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pycasperglow/default.nix
+++ b/pkgs/development/python-modules/pycasperglow/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  bleak,
+  bleak-retry-connector,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pycasperglow";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mikeodr";
+    repo = "pycasperglow";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sLjEo8GSGBtx0GDAHQZad5ePQAwzChdmBE5TU+ebuFI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    bleak
+    bleak-retry-connector
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pycasperglow" ];
+
+  meta = {
+    description = "Async Python library for controlling Casper Glow lights via BLE";
+    homepage = "https://github.com/mikeodr/pycasperglow";
+    changelog = "https://github.com/mikeodr/pycasperglow/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -908,11 +908,12 @@
         home-assistant-intents
         ifaddr
         mutagen
+        pycasperglow
         pymicro-vad
         pyspeex-noise
         serialx
         zeroconf
-      ]; # missing inputs: pycasperglow
+      ];
     "cast" =
       ps: with ps; [
         aiohasupervisor
@@ -7565,6 +7566,7 @@
     "cambridge_audio"
     "camera"
     "canary"
+    "casper_glow"
     "cast"
     "ccm15"
     "cert_expiry"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13516,6 +13516,8 @@ self: super: with self; {
 
   pycasbin = callPackage ../development/python-modules/pycasbin { };
 
+  pycasperglow = callPackage ../development/python-modules/pycasperglow { };
+
   pycatch22 = callPackage ../development/python-modules/pycatch22 { };
 
   pycayennelpp = callPackage ../development/python-modules/pycayennelpp { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/casper_glow/
- https://pypi.org/project/pycasperglow/
- https://github.com/mikeodr/pycasperglow

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
