### PR TITLE
[Backport release-25.11] fflogs: 8.17.101 -> 9.0.33

### DIFF
--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.17.101";
+  version = "8.17.115";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-yCnFN46/vHrQA8KkaoWQUBCOZ1+6Oa4UkdUhCghGByo=";
+    hash = "sha256-i16jMTbthl+XvL/I6tOqBKBdKyb6wOLYIQeWveR4Oyg=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.17.115";
+  version = "8.19.39";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-i16jMTbthl+XvL/I6tOqBKBdKyb6wOLYIQeWveR4Oyg=";
+    hash = "sha256-Po2UKrum4/OIDpnr4jtsm9RODC4ekjE3kzciKtV7Y8k=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.19.39";
+  version = "8.19.70";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-Po2UKrum4/OIDpnr4jtsm9RODC4ekjE3kzciKtV7Y8k=";
+    hash = "sha256-uDcQUAXDytrO3XFArJkuI0oV5/Z2dUJyY8OLx1WtraU=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.19.70";
+  version = "8.20.17";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-uDcQUAXDytrO3XFArJkuI0oV5/Z2dUJyY8OLx1WtraU=";
+    hash = "sha256-2gul6DwuhB9iy3BR8u+rIIWz2G+nX1IA7c6cqq1QYlg=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.20.17";
+  version = "8.20.36";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-2gul6DwuhB9iy3BR8u+rIIWz2G+nX1IA7c6cqq1QYlg=";
+    hash = "sha256-NwbRz6nqK4AxCEzZKHaAuw33CCjfF6C7oGsH2thNb+o=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "9.0.24";
+  version = "9.0.33";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-9L9eNpK2MI3P+mhUDCAzfi3YDdWpHGjiUS5LjksUjqo=";
+    hash = "sha256-gUIETMc0JQXONBt0+Pw52y37Pw4Wh5CHo1uY6IBhvkc=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.20.36";
+  version = "8.20.113";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-NwbRz6nqK4AxCEzZKHaAuw33CCjfF6C7oGsH2thNb+o=";
+    hash = "sha256-mwbATBhkbeZ2f4KAytOgp8XbCL4dY7S7OPHj//4kqGQ=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in

--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -6,10 +6,10 @@
 
 let
   pname = "fflogs";
-  version = "8.20.113";
+  version = "9.0.24";
   src = fetchurl {
     url = "https://github.com/RPGLogs/Uploaders-fflogs/releases/download/v${version}/fflogs-v${version}.AppImage";
-    hash = "sha256-mwbATBhkbeZ2f4KAytOgp8XbCL4dY7S7OPHj//4kqGQ=";
+    hash = "sha256-9L9eNpK2MI3P+mhUDCAzfi3YDdWpHGjiUS5LjksUjqo=";
   };
   extracted = appimageTools.extractType2 { inherit pname version src; };
 in


### PR DESCRIPTION
Backports a bunch of accumulated changes to stable, because I have been forgetting to apply the autobackport label. Oops!

Fixes #506617.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
