### PR TITLE
openjdk26: init at 26-ga

### DIFF
--- a/pkgs/by-name/op/openjfx/26/deps.json
+++ b/pkgs/by-name/op/openjfx/26/deps.json
@@ -1,0 +1,142 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://download.eclipse.org": {
+  "eclipse/updates/4.30/R-4.30-202312010110/plugins/org.eclipse.swt.gtk.linux.x86_64_3.124.200.v20231113-1355": {
+   "jar": "sha256-Q048o4oWnZ9Y33AxXiSxbxEeayfbWOf1HoxtoLS4SIs="
+  }
+ },
+ "https://github.com": {
+  "unicode-org/icu/releases/download/release-77-1/icu4c-77_1-data-bin-l": {
+   "zip": "sha256-CRNnT/ZzxYX4vAg3CRa2pszDD/tkCKXBvD7b9aaH/ZY="
+  }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "com/ibm/icu#icu4j/61.1": {
+   "jar": "sha256-VcmOsYOLKku5oH3Da9N4Uy1k0M3LfO7pFCNoZqfeRGQ=",
+   "pom": "sha256-E7h6QHnOsFUVsZrHoVIDlHB1YB1JQj9xk1ikmACYBWs="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "org/abego/treelayout#org.abego.treelayout.core/1.0.3": {
+   "jar": "sha256-+l4xOVw5wufUasoPgfcgYJMWB7L6Qb02A46yy2+5MyY=",
+   "pom": "sha256-o7KyI3lDcDVeeSQzrwEvyZNmfAMxviusrYTbwJrOSgw="
+  },
+  "org/antlr#ST4/4.1": {
+   "jar": "sha256-ixzK7Z7cVc0lXZwZxNjaR1bZtvy0NWcSkrQ0cLFtddg=",
+   "pom": "sha256-cz5r2XyjTMbfk6QkPlEeVnPLm4jHSxiETgQqRdUWmHw="
+  },
+  "org/antlr#antlr-master/3.5.2": {
+   "pom": "sha256-QtkaUx6lEA6wm1QaoALDuQjo8oK9c7bi9S83HvEzG9Y="
+  },
+  "org/antlr#antlr-runtime/3.5.2": {
+   "jar": "sha256-zj/I7LEPOemjzdy7LONQ0nLZzT0LHhjm/nPDuTichzQ=",
+   "pom": "sha256-RqnCIAu4sSvXEkqnpQl/9JCZkIMpyFGgTLIFFCCqfyU="
+  },
+  "org/antlr#antlr4-master/4.7.2": {
+   "pom": "sha256-upnLJdI5DzhoDHUChCoO4JWdHmQD4BPM/2mP1YVu6tE="
+  },
+  "org/antlr#antlr4-runtime/4.7.2": {
+   "jar": "sha256-TFGLh9S9/4tEzYy8GvgW6US2Kj/luAt4FQHPH0dZu8Q=",
+   "pom": "sha256-3AnLqYwl08BuSuxRaIXUw68DBiulX0/mKD/JzxdqYPs="
+  },
+  "org/antlr#antlr4/4.7.2": {
+   "pom": "sha256-z56zaUD6xEiBA4wb4/LFjgbmjRq/v9SmjTS72LrFV3E="
+  },
+  "org/antlr#antlr4/4.7.2/complete": {
+   "jar": "sha256-aFI4bXl17/KRcdrgAswiMlFRDTXyka4neUjzgaezgLQ="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache/lucene#lucene-core/7.7.3": {
+   "jar": "sha256-jrAzNcGjxqixiN9012G6qDVplTWCq0QLU0yIRJ6o4N4=",
+   "pom": "sha256-gvilIoHGyLp5dKy6rESzLXbiYAgvP0u+FlwPbkuJFCo="
+  },
+  "org/apache/lucene#lucene-grouping/7.7.3": {
+   "jar": "sha256-L1vNY7JXQ9MMMTmGIk0Qf3XFKThxSVQlNRDFfT9nvrg=",
+   "pom": "sha256-HwStk+IETUCP2SXu4K6ktKHvjAdXe0Jme7U2BgKCImU="
+  },
+  "org/apache/lucene#lucene-parent/7.7.3": {
+   "pom": "sha256-6PrdU9XwBMQN3SNdQ4ZI5yxyVZn+4VQ+ViTV+1AQcwU="
+  },
+  "org/apache/lucene#lucene-queries/7.7.3": {
+   "jar": "sha256-PLWS2wpulWnGrMvbiKmtex2nQo28p5Ia0cWlhl1bQiY=",
+   "pom": "sha256-rkBsiiuw12SllERCefRiihl2vQlB551CzmTgmHxYnFA="
+  },
+  "org/apache/lucene#lucene-queryparser/7.7.3": {
+   "jar": "sha256-F3XJ/o7dlobTt6ZHd4+kTqqW8cwMSZMVCHEz4amDnoQ=",
+   "pom": "sha256-z2klkhWscjC5+tYKXInKDp9bm6rM7dFGlY/76Q9OsNI="
+  },
+  "org/apache/lucene#lucene-sandbox/7.7.3": {
+   "jar": "sha256-VfG38J2uKwytMhw00Vw8/FmgIRviM/Yp0EbEK/FwErc=",
+   "pom": "sha256-1vbdxsz1xvymRH1HD1BJ4WN6xje/HbWuDV8WaP34EiI="
+  },
+  "org/apache/lucene#lucene-solr-grandparent/7.7.3": {
+   "pom": "sha256-Oig3WAynavNq99/i3B0zT8b/XybRDySJnbd3CtfP2f4="
+  },
+  "org/apiguardian#apiguardian-api/1.1.2": {
+   "jar": "sha256-tQlEisUG1gcxnxglN/CzXXEAdYLsdBgyofER5bW3Czg=",
+   "module": "sha256-4IAoExN1s1fR0oc06aT7QhbahLJAZByz7358fWKCI/w=",
+   "pom": "sha256-MjVQgdEJCVw9XTdNWkO09MG3XVSemD71ByPidy5TAqA="
+  },
+  "org/glassfish#javax.json/1.0.4": {
+   "jar": "sha256-Dh3sQKHt6WWUElHtqWiu7gUsxPUDeLwxbMSOgVm9vrQ=",
+   "pom": "sha256-a6+Dg/+pi2bqls1b/B7H8teUY7uYrJgFKWSxIcIhLVQ="
+  },
+  "org/glassfish#json/1.0.4": {
+   "pom": "sha256-bXxoQjEV+SFxjZRPhZkktMaFIX7AOkn3BFWossqpcuY="
+  },
+  "org/junit#junit-bom/5.12.2": {
+   "module": "sha256-3nCsXZGlJlbYiQptI7ngTZm5mxoEAlMN7K1xvzGyc14=",
+   "pom": "sha256-zvgP7IZFT2gGv7DfJGabXG8y4styhTnqhZ9H39ybvBc="
+  },
+  "org/junit/jupiter#junit-jupiter-api/5.12.2": {
+   "jar": "sha256-C5ynKOS82a3FfyneuVVv+e1eCLTohDuHWrpOTj4E8JI=",
+   "module": "sha256-VFfyRO3hjRFzbwfrnF8wklrrCW5Cw1m2oEqaDgOyKes=",
+   "pom": "sha256-VmKCFmSJvUCxLDUHuZXkj44CXgmgXn0W3SuY3GQs994="
+  },
+  "org/junit/jupiter#junit-jupiter-engine/5.12.2": {
+   "jar": "sha256-9XbAa4rM3pmFBjuLyAUmy5gO7CTe4LciH8jd16zmWAA=",
+   "module": "sha256-0W0wjmqiWjCz75JNnf5PiJqb/ybqvXLvMO6oH864SBU=",
+   "pom": "sha256-PHGRdFCb6dsfqBesY7eLIfH2fQaL5HHaPQR4G9RAKqM="
+  },
+  "org/junit/jupiter#junit-jupiter-params/5.12.2": {
+   "jar": "sha256-shn/qUm5CnGqO2wrYGRWuCvKCyCJt0Wcj/RhFW/1mw8=",
+   "module": "sha256-x3KP8z0SJgBzLq09DW+K3XRd4+lEFRmHE5WuiZymFHQ=",
+   "pom": "sha256-pcfvF8refV90q2IHK7xrxxy9AWgGJGvOQl/LvBEISTw="
+  },
+  "org/junit/jupiter#junit-jupiter/5.12.2": {
+   "jar": "sha256-OFSzrUNJBrgn/sR0qg2NqLVunlbV/H8uIPw/EuxL6JQ=",
+   "module": "sha256-ioIpqKD4Se/BzD/9XPlN4W6sgAYcX5M5eoXAk8nX6nA=",
+   "pom": "sha256-ka2OSkvzBCMslByQFKyRNnvroTHx21jVv+SZx5DUbxc="
+  },
+  "org/junit/platform#junit-platform-commons/1.12.2": {
+   "jar": "sha256-5oOgHoXfq+pSDAVqxgFaYWJ1bmAuxlPA2oXiM/CvvBg=",
+   "module": "sha256-ZMeQwnpztFz8b4TMtotI92SQNIZ+Fo1iJ1TUlmkrwic=",
+   "pom": "sha256-TyuKkGXJCcaJLYYi1VO2qwpwMhYkSZ47acEon1nswHc="
+  },
+  "org/junit/platform#junit-platform-engine/1.12.2": {
+   "jar": "sha256-zvDvy1vS4F4rgI04urXGVQicDDABUnN250y2BqeRHsg=",
+   "module": "sha256-+Xsxk2wRnAgtTQOM3resDmVvRR2eXX6Jg9IqJONvoQM=",
+   "pom": "sha256-lICxinlldp0Ag8LLcRBUI/UwKo8Ea7IEfm2/8J84NJA="
+  },
+  "org/junit/platform#junit-platform-launcher/1.12.2": {
+   "jar": "sha256-3M8sH6Cpd8U60JSthZv93dUk2XWUt2MHrXh95xmFdX8=",
+   "module": "sha256-UKBqBDdOMA57hhWIxdwNAhQh4Z8ToL2ymwYX/y/ehdE=",
+   "pom": "sha256-YZFFzSFdMiJTcr5iW7ooaD10FC/uGl39scZLUv6cC1E="
+  },
+  "org/opentest4j#opentest4j/1.3.0": {
+   "jar": "sha256-SOLfY2yrZWPO1k3N/4q7I1VifLI27wvzdZhoLd90Lxs=",
+   "module": "sha256-SL8dbItdyU90ZSvReQD2VN63FDUCSM9ej8onuQkMjg0=",
+   "pom": "sha256-m/fP/EEPPoNywlIleN+cpW2dQ72TfjCUhwbCMqlDs1U="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  }
+ }
+}

