### PR TITLE
nixos/lock-kernel-modules: filter built-in pseudo-filesystems from boot.kernelModules

### DIFF
--- a/nixos/modules/security/lock-kernel-modules.nix
+++ b/nixos/modules/security/lock-kernel-modules.nix
@@ -18,19 +18,37 @@
   };
 
   config = lib.mkIf config.security.lockKernelModules {
-    boot.kernelModules = lib.concatMap (
-      x:
-      lib.optionals (x.device != null) (
-        if x.fsType == "vfat" then
-          [
-            "vfat"
-            "nls-cp437"
-            "nls-iso8859-1"
-          ]
-        else
-          [ x.fsType ]
-      )
-    ) config.system.build.fileSystems;
+    boot.kernelModules =
+      let
+        # Pseudo-filesystems that are always built into the kernel (CONFIG_TMPFS=y,
+        # CONFIG_PROC_FS=y, etc.) and are never loadable modules.  Passing them to
+        # modprobe causes "Failed to find module 'tmpfs'" warnings from
+        # systemd-modules-load.service.
+        # This list mirrors `specialFSTypes` in tasks/filesystems.nix.
+        builtinFS = [
+          "proc"
+          "sysfs"
+          "tmpfs"
+          "ramfs"
+          "devtmpfs"
+          "devpts"
+        ];
+      in
+      lib.filter (m: !builtins.elem m builtinFS) (
+        lib.concatMap (
+          x:
+          lib.optionals (x.device != null) (
+            if x.fsType == "vfat" then
+              [
+                "vfat"
+                "nls-cp437"
+                "nls-iso8859-1"
+              ]
+            else
+              [ x.fsType ]
+          )
+        ) config.system.build.fileSystems
+      );
 
     systemd.services.disable-kernel-module-loading = {
       description = "Disable kernel module loading";


### PR DESCRIPTION
## Description

`security.lockKernelModules` ([lock-kernel-modules.nix]) adds every `fileSystems.*.fsType` to `boot.kernelModules` so that filesystem modules are pre-loaded before module loading is disabled. This was introduced in [1df6cf5] to fix #29019.

However, pseudo-filesystems like `tmpfs`, `ramfs`, `proc`, `sysfs`, `devtmpfs`, and `devpts` are **always built into the kernel** (`CONFIG_TMPFS=y`, `CONFIG_PROC_FS=y`, etc.) — they are never loadable `.ko` modules. When they end up in `/etc/modules-load.d/nixos.conf`, `systemd-modules-load.service` emits warnings at every boot:

    systemd-modules-load[347]: Failed to find module 'tmpfs'

This commonly triggers when users harden `/tmp` and `/var/tmp` as tmpfs mounts while also enabling `security.lockKernelModules`.

### Reproduction

    # configuration.nix
    {
      security.lockKernelModules = true;
      fileSystems."/tmp" = {
        device  = "tmpfs";
        fsType  = "tmpfs";
        options = [ "noexec" "nosuid" "nodev" "size=256M" "mode=1777" ];
      };
    }

After rebuild + reboot: `journalctl -b -u systemd-modules-load` shows `Failed to find module 'tmpfs'`.

### Fix

Filter out kernel built-in pseudo-filesystem types before adding to `boot.kernelModules`. The list mirrors `specialFSTypes` already defined in `nixos/modules/tasks/filesystems.nix`.

[lock-kernel-modules.nix]: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/security/lock-kernel-modules.nix
[1df6cf5]: https://github.com/NixOS/nixpkgs/commit/1df6cf5d1d6d4fa092252275ab82f409dd8f79fe

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test