### PR TITLE
exercise-timer: fix dependencies

### DIFF
--- a/pkgs/by-name/ex/exercise-timer/package.nix
+++ b/pkgs/by-name/ex/exercise-timer/package.nix
@@ -1,24 +1,21 @@
 {
   lib,
   stdenv,
-  alsa-lib,
   appstream-glib,
   blueprint-compiler,
-  cargo,
   desktop-file-utils,
   fetchFromGitHub,
-  json-glib,
   glib,
+  gst_all_1,
   gtk4,
+  json-glib,
   libadwaita,
   meson,
   ninja,
   nix-update-script,
   pkg-config,
-  rustPlatform,
-  rustc,
-  wrapGAppsHook4,
   vala,
+  wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,20 +33,20 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     appstream-glib
     blueprint-compiler
-    cargo
     desktop-file-utils
     glib
     gtk4
     meson
     ninja
     pkg-config
-    rustc
     wrapGAppsHook4
     vala
   ];
 
   buildInputs = [
-    alsa-lib
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gstreamer
     json-glib
     libadwaita
   ];


### PR DESCRIPTION
Rust is no longer needed as the app was rewritten in Vala and GStreamer is needed for sound.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
