### PR TITLE
[25.11] nhost-cli: 1.31.3 -> 1.42.1

### DIFF
--- a/pkgs/by-name/nh/nhost-cli/package.nix
+++ b/pkgs/by-name/nh/nhost-cli/package.nix
@@ -1,26 +1,28 @@
 {
   lib,
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGo126Module (finalAttrs: {
   pname = "nhost-cli";
-  version = "1.31.3";
+  version = "1.42.1";
 
   src = fetchFromGitHub {
     owner = "nhost";
-    repo = "cli";
-    tag = "v${version}";
-    hash = "sha256-hUltJCehmlIDRLdJNGC/Oyjl6rnQHzjxSjrQEaDCdAo=";
+    repo = "nhost";
+    tag = "cli@${finalAttrs.version}";
+    hash = "sha256-n61YgU1/Ad1NMZr/1/jnmuZpN8PemPUW/gomf+ETvRw=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/cli";
 
   vendorHash = null;
 
   ldflags = [
     "-s"
-    "-w"
-    "-X=main.Version=v${version}"
+    "-X=main.Version=v${finalAttrs.version}"
   ];
 
   postInstall = ''
@@ -30,12 +32,15 @@ buildGoModule rec {
   # require network access
   checkFlags = [ "-skip=^TestMakeJSONRequest$" ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   meta = {
     description = "Tool for setting up a local development environment for Nhost";
     homepage = "https://github.com/nhost/cli";
-    changelog = "https://github.com/nhost/cli/releases/tag/v${version}";
+    changelog = "https://github.com/nhost/nhost/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ moraxyc ];
     mainProgram = "nhost";
   };
-}
+})


### PR DESCRIPTION
Manual backport of #505710
Fixs [CVE-2026-34200](https://nvd.nist.gov/vuln/detail/CVE-2026-34200)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
