### PR TITLE
nixos/felix86: init program module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -210,6 +210,7 @@
   ./programs/extra-container.nix
   ./programs/fcast-receiver.nix
   ./programs/feedbackd.nix
+  ./programs/felix86.nix
   ./programs/firefox.nix
   ./programs/firejail.nix
   ./programs/fish.nix

--- a/nixos/modules/programs/felix86.nix
+++ b/nixos/modules/programs/felix86.nix
@@ -29,6 +29,13 @@ in
       example = "/opt/felix86/rootfs";
       description = "Path to the rootfs for felix86.";
     };
+
+    # TODO: only for testing. remove later
+    disableBinfmt = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Avoid cyclic dependency between Linux and RISC-V emulation";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -49,7 +56,7 @@ in
           fixBinary = false; # cannot have fixBinary when the interpreter is invoked through a shell
         };
       in
-      {
+      lib.mkIf (!cfg.disableBinfmt) {
         felix86-x86_64 = commonOptions // {
           magicOrExtension = ''\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00'';
           mask = ''\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff'';

--- a/nixos/modules/programs/felix86.nix
+++ b/nixos/modules/programs/felix86.nix
@@ -53,7 +53,8 @@ in
           # https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
           openBinary = true;
           matchCredentials = true;
-          fixBinary = false; # cannot have fixBinary when the interpreter is invoked through a shell
+          fixBinary = true;
+          wrapInterpreterInShell = false;
         };
       in
       lib.mkIf (!cfg.disableBinfmt) {

--- a/nixos/modules/programs/felix86.nix
+++ b/nixos/modules/programs/felix86.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.felix86;
+
+  package-wrapped = pkgs.symlinkJoin {
+    name = "felix86";
+    paths = [ cfg.package ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/felix86 \
+      --set-default FELIX86_ROOTFS ${lib.escapeShellArg cfg.rootfs}
+    '';
+  };
+in
+
+{
+  options.programs.felix86 = {
+    enable = lib.mkEnableOption "felix86 x86/x86-64 userspace emulator";
+    package = lib.mkPackageOption pkgs "felix86" { };
+
+    rootfs = lib.mkOption {
+      type = lib.types.path;
+      example = "/opt/felix86/rootfs";
+      description = "Path to the rootfs for felix86.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      package-wrapped
+    ];
+
+    # register binfmt_misc for transparent x86/x86-64 execution
+    boot.binfmt.registrations =
+      let
+        commonOptions = {
+          interpreter = "${package-wrapped}/bin/felix86";
+
+          # https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+          openBinary = true;
+          matchCredentials = true;
+          fixBinary = true;
+        };
+      in
+      {
+        felix86-x86_64 = commonOptions // {
+          magicOrExtension = ''\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00'';
+          mask = ''\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff'';
+        };
+
+        felix86-i386 = commonOptions // {
+          magicOrExtension = ''\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00'';
+          mask = ''\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff'';
+        };
+      };
+  };
+}

--- a/nixos/modules/programs/felix86.nix
+++ b/nixos/modules/programs/felix86.nix
@@ -33,19 +33,20 @@ in
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [
-      package-wrapped
+      # package-wrapped
+      cfg.package
     ];
 
     # register binfmt_misc for transparent x86/x86-64 execution
     boot.binfmt.registrations =
       let
         commonOptions = {
-          interpreter = "${package-wrapped}/bin/felix86";
+          interpreter = "${cfg.package}/bin/felix86";
 
           # https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
           openBinary = true;
           matchCredentials = true;
-          fixBinary = true;
+          fixBinary = false; # cannot have fixBinary when the interpreter is invoked through a shell
         };
       in
       {

--- a/pkgs/by-name/fe/felix86/package.nix
+++ b/pkgs/by-name/fe/felix86/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "felix86";
-  version = "26.03";
+  version = "26.04";
 
   src = fetchFromGitHub {
     owner = "OFFTKP";
     repo = "felix86";
     tag = finalAttrs.version;
-    hash = "sha256-A586hVKpS4Z/hZsesTBqpRzYJpaFxatCuBnoIPtoDFI=";
+    hash = "sha256-onhPibvO74yo95zop7EhG+EILn4M70X9ivhS9I+fIBY=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/fe/felix86/package.nix
+++ b/pkgs/by-name/fe/felix86/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  pkg-config,
+
+  libGL,
+  libx11,
+  vulkan-headers,
+  vulkan-loader,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "felix86";
+  version = "26.03";
+
+  src = fetchFromGitHub {
+    owner = "OFFTKP";
+    repo = "felix86";
+    tag = finalAttrs.version;
+    hash = "sha256-A586hVKpS4Z/hZsesTBqpRzYJpaFxatCuBnoIPtoDFI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    vulkan-headers
+  ];
+
+  buildInputs = [
+    libGL
+    libx11
+    vulkan-loader
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 felix86 $out/bin/felix86
+
+    runHook postInstall
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "ZYDIS_BUILD_DOXYGEN" false)
+    (lib.cmakeBool "BUILD_TESTS" true)
+  ];
+
+  meta = {
+    description = "x86 and x86-64 userspace emulator for RISC-V Linux";
+    homepage = "https://github.com/OFFTKP/felix86";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "felix86";
+    platforms = [ "riscv64-linux" ];
+  };
+})