--- a/pkgs/by-name/op/openjfx/26/source.json
+++ b/pkgs/by-name/op/openjfx/26/source.json
@@ -1,0 +1,6 @@
+{
+  "hash": "sha256-22ktloVRCw2+a9MbwspdOuNOIyszBDpahGSuT45/Qes=",
+  "owner": "openjdk",
+  "repo": "jfx26u",
+  "rev": "refs/tags/26-ga"
+}

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -36,11 +36,13 @@
   jdk17_headless,
   jdk21_headless,
   jdk25_headless,
+  jdk26_headless,
   jdk-bootstrap ?
     {
       "17" = jdk17_headless;
       "21" = jdk21_headless;
       "25" = jdk25_headless;
+      "26" = jdk26_headless;
     }
     .${featureVersion},
 }:

--- a/pkgs/development/compilers/openjdk/26/source.json
+++ b/pkgs/development/compilers/openjdk/26/source.json
@@ -1,0 +1,6 @@
+{
+  "hash": "sha256-kR++u1rVL1SkAa9l657Qz/m+eONJsvmoag8ZpX1moug=",
+  "owner": "openjdk",
+  "repo": "jdk26u",
+  "rev": "refs/tags/jdk-26-ga"
+}

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -1,6 +1,5 @@
 {
   featureVersion,
-
   lib,
   stdenv,
 
@@ -59,11 +58,13 @@
   openjfx17,
   openjfx21,
   openjfx25,
+  openjfx26,
   openjfx_jdk ?
     {
       "17" = openjfx17;
       "21" = openjfx21;
       "25" = openjfx25;
+      "26" = openjfx26;
     }
     .${featureVersion} or (throw "JavaFX is not supported on OpenJDK ${featureVersion}"),
 
@@ -77,6 +78,7 @@
   temurin-bin-17,
   temurin-bin-21,
   temurin-bin-25,
+  temurin-bin-26,
   jdk-bootstrap ?
     {
       "8" = temurin-bin-8.__spliced.buildBuild or temurin-bin-8;
@@ -84,6 +86,7 @@
       "17" = temurin-bin-17.__spliced.buildBuild or temurin-bin-17;
       "21" = temurin-bin-21.__spliced.buildBuild or temurin-bin-21;
       "25" = temurin-bin-25.__spliced.buildBuild or temurin-bin-25;
+      "26" = temurin-bin-26.__spliced.buildBuild or temurin-bin-26;
     }
     .${featureVersion},
 }:
