### PR TITLE
authelia: 4.39.12 -> 4.39.18

### DIFF
--- a/pkgs/by-name/au/authelia/sources.nix
+++ b/pkgs/by-name/au/authelia/sources.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub }:
 rec {
   pname = "authelia";
-  version = "4.39.12";
+  version = "4.39.18";
 
   src = fetchFromGitHub {
     owner = "authelia";
     repo = "authelia";
     rev = "v${version}";
-    hash = "sha256-u7TIhOGXfvWdAXvpL5qa43jaoa7PNAVL2MtGEuWBDPc=";
+    hash = "sha256-IROdncF3TC1X9000jw0RGtrcFrzqRpG7g2QuLGQ/Q4k=";
   };
-  vendorHash = "sha256-7RoPv4OvOhiv+TmYOJuW95h/uh2LuTrpUSAZiTvbh7g=";
-  pnpmDepsHash = "sha256-Ck2nqFwDv3OxN0ONA3A+h4Rli1te+EYqKivcqrAInKw=";
+  vendorHash = "sha256-ZDsLRMip2B8PPZu8VxW+91FVvwC2rXzohhAZFifT26g=";
+  pnpmDepsHash = "sha256-ki/jXNT9dIno1UIcDgBcsLdiKcaiw/dwnff3t9xv07o=";
 }

--- a/pkgs/by-name/au/authelia/web.nix
+++ b/pkgs/by-name/au/authelia/web.nix
@@ -40,8 +40,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
+    NL=$'\n'
+    LINE_BEFORE_HOST='allowedHosts: ["login.example.com", ...allowedHosts],'
+
     substituteInPlace ./vite.config.ts \
-      --replace 'outDir: "../internal/server/public_html"' 'outDir: "dist"'
+      --replace-fail 'outDir: "../internal/server/public_html"' 'outDir: "dist"' \
+      --replace-fail "$LINE_BEFORE_HOST" "$LINE_BEFORE_HOST$NL"'            host: "127.0.0.1",'
   '';
 
   postBuild = ''


### PR DESCRIPTION
Supersedes #452392

Upstream changes:
- https://github.com/authelia/authelia/releases/tag/v4.39.13
- https://github.com/authelia/authelia/releases/tag/v4.39.14
- https://github.com/authelia/authelia/releases/tag/v4.39.15
- https://github.com/authelia/authelia/releases/tag/v4.39.16
- https://github.com/authelia/authelia/releases/tag/v4.39.17
- https://github.com/authelia/authelia/releases/tag/v4.39.18
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
