### PR TITLE
nixos/drupal: refactor sites dir interface

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -319,3 +319,5 @@ gnuradioMinimal.override {
 ### Additions and Improvements {#sec-nixpkgs-release-26.05-lib-additions-improvements}
 
 - The builder `php.buildComposerProject2` for PHP applications has been improved for better reliability and stability.
+
+- The `services.drupal` module has a few improvements aimed at making it better for installing custom Drupal instances, namely a `webRoot` option and a some new settings for managing variable content and filepaths.

--- a/nixos/modules/services/web-apps/drupal.nix
+++ b/nixos/modules/services/web-apps/drupal.nix
@@ -10,6 +10,7 @@ let
     any
     attrValues
     flatten
+    getExe
     literalExpression
     mapAttrs
     mapAttrs'
@@ -23,6 +24,9 @@ let
     nameValuePair
     optionalAttrs
     types
+    ;
+  inherit (lib.strings)
+    removePrefix
     ;
   inherit (pkgs)
     mariadb
@@ -41,20 +45,39 @@ let
       name = "drupal-${hostName}";
       src = cfg.package;
 
+      buildInputs = [ pkgs.rsync ];
+
       installPhase = ''
         runHook preInstall
 
         mkdir -p $out
-        cp -r * $out/
+        rsync -aq * $out/ --exclude=${removePrefix "/" cfg.webRoot}/sites --exclude=sites
 
         runHook postInstall
       '';
 
       postInstall = ''
-        ln -s ${cfg.filesDir} $out/share/php/${cfg.package.pname}/sites/default/files
-        ln -s ${cfg.stateDir}/sites/default/settings.php $out/share/php/${cfg.package.pname}/sites/default/settings.php
+        ln -s ${cfg.stateDir}/sites $out/share/php/${cfg.package.pname}${cfg.webRoot}
         ln -s ${cfg.modulesDir} $out/share/php/${cfg.package.pname}/modules
         ln -s ${cfg.themesDir} $out/share/php/${cfg.package.pname}/themes
+      '';
+    });
+
+  sites =
+    hostName: cfg:
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "drupal-sites-${hostName}";
+      name = "drupal-sites-${hostName}";
+      src = cfg.package;
+      buildInputs = with pkgs; [ rsync ];
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/sites
+        rsync -a ./share/php/${cfg.package.pname}${cfg.webRoot}/sites/* $out/sites/
+
+        runHook postInstall
       '';
     });
 
@@ -87,6 +110,75 @@ let
       '';
     };
 
+  # Required .htaccess for private files directory
+  # See: https://www.drupal.org/docs/getting-started/installing-drupal/securing-drupal-file-directories
+  privateFilesHtAccess = pkgs.writeTextFile {
+    name = "private-files-htaccess";
+    text = ''
+      # Turn off all options we don't need.
+      Options -Indexes -ExecCGI -Includes -MultiViews
+
+      # Set the catch-all handler to prevent scripts from being executed.
+      SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+      <Files *>
+        # Override the handler again if we're run later in the evaluation list.
+        SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+      </Files>
+
+      # If we know how to do it safely, disable the PHP engine entirely.
+      <IfModule mod_php.c>
+        php_flag engine off
+      </IfModule>
+    '';
+  };
+
+  stateDirManage =
+    hostName: cfg:
+    pkgs.writeShellApplication {
+      name = "drupal-state-init-${hostName}";
+      excludeShellChecks = [ "SC2194" ];
+      runtimeInputs = with pkgs; [ rsync ];
+      text = ''
+        echo "Updating the sites directory for ${hostName}..."
+        rsync -auq "${sites hostName cfg}/sites/" "${cfg.stateDir}/sites/" \
+          --exclude "*/files" \
+          --delete-before
+
+        if [ ! -d "${cfg.filesDir}" ]; then
+          echo "Preparing files directory..."
+          mkdir -p "${cfg.filesDir}"
+          chown -R ${user}:${webserver.group} ${cfg.filesDir}
+        fi
+
+        case ${cfg.filesDir} in
+          ${cfg.stateDir}/sites*) echo "Files directory is in sites directory. Skipping optional link!";;
+          *) ln -sf "${cfg.filesDir}" "${cfg.stateDir}/sites/default/files";;
+        esac
+
+        if [ ! -f "${cfg.privateFilesDir}/.htaccess" ]; then
+          echo "Linking .htaccess file for private files directory..."
+          ln -s "${privateFilesHtAccess}" "${cfg.privateFilesDir}/.htaccess"
+        fi
+
+        echo "Preparing settings.php for ${hostName}..."
+        settings_file="${cfg.stateDir}/sites/default/settings.php"
+
+        if [ ! -f "$settings_file" ]; then
+          default_settings_file="${cfg.stateDir}/sites/default/default.settings.php";
+          cp "$default_settings_file" "$settings_file"
+        fi
+
+        cat < ${appendSettings hostName} >> "$settings_file"
+        chmod 644 "$settings_file"
+
+        # Link the NixOS-managed settings file to the state directory.
+        ln -sf ${drupalSettings hostName cfg} ${cfg.stateDir}/sites/default/settings.nixos-${hostName}.php
+
+        # Set or reset file permissions so that the web user and webserver owns them.
+        chown -R ${user}:${webserver.group} ${cfg.stateDir}
+      '';
+    };
+
   siteOpts =
     {
       options,
@@ -106,6 +198,9 @@ let
           defaultText = "/var/lib/drupal/<name>/sites/default/files";
           description = ''
             The location of the Drupal files directory.
+
+            Many of the files in this directory are variable, so they must be located
+            in a location writeable by users of the webgroup.
           '';
         };
 
