### PR TITLE
cargo-vet: 0.10.1 -> 0.10.2, add ilkecan to maintainers

### DIFF
--- a/pkgs/by-name/ca/cargo-vet/package.nix
+++ b/pkgs/by-name/ca/cargo-vet/package.nix
@@ -2,26 +2,30 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-vet";
-  version = "0.10.1";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "cargo-vet";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HSEhFCcdC79OA8MP73De+iLIjcr1XMHxfJ9a1Q3JJYI=";
+    hash = "sha256-sdjvCMLM8ThWXbotjRIsbLYucDzGvFOktqo6OKB//RI=";
   };
 
-  cargoHash = "sha256-+X6DLxWPWMcGzJMVZAj3C5P5MyywIb4ml0Jsyo9/uAE=";
+  cargoHash = "sha256-3pfOq2VfHbtohdgv73TT480bjCjdNKPJE+m4SHeXfGA=";
 
   # the test_project tests require internet access
   checkFlags = [ "--skip=test_project" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Tool to help projects ensure that third-party Rust dependencies have been audited by a trusted source";
+    changelog = "https://github.com/mozilla/cargo-vet/releases/tag/v${finalAttrs.version}";
     mainProgram = "cargo-vet";
     homepage = "https://mozilla.github.io/cargo-vet";
     license = with lib.licenses; [

--- a/pkgs/by-name/ca/cargo-vet/package.nix
+++ b/pkgs/by-name/ca/cargo-vet/package.nix
@@ -35,6 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       jk
       matthiasbeyer
+      ilkecan
     ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://github.com/mozilla/cargo-vet/releases/tag/v0.10.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 506349`
Commit: `33d4ab869b2885621bc74b8b2e7763afc97f9895`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>cargo-vet</li>
  </ul>
</details>
