### PR TITLE
scalapack: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/by-name/sc/scalapack/disable-tests-ilp64.patch
+++ b/pkgs/by-name/sc/scalapack/disable-tests-ilp64.patch
@@ -1,0 +1,46 @@
+diff --git a/TESTING/traditional/EIG/CMakeLists.txt b/TESTING/traditional/EIG/CMakeLists.txt
+index 935646d..87b77b1 100644
+--- a/TESTING/traditional/EIG/CMakeLists.txt
++++ b/TESTING/traditional/EIG/CMakeLists.txt
+@@ -21,12 +21,12 @@ add_executable(xztrd pztrddriver.f pzttrdtester.f pzlatran.f pztrdinfo.f pzhetdr
+ add_executable(xssvd pssvddriver.f pslagge.f pssvdchk.f pssvdcmp.f pssvdtst.f ${smatgen})
+ add_executable(xdsvd pdsvddriver.f pdlagge.f pdsvdchk.f pdsvdcmp.f pdsvdtst.f ${dmatgen})
+ 
+-add_executable(xssep psseptst.f pssepsubtst.f pssepchk.f pssepqtq.f pslagsy.f pslatms.f pslasizesep.f pslasizesyevx.f pssepdriver.f pssepreq.f pssepinfo.f pslasizesyev.f pssqpsubtst.f pslasizesqp.f pssdpsubtst.f ${smatgen})
++# add_executable(xssep psseptst.f pssepsubtst.f pssepchk.f pssepqtq.f pslagsy.f pslatms.f pslasizesep.f pslasizesyevx.f pssepdriver.f pssepreq.f pssepinfo.f pslasizesyev.f pssqpsubtst.f pslasizesqp.f pssdpsubtst.f ${smatgen})
+ add_executable(xdsep pdseptst.f pdsepsubtst.f pdsepchk.f pdsepqtq.f pdlagsy.f pdlatms.f pdlasizesep.f pdlasizesyevx.f pdsepdriver.f pdsepreq.f pdsepinfo.f pdlasizesyev.f pdsqpsubtst.f pdlasizesqp.f pdsdpsubtst.f ${dmatgen})
+ add_executable(xcsep pcseptst.f pcsepsubtst.f pcsepchk.f pcsepqtq.f pclagsy.f pclatms.f pclasizesep.f pclasizeheevx.f pcsepdriver.f pcsepreq.f pssepinfo.f pcsdpsubtst.f ${cmatgen})
+ add_executable(xzsep pzseptst.f pzsepsubtst.f pzsepchk.f pzsepqtq.f pzlagsy.f pzlatms.f pzlasizesep.f pzlasizeheevx.f pzsepdriver.f pzsepreq.f pdsepinfo.f pzsdpsubtst.f ${zmatgen})
+ 
+-add_executable(xsgsep psgseptst.f psgsepsubtst.f psgsepchk.f pslagsy.f pslatms.f pslasizesyevx.f pslasizegsep.f pslasizesep.f psgsepdriver.f psgsepreq.f pssepinfo.f ${smatgen})
++# add_executable(xsgsep psgseptst.f psgsepsubtst.f psgsepchk.f pslagsy.f pslatms.f pslasizesyevx.f pslasizegsep.f pslasizesep.f psgsepdriver.f psgsepreq.f pssepinfo.f ${smatgen})
+ add_executable(xdgsep pdgseptst.f pdgsepsubtst.f pdgsepchk.f pdlagsy.f pdlatms.f pdlasizesyevx.f pdlasizegsep.f pdlasizesep.f pdgsepdriver.f pdgsepreq.f pdsepinfo.f ${dmatgen})
+ add_executable(xcgsep pcgseptst.f pcgsepsubtst.f pcgsepchk.f pclagsy.f pclatms.f pclasizegsep.f pclasizeheevx.f pclasizesep.f pcgsepdriver.f pcgsepreq.f pssepinfo.f ${cmatgen})
+ add_executable(xzgsep pzgseptst.f pzgsepsubtst.f pzgsepchk.f pzlagsy.f pzlatms.f pzlasizegsep.f pzlasizeheevx.f pzlasizesep.f pzgsepdriver.f pzgsepreq.f pdsepinfo.f ${zmatgen})
+@@ -39,8 +39,8 @@ add_executable(xznep pznepdriver.f pznepinfo.f pznepfchk.f ${zmatgen})
+ add_executable(xcevc pcevcdriver.f pcevcinfo.f pcget22.f ${cmatgen})
+ add_executable(xzevc pzevcdriver.f pzevcinfo.f pzget22.f ${zmatgen})
+ 
+-add_executable(xssyevr pslasizesepr.f pslasizesyevr.f psseprdriver.f psseprreq.f psseprsubtst.f
+-pssepchk.f pssepqtq.f pslatms.f psseprtst.f pssepinfo.f pslagsy.f pslasizesep.f ${smatgen})
++# add_executable(xssyevr pslasizesepr.f pslasizesyevr.f psseprdriver.f psseprreq.f psseprsubtst.f
++# pssepchk.f pssepqtq.f pslatms.f psseprtst.f pssepinfo.f pslagsy.f pslasizesep.f ${smatgen})
+ add_executable(xdsyevr  pdlasizesepr.f pdlasizesyevr.f pdseprdriver.f pdseprreq.f pdseprsubtst.f
+ pdsepchk.f pdsepqtq.f pdlatms.f pdseprtst.f pdsepinfo.f pdlagsy.f pdlasizesep.f ${dmatgen})
+ add_executable(xcheevr pclasizesepr.f pclasizeheevr.f pcseprdriver.f pcseprreq.f pcseprsubtst.f
+@@ -83,15 +83,12 @@ endforeach()
+ set(test_set_4
+     xssvd
+     xdsvd
+-    xssep
+     xdsep
+     xcsep
+     xzsep
+-    xsgsep
+     xdgsep
+     xcgsep
+     xzgsep
+-    xssyevr
+     xdsyevr
+     xcheevr
+     xzheevr

--- a/pkgs/by-name/sc/scalapack/package.nix
+++ b/pkgs/by-name/sc/scalapack/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   gfortran,
   mpiCheckPhaseHook,
@@ -16,13 +15,13 @@ assert blas.isILP64 == lapack.isILP64;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scalapack";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "Reference-ScaLAPACK";
     repo = "scalapack";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KDMW/D7ubGaD2L7eTwULJ04fAYDPAKl8xKPZGZMkeik=";
+    hash = "sha256-cUdHC9DfJBSrxFVyCSSj9qxE5a+JFkI1W671iT7DP1M=";
   };
 
   passthru = {
@@ -34,36 +33,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   __structuredAttrs = true;
 
-  patches = [
-    (fetchpatch {
-      name = "version-string";
-      url = "https://github.com/Reference-ScaLAPACK/scalapack/commit/76cc1ed3032e9a4158a4513c9047c3746b269f04.patch";
-      hash = "sha256-kmllLa9GUeTrHRYeS0yIk9I8LwaIoEytdyQGRuinn3A=";
-    })
-
-    (fetchpatch {
-      name = "scalapack-fix-cmake-4.patch";
-      url = "https://github.com/Reference-ScaLAPACK/scalapack/commit/c3d6b22b0032fd2b8772d99c2239c18473e197a7.patch";
-      hash = "sha256-935KtaqPO2cghbD9Z8YMxGGOQJo1D1LqTje6/IL4bGI=";
-    })
-
-    # Fix build with gcc15
-    # https://github.com/Reference-ScaLAPACK/scalapack/pull/139
-    (fetchpatch {
-      name = "scalapack-fix-function-declaration-arguments.patch";
-      url = "https://github.com/Reference-ScaLAPACK/scalapack/commit/0cd017afa3eefd0597cfe71b7bcfd6356a258da2.patch";
-      hash = "sha256-uUdazKplDt8K5yuVaHX5pLFqDMh0F7eBBGEHfxOiM0Y=";
-    })
-  ];
+  # The xssep, xsgsep, and xsyevr tests need to be disabled for ILP64
+  patches = lib.optional finalAttrs.passthru.isILP64 ./disable-tests-ilp64.patch;
 
   # Required to activate ILP64.
   # See https://github.com/Reference-ScaLAPACK/scalapack/pull/19
   postPatch = lib.optionalString finalAttrs.passthru.isILP64 ''
-    sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/EIG/* TESTING/LIN/*
-    sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/EIG/* TESTING/LIN/*
-
-    # These tests are not adapted to ILP64
-    sed -i '/xssep/d;/xsgsep/d;/xssyevr/d' TESTING/CMakeLists.txt
+    sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/traditional/EIG/* TESTING/traditional/LIN/*
+    sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/traditional/EIG/* TESTING/traditional/LIN/*
   '';
 
   outputs = [
@@ -104,14 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
   # Increase individual test timeout from 1500s to 10000s because hydra's builds
   # sometimes fail due to this
   checkFlags = [ "ARGS=--timeout 10000" ];
-
-  postFixup = ''
-    # _IMPORT_PREFIX, used to point to lib, points to dev output. Every package using the generated
-    # cmake file will thus look for the library in the dev output instead of out.
-    # Use the absolute path to $out instead to fix the issue.
-    substituteInPlace  $dev/lib/cmake/scalapack-${finalAttrs.version}/scalapack-targets-release.cmake \
-      --replace-fail "\''${_IMPORT_PREFIX}" "$out"
-  '';
 
   meta = {
     homepage = "http://www.netlib.org/scalapack/";


### PR DESCRIPTION
Changelog: https://github.com/Reference-ScaLAPACK/scalapack/releases/tag/v2.2.3


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
