### PR TITLE
darwin.ICU: avoid conflicts with the system libicucore

### DIFF
--- a/pkgs/os-specific/darwin/by-name/ic/ICU/package.nix
+++ b/pkgs/os-specific/darwin/by-name/ic/ICU/package.nix
@@ -133,6 +133,16 @@ let
           --replace-fail '$(top_srcdir)/../LICENSE' "$NIX_BUILD_TOP/source/icu/LICENSE"
         substituteInPlace config/dist-data.sh \
           --replace-fail "\''${top_srcdir}/../LICENSE" "$NIX_BUILD_TOP/source/icu/LICENSE"
+
+        # Make sure this ICU build puts C++ symbols in a distinct namespace to avoid symbol clashes with other ICU
+        # implementations (including both the system ICU and builds of the upstream ICU).
+        # This breaks binary compatibility for the C++ API, but it’s not ABI stable anyway. Without doing this,
+        # `dotnet` crashes on macOS 26.4 when linked against `libicucore.A.dylib` from Nixpkgs.
+        substituteInPlace common/unicode/uvernum.h \
+          --replace-fail 'U_ICU_VERSION_SUFFIX ' 'U_ICU_VERSION_SUFFIX _nix'
+        # Only enable symbol renaming for C++ symbols. C symbols need to remain unversioned for compatibility.
+        substituteInPlace common/unicode/uversion.h \
+          --replace-fail U_DISABLE_RENAMING 0
       '';
 
     # remove dependency on bootstrap-tools in early stdenv build


### PR DESCRIPTION
The ICU C++ ABI is not stable and can change from version to version. If the system `libicucore.A.dylib` is pulled into a process at the same time as `libicucore.A.dylib` from Nixpkgs, it can result in a crash when those two dylibs are from different ICU versions.

For example, macOS 26.4 appears to have updated ICU to ICU 78, but the source release packages is still ICU 76. This causes `dotnet --info` to crash when it tries to load `libicucore.dylib`, gets both, and the symbols get mixed up.

This patch avoids the issue by adding a version suffix to the C++ symbols. When `dotnet` loads `libicucore.dylib`, the symbols are resolved correctly, and it no longer crashes. Note that the C symbols are note versioned because they are exported as the stable ABI.

Fixes https://github.com/NixOS/nixpkgs/issues/502224.

Note: I tested with `nix build -f . dotnet-sdk_10` and confirmed that `dotnet --info` works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
