### PR TITLE
actual-client: init at 26.7.0

### DIFF
--- a/pkgs/by-name/ac/actual-client/package.nix
+++ b/pkgs/by-name/ac/actual-client/package.nix
@@ -1,0 +1,151 @@
+{
+  lib,
+  actual-server,
+  copyDesktopItems,
+  electron_39,
+  imagemagick,
+  jq,
+  makeDesktopItem,
+  removeReferencesTo,
+  stdenv,
+}:
+let
+  electron = electron_39;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "actual-client";
+
+  inherit (actual-server)
+    srcs
+    version
+    sourceRoot
+    offlineCache
+    env
+    ;
+  inherit (actual-server.offlineCache) missingHashes;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  postPatch =
+    actual-server.postPatch
+    +
+    # bash
+    ''
+      # upstream had an issue, where binaries for x86 Mac had included blobs for
+      # aarch (cross-compiling issue?) so they decided to recompile some
+      # packages after `yarn install` for the right architecture. however, this
+      # breaks build on Nix, and I doubt someone would cross-compile this
+      # package using Nix
+      cat <<< $(${lib.getExe jq} 'del(.build.beforePack)' packages/desktop-electron/package.json) > packages/desktop-electron/package.json
+    '';
+
+  nativeBuildInputs = actual-server.nativeBuildInputs ++ [
+    copyDesktopItems
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+
+    # rebuild better-sqlite3; copied from splayer package
+    # we need to use headers from electron to avoid ABI mismatches.
+    pushd node_modules/better-sqlite3
+    npm run build-release --offline --nodedir="${electron.headers}"
+    rm -rf build/Release/{.deps,obj,obj.target,test_extension.node}
+    find build -type f -exec \
+      ${lib.getExe removeReferencesTo} \
+      -t "${electron.headers}" {} \;
+    popd
+
+    ./bin/package-electron --skip-translations --skip-exe-build
+
+    pushd packages/desktop-electron/
+    yarn build:dist
+    yarn run electron-builder \
+      --dir \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/lib/"
+    cp -Pr --no-preserve=ownership packages/desktop-electron/dist/*-unpacked/ "$out/share/lib/actual/"
+
+    mkdir icons
+    declare -a icon_sizes=(16x16 32x32 48x48 64x64 128x128 256x256 512x512)
+    for size in "''${icon_sizes[@]}"; do
+      ${lib.getExe imagemagick} \
+        -background none \
+        packages/desktop-electron/icons/icon.png \
+        -resize "!$size" \
+        "icons/$size.png"
+      install -D "icons/$size.png" \
+        "$out/share/icons/hicolor/$size/apps/com.actualbudget.actual.png"
+    done
+
+    # I am setting ELECTRON_FORCE_IS_PACKAGED because for some weird reason,
+    # electron always thinks it is not packaged
+    # (it is checking if binary name is `electron`, and if it is, electron just
+    # assumes it is not packaged. I have no idea what I do different from other
+    # packages)
+    # https://github.com/electron/electron/issues/35153#issuecomment-1202718531
+
+    makeWrapper ${lib.getExe electron} "$out/bin/actual" \
+      --add-flags "$out/share/lib/actual/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.actualbudget.actual";
+      desktopName = "Actual";
+      exec = "actual %U";
+      terminal = false;
+      type = "Application";
+      icon = "com.actualbudget.actual";
+      startupWMClass = "Actual";
+      comment = "Super fast privacy-focused app for managing your finances";
+      categories = [
+        "Office"
+        "Finance"
+      ];
+      keywords = [
+        "Budget"
+        "Finance"
+        "Money"
+        "Expenses"
+        "Savings"
+      ];
+    })
+  ];
+
+  passthru = {
+    inherit (finalAttrs) offlineCache;
+  };
+
+  meta = {
+    changelog = "https://actualbudget.org/docs/releases";
+    description = "Super fast privacy-focused app for managing your finances";
+    homepage = "https://actualbudget.org/";
+    mainProgram = "actual";
+    license = lib.licenses.mit;
+    # I don't have a GUI Mac, so I am not confident in my ability to support darwin
+    platforms = with lib.platforms; linux;
+    maintainers = [
+      lib.maintainers.PerchunPak
+    ];
+  };
+})

--- a/pkgs/by-name/ac/actual-client/package.nix
+++ b/pkgs/by-name/ac/actual-client/package.nix
@@ -1,0 +1,166 @@
+{
+  lib,
+  actual-server,
+  copyDesktopItems,
+  electron_41,
+  imagemagick,
+  jq,
+  makeDesktopItem,
+  makeWrapper,
+  removeReferencesTo,
+  stdenv,
+}:
+let
+  electron = electron_41;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "actual-client";
+
+  inherit (actual-server)
+    srcs
+    version
+    sourceRoot
+    offlineCache
+    env
+    patches
+    ;
+  inherit (actual-server.offlineCache) missingHashes;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  postPatch =
+    actual-server.postPatch
+    +
+    # bash
+    ''
+      cat <<< $(${lib.getExe jq} 'del(.build.beforePack, .build.electronFuses)' packages/desktop-electron/package.json) > packages/desktop-electron/package.json
+    '';
+
+  nativeBuildInputs = actual-server.nativeBuildInputs ++ [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # verify electron version
+    upstreamElectronMajor=$(${lib.getExe jq} -r '.devDependencies.electron | match("[0-9]+").string' packages/desktop-electron/package.json)
+    if [[ "$upstreamElectronMajor" != "${lib.versions.major electron.version}" ]]; then
+      echo "Electron major version mismatch: Actual expects $upstreamElectronMajor, nixpkgs provides ${electron.version}" >&2
+      exit 1
+    fi
+
+    export HOME=$(mktemp -d)
+
+    # lage hashes source files via `git ls-tree HEAD`, so it needs a repo with
+    # at least one commit.
+    git -c init.defaultBranch=main init -q
+    git add -A
+    git -c user.email=nix@localhost -c user.name=nix commit -q --allow-empty -m "snapshot"
+
+    # rebuild better-sqlite3; copied from splayer package
+    # we need to use headers from electron to avoid ABI mismatches.
+    pushd node_modules/better-sqlite3
+    npm run build-release --offline --nodedir="${electron.headers}"
+    rm -rf build/Release/{.deps,obj,obj.target,test_extension.node}
+    find build -type f -exec \
+      ${lib.getExe removeReferencesTo} \
+      -t "${electron.headers}" {} \;
+    popd
+
+    ./bin/package-electron --skip-translations --skip-exe-build
+
+    pushd packages/desktop-electron/
+
+    yarn run electron-builder \
+      --dir \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # The shared electron package will be used so only install the application resources produced by electron-builder
+    mkdir -p "$out/share/lib/actual/resources"
+    cp -Pr --no-preserve=ownership \
+      packages/desktop-electron/dist/*-unpacked/resources/{app.asar,app.asar.unpacked,extra-resources} \
+      "$out/share/lib/actual/resources/"
+
+    mkdir icons
+    declare -a icon_sizes=(16x16 32x32 48x48 64x64 128x128 256x256 512x512)
+    for size in "''${icon_sizes[@]}"; do
+      ${lib.getExe imagemagick} \
+        -background none \
+        packages/desktop-electron/icons/icon.png \
+        -resize "!$size" \
+        "icons/$size.png"
+      install -D "icons/$size.png" \
+        "$out/share/icons/hicolor/$size/apps/com.actualbudget.actual.png"
+    done
+
+    # We set ELECTRON_FORCE_IS_PACKAGED because Usually electron apps have
+    # a different executable name. Since we use the nixpkgs electron, it thinks
+    # it has no app packaged into it even though we do add the resources for
+    # Actual.
+
+    makeShellWrapper ${lib.getExe electron} "$out/bin/actual" \
+      --add-flags "$out/share/lib/actual/resources/app.asar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --inherit-argv0
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.actualbudget.actual";
+      desktopName = "Actual";
+      exec = "actual %U";
+      terminal = false;
+      type = "Application";
+      icon = "com.actualbudget.actual";
+      startupWMClass = "Actual";
+      comment = "Super fast privacy-focused app for managing your finances";
+      categories = [
+        "Office"
+        "Finance"
+      ];
+      keywords = [
+        "Budget"
+        "Finance"
+        "Money"
+        "Expenses"
+        "Savings"
+      ];
+    })
+  ];
+
+  passthru = {
+    inherit (finalAttrs) offlineCache;
+  };
+
+  meta = {
+    changelog = "https://actualbudget.org/docs/releases";
+    description = "Super fast privacy-focused app for managing your finances";
+    homepage = "https://actualbudget.org/";
+    mainProgram = "actual";
+    license = lib.licenses.mit;
+    # I don't have a GUI Mac, so I am not confident in my ability to support darwin
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = [
+      lib.maintainers.PerchunPak
+    ];
+  };
+})

--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Patch all references to `git` to a no-op `true`. This neuter automatic
     # translation update.
-    substituteInPlace bin/package-browser \
+    substituteInPlace bin/package-browser bin/package-electron \
       --replace-fail "git" "true"
 
     # Allow `remove-untranslated-languages` to do its job.
@@ -131,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    inherit (finalAttrs) offlineCache;
+    inherit (finalAttrs) offlineCache env;
     inherit translations;
     tests = nixosTests.actual;
     updateScript = ./update.sh;

--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Patch all references to `git` to a no-op `true`. This neuter automatic
     # translation update.
-    substituteInPlace bin/package-browser \
+    substituteInPlace bin/package-browser bin/package-electron \
       --replace-fail "git" "true"
 
     # Allow `remove-untranslated-languages` to do its job.
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    inherit (finalAttrs) offlineCache;
+    inherit (finalAttrs) offlineCache env;
     inherit translations;
     tests = nixosTests.actual;
     updateScript = ./update.sh;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since Actual's client and server are in the same monorepo, I decided not to fork the `actual-server` package and instead inherit most of the steps from it. And I decided against `actual-server.overrideAttrs` since it pulls in stuff implicitly, explicit is better in my opinion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
