### PR TITLE
snid: init at 0.4.0

### DIFF
--- a/pkgs/by-name/sn/snid/package.nix
+++ b/pkgs/by-name/sn/snid/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "snid";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "AGWA";
+    repo = "snid";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-syKEtG/B1Yy0BAQqlR6o4uIRSwCnFOBsPpV4arqO/I4=";
+  };
+
+  vendorHash = "sha256-cVarG6Tx4yWpZE5BLZsMtLV9LF1lsiFfIXxhYiNjQlY=";
+
+  meta = {
+    description = "Zero config TLS proxy server that uses SNI";
+    homepage = "https://github.com/AGWA/snid";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomfitzhenry ];
+    mainProgram = "snid";
+  };
+})


### PR DESCRIPTION
https://github.com/AGWA/snid

snid is a lightweight proxy server that forwards TLS connections based on the server name indication (SNI) hostname.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
