### PR TITLE
bombsquad: 1.7.37 -> 1.7.61

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18317,6 +18317,11 @@
     githubId = 8165792;
     name = "Mark Karpov";
   };
+  mrmaxmeier = {
+    github = "mrmaxmeier";
+    githubId = 3913977;
+    name = "Mrmaxmeier";
+  };
   mrmebelman = {
     email = "burzakovskij@protonmail.com";
     github = "MrMebelMan";

--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -2,12 +2,15 @@
   lib,
   stdenv,
   fetchurl,
-  python312,
+  python313,
   SDL2,
+  cairo,
+  pango,
   libvorbis,
   openal,
   curl,
   gnugrep,
+  gnused,
   libgcc,
   makeBinaryWrapper,
   makeDesktopItem,
@@ -22,11 +25,11 @@ let
     {
       x86_64-linux = {
         name = "BombSquad_Linux_x86_64";
-        hash = "sha256-ICjaNZSCUbslB5pELbI4e+1zXWrZzkCkv69jLRx4dr0=";
+        hash = "sha256-VHhDRzB7sSvb3Ou/Sg+PjTKFDG9sKsXueu2qLNfC06k=";
       };
-      aarch-64-linux = {
+      aarch64-linux = {
         name = "BombSquad_Linux_Arm64";
-        hash = "sha256-/m0SOQbHssk0CqZJPRLK9YKphup3dtMqkbWGzqcF0+g=";
+        hash = "sha256-usrhPOsXkJZk0HCSBIGnc4qdIu2SW7STp6Y/e6RmZlM=";
       };
     }
     .${stdenv.targetPlatform.system} or (throw "${stdenv.targetPlatform.system} is unsupported.");
@@ -39,10 +42,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bombsquad";
-  version = "1.7.37";
+  # Note: This version trails behind the latest version by one since the latest
+  # version sometimes gets replaced for minor updates. The builds in /old/ are
+  # stable.
+  version = "1.7.61";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20240825230506if_/https://files.ballistica.net/bombsquad/builds/${archive.name}_${finalAttrs.version}.tar.gz";
+    url = "https://files.ballistica.net/bombsquad/builds/old/${archive.name}_${finalAttrs.version}.tar.gz";
     inherit (archive) hash;
   };
 
@@ -50,10 +56,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
+    cairo
     libgcc
     libvorbis
     openal
-    python312
+    pango
+    python313
   ];
 
   nativeBuildInputs = [
@@ -98,11 +106,12 @@ stdenv.mkDerivation (finalAttrs: {
       runtimeInputs = [
         curl
         gnugrep
+        gnused
       ];
       text = ''
         curl -sL "https://files.ballistica.net/bombsquad/builds/CHANGELOG.md" \
             | grep -oP '^### \K\d+\.\d+\.\d+' \
-            | head -n 1
+            | sed -n 2p
       '';
     });
   };
@@ -118,6 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       syedahkam
       coffeeispower
+      mrmaxmeier
     ];
     mainProgram = "bombsquad";
     platforms = lib.platforms.linux;


### PR DESCRIPTION
This also fixes the build on aarch64 and changes the updater to skip the latest version (which sometimes gets replaced so it's doesn't have a stable hash).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