@@ -120,7 +215,22 @@ let
           type = types.path;
           default = "/var/lib/drupal/${name}/config/sync";
           defaultText = "/var/lib/drupal/<name>/config/sync";
-          description = "The location of the Drupal config sync directory.";
+          description = ''
+            The location of the user-managed Drupal config sync directory.
+            Drupal will both read from and write to this directory when executing
+            configuration management operations.
+          '';
+        };
+
+        webRoot = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            An optional path string with a leading slash
+            indicating the location of the Drupal webroot relative to the
+            project root directory, if one exists.
+          '';
+          example = "/web";
         };
 
         extraConfig = mkOption {
@@ -140,21 +250,41 @@ let
           type = types.path;
           default = "/var/lib/drupal/${name}";
           defaultText = "/var/lib/drupal/<name>";
-          description = "The location of the Drupal site state directory.";
+          description = ''
+            The location of the user-managed Drupal site state directory.
+            This directory will contain the settings and configuration files for
+            your Drupal instance. It may also contain your files directory if the
+            `filesDir` option remains unchanged.
+
+            Many of the files in this directory are variable, so they must be located
+            in a location writeable by users of the webgroup.
+          '';
         };
 
         modulesDir = mkOption {
           type = types.path;
           default = "/var/lib/drupal/${name}/modules";
           defaultText = "/var/lib/drupal/<name>/modules";
-          description = "The location for users to install Drupal modules.";
+          description = ''
+            The location for users to manually install Drupal modules.
+
+            Note: in most instances, it is preferable to install modules using
+            composer, or to package them with your source code repository, if
+            you are using a custom Drupal.
+          '';
         };
 
         themesDir = mkOption {
           type = types.path;
           default = "/var/lib/drupal/${name}/themes";
           defaultText = "/var/lib/drupal/<name>/themes";
-          description = "The location for users to install Drupal themes.";
+          description = ''
+            The location for users to manually install Drupal themes.
+
+            Note: in most instances, it is preferable to install themes using
+            composer, or to package them with your source code repository, if
+            you are using a custom Drupal.
+          '';
         };
 
         phpOptions = mkOption {
@@ -357,6 +487,8 @@ in
           "d '${cfg.themesDir}' 0750 ${user} ${webserver.group} - -"
           "Z '${cfg.themesDir}' 0750 ${user} ${webserver.group} - -"
           "d '${cfg.privateFilesDir}' 0750 ${user} ${webserver.group} - -"
+          "d '${cfg.filesDir}' 0750 ${user} ${webserver.group} - -"
+          "Z '${cfg.filesDir}' 0750 ${user} ${webserver.group} - -"
           "d '${cfg.configSyncDir}' 0750 ${user} ${webserver.group} - -"
         ]) eachSite
       );
@@ -382,42 +514,15 @@ in
               User = "root";
               RemainAfterExit = true;
 
-              ExecStart = writeShellScript "drupal-state-init-${hostName}" ''
-                set -e
-
-                if [ ! -d "${cfg.stateDir}/sites" ]; then
-                  echo "Preparing sites directory..."
-                  cp -r "${cfg.package}/share/php/${cfg.package.pname}/sites" "${cfg.stateDir}"
-                fi
-
-                if [ ! -d "${cfg.filesDir}" ]; then
-                  echo "Preparing files directory..."
-                  mkdir -p "${cfg.filesDir}"
-                  chown -R ${user}:${webserver.group} ${cfg.filesDir}
-                fi
-
-                settings_file="${cfg.stateDir}/sites/default/settings.php"
-                default_settings="${cfg.package}/share/php/${cfg.package.pname}/sites/default/default.settings.php"
-
-                if [ ! -f "$settings_file" ]; then
-                  echo "Preparing settings.php for ${hostName}..."
-                  cp "$default_settings" "$settings_file"
-                  cat < ${appendSettings hostName} >> "$settings_file"
-                  chmod 644 "$settings_file"
-                fi
-
-                # Link the NixOS-managed settings file to the state directory.
-                ln -sf ${drupalSettings hostName cfg} ${cfg.stateDir}/sites/default/settings.nixos-${hostName}.php
-
-                # Set or reset file permissions so that the web user and webserver owns them.
-                chown -R ${user}:${webserver.group} ${cfg.stateDir}
-              '';
+              ExecStart = getExe (stateDirManage hostName cfg);
             };
 
             # Rerun this service if certain settings were updated
             reloadTriggers = [
               cfg.extraConfig
               cfg.privateFilesDir
+              cfg.filesDir
+              cfg.stateDir
               cfg.configSyncDir
             ];
           })
