### PR TITLE
python3Packages.diceware: fix test failure with python 3.14

### DIFF
--- a/pkgs/development/python-modules/diceware/default.nix
+++ b/pkgs/development/python-modules/diceware/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   setuptools,
   pytestCheckHook,
+  fetchpatch2,
 }:
 
 buildPythonPackage rec {
@@ -15,6 +16,20 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-VLaQgJ8MVqswhaGOFaDDgE1KDRJ/OK7wtc9fhZ0PZjk=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      # Set prog in ArgumentParser explicitly to fix test failure with Python 3.14
+      # https://github.com/ulif/diceware/issues/122
+      url = "https://github.com/ulif/diceware/commit/77d98606748df7755f36ebbb3bd838b1cdd80c61.patch";
+      includes = [ "diceware/__init__.py" ];
+      hunks = [
+        2
+        3
+      ];
+      hash = "sha256-yXGotV/tq7/vCYhY+1OZgCW3r6/SXTTvsHIU/jywbHc=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Backport upstream fix that sets `prog` explicitly in `ArgumentParser`, since Python 3.14 changed how the default prog name is derived and monkeypatching `sys.argv` no longer affects it.

Example failure: https://hydra.nixos.org/build/324307309


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
