### PR TITLE
noti: update project home

### DIFF
--- a/pkgs/by-name/no/noti/package.nix
+++ b/pkgs/by-name/no/noti/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   installShellFiles,
 }:
 
@@ -9,8 +9,8 @@ buildGoModule (finalAttrs: {
   pname = "noti";
   version = "3.8.0";
 
-  src = fetchFromGitHub {
-    owner = "variadico";
+  src = fetchFromCodeberg {
+    owner = "roble";
     repo = "noti";
     tag = finalAttrs.version;
     hash = "sha256-FwOS4ifMiODIzKVQufLhkDYOcmXz9dAfWw+hM3rXT/Y=";
@@ -44,7 +44,7 @@ buildGoModule (finalAttrs: {
       Never sit and wait for some long-running process to finish. Noti can alert
       you when it's done. You can receive messages on your computer or phone.
     '';
-    homepage = "https://github.com/variadico/noti";
+    homepage = "https://codeberg.org/roble/noti";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.stites ];
     mainProgram = "noti";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

The noti project is moving to Codeberg. This change updates where nix fetches the source code from to point to the new home at Codeberg.

The notice on the old home is here: https://github.com/variadico/noti?tab=readme-ov-file#notice-noti-is-moving-to-codebergorgroblenoti-

The new home is here: https://codeberg.org/roble/noti