### PR TITLE
easyturn: convert to modular service

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -19,6 +19,7 @@ let
 
   modularServicesModule = {
     options = {
+      "<imports = [ pkgs.easytier.services.default ]>" = fakeSubmodule pkgs.easytier.services.default;
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
     };

--- a/nixos/modules/services/networking/easytier.nix
+++ b/nixos/modules/services/networking/easytier.nix
@@ -5,288 +5,207 @@
   ...
 }:
 
-with lib;
 let
   cfg = config.services.easytier;
-  settingsFormat = pkgs.formats.toml { };
-
-  genFinalSettings =
-    inst:
-    attrsets.filterAttrsRecursive (_: v: v != { }) (
-      attrsets.filterAttrsRecursive (_: v: v != null) (
-        {
-          inherit (inst.settings)
-            instance_name
-            hostname
-            ipv4
-            dhcp
-            listeners
-            ;
-          network_identity = {
-            inherit (inst.settings) network_name network_secret;
-          };
-          peer = map (p: { uri = p; }) inst.settings.peers;
-        }
-        // inst.extraSettings
-      )
-    );
-
-  genConfigFile =
-    name: inst:
-    if inst.configFile == null then
-      settingsFormat.generate "easytier-${name}.toml" (genFinalSettings inst)
-    else
-      inst.configFile;
-
-  activeInsts = filterAttrs (_: inst: inst.enable) cfg.instances;
-
-  settingsModule = name: {
-    options = {
-      instance_name = mkOption {
-        type = types.str;
-        default = name;
-        description = "Identify different instances on same host";
-      };
-
-      hostname = mkOption {
-        type = with types; nullOr str;
-        default = null;
-        description = "Hostname shown in peer list and web console.";
-      };
-
-      network_name = mkOption {
-        type = with types; nullOr str;
-        default = null;
-        description = "EasyTier network name.";
-      };
-
-      network_secret = mkOption {
-        type = with types; nullOr str;
-        default = null;
-        description = ''
-          EasyTier network credential used for verification and
-          encryption. It can also be set in environmentFile.
-        '';
-      };
-
-      ipv4 = mkOption {
-        type = with types; nullOr str;
-        default = null;
-        description = ''
-          IPv4 cidr address of this peer in the virtual network. If
-          empty, this peer will only forward packets and no TUN device
-          will be created.
-        '';
-        example = "10.144.144.1/24";
-      };
-
-      dhcp = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Automatically determine the IPv4 address of this peer based on
-          existing peers on network.
-        '';
-      };
-
-      listeners = mkOption {
-        type = with types; listOf str;
-        default = [
-          "tcp://0.0.0.0:11010"
-          "udp://0.0.0.0:11010"
-        ];
-        description = ''
-          Listener addresses to accept connections from other peers.
-          Valid format is: `<proto>://<addr>:<port>`, where the protocol
-          can be `tcp`, `udp`, `ring`, `wg`, `ws`, `wss`.
-        '';
-      };
-
-      peers = mkOption {
-        type = with types; listOf str;
-        default = [ ];
-        description = ''
-          Peers to connect initially. Valid format is: `<proto>://<addr>:<port>`.
-        '';
-        example = [
-          "tcp://example.com:11010"
-        ];
-      };
-    };
-  };
-
-  instanceModule =
-    { name, ... }:
-    {
-      options = {
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-          description = "Enable the instance.";
-        };
-
-        configServer = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          description = ''
-            Configure the instance from config server. When this option
-            set, any other settings for configuring the instance manually
-            except `hostname` will be ignored. Valid formats are:
-
-            - full uri for custom server: `udp://example.com:22020/<token>`
-            - username only for official server: `<token>`
-          '';
-          example = "udp://example.com:22020/myusername";
-        };
-
-        configFile = mkOption {
-          type = with types; nullOr path;
-          default = null;
-          description = ''
-            Path to easytier config file. Setting this option will
-            override `settings` and `extraSettings` of this instance.
-          '';
-        };
-
-        environmentFiles = mkOption {
-          type = with types; listOf path;
-          default = [ ];
-          description = ''
-            Environment files for this instance. All command-line args
-            have corresponding environment variables.
-          '';
-          example = literalExpression ''
-            [
-              /path/to/.env
-              /path/to/.env.secret
-            ]
-          '';
-        };
-
-        settings = mkOption {
-          type = types.submodule (settingsModule name);
-          default = { };
-          description = ''
-            Settings to generate {file}`easytier-${name}.toml`
-          '';
-        };
-
-        extraSettings = mkOption {
-          type = settingsFormat.type;
-          default = { };
-          description = ''
-            Extra settings to add to {file}`easytier-${name}.toml`.
-          '';
-        };
-
-        extraArgs = mkOption {
-          type = with types; listOf str;
-          default = [ ];
-          description = ''
-            Extra args append to the easytier command-line.
-          '';
-        };
-      };
-    };
-
+  activeInsts = lib.filterAttrs (_: inst: inst.enable) cfg.instances;
 in
 {
   options.services.easytier = {
-    enable = mkEnableOption "EasyTier daemon";
+    enable = lib.mkEnableOption "EasyTier daemon";
 
-    package = mkPackageOption pkgs "easytier" { };
+    package = lib.mkPackageOption pkgs "easytier" { };
 
-    allowSystemForward = mkEnableOption ''
+    allowSystemForward = lib.mkEnableOption ''
       Allow the system to forward packets from easytier. Useful when
       `proxy_forward_by_system` enabled.
     '';
 
-    instances = mkOption {
+    instances = lib.mkOption {
       description = ''
         EasyTier instances.
       '';
-      type = types.attrsOf (types.submodule instanceModule);
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = "Enable the instance.";
+              };
+
+              configServer = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = ''
+                  Configure the instance from config server. When this option
+                  set, any other settings for configuring the instance manually
+                  except `hostname` will be ignored. Valid formats are:
+
+                  - full uri for custom server: `udp://example.com:22020/<token>`
+                  - username only for official server: `<token>`
+                '';
+                example = "udp://example.com:22020/myusername";
+              };
+
+              configFile = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+                description = ''
+                  Path to easytier config file. Setting this option will
+                  override `settings` and `extraSettings` of this instance.
+                '';
+              };
+
+              environmentFiles = lib.mkOption {
+                type = lib.types.listOf lib.types.path;
+                default = [ ];
+                description = ''
+                  Environment files for this instance. All command-line args
+                  have corresponding environment variables.
+                '';
+              };
+
+              settings = lib.mkOption {
+                type = lib.types.submodule {
+                  options = {
+                    instance_name = lib.mkOption {
+                      type = lib.types.str;
+                      default = name;
+                      description = "Identify different instances on same host.";
+                    };
+
+                    hostname = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "Hostname shown in peer list and web console.";
+                    };
+
+                    network_name = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = "EasyTier network name.";
+                    };
+
+                    network_secret = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = ''
+                        EasyTier network credential used for verification and
+                        encryption. It can also be set in environmentFile.
+                      '';
+                    };
+
+                    ipv4 = lib.mkOption {
+                      type = lib.types.nullOr lib.types.str;
+                      default = null;
+                      description = ''
+                        IPv4 cidr address of this peer in the virtual network. If
+                        empty, this peer will only forward packets and no TUN device
+                        will be created.
+                      '';
+                      example = "10.144.144.1/24";
+                    };
+
+                    dhcp = lib.mkOption {
+                      type = lib.types.bool;
+                      default = false;
+                      description = ''
+                        Automatically determine the IPv4 address of this peer based on
+                        existing peers on network.
+                      '';
+                    };
+
+                    listeners = lib.mkOption {
+                      type = lib.types.listOf lib.types.str;
+                      default = [
+                        "tcp://0.0.0.0:11010"
+                        "udp://0.0.0.0:11010"
+                      ];
+                      description = ''
+                        Listener addresses to accept connections from other peers.
+                        Valid format is: `<proto>://<addr>:<port>`, where the protocol
+                        can be `tcp`, `udp`, `ring`, `wg`, `ws`, `wss`.
+                      '';
+                    };
+
+                    peers = lib.mkOption {
+                      type = lib.types.listOf lib.types.str;
+                      default = [ ];
+                      description = ''
+                        Peers to connect initially. Valid format is: `<proto>://<addr>:<port>`.
+                      '';
+                      example = [
+                        "tcp://example.com:11010"
+                      ];
+                    };
+                  };
+                };
+                default = { };
+                description = ''
+                  Settings to generate the easytier config file.
+                '';
+              };
+
+              extraSettings = lib.mkOption {
+                type = (pkgs.formats.toml { }).type;
+                default = { };
+                description = ''
+                  Extra settings to add to the easytier config file.
+                '';
+              };
+
+              extraArgs = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = ''
+                  Extra args appended to the easytier command-line.
+                '';
+              };
+            };
+          }
+        )
+      );
       default = { };
