### PR TITLE
claude-code: 2.1.90 -> 2.1.91

### DIFF
--- a/pkgs/by-name/cl/claude-code-bin/manifest.json
+++ b/pkgs/by-name/cl/claude-code-bin/manifest.json
@@ -1,46 +1,46 @@
 {
-  "version": "2.1.90",
-  "buildDate": "2026-04-01T22:59:02Z",
+  "version": "2.1.91",
+  "buildDate": "2026-04-02T22:04:30Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "73c1a7570501ca743cd2d7467cb4699103534a2138052a4e6cab53c0e09d79c8",
-      "size": 197828752
+      "checksum": "7433d76d3ec5d223a340e21d7a05f3d481d89999f228113168ad5d64c66fd376",
+      "size": 198092944
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "9934675063ea4360665b7a43f649c92e6ba5cf93257324af7af1a6b490746395",
-      "size": 199326928
+      "checksum": "47409dc476c199711d5c776cf359773f75cb9dc72ce7494a4e4cb100520e8ab4",
+      "size": 199574608
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "15d5089ee7d9981faacf5463eabd427a012814d9fc02113883bb23a4f387ad4a",
-      "size": 230165056
+      "checksum": "dddba100b352ea6d06aa7e036d5afe49749edddd1309a4aa22e47049fafcadf9",
+      "size": 230427200
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "6074e3959989b2958a9abec60adf7b441a0f6f1c7e66401abff0fe54dad04fd6",
-      "size": 229902976
+      "checksum": "01b74e1b02e3330940b3526d2f6e00bf32f7fd9e6b3861be6a61e01cfd7296e6",
+      "size": 230161024
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "2508fa1c9c0575cf6fa26f2561ff7f0fd83be5fb4c6f9ec8281dfd5911d44371",
-      "size": 223218112
+      "checksum": "3dcaacefb510f6aee3573d35fe65f5dccbbbf4b6fdcca9a5a5455c03556a2f8b",
+      "size": 223480256
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "854746d04db11f543ed8d3836b5316366d965e6b6cfa2ac6312e6f7a5c4b5cb1",
-      "size": 224201152
+      "checksum": "b05d9447b7d9a4fa92f936b2275ca87db3bada52d8589bf4e4c49d437366942a",
+      "size": 224459200
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "f6be38fbdcadc373e93f751d1286845f58b032690e32be8f64799380a295a79f",
-      "size": 239622816
+      "checksum": "12f69849f6774749718520f41fb94f6fc30779b55d8f9b0acaaf20c755e6b55d",
+      "size": 239873184
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "019f7210055cd7a884d13c4e6a0b6caf1a82348ee42950b7b5247a4b0484709c",
-      "size": 236335776
+      "checksum": "389de7f1f2b979cb4098f7752ca0099275cedabcfe3908a9886d143ef594972b",
+      "size": 236586144
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.90",
+  "version": "2.1.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.90",
+      "version": "2.1.91",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -15,14 +15,14 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.90";
+  version = "2.1.91";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-4/hqWrY2fncQ8p0TxwBAI+mNH98ZDhjvFqB9us7GJK0=";
+    hash = "sha256-u7jdM6hTYN05ZLPz630Yj7gI0PeCSArg4O6ItQRAMy4=";
   };
 
-  npmDepsHash = "sha256-kWbbIAoNAQ/BtsICmsabkfnS/1Nta5MQ4iX9+oH7WRw=";
+  npmDepsHash = "sha256-0ppKP+XMgTzVVZtL7GDsOjgvSPUDrUa7SoG048RLaNg=";
 
   strictDeps = true;
 


### PR DESCRIPTION
Update claude-code and claude-code-bin to 2.1.91.

Note: vscode-extensions.anthropic.claude-code remains at 2.1.90 as 2.1.91 is not yet published on the VS Code Marketplace.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
