### PR TITLE
nixos/ramoops: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1905,6 +1905,7 @@
   ./system/boot/nix-store-veritysetup.nix
   ./system/boot/plymouth-tpm2-totp.nix
   ./system/boot/plymouth.nix
+  ./system/boot/ramoops.nix
   ./system/boot/resolved.nix
   ./system/boot/shutdown.nix
   ./system/boot/stage-1.nix

--- a/nixos/modules/system/boot/ramoops.nix
+++ b/nixos/modules/system/boot/ramoops.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.boot.ramoops;
+
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+in
+{
+  options.boot.ramoops = {
+    enable = mkEnableOption "dumping kernel panics to RAM";
+
+    memorySize = mkOption {
+      description = ''
+        Size of reserved memory area for ramoops.
+      '';
+      default = "4M";
+      example = "8M";
+      type = types.str;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    boot.initrd.kernelModules = [ "ramoops" ];
+    boot.kernelParams = [
+      # reserve_mem will not always return the same memory area, depending on hardware and kernel
+      # We should also allow static allocation in the future
+      "reserve_mem=${cfg.memorySize}:4096:oops"
+      "ramoops.mem_name=oops"
+    ];
+
+    boot.kernel.sysctl = {
+      "kernel.panic" = -1;
+      "kernel.panic_on_oops" = 1;
+      "kernel.hardlockup_panic" = 1;
+      "kernel.softlockup_panic" = 1;
+    };
+  };
+}

--- a/nixos/tests/systemd-pstore.nix
+++ b/nixos/tests/systemd-pstore.nix
@@ -1,14 +1,26 @@
 {
   name = "systemd-pstore";
 
-  nodes.machine = { };
+  nodes.machine = {
+    boot.ramoops.enable = true;
+    boot.kernel.sysctl."kernel.sysrq" = 1;
+  };
 
   testScript = ''
+    machine.start(allow_reboot=True)
+
     with subtest("pstore API fs is mounted"):
       machine.succeed("stat /sys/fs/pstore")
 
     with subtest("systemd-pstore.service doesn't run because nothing crashed"):
       output = machine.execute("systemctl status systemd-pstore.service", check_return=False)[1]
       t.assertIn("condition unmet", output)
+
+    machine.wait_for_unit("multi-user.target")
+    machine.execute("echo c > /proc/sysrq-trigger", check_output=False, check_return=False)
+    machine.connected = False # We need to reconnect after the panic
+
+    machine.wait_for_unit("systemd-pstore.service")
+    machine.succeed("grep -r 'Kernel panic - not syncing: sysrq triggered crash' /var/lib/systemd/pstore")
   '';
 }


### PR DESCRIPTION
Much simpler alternative to https://github.com/NixOS/nixpkgs/pull/449565
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
