### PR TITLE
python3Packages.blackjax: 1.4 -> 1.5

### DIFF
--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -8,8 +9,6 @@
   setuptools-scm,
 
   # dependencies
-  fastprogress,
-  ipython,
   jax,
   jaxlib,
   numpy,
@@ -17,22 +16,25 @@
   scipy,
   typing-extensions,
 
+  # optional-dependencies
+  fastprogress,
+
   # checks
   chex,
-  pytestCheckHook,
   pytest-xdist,
+  pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "blackjax";
-  version = "1.4";
+  version = "1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "blackjax-devs";
     repo = "blackjax";
     tag = finalAttrs.version;
-    hash = "sha256-x/K/M7C+XNhqMdRZdDPpKmGgmnrjGsruDL3lFia2ioQ=";
+    hash = "sha256-tKJfukTqSiW2Xg3/8DakxtxlwGpJ14S/7qUE1OGM97I=";
   };
 
   build-system = [
@@ -41,8 +43,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    fastprogress
-    ipython
     jax
     jaxlib
     numpy
@@ -51,11 +51,18 @@ buildPythonPackage (finalAttrs: {
     typing-extensions
   ];
 
+  optional-dependencies = {
+    progress = [
+      fastprogress
+    ];
+  };
+
   nativeCheckInputs = [
     chex
     pytestCheckHook
     pytest-xdist
-  ];
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.progress;
 
   disabledTestPaths = [
     "tests/test_benchmarks.py"
@@ -78,6 +85,10 @@ buildPythonPackage (finalAttrs: {
     "test_nuts__without_device"
     "test_nuts__without_jit"
     "test_smc_waste_free__with_jit"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # AssertionError: Not equal to tolerance rtol=1e-07, atol=1e-05
+    "test_equal_matrices"
   ];
 
   pythonImportsCheck = [ "blackjax" ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/blackjax-devs/blackjax/compare/1.4...1.5
Changelog: https://github.com/blackjax-devs/blackjax/releases/tag/1.5

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test