### PR TITLE
uhexen2: 1.5.9 -> 1.5.9-unstable-2026-03-15

### DIFF
--- a/pkgs/by-name/uh/uhexen2/package.nix
+++ b/pkgs/by-name/uh/uhexen2/package.nix
@@ -13,12 +13,13 @@
 
 stdenv.mkDerivation {
   pname = "uhexen2";
-  version = "1.5.9";
+  # Switch to stable once it's tagged https://github.com/sezero/uhexen2/issues/76#issuecomment-3488634804
+  version = "1.5.9-unstable-2026-03-15";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/uhexen2/uhexen2";
-    sha256 = "0crdihbnb92awkikn15mzdpkj1x9s34xixf1r7fxxf762m60niks";
-    rev = "4ef664bc41e3998b0d2a55ff1166dadf34c936be";
+    rev = "adbdb95d941c7190984123cd4b7479720a294de6";
+    hash = "sha256-6bPBxaIkhDGC1eUAdamuoOlJU94TJou/ZvyFRFWP4A0=";
   };
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This release is not tagged yet https://github.com/sezero/uhexen2/issues/76#issuecomment-3488634804

Fixes https://hydra.nixos.org/build/324708531

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
