### PR TITLE
intiface-central: 3.0.0 -> 3.0.4+40

### DIFF
--- a/pkgs/by-name/in/intiface-central/package.nix
+++ b/pkgs/by-name/in/intiface-central/package.nix
@@ -27,13 +27,13 @@ let
 
   pname = "intiface-central";
 
-  version = "3.0.0";
+  version = "3.0.4+40";
 
   src = fetchFromGitHub {
     owner = "intiface";
     repo = "intiface-central";
     tag = "v${version}";
-    hash = "sha256-yKWaXkSjg7LMIKIeRfviu4SmStxl9BSXncJSxXJeU0Y=";
+    hash = "sha256-RMllaThwCp2mRl0ecMtj3z6DC4uhdLqYNPI8lZChmhI=";
   };
 
   rustDep = rustPlatform.buildRustPackage {
@@ -46,7 +46,7 @@ let
       ln -s ${buttplug} ../../buttplug
     '';
 
-    cargoHash = "sha256-HpmGmMMocLQ5/DJq8PJ5u04DipSlrReJ/3l76L9j8Yk=";
+    cargoHash = "sha256-2KmwfvSDIaLvGda/EofUxGPRevv+/UQOUdSPRF2LEJw=";
 
     nativeBuildInputs = [ pkg-config ];
 
@@ -61,15 +61,15 @@ let
   buttplug_dart = fetchFromGitHub {
     owner = "buttplugio";
     repo = "buttplug_dart";
-    tag = "v1.0.0-beta1";
-    hash = "sha256-cJJU/DRTuQawdfi0aMyi7Vfmv4GtUj7nEBRNYEuZ8JQ=";
+    tag = "v1.0.0";
+    hash = "sha256-nm9TdEL9+80hCbaPnpAJTQ0w1t40vWYcxyilQTwvEBU=";
   };
 
   buttplug = fetchFromGitHub {
     owner = "buttplugio";
     repo = "buttplug";
-    tag = "intiface_engine-4.0.0";
-    hash = "sha256-F3mMQviTeyw9Wlrf8vcbJ9oGTYoKCIpPbj2jayQlpeg=";
+    tag = "intiface_engine_4.0.2";
+    hash = "sha256-4tzGZEsqfCnz/ZX6qNx/Hku6yDK0g6gyep6p6WZGoQk=";
   };
 in
 flutter338.buildFlutterApplication {

--- a/pkgs/by-name/in/intiface-central/pubspec.lock.json
+++ b/pkgs/by-name/in/intiface-central/pubspec.lock.json
@@ -60,6 +60,16 @@
       "source": "hosted",
       "version": "9.2.0"
     },
+    "bloc_concurrency": {
+      "dependency": "direct main",
+      "description": {
+        "name": "bloc_concurrency",
+        "sha256": "86b7b17a0a78f77fca0d7c030632b59b593b22acea2d96972588f40d4ef53a94",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.0"
+    },
     "boolean_selector": {
       "dependency": "transitive",
       "description": {
@@ -165,11 +175,11 @@
       "dependency": "transitive",
       "description": {
         "name": "characters",
-        "sha256": "f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803",
+        "sha256": "faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     "checked_yaml": {
       "dependency": "transitive",
@@ -687,11 +697,21 @@
       "dependency": "transitive",
       "description": {
         "name": "material_color_utilities",
-        "sha256": "f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec",
+        "sha256": "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.11.1"
+      "version": "0.13.0"
+    },
+    "menu_base": {
+      "dependency": "transitive",
+      "description": {
+        "name": "menu_base",
+        "sha256": "820368014a171bd1241030278e6c2617354f492f5c703d7b7d4570a6b8b84405",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.1"
     },
     "meta": {
       "dependency": "direct main",
@@ -1202,6 +1222,16 @@
       "source": "hosted",
       "version": "3.0.0"
     },
+    "shortid": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shortid",
+        "sha256": "d0b40e3dbb50497dad107e19c54ca7de0d1a274eb9b4404991e443dadb9ebedb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.2"
+    },
     "sky_engine": {
       "dependency": "transitive",
       "description": "flutter",
@@ -1297,6 +1327,16 @@
       },
       "source": "hosted",
       "version": "0.7.8"
+    },
+    "tray_manager": {
+      "dependency": "direct main",
+      "description": {
+        "name": "tray_manager",
+        "sha256": "c5fd83b0ae4d80be6eaedfad87aaefab8787b333b8ebd064b0e442a81006035b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.2"
     },
     "typed_data": {
       "dependency": "transitive",


### PR DESCRIPTION
Updated intiface-central from 3.0.0 to 3.0.4, since 3.0.0 fails to start, getting stuck on the logo. No derivation changes beyond just version bumps.
https://github.com/intiface/intiface-central/blob/v3.0.4%2B40/CHANGELOG.md#v304---20260401-all-platforms

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. *(application startup only)*
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
