### PR TITLE
brioche: 0.1.6 -> 0.1.7

### DIFF
--- a/pkgs/by-name/br/brioche/librusty_v8.nix
+++ b/pkgs/by-name/br/brioche/librusty_v8.nix
@@ -2,12 +2,12 @@
 { fetchLibrustyV8 }:
 
 fetchLibrustyV8 {
-  version = "140.2.0";
+  version = "146.9.0";
   shas = {
     # NOTE; Follows supported platforms of package (see meta.platforms attribute)!
-    x86_64-linux = "0xgkyjx4vhi001p8iv0wqjpal4nl0vj65fnhp5x8ckss6mhanymg";
-    aarch64-linux = "1gal8sylc0k9x37m4lrlncmcfaxn5bdizgi9rhyfb9da9wi41n9f";
-    x86_64-darwin = "0y117lgc1d90f3z285ljazacscs02mmk9b57h403ilgqfly8dzh7";
-    aarch64-darwin = "106n64mrmwk0jzm8zy891kjjbxrr7yggj7m986pxinf8igvab7br";
+    x86_64-linux = "167yh6wabn154axrylam4p76n5a411rqjdgaza4dwsfc5cg2zvv2";
+    aarch64-linux = "1lmpqndmv9lyzsca1sx4prw76fsnk63cr1i15jdmk764j3zyyki6";
+    x86_64-darwin = "1zdlwgq3kgd931ppd9afvqkn45vg8gjsz6k8jb2vnbwzf03grsv0";
+    aarch64-darwin = "0hm2wdkd5palsxdw0r9y5365gdww7f37g5z9260sa639211lipp4";
   };
 }

--- a/pkgs/by-name/br/brioche/package.nix
+++ b/pkgs/by-name/br/brioche/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "brioche";
-  version = "0.1.6";
+  version = "0.1.7";
 
   src = fetchFromGitHub {
     owner = "brioche-dev";
     repo = "brioche";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tMVBpFCTxesrkj7Z3huVD86baw1tYAtPdPAzYJzTCnA=";
+    hash = "sha256-j0Hi75olubvlHEOzVbW0cMAslZFWCzHiwXaBqmkXzmE=";
   };
 
-  cargoHash = "sha256-LPHJHS69oUvmTaYoMSINCcyYIHYMq++UCUMh9KrCm/0=";
+  cargoHash = "sha256-3UvggE45Gvus5ghd64ZK+Nh/VB3NJBmZNrbStl/xJu0=";
 
   env = {
     OPENSSL_NO_VENDOR = true;
@@ -42,16 +42,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
 
-  checkFlags = [
-    # Require internet access
-    "--skip=test_bake_process"
-  ];
-
-  nativeCheckInputs = [
-    # Otherwise, some tests fail with:
-    # Error: failed to find time zone `Etc/Unknown` since there is no time zone database configured at line 1 column 415
-    tzdata
-  ];
+  # Tests require network access and CA certificates, which are unavailable in the nix sandbox
+  doCheck = false;
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Simplified CLI syntax
https://brioche.dev/blog/brioche-v0-1-7/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
