### PR TITLE
installShellFiles: add PowerShell completion support

### DIFF
--- a/pkgs/by-name/in/installShellFiles/setup-hook.sh
+++ b/pkgs/by-name/in/installShellFiles/setup-hook.sh
@@ -100,14 +100,14 @@ installManPage() {
     done
 }
 
-# installShellCompletion [--cmd <name>] ([--bash|--fish|--zsh] [--name <name>] <path>)...
+# installShellCompletion [--cmd <name>] ([--bash|--fish|--nushell|--powershell|--zsh] [--name <name>] <path>)...
 #
 # Each path is installed into the appropriate directory for shell completions for the given shell.
-# If one of `--bash`, `--fish`, `--zsh`, or `--nushell` is given the path is assumed to belong to
-# that shell. Otherwise the file extension will be examined to pick a shell. If the shell is
-# unknown a warning will be logged and the command will return a non-zero status code after
-# processing any remaining paths. Any of the shell flags will affect all subsequent paths (unless
-# another shell flag is given).
+# If one of `--bash`, `--fish`, `--nushell`, `--powershell`, or `--zsh` is given, the path is
+# assumed to belong to that shell. Otherwise the file extension will be examined to pick a shell. If
+# the shell is unknown, a warning will be logged and the command will return a non-zero status code
+# after processing any remaining paths. Any of the shell flags will affect all subsequent paths
+# (unless another shell flag is given).
 #
 # If the shell completion needs to be renamed before installing the optional `--name <name>` flag
 # may be given. Any name provided with this flag only applies to the next path.
@@ -137,6 +137,7 @@ installManPage() {
 #   installShellCompletion --bash --name foobar.bash share/completions.bash
 #   installShellCompletion --fish --name foobar.fish share/completions.fish
 #   installShellCompletion --nushell --name foobar share/completions.nu
+#   installShellCompletion --powershell --name foobar.Completion.ps1 share/completions.ps1
 #   installShellCompletion --zsh --name _foobar share/completions.zsh
 #
 # Or to use shell newline escaping to split a single invocation across multiple lines:
@@ -144,7 +145,8 @@ installManPage() {
 #   installShellCompletion --cmd foobar \
 #     --bash <($out/bin/foobar --bash-completion) \
 #     --fish <($out/bin/foobar --fish-completion) \
-#     --nushell <($out/bin/foobar --nushell-completion)
+#     --nushell <($out/bin/foobar --nushell-completion) \
+#     --powershell <($out/bin/foobar --powershell-completion) \
 #     --zsh <($out/bin/foobar --zsh-completion)
 #
 # If any argument is `--` the remaining arguments will be treated as paths.
@@ -154,7 +156,7 @@ installShellCompletion() {
         # Parse arguments
         if (( parseArgs )); then
             case "$arg" in
-            --bash|--fish|--zsh|--nushell)
+            --bash|--fish|--powershell|--zsh|--nushell)
                 shell=${arg#--}
                 continue;;
             --name)
@@ -200,7 +202,7 @@ installShellCompletion() {
         elif [[ -p "$arg" ]]; then
             # this is a named fd or fifo
             if [[ -z "$curShell" ]]; then
-                nixErrorLog "${FUNCNAME[0]}: named pipe requires one of --bash, --fish, --zsh, or --nushell"
+                nixErrorLog "${FUNCNAME[0]}: named pipe requires one of --bash, --fish, --powershell, --zsh, or --nushell"
                 return 1
             elif [[ -z "$name" && -z "$cmdname" ]]; then
                 nixErrorLog "${FUNCNAME[0]}: named pipe requires one of --cmd or --name"
@@ -216,6 +218,7 @@ installShellCompletion() {
                 ?*.bash) curShell=bash;;
                 ?*.fish) curShell=fish;;
                 ?*.nu) curShell=nushell;;
+                ?*.ps1) curShell=powershell;;
                 ?*.zsh) curShell=zsh;;
                 *)
                     if [[ "$argbase" = _* && "$argbase" != *.* ]]; then
@@ -238,6 +241,7 @@ installShellCompletion() {
             case "$curShell" in
             bash|fish) outName=$cmdname.$curShell;;
             nushell) outName=$cmdname.nu;;
+            powershell) outName=$cmdname.Completion.ps1;;
             zsh) outName=_$cmdname;;
             *)
                 # Our list of shells is out of sync with the flags we accept or extensions we detect.
@@ -250,6 +254,13 @@ installShellCompletion() {
         bash) sharePath=bash-completion/completions;;
         fish) sharePath=fish/vendor_completions.d;;
         nushell) sharePath=nushell/vendor/autoload;;
