### PR TITLE
greed: 4.3 -> 4.5

### DIFF
--- a/pkgs/by-name/gr/greed/package.nix
+++ b/pkgs/by-name/gr/greed/package.nix
@@ -9,22 +9,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "greed";
-  version = "4.3";
+  version = "4.5";
 
   src = fetchFromGitLab {
     owner = "esr";
     repo = "greed";
     tag = finalAttrs.version;
-    hash = "sha256-NmX0hYHODe55N0edhdfdm0a/Yqm/UwkU/RREjYl3ePc=";
+    hash = "sha256-S2K6nn4WS1gOvhlYK/UH1hfA0pzij4w5SeP004WVZik=";
   };
 
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail "-lcurses" "-lncurses" \
-      --replace-fail "BIN=/usr/games" "BIN=$out/bin" \
-      --replace-fail "/usr/share" "$out/share" \
       --replace-fail "/usr/games/lib/greed.hs" "/var/lib/greed/greed.hs"
   '';
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  makeFlags = [ "PREFIX=$(out)" ];
 
   buildInputs = [
     ncurses
@@ -33,11 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     asciidoctor
   ];
-
-  preInstall = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man6
-  '';
 
   passthru = {
     updateScript = gitUpdater { };


### PR DESCRIPTION
The build was failing
```
$ hydra-check --arch=aarch64-linux greed
Build Status for nixpkgs.greed.aarch64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.greed.aarch64-linux
✖ (Failed)  greed-4.3  2026-03-21  https://hydra.nixos.org/build/324224966
✖ (Failed)  greed-4.3  2026-03-16  https://hydra.nixos.org/build/322117334
✖ (Failed)  greed-4.3  2026-02-13  https://hydra.nixos.org/build/319716094
✖ (Failed)  greed-4.3  2026-01-07  https://hydra.nixos.org/build/317841611
✔           greed-4.3  2025-11-24  https://hydra.nixos.org/build/314586160
✔           greed-4.3  2025-11-23  https://hydra.nixos.org/build/314168693
✔           greed-4.3  2025-11-13  https://hydra.nixos.org/build/313152818
✔           greed-4.3  2025-10-21  https://hydra.nixos.org/build/310381633
✔           greed-4.3  2025-10-06  https://hydra.nixos.org/build/308821157
✔           greed-4.3  2025-09-11  https://hydra.nixos.org/build/306899135
```

Updating to 4.5 seems to have fixed the issue.

https://gitlab.com/esr/greed/-/compare/4.3...4.5?from_project_id=312498



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
