### PR TITLE
lib.systems.equals: optimize removeFunctions

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -43,7 +43,9 @@ let
   */
   equals =
     let
-      removeFunctions = a: filterAttrs (_: v: !isFunction v) a;
+      # perf: avoid lib.isFunction because system attrs are never __functor-style attrsets.
+      removeFunctions =
+        a: removeAttrs a (builtins.filter (n: builtins.isFunction a.${n}) (builtins.attrNames a));
     in
     a: b: removeFunctions a == removeFunctions b;
 


### PR DESCRIPTION
**Disclaimer: I used an LLM agent to drive this discovery**

Replace `filterAttrs` + `lib.isFunction` with `removeAttrs` + `builtins.filter` + `builtins.isFunction` in `lib.systems.equals`.

System attrs are never `__functor`-style attrsets, so `lib.isFunction`'s wrapper is unnecessary overhead. The double negation (`!pred` composed with `!isFunction`) also cancels out.

**NIX_SHOW_STATS delta on `hello.drvPath`:**

| Stat | Before | After | Delta |
|---|---|---|---|
| nrFunctionCalls | 229,883 | 154,411 | -75,472 (-32.8%) |
| envs.number | 250,215 | 174,743 | -75,472 (-30.2%) |
| envs.bytes | 4.6M | 3.4M | -1.2M (-26.4%) |
| nrAvoided | 291,314 | 216,054 | -75,260 (-25.8%) |
| gc.totalBytes | 49.7M | 48.5M | -1.2M (-2.4%) |

<details>
<summary>Repro</summary>

```bash
NIX_SHOW_STATS=1 nix-instantiate --eval \
  -E '(import ./. {}).hello.drvPath' 2>stats.json >/dev/null
jq . stats.json
```

</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test