### PR TITLE
rke2: Use Go's native FIPS 140-3 compliance mode instead of BoringCrypto

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -74,8 +74,13 @@ buildGoModule (finalAttrs: {
     lvm2 # dmsetup
   ];
 
-  # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
-  env.GOEXPERIMENT = "boringcrypto";
+  # Enable FIPS 140-3 compliance mode for Go
+  # at time of writing, upstream RKE2 uses the GOEXPERIMENT BoringCrypto module instead:
+  # https://docs.rke2.io/security/fips_support
+  # which has been superseded by this - see https://go.dev/doc/security/fips140#goboringcrypto
+  env.GOFIPS140 = "latest";
+  # tlsmlkem=0 can be removed in a future version of Go, see https://github.com/golang/go/issues/75166
+  env.GODEBUG = "fips140=only,tlsmlkem=0";
 
   # https://github.com/rancher/rke2/blob/104ddbf3de65ab5490aedff36df2332d503d90fe/scripts/build-binary#L27-L39
   ldflags =
@@ -131,12 +136,6 @@ buildGoModule (finalAttrs: {
   doCheck = false;
 
   doInstallCheck = true;
-  installCheckPhase = ''
-    runHook preInstallCheck
-    # Verify that the binary uses BoringCrypto
-    go tool nm $out/bin/.rke2-wrapped | grep '_Cfunc__goboringcrypto_' > /dev/null
-    runHook postInstallCheck
-  '';
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
 


### PR DESCRIPTION
See https://go.dev/doc/security/fips140#goboringcrypto

A side effect (though really the main motivation for this change) is fixing that since 1.26, Go reports versions built with any `GOEXPERIMENT`s with a dash (`go1.26.1-X:boringcrypto`) instead of a space (`go1.25.6 X:boringcrypto`), and tests are currently failing on master because of this:
```console
machine # [   19.871409] rke2[1002]: time="2026-04-04T11:27:31Z" level=fatal msg="Failed to validate golang version: incorrect golang build version - kubernetes v1.35.2 should be built with go1.26.1, runtime version is go1.26.1-X:boringcrypto"
machine # [   19.882605] systemd[1]: rke2-server.service: Main process exited, code=exited, status=1/FAILURE
```

This PR is kind of a bandaid fix, but I think it makes sense considering `GOEXPERIMENT=boringcrypto` is unsupported and getting replaced with this anyway. I'm also hesitant to report the issue to upstream since the versioning change might just be a problem with the nix package.

(Fixes #515110)

cc @rorosen @zimbatm @stefan-bordei

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
