### PR TITLE
[25.11] {wolfssl,vde2}: correct `meta.license`; vde2: switch to Mbed TLS

### DIFF
--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   autoreconfHook,
   libpcap,
-  wolfssl,
+  mbedtls,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +20,13 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # See: <https://github.com/virtualsquare/vde-2/issues/69>
+    (fetchpatch {
+      name = "vde2-backport-mbedtls-support.patch";
+      url = "https://github.com/virtualsquare/vde-2/commit/e3f701978a0a20e56cd9829353d110d4ddcedd90.patch";
+      hash = "sha256-cq3yrA3w/K6J+RtwYX9AcG/nfctlAkc3aYJZpJxJXTQ=";
+    })
+
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/vde2/musl-build-fix.patch?id=ddee2f86a48e087867d4a2c12849b2e3baccc238";
       sha256 = "0b5382v541bkxhqylilcy34bh83ag96g71f39m070jzvi84kx8af";
@@ -30,7 +37,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libpcap
-    wolfssl
+    mbedtls
+  ];
+
+  configureFlags = [
+    "--with-crypt=mbedtls"
   ];
 
   meta = {

--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Yf6QB7j5lYld2XtqhYspK4037lTtimoFc7nCavCP+mU=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/vde2/musl-build-fix.patch?id=ddee2f86a48e087867d4a2c12849b2e3baccc238";
       sha256 = "0b5382v541bkxhqylilcy34bh83ag96g71f39m070jzvi84kx8af";

--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/virtualsquare/vde-2";
     description = "Virtual Distributed Ethernet, an Ethernet compliant virtual network";
     platforms = lib.platforms.unix;
-    license = lib.licenses.gpl2Plus;
+    license = [
+      # Effectively `lib.licenses.gpl2Only`, but file headers differ.
+      lib.licenses.gpl2Plus
+      lib.licenses.gpl2Only
+      # libvdeplug and code copied from glibc.
+      lib.licenses.lgpl21Plus
+    ];
   };
 }

--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
-    MACOSX_DEPLOYMENT_TARGET=10.16
-  '';
-
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [

--- a/pkgs/by-name/wo/wolfssl/package.nix
+++ b/pkgs/by-name/wo/wolfssl/package.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.wolfssl.com/";
     changelog = "https://github.com/wolfSSL/wolfssl/releases/tag/v${finalAttrs.version}-stable";
     platforms = lib.platforms.all;
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       fab
       vifino


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/504446.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
