### PR TITLE
splice: replace listToAttrs+map with mapAttrs

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -31,43 +31,42 @@ let
         # The same pkgs sets one probably intends
         // inputs.buildHost
         // inputs.hostTarget;
-      merge = name: {
-        inherit name;
-        value =
-          let
-            defaultValue = mash.${name};
-            # `or {}` is for the non-derivation attsert splicing case, where `{}` is the identity.
-            value' = mapCrossIndex (x: x.${name} or { }) inputs;
+      # perf: mapAttrs defers merge calls until a key is selected, avoiding
+      # ~60k eager closures that listToAttrs+map would create.
+      merge =
+        name: defaultValue:
+        let
+          # `or {}` is for the non-derivation attsert splicing case, where `{}` is the identity.
+          value' = mapCrossIndex (x: x.${name} or { }) inputs;
 
-            augmentedValue = defaultValue // {
-              __spliced = lib.filterAttrs (k: v: inputs.${k} ? ${name}) value';
-            };
-            # Get the set of outputs of a derivation. If one derivation fails to
-            # evaluate we don't want to diverge the entire splice, so we fall back
-            # on {}
-            tryGetOutputs =
-              value0:
-              let
-                inherit (builtins.tryEval value0) success value;
-              in
-              getOutputs (lib.optionalAttrs success value);
-            getOutputs =
-              value: lib.genAttrs (value.outputs or (lib.optional (value ? out) "out")) (output: value.${output});
-          in
-          # The derivation along with its outputs, which we recur
-          # on to splice them together.
-          if lib.isDerivation defaultValue then
-            augmentedValue
-            // spliceReal (mapCrossIndex tryGetOutputs value' // { hostTarget = getOutputs value'.hostTarget; })
-          else if lib.isAttrs defaultValue then
-            spliceReal value'
-          else
-            # Don't be fancy about non-derivations. But we could have used used
-            # `__functor__` for functions instead.
-            defaultValue;
-      };
+          augmentedValue = defaultValue // {
+            __spliced = lib.filterAttrs (k: v: inputs.${k} ? ${name}) value';
+          };
+          # Get the set of outputs of a derivation. If one derivation fails to
+          # evaluate we don't want to diverge the entire splice, so we fall back
+          # on {}
+          tryGetOutputs =
+            value0:
+            let
+              inherit (builtins.tryEval value0) success value;
+            in
+            getOutputs (lib.optionalAttrs success value);
+          getOutputs =
+            value: lib.genAttrs (value.outputs or (lib.optional (value ? out) "out")) (output: value.${output});
+        in
+        # The derivation along with its outputs, which we recur
+        # on to splice them together.
+        if lib.isDerivation defaultValue then
+          augmentedValue
+          // spliceReal (mapCrossIndex tryGetOutputs value' // { hostTarget = getOutputs value'.hostTarget; })
+        else if lib.isAttrs defaultValue then
+          spliceReal value'
+        else
+          # Don't be fancy about non-derivations. But we could have used used
+          # `__functor__` for functions instead.
+          defaultValue;
     in
-    lib.listToAttrs (map merge (lib.attrNames mash));
+    builtins.mapAttrs merge mash;
 
   splicePackages =
     {


### PR DESCRIPTION
**Disclaimer: I used an LLM agent to drive this discovery**

Replace `listToAttrs (map merge (attrNames mash))` with `builtins.mapAttrs merge mash` in splice.

`listToAttrs` forces every list element to extract `.name`, calling `merge` eagerly for the entire union of attribute names (~60k). `mapAttrs` already knows the keys; the lambda is only invoked when a key is selected, letting the 99.7% unforced ones stay as untouched thunks.

**NIX_SHOW_STATS delta on `pkgsCross.aarch64-multiplatform.hello.drvPath`:**

| Stat | Before | After | Delta |
|---|---|---|---|
| nrFunctionCalls | 567,512 | 507,404 | -60,108 (-10.6%) |
| nrThunks | 613,138 | 552,356 | -60,782 (-9.9%) |
| sets.number | 158,787 | 98,339 | -60,448 (-38.1%) |
| list.elements | 295,085 | 174,189 | -120,896 (-41.0%) |
| gc.totalBytes | 117.5M | 111.7M | -5.8M (-4.9%) |

<details>
<summary>Repro</summary>

```bash
NIX_SHOW_STATS=1 nix-instantiate --eval \
  -E '(import ./. {}).pkgsCross.aarch64-multiplatform.hello.drvPath' \
  2>stats.json >/dev/null
jq . stats.json
```

</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test