### PR TITLE
devenv: fix build with lowdown 3.0

### DIFF
--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
+  applyPatches,
   gitMinimal,
   makeBinaryWrapper,
   installShellFiles,
@@ -27,18 +29,30 @@ let
   devenvNixVersion = "2.32";
   devenvNixRev = "e127c1c94cefe02d8ca4cca79ef66be4c527510e";
 
-  nix_components =
-    (nixVersions.nixComponents_git.overrideSource (fetchFromGitHub {
+  devenvNixSrc = applyPatches {
+    name = "devenv-nix-${devenvNixVersion}-source";
+    src = fetchFromGitHub {
       owner = "cachix";
       repo = "nix";
       rev = devenvNixRev;
       hash = "sha256-MRNVInSmvhKIg3y0UdogQJXe+omvKijGszFtYpd5r9k=";
-    })).overrideScope
-      (
-        finalScope: prevScope: {
-          version = devenvNixVersion;
-        }
-      );
+    };
+    patches = [
+      # Lowdown 3.0 compatibility; devenv's nix fork (2.32-based) predates
+      # the upstream fix.
+      (fetchpatch {
+        name = "nix-lowdown-3.0-support.patch";
+        url = "https://github.com/NixOS/nix/commit/472c35c561bd9e8db1465e0677f1efe2cb88c568.patch";
+        hash = "sha256-ZCQgI/euBN8t9rgdCsGRgrcEWG3T5MUc+bQc4tIcHuI=";
+      })
+    ];
+  };
+
+  nix_components = (nixVersions.nixComponents_git.overrideSource devenvNixSrc).overrideScope (
+    finalScope: prevScope: {
+      version = devenvNixVersion;
+    }
+  );
 in
 rustPlatform.buildRustPackage {
   pname = "devenv";


### PR DESCRIPTION
The devenv nix fork (2.32-based) uses `LOWDOWN_TERM_NORELLINK` which was removed in lowdown 3.0. I applied the upstream compatibility patch via `applyPatches` to avoid the `+N` version suffix that `appendPatches` adds, which breaks `devenv`'s `nix-bindings-store` build script.

Broken in:
- https://github.com/NixOS/nixpkgs/pull/499793

cc @vcunat @sternenseemann

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test