### PR TITLE
rke2: update packages

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "641e70087040bffb40e5d021f125ddfe3c3fd1cfa60a6c47abd1647bbc69a460"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "b91a3ffe046a2a3c6938352a0698da76bb88766df71c30e47ecf1ba41cd91da7"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "02579703f9ec013132fb4f1a34d61bb067caa8a0eed987f09bab26bdf34c9d85"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "ba406b694207371dd59a08a4e22b6b8ad2506c5a617df1399d7084f52c04f383"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "60ebbb953e2f86f5a8fdc3617298d2fa5b867913c7d1223e7b2a6058a4b55cf4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "60004be2877bc9e018c47b76f82779e754acd4931b19bfa4bb158c5013a44362"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "0cf92d03e00550af2edbef01f248588dc0ec84346c9068c38dea01e5b33cca0b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "d7eb347708ea97b387e90eed671c64b4e0a1e11fb60af4f94995d21e0ba840d4"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "825a67b5c88bcd4572b41d684d3a78bc860057331b446b906a43507f6313a40c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "45709e41c8b5d1ff3c9e780c8f22754cb1102d25e78932572033a716ebf7b0f7"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "a7c22d3de484a2f9e9b6ca9d2a454d392160a1fada9a958917f2aa3bf3f38b81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "d513d2d3887b6d6a9b91f24a177aaae736fe34af64d67b772b0e5c322c717437"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "65354b633f282f77d1462430e05d1814676235c257895c759f4ab67e5d995458"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "75afdb00dc9bf90a0bf153909df0886ea41d28c39387a6440d4830e00dd05f95"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "8b8af6dadeb165fed27993f0763c31f2fc55742e152c6432d712aa13841650b5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "be15ffd05156b50b27cdac28768005a27484c0b16946f9ef2531bb1d0a6185e2"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "079198afe353632ede96795721c8c06d25095e94a37143d82aacffaa0858fad1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "fa2d53df0ec302f5a5f418cb0eb4dc7c19e653c2345b1f4f9ae9a46f267013ad"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "094ec55290bd89bb058c979a80216ac4d49e3d081e45ee7e1ebb08fb12ea0f50"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "ce5325e6bd901a241bf0f06929da7ac35352c304f9180598b89502adbde603cf"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "d439daf97b18bd91c1b716c22c51a3131ca30b8a8107a33cc98e2238d7fe2ff7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "cadcaa43d750d68ea137b63b1a4bf36eea64b4c05d3d7573420ea065b58c9803"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "8d02d4ef7460929b8dcc8f6be838e8822443bee546e01f0852b158fa8ea1d18e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "7099afbc3ea21b9969cbb90a694093f91d862c6da671340753f01ddbdb7c6d25"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "8a21224c48ddfa8d234045cfeb4f8610df3f4114d2e927310694ce563d5db6e4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "92e2f3d822fdd264a133680a909aa03104e75ab784e8b819c5ab3c6e7452ba79"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "824fc4f4c13d04acec697355dd6c89fe334ec7a0034305fbbe55410d08584e10"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "3916099fd9c991ce5f837dad902f187aed47d7fce066cc5ffcc37ad43a909ece"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "fcae3611339ad4f0437fb5cc8c4f246dd3d49b88d908533c9293eaef14544b4f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "24a3e2a68b8f4c16dea632ebe2b10876737c8fb5a457273cef83f0b935e3e793"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "51ed4890c66fdaa75fa33dc2c01296b5231e678b5f0da674216f9f0e9ab04dc3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "1440c406f7c9def8170e8b279de5298cbc2a91f72fda2290581660fcd614e1a8"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "8527c05d35be8b89343236c2e8c0d0159717750414afb554e14382e348a3984f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "de3abd803043588ae3c349a276dd52093528a3ae86115c9d4979982b6a1d59d3"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "99e1aa2dcf3f39d736abaf8cddf229d9931ab4c80940881cd7c6b89ff357bd17"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "68b492ed357fcc513adc0baf0a5306a625d5eccfda4389ab303e4f03d1d54ca3"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "0e14946966080e5a71852eb140489916271de41ef9c7a91c5c3bd1dc6c4c3ad8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "046f1884d788be8fcc343c73d7ff699d8be89fe6c607e0536b4a8732c5d27a13"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "c94fecb19b6b1eaa347c49fc60def2e1251d866714e9ab05ea6ce29d5da41fb3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "0d1c03990ca8e243ba4a291312f1a1ce62b52e28170ee6f85b0a95f8032b3eef"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "2580870d652d80dc9d2f6904cb247d42490a96760d020a4a054e5cdc6f68a873"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "b0f286a53c7da0f9275da9a4e648913b588ccfcf70c8289886e48008f256ea51"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "9def3c6c9094030c258e6e02aa24195f33e4f2ce6abdb5d7a219100bf1d86e11"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "4d4340241b1e417cac9be28f60b6a4f48bb6e513fb01f261bb72e47b162b8917"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "9f5777b154a7df4977cd12d162ab559edd8c1ec1a716aab4e2b33e5bb39ae69e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "a5a225e9b8d57bccbb04095ab86d77897ef39beda4c9db56fe43152f7922e213"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "47f9647b674c412ceb915c71790ca1ce71424f733d0dbdb675699335fb33d2d8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "3786e9642a9ad14a55c87917ca8a3b2a03b9cb8cf7ee7320d0ea4e122c566a8f"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "7e3ed1fa01a9f44dc957f2adc6e5e877b1e1d32b94a3ea5a1722ed1d12c9189b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "a6d84f504820e9199859f7943662e1232621ece3bd1559c1e630dfac2726f344"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "8d3884444e465f8f41a8fc64d2af0a9ee010239ab5d7cc531fdad8e8e48952f9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "d2084cdb68c8a68d70854b68d15382baddc197980d48de0d45707391f252656e"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "92fc511e73ffc08defc7b8e71fb6ef769531cb2a8fe3ed2053d4a7d337644cf4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "ceb393f3f89bd550de3ac4bfdbfa4d090fa6693d7f0b3428bd0db5dc4ebd7ac0"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "ba77ac84eda9704594aa9eb6629430f7b60606fb532e245c21bf4ca0f7fbee9b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "fe7cda504690bcc90694b9c88c6bab70ea4e89d14c17ab0b726de6eaa3c3055d"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "87ab074fda05e5d55dfeda6c1af492c8e87b2f37a1087183a8faa73ca07d7499"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "d24aeb2d60ee5009dcf663b6edea6a5a30ff4486a98b91f87661b02d83fc116c"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "3b5b1a5016c70cc91676165a21594ce9ddc8866704c54613b98e5360e59a9f30"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "2fbbcb3af0673dfd2f046150fb0775468f6139dd41537bd8bff77f3bdfb5ffbe"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "beaee2bd0190ecaee7a61f74c20cc4586c1f6e80f74dfe4d2993ec5468f7d26a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "ae97992ad44e403271ce5b54ed5856c06ab8a2decade2768debc06d3ca6e0486"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "c642a0fece74ba83840a1683159c06ca029012eda63458f42919ca69d14bd724"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "c458b9de8dd82d2f39b071551ce3605fd602ece178e03bb81b756dabf69471e8"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "0e62fd6dae520a9ef9d0ab252cba54d86d434c5de60eb4018f7577877a6b3ae5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "857457306f280f261deb1bea6663a8146ca3d0539311920a81252ad611b93a72"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.9%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "b954552b6235421c910330e2c80a7bea34c93ea64ad15fdfcbced66b826203b2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.11%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "c78e808f09935dd0c633ed4b63c9fadbe6577b7992b2111a9c884bf042710a97"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.33.9+rke2r1";
-  rke2Commit = "91477e5799063a35553b4d855e7a21bdd53c7009";
-  rke2TarballHash = "sha256-2QLG5FHmKQJWu/UjdwtXvXpoNu/to29ORDbo7SgjXSI=";
-  rke2VendorHash = "sha256-1hkGjui1RDE8UzK7h2SrhYwUX59lRsHLJ3g/OQZ9JTQ=";
-  k8sImageTag = "v1.33.9-rke2r1-build20260227";
-  etcdVersion = "v3.5.26-k3s1-build20260227";
+  rke2Version = "1.33.11+rke2r1";
+  rke2Commit = "9e559b0969f73df7242fd618386ffb475ae2d460";
+  rke2TarballHash = "sha256-+OnesNR5rnT/jwANvHGyM9ZLoBm/yvTyDD/idP7ncT0=";
+  rke2VendorHash = "sha256-9zXirLuvIR/su5irILDgOI6OqbatSeTrenBLgSZEAqY=";
+  k8sImageTag = "v1.33.11-rke2r1-build20260416";
+  etcdVersion = "v3.6.7-k3s1-build20260415";
   pauseVersion = "3.6";
