### PR TITLE
pinta: stable on darwin

### DIFF
--- a/pkgs/by-name/pi/pinta/package.nix
+++ b/pkgs/by-name/pi/pinta/package.nix
@@ -1,20 +1,35 @@
 {
   lib,
-  buildDotnetModule,
+  stdenv,
   dotnetCorePackages,
+  buildDotnetModule,
   fetchFromGitHub,
   glibcLocales,
   gtk4,
   glib,
-  intltool,
   libadwaita,
+  intltool,
   wrapGAppsHook4,
+  nix-update-script,
+
+  # Darwin transitive deps
+  graphene,
+  gettext,
+  pango,
+  gdk-pixbuf,
+  cairo,
+  harfbuzz,
+  fribidi,
+  fontconfig,
+  freetype,
+  libthai,
+  pcre2,
+  libepoxy,
 }:
 
 buildDotnetModule rec {
   pname = "Pinta";
   version = "3.1.1";
-
   src = fetchFromGitHub {
     owner = "PintaProject";
     repo = "Pinta";
@@ -31,6 +46,22 @@ buildDotnetModule rec {
     gtk4
     glib
     libadwaita
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # Transitive dylib deps that Pinta's NativeImportResolver dlopen's by bare name.
+    # These are not pulled in by wrapGAppsHook4's LD_LIBRARY_PATH on Darwin, so symlink is needed.
+    graphene
+    gettext
+    pango
+    gdk-pixbuf
+    cairo
+    harfbuzz
+    fribidi
+    fontconfig
+    freetype
+    libthai
+    pcre2
+    libepoxy
   ];
 
   buildInputs = runtimeDeps;
@@ -38,63 +69,74 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
-  # How-to update deps:
-  # $ nix-build -A pinta.fetch-deps
-  # $ ./result
-  # TODO: create update script
   nugetDeps = ./deps.json;
 
   projectFile = "Pinta";
 
-  # https://github.com/NixOS/nixpkgs/issues/38991
-  # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-  env.LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  env = lib.optionalAttrs (!stdenv.isDarwin) {
+    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  };
 
-  # Do the autoreconf/Makefile job manually
-  # TODO: use upstream build system
+  dotnetFlags = [ "-p:BuildTranslations=true" ];
+
   postBuild = ''
-    # Substitute translation placeholders
     intltool-merge -x po/ xdg/com.github.PintaProject.Pinta.metainfo.xml.in xdg/com.github.PintaProject.Pinta.metainfo.xml
     intltool-merge -d po/ xdg/com.github.PintaProject.Pinta.desktop.in xdg/com.github.PintaProject.Pinta.desktop
-
-    # Build translations
-    dotnet build Pinta \
-      --no-restore \
-      -p:ContinuousIntegrationBuild=true \
-      -p:Deterministic=true \
-      -target:CompileTranslations,PublishTranslations \
-      -p:BuildTranslations=true \
-      -p:PublishDir="$NIX_BUILD_TOP/source/publish"
   '';
 
   postFixup = ''
-    # Rename the binary
-    mv "$out/bin/Pinta" "$out/bin/pinta"
+    # Two-step rename needed on macOS: 'Pinta' is the same as 'pinta' on case-insensitive filesystems.
+    mv "$out/bin/Pinta" "$out/bin/pinta_tmp"
+    mv "$out/bin/pinta_tmp" "$out/bin/pinta"
 
-    # Copy runtime icons
-    for i in "Pinta.Resources/icons/hicolor/"*; do
-      res="$(basename $i)"
-      mkdir -p "$out/share/icons/hicolor/$res"
-      cp -rv "Pinta.Resources/icons/hicolor/$res/"* "$out/share/icons/hicolor/$res/"
-    done
-
-    # Install
+    # Use icons from the dotnet publish output (already at $out/lib/Pinta/icons/).
+    mkdir -p "$out/share/icons"
+    cp -r "$out/lib/Pinta/icons/." "$out/share/icons/"
+  ''
+  + lib.optionalString (!stdenv.isDarwin) ''
     dotnet build installer/linux/install.proj \
       -target:Install \
       -p:ContinuousIntegrationBuild=true \
       -p:Deterministic=true \
       -p:SourceDir="$NIX_BUILD_TOP/source" \
-      -p:PublishDir="$NIX_BUILD_TOP/source/publish" \
+      -p:PublishDir="$out/lib/Pinta" \
       -p:InstallPrefix="$out"
+  ''
+  + lib.optionalString stdenv.isDarwin ''
+    # Symlink all dylibs from runtimeDeps into the assembly dir.
+    # GirCore and Pinta's own NativeImportResolver both search here by bare name.
+    for dir in ${lib.concatMapStringsSep " " (d: "${lib.getLib d}/lib") runtimeDeps}; do
+      for dylib in "$dir"/*.dylib; do
+        [ -e "$dylib" ] || continue
+        ln -sf "$dylib" "$out/lib/Pinta/$(basename "$dylib")"
+      done
+    done
+
+    APP="$out/Applications/Pinta.app/Contents"
+    mkdir -p "$APP/MacOS" "$APP/Resources"
+
+    cp "$NIX_BUILD_TOP/source/installer/macos/Info.plist" "$APP/Info.plist"
+    cp "$NIX_BUILD_TOP/source/installer/macos/pinta.icns" "$APP/Resources/pinta.icns"
+
+    ln -s "$out/bin/pinta" "$APP/MacOS/pinta"
+    ln -s "$out/share" "$APP/Resources/share"
+    ln -s "$out/lib"   "$APP/Resources/lib"
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://www.pinta-project.com/";
     description = "Drawing/editing program modeled after Paint.NET";
     changelog = "https://github.com/PintaProject/Pinta/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ thiagokokada ];
-    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      thiagokokada
+      philocalyst
+    ];
+    platforms = lib.platforms.unix;
     mainProgram = "pinta";
   };
 }


### PR DESCRIPTION
- Handled the weird darwin linking issues that were causing issues
- Added a passthru script
- Fixed icon generation and setup a .app bundle
- Updated nuget deps (Which got out of date somehow)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
