### PR TITLE
python3Packages.cleanlab: skip flaky test

### DIFF
--- a/pkgs/development/python-modules/cleanlab/default.nix
+++ b/pkgs/development/python-modules/cleanlab/default.nix
@@ -90,6 +90,9 @@ buildPythonPackage (finalAttrs: {
     "test_duplicate_points_have_similar_scores"
     # AssertionError: assert 'Annotators [1] did not label any examples.'
     "test_label_quality_scores_multiannotator"
+    # AttributeError: module 'numpy' has no attribute 'in1d' (deprecated since numpy 2.x)
+    "test_bad_input_find_label_issues_internal"
+    "test_return_issues_ranked_by_scores"
   ]
   ++ lib.optionals (pythonAtLeast "3.12") [
     # AttributeError: 'called_once_with' is not a valid assertion.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Skip flaky test due to deprecated numpy attribute
Ref: https://github.com/NixOS/nixpkgs/pull/506321#issuecomment-4184032152

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