-  ccmVersion = "v1.33.8-0.20260211145912-3552cfc26032-build20260211";
-  dockerizedVersion = "v1.33.9-rke2r1";
-  helmJobVersion = "v0.9.14-build20260210";
+  ccmVersion = "v1.33.11-0.20260415182038-2566e39d309b-build20260416";
+  dockerizedVersion = "v1.33.11-rke2r1";
+  helmJobVersion = "v0.9.17-build20260422";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "3bb5170ba08641b4a285dde9fabb65348f186e1c507d84fa540fe6e966e8aad0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "a1dceccd822e24281f715a4a608539507968ffd97810484d3e370b96017f16ff"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "279b3a0ce8d142c8c24a60e1af7a1be542355da75549cec27b3b1135da3da0bd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "a9de3a4aef52e0ead9a69156556f8432d9026a7fd1716770185863f14c7d7f07"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "b144a24be9db33353d78c3c7147c0cbdc3ac66e80e914760d17851f5ecd69373"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "df74183ec867c9c607d8ab3286fa3bc19dd92088e1074a1f8a75be7a4a290e57"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "2a2345c6daa2742119fc36118f6b08240465c65354efea0d67c1272fb0d905c7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "8c91f98adc2f4ee970d13e230525692b5622124627163e956e7a597e24fc5c80"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "e500be563eca5c594af9b893abb8187a7f1d8a5dabff2f901d3b5f43c9e7ee31"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "51ba6ed5197c381f2303e8a09cf4a453026b910bf265b077c3fc7ab3428f6ced"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "a7c22d3de484a2f9e9b6ca9d2a454d392160a1fada9a958917f2aa3bf3f38b81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "924e92a89d33e1cd8ffbcf15787d4d5b02883a8b3714f3671d239670aef59ecc"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "c6aa1b6be5e0795b9261ce53b98421272a03f3351844a70f2677fc36a24af96e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "2e2386f91dc12d6f50a69d04e90322d0075bc0881263b2566679e94a9da11873"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "8b8af6dadeb165fed27993f0763c31f2fc55742e152c6432d712aa13841650b5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "be15ffd05156b50b27cdac28768005a27484c0b16946f9ef2531bb1d0a6185e2"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "34c22f24882d990843880e297c3296406b76ed270423b6a512c7bba6a3d855cd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "e3773afb1951f0c21eb37e155fa7375bbf12c8fa884dca2cd5338dcc918d0151"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c16049340ede6c1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "944c1785483bffb7f20559432fea2d1b7d3ce6a37ac344557c7a1c8293fa4e8c"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "f5736ff7058e98562a6de4720207a7aa47e85633e6cd186c2d50b743934c44cc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "8426be3703efc7126d1a25b2fc2738d6b63ca202c32dc3b3d9c72d4b1e0f8757"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "41dd1cefcaf487a8b3269c6a06ef114ee91d362855bb3c807d15795616bc346c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "7136a51e4c62479664010d19fb4acb05794cdbea9c0d7c9ab0f2cd1486ba96ae"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "2622a22bb70fb4d5167bb116fde2206925d209429ff1ae62fd585f788aa2b885"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "11659fecf1ec1b98a2fabfdc4b9db4fac79513b383b0ae51c0bd4d359317548d"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "0916003d2cb70501fffd58f278a8b24a1f2c991a9b5d9013b4ba7e8aef92e577"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "2fe0b9b21ad6db41b7d6d6d682353844efb9e44d520d69824b7e46c503a73a67"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "e3f71f6ac15157c2f03ca9999580f112acdc11f440b1a2f084e08ab7dbafb0fd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "0bdcf82427f6fe49e211c28023ea0a4390f0abf4811f1c94b5b3442cdab9c2e0"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "92b648b60561fec1252194c70949e5e9ea4bd3fa4157e05663f69493bae74138"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "44212de2ccbed50fccd9c9c5c2648a3883b3efcc1ee00fc4554defe61bb64ffa"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "d0350e10ed7766927b4400eab8dda06029ebc72df4ef36f5708056110b74b2fc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "7ad8b7519b8b7faed7788eb362a0f667da81021466c6bd5a911be2095be47c87"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "d843630e86003cf4b18a1ef070b44c3a73e1431770244e853eafcecdb714bfa3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "05d378074e3886f42858bd67dedcda0ad1f926faf69f2ce5bdc6e2a97a29a436"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "8037cc34fc3de43395ef89025509c584ac98b9bf4a9e7cb7159b0f24540765bb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "618934aaa80d160f8b39466f260b7d47946eda18ed8c0f52e3a1545e087f01cf"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "c94fecb19b6b1eaa347c49fc60def2e1251d866714e9ab05ea6ce29d5da41fb3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "26803301b9d26b82afeaa7aa94b66ec80825c3cb2b42f7468f60a3770926744f"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "6f8bd02f7c9122238c667f97379ed59756c4dcd2c556ab222ba32970eb1889b9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "bd9f7cf98e625f62b10bbdfded475f3f05d04e80f07deb195f6778fb1b9c9df0"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "236fb612c6cc5870fb075c0fe964544e3b1c66463c11f8fa84c9bcc6c5c1e93e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "532ee3aef895744d85899634cbd65023f6026b3b494c97ab9ac8b38188ce3bdf"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "dd3649306bef4a412ca4125c7a71c00225dec711dbe218b2b402f1c7ded8b277"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "63c55631be709190646f5e70a17dd7ba54f5593420b83496e252e01543f02096"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "66e2f545da94a72d29090d69cf9a225024095a4f1a644a5bacf1b2e1873665ee"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "cd12831ceb77a071fdbd9f0ec37fbcc60cb99d6dfd4f3901803b27ea318fa38d"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "1e25054f03859407565f9598791212868bdffc007513e21a537a20ada1da8a22"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "00a39e85d561fac062c000bc8e663b10d44c9d14a425ee6cff343f2869bf2ed5"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "035612c8628d1d18548082bfd72db0393949fbfd5f21a35d96e22dc7070a5d52"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "cfb4cea40d0ff547033bb75eb5ff3fb160633284bd433e0acee57e88c6b697cd"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "1b6b6f55366e0e7014fb3241d7bb01b786eebf72a13ed1e7c7ea86850d31f28f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "753a1715fc153dfe940778bdc00fb86ff5b0de1c590261777e6e280d838aa02a"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "d3eb6dab20944a417d0cbc6eed3a4838c008646a40c3e6b637729f7f9251ff8c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "d84f65ba2aae7706313d3009fc471335a1acb8ef091e1369ccd3054bf010f0c0"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "3e0daa3ef4f04bf1739e76640fdec8956d81f07d2263b1a3d66555cc0944c17e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "dc97c8fc3016eae77ef15de114d7d26b850d5ad6d15555a1e827a7fb78c0573a"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "3b5b1a5016c70cc91676165a21594ce9ddc8866704c54613b98e5360e59a9f30"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "2fbbcb3af0673dfd2f046150fb0775468f6139dd41537bd8bff77f3bdfb5ffbe"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "5313e18d388665b358dc8c4f11112d0798ae76b0d03c4bb101de44b334c11479"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "a067bc1b29dd65e7c96fee7e69659bb254abfccd77451d357f17c0c017849b1b"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "c642a0fece74ba83840a1683159c06ca029012eda63458f42919ca69d14bd724"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "c458b9de8dd82d2f39b071551ce3605fd602ece178e03bb81b756dabf69471e8"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "4435f093077efbd3e635aab2adb30837d91e45cc28c062918ec0af275317334b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "5f1e96e34a1ba8d3e5aa703a259ac0726b994efab1a9f38a058ee6c7b056b41b"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.5%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "861be8cbcc110ba986dc1443c83811c2c4ce92a534895f4cfc231d446ecf11d0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.7%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "3a7cb81f2635f5771c95e57029c0a6538b2b470857b92188a5180ecffc665624"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.34.5+rke2r1";
-  rke2Commit = "105ddbd880270e1edcf8ea26a73e1f9be922ec83";
-  rke2TarballHash = "sha256-Wc0kZsPfxSi+HoNLo//CYDUROiOkdYreUkcnlYQc7uA=";
-  rke2VendorHash = "sha256-qYMOtIyRb3iZnEunssZOO/O8a9muhFZr62rLH9P7+WU=";
-  k8sImageTag = "v1.34.5-rke2r1-build20260227";
-  etcdVersion = "v3.6.7-k3s1-build20260227";
+  rke2Version = "1.34.7+rke2r1";
+  rke2Commit = "6fb975ad761d191a245a4c0215843e8c19423ac9";
+  rke2TarballHash = "sha256-2+EVvexT0oco6xI/nAfau4yz9wotynD4ejm6xC8JssQ=";
+  rke2VendorHash = "sha256-eX29l/K8UIWkSKIcJBn9Be2zPqxqoWlsmK0xs/bdxOo=";
+  k8sImageTag = "v1.34.7-rke2r1-build20260416";
+  etcdVersion = "v3.6.7-k3s1-build20260415";
   pauseVersion = "3.6";
