### PR TITLE
segger-ozone: add udev to lib path

### DIFF
--- a/pkgs/by-name/se/segger-ozone/package.nix
+++ b/pkgs/by-name/se/segger-ozone/package.nix
@@ -14,6 +14,8 @@
   libxrandr,
   libxrender,
   makeDesktopItem,
+  makeWrapper,
+  udev,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
+    makeWrapper
   ];
 
   buildInputs = [
@@ -43,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxrender
     (lib.getLib stdenv.cc.cc)
+    udev
   ];
 
   desktopItems = [
@@ -72,7 +76,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/libexec $out/bin
     cp --recursive . $out/libexec/segger-ozone
-    ln -s $out/libexec/segger-ozone/Ozone $out/bin/Ozone
+    # Enables package in non-nixos platforms
+    makeWrapper $out/libexec/segger-ozone/Ozone $out/bin/Ozone \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          udev
+        ]
+      }"
     install -D --mode=0644 Ozone.png $out/share/icons/hicolor/256x256/apps/Ozone.png
 
     runHook postInstall


### PR DESCRIPTION
- Added wrapper to include udev in library path to enable ozone in non-nixos environments.
- Resolves the libudev.so error from Ozone:
`USBBULK: Failed to load libudev.so. Needed for identification of J-Links connected via USB`
- Tested on Ubuntu 24.04.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
