### PR TITLE
lovely-injector: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/lo/lovely-injector/package.nix
+++ b/pkgs/by-name/lo/lovely-injector/package.nix
@@ -7,7 +7,7 @@
   cmake,
 }:
 let
-  version = "0.8.0";
+  version = "0.9.0";
 in
 rustPlatform.buildRustPackage {
   pname = "lovely-injector";
@@ -16,11 +16,11 @@ rustPlatform.buildRustPackage {
     owner = "ethangreen-dev";
     repo = "lovely-injector";
     tag = "v${version}";
-    hash = "sha256-leTe7j4RTqc6BkiS7W5e0viK8FEwJpPLNoyf4GLOI3E=";
+    hash = "sha256-TzBxyIf7MjzsdFaJLBp2dXWNj5sOXyoMifaaztNIOog=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-MnXB2ho48VPYtFSnGHGkuSv1eprOhmj4wMG2YmFSGec=";
+  cargoHash = "sha256-4ECH8E/GuV2NYvvjSkanmj4gPIahY40HlCrhR2aFJ5M=";
   cargoBuildFlags = [
     "--package"
     "lovely-unix"


### PR DESCRIPTION
Changelog: https://github.com/ethangreen-dev/lovely-injector/releases/tag/v0.9.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