-  ccmVersion = "v1.34.4-0.20260211145917-c6017918a65c-build20260211";
-  dockerizedVersion = "v1.34.5-rke2r1";
-  helmJobVersion = "v0.9.14-build20260210";
+  ccmVersion = "v1.34.7-0.20260415182025-e7567db58dd7-build20260416";
+  dockerizedVersion = "v1.34.7-rke2r1";
+  helmJobVersion = "v0.9.17-build20260422";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_35/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_35/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "adc04088139474163dd7e2f0f80ec7cd9918c50c1f6e4a518d84b1e6f0a717b8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "1563bfb894ac077320a8ef535c3c3caa541b7ed19ca9181920702bfdd7e6e57d"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "13b07010c7f9e002557786590b4e3a7e8ad043f6d90ec557eff59e2ffddda11b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "30a3c779a7b87884d6a2185345407842c42d4d5de16e1303f4a86cb07de316ac"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "4e48981cdb0c47b0bc4d19ba7851203c9f862e175a0e791291c69ad5b7f10147"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "b4afde3c8932c286bbaa0835a50dc7854cc951a84dddfa1d376aaf49e97bc3d2"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "1a7db48cd3667b5142eab1ebfd03c1e2c33dd4555aef9a928682c744ea8e568a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "3d7536615244d0f60d666c95fad1efa834b93e64b7b1117e2a0d33d7869136bd"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "d5d7e0ec035ce8d8c206791a40e384376afad18f830412977c51a280ff2c8067"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "e031ac4cd1c2e5152b751370af1905404edd15e6bf662213dc22441c535c8985"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "a7c22d3de484a2f9e9b6ca9d2a454d392160a1fada9a958917f2aa3bf3f38b81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "d513d2d3887b6d6a9b91f24a177aaae736fe34af64d67b772b0e5c322c717437"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "441b03258d68260f7ce0a6bda7acee9c2b2a4515182a5ecf55e33876586ea50a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "9ee8839e3060464ff0d3c8aabf9d992bcffc97df7e0ec04445b56d0a36fb341b"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "50f4d1b1bb03523b922d7ce989d2d83f009d751d7fbf4aa8821fe52c9b9fd96d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "837a399259b8fd41e52d7e9f7f9d263c4678b76954fd280966b012a2516a00aa"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "feaddac5752336c1a883d39848fc604ff2e0c92de3a027460f55303b2591c228"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "a86d13c29b8c7cc65d1bb4575352ea4106c7a893fa34071b00d8abf7c96fdb3f"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "443a2c6052035d4953f27516d0dcab0f9a7f68ae93f0c48da74f9569096b87cc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "96757062b058c0a3617a4b20c3749ad9be738f884f70d2ace87f18b9a943d77e"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "98dbee7b3e4a17e42dcf60d1d9bea593ad961893659504a7388ee4dbf1cab4a9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "af212d7b0925dedd7099b212a7d6ae3b315cf87cb744d0448bbc10a7b3754dfc"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "827081118238089e882b2b14218fcb8bade4ea27fde7a460b626c111796cdc50"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "1b1faaa36f90cfe78e74008a68af69919fb661c34cc8a567e8a06bdb4a398f06"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "e5447136a26f542f7bb0ef9045c1900472928952623e73737e1e6f1eb3900b8f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "4a01c3364f5891fbcb329e17e9f6662631d303be63b545373f483377f055257c"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "8f802a9ca9822c0cae78b84e8a67c172294c9278ac76503b1f8b04c5701d9491"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "e8355a07f9fbb1e2d3442a07796d8a5e0f359ec0f1cbd10f372812970542fabb"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "06f57e254ac74f4a7d7a1195592c0fee130470dd0fe23bd7f6fd54f25f3b749a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "3875876ee6d45d3bcb1fcbb97cf738c8afd64242d590f896100b1f71c531d8c0"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "aeca03ab172bd667742262e942b1d799f5524a96757de3c0aab4b84f19b02ba0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "ddfc6020222b15fc0eed8a5e9f9aefdee8334a039a20d0000801f40c81dd22d1"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "f50f5e118230b2b63f85a7a1c99f63a5331e1f7bccf0514b9800012e8a91339c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "7df86fe7e2481bb9c04ec775d48f832899bd456c19208271ec23fd05f4176d2d"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "99e1aa2dcf3f39d736abaf8cddf229d9931ab4c80940881cd7c6b89ff357bd17"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "05d378074e3886f42858bd67dedcda0ad1f926faf69f2ce5bdc6e2a97a29a436"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "0e3669bc9b0d5f265b361817949f00e5f8cb2fea647b22d69a6c3c8bbf7409ae"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "2db5385f6d06d08296eb936bec9cad3db3d37620cd48b2b6def2deca58b11e78"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "fd01dba6b0b12d99e575f6c6f428be59d93d7bf89eba6721dab5f9727483facb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "26803301b9d26b82afeaa7aa94b66ec80825c3cb2b42f7468f60a3770926744f"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "9d43e3d5cbebd9b060c645b101cc11025184309a33c448f91036f9b4c63fe7a1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "5c3f8ea51103b12549d64bb790ec511aebd7ce53bd34fcbdc8564e641ae029ed"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "06b37736600989520644d34d2d5a4b797e40f298a9775c2a923e33a159d2c600"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "61804cf3ed8347bbea0dd47f7805bbbc550b3eb39844782beae442f8b7ef44dc"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "cd1b237ef3fcdbc193aa324c42385c21e5fd6493824b79e69e360036383589af"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "b9aec99429066e3cea35ddd6aaa16b1eb84435a2feb156f8a0a5af541f87bb07"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "7321e46d1822e3d3f5c9e751563e8cbd34eaeab77cbd85c7c93e42658ce82f17"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "d359809efb1030af287b2077e534e1ae0e2c1b777280ef65b614939026f9ae0f"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "45468bf2b855ea9ac2d4b560b9a974796bbcb9a9681c758e78db41cea0f94229"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "725862931f0675fa8699ce8a1167914d222d1d2fc3e689a20e662b9319a48683"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "988106315218556fd3ea366a6c27dde2a72c231e14d295c0f0f4cb26eddb88fa"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "c2015d80e510d2a9a3d8f0eebadaa65c8c4a4eed7f63948011ab8d0a3549a97f"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "1c85da0b7a7946c88d5f4d489b7a76517909f68d436a0558fe89d01a94c0f9ef"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "69b950a05bc980405a0f7a7ae96233924b33685d812def46cfae11fb30891010"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "27b8fbe74bcc4d7956b7a341e107b279372a295ae6a37855b20340defd8a6768"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "f5f6ffdfd37164d12624390c9292ee7436c4c6dfa5c8cc889852f356e6964167"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "dd6d4f1272bcda3e23d8730359848b346b8baed70b5b18eab64fd0dee555b4fc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "6c98ce847abbd827e9c48ecba380084348dd6abca838de34d748c502bf3a7978"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "3b5b1a5016c70cc91676165a21594ce9ddc8866704c54613b98e5360e59a9f30"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "2fbbcb3af0673dfd2f046150fb0775468f6139dd41537bd8bff77f3bdfb5ffbe"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "be4d81082cd9334ae1e196165f3a0a18f7d836560eb410b027f3d5ce1d5afb8e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "ff9491f09bb3c8e0444209c1070542d2381bc1ff450cda26ff9c000bb929a614"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "c642a0fece74ba83840a1683159c06ca029012eda63458f42919ca69d14bd724"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "c458b9de8dd82d2f39b071551ce3605fd602ece178e03bb81b756dabf69471e8"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "4dc6c827aee2411205c2dd9310f761b1f34fd481bae2d2dade3beb9b2e44dea4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "311aa5805c5a6e947e65f1d48dac789428ee056679d142d8b96e791e78868b6b"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.2%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "945d0d7cce48975f14e4b5c1230d6ce70cdc4a968df63f8e2d1f6921387b7513"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.4%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "4000891ee00df8441d49b8d1864208dfd4d1287efcfed59fbb6c44626144ceaa"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_35/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_35/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.35.2+rke2r1";
-  rke2Commit = "b1cd9d8e735bcd84cad7407109423a8dd7b648d8";
-  rke2TarballHash = "sha256-s5lZK7S+WReRF+Io9+X4bSd6mAvBq9qUXbYEOH++cFA=";
-  rke2VendorHash = "sha256-3i//hVONK/QxIsiOth92fN0Rxw6Ex4cgBQe7NG//URc=";
-  k8sImageTag = "v1.35.2-rke2r1-build20260227";
-  etcdVersion = "v3.6.7-k3s1-build20260227";
+  rke2Version = "1.35.4+rke2r1";
+  rke2Commit = "5dc4f4390d27d77b17b6506d8b22aed72aa4fbe6";
+  rke2TarballHash = "sha256-VWhml35keKn9Fhj/SeySpusi8yzz9dwgPC2rfABXPrk=";
+  rke2VendorHash = "sha256-uaPjOFSwCxMWH/LD8tvE0VttPWJ9agMYm4E2mWiuYfw=";
+  k8sImageTag = "v1.35.4-rke2r1-build20260416";
+  etcdVersion = "v3.6.7-k3s1-build20260415";
   pauseVersion = "3.6";
