### PR TITLE
material-symbols: preserve upstream font filenames

### DIFF
--- a/pkgs/by-name/ma/material-symbols/package.nix
+++ b/pkgs/by-name/ma/material-symbols/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  rename,
   unstableGitUpdater,
 }:
 stdenvNoCC.mkDerivation {
@@ -17,12 +16,9 @@ stdenvNoCC.mkDerivation {
     sparseCheckout = [ "variablefont" ];
   };
 
-  nativeBuildInputs = [ rename ];
-
   installPhase = ''
     runHook preInstall
 
-    rename 's/\[FILL,GRAD,opsz,wght\]//g' variablefont/*
     install -Dm755 variablefont/*.ttf -t $out/share/fonts/TTF
     install -Dm755 variablefont/*.woff2 -t $out/share/fonts/woff2
 


### PR DESCRIPTION
Currently, the `installPhase` strip the `[FILL,GRAD,opsz,wght]` from the font filenames
Renaming these files cause lag in Quickshell shells that expect standart font name ( See https://github.com/caelestia-dots/shell/issues/1315)
This PR removes the rename to preserve the exact filenames provided by the upstream repo

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.