### PR TITLE
foomatic-db-engine: 0-unstable-2024-02-10 -> 0-unstable-2026-04-03

### DIFF
--- a/pkgs/by-name/fo/foomatic-db-engine/package.nix
+++ b/pkgs/by-name/fo/foomatic-db-engine/package.nix
@@ -18,15 +18,15 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "foomatic-db-engine";
-  version = "0-unstable-2024-02-10";
+  version = "0-unstable-2026-04-13";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db-engine";
-    rev = "a2b12271e145fe3fd34c3560d276a57e928296cb";
-    hash = "sha256-qM12qtGotf9C0cjO9IkmzlW9GWCkT2Um+6dU3mZm3DU=";
+    rev = "e4e7b9cd28ba160428f82bc5234559d1f50e5c42";
+    hash = "sha256-wpGFGr2H2adN4AVrYBNc+f4nE9x7OtzAxF5PkzmieXc=";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

PPD files in packages `foomatic-db-ppds`, `foomatic-db-ppds-withNonfreeDb` and `ptouch-driver` are not affected by this update in any way (they are bit-wise identical, up to references to `$out` of course).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `b0b8fdc5e555370c1353abf7c997c1248cca7b34`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>foomatic-db-engine</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
    <li>ptouch-driver</li>
  </ul>
</details>
