### PR TITLE
openrct2: add overrides for rct1/2 installation paths

### DIFF
--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -25,12 +25,16 @@
   libpthread-stubs,
   libvorbis,
   libzip,
+  makeWrapper,
   nlohmann_json,
   openssl,
   pkg-config,
   speexdsp,
   zlib,
   withDiscordRpc ? false,
+  # Paths to RCT1 and RCT2 installs can be specified to have them added as a wrapped argument
+  rct1Path ? null,
+  rct2Path ? null,
 }:
 
 let
@@ -75,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     unzip
+    makeWrapper
   ];
 
   buildInputs = [
@@ -139,6 +144,12 @@ stdenv.mkDerivation (finalAttrs: {
       + (versionCheck "OPENSFX" opensfx-version)
       + (versionCheck "TITLE_SEQUENCE" title-sequences-version)
     );
+
+  postInstall = ''
+    wrapProgram $out/bin/openrct2 \
+      ${lib.optionalString (rct1Path != null) "--add-flags '--rct1-data-path=\"${rct1Path}\"'"} \
+      ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}
+  '';
 
   meta = {
     description = "Open source re-implementation of RollerCoaster Tycoon 2 (original game required)";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds two override options to set paths to an RCT1 and an RCT2 installation.

At present, a fresh install of `openrct2` requires manually setting `game_path = ""` in `config.ini`. This isn't particularly user friendly, and creates some reproducibility issues with configs. `home-manager` can't easily be used either since the config file needs to be modifiable by the game.

`openrct2` has a convenient pair of available flags, `--rct1-data-path=<str>` and `--rct2-data-path=<str>`. This pr adds a wrapper and options to set the paths to both an RCT and RCT2 install, allowing for them to be easily added to a configuration without needing to overwrite `config.ini`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
