### PR TITLE
gbenchmark: 1.9.4 -> 1.9.5; adopt

### DIFF
--- a/pkgs/by-name/gb/gbenchmark/package.nix
+++ b/pkgs/by-name/gb/gbenchmark/package.nix
@@ -64,6 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/google/benchmark";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux ++ lib.platforms.darwin ++ lib.platforms.freebsd;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/gb/gbenchmark/package.nix
+++ b/pkgs/by-name/gb/gbenchmark/package.nix
@@ -5,18 +5,19 @@
   cmake,
   ninja,
   gtest,
+  glibcLocales,
   prometheus-cpp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gbenchmark";
-  version = "1.9.4";
+  version = "1.9.5";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "benchmark";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-P7wJcKkIBoWtN9FCRticpBzYbEZPq71a0iW/2oDTZRU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Mm4pG7zMB00iof32CxreoNBFnduPZTMp3reHMCIAFPQ=";
   };
 
   nativeBuildInputs = [
@@ -26,20 +27,30 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ gtest ];
 
+  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isLinux [ glibcLocales ];
+
   cmakeFlags = [
     (lib.cmakeBool "BENCHMARK_USE_BUNDLED_GTEST" false)
     (lib.cmakeBool "BENCHMARK_ENABLE_WERROR" false)
   ];
 
-  # We ran into issues with gtest 1.8.5 conditioning on
-  # `#if __has_cpp_attribute(maybe_unused)`, which was, for some
-  # reason, going through even when C++14 was being used and
-  # breaking the build on Darwin by triggering errors about using
-  # C++17 features.
-  #
-  # This might be a problem with our Clang, as it does not reproduce
-  # with Xcode, but we just work around it by silencing the warning.
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-c++17-attribute-extensions";
+  env = {
+    # We ran into issues with gtest 1.8.5 conditioning on
+    # `#if __has_cpp_attribute(maybe_unused)`, which was, for some
+    # reason, going through even when C++14 was being used and
+    # breaking the build on Darwin by triggering errors about using
+    # C++17 features.
+    #
+    # This might be a problem with our Clang, as it does not reproduce
+    # with Xcode, but we just work around it by silencing the warning.
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-c++17-attribute-extensions";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # For test:locale_impermeability_test
+    LANG = "en_US.UTF-8";
+    LC_ALL = "en_US.UTF-8";
+    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  };
 
   # Tests fail on 32-bit due to not enough precision
   doCheck = stdenv.hostPlatform.is64bit;


### PR DESCRIPTION
Release: https://github.com/google/benchmark/releases/tag/v1.9.5
Diff: https://github.com/google/benchmark/compare/v1.9.4...v1.9.5

\+ Add myself as a maintainer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
