### PR TITLE
lib.systems: warn on usage of mingw aliases

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -396,11 +396,10 @@ rec {
   };
 
   # mingw-64 back compat
-  # TODO: Warn after 26.05, and remove after 26.11.
-  mingw32 = mingw-msvcrt-i686;
-  mingwW64 = mingw-msvcrt-x86_64;
-  ucrt64 = mingw-ucrt-x86_64;
-  ucrtAarch64 = mingw-ucrt-aarch64;
+  mingw32 = builtins.warn "mingw32 has been replaced by mingw-msvcrt-i686" mingw-msvcrt-i686;
+  mingwW64 = builtins.warn "mingwW64 has been replaced by mingw-msvcrt-x86_64" mingw-msvcrt-x86_64;
+  ucrt64 = builtins.warn "ucrt64 has been replaced by mingw-ucrt-x86_64" mingw-ucrt-x86_64;
+  ucrtAarch64 = lib.warn "ucrtAarch64 has been replaced by mingw-ucrt-aarch64" mingw-ucrt-aarch64;
 
   # Target the MSVC ABI
   x86_64-windows = {


### PR DESCRIPTION
Fixes TODO to warn aliases for 26.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
