### PR TITLE
haskellPackages.duckdb-ffi: include duckdb C++ library

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2096,6 +2096,15 @@ with haskellLib;
     jailbreak = true;
   } super.feed;
 
+  # 2026-04-14: Apache Iceberg not included in NixOS duckdb
+  # and there's no way to download it in sandbox
+  beam-duckdb = overrideCabal (drv: {
+    testFlags = (drv.testFlags or [ ]) ++ [
+      "--pattern"
+      "!/Iceberg/"
+    ];
+  }) super.beam-duckdb;
+
   # 2026-03-25: one test fails
   # https://github.com/Tritlo/duckdb-haskell/issues/8
   # TODO: remove after PR https://github.com/Tritlo/duckdb-haskell/pull/9 is merged

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2106,6 +2106,11 @@ with haskellLib;
     ];
   }) super.duckdb-ffi;
 
+  # 2026-03-30: too strict bounds on quickcheck <=2.15
+  # https://github.com/Tritlo/duckdb-haskell/pull/10
+  # TODO: remove after PR is merged
+  duckdb-simple = doJailbreak super.duckdb-simple;
+
   spacecookie = overrideCabal (old: {
     buildTools = (old.buildTools or [ ]) ++ [ pkgs.buildPackages.installShellFiles ];
     # let testsuite discover the resulting binary

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -29,6 +29,9 @@ default-package-overrides:
   # 2026-01-23: dataframe >= 0.3.3.7 uses random-1.3, which breaks dependency coherence on 25.11, whose default version is random-1.2
   # TODO: when (likely in 25.x) Stackage bumps random to 1.3, review
   - dataframe == 0.3.3.6
+  # 2026-04-13: 0.1.5 introduced breaking change
+  # https://github.com/Tritlo/duckdb-haskell/issues/6
+  - duckdb-simple < 0.1.5
   # 2025-12-26: Needs to match egison-pattern-src from Stackage LTS
   - egison-pattern-src-th-mode < 0.2.2
   - extensions == 0.1.0.2 # matches Cabal 3.12 (GHC 9.10)

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -215,7 +215,6 @@ dont-distribute-packages:
  - bbi
  - bdcs
  - bdcs-api
- - beam-duckdb
  - beam-th
  - beautifHOL
  - bech32-th


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I added `duckdb`'s C++ libraries as a build dependency for `duckdb-ffi`, in similar manner as `libtorch-ffi`. This should help with https://github.com/Tritlo/duckdb-haskell/issues/4.

There is a test that fails, that will be fixed upstream (https://github.com/Tritlo/duckdb-haskell/issues/8). Disabled that test for now, since a PR (https://github.com/Tritlo/duckdb-haskell/pull/9) will be fixing that soon.

- ~~updated `duckdb` to v1.5.1 to support `duckdb-ffi` v1.5; `duckdb` follows semantic versioning so this should not break anything~~ already updated in `master`
- ~~patched `duckdb-simple` (https://github.com/Tritlo/duckdb-haskell/pull/11) and `beam-duckdb` (https://github.com/haskell-beam/beam/pull/790) to work with `duckdb` v1.5~~
- pinned `duckdb-simple` to `< 0.1.5`  to avoid some breaking changes in 0.1.5 above

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (see section above)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
