### PR TITLE
meritous: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/me/meritous/gcc15-fix.patch
+++ b/pkgs/by-name/me/meritous/gcc15-fix.patch
@@ -1,0 +1,34 @@
+diff --git a/src/levelblit.c b/src/levelblit.c
+index 5a04a8e..f530aa8 100644
+--- a/src/levelblit.c
++++ b/src/levelblit.c
+@@ -2575,7 +2575,7 @@ void SpecialTile(int x, int y)
+ 			break;
+ 		case 42:
+ 			if (rooms[player_room].room_type == 5) {
+-				if (CanGetArtifact(rooms[player_room].room_param)) {
++				if (CanGetArtifact()) {
+ 					
+ 				} else {
+ 					sprintf(message, _("The artifact is tainted with shadow. You must slay more of the shadow first.") );
+diff --git a/src/save.h b/src/save.h
+index dd67443..bcf0471 100644
+--- a/src/save.h
++++ b/src/save.h
+@@ -24,7 +24,7 @@
+ #ifndef SAVE_H
+ #define SAVE_H
+ 
+-void DoSaveGame();
++void DoSaveGame(char *);
+ 
+ void FWInt(int val);
+ void FWChar(unsigned char i);
+@@ -39,6 +39,6 @@ void SaveGame(char *);
+ void LoadGame(char *);
+ void CloseFile();
+ 
+-int IsSaveFile();
++int IsSaveFile(char *);
+ 
+ #endif

--- a/pkgs/by-name/me/meritous/package.nix
+++ b/pkgs/by-name/me/meritous/package.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/meritous/meritous/-/commit/68029f02ccaea86fb96d6dd01edb269ac3e6eff0.patch";
       hash = "sha256-YRV0cEcn6nEJUdHF/cheezNbsgZmjy0rSUw0tuhUYf0=";
     })
+
+    # https://gitlab.com/meritous/meritous/-/merge_requests/6
+    ./gcc15-fix.patch
   ];
 
   prePatch = ''


### PR DESCRIPTION
Part of: https://github.com/NixOS/nixpkgs/issues/475479


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
