### PR TITLE
intel-lpmd: init at 0.1.0-unstable-2026-04-13

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,6 +128,8 @@
 
 - [Tdarr](https://tdarr.io), Audio/Video Library Analytics & Transcode/Remux Automation. Available as [services.tdarr](#opt-services.tdarr.enable)
 
+- [Intel Low Power Mode Daemon](https://github.com/intel/intel-lpmd), a Linux daemon designed to optimize active idle power on supported Intel systems. Available as [services.intel-lpmd](#opt-services.intel-lpmd.enable).
+
 - [whois](https://packages.qa.debian.org/w/whois.html), an intelligent WHOIS client. Available as `programs.whois`.
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -18,6 +18,8 @@
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
+- [Intel Low Power Mode Daemon](https://github.com/intel/intel-lpmd), a Linux daemon designed to optimize active idle power on supported Intel systems. Available as [services.intel-lpmd](#opt-services.intel-lpmd.enable).
+
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -675,6 +675,7 @@
   ./services/hardware/hddfancontrol.nix
   ./services/hardware/illum.nix
   ./services/hardware/inputplumber.nix
+  ./services/hardware/intel-lpmd.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/iptsd.nix
   ./services/hardware/irqbalance.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -677,6 +677,7 @@
   ./services/hardware/hddfancontrol.nix
   ./services/hardware/illum.nix
   ./services/hardware/inputplumber.nix
+  ./services/hardware/intel-lpmd.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/iptsd.nix
   ./services/hardware/irqbalance.nix

--- a/nixos/modules/services/hardware/intel-lpmd.nix
+++ b/nixos/modules/services/hardware/intel-lpmd.nix
@@ -1,0 +1,116 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.intel-lpmd;
+  packageDefaultConfigDir = "share/intel-lpmd";
+
+  defaultConfigFiles = [
+    "intel_lpmd_config.xml"
+    "intel_lpmd_config_F6_M170.xml"
+    "intel_lpmd_config_F6_M189.xml"
+    "intel_lpmd_config_F6_M204.xml"
+  ];
+
+  managedConfigFiles = lib.filterAttrs (_: path: path != null) cfg.configFiles;
+
+  mkProfileDef =
+    profileName:
+    lib.mkOption {
+      type = lib.types.enum [
+        (-1)
+        0
+        1
+      ];
+      default = -1;
+      description = ''
+        Default behavior when the ${profileName} power profile is active.
+      '';
+    };
+in
+{
+  options = {
+    services.intel-lpmd = {
+      enable = lib.mkEnableOption "Intel's low power mode daemon";
+      package = lib.mkPackageOption pkgs "intel-lpmd" {
+        extraDescription = ''
+          The package is expected to provide a `patchedConfigs` passthru for the default value of
+          {option}`services.intel-lpmd.overriddenConfigs`.
+        '';
+      };
+
+      overrideDefaults = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            PerformanceDef = mkProfileDef "Performance";
+            BalancedDef = mkProfileDef "Balanced";
+            PowersaverDef = mkProfileDef "Power Saver";
+          };
+        };
+        default = { };
+        description = ''
+          Override the upstream default profile behavior values in shipped XML configuration files.
+        '';
+      };
+
+      overriddenConfigs = lib.mkOption {
+        type = lib.types.package;
+        internal = true;
+        readOnly = true;
+        default = cfg.package.patchedConfigs cfg.overrideDefaults;
+        defaultText = lib.literalExpression ''
+          config.services.intel-lpmd.package.patchedConfigs config.services.intel-lpmd.overrideDefaults
+        '';
+      };
+
+      configFiles = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.nullOr lib.types.path);
+        default = lib.genAttrs defaultConfigFiles (
+          name: "${cfg.overriddenConfigs}/${packageDefaultConfigDir}/${name}"
+        );
+        defaultText = lib.literalExpression ''
+          patched XML files from `''${config.services.intel-lpmd.overriddenConfigs}/${packageDefaultConfigDir}`
+        '';
+        description = ''
+          XML configuration files to manage under `/etc/intel_lpmd`.
+
+          By default, the module installs the configuration files created by
+          {option}`services.intel-lpmd.overriddenConfigs`.
+          Override individual entries to use a custom config file instead.
+
+          Set an entry to `null` to stop managing that filename in `/etc/intel_lpmd`,
+          which allows it to be managed mutably.
+
+          Upstream loads the most specific matching file first:
+          `intel_lpmd_config_F<family>_M<model>_T<tdp>.xml`, then
+          `intel_lpmd_config_F<family>_M<model>.xml`, then `intel_lpmd_config.xml`.
+        '';
+        example = lib.literalExpression ''
+          {
+            "intel_lpmd_config.xml" = ./intel_lpmd_config.xml;
+            "intel_lpmd_config_F6_M170.xml" = null;
+          }
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc = lib.mapAttrs' (name: path: {
+      name = "intel_lpmd/${name}";
+      value.source = path;
+    }) managedConfigFiles;
+
+    services.dbus.packages = [ cfg.package ];
+
+    systemd = {
+      packages = [ cfg.package ];
+      services.intel_lpmd.wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/pkgs/by-name/in/intel-lpmd/package.nix
+++ b/pkgs/by-name/in/intel-lpmd/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  glib,
+  gtk-doc,
+  libnl,
+  libxml2,
+  systemd,
+  upower,
+  coreutils,
+  runCommand,
+  configDirPrefix ? "/etc",
+}:
+let
+  defaultConfigDir = "/share/intel-lpmd";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "intel-lpmd";
+  version = "0.1.0-unstable-2026-04-13";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "intel-lpmd";
+    rev = "876db2042df2c168a7ff68f91c2f8c152f4e99a8";
+    hash = "sha256-6maTFZL7cfvXg89bUNggj9X2HBBpVSVZmrIroM9zqYc=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    glib
+    autoreconfHook
+    pkg-config
+    gtk-doc
+  ];
+
+  buildInputs = [
+    glib
+    libnl
+    libxml2
+    systemd
+    upower
+  ];
+
+  postPatch = ''
+    substituteInPlace "data/Makefile.am" \
+      --replace-fail 'lpmd_configdir = $(lpmd_confdir)' 'lpmd_configdir = ${placeholder "out"}${defaultConfigDir}'
+
+    substituteInPlace "data/org.freedesktop.intel_lpmd.service.in" \
+      --replace-fail "/bin/false" "${lib.getExe' coreutils "false"}"
+  '';
+
+  configureFlags = [
+    "--sysconfdir=${configDirPrefix}"
+    "--localstatedir=/var"
+    "--with-dbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  passthru = {
+    patchedConfigs =
+      {
+        PerformanceDef ? -1,
+        BalancedDef ? -1,
+        PowersaverDef ? -1,
+      }@defs:
+      lib.throwIf
+        (
+          !builtins.all (
+            val:
+            builtins.elem val [
+              (-1)
+              0
+              1
+            ]
+          ) (builtins.attrValues defs)
+        )
+        "intel-lpmd.patchedConfigs expects PerformanceDef, BalancedDef, and PowersaverDef to be one of -1, 0, or 1"
+        (
+          runCommand "${finalAttrs.pname}-config-${finalAttrs.version}" { } ''
+            mkdir -p "$out${defaultConfigDir}"
+            cp -r ${finalAttrs.finalPackage}${defaultConfigDir}/. "$out${defaultConfigDir}/"
+
+            for file in "$out${defaultConfigDir}"/*.xml; do
+              substituteInPlace "$file" \
+                --replace-fail "<PerformanceDef>-1</PerformanceDef>" "<PerformanceDef>${toString PerformanceDef}</PerformanceDef>" \
+                --replace-fail "<BalancedDef>-1</BalancedDef>" "<BalancedDef>${toString BalancedDef}</BalancedDef>" \
+                --replace-fail "<PowersaverDef>-1</PowersaverDef>" "<PowersaverDef>${toString PowersaverDef}</PowersaverDef>"
+            done
+          ''
+        );
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/intel/intel-lpmd";
+    description = "Linux daemon used to optimize active idle power";
+    longDescription = ''
+      Intel Low Power Model Daemon is a Linux daemon used to optimize active
+      idle power. It selects a set of most power efficient CPUs based on
+      configuration file or CPU topology. Based on system utilization and other
+      hints, it puts the system into Low Power Mode by activate the power
+      efficient CPUs and disable the rest, and restore the system from Low Power
+      Mode by activating all CPUs.
+    '';
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ merrkry ];
+    mainProgram = "intel_lpmd";
+  };
+})

--- a/pkgs/by-name/in/intel-lpmd/package.nix
+++ b/pkgs/by-name/in/intel-lpmd/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  glib,
+  gtk-doc,
+  libnl,
+  libxml2,
+  systemd,
+  upower,
+  coreutils,
+  runCommand,
+  configDirPrefix ? "/etc",
+}:
+let
+  defaultConfigDir = "/share/intel-lpmd";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "intel-lpmd";
+  version = "0.1.0-unstable-2026-06-09";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "intel-lpmd";
+    rev = "40d18a6cc22c37addc3e636bc9c5cf1ab5d5fbda";
+    hash = "sha256-gvPO7KqDVQDHC2DRDXJG52IYhHim8vex6Yrbsy3iLBI=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    glib
+    autoreconfHook
+    pkg-config
+    gtk-doc
+  ];
+
+  buildInputs = [
+    glib
+    libnl
+    libxml2
+    systemd
+    upower
+  ];
+
+  postPatch = ''
+    substituteInPlace "data/Makefile.am" \
+      --replace-fail 'lpmd_configdir = $(lpmd_confdir)' 'lpmd_configdir = ${placeholder "out"}${defaultConfigDir}'
+
+    substituteInPlace "data/org.freedesktop.intel_lpmd.service.in" \
+      --replace-fail "/bin/false" "${lib.getExe' coreutils "false"}"
+  '';
+
+  configureFlags = [
+    "--sysconfdir=${configDirPrefix}"
+    "--localstatedir=/var"
+    "--with-dbus-sys-dir=${placeholder "out"}/share/dbus-1/system.d"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  passthru = {
+    patchedConfigs =
+      {
+        PerformanceDef ? -1,
+        BalancedDef ? -1,
+        PowersaverDef ? -1,
+      }@defs:
+      lib.throwIf
+        (
+          !builtins.all (
+            val:
+            builtins.elem val [
+              (-1)
+              0
+              1
+            ]
+          ) (builtins.attrValues defs)
+        )
+        "intel-lpmd.patchedConfigs expects PerformanceDef, BalancedDef, and PowersaverDef to be one of -1, 0, or 1"
+        (
+          runCommand "${finalAttrs.pname}-config-${finalAttrs.version}" { } ''
+            mkdir -p "$out${defaultConfigDir}"
+            cp -r ${finalAttrs.finalPackage}${defaultConfigDir}/. "$out${defaultConfigDir}/"
+
+            for file in "$out${defaultConfigDir}"/*.xml; do
+              substituteInPlace "$file" \
+                --replace-fail "<PerformanceDef>-1</PerformanceDef>" "<PerformanceDef>${toString PerformanceDef}</PerformanceDef>" \
+                --replace-fail "<BalancedDef>-1</BalancedDef>" "<BalancedDef>${toString BalancedDef}</BalancedDef>" \
+                --replace-fail "<PowersaverDef>-1</PowersaverDef>" "<PowersaverDef>${toString PowersaverDef}</PowersaverDef>"
+            done
+          ''
+        );
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/intel/intel-lpmd";
+    description = "Linux daemon used to optimize active idle power";
+    longDescription = ''
+      Intel Low Power Model Daemon is a Linux daemon used to optimize active
+      idle power. It selects a set of most power efficient CPUs based on
+      configuration file or CPU topology. Based on system utilization and other
+      hints, it puts the system into Low Power Mode by activate the power
+      efficient CPUs and disable the rest, and restore the system from Low Power
+      Mode by activating all CPUs.
+    '';
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ merrkry ];
+    mainProgram = "intel_lpmd";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Contiuation of work in #349198.

## TODO

- [x] confirmation from actual users
- ~[] tests, at least version check hook~ Seems version check hook doesn't really support unstable-date style version number.
- [x] release notes

## LLM disclosure

OpenAI Codex (GPT-6) assisted with reviewing upstream changes, updating the package and NixOS module configuration handling, resolving the release-notes merge conflict, and checking previous review feedback.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
