### PR TITLE
temurin-{,jre-}bin-26: init at 26.0.1

### DIFF
--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -2,11 +2,11 @@
 #!nix-shell --pure -i python3 -p "python3.withPackages (ps: with ps; [ requests ])"
 
 import json
-import re
+import os
 import requests
 import sys
 
-feature_versions = (8, 11, 17, 21, 25)
+all_feature_versions = (8, 11, 17, 21, 25, 26)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
 impls = ("hotspot",)
@@ -57,7 +57,30 @@ def generate_sources(assets, feature_version, out):
     return out
 
 
-out = {}
+# Parse optional version arguments; default to all known versions.
+# This is especially helpful when adding a new version without updating everything..
+if len(sys.argv) > 1:
+    try:
+        feature_versions = tuple(int(v) for v in sys.argv[1:])
+    except ValueError:
+        print(f"usage: {sys.argv[0]} [version ...]", file=sys.stderr)
+        print(f"  version: one or more feature version numbers, e.g. 21 25", file=sys.stderr)
+        sys.exit(1)
+    unknown = [v for v in feature_versions if v not in all_feature_versions]
+    if unknown:
+        print(f"warning: unknown feature version(s): {', '.join(str(v) for v in unknown)}", file=sys.stderr)
+else:
+    feature_versions = all_feature_versions
+
+sources_path = os.path.join(os.path.dirname(__file__), "sources.json")
+
+# Load existing sources so unrelated versions are preserved during partial updates.
+try:
+    with open(sources_path) as f:
+        out = json.load(f)
+except FileNotFoundError:
+    out = {}
+
 for feature_version in feature_versions:
     # Default user-agent is blocked by Azure WAF.
     headers = {'user-agent': 'nixpkgs-temurin-generate-sources/1.0.0'}
@@ -68,6 +91,6 @@ for feature_version in feature_versions:
         sys.exit(1)
     generate_sources(resp.json(), f"openjdk{feature_version}", out)
 
