### PR TITLE
[25.11] libcerf: 3.2 -> 3.3, adopt

### DIFF
--- a/pkgs/by-name/li/libcerf/package.nix
+++ b/pkgs/by-name/li/libcerf/package.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcerf";
-  version = "3.2";
+  version = "3.3";
 
   src = fetchFromGitLab {
     domain = "jugit.fz-juelich.de";
     owner = "mlz";
     repo = "libcerf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Q79E9YsmYFRZI21vi62d8tWA/+AU3YJMaY1CgdTLQGc=";
+    hash = "sha256-EPloejabyLzLP+GIPSIsh6dZDk2WodSEU6CPoICRxnM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libcerf/package.nix
+++ b/pkgs/by-name/li/libcerf/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Complex error (erf), Dawson, Faddeeva, and Voigt function library";
     homepage = "https://jugit.fz-juelich.de/mlz/libcerf";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/libcerf/package.nix
+++ b/pkgs/by-name/li/libcerf/package.nix
@@ -1,19 +1,23 @@
 {
   stdenv,
   lib,
-  fetchurl,
   cmake,
-  perl,
+  fetchFromGitLab,
   gnuplot,
+  nix-update-script,
+  perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libcerf";
   version = "3.2";
 
-  src = fetchurl {
-    url = "https://jugit.fz-juelich.de/mlz/libcerf/-/archive/v${version}/libcerf-v${version}.tar.gz";
-    sha256 = "sha256-6o0RDXPsJKZDBCyjlARhzLsbZUHiExDstwq05NwUSu8=";
+  src = fetchFromGitLab {
+    domain = "jugit.fz-juelich.de";
+    owner = "mlz";
+    repo = "libcerf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Q79E9YsmYFRZI21vi62d8tWA/+AU3YJMaY1CgdTLQGc=";
   };
 
   nativeBuildInputs = [
@@ -21,15 +25,18 @@ stdenv.mkDerivation rec {
     perl
   ];
 
-  passthru.tests = {
-    inherit gnuplot;
+  passthru = {
+    tests = {
+      inherit gnuplot;
+    };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Complex error (erf), Dawson, Faddeeva, and Voigt function library";
     homepage = "https://jugit.fz-juelich.de/mlz/libcerf";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ orivej ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Manual backport of #501402
This can't be cherry-picked 1 to 1 since the package has been changed to use `finalAttrs` and `orivej` is still a maintainer on this branch. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
