### PR TITLE
gemini-cli-bin: 0.34.0 -> 0.36.0

### DIFF
--- a/pkgs/by-name/ge/gemini-cli-bin/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-bin/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  fetchurl,
+  fetchzip,
   nodejs,
   sysctl,
   writableTmpDirAsHomeHook,
@@ -11,14 +11,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "gemini-cli-bin";
-  version = "0.34.0";
+  version = "0.36.0";
 
-  src = fetchurl {
-    url = "https://github.com/google-gemini/gemini-cli/releases/download/v${finalAttrs.version}/gemini.js";
-    hash = "sha256-Qfol6zATjVK6d4gfA6ql3aVwjqRE7NAYqg5YTyEVDHk=";
+  src = fetchzip {
+    url = "https://github.com/google-gemini/gemini-cli/releases/download/v${finalAttrs.version}/gemini-cli-bundle.zip";
+    hash = "sha256-wu+QZ5roBNY1mwtte+7opKFBRdOCXONW95UEJ7M3gJI=";
+    stripRoot = false;
   };
-
-  dontUnpack = true;
 
   strictDeps = true;
 
@@ -31,24 +30,41 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ripgrep
   ];
 
+  patchPhase = ''
+    runHook prePatch
+
+    # chunk filenames contain unpredictable hashes, use glob to iterate
+    for chunk in ./chunk-*.js; do
+
+      # disable auto-update
+      if grep -q 'enableAutoUpdate: {' "$chunk"; then
+        sed -i '/enableAutoUpdate: {/,/}/ s/default: true/default: false/' "$chunk"
+      fi
+
+      # use `ripgrep` from `nixpkgs`, more dependencies but prevent downloading incompatible binary on NixOS
+      # this workaround can be removed once the following upstream issue is resolved:
+      # https://github.com/google-gemini/gemini-cli/issues/11438
+      if grep -q 'await resolveExistingRgPath();' "$chunk"; then
+        substituteInPlace "$chunk" \
+          --replace-fail 'const existingPath = await resolveExistingRgPath();' 'const existingPath = "${lib.getExe ripgrep}";'
+      fi
+
+    done
+
+    runHook postPatch
+  '';
+
   installPhase = ''
     runHook preInstall
 
-    local dest="$out/lib/gemini/gemini.js"
-    install -Dm644 "$src" "$dest"
+    local bundleDir="$out/lib/gemini"
 
-    # disable auto-update
-    sed -i '/enableAutoUpdate: {/,/}/ s/default: true/default: false/' "$dest"
-
-    # use `ripgrep` from `nixpkgs`, more dependencies but prevent downloading incompatible binary on NixOS
-    # this workaround can be removed once the following upstream issue is resolved:
-    # https://github.com/google-gemini/gemini-cli/issues/11438
-    substituteInPlace "$dest" \
-      --replace-fail 'const existingPath = await resolveExistingRgPath();' 'const existingPath = "${lib.getExe ripgrep}";'
+    mkdir -p "$bundleDir"
+    cp -aT . "$bundleDir"
 
     makeWrapper "${lib.getExe nodejs}" "$out/bin/gemini" \
       --add-flags "--no-warnings=DEP0040" \
-      --add-flags "$dest"
+      --add-flags "$bundleDir/gemini.js"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ge/gemini-cli-bin/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-bin/package.nix
@@ -76,19 +76,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ++ lib.optionals (with stdenvNoCC.hostPlatform; isDarwin && isx86_64) [
     sysctl
   ];
-  # versionCheckHook cannot be used because the reported version might be incorrect (e.g., 0.6.1 returns 0.6.0).
+
+  # versionCheckHook cannot be used because it assumes the executable is hermetic,
+  # but we need `nativeInstallCheckInputs`
   installCheckPhase = ''
     runHook preInstallCheck
 
-    "$out/bin/gemini" -v
+    "$out/bin/gemini" -v | grep "${finalAttrs.version}"
 
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = nix-update-script {
-    # Ignore `preview` and `nightly` tags
-    extraArgs = [ "--version-regex=^v([0-9.]+)$" ];
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "AI agent that brings the power of Gemini directly into your terminal";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream switched from the standalone JS release to a bundle zip, splitting the `gemini.js` into multiple chunks.
Migrate to `fetchzip` and move Nix-specific modifications into a loop over chunks in `patchPhase`.
And drop some outdated workarounds as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
