### PR TITLE
[25.11] {wolfssl,vde2}: correct meta.license; vde2: switch to Mbed TLS

### DIFF
--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   autoreconfHook,
   libpcap,
-  wolfssl,
+  mbedtls,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +20,13 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # See: <https://github.com/virtualsquare/vde-2/issues/69>
+    (fetchpatch {
+      name = "vde2-backport-mbedtls-support.patch";
+      url = "https://github.com/virtualsquare/vde-2/commit/e3f701978a0a20e56cd9829353d110d4ddcedd90.patch";
+      hash = "sha256-cq3yrA3w/K6J+RtwYX9AcG/nfctlAkc3aYJZpJxJXTQ=";
+    })
+
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/vde2/musl-build-fix.patch?id=ddee2f86a48e087867d4a2c12849b2e3baccc238";
       sha256 = "0b5382v541bkxhqylilcy34bh83ag96g71f39m070jzvi84kx8af";
@@ -30,7 +37,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libpcap
-    wolfssl
+    mbedtls
+  ];
+
+  configureFlags = [
+    "--with-crypt=mbedtls"
   ];
 
   meta = {

--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Yf6QB7j5lYld2XtqhYspK4037lTtimoFc7nCavCP+mU=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/vde2/musl-build-fix.patch?id=ddee2f86a48e087867d4a2c12849b2e3baccc238";
       sha256 = "0b5382v541bkxhqylilcy34bh83ag96g71f39m070jzvi84kx8af";

--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/virtualsquare/vde-2";
     description = "Virtual Distributed Ethernet, an Ethernet compliant virtual network";
     platforms = lib.platforms.unix;
-    license = lib.licenses.gpl2Plus;
+    license = [
+      # Effectively `lib.licenses.gpl2Only`, but file headers differ.
+      lib.licenses.gpl2Plus
+      lib.licenses.gpl2Only
+      # libvdeplug and code copied from glibc.
+      lib.licenses.lgpl21Plus
+    ];
   };
 }

--- a/pkgs/by-name/vd/vde2/package.nix
+++ b/pkgs/by-name/vd/vde2/package.nix
@@ -26,10 +26,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
-    MACOSX_DEPLOYMENT_TARGET=10.16
-  '';
-
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [

--- a/pkgs/by-name/wo/wolfssl/package.nix
+++ b/pkgs/by-name/wo/wolfssl/package.nix
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.wolfssl.com/";
     changelog = "https://github.com/wolfSSL/wolfssl/releases/tag/v${finalAttrs.version}-stable";
     platforms = lib.platforms.all;
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       fab
       vifino


### PR DESCRIPTION
This is just a topologically earlier remerge of PR https://github.com/NixOS/nixpkgs/pull/506442