### PR TITLE
doc: fix `nix repl` command usage in NixOS manual

### DIFF
--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -17,7 +17,7 @@ Each supported language or software ecosystem has its own package set named `<la
   # Navigate Java compiler variants in `javaPackages` with `nix repl`
 
   ```shell-session
-  $ nix repl '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable
+  $ nix repl -f '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable
   nix-repl> javaPackages.<tab>
   javaPackages.compiler               javaPackages.openjfx15              javaPackages.openjfx21              javaPackages.recurseForDerivations
   javaPackages.jogl_2_4_0             javaPackages.openjfx17              javaPackages.openjfx25

--- a/nixos/doc/manual/configuration/modularity.section.md
+++ b/nixos/doc/manual/configuration/modularity.section.md
@@ -113,7 +113,7 @@ Interactive exploration of the configuration is possible using `nix
   repl`, a read-eval-print loop for Nix expressions. A typical use:
 
 ```ShellSession
-$ nix repl '<nixpkgs/nixos>'
+$ nix repl -f '<nixpkgs/nixos>'
 
 nix-repl> config.networking.hostName
 "mandark"

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -285,7 +285,7 @@ A complete list of options for the PostgreSQL module may be found [here](#opt-se
 
 The collection of plugins for each PostgreSQL version can be accessed with `.pkgs`. For example, for the `pkgs.postgresql_15` package, its plugin collection is accessed by `pkgs.postgresql_15.pkgs`:
 ```ShellSession
-$ nix repl '<nixpkgs>'
+$ nix repl -f '<nixpkgs>'
 
 Loading '<nixpkgs>'...
 Added 10574 variables.


### PR DESCRIPTION
I think there are various other places where this is wrong in the manual.

`nix repl` now needs the `-f` flag when used with `'<nixpkgs/nixos>'`