### PR TITLE
postgresqlPackages.pg_search: 0.22.4 -> 0.22.5

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_search.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_search.nix
@@ -9,79 +9,73 @@
   postgresql,
 }:
 
-let
-  # https://github.com/paradedb/paradedb/blob/v0.22.1/Cargo.lock#L4239-L4269
-  linderaVersion = "1.4.1";
-  linderaWebsite = "https://lindera.dev";
-
-  # pg_search's tokenizer uses several language dictionaries used by the Lindera crate
-  dictionaries = {
-    # https://github.com/lindera/lindera/blob/v1.4.1/lindera-ko-dic/build.rs#L15-L22
-    lindera-ko-dic = rec {
-      language = "Korean";
-      filename = "mecab-ko-dic-2.1.1-20180720.tar.gz";
-      source = fetchurl {
-        url = "${linderaWebsite}/${filename}";
-        hash = "sha256-cCztIcYWfp2a68Z0q17lSvWNREOXXylA030FZ8AgWRo=";
-      };
-    };
-
-    # https://github.com/lindera/lindera/blob/v1.4.1/lindera-cc-cedict/build.rs#L15-L22
-    lindera-cc-cedict = rec {
-      language = "Chinese";
-      filename = "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz";
-      source = fetchurl {
-        url = "${linderaWebsite}/${filename}";
-        hash = "sha256-7Tz54+yKgGR/DseD3Ana1DuMytLplPXqtv8TpB0JFsg=";
-      };
-    };
-
-    # https://github.com/lindera/lindera/blob/v1.4.1/lindera-ipadic/build.rs#L15-L22
-    lindera-ipadic = rec {
-      language = "Japanese";
-      filename = "mecab-ipadic-2.7.0-20250920.tar.gz";
-      source = fetchurl {
-        url = "${linderaWebsite}/${filename}";
-        hash = "sha256-p7qfZF/+cJTlauHEqB0QDfj7seKLvheSYi6XKOFi2z0=";
-      };
-    };
-  };
-in
 buildPgrxExtension (finalAttrs: {
   pname = "pg_search";
-  version = "0.22.4";
+  version = "0.22.5";
 
   src = fetchFromGitHub {
     owner = "paradedb";
     repo = "paradedb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WPkgVqrA2mOgj7IGh/GSjpJoLP7usdUWbFVY1SqGHq4=";
+    hash = "sha256-b5sdKEWy4/uXLIE6HtcRMihtRK9iO9jM8pvktO3rOUU=";
   };
 
-  cargoHash = "sha256-f8/5wDle97O3RoIvM+iPWeEzfASsaQm2k8YnaYg32Do=";
+  cargoHash = "sha256-Umbx1ZrQEYifp09+unfaN/MBcbSq16NcqhP6h703Sb8=";
 
   inherit postgresql;
 
-  # Lindera dictionaries are copied to a temporary directory and the
-  # LINDERA_CACHE environment variable prevents the build.rs files in
-  # the Lindera crates from downloading their dictionary from an
-  # external URL, which doesn't work in the Nix sandbox
-  preConfigure = ''
-    export LINDERA_CACHE=$TMPDIR/lindera-cache
-    mkdir -p $LINDERA_CACHE/${linderaVersion}
+  preConfigure =
+    let
+      # Lindera dictionaries are copied to a temporary directory and the
+      # LINDERA_CACHE environment variable prevents the build.rs files in
+      # the Lindera crates from downloading their dictionary from an
+      # external URL, which doesn't work in the Nix sandbox.
 
-    ${lib.concatMapStringsSep "\n" (dict: ''
-      echo "Copying ${dict.language} dictionary to Lindera cache"
-      cp ${dict.source} $LINDERA_CACHE/${linderaVersion}/${dict.filename}
-    '') (lib.attrValues dictionaries)}
+      # You can see which Lindera version pg_search is using here:
+      # https://github.com/paradedb/paradedb/tree/${version}/Cargo.lock
+      linderaVersion = "1.5.1";
 
-    echo "Lindera cache prepared at $LINDERA_CACHE"
-  '';
+      # pg_search's tokenizer uses several language dictionaries used by the Lindera crate
+      # Check the relevant build.rs files to get the proper URLs:
+      # https://github.com/lindera/lindera/blob/${linderaVersion}/${dictionaryKey}/build.rs
+      # Here's an example URL:
+      # https://github.com/lindera/lindera/blob/v1.5.1/lindera-cc-cedict/build.rs
 
-  # https://github.com/paradedb/paradedb/blob/v0.22.1/Cargo.toml#L38-L39
+      dict = language: filename: hash: {
+        inherit filename language;
+        source = fetchurl {
+          url = "https://lindera.dev/${filename}";
+          inherit hash;
+        };
+      };
+
+      dictionaries = {
+        lindera-ko-dic =
+          dict "Korean" "mecab-ko-dic-2.1.1-20180720.tar.gz"
+            "sha256-cCztIcYWfp2a68Z0q17lSvWNREOXXylA030FZ8AgWRo=";
+        lindera-cc-cedict =
+          dict "Chinese" "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz"
+            "sha256-7Tz54+yKgGR/DseD3Ana1DuMytLplPXqtv8TpB0JFsg=";
+        lindera-ipadic =
+          dict "Japanese" "mecab-ipadic-2.7.0-20250920.tar.gz"
+            "sha256-p7qfZF/+cJTlauHEqB0QDfj7seKLvheSYi6XKOFi2z0=";
+      };
+    in
+    ''
+      export LINDERA_CACHE=$TMPDIR/lindera-cache
+      mkdir -p $LINDERA_CACHE/${linderaVersion}
+      ${lib.concatMapStringsSep "\n" (dict: ''
+        echo "Copying ${dict.language} dictionary to Lindera cache"
+        cp ${dict.source} $LINDERA_CACHE/${linderaVersion}/${dict.filename}
+      '') (lib.attrValues dictionaries)}
+      echo "Lindera cache prepared at $LINDERA_CACHE"
+    '';
+
+  # To determinate which version of cargo-pgrx to use, consult the project's main Cargo.toml:
+  # https://github.com/paradedb/paradedb/tree/${version}/Cargo.toml
+  # In that file, check the version of pgrx and pgrx-tests under workspace.dependencies
   cargo-pgrx = cargo-pgrx_0_17_0;
 
-  # https://github.com/paradedb/paradedb/tree/v0.22.1/pg_search
   cargoPgrxFlags = [
     "--package"
     "pg_search"
@@ -102,7 +96,8 @@ buildPgrxExtension (finalAttrs: {
     changelog = "https://github.com/paradedb/paradedb/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.lucperkins ];
-    # https://github.com/paradedb/paradedb/blob/v0.22.1/pg_search/Cargo.toml#L14-L17
+    # For a list of versions, look under the features dictionary in:
+    # https://github.com/paradedb/paradedb/tree/${version}/pg_search/Cargo.toml
     broken = lib.versionOlder postgresql.version "15";
     platforms = postgresql.meta.platforms;
   };


### PR DESCRIPTION
This updates the package to 0.22.5 and also refactors the derivation a bit, eliminating doc comments that are bound to become stale and moving the dictionary loading into a more targeted `let` statement.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
