### PR TITLE
c64-debugger: fix the build against `gcc-15`

### DIFF
--- a/pkgs/by-name/c6/c64-debugger/package.nix
+++ b/pkgs/by-name/c6/c64-debugger/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
 
     # Build C64 debugger
     make -C MTEngine \
-      CFLAGS="-w -O2 -fcommon" \
+      CFLAGS="-w -O2 -fcommon -std=gnu17" \
       CXXFLAGS="-w -O2 --std=c++11" \
       DEFINES="-DRUN_COMMODORE64" \
       -j$NIX_BUILD_CORES
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
 
     # Build 65XE debugger
     make -C MTEngine \
-      CFLAGS="-w -O2 -fcommon" \
+      CFLAGS="-w -O2 -fcommon -std=gnu17" \
       CXXFLAGS="-w -O2 --std=c++11" \
       DEFINES="-DRUN_ATARI" \
       -j$NIX_BUILD_CORES
@@ -64,7 +64,7 @@ stdenv.mkDerivation {
 
     # Build NES debugger
     make -C MTEngine \
-      CFLAGS="-w -O2 -fcommon" \
+      CFLAGS="-w -O2 -fcommon -std=gnu17" \
       CXXFLAGS="-w -O2 --std=c++11" \
       DEFINES="-DRUN_NES" \
       -j$NIX_BUILD_CORES


### PR DESCRIPTION
Without the chnage the build fails on `master` as
https://hydra.nixos.org/build/324451165:

```
In file included from Games/c64/Emulators/vice/monitor/asm6502.c:38:
Games/c64/Emulators/vice/monitor/montypes.h:44:13: error: 'bool' cannot be defined via 'typedef'
   44 | typedef int bool;
      |             ^~~~
Games/c64/Emulators/vice/monitor/montypes.h:44:13: note: 'bool' is a keyword with '-std=c23' onwards
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
