### PR TITLE
gamescope: add stb_image_resize2 compatibility patch

### DIFF
--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -84,6 +84,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ValveSoftware/gamescope/commit/4ce1a91fb219f570b0871071a2ec8ac97d90c0bc.diff";
       hash = "sha256-O358ScIIndfkc1S0A8g2jKvFWoCzcXB/g6lRJamqOI4=";
     })
+
+    # Pending upstream patch to support stb_image_resize2.h
+    # See: https://github.com/ValveSoftware/gamescope/pull/2130
+    (fetchpatch {
+      url = "https://github.com/ValveSoftware/gamescope/commit/d49a2aded261030e649fee42ad295f1ef56b736b.diff";
+      hash = "sha256-C0DlqDeO49mYAdUmk9hp68Jh0jr9tPzNrmpOoOWmO0o=";
+    })
   ];
 
   # We can't substitute the patch itself because substituteAll is itself a derivation,

--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -92,6 +92,13 @@ stdenv.mkDerivation (finalAttrs: {
       extraPrefix = "subprojects/wlroots/";
       hash = "sha256-q2zekWNn111lX8N938y8HjREvlNMtdCLJ4RveX9z8u8=";
     })
+
+    # Pending upstream patch to support stb_image_resize2.h
+    # See: https://github.com/ValveSoftware/gamescope/pull/2130
+    (fetchpatch {
+      url = "https://github.com/ValveSoftware/gamescope/commit/d49a2aded261030e649fee42ad295f1ef56b736b.diff";
+      hash = "sha256-Uh08ZRaV912ZOsl1DMpbVLxIgh4jEXevgihQf2W9KFk=";
+    })
   ];
 
   # We can't substitute the patch itself because substituteAll is itself a derivation,


### PR DESCRIPTION
Pulls in a pending upstream patch (ValveSoftware/gamescope#2130) that supports both `stb_image_resize.h` (old) and `stb_image_resize2.h` (new) using `__has_include` for compile-time detection. This prepares gamescope for the stb update in #491159, which removes the deprecated `stb_image_resize.h`.

The patch is a no-op with the current stb version and will activate the new code path once stb is updated. By landing this compatibility patch first, the stb update becomes safe for gamescope.

CuraEngine was also flagged in #491159 but does not use `stb_image_resize.h` — it only uses `stb_image.h` whose API is unchanged. Its current build failure is a pre-existing issue in `libarcus` (protobuf type mismatch), reproducible on master without any stb changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Test details

Tested against both old and new stb on x86_64-linux and aarch64-linux:

- **Old stb** (`0-unstable-2023-01-29`, current master): `#else` code path exercised, build succeeds on both platforms
- **New stb** (`0-unstable-2025-10-25`, from #491159): `#if __has_include` code path exercised via `gamescope.override { stb = stb-new; }`, build succeeds on both platforms
- gamescope is Linux-only (`platforms = lib.platforms.linux`), so x86_64-darwin and aarch64-darwin are N/A