### PR TITLE
cargo-tauri: fix NVIDIA issue by disabling explicit sync 

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/hook.nix
+++ b/pkgs/by-name/ca/cargo-tauri/hook.nix
@@ -41,6 +41,9 @@ makeSetupHook {
         --prefix WEBKIT_GST_ALLOWED_URI_PROTOCOLS : "asset"
         # Not picked up automatically by the wrappers from the propagatedBuildInputs.
         --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${cargo-tauri.gst-plugin}/lib/gstreamer-1.0/"
+        # fix NVIDIA issues with Tauri
+        # https://github.com/tauri-apps/tauri/issues/9394#issuecomment-3795449374
+        --set-default __NV_DISABLE_EXPLICIT_SYNC 1
       )
     '';
 

--- a/pkgs/by-name/ci/cinny-desktop/package.nix
+++ b/pkgs/by-name/ci/cinny-desktop/package.nix
@@ -64,12 +64,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
         $out/share/applications/Cinny.desktop
     '';
 
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --set-default WEBKIT_DISABLE_DMABUF_RENDERER "1"
-    )
-  '';
-
   nativeBuildInputs = [
     cargo-tauri.hook
   ]

--- a/pkgs/by-name/fe/fedistar/package.nix
+++ b/pkgs/by-name/fe/fedistar/package.nix
@@ -62,13 +62,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doCheck = false; # This version's tests do not pass
 
-  # A fix for a problem with Tauri (tauri-apps/tauri#9304)
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1
-    )
-  '';
-
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--subpackage"

--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -135,8 +135,6 @@ rustPlatform.buildRustPackage rec {
 
   preFixup = ''
     gappsWrapperArgs+=(
-      # Otherwise blank screen, see https://github.com/tauri-apps/tauri/issues/9304
-      --set WEBKIT_DISABLE_DMABUF_RENDERER 1
       --prefix PATH ":" ${
         lib.makeBinPath [
           zenity

--- a/pkgs/by-name/fl/flying-carpet/package.nix
+++ b/pkgs/by-name/fl/flying-carpet/package.nix
@@ -65,11 +65,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 "Flying Carpet/src-tauri/icons/128x128@2x.png" "$out/share/icons/hicolor/256x256@2/apps/FlyingCarpet.png"
   '';
 
-  preFixup = ''
-    # https://github.com/tauri-apps/tauri/issues/9304
-    gappsWrapperArgs+=(--set WEBKIT_DISABLE_DMABUF_RENDERER 1)
-  '';
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -18,10 +18,6 @@
   moreutils,
   jq,
   gst_all_1,
-
-  # NOTE: this is enabled by default for better compatibility, but it may slow
-  # down performance.
-  withNvidiaFix ? true,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
@@ -93,15 +89,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   preBuild = ''
     # set up pdfjs and simplecc
     pnpm setup-vendors
-  '';
-
-  preFixup = lib.optionalString withNvidiaFix ''
-    # fix Nvidia issues with Tauri
-    # https://github.com/tauri-apps/tauri/issues/9394
-    # https://github.com/tauri-apps/tauri/issues/9304
-    gappsWrapperArgs+=(
-      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1
-    )
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ya/yaak/package.nix
+++ b/pkgs/by-name/ya/yaak/package.nix
@@ -138,13 +138,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       popd
     '';
 
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    wrapProgram $out/bin/yaak-app \
-      --inherit-argv0 \
-      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1 \
-      --set-default WEBKIT_DISABLE_COMPOSITING_MODE 1
-  '';
-
   passthru.updateScript = nix-update-script { };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/tauri-apps/tauri/issues/9394#issuecomment-3795449374
This approach fixes the issue without disabling the DMABUF renderer and should have better performance.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
