### PR TITLE
imapgoose: 0.4.2 -> 0.5.0

### DIFF
--- a/pkgs/by-name/im/imapgoose/package.nix
+++ b/pkgs/by-name/im/imapgoose/package.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "imapgoose";
-  version = "0.4.2";
+  version = "0.5.0";
 
   src = fetchFromSourcehut {
     owner = "~whynothugo";
     repo = "ImapGoose";
     tag = "v${version}";
-    hash = "sha256-Zu2cHCTl6RyZzndFrLM7xTeD/T3isVerIB8D6vD3jIU=";
+    hash = "sha256-H+6S+jAZT4jj1R8sJeLzFjyNkZqo0WlTLVfu1BH+RM4=";
   };
 
-  vendorHash = "sha256-6mh6KsJlijXn+bLzmtJSC4lcYFChQdyBKEjFzbQMIM0=";
+  vendorHash = "sha256-75dP0iB3Tu1GQfi9w+H1dgWHZh7X9FJOlsLbC3Baqjg=";
 
   subPackages = [
     "cmd/imapgoose"


### PR DESCRIPTION
## Summary
- Bump imapgoose from 0.4.2 to 0.5.0
- Update src and vendor hashes

## Things done
- [x] Built on x86_64-linux
- [x] Verified binaries (`imapgoose`, `capcheck`) and man pages install correctly

## Metadata
- Maintainer update