### PR TITLE
btest: init at 0.6.2

### DIFF
--- a/pkgs/by-name/bt/btest/package.nix
+++ b/pkgs/by-name/bt/btest/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  sqlite,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "btest";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "manawenuz";
+    repo = "btest-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ltePF8HX46FDbdyq30u19FNVpIwPxhOo8AgNvKRzKHE=";
+  };
+
+  cargoHash = "sha256-8AO7eTzZMzvNWcls3VXP0kPun/D5gsA1ih0FOqZ57R0=";
+
+  postPatch = ''
+    # https://github.com/manawenuz/btest-rs/pull/1
+    substituteInPlace Cargo.toml \
+      --replace-fail "0.6.0" "${finalAttrs.version}"
+  '';
+
+  nativeBuildInputs = [ pkg-config ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  buildInputs = [
+    openssl
+    sqlite
+  ];
+
+  # Tests require network features
+  doCheck = false;
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Bandwidth Test server and client";
+    homepage = "https://github.com/manawenuz/btest-rs";
+    changelog = "https://github.com/manawenuz/btest-rs/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "btest";
+  };
+})


### PR DESCRIPTION
Bandwidth Test server and client

https://github.com/manawenuz/btest-rs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
