### PR TITLE
firebird-emu: migrate to by-name, switch from rev to tag

### DIFF
--- a/pkgs/by-name/fi/firebird-emu/package.nix
+++ b/pkgs/by-name/fi/firebird-emu/package.nix
@@ -2,11 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  qmake,
-  qtbase,
-  qtdeclarative,
-  qtquickcontrols,
-  wrapQtAppsHook,
+  qt5,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "firebird-emu";
@@ -21,14 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    wrapQtAppsHook
-    qmake
+    qt5.wrapQtAppsHook
+    qt5.qmake
   ];
 
   buildInputs = [
-    qtbase
-    qtdeclarative
-    qtquickcontrols
+    qt5.qtbase
+    qt5.qtdeclarative
+    qt5.qtquickcontrols
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/fi/firebird-emu/package.nix
+++ b/pkgs/by-name/fi/firebird-emu/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nspire-emus";
     repo = "firebird";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-ZptjlnOiF+hKuKYvBFJL95H5YQuR99d4biOco/MVEmE=";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1249,8 +1249,6 @@ with pkgs;
   fceux-qt5 = fceux.override { ___qtVersion = "5"; };
   fceux-qt6 = fceux.override { ___qtVersion = "6"; };
 
-  firebird-emu = libsForQt5.callPackage ../applications/emulators/firebird-emu { };
-
   gcdemu = callPackage ../applications/emulators/cdemu/gui.nix { };
 
   goldberg-emu = callPackage ../applications/emulators/goldberg-emu {


### PR DESCRIPTION
This pull request reorganizes the packaging of the `firebird-emu` emulator by moving its Nix expression to a new location and updating its dependencies to use the `libsForQt5` set. This change modernizes and standardizes how Qt5 dependencies are referenced, making future maintenance easier.

Key changes:

**Package Reorganization:**
* Moved the `firebird-emu` package definition from `pkgs/applications/emulators/firebird-emu/default.nix` to `pkgs/by-name/fi/firebird-emu/package.nix`, following the new package naming and organization convention.

**Dependency Updates:**
* Updated all Qt5-related dependencies to use the `libsForQt5` set (e.g., `libsForQt5.qmake`, `libsForQt5.qtbase`, etc.), which is the preferred way to reference Qt5 libraries in Nixpkgs. 

**Build Improvements:**
* Changed the source attribute from `rev` to `tag` in the `fetchFromGitHub` call, which is more accurate for versioned releases.

**Top-level Package Reference:**
* Removed the old reference to `firebird-emu` in `all-packages.nix`, as the package is now organized under the new naming convention and will be picked up differently.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
