### PR TITLE
semgrep: 1.152.0 -> 1.161.0

### DIFF
--- a/pkgs/development/python-modules/semgrep/common.nix
+++ b/pkgs/development/python-modules/semgrep/common.nix
@@ -1,9 +1,13 @@
 { lib }:
 
 rec {
-  version = "1.152.0";
+  version = "1.161.0";
 
-  srcHash = "sha256-CwF9URo3nUfkIWP277y03Bq9P6FUC4CQLjuiYwCPR6M=";
+  srcHash = "sha256-WvvEn5PUEXgwtYd72IuEljHUxcJRJh7uHzNLFqaVEbc=";
+
+  # This tag is used to select the correct wheel from PyPI.
+  # It is updated by the update.sh script.
+  pythonWheelTag = "cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314";
 
   # submodule dependencies
   # these are fetched so we:
@@ -13,8 +17,8 @@ rec {
     "cli/src/semgrep/semgrep_interfaces" = {
       owner = "semgrep";
       repo = "semgrep-interfaces";
-      rev = "76ce6450aba3422c297b35a16e38b9fd740fc860";
-      hash = "sha256-hU76aICQEI7n4tWwZX2fRjgiVw811E4UDkfqQqxX8c0=";
+      rev = "8a09b2ed5838118f0ecc45305eb9d956aabcd700";
+      hash = "sha256-jWv0/DADhYmBGJdMpxX8Rq2KQ2wlYIrJGGeYikcskOM=";
     };
   };
 
@@ -24,20 +28,20 @@ rec {
   # on github releases
   core = {
     x86_64-linux = {
-      platform = "musllinux_1_0_x86_64.manylinux2014_x86_64";
-      hash = "sha256-XFZfCxvfCSAs2NxCCbmIU2uN0StNwEPSGaTmaHpYMPo=";
+      platform = "manylinux_2_35_x86_64";
+      hash = "sha256-ioIlfWVDSPlCUPQQcB8RJNxwoMQzhGGsxe5xPhAbDZ0=";
     };
     aarch64-linux = {
-      platform = "musllinux_1_0_aarch64.manylinux2014_aarch64";
-      hash = "sha256-XdmzHKizsxrls1Ry7pW40f4BRjA6HEayhDUXuxDHoWk=";
+      platform = "manylinux_2_35_aarch64";
+      hash = "sha256-yDFnKdVIgt7eFNcWb0za9hdJJ7BYldEoiK46D0eRx4U=";
     };
     x86_64-darwin = {
       platform = "macosx_10_14_x86_64";
-      hash = "sha256-4ZVFhsN5VyDE/VTnzfellv2dHQIT2nCTKd/54UBRPw0=";
+      hash = "sha256-NFBo32ZfO0h0KunOaWefWRnyuu1XkYku5RTxOpCfWWQ=";
     };
     aarch64-darwin = {
       platform = "macosx_11_0_arm64";
-      hash = "sha256-rEK6kAEKdwIOcmdMhyjTn5MIXbEwLPqrZV3pg3cQINk=";
+      hash = "sha256-H51DqX94yMqbwvDrlIa3D64hBtvYAvelK7HLnVj588g=";
     };
   };
 

--- a/pkgs/development/python-modules/semgrep/semgrep-core.nix
+++ b/pkgs/development/python-modules/semgrep/semgrep-core.nix
@@ -1,23 +1,25 @@
 {
   lib,
-  stdenvNoCC,
+  stdenv,
   fetchPypi,
   unzip,
+  autoPatchelfHook,
 }:
 
 let
   common = import ./common.nix { inherit lib; };
 in
-stdenvNoCC.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "semgrep-core";
   inherit (common) version;
+
   # fetch pre-built semgrep-core since the ocaml build is complex and relies on
   # the opam package manager at some point
   # pulling it out of the python wheel as r2c no longer release a built binary
   # on github releases
   src =
     let
-      inherit (stdenvNoCC.hostPlatform) system;
+      inherit (stdenv.hostPlatform) system;
       data = common.core.${system} or (throw "Unsupported system: ${system}");
     in
     fetchPypi rec {
@@ -25,11 +27,16 @@ stdenvNoCC.mkDerivation rec {
       inherit version;
       format = "wheel";
       dist = python;
-      python = "cp310.cp311.cp312.cp313.cp314.py310.py311.py312.py313.py314";
+      python = common.pythonWheelTag;
       inherit (data) platform hash;
     };
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [
+    unzip
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux stdenv.cc.cc.lib;
 
   # _tryUnzip from unzip's setup-hook doesn't recognise .whl
   # "do not know how to unpack source archive"
@@ -46,6 +53,18 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     install -Dm 755 -t $out/bin semgrep-${version}.data/purelib/semgrep/bin/semgrep-core
+
+    # copy bundled libs as well
+    # keeping them in bin/libs matches the layout in the wheel
+    if [ -d semgrep-${version}.data/purelib/semgrep/bin/libs ]; then
+      mkdir -p $out/bin/libs
+      cp -rf semgrep-${version}.data/purelib/semgrep/bin/libs/* $out/bin/libs/
+
+      # help autoPatchelfHook find these libs
+      if [ -n "''${autoPatchelfHook:-}" ]; then
+        appendAutoPatchelfSearchPath $out/bin/libs
+      fi
+    fi
     runHook postInstall
   '';
 

--- a/pkgs/development/python-modules/semgrep/update.sh
+++ b/pkgs/development/python-modules/semgrep/update.sh
@@ -19,7 +19,7 @@ NIXPKGS_ROOT="$ROOT/../../../.."
 COMMON_FILE="$ROOT/common.nix"
 
 instantiateClean() {
-    nix-instantiate -A "$1" --eval --strict | cut -d\" -f2
+    nix-instantiate "$NIXPKGS_ROOT" -A "$1" --eval --strict | cut -d\" -f2
 }
 
 # get latest version
@@ -40,10 +40,25 @@ replace() {
 
 fetchgithub() {
     set +eo pipefail
-    nix-build -A "$1" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g'
+    nix-build "$NIXPKGS_ROOT" -A "$1" 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g'
     set -eo pipefail
 }
-replace "$OLD_VERSION" "$NEW_VERSION" "$COMMON_FILE"
+
+if [[ "$OLD_VERSION" != "$NEW_VERSION" ]]; then
+    replace "$OLD_VERSION" "$NEW_VERSION" "$COMMON_FILE"
+fi
+
+echo "Fetching PyPI metadata for $NEW_VERSION"
+PYPI_JSON=$(curl -s "https://pypi.org/pypi/semgrep/$NEW_VERSION/json")
+
+# Update Python compatibility tag from any Linux wheel
+NEW_PYTHON_TAG=$(echo "$PYPI_JSON" | jq -r '.urls[].filename' | grep 'manylinux' | head -n 1 | sed -E 's/semgrep-.*-(.*)-none-.*\.whl/\1/')
+OLD_PYTHON_TAG=$(instantiateClean semgrep.passthru.common.pythonWheelTag)
+
+if [[ "$OLD_PYTHON_TAG" != "$NEW_PYTHON_TAG" ]]; then
+    echo "Updating Python wheel tag: $OLD_PYTHON_TAG -> $NEW_PYTHON_TAG"
+    replace "$OLD_PYTHON_TAG" "$NEW_PYTHON_TAG" "$COMMON_FILE"
+fi
 
 echo "Updating src"
 
@@ -60,24 +75,38 @@ echo "Updated src"
 
 update_core_platform() {
     SYSTEM=$1
+    PYPI_ARCH=$2
+    PYPI_DISTRO=$3
     echo "Updating core src $SYSTEM"
 
-    PLATFORM="$(instantiateClean "semgrep.passthru.common.core.$SYSTEM.platform")"
+    OLD_PLATFORM="$(instantiateClean "semgrep.passthru.common.core.$SYSTEM.platform")"
+    NEW_PLATFORM=$(echo "$PYPI_JSON" | jq -r '.urls[].filename' | grep "$PYPI_DISTRO" | grep "$PYPI_ARCH" | head -n 1 | sed -E 's/semgrep-.*-none-(.*)\.whl/\1/')
+
+    if [[ -z "$NEW_PLATFORM" ]]; then
+        echo "Error: Could not find platform tag for $SYSTEM ($PYPI_DISTRO, $PYPI_ARCH) on PyPI" >&2
+        exit 1
+    fi
+
+    if [[ "$OLD_PLATFORM" != "$NEW_PLATFORM" ]]; then
+        echo "Updating platform: $OLD_PLATFORM -> $NEW_PLATFORM"
+        replace "$OLD_PLATFORM" "$NEW_PLATFORM" "$COMMON_FILE"
+    fi
 
     OLD_HASH="$(instantiateClean "semgrep.passthru.common.core.$SYSTEM.hash")"
-    URL="$(nix-instantiate -A "semgrep.passthru.semgrep-core.src.url" --raw --eval --strict --argstr system "$SYSTEM")"
+    URL="$(nix-instantiate "$NIXPKGS_ROOT" -A "semgrep.passthru.semgrep-core.src.url" --raw --eval --strict --argstr system "$SYSTEM")"
     echo "Old core hash $OLD_HASH"
-    NEW_HASH="$(nix hash convert --hash-algo sha256 --to sri $(nix-prefetch-url $URL))"
+    NEW_HASH="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --type sha256 "$URL")")"
     echo "New core hash $NEW_HASH"
     replace "$OLD_HASH" "$NEW_HASH" "$COMMON_FILE"
 
     echo "Updated core src $SYSTEM"
 }
 
-update_core_platform "x86_64-linux"
-update_core_platform "aarch64-linux"
-update_core_platform "x86_64-darwin"
-update_core_platform "aarch64-darwin"
+# update_core_platform <nix-system> <pypi-arch> <pypi-distro>
+update_core_platform "x86_64-linux" "x86_64" "manylinux"
+update_core_platform "aarch64-linux" "aarch64" "manylinux"
+update_core_platform "x86_64-darwin" "x86_64" "macosx"
+update_core_platform "aarch64-darwin" "arm64" "macosx"
 
 OLD_PWD=$PWD
 TMPDIR="$(mktemp -d)"


### PR DESCRIPTION
Updates `semgrep` from `1.152.0` to `1.161.0`.

`update.sh` was adjusted in the same PR because upstream changed the Linux wheel naming on PyPI for current releases, and using `nix-hash` keeps the updater working without relying on the experimental `nix hash` interface.

This release introduced structural changes to how the `semgrep-core` binary is distributed and linked in the upstream Python wheels, requiring adjustments to the Nix derivation to maintain a functional package.

Starting with version 1.159.0, the `semgrep-core` binary is dynamically linked against several shared libraries (e.g., `libtree-sitter`, `libzstd`, `libcurl`, `libgmp`). Upstream now bundles these dependencies within a `libs/` directory inside the Python wheel.

Upstream has updated their build target for Linux wheels. The `manylinux2014` tag is no longer used for version 1.159.0 on PyPI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

