### PR TITLE
geoserver: add service

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -258,6 +258,8 @@
 
 - The `services.nextcloud-spreed-signaling` NixOS module has been added to facilitate declarative management of a standalone Spreed signaling server ("High Performance Backend" for Nextcloud Talk).
 
+- The `services.geoserver` NixOS module has been added to allow running [Geoserver](https://geoserver.org/) as a service.
+
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
 - `buildNpmPackage` now supports `npmDepsFetcherVersion` (and `fetchNpmDeps` now supports `fetcherVersion`). Set to `2` to enable packument caching, which fixes builds for projects using npm workspaces.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1644,6 +1644,7 @@
   ./services/web-apps/froide-govplan.nix
   ./services/web-apps/galene.nix
   ./services/web-apps/gancio.nix
+  ./services/web-apps/geoserver.nix
   ./services/web-apps/gerrit.nix
   ./services/web-apps/glance.nix
   ./services/web-apps/glitchtip.nix

--- a/nixos/modules/services/web-apps/geoserver.nix
+++ b/nixos/modules/services/web-apps/geoserver.nix
@@ -1,0 +1,81 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+
+  cfg = config.services.geoserver;
+
+in
+{
+  options = {
+    services.geoserver = {
+      enable = mkEnableOption "Geoserver service";
+
+      package = lib.mkPackageOption pkgs "geoserver" { };
+
+      user = mkOption {
+        type = types.str;
+        default = "geoserver";
+        description = "The (system) user that will run the service.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "geoserver";
+        description = "The user's group.";
+      };
+
+      jvmOpts = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Any options passed to the JVM via the `JAVA_OPTS` environment variable. See [startup.sh](https://github.com/geoserver/geoserver/blob/main/src/release/bin/startup.sh) for details.";
+      };
+
+      jettyOpts = mkOption {
+        type = types.lines;
+        default = "";
+        example = "jetty.http.port=1234";
+        description = "Any options passed to the Jetty web server via the `JETTY_OPTS` environment variable. See [startup.sh](https://github.com/geoserver/geoserver/blob/main/src/release/bin/startup.sh) for details.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    users.users."${cfg.user}" = {
+      group = cfg.group;
+      isSystemUser = true;
+    };
+    users.groups."${cfg.group}" = { };
+
+    systemd.services.geoserver = {
+      description = "Geoserver";
+
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        GEOSERVER_HOME = "${cfg.package}/share/geoserver";
+        GEOSERVER_DATA_DIR = "/var/lib/geoserver";
+        JAVA_OPTS = "${cfg.jvmOpts}";
+        JETTY_OPTS = "${cfg.jettyOpts}";
+      };
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/geoserver-startup";
+        User = cfg.user;
+        Group = cfg.group;
+        NoNewPrivileges = true;
+        ProtectHome = true; # true=deny access to /home, /root, /run/user
+        StateDirectory = "geoserver";
+      };
+    };
+  };
+
+  meta.teams = [ lib.teams.geospatial ];
+}

--- a/nixos/tests/geoserver.nix
+++ b/nixos/tests/geoserver.nix
@@ -28,59 +28,86 @@ in
       {
         virtualisation.diskSize = 2 * 1024;
 
+        # The VM has several Geoserver package installations. They can't be run
+        # in parallel but are launched sequentially during the test run.
+        # Context managers (see below) are used to start/stop them selectively.
         environment.systemPackages = [
           geoserver
-          geoserverWithImporterExtension
           geoserverWithAllExtensions
         ];
+
+        services.geoserver = {
+          enable = true;
+          jettyOpts = "jetty.http.port=8090";
+          package = geoserverWithImporterExtension;
+        };
+        systemd.services.geoserver.wantedBy = lib.mkForce [ ]; # do not start the service at boot
       };
   };
 
   testScript = ''
     from contextlib import contextmanager
 
-    curl_cmd = "curl --fail --connect-timeout 2"
-    curl_cmd_rest = f"{curl_cmd} -u admin:geoserver -X GET"
-    base_url = "http://localhost:8080/geoserver"
+    CURL_CMD = "curl --fail --connect-timeout 2"
+    CURL_CMD_REST = f"{CURL_CMD} -u admin:geoserver -X GET"
+    BASE_URL_PKG = "http://localhost:8080/geoserver"
+    BASE_URL_SERVICE = "http://localhost:8090/geoserver"
     log_file = "./log.txt"
 
     @contextmanager
-    def running_geoserver(pkg):
+    def running_geoserver_pkg(pkg):
       try:
         print(f"Launching geoserver from {pkg}...")
         machine.execute(f"{pkg}/bin/geoserver-startup > {log_file} 2>&1 &")
-        machine.wait_until_succeeds(f"{curl_cmd} {base_url} 2>&1", timeout=60)
+        machine.wait_until_succeeds(f"{CURL_CMD} {BASE_URL_PKG} 2>&1", timeout=60)
         yield
       finally:
         # We need to wait a little bit to make sure the server is properly
         # shutdown before launching a new instance.
         machine.execute(f"{pkg}/bin/geoserver-shutdown; sleep 1")
 
