### PR TITLE
maintainers: remove hqurve

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10856,12 +10856,6 @@
     githubId = 44043764;
     name = "Liam Hupfer";
   };
-  hqurve = {
-    email = "hqurve@outlook.com";
-    github = "hqurve";
-    githubId = 53281855;
-    name = "hqurve";
-  };
   hraban = {
     email = "hraban@0brg.net";
     github = "hraban";

--- a/pkgs/applications/misc/openbangla-keyboard/default.nix
+++ b/pkgs/applications/misc/openbangla-keyboard/default.nix
@@ -73,10 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "openbangla-gui";
     homepage = "https://openbangla.github.io/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      hqurve
-      johnrtitor
-    ];
+    maintainers = with lib.maintainers; [ johnrtitor ];
     platforms = lib.platforms.linux;
     # never built on aarch64-linux since first introduction in nixpkgs
     broken = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64;

--- a/pkgs/applications/science/math/labplot/default.nix
+++ b/pkgs/applications/science/math/labplot/default.nix
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
       lgpl3Plus
       mit
     ];
-    maintainers = with lib.maintainers; [ hqurve ];
+    maintainers = [ ];
     mainProgram = "labplot2";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/cu/cubiomes-viewer/package.nix
+++ b/pkgs/by-name/cu/cubiomes-viewer/package.nix
@@ -71,6 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     platforms = lib.platforms.all;
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ hqurve ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ja/java-language-server/package.nix
+++ b/pkgs/by-name/ja/java-language-server/package.nix
@@ -71,6 +71,6 @@ maven.buildMavenPackage {
     mainProgram = "java-language-server";
     homepage = "https://github.com/georgewfraser/java-language-server";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ hqurve ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ju/junction/package.nix
+++ b/pkgs/by-name/ju/junction/package.nix
@@ -73,7 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Choose the application to open files and links";
     homepage = "https://apps.gnome.org/Junction/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ hqurve ];
     teams = [ lib.teams.gnome-circle ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/lo/lorien/package.nix
+++ b/pkgs/by-name/lo/lorien/package.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     '';
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ hqurve ];
+    maintainers = [ ];
     mainProgram = "lorien";
   };
 }

--- a/pkgs/by-name/pd/pdfchain/package.nix
+++ b/pkgs/by-name/pd/pdfchain/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
     description = "Graphical user interface for the PDF Toolkit (PDFtk)";
     homepage = "https://pdfchain.sourceforge.io";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ hqurve ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "pdfchain";
   };

--- a/pkgs/by-name/sp/space-cadet-pinball/package.nix
+++ b/pkgs/by-name/sp/space-cadet-pinball/package.nix
@@ -76,10 +76,7 @@ stdenv.mkDerivation rec {
       unfree
       mit
     ];
-    maintainers = with lib.maintainers; [
-      hqurve
-      nadiaholmquist
-    ];
+    maintainers = with lib.maintainers; [ nadiaholmquist ];
     platforms = lib.platforms.all;
     mainProgram = "SpaceCadetPinball";
   };


### PR DESCRIPTION
## Reasons

- Last commented in [Mar 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ahqurve)
- Hasn't created any PRs / Issues since [May 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3Ahqurve)
- About 50 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ahqurve%20-commenter%3Ahqurve%20-author%3Ahqurve%20-reviewed-by%3Ahqurve) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] cubiomes-viewer
- [ ] java-language-server
- [ ] labplot
- [ ] lorien
- [ ] pdfchain