### PR TITLE
doc: document pkgs.callPackage and friends

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -67,11 +67,11 @@ rec {
 
     `drv`
 
-    : 1\. Function argument
+    : Derivation to override.
 
     `f`
 
-    : 2\. Function argument
+    : Function called with original derivation attributes, returning attributes to override.
 
     # Type
 
@@ -224,11 +224,12 @@ rec {
     );
 
   /**
-    Call the package function in the file `fn` with the required
-    arguments automatically.  The function is called with the
-    arguments `args`, but any missing arguments are obtained from
-    `autoArgs`.  This function is intended to be partially
-    parameterised, e.g.,
+    Call the package function in the file `fn` with the required arguments
+    automatically and make the result overridable with
+    [`makeOverridable`](#function-library-lib.customisation.makeOverridable).
+    The function is called with the arguments `args`, but any missing
+    arguments are obtained from `autoArgs`.  This function is intended to be
+    partially parameterised, e.g.,
 
       ```nix
       callPackage = callPackageWith pkgs;
@@ -255,15 +256,15 @@ rec {
 
     `autoArgs`
 
-    : 1\. Function argument
+    : Attribute set to automatically apply to `fn`'s arguments.
 
     `fn`
 
-    : 2\. Function argument
+    : Function (or path to import) that takes in an attribute set composed of `autoArgs`, `args` and overridden arguments.
 
     `args`
 
-    : 3\. Function argument
+    : Attribute set to always apply to `fn`'s arguments.
 
     # Type
 
@@ -339,7 +340,7 @@ rec {
       abort "lib.customisation.callPackageWith: ${error}";
 
   /**
-    Like `callPackage`, but for a function that returns an attribute
+    Like `callPackageWith`, but for a function that returns an attribute
     set of derivations. The override function is added to the
     individual attributes.
 
@@ -347,15 +348,15 @@ rec {
 
     `autoArgs`
 
-    : 1\. Function argument
+    : Attribute set to automatically apply to `fn`'s arguments.
 
     `fn`
 
-    : 2\. Function argument
+    : Function (or path to import) that takes in an attribute set composed of `autoArgs`, `args` and overridden arguments.
 
     `args`
 
-    : 3\. Function argument
+    : Attribute set to always apply to `fn`'s arguments.
 
     # Type
 

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -116,10 +116,99 @@ in
   # We use `callPackage' to be able to omit function arguments that can be
   # obtained from `pkgs` or `buildPackages`.
   # Use `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
+  /**
+    Partially parametrized form of [`lib.callPackageWith`](#function-library-lib.customisation.callPackageWith) with `autoArgs` set to a spliced package set. See its documentation for details.
+
+    # Examples
+
+    :::{.example}
+    ## `pkgs.callPackage` usage example
+
+    ```nix
+    let
+      pkgs = import <nixpkgs> { };
+
+      packageFn =
+        { foo, enableBaz ? true, stdenv }:
+        stdenv.mkDerivation {
+          ...
+        };
+
+      package = pkgs.callPackage packageFn { foo = "bar"; };
+    in
+    {
+      inherit package;
+      packageWithoutBaz = package.override { enableBaz = false; };
+    }
+    ```
+    :::
+
+    # Inputs
+
+    `fn`
+
+    : Function (or path to import) that takes in an attribute set composed of a spliced package set, `args` and overridden arguments.
+
+    `args`
+
+    : Attribute set to always apply to `fn`'s arguments.
+
+    # Type
+
+    ```
+    callPackage :: ((AttrSet -> a) | Path) -> AttrSet -> a
+    ```
+  */
   callPackage = pkgs.newScope { };
 
+  /**
+    Like `callPackage`, but for a function that returns an attribute
+    set of derivations. The override function is added to the
+    individual attributes.
+
+    # Inputs
+
+    `fn`
+
+    : Function (or path to import) that takes in an attribute set composed of a spliced package set, `args` and overridden arguments.
+
+    `args`
+
+    : Attribute set to always apply to `fn`'s arguments.
+
+    # Type
+
+    ```
+    callPackage :: ((AttrSet -> a) | Path) -> AttrSet -> a
+    ```
+  */
   callPackages = lib.callPackagesWith pkgsForCall;
 
+  /**
+    Partially parametrized form of [`lib.callPackageWith`](#function-library-lib.customisation.callPackageWith) with `autoArgs` set to `extraAutoArgs` on top of a spliced package set. See its documentation for details.
+
+    # Examples
+
+    # Inputs
+
+    `extraAutoArgs`
+
+    : Attribute set on top of a spliced package set to automatically apply to `fn`'s arguments.
+
+    `fn`
+
+    : Function (or path to import) that takes in an attribute set composed of `extraAutoArgs`, a spliced package set, `args` and overridden arguments.
+
+    `args`
+
+    : Attribute set to always apply to `fn`'s arguments.
+
+    # Type
+
+    ```
+    callPackage :: ((AttrSet -> a) | Path) -> AttrSet -> a
+    ```
+  */
   newScope = extra: lib.callPackageWith (pkgsForCall // extra);
 
   pkgs = if actuallySplice then splicedPackages // { recurseForDerivations = false; } else pkgs;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
