### PR TITLE
nixos/manual: reference test options & explain runNixOSTest pkgs re-use

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -43,6 +43,8 @@ We refer to the whole test above as a test module, whereas the values
 in [`nodes.<name>`](#test-opt-nodes) and [`containers.<name>`](#test-opt-containers)
 are NixOS modules themselves.
 
+All test options are listed in [](#sec-test-options-reference).
+
 The option [`testScript`](#test-opt-testScript) is a piece of Python code that executes the
 test (described [below](#ssec-test-script)). During the test, it will start one or more
 virtual machines and/or `systemd-nspawn` containers, the configuration of which is described by
@@ -109,6 +111,8 @@ pkgs.testers.runNixOSTest {
 ```
 
 `runNixOSTest` returns a derivation that runs the test.
+It accepts a test module with [these options](#sec-test-options-reference) available.
+It defaults to re-using `pkgs` for the [`hostPkgs`](#test-opt-hostPkgs) & [`node.pkgs`](#test-opt-node.pkgs) options.
 
 ## Test machines {#ssec-nixos-test-machines}
 


### PR DESCRIPTION
- for making the "Test Options Reference" more visible & noticable, esp. for people who "just" want to look into what runNixOSTest accepts
- pkgs re-use indications because it may affect people migrating from nixosTest to runNixOSTest when using overlays in their nixos-modules

fixes #506552 (which was my own foolishness)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