-      example = {
-        settings = {
-          network_name = "easytier";
-          network_secret = "easytier";
-          ipv4 = "10.144.144.1/24";
-          peers = [
-            "tcp://public.easytier.cn:11010"
-            "wss://example.com:443"
-          ];
-        };
-        extraSettings = {
-          flags.dev_name = "tun1";
-        };
-      };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    systemd.services = mapAttrs' (
+    system.services = lib.mapAttrs' (
       name: inst:
-      let
-        configFile = genConfigFile name inst;
-      in
-      nameValuePair "easytier-${name}" {
-        description = "EasyTier Daemon - ${name}";
-        wants = [
-          "network-online.target"
-          "nss-lookup.target"
-        ];
-        after = [
-          "network-online.target"
-          "nss-lookup.target"
-        ];
-        wantedBy = [ "multi-user.target" ];
-        path = with pkgs; [
+      lib.nameValuePair "easytier-${name}" {
+        imports = [ pkgs.easytier.services.default ];
+        easytier = {
+          package = cfg.package;
+          instanceName = name;
+          inherit (inst)
+            configServer
+            configFile
+            environmentFiles
+            settings
+            extraSettings
+            extraArgs
+            ;
+        };
+        # Runtime PATH dependencies (iproute2 for ip commands, bash for scripts)
+        systemd.service.path = with pkgs; [
           cfg.package
           iproute2
           bash
         ];
-        restartTriggers = inst.environmentFiles ++ (optionals (inst.configServer == null) [ configFile ]);
-        serviceConfig = {
-          Type = "simple";
-          Restart = "on-failure";
-          EnvironmentFile = inst.environmentFiles;
-          StateDirectory = "easytier/easytier-${name}";
-          StateDirectoryMode = "0700";
-          WorkingDirectory = "/var/lib/easytier/easytier-${name}";
-          ExecStart = escapeShellArgs (
-            [
-              "${cfg.package}/bin/easytier-core"
-            ]
-            ++ optionals (inst.configServer != null) (
-              [
-                "-w"
-                "${inst.configServer}"
-              ]
-              ++ (optionals (inst.settings.hostname != null) [
-                "--hostname"
-                "${inst.settings.hostname}"
-              ])
-            )
-            ++ optionals (inst.configServer == null) [
-              "-c"
-              "${configFile}"
-            ]
-            ++ inst.extraArgs
-          );
-        };
       }
     ) activeInsts;
 
-    boot.kernel.sysctl = mkIf cfg.allowSystemForward {
-      "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
-      "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
+    boot.kernel.sysctl = lib.mkIf cfg.allowSystemForward {
+      "net.ipv4.conf.all.forwarding" = lib.mkOverride 97 true;
+      "net.ipv6.conf.all.forwarding" = lib.mkOverride 97 true;
     };
   };
 
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     ltrump
   ];
 }

