### PR TITLE
openshell: init at 0.0.22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29156,6 +29156,12 @@
     githubId = 42300264;
     name = "wishfort36";
   };
+  wishstudio = {
+    email = "wishstudio@gmail.com";
+    github = "wishstudio";
+    githubId = 946459;
+    name = "Xiangyan Sun";
+  };
   witchof0x20 = {
     name = "Jade";
     email = "jade@witchof.space";

--- a/pkgs/by-name/op/openshell/package.nix
+++ b/pkgs/by-name/op/openshell/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  cacert,
+  gitMinimal,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "openshell";
+  version = "0.0.22";
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "OpenShell";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-98wmBhj1Bqkod9DWh4qhkT3287c56ZKRDf/Z3QCYf4Q=";
+  };
+
+  cargoHash = "sha256-lzS8V8e+wMX8KUfgrftNLdbyivoj0wtRWOThBRS1IdM=";
+
+  nativeCheckInputs = [
+    cacert
+    gitMinimal
+  ];
+
+  postPatch = ''
+    # fill in package version to Cargo
+    substituteInPlace Cargo.toml \
+      --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+    # only build openshell-cli crate
+    substituteInPlace Cargo.toml \
+      --replace-fail 'members = ["crates/*"]' 'members = ["crates/openshell-cli"]'
+  '';
+
+  env = {
+    # docker image tag baked in at compile time, must match binary version
+    OPENSHELL_IMAGE_TAG = finalAttrs.version;
+  };
+
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    changelog = "https://github.com/NVIDIA/OpenShell/releases/tag/v${finalAttrs.version}";
+    description = "The safe, private runtime for autonomous AI agents.";
+    homepage = "https://docs.nvidia.com/openshell/index.html";
+    license = lib.licenses.asl20;
+    longDescription = ''
+      NVIDIA OpenShell is an open source runtime to build and deploy autonomous,
+      self-evolving agents more safely. OpenShell sits between your agent and
+      your infrastructure to govern how the agent executes, what the agent can
+      see and do, and where inference goes. It enables claws to run in isolated
+      sandboxes, with fine-grained control over privacy and security.
+    '';
+    maintainers = with lib.maintainers; [ wishstudio ];
+    mainProgram = "openshell";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
> OpenShell is the safe, private runtime for autonomous AI agents. It provides sandboxed execution environments that protect your data, credentials, and infrastructure — governed by declarative YAML policies that prevent unauthorized file access, data exfiltration, and uncontrolled network activity.

Homepage: https://docs.nvidia.com/openshell/index.html
Repo: https://github.com/NVIDIA/OpenShell

Can be built as either a rust package or a python wheel via maturin. Upon inspection the python code is just simple wrappers and has zero documentation. So I doubt they are expected to be called at this moment.

The rust package builds three binaries, of which one is the main CLI tool and the other two are designed to be included in the docker images, which are prebuilt by upstream and pulled at runtime. I decided to only build the main binary as the others are really not intended for end user and some patches are needed to make them test successfully, which I think is not worth the maintenance burden.

Tested basic functionality with both `docker` and `podman`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
