### PR TITLE
serena: init at 0.1.4

### DIFF
--- a/pkgs/by-name/se/serena/package.nix
+++ b/pkgs/by-name/se/serena/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  pyright,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "serena";
+  version = "0.1.4";
+  pyproject = true;
+
+  disabled = python3Packages.pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "oraios";
+    repo = "serena";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oj5iaQZa9gKjjaqq/DDT0j5UqVbPjWEztSuaOH24chI=";
+  };
+
+  postPatch = ''
+    # Remove the deprecated dotenv stub package (serena uses python-dotenv)
+    substituteInPlace pyproject.toml \
+      --replace-fail '"dotenv>=0.9.9",' ""
+
+    # Remove pyright from Python dependencies and make it available at runtime
+    # instead
+    substituteInPlace pyproject.toml \
+      --replace-fail '"pyright>=1.1.396,<2",' ""
+  '';
+
+  build-system = [ python3Packages.hatchling ];
+
+  pythonRelaxDeps = [
+    "mcp"
+  ];
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ pyright ]}"
+  ];
+
+  dependencies = with python3Packages; [
+    anthropic
+    docstring-parser
+    flask
+    jinja2
+    joblib
+    mcp
+    overrides
+    pathspec
+    psutil
+    pydantic
+    python-dotenv
+    pyyaml
+    requests
+    ruamel-yaml
+    sensai-utils
+    tiktoken
+    tqdm
+    types-pyyaml
+  ];
+
+  optional-dependencies = with python3Packages; {
+    google = [ google-genai ];
+  };
+
+  pythonImportsCheck = [ "serena" ];
+
+  meta = {
+    description = "Coding agent toolkit providing semantic code operations for LLMs via MCP";
+    homepage = "https://github.com/oraios/serena";
+    changelog = "https://github.com/oraios/serena/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+})


### PR DESCRIPTION
https://github.com/oraios/serena - package as a Python application.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
