### PR TITLE
treewide: fix typo of NPM → npm

### DIFF
--- a/doc/hooks/npm-config-hook.section.md
+++ b/doc/hooks/npm-config-hook.section.md
@@ -13,7 +13,7 @@ Primarily made for a multi-language environment.
 
 #### `npmDeps` {#npm-config-hook-deps}
 
-Derivation that contains the NPM package dependencies.
+Derivation that contains the npm package dependencies.
 Usually built with `fetchNpmDeps`.
 This attribute is required or the hook will abort the build.
 

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -348,7 +348,7 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `fetchgit` now accepts a `rootDir` argument to limit the resulting source to one subdirectory of the whole Git repository. Corresponding `--root-dir` option added to `nix-prefetch-git`.
 
-- `fetchNpmDeps` now accepts a `npmRegistryOverridesString` argument to pass NPM registry overrides to the fetcher.
+- `fetchNpmDeps` now accepts a `npmRegistryOverridesString` argument to pass npm registry overrides to the fetcher.
 
 - `ffmpeg_8`, `ffmpeg_8-headless`, and `ffmpeg_8-full` have been added. The default version of FFmpeg is now `ffmpeg_8`. You can install previous versions from package attributes such as `ffmpeg_7`.
 

--- a/nixos/doc/manual/configuration/mattermost.chapter.md
+++ b/nixos/doc/manual/configuration/mattermost.chapter.md
@@ -99,7 +99,7 @@ these assumptions the best it can.
 
 Here is how to build the above Todo plugin. Note that we rely on
 package-lock.json being assembled correctly, so must use a version where it is!
