### PR TITLE
programs.neovim: disable python3 and ruby providers by default

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -310,7 +310,7 @@ gnuradioMinimal.override {
 
 - `mold` is now wrapped by default.
 
-- `neovim` now disables by default the `python3` and `ruby` providers, unused by most users and reducing closure size from 365MiB to 240MiB. Host provider executables are not exposed anymore along with the neovim wrapper. You can still refer to those using the neovim provider variables (e.g., `python3_host_prog`).
+- The `neovim` package and module now disable by default the `python3` and `ruby` providers, unused by most users and reducing closure size from 365MiB to 240MiB. Host provider executables are not exposed anymore along with the neovim wrapper. You can still refer to those using the neovim provider variables (e.g., `python3_host_prog`).
 
 ### Deprecations {#sec-nixpkgs-release-26.05-lib-deprecations}
 

--- a/nixos/modules/programs/neovim.nix
+++ b/nixos/modules/programs/neovim.nix
@@ -51,13 +51,13 @@ in
 
     withRuby = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = "Enable Ruby provider.";
     };
 
     withPython3 = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = "Enable Python 3 provider.";
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