--- a/pkgs/by-name/ea/easytier/package.nix
+++ b/pkgs/by-name/ea/easytier/package.nix
@@ -7,6 +7,7 @@
   nixosTests,
   nix-update-script,
   installShellFiles,
+  formats,
   withQuic ? false, # with QUIC protocol support
 }:
 
@@ -46,6 +47,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false; # tests failed due to heavy rely on network
 
   passthru = {
+    services.default = {
+      imports = [
+        (lib.modules.importApply ./service.nix { settingsFormat = formats.toml { }; })
+      ];
+      easytier.package = lib.mkDefault finalAttrs.finalPackage;
+    };
     tests = { inherit (nixosTests) easytier; };
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/ea/easytier/service.nix
+++ b/pkgs/by-name/ea/easytier/service.nix
@@ -1,0 +1,246 @@
+# Non-module dependencies (`importApply`)
+{ settingsFormat }:
+
+# Service module
+{
+  lib,
+  config,
+  options,
+  name,
+  ...
+}:
+
+let
+  cfg = config.easytier;
+
+  genFinalSettings = lib.attrsets.filterAttrsRecursive (_: v: v != { }) (
+    lib.attrsets.filterAttrsRecursive (_: v: v != null) (
+      {
+        inherit (cfg.settings)
+          instance_name
+          hostname
+          ipv4
+          dhcp
+          listeners
+          ;
+        network_identity = {
+          inherit (cfg.settings) network_name network_secret;
+        };
+        peer = map (p: { uri = p; }) cfg.settings.peers;
+      }
+      // cfg.extraSettings
+    )
+  );
+
+  configFile =
+    if cfg.configFile == null then
+      settingsFormat.generate "easytier-${cfg.instanceName}.toml" genFinalSettings
+    else
+      cfg.configFile;
+
+  settingsModule = {
+    options = {
+      instance_name = lib.mkOption {
+        type = lib.types.str;
+        default = name;
+        description = "Identify different instances on same host";
+      };
+
+      hostname = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Hostname shown in peer list and web console.";
+      };
+
+      network_name = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "EasyTier network name.";
+      };
+
+      network_secret = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          EasyTier network credential used for verification and
+          encryption. It can also be set in environmentFile.
+        '';
+      };
+
+      ipv4 = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          IPv4 cidr address of this peer in the virtual network. If
+          empty, this peer will only forward packets and no TUN device
+          will be created.
+        '';
+        example = "10.144.144.1/24";
+      };
+
+      dhcp = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Automatically determine the IPv4 address of this peer based on
+          existing peers on network.
+        '';
+      };
+
+      listeners = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "tcp://0.0.0.0:11010"
+          "udp://0.0.0.0:11010"
+        ];
+        description = ''
+          Listener addresses to accept connections from other peers.
+          Valid format is: `<proto>://<addr>:<port>`, where the protocol
+          can be `tcp`, `udp`, `ring`, `wg`, `ws`, `wss`.
+        '';
+      };
+
+      peers = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = ''
+          Peers to connect initially. Valid format is: `<proto>://<addr>:<port>`.
+        '';
+        example = [
+          "tcp://example.com:11010"
+        ];
+      };
+    };
+  };
+
+in
+{
+  _class = "service";
+
+  options.easytier = {
+    package = lib.mkOption {
+      description = "The easytier package to use.";
+      defaultText = "The easytier package that provided this module.";
+      type = lib.types.package;
+    };
+
+    instanceName = lib.mkOption {
+      type = lib.types.str;
+      default = name;
+      defaultText = lib.literalExpression "name";
+      description = ''
+        Instance name used for state directory and config file naming.
+        Defaults to the modular service instance name.
+      '';
+    };
+
+    configServer = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Configure the instance from config server. When this option
+        set, any other settings for configuring the instance manually
+        except `hostname` will be ignored. Valid formats are:
+
+        - full uri for custom server: `udp://example.com:22020/<token>`
+        - username only for official server: `<token>`
+      '';
+      example = "udp://example.com:22020/myusername";
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to easytier config file. Setting this option will
+        override `settings` and `extraSettings` of this instance.
+      '';
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      description = ''
+        Environment files for this instance. All command-line args
+        have corresponding environment variables.
+      '';
+      example = lib.literalExpression ''
+        [
+          /path/to/.env
+          /path/to/.env.secret
+        ]
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule settingsModule;
+      default = { };
+      description = ''
+        Settings to generate {file}`easytier-${name}.toml`
+      '';
+    };
+
+    extraSettings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        Extra settings to add to {file}`easytier-${name}.toml`.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Extra args append to the easytier command-line.
+      '';
+    };
+  };
+
+  config = {
+    process.argv = [
+      "${cfg.package}/bin/easytier-core"
+    ]
+    ++ lib.optionals (cfg.configServer != null) (
+      [
+        "-w"
+        "${cfg.configServer}"
+      ]
+      ++ (lib.optionals (cfg.settings.hostname != null) [
+        "--hostname"
+        "${cfg.settings.hostname}"
+      ])
+    )
+    ++ lib.optionals (cfg.configServer == null) [
+      "-c"
+      "${configFile}"
+    ]
+    ++ cfg.extraArgs;
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      wants = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      after = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      restartTriggers = cfg.environmentFiles ++ (lib.optionals (cfg.configServer == null) [ configFile ]);
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        EnvironmentFile = cfg.environmentFiles;
+        StateDirectory = "easytier/easytier-${cfg.instanceName}";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = "/var/lib/easytier/easytier-${cfg.instanceName}";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    ltrump
+    kiara
+  ];
+}


### PR DESCRIPTION
build upon #475372 to answer a few further questions in making compatibility layers for porting NixOS services to modular services:

- how to handle 1:n relations between a NixOS service option space (here: `services.easytier`) yielding multiple (systemd/modular) services
- handling NixOS options shared across such corresponding modular services in this above case

as with #475372, i know little of this particular package, i just picked one that seemed to fit this particular proof of concept.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