@@ -100,6 +103,7 @@ let
   atLeast21 = lib.versionAtLeast featureVersion "21";
   atLeast23 = lib.versionAtLeast featureVersion "23";
   atLeast25 = lib.versionAtLeast featureVersion "25";
+  atLeast26 = lib.versionAtLeast featureVersion "26";
 
   tagPrefix = if atLeast11 then "jdk-" else "jdk";
   version = lib.removePrefix "refs/tags/${tagPrefix}" source.src.rev;
@@ -143,7 +147,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (
-      if atLeast25 then
+      if atLeast26 then
+        { }
+      else if atLeast25 then
         ./25/patches/fix-java-home-jdk25.patch
       else if atLeast21 then
         ./21/patches/fix-java-home-jdk21.patch

--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-feature_versions = (8, 11, 17, 21, 25)
+feature_versions = (8, 11, 17, 21, 25, 26)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
 impls = ("hotspot",)

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -21,4 +21,7 @@ in
 
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
+
+  jdk-26 = common { sourcePerArch = sources.jdk.openjdk26; };
+  jre-26 = common { sourcePerArch = sources.jre.openjdk26; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
@@ -86,7 +86,6 @@ let
 
     installPhase = ''
       cd ..
-
       mv $sourceRoot $out
 
       # jni.h expects jni_md.h to be in the header search path.

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -26,4 +26,8 @@ in
 
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
+
+  jdk-26 = common { sourcePerArch = sources.jdk.openjdk26; };
+  jre-26 = common { sourcePerArch = sources.jre.openjdk26; };
+
 }

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -54,6 +54,22 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "049027647a2d1cf3b1e3c1e7dad746aa6436928932bbed9130b87a25f585908a",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_aarch64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "c105e581fdccb4e7120d889235d1ad8d5b2bed0af4972bc881e0a8ba687c94a4",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -116,6 +132,22 @@
             "sha256": "aa5160aa130f0f0b4379fc62a0d5198c065815224e01318272864e56f260de34",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jre_x64_alpine-linux_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "f3c21f425f9e9f53ab8a19aed6a25cedee662be19fa221696c1450eb67470905",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_aarch64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "4f0866bd8aa88eb6dfd0489793f8b2fb3eb0f6c20aadb27cae1b140f10897f8e",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
           }
         },
         "openjdk8": {
@@ -260,6 +292,28 @@
             "sha256": "ee04de95ab9da7287d40bd2173076ecc2a6dd662f007bedfc6eb0380c0ef90e8",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jdk_x64_linux_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "e8ff1f23c5acef74d1b4937dadd67286d67be06758f5d9dca5478c35bf404e83",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_aarch64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "35",
+            "sha256": "7396fc32c311429c4b1573ebfc98eca6b82c2735f9f0e23acbccdcb43e0edee9",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_ppc64le_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "68e19ba53b7f1f74635c13f809e5db36cebccf3ae9e752423dd92d2ad7d831ef",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
           }
         },
         "openjdk8": {
@@ -428,6 +482,28 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "460dff59e58d77980d8f3aa3172f53d09c17beca1a16b5762f388aee8c91656c",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_aarch64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "35",
+            "sha256": "f6d3b8e1f76c1dac5c9955ba77571e8e77aa02724f7423737627244174f41d5e",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_ppc64le_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "3a65331f4c4b671a5e5bb3ae4e4a65fd0eb5bf8672c0c2fba6ba36972c4042a4",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -530,6 +606,22 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "596ba026474808b75e934aa8c32cf9b340fafc455d06f366ede4f2932f206eb1",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_aarch64_mac_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "a5cabec41a19e83e33fde381a978f93bc7f5bd5accadf5b7c34770f08f4b5504",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_mac_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -604,6 +696,22 @@
             "sha256": "70843c642a998d627aa3731535493fcb2ac94dac8ad5b24516fd89ebec094c4d",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jre_x64_mac_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "935060cf2e94875da1e4ffd7028a88efc87261f3843bf77520c6276ed4c6e46d",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_aarch64_mac_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "67d8049ff31ca1ffe3329162c0ed895cc074e37a19dd2c43ac3121ec3d889084",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_mac_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
           }
         },
         "openjdk8": {

--- a/pkgs/development/compilers/zulu/26.nix
+++ b/pkgs/development/compilers/zulu/26.nix
@@ -1,0 +1,58 @@
+{
+  callPackage,
+  enableJavaFX ? false,
+  ...
+}@args:
+
+let
+  # FX and non-FX versions can differ
+  zuluVersion = if enableJavaFX then "26.28.63" else "26.28.59";
+in
+callPackage ./common.nix (
+  {
+    # Details from https://www.azul.com/downloads/?version=java-26&package=jdk
+    # Note that the latest build may differ by platform
+    dists = {
+      x86_64-linux = {
+        inherit zuluVersion;
+        jdkVersion = "26.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-G9cMHwzNLF4B+ktHkbG0tCqf2PCpowfGf3ugySAPhzs="
+          else
+            "sha256-tjdGK5wWv7lV8CQKTN1WOPlSP7Nd4We8oYnThHXxk/0=";
+      };
+
+      aarch64-linux = {
+        inherit zuluVersion;
+        jdkVersion = "26.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-p9PxZjLgcGgxuQcf8inWySseI3SbCr5JgK0mLBZ68NI="
+          else
+            "sha256-eX/at6DSefwfWedxD7AxzyC9DUvjZvHaFRAJ+ptdPKA=";
+      };
+
+      x86_64-darwin = {
+        inherit zuluVersion;
+        jdkVersion = "26.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-WKv3CC8OgAmXaxremyAv0xegCVynyaCHrr+EvxbpLIc="
+          else
+            "sha256-Oo1SDGPurZ2nZRcpG15Y3rySO1rXpIplSAWhWm8IB/k=";
+      };
+
+      aarch64-darwin = {
+        inherit zuluVersion;
+        jdkVersion = "26.0.0";
+        hash =
+          if enableJavaFX then
+            "sha256-GSI3mLyQ/ELtYLQdN0Yc7XQrn5bH9on88qY7sfRhTxk="
+          else
+            "sha256-99FRrcyRtqJROYMGawyh20Cd+Z16OoesMbIeYMl4pcc=";
+      };
+    };
+  }
+  // removeAttrs args [ "callPackage" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3727,6 +3727,9 @@ with pkgs;
   powerline = with python3Packages; toPythonApplication powerline;
 
   ### DEVELOPMENT / COMPILERS
+  temurin-bin-26 = javaPackages.compiler.temurin-bin.jdk-26;
+  temurin-jre-bin-26 = javaPackages.compiler.temurin-bin.jre-26;
+
   temurin-bin-25 = javaPackages.compiler.temurin-bin.jdk-25;
   temurin-jre-bin-25 = javaPackages.compiler.temurin-bin.jre-25;
 
@@ -3742,8 +3745,8 @@ with pkgs;
   temurin-bin-8 = javaPackages.compiler.temurin-bin.jdk-8;
   temurin-jre-bin-8 = javaPackages.compiler.temurin-bin.jre-8;
 
-  temurin-bin = temurin-bin-21;
-  temurin-jre-bin = temurin-jre-bin-21;
+  temurin-bin = temurin-bin-25;
+  temurin-jre-bin = temurin-jre-bin-25;
 
   semeru-bin-21 = javaPackages.compiler.semeru-bin.jdk-21;
   semeru-jre-bin-21 = javaPackages.compiler.semeru-bin.jre-21;
@@ -4352,6 +4355,7 @@ with pkgs;
   openjfx17 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "17"; };
   openjfx21 = openjfx;
   openjfx25 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "25"; };
