### PR TITLE
ladybird: 0-unstable-2026-02-14 -> 0-unstable-2026-04-04

### DIFF
--- a/pkgs/by-name/la/ladybird/package.nix
+++ b/pkgs/by-name/la/ladybird/package.nix
@@ -21,9 +21,13 @@
   python3,
   qt6Packages,
   woff2,
+  cargo,
   fast-float,
   ffmpeg,
+  fmt,
   fontconfig,
+  rustPlatform,
+  rustc,
   simdutf,
   skia,
   nixosTests,
@@ -36,13 +40,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ladybird";
-  version = "0-unstable-2026-02-14";
+  version = "0-unstable-2026-04-04";
 
   src = fetchFromGitHub {
     owner = "LadybirdBrowser";
     repo = "ladybird";
-    rev = "ae9106a29da6b93695da2954e2a43b8ab2c2c112";
-    hash = "sha256-cmF5YVnS2kwS3YghPFcuCAP9PWnDs6xbS8XkdH268Qc=";
+    rev = "b11f30b32eff7c5e7baf6e84d0a432975631486d";
+    hash = "sha256-Fv74py0dQG2hQti40eh7vXCkN0rkheeqQ/JM3KIuLDA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-5CB5mRdmvsmTmy3PGKhCx3NZm7Et2cIwIg9vF2wA7xE=";
   };
 
   postPatch = ''
@@ -73,10 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
+    cargo
     cmake
     ninja
     pkg-config
     python3
+    rustPlatform.cargoSetupHook
+    rustc
     qt6Packages.wrapQtAppsHook
     libtommath
   ];
@@ -85,6 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     curlFull
     fast-float
     ffmpeg
+    fmt
     fontconfig
     libavif
     angle # libEGL


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes and closes https://github.com/NixOS/nixpkgs/pull/492938

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
