### PR TITLE
maintainers: drop Gonzih

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9886,12 +9886,6 @@
     githubId = 2041764;
     name = "Andreas Wendleder";
   };
-  Gonzih = {
-    email = "gonzih@gmail.com";
-    github = "Gonzih";
-    githubId = 266275;
-    name = "Max Gonzih";
-  };
   goodrone = {
     email = "goodrone@gmail.com";
     github = "goodrone";

--- a/pkgs/applications/audio/mopidy/mopify.nix
+++ b/pkgs/applications/audio/mopidy/mopify.nix
@@ -34,6 +34,6 @@ pythonPackages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/dirkgroenen/mopidy-mopify";
     description = "Mopidy webclient based on the Spotify webbased interface";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.Gonzih ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/applications/networking/cluster/linkerd/generic.nix
+++ b/pkgs/applications/networking/cluster/linkerd/generic.nix
@@ -68,8 +68,7 @@ buildGoModule rec {
     downloadPage = "https://github.com/linkerd/linkerd2/";
     homepage = "https://linkerd.io/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      Gonzih
+    maintainers = [
     ];
   };
 }

--- a/pkgs/by-name/ai/air/package.nix
+++ b/pkgs/by-name/ai/air/package.nix
@@ -30,6 +30,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "air";
     homepage = "https://github.com/air-verse/air";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ Gonzih ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/do/doge/package.nix
+++ b/pkgs/by-name/do/doge/package.nix
@@ -32,7 +32,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "doge";
     maintainers = with lib.maintainers; [
-      Gonzih
       quantenzitrone
     ];
   };

--- a/pkgs/by-name/k9/k9s/package.nix
+++ b/pkgs/by-name/k9/k9s/package.nix
@@ -73,7 +73,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "k9s";
     maintainers = with lib.maintainers; [
-      Gonzih
       markus1189
       qjoly
       devusb


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3AGonzih) since February 2025 despite 28 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-03-01+user-review-requested%3AGonzih). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@Gonzih if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
