### PR TITLE
cups-kyodialog: replace pypdf3 with pypdf

### DIFF
--- a/pkgs/by-name/cu/cups-kyodialog/package.nix
+++ b/pkgs/by-name/cu/cups-kyodialog/package.nix
@@ -67,6 +67,10 @@ stdenv.mkDerivation rec {
       ar p "$src/Debian/${region}/kyodialog_${platform}/kyodialog_${kyodialog_version}-0_${platform}.deb" data.tar.gz | tar -xz
     '';
 
+  patches = [
+    ./pypdf.patch
+  ];
+
   nativeBuildInputs = [
     autoPatchelfHook
     python3Packages.wrapPython
@@ -89,22 +93,14 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/cups/model
     mv ./usr/share/kyocera${kyodialog_version}/ppd${kyodialog_version} $out/share/cups/model/Kyocera
 
+    # patch Nix-specific config path before installing the filter
+    substituteInPlace ./usr/lib/cups/filter/kyofilter_pre_H \
+    --replace-fail 'CONFIG_DIR = "/usr/share/kyocera/"' 'CONFIG_DIR = "'"$out"'/share/kyocera/"'
+
     # remove absolute path prefixes to filters in ppd
     find $out -name "*.ppd" -exec sed -E -i "s:/usr/lib/cups/filter/::g" {} \;
-
-
     mkdir -p $out/lib/cups/
     mv ./usr/lib/cups/filter/ $out/lib/cups/
-    substituteInPlace $out/lib/cups/filter/kyofilter_pre_H \
-      --replace-fail 'from PyPDF3 import PdfFileWriter, PdfFileReader' 'from pypdf import PdfWriter, PdfReader' \
-      --replace-fail 'CONFIG_DIR = "/usr/share/kyocera/"' 'CONFIG_DIR = "'"$out"'/share/kyocera/"' \
-      --replace-fail 'PdfFileReader' 'PdfReader' \
-      --replace-fail 'PdfFileWriter()' 'PdfWriter()' \
-      --replace-fail 'base_pdf.getNumPages()' 'len(base_pdf.pages)' \
-      --replace-fail 'watermark_pdf.getPage(0)' 'watermark_pdf.pages[0]' \
-      --replace-fail 'base_pdf.getPage(p)' 'base_pdf.pages[p]' \
-      --replace-fail 'page.mergePage(watermark)' 'page.merge_page(watermark)' \
-      --replace-fail 'new_pdf.addPage(page)' 'new_pdf.add_page(page)'
     # for lib/cups/filter/kyofilter_pre_H
     wrapPythonProgramsIn $out/lib/cups/filter "$propagatedBuildInputs"
 

--- a/pkgs/by-name/cu/cups-kyodialog/package.nix
+++ b/pkgs/by-name/cu/cups-kyodialog/package.nix
@@ -76,10 +76,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ cups ] ++ lib.optionals withQtGui [ qt5.qtbase ];
 
   # For lib/cups/filter/kyofilter_pre_H.
-  # The source already contains a copy of pypdf3, but we use the Nix package
+  # The source already contains a copy of pypdf3, but we use the maintained
+  # Nix package instead and patch the legacy filter import accordingly.
   propagatedBuildInputs = with python3Packages; [
     reportlab
-    pypdf3
+    pypdf
     setuptools
   ];
 
@@ -94,6 +95,16 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/lib/cups/
     mv ./usr/lib/cups/filter/ $out/lib/cups/
+    substituteInPlace $out/lib/cups/filter/kyofilter_pre_H \
+      --replace-fail 'from PyPDF3 import PdfFileWriter, PdfFileReader' 'from pypdf import PdfWriter, PdfReader' \
+      --replace-fail 'CONFIG_DIR = "/usr/share/kyocera/"' 'CONFIG_DIR = "'"$out"'/share/kyocera/"' \
+      --replace-fail 'PdfFileReader' 'PdfReader' \
+      --replace-fail 'PdfFileWriter()' 'PdfWriter()' \
+      --replace-fail 'base_pdf.getNumPages()' 'len(base_pdf.pages)' \
+      --replace-fail 'watermark_pdf.getPage(0)' 'watermark_pdf.pages[0]' \
+      --replace-fail 'base_pdf.getPage(p)' 'base_pdf.pages[p]' \
+      --replace-fail 'page.mergePage(watermark)' 'page.merge_page(watermark)' \
+      --replace-fail 'new_pdf.addPage(page)' 'new_pdf.add_page(page)'
     # for lib/cups/filter/kyofilter_pre_H
     wrapPythonProgramsIn $out/lib/cups/filter "$propagatedBuildInputs"
 

--- a/pkgs/by-name/cu/cups-kyodialog/pypdf.patch
+++ b/pkgs/by-name/cu/cups-kyodialog/pypdf.patch
@@ -1,0 +1,50 @@
+--- a/usr/lib/cups/filter/kyofilter_pre_H	2024-05-21 13:05:42.000000000 +0200
++++ b/usr/lib/cups/filter/kyofilter_pre_H	2026-04-05 10:41:59.608496326 +0200
+@@ -9,7 +9,7 @@
+ import tempfile
+ import time
+ import datetime
+-from PyPDF3 import PdfFileWriter, PdfFileReader
++from pypdf import PdfWriter, PdfReader
+ import re
+ import os
+ import ntpath
+@@ -247,7 +247,7 @@
+     fileout.write(kyo_in.read())
+     fileout.seek(0)
+     
+-    in_pdf = PdfFileReader(fileout)
++    in_pdf = PdfReader(fileout)
+ 
+     kyo_in.close()
+ 
+@@ -260,7 +260,7 @@
+     packet = BytesIO()
+     draw_watermark(packet, watermark_arguments)
+     packet.seek(0)
+-    watermark_pdf = PdfFileReader(packet)
++    watermark_pdf = PdfReader(packet)
+     return watermark_pdf
+ 
+ def get_base_watermark_position(page_size):
+@@ -453,14 +453,14 @@
+ 
+ def apply_watermark_to_pdf(base_pdf, watermark_pdf):
+     
+-    new_pdf = PdfFileWriter()
++    new_pdf = PdfWriter()
+     
+-    num_of_pages = base_pdf.getNumPages()
+-    watermark = watermark_pdf.getPage(0)
++    num_of_pages = len(base_pdf.pages)
++    watermark = watermark_pdf.pages[0]
+     for p in range(num_of_pages):
+-        page = base_pdf.getPage(p)
+-        page.mergePage(watermark)
+-        new_pdf.addPage(page)
++        page = base_pdf.pages[p]
++        page.merge_page(watermark)
++        new_pdf.add_page(page)
+ 
+     return new_pdf
+     


### PR DESCRIPTION
Replace the insecure pypdf3 dependency in cups-kyodialog with pypdf and patch kyofilter_pre_H
to use the current pypdf API.

This also patches CONFIG_DIR so the Python filter reads its runtime config from the package output
instead of a hardcoded /usr/share/kyocera/ path.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