--- a/pkgs/by-name/fe/felix86/package.nix
+++ b/pkgs/by-name/fe/felix86/package.nix
@@ -10,6 +10,8 @@
   libx11,
   vulkan-headers,
   vulkan-loader,
+
+  callPackage,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -49,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ZYDIS_BUILD_DOXYGEN" false)
     (lib.cmakeBool "BUILD_TESTS" true)
   ];
+
+  passthru.tests = callPackage ./test.nix { };
 
   meta = {
     description = "x86 and x86-64 userspace emulator for RISC-V Linux";

--- a/pkgs/by-name/fe/felix86/test.nix
+++ b/pkgs/by-name/fe/felix86/test.nix
@@ -1,5 +1,5 @@
 # Run with:
-#   nix-build -A pkgsCross.riscv64.felix86.passthru.tests
+#   NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-build -A felix86.passthru.tests
 
 {
   pkgs,
@@ -9,33 +9,28 @@
 pkgs.testers.nixosTest {
   name = "felix86";
 
-  # FIX:
-  # generate-driver-symbols: line 3: syntax error near unexpected token `lambda'
-  skipTypeCheck = true;
-
   nodes.machine =
     {
+      config,
       pkgs,
       ...
     }:
     {
-      nixpkgs.crossSystem.system = "riscv64-linux";
+      boot.binfmt.emulatedSystems = [ "riscv64-linux" ];
 
-      # grub depends on Perl, which fails to build
-      boot.loader.systemd-boot.enable = true;
-
-      # /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 1: /nix/store/xgll7lrnl7l7q5p43lb3nn9y760gp9qh-xxd-tinyxxd-riscv64-unknown-linux-gnu-1.3.10/bin/xxd: cannot execute binary file: Exec format error
-      environment.stub-ld.enable = false;
-
-      programs.felix86.enable = true;
-      programs.felix86.rootfs =
-        (pkgs.pkgsCross.gnu64.buildFHSEnv {
-          name = "felix86-rootfs";
-          targetPkgs = pkgs: [
-            pkgs.bash
-            pkgs.coreutils
-          ];
-        }).fhsenv;
+      programs.felix86 = {
+        enable = true;
+        disableBinfmt = true;
+        package = pkgs.pkgsCross.riscv64.felix86;
+        rootfs =
+          (pkgs.pkgsCross.gnu64.buildFHSEnv {
+            name = "felix86-rootfs";
+            targetPkgs = pkgs: [
+              pkgs.bash
+              pkgs.coreutils
+            ];
+          }).fhsenv;
+      };
     };
 
   testScript =
@@ -44,4 +39,12 @@ pkgs.testers.nixosTest {
       machine.wait_for_unit("multi-user.target")
       machine.succeed("felix86 --help")
     '';
+
+  interactive.nodes.machine = {
+    virtualisation.graphics = false;
+    environment.systemPackages = [
+      pkgs.binutils
+    ];
+  };
+  interactive.sshBackdoor.enable = true;
 }

--- a/pkgs/by-name/fe/felix86/test.nix
+++ b/pkgs/by-name/fe/felix86/test.nix
@@ -1,0 +1,47 @@
+# Run with:
+#   nix-build -A pkgsCross.riscv64.felix86.passthru.tests
+
+{
+  pkgs,
+  ...
+}:
+
+pkgs.testers.nixosTest {
+  name = "felix86";
+
+  # FIX:
+  # generate-driver-symbols: line 3: syntax error near unexpected token `lambda'
+  skipTypeCheck = true;
+
+  nodes.machine =
+    {
+      pkgs,
+      ...
+    }:
+    {
+      nixpkgs.crossSystem.system = "riscv64-linux";
+
+      # grub depends on Perl, which fails to build
+      boot.loader.systemd-boot.enable = true;
+
+      # /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 1: /nix/store/xgll7lrnl7l7q5p43lb3nn9y760gp9qh-xxd-tinyxxd-riscv64-unknown-linux-gnu-1.3.10/bin/xxd: cannot execute binary file: Exec format error
+      environment.stub-ld.enable = false;
+
+      programs.felix86.enable = true;
+      programs.felix86.rootfs =
+        (pkgs.pkgsCross.gnu64.buildFHSEnv {
+          name = "felix86-rootfs";
+          targetPkgs = pkgs: [
+            pkgs.bash
+            pkgs.coreutils
+          ];
+        }).fhsenv;
+    };
+
+  testScript =
+    # python
+    ''
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("felix86 --help")
+    '';
+}


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/499514

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