-If there is no lockfile or the lockfile is incorrect, Nix cannot fetch NPM build
+If there is no lockfile or the lockfile is incorrect, Nix cannot fetch npm build
 and runtime dependencies for a sandbox build.
 
 ```nix

--- a/nixos/modules/services/video/epgstation/default.nix
+++ b/nixos/modules/services/video/epgstation/default.nix
@@ -306,7 +306,7 @@ in
       group = config.users.groups.epgstation.name;
       isSystemUser = true;
 
-      # NPM insists on creating ~/.npm
+      # npm insists on creating ~/.npm
       home = "/var/cache/epgstation";
     };
 

--- a/nixos/modules/services/video/mirakurun.nix
+++ b/nixos/modules/services/video/mirakurun.nix
@@ -160,7 +160,7 @@ in
       group = "video";
       isSystemUser = true;
 
-      # NPM insists on creating ~/.npm
+      # npm insists on creating ~/.npm
       home = "/var/cache/mirakurun";
     };
 

--- a/nixos/modules/services/web-apps/node-red.nix
+++ b/nixos/modules/services/web-apps/node-red.nix
@@ -29,7 +29,7 @@ in
       type = types.bool;
       default = false;
       description = ''
-        Give Node-RED access to NPM and GCC at runtime, so 'Nodes' can be
+        Give Node-RED access to npm and GCC at runtime, so 'Nodes' can be
         downloaded and managed imperatively via the 'Palette Manager'.
       '';
     };

--- a/pkgs/build-support/node/prefetch-npm-deps/src/util.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/util.rs
@@ -57,7 +57,7 @@ pub fn get_url(url: &Url) -> Result<Body, anyhow::Error> {
         && let Ok(tokens) = serde_json::from_str::<Map<String, Value>>(&npm_tokens)
         && let Some(token) = tokens.get(host).and_then(serde_json::Value::as_str)
     {
-        info!("Found NPM token for {host}. Adding authorization header to request.");
+        info!("Found npm token for {host}. Adding authorization header to request.");
         request = request.header("Authorization", format!("Bearer {token}"));
     }
 

--- a/pkgs/by-name/bl/bluesky-pds/package.nix
+++ b/pkgs/by-name/bl/bluesky-pds/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     cctools.libtool
   ];
 
-  # Required for `sharp` NPM dependency
+  # Required for `sharp` npm dependency
   buildInputs = [ vips ];
 
   pnpmDeps = fetchPnpmDeps {

--- a/pkgs/by-name/co/corepack/package.nix
+++ b/pkgs/by-name/co/corepack/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   cacert,
   yarn-berry,
-  nodejs-slim, # no need for NPM
+  nodejs-slim, # no need for npm
   fetchFromGitHub,
   nix-update-script,
   versionCheckHook,

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -22,7 +22,7 @@
 }:
 
 let
-  nodejs = nodejs_22; # NPM v11 included in nodejs_24 doesn't work with the current lockfile
+  nodejs = nodejs_22; # npm v11 included in nodejs_24 doesn't work with the current lockfile
 in
 buildNpmPackage.override { inherit nodejs; } rec {
   pname = "kando";

--- a/pkgs/by-name/lr/lrcget/package.nix
+++ b/pkgs/by-name/lr/lrcget/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
     # needed to not attempt codesigning on darwin
     ./remove-signing-identity.patch
 
-    # Update NPM package versions to fix https://github.com/tranxuanthang/lrcget/issues/309
+    # Update npm package versions to fix https://github.com/tranxuanthang/lrcget/issues/309
     ./fix-tauri-version-mismatch.patch
   ];
 

--- a/pkgs/by-name/ma/mattermost/build-plugin.nix
+++ b/pkgs/by-name/ma/mattermost/build-plugin.nix
@@ -30,7 +30,7 @@
   # True to build the webapp.
   buildWebapp ? true,
 
-  # The NPM dependency hash.
+  # The npm dependency hash.
   npmDepsHash ? lib.fakeHash,
 
   # Any extra attributes to pass to buildGoModule.
@@ -91,7 +91,7 @@ buildGoModule (
         go mod tidy
       '';
 
-      # Adding the NPM config hook here breaks things, and isn't even needed.
+      # Adding the npm config hook here breaks things, and isn't even needed.
       nativeBuildInputs = lib.lists.remove npmHooks.npmConfigHook final.nativeBuildInputs;
     };
 

--- a/pkgs/by-name/pr/prisma-engines_6/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_6/package.nix
@@ -82,7 +82,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 # Read the example's README: https://github.com/pimeys/nix-prisma-example/blob/main/README.md
 # Prisma requires 2 packages, `prisma-engines` and `prisma`, to be at *exact* same versions.
 # Certify at `package.json` that dependencies "@prisma/client" and "prisma" are equal, meaning no caret (`^`) in version.
-# Configure NPM to use exact version: `npm config set save-exact=true`
+# Configure npm to use exact version: `npm config set save-exact=true`
 # Delete `package-lock.json`, delete `node_modules` directory and run `npm install`.
 # Run prisma client from `node_modules/.bin/prisma`.
 # Run `./node_modules/.bin/prisma --version` and check if both prisma packages versions are equal, current platform is `linux-nixos`, and other keys equal to the prisma environment variables you defined for prisma.

--- a/pkgs/by-name/pr/prisma-engines_7/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_7/package.nix
@@ -67,7 +67,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 # Read the example's README: https://github.com/pimeys/nix-prisma-example/blob/main/README.md
 # Prisma requires 2 packages, `prisma-engines` and `prisma`, to be at *exact* same versions.
 # Certify at `package.json` that dependencies "@prisma/client" and "prisma" are equal, meaning no caret (`^`) in version.
-# Configure NPM to use exact version: `npm config set save-exact=true`
+# Configure npm to use exact version: `npm config set save-exact=true`
 # Delete `package-lock.json`, delete `node_modules` directory and run `npm install`.
 # Run prisma client from `node_modules/.bin/prisma`.
 # Run `./node_modules/.bin/prisma --version` and check if both prisma packages versions are equal, current platform is `linux-nixos`, and other keys equal to the prisma environment variables you defined for prisma.

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -655,7 +655,7 @@ builtins.intersectAttrs super {
   # Wants to check against a real DB, Needs freetds
   odbc = dontCheck (addExtraLibraries [ pkgs.freetds ] super.odbc);
 
-  # Tests attempt to use NPM to install from the network into
+  # Tests attempt to use npm to install from the network into
   # /homeless-shelter. Disabled.
   purescript = dontCheck super.purescript;
 

--- a/pkgs/development/python-modules/sphinx-rtd-theme/default.nix
+++ b/pkgs/development/python-modules/sphinx-rtd-theme/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   preBuild = ''
-    # Don't use NPM to fetch assets. Assets are included in sdist.
+    # Don't use npm to fetch assets. Assets are included in sdist.
     export CI=1
   '';
 

--- a/pkgs/misc/documentation-highlighter/README.md
+++ b/pkgs/misc/documentation-highlighter/README.md
@@ -6,7 +6,7 @@ This file was generated with pkgs/misc/documentation-highlighter/update.sh
 
 **This package contains only the CDN build assets of highlight.js.**
 
-This may be what you want if you'd like to install the pre-built distributable highlight.js client-side assets via NPM. If you want to use highlight.js mainly on the server-side, you likely want the [highlight.js][1] package instead.
+This may be what you want if you'd like to install the pre-built distributable highlight.js client-side assets via npm. If you want to use highlight.js mainly on the server-side, you likely want the [highlight.js][1] package instead.
 
 To access these files via CDN:<br>
 https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@latest/build/

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -149,7 +149,7 @@ let
     npmRegistryOverrides = mkOption {
       type = types.attrsOf types.str;
       description = ''
-        The default NPM registry overrides for all `fetchNpmDeps` calls, as an attribute set.
+        The default npm registry overrides for all `fetchNpmDeps` calls, as an attribute set.
 
         For each attribute, all files fetched from the host corresponding to the name will instead be fetched from the host (and sub-path) specified in the value.
 
@@ -172,7 +172,7 @@ let
         lib.isAttrs j && lib.all builtins.isString (builtins.attrValues j)
       );
       description = ''
-        A string containing a string with a JSON representation of NPM registry overrides for `fetchNpmDeps`.
+        A string containing a string with a JSON representation of npm registry overrides for `fetchNpmDeps`.
 
         This overrides the [`npmRegistryOverrides`](#opt-npmRegistryOverrides) option, see its documentation for more details.
       '';


### PR DESCRIPTION
the official name casing is “npm”

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
