### PR TITLE
boomerang: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/bo/boomerang/package.nix
+++ b/pkgs/by-name/bo/boomerang/package.nix
@@ -4,11 +4,10 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
-  qtbase,
+  qt5,
   capstone,
   bison,
   flex,
-  wrapQtAppsHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -34,10 +33,10 @@ stdenv.mkDerivation rec {
     cmake
     bison
     flex
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ];
   buildInputs = [
-    qtbase
+    qt5.qtbase
     capstone
   ];
   patches = [

--- a/pkgs/by-name/bo/boomerang/package.nix
+++ b/pkgs/by-name/bo/boomerang/package.nix
@@ -10,7 +10,7 @@
   flex,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "boomerang";
   version = "0.5.2";
   # NOTE: When bumping version beyond 0.5.2, you likely need to remove
@@ -19,9 +19,9 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "BoomerangDecompiler";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "0xncdp0z8ry4lkzmvbj5d7hlzikivghpwicgywlv47spgh8ny0ix";
+    repo = "boomerang";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PQJvEXxXH7Ip949FfuHbccZP4WlFrl3/pMRn9MFtzHY=";
   };
 
   # Boomerang usually compiles with -Werror but has not been updated for newer
@@ -35,15 +35,17 @@ stdenv.mkDerivation rec {
     flex
     qt5.wrapQtAppsHook
   ];
+
   buildInputs = [
     qt5.qtbase
     capstone
   ];
+
   patches = [
     (fetchpatch {
       name = "include-missing-cstdint.patch";
       url = "https://github.com/BoomerangDecompiler/boomerang/commit/3342b0eac6b7617d9913226c06c1470820593e74.patch";
-      sha256 = "sha256-941IydcV3mqj7AWvXTM6GePW5VgawEcL0wrBCXqeWvc=";
+      hash = "sha256-941IydcV3mqj7AWvXTM6GePW5VgawEcL0wrBCXqeWvc=";
     })
   ];
 
@@ -53,4 +55,4 @@ stdenv.mkDerivation rec {
     description = "General, open source, retargetable decompiler";
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1622,8 +1622,6 @@ with pkgs;
   bogofilter-sqlite = bogofilter.override { database = sqlite; };
   bogofilter-db = bogofilter.override { database = db; };
 
-  boomerang = libsForQt5.callPackage ../development/tools/boomerang { };
-
   bozohttpd-minimal = bozohttpd.override { minimal = true; };
 
   cabal2nix-unwrapped = haskell.lib.compose.justStaticExecutables (


### PR DESCRIPTION
This pull request refactors the packaging and location of the `boomerang` decompiler in the Nixpkgs repository, modernizing its expression and updating dependencies to use the `libsForQt5` set. The changes also improve the package's maintainability by relocating it to the `by-name` directory structure.

Key changes:

**Package relocation and modernization:**
* Moved the `boomerang` package from `pkgs/development/tools/boomerang/default.nix` to `pkgs/by-name/bo/boomerang/package.nix`, aligning with the by-name directory convention.
* Updated the package expression to use the `finalAttrs` argument style instead of `rec`, improving consistency with modern Nixpkgs practices.

**Dependency and build improvements:**
* Switched dependencies from `qtbase` and `wrapQtAppsHook` to `libsForQt5.qtbase` and `libsForQt5.wrapQtAppsHook`, ensuring compatibility with the Qt5 ecosystem and simplifying dependency management.

* Updated the source fetcher to use the `tag` and `hash` attributes, and explicitly set the repository name, improving clarity and reproducibility.

**Repository maintenance:**
* Removed the old reference to `boomerang` from `pkgs/top-level/all-packages.nix`, as the package is now managed via the by-name directory.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