-  ccmVersion = "v1.35.1-0.20260211145923-50fa2d70c239-build20260211";
-  dockerizedVersion = "v1.35.2-rke2r1";
-  helmJobVersion = "v0.9.14-build20260210";
+  ccmVersion = "v1.35.4-0.20260415195656-e51c0636351d-build20260415";
+  dockerizedVersion = "v1.35.4-rke2r1";
+  helmJobVersion = "v0.9.17-build20260422";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -74,8 +74,13 @@ buildGoModule (finalAttrs: {
     lvm2 # dmsetup
   ];
 
-  # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
-  env.GOEXPERIMENT = "boringcrypto";
+  # Enable FIPS 140-3 compliance mode for Go
+  # at time of writing, upstream RKE2 uses the GOEXPERIMENT BoringCrypto module instead:
+  # https://docs.rke2.io/security/fips_support
+  # which has been superseded by this - see https://go.dev/doc/security/fips140#goboringcrypto
+  env.GOFIPS140 = "latest";
+  # tlsmlkem=0 can be removed in a future version of Go, see https://github.com/golang/go/issues/75166
+  env.GODEBUG = "fips140=only,tlsmlkem=0";
 
   # https://github.com/rancher/rke2/blob/104ddbf3de65ab5490aedff36df2332d503d90fe/scripts/build-binary#L27-L39
   ldflags =
@@ -131,12 +136,6 @@ buildGoModule (finalAttrs: {
   doCheck = false;
 
   doInstallCheck = true;
-  installCheckPhase = ''
-    runHook preInstallCheck
-    # Verify that the binary uses BoringCrypto
-    go tool nm $out/bin/.rke2-wrapped | grep '_Cfunc__goboringcrypto_' > /dev/null
-    runHook postInstallCheck
-  '';
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
 


### PR DESCRIPTION
Based on #506579 so tests can pass, 1.32 isn't updated as it's being dropped in #506583.

https://github.com/rancher/rke2/releases/tag/v1.33.10%2Brke2r1
https://github.com/rancher/rke2/releases/tag/v1.34.6%2Brke2r1
https://github.com/rancher/rke2/releases/tag/v1.35.3%2Brke2r1

cc @rorosen @zimbatm @stefan-bordei

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
