### PR TITLE
protonmail-bridge: 3.21.2 -> 3.23.1

### DIFF
--- a/pkgs/by-name/pr/protonmail-bridge/package.nix
+++ b/pkgs/by-name/pr/protonmail-bridge/package.nix
@@ -4,24 +4,28 @@
   fetchFromGitHub,
   pkg-config,
   libsecret,
+  libfido2,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "protonmail-bridge";
-  version = "3.21.2";
+  version = "3.23.1";
 
   src = fetchFromGitHub {
     owner = "ProtonMail";
     repo = "proton-bridge";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IQgP+eWUCyViEBi0WFIOW2rXZLtoyVlrQrtAaqaLOv0=";
+    hash = "sha256-QSK+MiHE8JFtUM4r+4xswOcNrcUd0flxuSf5uG2kZnI=";
   };
 
-  vendorHash = "sha256-aW7N6uacoP99kpvw9E5WrHaQ0fZ4P5WGsNvR/FAZ+cA=";
+  vendorHash = "sha256-Ww42BbdMHVUUc074vWNYTEMr1myqDPLgkMsaTarziag=";
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ libsecret ];
+  buildInputs = [
+    libsecret
+    libfido2
+  ];
 
   preBuild = ''
     patchShebangs ./utils/


### PR DESCRIPTION
Closes: #506636

Changelog: https://github.com/ProtonMail/proton-bridge/blob/v3.23.1/Changelog.md
Diff: https://github.com/ProtonMail/proton-bridge/compare/v3.21.2...v3.23.1

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
