### PR TITLE
tensor: migrate to by-name, use finalAttrs

### DIFF
--- a/pkgs/by-name/te/tensor/package.nix
+++ b/pkgs/by-name/te/tensor/package.nix
@@ -2,10 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qmake,
-  wrapQtAppsHook,
-  qtbase,
-  qtquickcontrols,
+  libsForQt5,
   makeDesktopItem,
 }:
 
@@ -25,13 +22,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
-    wrapQtAppsHook
+    libsForQt5.qmake
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qtbase
-    qtquickcontrols
+    libsForQt5.qtbase
+    libsForQt5.qtquickcontrols
   ];
 
   desktopItem = makeDesktopItem {
@@ -80,6 +77,6 @@ stdenv.mkDerivation rec {
     mainProgram = "tensor";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ peterhoeg ];
-    inherit (qtbase.meta) platforms;
+    platforms = libsForQt5.qtbase.meta.platforms;
   };
 }

--- a/pkgs/by-name/te/tensor/package.nix
+++ b/pkgs/by-name/te/tensor/package.nix
@@ -9,7 +9,7 @@
 # we now have libqmatrixclient so a future version of tensor that supports it
 # should use that
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tensor";
   version = "unstable-2017-02-21";
 
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
     name = "tensor";
     exec = "@bin@";
     icon = "tensor.png";
-    comment = meta.description;
+    comment = finalAttrs.meta.description;
     desktopName = "Tensor Matrix Client";
-    genericName = meta.description;
+    genericName = finalAttrs.meta.description;
     categories = [
       "Chat"
       "Utility"
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
         install -Dm755 tensor $out/bin/tensor
         install -Dm644 client/logo.png \
                        $out/share/icons/hicolor/512x512/apps/tensor.png
-        install -Dm644 ${desktopItem}/share/applications/tensor.desktop \
+        install -Dm644 ${finalAttrs.desktopItem}/share/applications/tensor.desktop \
                        $out/share/applications/tensor.desktop
 
         substituteInPlace $out/share/applications/tensor.desktop \
@@ -79,4 +79,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = libsForQt5.qtbase.meta.platforms;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1621,8 +1621,6 @@ with pkgs;
     charles5
     ;
 
-  tensor = libsForQt5.callPackage ../applications/networking/instant-messengers/tensor { };
-
   libtensorflow = python3.pkgs.tensorflow-build.libtensorflow;
 
   libtorch-bin = callPackage ../development/libraries/science/math/libtorch/bin.nix { };


### PR DESCRIPTION
This pull request refactors the packaging of the `tensor` instant messenger application for Nixpkgs. The main focus is to modernize and relocate the package, update its dependencies to use `libsForQt5`, and improve code clarity and maintainability.

**Package relocation and refactoring:**

* Moved the `tensor` package from `pkgs/applications/networking/instant-messengers/tensor/default.nix` to `pkgs/by-name/te/tensor/package.nix`, aligning it with the by-name package structure.

**Dependency and code improvements:**

* Updated all Qt5-related dependencies (`qmake`, `wrapQtAppsHook`, `qtbase`, `qtquickcontrols`) to use the `libsForQt5` attribute set, ensuring better compatibility and future maintenance.

* Refactored the `mkDerivation` call to use the newer `finalAttrs` style and improved references to metadata within the package definition for better code clarity.

**Top-level package set cleanup:**

* Removed the old `tensor` package definition from `pkgs/top-level/all-packages.nix`, as it is now handled via the by-name package system.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
