### PR TITLE
asphalt: init at 2.0.0-rc.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18499,6 +18499,12 @@
     githubId = 16356569;
     name = "Marcos Benevides";
   };
+  mudmaster556 = {
+    email = "mityakuz2308@gmail.com";
+    github = "mudmaster556";
+    githubId = 214629159;
+    name = "Dmitry Kuznetsov";
+  };
   mudri = {
     email = "lamudri@gmail.com";
     github = "laMudri";

--- a/pkgs/by-name/as/asphalt/package.nix
+++ b/pkgs/by-name/as/asphalt/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "asphalt";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jackTabsCode";
+    repo = "asphalt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2PiFdz8vQmQbFw55INHD0arqGZCFCqCKkdABxGCXhvw=";
+  };
+
+  cargoHash = "sha256-w0r3wuf6oYHDPAu1aH/5AOhhdBI7g11xu7bkqlQ2euQ=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Assets-as-files tool for Roblox";
+    longDescription = ''
+      Asphalt is a command line tool used to upload assets to Roblox
+      and easily reference them in code.  It's a modern alternative to
+      [Tarmac](https://github.com/Roblox/Tarmac).
+    '';
+    homepage = "https://github.com/jackTabsCode/asphalt";
+    changelog = "https://github.com/jackTabsCode/asphalt/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "asphalt";
+    maintainers = with lib.maintainers; [ mudmaster556 ];
+  };
+})


### PR DESCRIPTION
Adds `asphalt`, a CLI tool for uploading and referencing Roblox assets in code.

Homepage: https://github.com/jackTabsCode/asphalt

I packaged upstream version `2.0.0-rc.5` and verified that it builds and runs correctly on:
- aarch64-darwin
- x86_64-linux

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Note:
- upstream `2.0.0-rc.5` is the latest available release