### PR TITLE
nixos/buffyboard: fixes for 3.5.1

### DIFF
--- a/nixos/modules/services/hardware/buffyboard.nix
+++ b/nixos/modules/services/hardware/buffyboard.nix
@@ -10,8 +10,8 @@
 # Desktop users are recommended to either:
 # 1. Stop buffyboard once your DE is started.
 #   e.g. `services.buffyboard.unitConfig.Conflicts = [ "my-de.service" ];`
-# 2. Configure your DE to ignore input events from buffyboard (product-id=25209; vendor-id=26214; name=rd)
-#   e.g. `echo 'input "26214:25209:rd" events disabled' > ~/.config/sway/config`
+# 2. Configure your DE to ignore input events from buffyboard (product-id=0; vendor-id=0; name=buffyboard)
+#   e.g. `echo 'input "0:0:buffyboard" events disabled' > ~/.config/sway/config`
 
 {
   config,

--- a/nixos/modules/services/hardware/buffyboard.nix
+++ b/nixos/modules/services/hardware/buffyboard.nix
@@ -68,6 +68,24 @@ in
         type = types.submodule {
           freeformType = ini.type;
 
+          options.keyboard.haptic_feedback = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Enable or disable vibrations when pressing keys.
+            '';
+          };
+
+          options.keyboard.sticky_shift = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Changes shift key behavior. When true, the keyboard remains in uppercase mode until
+              the shift key is pressed again (sticky). When false, the keyboard switches back to
+              lowercase mode and the shift key deactivates after a non-modifier key is pressed.
+            '';
+          };
+
           options.input.pointer = mkOption {
             type = types.nullOr types.bool;
             default = null;


### PR DESCRIPTION
the buffybox package (which provides buffyboard.service) was updated to 3.5.1 [here](https://github.com/NixOS/nixpkgs/pull/505646). 3.5.1 brings:
- new config options `keyboard.haptic_feedback = ...`, `keyboard.sticky_shift = ...`.
- a new libinput device ID: `0:0:buffyboard` instead of `26214:25209:rd`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