@@ -434,9 +539,9 @@ in
         enable = true;
         virtualHosts = mapAttrs (hostName: cfg: {
           serverName = mkDefault hostName;
-          root = "${pkg hostName cfg}/share/php/${cfg.package.pname}";
+          root = "${pkg hostName cfg}/share/php/${cfg.package.pname}${cfg.webRoot}";
           extraConfig = ''
-            index index.php;
+            index index.php index.htm index.html;
           '';
           locations = {
             "~ '\\.php$|^/update\\.php'" = {
@@ -515,11 +620,19 @@ in
             };
             "~ ^/sites/.*/files/styles/" = {
               extraConfig = ''
+                alias ${cfg.filesDir}/;
+                try_files $uri @rewrite;
+              '';
+            };
+            "^~ /sites/.*/files/" = {
+              extraConfig = ''
+                alias ${cfg.filesDir}/;
                 try_files $uri @rewrite;
               '';
             };
             "~ ^(/[a-z\\-]+)?/system/files/" = {
               extraConfig = ''
+                alias ${cfg.privateFilesDir}/;
                 try_files $uri /index.php?$query_string;
               '';
             };
@@ -535,8 +648,9 @@ in
           hostName: cfg:
           (nameValuePair hostName {
             extraConfig = ''
-              root * ${pkg hostName cfg}/share/php/${cfg.package.pname}
+              root * ${pkg hostName cfg}/share/php/${cfg.package.pname}${cfg.webRoot}
               file_server
+              root /sites/*/files ${cfg.filesDir}
 
               encode zstd gzip
               php_fastcgi unix/${config.services.phpfpm.pools."drupal-${hostName}".socket}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `/sites` directory in Drupal is made up of nothing but variable content. Some of it is public, some of it is private. None of it plays nice with `/nix/store`. This is why we've traditionally had to lean on a directory in `/var` to manage this part of Drupal. The `/sites` direcotry hosts per-site configuration, development configs, yml files used for controlling site services, content configuration (if the config sync directory isn't set to something else). and all of the user file uploads. All of this content needs to exist and be writable by the webserver at install time (not package build time) and afterward at run time, or else the site just doesn't work.

It is a complicated place. And it's also been a pain to try and manage in a nix-forward way.

This PR is an attempt at making that interface easier to manage. It makes site installation and management more predictable, modular, and easier to customize.

It also fixes some bugs related to the '/sites' dir,  makes file management easier, makes installing custom Drupal distributions possible, expands the optionset for the Drupal service, and adds a little extra guidance for configuring your Drupal site.

## Changes

 - Changed the build process for the service module. 

The provided Drupal package now gets cut up into a few separate derivations at build time and glued back together at run time. The key advantage of this strategy is that the /sites directory, which contains variable content, can now be regularly copied down into a user writeable space and symlinked, as a full directory, back up to the package. Drupal is pretty picky about the structure of this directory, and it takes great pains to make sure it is built properly before allowing you to install. Drupal doesn't like when any of these files are messed up or in the wrong place,  but it does follow symlinks, so this technique works better than telling the webserver to patch it all together on behalf of the app and risk messing up the mixed public/private concerns in this all-important directory.

 - Made it so the `/sites/defualt/fies` directory can exist outside of `/sites`

This module provides an option for putting the public files directory anywhere you want, but in past iterations, Drupal would throw a fit unless it could find its files inside of the `/sites/default/files` directory. So this PR fixes that with a combination of symlinking in user space, and a few new webserver rules that tell nginx and caddy to look in a specific location when searching for public files.

 - Added a new `webRoot` option.

The Drupal package in nixpkgs comes directly from the Drupal core git repo. It is a working project in its own right, but most users aren't forking or cloning this repo to make a new Drupal website. Instead, they're using composer, which installs Drupal inside of a public webroot, usually `/web`, but sometimes also `/public` or `/static` or some such. I've added an option that allows users to set the name of this directory. Having this also helps with a lot of the filesystem manipulation that takes place in the service module. In effect, it makes installing custom Drupal distros possible without a bunch of black magic.

 - Miscellany and maintaience
I added a htaccess file for the private files directory which protects it from arbitrary PHP execution. This is a long standing convention in Drupal, and something the site asks you to do when using a private files directory. This just makes that process automated.

There is also some expanded option definitions to make it clear how Drupal uses some of the directories set by the service module, and how you, the user, should be thinking about them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
