### PR TITLE
darkplaces: unstable-2022-05-10 -> 20140513-unstable-2026-01-22; nexuiz: use darkplaces from nixpkgs

### DIFF
--- a/pkgs/by-name/da/darkplaces/package.nix
+++ b/pkgs/by-name/da/darkplaces/package.nix
@@ -10,13 +10,13 @@
 }:
 stdenv.mkDerivation {
   pname = "darkplaces";
-  version = "unstable-2022-05-10";
+  version = "20140513-unstable-2026-01-22";
 
   src = fetchFromGitHub {
     owner = "DarkPlacesEngine";
     repo = "darkplaces";
-    rev = "f16954a9d40168253ac5d9890dabcf7dbd266cd9";
-    hash = "sha256-5KsUcgHbuzFUE6LcclqI8VPSFbXZzBnxzOBB9Kf8krI=";
+    rev = "d93f9c4292039354a2b8d40d11bc386891e55fe5";
+    hash = "sha256-/xbQhQZveRCSnotZz3Wbw+9VwNC+kqoEJ7GuNZTpkLA=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ne/nexuiz/package.nix
+++ b/pkgs/by-name/ne/nexuiz/package.nix
@@ -2,28 +2,9 @@
   lib,
   stdenv,
   fetchurl,
-  # required for both
   unzip,
-  zlib,
-  curl,
-  libjpeg,
-  libpng,
-  libvorbis,
-  libtheora,
-  libogg,
-  libmodplug,
-  # glx
-  libx11,
-  libGLU,
-  libGL,
-  libxpm,
-  libxext,
-  libxxf86vm,
-  libxxf86dga,
-  alsa-lib,
-  # sdl
-  SDL,
-  # icon
+  makeBinaryWrapper,
+  darkplaces,
   copyDesktopItems,
   makeDesktopItem,
 }:
@@ -45,19 +26,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     unzip
     copyDesktopItems
-  ];
-  buildInputs = [
-    # glx
-    libx11
-    libGLU
-    libGL
-    libxpm
-    libxext
-    libxxf86vm
-    libxxf86dga
-    alsa-lib
-    # sdl
-    SDL
+    makeBinaryWrapper
   ];
 
   postUnpack = ''
@@ -66,41 +35,23 @@ stdenv.mkDerivation {
     cd ../../
   '';
 
-  env.NIX_LDFLAGS = toString [
-    "-rpath ${zlib.out}/lib"
-    "-rpath ${curl.out}/lib"
-    "-rpath ${libjpeg.out}/lib"
-    "-rpath ${libpng.out}/lib"
-    "-rpath ${libvorbis.out}/lib"
-    "-rpath ${libtheora.out}/lib"
-    "-rpath ${libogg.out}/lib"
-    "-rpath ${libmodplug.out}/lib"
-  ];
-
-  buildPhase = ''
-    cd sources/darkplaces/
-    DP_FS_BASEDIR="$out/share/nexuiz"
-    make DP_FS_BASEDIR=$DP_FS_BASEDIR cl-release
-    make DP_FS_BASEDIR=$DP_FS_BASEDIR sdl-release
-    make DP_FS_BASEDIR=$DP_FS_BASEDIR sv-release
-    cd ../../
-  '';
+  dontBuild = true;
 
   installPhase = ''
     runHook preInstall
     mkdir -pv "$out/bin/"
-    cp -v sources/darkplaces/darkplaces-glx "$out/bin/nexuiz-glx"
-    cp -v sources/darkplaces/darkplaces-sdl "$out/bin/nexuiz-sdl"
-    cp -v sources/darkplaces/darkplaces-dedicated "$out/bin/nexuiz-dedicated"
+    makeWrapper ${lib.getBin darkplaces}/bin/darkplaces $out/bin/nexuiz \
+      --inherit-argv0 \
+      --add-flags "-basedir $out/share/nexuiz"
+    makeWrapper ${lib.getBin darkplaces}/bin/darkplaces-dedicated $out/bin/nexuiz-dedicated \
+      --inherit-argv0 \
+      --add-flags "-basedir $out/share/nexuiz"
     mkdir -pv "$out/share/nexuiz/"
     cp -rv data/ "$out/share/nexuiz/"
-    ln -s "$out/bin/nexuiz-sdl" "$out/bin/nexuiz"
     mkdir -pv $out/share/icon/
     cp sources/darkplaces/nexuiz.ico $out/share/icon/nexuiz.ico
     runHook postInstall
   '';
-
-  dontPatchELF = true;
 
   desktopItems = [
     (makeDesktopItem {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes: https://hydra.nixos.org/build/324539609

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
