### PR TITLE
Reapply "ci: update pinned"

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -95,15 +95,12 @@ runs:
           // This would fail without --refetch, because the we had a partial clone before, but changed it above.
           await run('git', 'fetch', '--depth=1', '--refetch', 'origin', ...(commits.map(({ sha }) => sha)))
 
-          // Checking out onto tmpfs takes 1s and is faster by at least factor 10x.
+          // On Linux, checking out onto tmpfs takes 1s and is faster by at least 10x.
+          // Currently, on Darwin we can only allocate 3.5GB, which isn't enough.
+          // See https://github.com/NixOS/nixpkgs/pull/506437
           await run('mkdir', 'nixpkgs')
-          switch (process.env.RUNNER_OS) {
-            case 'macOS':
-              await run('sudo', 'mount_tmpfs', 'nixpkgs')
-              break
-            case 'Linux':
-              await run('sudo', 'mount', '-t', 'tmpfs', 'tmpfs', 'nixpkgs')
-              break
+          if (process.env.RUNNER_OS === 'Linux') {
+            await run('sudo', 'mount', '-t', 'tmpfs', 'tmpfs', 'nixpkgs')
           }
 
           // Create all worktrees in parallel.
@@ -134,3 +131,6 @@ runs:
               await rm('pin-bump.patch')
             }
           }
+
+          console.log('final disk usage:')
+          await run('df', '-h')

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,3 +10,5 @@
 rules:
   dangerous-triggers:
     disable: true
+  secrets-outside-env:
+    disable: true

--- a/ci/pinned.json
+++ b/ci/pinned.json
@@ -9,9 +9,9 @@
       },
       "branch": "nixpkgs-unstable",
       "submodules": false,
-      "revision": "bde09022887110deb780067364a0818e89258968",
-      "url": "https://github.com/NixOS/nixpkgs/archive/bde09022887110deb780067364a0818e89258968.tar.gz",
-      "hash": "13mi187zpa4rw680qbwp7pmykjia8cra3nwvjqmsjba3qhlzif5l"
+      "revision": "106eb93cbb9d4e4726bf6bc367a3114f7ed6b32f",
+      "url": "https://github.com/NixOS/nixpkgs/archive/106eb93cbb9d4e4726bf6bc367a3114f7ed6b32f.tar.gz",
+      "hash": "0wyyhddz2mqhmq938d337223675jpd83dd5lsks2nhz0hs4r3jha"
     },
     "treefmt-nix": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
-      "url": "https://github.com/numtide/treefmt-nix/archive/e96d59dff5c0d7fddb9d113ba108f03c3ef99eca.tar.gz",
-      "hash": "02gqyxila3ghw8gifq3mns639x86jcq079kvfvjm42mibx7z5fzb"
+      "revision": "75925962939880974e3ab417879daffcba36c4a3",
+      "url": "https://github.com/numtide/treefmt-nix/archive/75925962939880974e3ab417879daffcba36c4a3.tar.gz",
+      "hash": "118zlbyzmh21x6rad2vrxjkdfyicd8lx3s0if8b791n51hz1r9ns"
     }
   },
   "version": 5


### PR DESCRIPTION
I figured out why "Build / darwin: shell" failed on #505118 and the previous PRs. [It's because we run out of disk](https://github.com/NixOS/nixpkgs/actions/runs/23965563439/job/69904729532#step:3:1001) (well, tmpfs) on the latest pinned version on MacOS only. This is because the checkouts are larger now, and by default the checkout action allocates 50% of memory for the tmpfs, which is 3.5GiB on MacOS (and 4GiB on Linux).

But we can't just allocate 4GiB instead. That would be too simple, and so we get the error "Desired memsize 4294967296 too large - defaulting to 3758096384 bytes" if we do that. Instead, I just remove the code that creates a tmpfs on MacOS. Surprisingly, the speed is good enough, nowhere near the 10x slowdown mentioned in the comment.

The logging I added would have saved me a lot of trouble figuring this out.

I've tested this by using the test workflow and hardcoding the checkout ref (which was adaquate to allow me to reproduce failures before I figured this out). It works! https://github.com/NixOS/nixpkgs/actions/runs/23966574483/job/69907603364?pr=506437

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