+    @contextmanager
+    def running_geoserver_service():
+      service_name = "geoserver"
+      try:
+        print(f"Launching service {service_name}...")
+        machine.execute(f"systemctl start {service_name} > tee {log_file} 2>&1")
+        machine.wait_until_succeeds(f"{CURL_CMD} {BASE_URL_SERVICE} 2>&1", timeout=60)
+        yield
+      finally:
+        # We need to wait a little bit to make sure the server is properly
+        # shutdown before launching a new instance.
+        machine.execute(f"systemctl stop {service_name}; sleep 1")
+
     start_all()
 
-    with running_geoserver("${geoserver}"):
-      machine.succeed(f"{curl_cmd} {base_url}/ows?service=WMS&version=1.3.0&request=GetCapabilities")
+    with subtest("A standalone Geoserver installation without extensions can be started."):
+      with running_geoserver_pkg("${geoserver}"):
+        machine.succeed(f"{CURL_CMD} {BASE_URL_PKG}/ows?service=WMS&version=1.3.0&request=GetCapabilities")
 
-      # No extensions yet.
-      machine.fail(f"{curl_cmd_rest} {base_url}/rest/imports")
-      machine.fail(f"{curl_cmd_rest} {base_url}/rest/monitor/requests.csv")
+        # No extensions yet.
+        machine.fail(f"{CURL_CMD_REST} {BASE_URL_PKG}/rest/imports")
+        machine.fail(f"{CURL_CMD_REST} {BASE_URL_PKG}/rest/monitor/requests.csv")
 
+    with subtest("A standalone Geoserver installation with numerous extensions can be started."):
+      with running_geoserver_pkg("${geoserverWithAllExtensions}"):
+        machine.succeed(f"{CURL_CMD_REST} {BASE_URL_PKG}/rest/imports")
+        machine.succeed(f"{CURL_CMD_REST} {BASE_URL_PKG}/rest/monitor/requests.csv")
+        _, stdout = machine.execute(f"cat {log_file}")
+        print(stdout.replace("\\n", "\n"))
+        assert "GDAL Native Library loaded" in stdout, "gdal"
+        assert "org.geotools.imageio.netcdf.utilities.NetCDFUtilities" in stdout, "netcdf"
+        assert "Unable to load library 'netcdf'" not in stdout, "netcdf"
 
-    with running_geoserver("${geoserverWithImporterExtension}"):
-      machine.succeed(f"{curl_cmd_rest} {base_url}/rest/imports")
-      machine.fail(f"{curl_cmd_rest} {base_url}/rest/monitor/requests.csv")
+        # libjpeg-turbo is disabled as of 2.28.1.
+        # assert "The turbo jpeg encoder is available for usage" in stdout, "libjpeg-turbo"
 
-    with running_geoserver("${geoserverWithAllExtensions}"):
-      machine.succeed(f"{curl_cmd_rest} {base_url}/rest/imports")
-      machine.succeed(f"{curl_cmd_rest} {base_url}/rest/monitor/requests.csv")
-      _, stdout = machine.execute(f"cat {log_file}")
-      print(stdout.replace("\\n", "\n"))
-      assert "GDAL Native Library loaded" in stdout, "gdal"
-      assert "org.geotools.imageio.netcdf.utilities.NetCDFUtilities" in stdout, "netcdf"
-      assert "Unable to load library 'netcdf'" not in stdout, "netcdf"
+    with subtest("Geoserver can be run as a service. Some Extensions are available."):
+      with running_geoserver_service():
+        # Only the importer extension is available.
+        machine.succeed(f"{CURL_CMD_REST} {BASE_URL_SERVICE}/rest/imports")
+        machine.fail(f"{CURL_CMD_REST} {BASE_URL_SERVICE}/rest/monitor/requests.csv")
 
-      # libjpeg-turbo is disabled as of 2.28.1.
-      # assert "The turbo jpeg encoder is available for usage" in stdout, "libjpeg-turbo"
 
   '';
 }


### PR DESCRIPTION
This PR adds a new services.geoserver module which allows to run geoserver as a systemd service.

This PR replaces a [previous one](https://github.com/NixOS/nixpkgs/pull/318188). When reviewing, please consider having a look into [the](https://github.com/NixOS/nixpkgs/pull/318188#pullrequestreview-2110254492) [comments](https://github.com/NixOS/nixpkgs/pull/318188#issuecomment-2222908557) [there](https://github.com/NixOS/nixpkgs/pull/318188#issuecomment-4180318744): 
- I did not use `DynamicUser` because non-root does not have access to the state dir (but I'm fine change this again).
- I did not allow to configure the data dir because I had permission problems, even with the bind mount. The code from two years ago didn't work anymore (maybe systemd/NixOS had changed since then?).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
