### PR TITLE
deviceTree: apply_overlays: Use libufdt instead of libfdt

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7767,6 +7767,11 @@
     githubId = 18375468;
     name = "Elliot Xu";
   };
+  elliotberman = {
+    name = "Elliot Berman";
+    github = "elliotberman";
+    githubId = 210410075;
+  };
   elliottslaughter = {
     name = "Elliott Slaughter";
     email = "elliottslaughter@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7934,6 +7934,11 @@
     githubId = 18375468;
     name = "Elliot Xu";
   };
+  elliotberman = {
+    name = "Elliot Berman";
+    github = "elliotberman";
+    githubId = 210410075;
+  };
   elliottslaughter = {
     name = "Elliott Slaughter";
     email = "elliottslaughter@gmail.com";

--- a/pkgs/by-name/uf/ufdt/meson.build
+++ b/pkgs/by-name/uf/ufdt/meson.build
@@ -1,0 +1,73 @@
+project('libufdt', 'c',
+  default_options : ['warning_level=2'])
+
+libfdt_dep = dependency('libfdt')
+
+sysdeps_inc = include_directories('sysdeps/include')
+libufdt_sysdeps = static_library('ufdt_sysdeps',
+  'sysdeps/libufdt_sysdeps_posix.c',
+  include_directories : sysdeps_inc,
+)
+sysdeps_dep = declare_dependency(
+  link_with : libufdt_sysdeps,
+  include_directories : sysdeps_inc,
+)
+
+libufdt_inc = include_directories('include', '.')
+libufdt = shared_library('ufdt',
+  files(
+    'ufdt_overlay.c',
+    'ufdt_convert.c',
+    'ufdt_node.c',
+    'ufdt_node_pool.c',
+    'ufdt_prop_dict.c',
+  ),
+  include_directories : [libufdt_inc, sysdeps_inc],
+  dependencies : [libfdt_dep, sysdeps_dep],
+  install : true,
+)
+libufdt_dep = declare_dependency(
+  link_with : libufdt,
+  include_directories : libufdt_inc,
+  dependencies : [libfdt_dep, sysdeps_dep],
+)
+
+pkg = import('pkgconfig')
+pkg.generate(libufdt)
+
+install_headers(
+  'include/libufdt.h',
+  'include/ufdt_overlay.h',
+  'include/ufdt_overlay_internal.h',
+  'include/ufdt_node_pool.h',
+  'include/ufdt_types.h',
+  'sysdeps/include/libufdt_sysdeps.h',
+)
+
+test_inc = include_directories('tests/src')
+
+ufdt_apply_overlay_exe = executable('ufdt_apply_overlay',
+  files('tests/src/ufdt_overlay_test_app.c', 'tests/src/util.c'),
+  include_directories : test_inc,
+  c_args : ['-Wno-error=format'],
+  dependencies : libufdt_dep,
+  install : true,
+)
+
+# libfdt reference implementation used by tests for comparison
+fdt_apply_overlay_exe = executable('fdt_apply_overlay',
+  files('tests/src/fdt_overlay_test_app.c', 'tests/src/util.c'),
+  include_directories : test_inc,
+  c_args : ['-Wno-error=format'],
+  dependencies : [libfdt_dep, sysdeps_dep],
+)
+
+test_env = environment()
+test_env.prepend('PATH', meson.current_build_dir())
+test_env.set('ANDROID_BUILD_TOP', '1') # run_tests.sh checks this is non-empty; any value satisfies it
+
+test('libufdt', find_program('tests/run_tests.sh'),
+  workdir : meson.current_source_dir() / 'tests',
+  env     : test_env,
+  depends : [fdt_apply_overlay_exe, ufdt_apply_overlay_exe],
+)

--- a/pkgs/by-name/uf/ufdt/meson.build
+++ b/pkgs/by-name/uf/ufdt/meson.build
@@ -1,0 +1,80 @@
+project('libufdt', 'c',
+  default_options : ['warning_level=2'])
+
+libfdt_dep = dependency('libfdt')
+
+sysdeps_inc = include_directories('sysdeps/include')
+libufdt_sysdeps = static_library('ufdt_sysdeps',
+  'sysdeps/libufdt_sysdeps_posix.c',
+  include_directories : sysdeps_inc,
+)
+sysdeps_dep = declare_dependency(
+  link_with : libufdt_sysdeps,
+  include_directories : sysdeps_inc,
+)
+
+libufdt_inc = include_directories('include', '.')
+libufdt = shared_library('ufdt',
+  files(
+    'ufdt_overlay.c',
+    'ufdt_convert.c',
+    'ufdt_node.c',
+    'ufdt_node_pool.c',
+    'ufdt_prop_dict.c',
+  ),
+  include_directories : [libufdt_inc, sysdeps_inc],
+  dependencies : [libfdt_dep, sysdeps_dep],
+  install : true,
+)
+libufdt_dep = declare_dependency(
+  link_with : libufdt,
+  include_directories : libufdt_inc,
+  dependencies : [libfdt_dep, sysdeps_dep],
+)
+
+pkg = import('pkgconfig')
+pkg.generate(libufdt)
+
+install_headers(
+  'include/libufdt.h',
+  'include/ufdt_overlay.h',
+  'include/ufdt_overlay_internal.h',
+  'include/ufdt_node_pool.h',
+  'include/ufdt_types.h',
+  'sysdeps/include/libufdt_sysdeps.h',
+)
+
+install_data(
+  'utils/src/mkdtboimg.py',
+  install_dir : get_option('bindir'),
+  install_mode : 'rwxr-xr-x',
+  rename : 'mkdtboimg',
+)
+
+test_inc = include_directories('tests/src')
+
+ufdt_apply_overlay_exe = executable('ufdt_apply_overlay',
+  files('tests/src/ufdt_overlay_test_app.c', 'tests/src/util.c'),
+  include_directories : test_inc,
+  c_args : ['-Wno-error=format'],
+  dependencies : libufdt_dep,
+  install : true,
+)
+
+# libfdt reference implementation used by tests for comparison
+fdt_apply_overlay_exe = executable('fdt_apply_overlay',
+  files('tests/src/fdt_overlay_test_app.c', 'tests/src/util.c'),
+  include_directories : test_inc,
+  c_args : ['-Wno-error=format'],
+  dependencies : [libfdt_dep, sysdeps_dep],
+)
+
+test_env = environment()
+test_env.prepend('PATH', meson.current_build_dir())
+test_env.set('ANDROID_BUILD_TOP', '1') # run_tests.sh checks this is non-empty; any value satisfies it
+
+test('libufdt', find_program('tests/run_tests.sh'),
+  workdir : meson.current_source_dir() / 'tests',
+  env     : test_env,
+  depends : [fdt_apply_overlay_exe, ufdt_apply_overlay_exe],
+)

--- a/pkgs/by-name/uf/ufdt/package.nix
+++ b/pkgs/by-name/uf/ufdt/package.nix
@@ -1,0 +1,59 @@
+{
+  bash,
+  diffutils,
+  dtc,
+  fetchFromGitiles,
+  lib,
+  meson,
+  ninja,
+  pkg-config,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  pname = "libufdt";
+  version = "0-unstable-2026-04-02";
+
+  src = fetchFromGitiles {
+    url = "https://android.googlesource.com/platform/system/libufdt";
+    rev = "30486c8b56ac46b2a368918f8851618488832caf"; # tracking main-kernel
+    hash = "sha256-L5U/L1+ra20lZDsag4yNHKNGkovZg4MD8vrdkqB1pEU=";
+  };
+
+  # libufdt uses Android.bp files. The meson.build is derived from the Soong build files.
+  preConfigure = ''
+    cp ${./meson.build} meson.build
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [ dtc ];
+
+  postPatch = ''
+    patchShebangs tests/
+  '';
+
+  doCheck = true;
+  mesonCheckFlags = [ "--verbose" ];
+  nativeCheckInputs = [
+    dtc
+    bash
+    diffutils
+  ];
+
+  meta = {
+    description = "Library and tools for manipulating Flattened Device Trees";
+    homepage = "https://android.googlesource.com/platform/system/libufdt";
+    license = lib.licenses.asl20;
+    mainProgram = "ufdt_apply_overlay";
+    maintainers = [ lib.maintainers.elliotberman ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/uf/ufdt/package.nix
+++ b/pkgs/by-name/uf/ufdt/package.nix
@@ -1,0 +1,76 @@
+{
+  bash,
+  diffutils,
+  dtc,
+  fetchFromGitiles,
+  lib,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  stdenv,
+  unstableGitUpdater,
+}:
+let
+  url = "https://android.googlesource.com/platform/system/libufdt";
+in
+stdenv.mkDerivation {
+  pname = "libufdt";
+  version = "0-unstable-2026-05-14";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitiles {
+    inherit url;
+    rev = "be62b37978e6cf0ab5115701ec4afeaa463e7533";
+    hash = "sha256-kWD3U5BLCFnPQpjn5aYPklrAbBtyIWXQWZcvyVvZef8=";
+  };
+
+  # libufdt uses Android.bp files. The meson.build is derived from the Soong build files.
+  preConfigure = ''
+    cp ${./meson.build} meson.build
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+  buildInputs = [
+    dtc
+    python3
+  ];
+
+  postPatch = ''
+    patchShebangs tests/ utils/src/mkdtboimg.py
+  '';
+
+  doCheck = true;
+  mesonCheckFlags = [ "--verbose" ];
+  nativeCheckInputs = [
+    dtc
+    bash
+    diffutils
+  ];
+
+  passthru.updateScript = unstableGitUpdater {
+    inherit url;
+    branch = "main-kernel";
+    hardcodeZeroVersion = true;
+  };
+
+  meta = {
+    description = "Library and tools for manipulating Flattened Device Trees";
+    homepage = "https://android.googlesource.com/platform/system/libufdt";
+    license = lib.licenses.asl20;
+    mainProgram = "ufdt_apply_overlay";
+    maintainers = [ lib.maintainers.elliotberman ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/device-tree/apply_overlays.py
+++ b/pkgs/os-specific/linux/device-tree/apply_overlays.py
@@ -4,8 +4,10 @@ from functools import cached_property
 import json
 from pathlib import Path
 import shutil
+import subprocess
+import os
 
-from libfdt import Fdt, FdtException, FDT_ERR_NOSPACE, FDT_ERR_NOTFOUND, fdt_overlay_apply
+from libfdt import Fdt, FdtException, FDT_ERR_NOTFOUND
 
 
 @dataclass
@@ -35,39 +37,27 @@ def get_compatible(fdt) -> set[str]:
         else:
             raise e
 
+def apply_overlay(base: Path, dtbo: Path):
+    temp = base.with_suffix(".tmp")
+    subprocess.check_call(["ufdt_apply_overlay", base, dtbo, temp])
+    os.replace(temp, base)
 
-def apply_overlay(dt: Fdt, dto: Fdt) -> Fdt:
-    while True:
-        # we need to copy the buffers because they can be left in an inconsistent state
-        # if the operation fails (ref: fdtoverlay source)
-        result = dt.as_bytearray().copy()
-        err = fdt_overlay_apply(result, dto.as_bytearray().copy())
-
-        if err == 0:
-            new_dt = Fdt(result)
-            # trim the extra space from the final tree
-            new_dt.pack()
-            return new_dt
-
-        if err == -FDT_ERR_NOSPACE:
-            # not enough space, add some blank space and try again
-            # magic number of more space taken from fdtoverlay
-            dt.resize(dt.totalsize() + 65536)
-            continue
-
-        raise FdtException(err)
 
 def process_dtb(rel_path: Path, source: Path, destination: Path, overlays_data: list[Overlay]):
     source_dt = source / rel_path
+    dest_path = destination / rel_path
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(source / rel_path, dest_path)
+
     print(f"Processing source device tree {rel_path}...")
-    with source_dt.open("rb") as fd:
-        dt = Fdt(fd.read())
 
     for overlay in overlays_data:
         if overlay.filter and overlay.filter not in str(rel_path):
             print(f"  Skipping overlay {overlay.name}: filter does not match")
             continue
 
+        with dest_path.open("rb") as fd:
+            dt = Fdt(fd.read())
         dt_compatible = get_compatible(dt)
         if len(dt_compatible) == 0:
             print(f"  Device tree {rel_path} has no compatible string set. Assuming it's compatible with overlay")
@@ -76,13 +66,7 @@ def process_dtb(rel_path: Path, source: Path, destination: Path, overlays_data: 
             continue
 
         print(f"  Applying overlay {overlay.name}")
-        dt = apply_overlay(dt, overlay.fdt)
-
-    print(f"Saving final device tree {rel_path}...")
-    dest_path = destination / rel_path
-    dest_path.parent.mkdir(parents=True, exist_ok=True)
-    with dest_path.open("wb") as fd:
-        fd.write(dt.as_bytearray())
+        apply_overlay(dest_path, overlay.dtbo_file)
 
 def main():
     parser = ArgumentParser(description='Apply a list of overlays to a directory of device trees')

--- a/pkgs/os-specific/linux/device-tree/default.nix
+++ b/pkgs/os-specific/linux/device-tree/default.nix
@@ -5,6 +5,7 @@
   dtc,
   writers,
   python3,
+  ufdt,
 }:
 
 {
@@ -40,6 +41,7 @@
       name = "device-tree-overlays";
       nativeBuildInputs = [
         (python3.pythonOnBuildForHost.withPackages (ps: [ ps.libfdt ]))
+        ufdt
       ];
       buildCommand = ''
         python ${./apply_overlays.py} --source ${base} --destination $out --overlays ${writers.writeJSON "overlays.json" overlays'}


### PR DESCRIPTION
libfdt does not provide helpful error messages when failing to apply a devicetree overlay; it simply reports:

```
libfdt.FdtException: pylibfdt error -1: FDT_ERR_NOTFOUND
```

ufdt_apply_overlay instead provides a bit more helpful message:

```
ERROR: ufdt_overlay_do_fixups():Couldn't find 'foo' symbol in main dtb
ERROR: ufdt_overlay_apply():failed to perform fixups in overlay
```

Instead of using pylibfdt's fdt_overlay_apply, shell out to ufdt_apply_overlay when using `hardware.deviceTree.overlays`. This is a little less ideal than FFI used today, but apply_overlays is not performance sensitive and we get much more helpful output when things go wrong.

This PR also packages ufdt from [AOSP](https://android.googlesource.com/platform/system/libufdt/+/refs/heads/main-kernel)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
