### PR TITLE
chiri: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24059,6 +24059,12 @@
     email = "hey@sandydoo.me";
     matrix = "@sandydoo:matrix.org";
   };
+  SapphoSys = {
+    name = "Chloe";
+    github = "SapphoSys";
+    githubId = 22654782;
+    email = "contact@sapphic.moe";
+  };
   sarahec = {
     email = "seclark@nextquestion.net";
     github = "sarahec";

--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # build tools
+  cargo-tauri,
+  nodejs_20,
+  pnpmConfigHook,
+  pnpm_9,
+  fetchPnpmDeps,
+  pkg-config,
+  makeBinaryWrapper,
+  wrapGAppsHook4,
+
+  # Linux dependencies
+  glib-networking,
+  libayatana-appindicator,
+  openssl,
+  webkitgtk_4_1,
+
+  # macOS dependencies
+  libiconv,
+  apple-sdk_14,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "chiri";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "SapphoSys";
+    repo = "chiri";
+    tag = "app-v${finalAttrs.version}";
+    hash = "sha256-VrENUwkItT+8C7JowoEfqjIX4RhThTm+4hntdm9ifVk=";
+  };
+
+  cargoHash = "sha256-2CDwuZiE4b5cBUPZs8l4pf9/FyvtSpRwNwQZ5gp85zc=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_9;
+    hash = "sha256-3tUuOSW4SdcEh/dtmu2YLuTFf3mLncBo3xwPU8KA5Pw=";
+    fetcherVersion = 3;
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs_20
+    pnpmConfigHook
+    pnpm_9
+    rustPlatform.cargoSetupHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook4
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    libayatana-appindicator
+    webkitgtk_4_1
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
+    apple-sdk_14
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  postPatch =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace $cargoDepsCopy/libappindicator-sys-*/src/lib.rs \
+        --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+    ''
+    + ''
+      substituteInPlace src-tauri/tauri.conf.json \
+        --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
+    '';
+
+  preBuild = ''
+    unset TAURI_SIGNING_PRIVATE_KEY
+    unset TAURI_SIGNING_PUBLIC_KEY
+    pnpm build
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/bin
+    makeWrapper "$out/Applications/Chiri.app/Contents/MacOS/chiri" "$out/bin/chiri"
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Cross-platform CalDAV task management app";
+    homepage = "https://github.com/SapphoSys/chiri";
+    changelog = "https://github.com/SapphoSys/chiri/releases/tag/app-v${finalAttrs.version}";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ SapphoSys ];
+    mainProgram = "chiri";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Chiri is a (work in progress) cross-platform CalDAV compatible task management app.
https://github.com/SapphoSys/chiri

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