+  openjfx26 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "26"; };
 
   openjdk8-bootstrap = javaPackages.compiler.openjdk8-bootstrap;
   openjdk8 = javaPackages.compiler.openjdk8;
@@ -4383,9 +4387,14 @@ with pkgs;
   jdk25 = openjdk25;
   jdk25_headless = openjdk25_headless;
 
+  openjdk26 = javaPackages.compiler.openjdk26;
+  openjdk26_headless = javaPackages.compiler.openjdk26.headless;
+  jdk26 = openjdk26;
+  jdk26_headless = openjdk26_headless;
+
   # default JDK
-  jdk = jdk21;
-  jdk_headless = jdk21_headless;
+  jdk = jdk25;
+  jdk_headless = jdk25_headless;
 
   # Since the introduction of the Java Platform Module System in Java 9, Java
   # no longer ships a separate JRE package.
@@ -4414,6 +4423,10 @@ with pkgs;
       jre25_minimal = callPackage ../development/compilers/openjdk/jre.nix {
         jdk = jdk25;
         jdkOnBuild = buildPackages.jdk25;
+      };
+      jre26_minimal = callPackage ../development/compilers/openjdk/jre.nix {
+        jdk = jdk26;
+        jdkOnBuild = buildPackages.jdk26;
       };
       jre_minimal = callPackage ../development/compilers/openjdk/jre.nix {
         jdkOnBuild = buildPackages.jdk;
@@ -4876,12 +4889,14 @@ with pkgs;
       zulu17 = callPackage ../development/compilers/zulu/17.nix { };
       zulu21 = callPackage ../development/compilers/zulu/21.nix { };
       zulu25 = callPackage ../development/compilers/zulu/25.nix { };
+      zulu26 = callPackage ../development/compilers/zulu/26.nix { };
     })
     zulu8
     zulu11
     zulu17
     zulu21
     zulu25
+    zulu26
     ;
   zulu = zulu21;
 

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -8,7 +8,12 @@ let
     ;
 in
 {
-  inherit (pkgs) openjfx17 openjfx21 openjfx25;
+  inherit (pkgs)
+    openjfx17
+    openjfx21
+    openjfx25
+    openjfx26
+    ;
   compiler = lib.recurseIntoAttrs (
     let
       # merge meta.platforms of both packages so that dependent packages and hydra build them
@@ -54,6 +59,7 @@ in
       openjdk17 = mkOpenjdk "17";
       openjdk21 = mkOpenjdk "21";
       openjdk25 = mkOpenjdk "25";
+      openjdk26 = mkOpenjdk "26";
 
       # Legacy aliases
       openjdk8-bootstrap = temurin-bin.jdk-8;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