+        powershell)
+            sharePath=powershell
+            # only apply automatic renaming if we didn't have a manual rename
+            if [[ -z "$name" && -z "$cmdname" ]]; then
+                # convert a name like `foo.ps1` into `foo.Completion.ps1`
+                outName=${outName%.ps1}.Completion.ps1
+            fi;;
         zsh)
             sharePath=zsh/site-functions
             # only apply automatic renaming if we didn't have a manual rename

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion-cmd.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion-cmd.nix
@@ -15,16 +15,19 @@ runCommandLocal "install-shell-files--install-completion-cmd"
     echo baz > baz.fish
     echo qux > qux.fish
     echo buzz > buzz.nu
+    echo corge > corge.ps1
 
     installShellCompletion \
       --cmd foobar --bash foo.bash \
       --zsh bar.zsh \
       --fish baz.fish --name qux qux.fish \
-      --nushell --cmd buzzbar buzz.nu
+      --nushell --cmd buzzbar buzz.nu \
+      --powershell --cmd corgebar corge.ps1
 
     cmp foo.bash $out/share/bash-completion/completions/foobar.bash
     cmp bar.zsh $out/share/zsh/site-functions/_foobar
     cmp baz.fish $out/share/fish/vendor_completions.d/foobar.fish
     cmp qux.fish $out/share/fish/vendor_completions.d/qux
     cmp buzz.nu $out/share/nushell/vendor/autoload/buzzbar.nu
+    cmp corge.ps1 $out/share/powershell/corgebar.Completion.ps1
   ''

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion-fifo.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion-fifo.nix
@@ -14,10 +14,12 @@ runCommandLocal "install-shell-files--install-completion-fifo"
       --bash --name foo.bash <(echo foo) \
       --zsh --name _foo <(echo bar) \
       --fish --name foo.fish <(echo baz) \
-      --nushell --name foo.nu <(echo bucks)
+      --nushell --name foo.nu <(echo bucks) \
+      --powershell --name foo.Completion.ps1 <(echo corge)
 
     [[ $(<$out/share/bash-completion/completions/foo.bash) == foo ]] || { echo "foo.bash comparison failed"; exit 1; }
     [[ $(<$out/share/zsh/site-functions/_foo) == bar ]] || { echo "_foo comparison failed"; exit 1; }
     [[ $(<$out/share/fish/vendor_completions.d/foo.fish) == baz ]] || { echo "foo.fish comparison failed"; exit 1; }
     [[ $(<$out/share/nushell/vendor/autoload/foo.nu) == bucks ]] || { echo "foo.nu comparison failed"; exit 1; }
+    [[ $(<$out/share/powershell/foo.Completion.ps1) == corge ]] || { echo "foo.Completion.ps1 comparison failed"; exit 1; }
   ''

--- a/pkgs/by-name/in/installShellFiles/tests/install-completion.nix
+++ b/pkgs/by-name/in/installShellFiles/tests/install-completion.nix
@@ -16,12 +16,14 @@ runCommandLocal "install-shell-files--install-completion"
     echo qux > qux.zsh
     echo quux > quux
     echo quokka > quokka
+    echo corge > corge.ps1
 
     installShellCompletion \
       --bash foo bar \
       --zsh baz qux.zsh \
       --fish quux \
-      --nushell quokka
+      --nushell quokka \
+      --powershell corge.ps1
 
     cmp foo $out/share/bash-completion/completions/foo
     cmp bar $out/share/bash-completion/completions/bar
@@ -29,4 +31,5 @@ runCommandLocal "install-shell-files--install-completion"
     cmp qux.zsh $out/share/zsh/site-functions/_qux
     cmp quux $out/share/fish/vendor_completions.d/quux
     cmp quokka $out/share/nushell/vendor/autoload/quokka
+    cmp corge.ps1 $out/share/powershell/corge.Completion.ps1
   ''

--- a/pkgs/by-name/te/tea/package.nix
+++ b/pkgs/by-name/te/tea/package.nix
@@ -42,10 +42,8 @@ buildGoModule (finalAttrs: {
     installShellCompletion --cmd tea \
       --bash <($out/bin/tea completion bash) \
       --fish <($out/bin/tea completion fish) \
+      --powershell <($out/bin/tea completion pwsh) \
       --zsh <($out/bin/tea completion zsh)
-
-    mkdir $out/share/powershell/ -p
-    $out/bin/tea completion pwsh > $out/share/powershell/tea.Completion.ps1
 
     $out/bin/tea man --out $out/share/man/man1/tea.1
   '';


### PR DESCRIPTION
As requested in #384084, adds `--powershell` flag to `installShellCompletion`. This installs completions to `$out/share/powershell/` with synthesized names of the form `$cmd.Completion.ps1` when using `--cmd`.

Updated the tea package to use this new flag.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