-with open("sources.json", "w") as f:
+with open(sources_path, "w") as f:
     json.dump(out, f, indent=2, sort_keys=True)
     f.write('\n')

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -21,4 +21,7 @@ in
 
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
+
+  jdk-26 = common { sourcePerArch = sources.jdk.openjdk26; };
+  jre-26 = common { sourcePerArch = sources.jre.openjdk26; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -3,6 +3,12 @@
 let
   sources = (lib.importJSON ./sources.json).hotspot.mac;
   common = opts: callPackage (import ./jdk-darwin-base.nix opts) { };
+  withModernDrvAttrs =
+    drv:
+    drv.overrideAttrs (_: {
+      __structuredAttrs = true;
+      strictDeps = true;
+    });
 
 in
 # EOL = [ "This JDK version has reached End of Life." ];
@@ -21,4 +27,11 @@ in
 
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
+
+  jdk-26 = withModernDrvAttrs (common {
+    sourcePerArch = sources.jdk.openjdk26;
+  });
+  jre-26 = withModernDrvAttrs (common {
+    sourcePerArch = sources.jre.openjdk26;
+  });
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -26,4 +26,7 @@ in
 
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
+
+  jdk-26 = common { sourcePerArch = sources.jdk.openjdk26; };
+  jre-26 = common { sourcePerArch = sources.jre.openjdk26; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -8,6 +8,12 @@ let
   variant = if stdenv.hostPlatform.isMusl then "alpine-linux" else "linux";
   sources = (lib.importJSON ./sources.json).hotspot.${variant};
   common = opts: callPackage (import ./jdk-linux-base.nix opts) { };
+  withModernDrvAttrs =
+    drv:
+    drv.overrideAttrs (_: {
+      __structuredAttrs = true;
+      strictDeps = true;
+    });
 
 in
 # EOL = [ "This JDK version has reached End of Life." ];
@@ -26,4 +32,11 @@ in
 
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
+
+  jdk-26 = withModernDrvAttrs (common {
+    sourcePerArch = sources.jdk.openjdk26;
+  });
+  jre-26 = withModernDrvAttrs (common {
+    sourcePerArch = sources.jre.openjdk26;
+  });
 }

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -54,6 +54,22 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "049027647a2d1cf3b1e3c1e7dad746aa6436928932bbed9130b87a25f585908a",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_aarch64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "c105e581fdccb4e7120d889235d1ad8d5b2bed0af4972bc881e0a8ba687c94a4",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -116,6 +132,22 @@
             "sha256": "aa5160aa130f0f0b4379fc62a0d5198c065815224e01318272864e56f260de34",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jre_x64_alpine-linux_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "f3c21f425f9e9f53ab8a19aed6a25cedee662be19fa221696c1450eb67470905",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_aarch64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "4f0866bd8aa88eb6dfd0489793f8b2fb3eb0f6c20aadb27cae1b140f10897f8e",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_alpine-linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
           }
         },
         "openjdk8": {
@@ -260,6 +292,28 @@
             "sha256": "ee04de95ab9da7287d40bd2173076ecc2a6dd662f007bedfc6eb0380c0ef90e8",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jdk_x64_linux_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "e8ff1f23c5acef74d1b4937dadd67286d67be06758f5d9dca5478c35bf404e83",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_aarch64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "35",
+            "sha256": "7396fc32c311429c4b1573ebfc98eca6b82c2735f9f0e23acbccdcb43e0edee9",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_ppc64le_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "68e19ba53b7f1f74635c13f809e5db36cebccf3ae9e752423dd92d2ad7d831ef",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
           }
         },
         "openjdk8": {
@@ -428,6 +482,28 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "35",
+            "sha256": "460dff59e58d77980d8f3aa3172f53d09c17beca1a16b5762f388aee8c91656c",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_aarch64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "35",
+            "sha256": "f6d3b8e1f76c1dac5c9955ba77571e8e77aa02724f7423737627244174f41d5e",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_ppc64le_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "3a65331f4c4b671a5e5bb3ae4e4a65fd0eb5bf8672c0c2fba6ba36972c4042a4",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_linux_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -530,6 +606,16 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "a5cabec41a19e83e33fde381a978f93bc7f5bd5accadf5b7c34770f08f4b5504",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_x64_mac_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -604,6 +690,16 @@
             "sha256": "70843c642a998d627aa3731535493fcb2ac94dac8ad5b24516fd89ebec094c4d",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jre_x64_mac_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "35",
+            "sha256": "67d8049ff31ca1ffe3329162c0ed895cc074e37a19dd2c43ac3121ec3d889084",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_mac_hotspot_26_35.tar.gz",
+            "version": "26.0.0"
           }
         },
         "openjdk8": {

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -54,6 +54,22 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "7e32b89349385f10d7805197c7696b46556717d041e681017b12590bae6692ca",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_aarch64_alpine-linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "0c97fe7e503fb6daf36a5e86e8d083b97cc2354cda4d11288e6c3b8ec0818afc",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_alpine-linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -116,6 +132,22 @@
             "sha256": "aa5160aa130f0f0b4379fc62a0d5198c065815224e01318272864e56f260de34",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jre_x64_alpine-linux_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "3106f091aad558977d890b0f6639beacd2815ea051a75a23733b3b16fee6ca55",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_aarch64_alpine-linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "d218b359f735122cadeb9cbb226c4ddff8746c46a8d5b833809aedff85bd48a6",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_alpine-linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
           }
         },
         "openjdk8": {
@@ -260,6 +292,34 @@
             "sha256": "ee04de95ab9da7287d40bd2173076ecc2a6dd662f007bedfc6eb0380c0ef90e8",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jdk_x64_linux_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "613f9b2861dea937b24d5eca745ef8567733b377d0bb612195acaad0e3f61360",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_aarch64_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "60e016faf4177840430035d948f83f2887d556fe512b78c1d43b320322fe6685",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_ppc64le_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "riscv64": {
+            "build": "8",
+            "sha256": "f1b762d6d86599627983df200f215bc970444a697159ca3fae93208756b44715",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_riscv64_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "8e512f13e575a43655fc92319436c94890c137b9035cc6bd6f9cf24239704d3a",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
           }
         },
         "openjdk8": {
@@ -428,6 +488,34 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "bf5f733066599065de5e720edda550b39d85876f5bf23a94fee2cb6a8379cb36",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_aarch64_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "d8f66903603c3661c0d8c03de41b76459260ed2e295ba874bb7b3f37a012c026",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_ppc64le_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "riscv64": {
+            "build": "8",
+            "sha256": "277d00ea87cf0ec0ede6736007b2fb44432fac754613df4649e61f385beb55f0",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_riscv64_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "2e90cf68d31b28553fb2c8202d5a4c3a5e99a60285e125dc28c94ba5fb2ac1ef",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_linux_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -530,6 +618,22 @@
             "version": "25.0.0"
           }
         },
+        "openjdk26": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "10c436258e24693ce8baf13dbffce98b77275797455e8b72510967547f13234a",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_aarch64_mac_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "032df492c8749864ee8b135e3d0ea5a17ef5c847309d5fdf8f1dd55e246b8319",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_mac_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -604,6 +708,22 @@
             "sha256": "70843c642a998d627aa3731535493fcb2ac94dac8ad5b24516fd89ebec094c4d",
             "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jre_x64_mac_hotspot_25_36.tar.gz",
             "version": "25.0.0"
+          }
+        },
+        "openjdk26": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "ae27bc97ad353fe910df1b50ca989146561260c00762d65a797682068275dec9",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_aarch64_mac_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "c717204061632d41439e5197a36f26cbfe7695fe1161bcf12d613394cafdae3a",
+            "url": "https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_mac_hotspot_26.0.1_8.tar.gz",
+            "version": "26.0.1"
           }
         },
         "openjdk8": {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3740,6 +3740,9 @@ with pkgs;
   powerline = with python3Packages; toPythonApplication powerline;
 
   ### DEVELOPMENT / COMPILERS
+  temurin-bin-26 = javaPackages.compiler.temurin-bin.jdk-26;
+  temurin-jre-bin-26 = javaPackages.compiler.temurin-bin.jre-26;
+
   temurin-bin-25 = javaPackages.compiler.temurin-bin.jdk-25;
   temurin-jre-bin-25 = javaPackages.compiler.temurin-bin.jre-25;
 


### PR DESCRIPTION
Add the temurin 26 binary, so that we can use it as a bootstrap jdk for openjdk builds.

I updated the `generate-sources.py` script to only update a specific version instead of everything (see #484741).
It might make sense to expand that to remove outdated versions, but that requires a bit more work I think.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
