### PR TITLE
picoclaw: 0.2.1 -> 0.2.9

### DIFF
--- a/pkgs/by-name/pi/picoclaw/package.nix
+++ b/pkgs/by-name/pi/picoclaw/package.nix
@@ -2,22 +2,25 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  olm,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "picoclaw";
-  version = "0.2.1";
+  version = "0.2.5";
 
   src = fetchFromGitHub {
     owner = "sipeed";
     repo = "picoclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JvcvpaGPPBiABK28rQhe63chYm7MRdfU6uflZosNRKg=";
+    hash = "sha256-Cn3ibZw2HscSAXYKICHTIHMiO9PIFRMphw75bH/s+qI=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-K9LssS1Hff19dv6oa8EaFOUZIRnOtAqC5jgnY5HuWTk=";
+  vendorHash = "sha256-vECQmX9p+CsVZkZ120ShOS4itRrDL+ua7fe2eEh8nV0=";
+
+  buildInputs = [ olm ];
 
   preBuild = ''
     go generate ./...
@@ -26,7 +29,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/sipeed/picoclaw/cmd/picoclaw/internal.version=${finalAttrs.version}"
+    "-X github.com/sipeed/picoclaw/pkg/config.Version=${finalAttrs.version}"
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/pi/picoclaw/package.nix
+++ b/pkgs/by-name/pi/picoclaw/package.nix
@@ -2,22 +2,25 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  olm,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "picoclaw";
-  version = "0.2.1";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "sipeed";
     repo = "picoclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JvcvpaGPPBiABK28rQhe63chYm7MRdfU6uflZosNRKg=";
+    hash = "sha256-oMees7EKANS5dkMHIqAHfGcumrNMtTEEA+dmpl8/dLE=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-K9LssS1Hff19dv6oa8EaFOUZIRnOtAqC5jgnY5HuWTk=";
+  vendorHash = "sha256-LjTLLeK2M8W34z1M11wKuBAoDI6ciCG3f4FRWAre/sY=";
+
+  buildInputs = [ olm ];
 
   preBuild = ''
     go generate ./...
@@ -26,7 +29,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/sipeed/picoclaw/cmd/picoclaw/internal.version=${finalAttrs.version}"
+    "-X github.com/sipeed/picoclaw/pkg/config.Version=${finalAttrs.version}"
   ];
 
   doInstallCheck = true;
@@ -40,6 +43,8 @@ buildGoModule (finalAttrs: {
         "TestCodexCliProvider_MockCLI_Success"
         "TestCodexCliProvider_MockCLI_Error"
         "TestCodexCliProvider_MockCLI_WithModel"
+        "TestGatewayStopRefusesNonGatewayAttachedProcess"
+        "TestGatewayStatusIgnoresAndRemovesPidFileForNonGatewayProcess"
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];


### PR DESCRIPTION
Release: https://github.com/sipeed/picoclaw/releases/tag/v0.2.5
Diff: https://github.com/sipeed/picoclaw/compare/v0.2.1...v0.2.5
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
