### PR TITLE
texlive.withPackages: use new buildEnv (finalAttrs: ...), init texliveFullWithDocs

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -42,13 +42,11 @@ Release 23.11 ships with a new interface that will eventually replace `texlive.c
   ```
   Note that the packages in `texlive.pkgs` are only provided for search purposes and must not be used directly.
 
-- **Experimental and subject to change without notice:** to add the documentation for all packages in the environment, use
+- To add the documentation for all packages in the environment, use
   ```nix
-  texliveSmall.__overrideTeXConfig { withDocs = true; }
+  texliveSmall.overrideAttrs { withDocs = true; }
   ```
-  This can be applied before or after calling `withPackages`.
-
-  The function currently supports the parameters `withDocs`, `withSources`, and `requireTeXPackages`.
+  This can be applied before or after calling `withPackages`. The parameter `withSources` adds all source containers.
 
 ## User's guide {#sec-language-texlive-user-guide}
 

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -239,11 +239,7 @@ rec {
     runCommand "texlive-test-texdoc"
       {
         nativeBuildInputs = [
-          (texlive.withPackages (ps: [
-            ps.luatex
-            ps.texdoc
-            ps.texdoc.texdoc
-          ]))
+          ((texlive.withPackages (ps: [ ps.texdoc ])).overrideAttrs { withDocs = true; })
         ];
       }
       ''

--- a/pkgs/test/texlive/default.nix
+++ b/pkgs/test/texlive/default.nix
@@ -928,7 +928,7 @@ rec {
         scheme:
         builtins.foldl' (
           acc: pkg: concatLicenses acc (lib.toList (pkg.meta.license or [ ]))
-        ) [ ] scheme.passthru.requiredTeXPackages;
+        ) [ ] scheme.passthru.includedTeXPackages;
       correctLicensesAttrNames = scheme: lib.sort lt (map licenseToAttrName (correctLicenses scheme));
 
       hasLicenseMismatch =

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -474,6 +474,8 @@ lib.fix (
           builtins.attrValues nonEnvOutputs
         );
 
+        strictDeps = true;
+
         nativeBuildInputs = [
           makeWrapper
           libfaketime

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -40,9 +40,6 @@ lib.fix (
     finalAttrs:
 
     let
-      withDocs = finalAttrs.withDocs or false;
-      withSources = finalAttrs.withSources or false;
-
       # if necessary, convert old style { pkgs = [ ... ]; } packages to attribute sets
       isOldPkgList = p: !p.outputSpecified or false && p ? pkgs && builtins.all (p: p ? tlType) p.pkgs;
       ensurePkgSets =
@@ -133,13 +130,13 @@ lib.fix (
                 lib.concatMap (
                   p:
                   lib.optional (p ? tex) p.tex
-                  ++ lib.optional ((withDocs || p ? man) && p ? texdoc) p.texdoc
-                  ++ lib.optional (withSources && p ? texsource) p.texsource
+                  ++ lib.optional ((finalAttrs.withDocs || p ? man) && p ? texdoc) p.texdoc
+                  ++ lib.optional (finalAttrs.withSources && p ? texsource) p.texsource
                 ) specified.wrong
               else
                 otherOutputs.tex or [ ]
-                ++ lib.optionals withDocs (otherOutputs.texdoc or [ ])
-                ++ lib.optionals withSources (otherOutputs.texsource or [ ])
+                ++ lib.optionals finalAttrs.withDocs (otherOutputs.texdoc or [ ])
+                ++ lib.optionals finalAttrs.withSources (otherOutputs.texsource or [ ])
             )
             ++ specifiedOutputs.tex or [ ]
             ++ specifiedOutputs.texdoc or [ ]
@@ -260,9 +257,9 @@ lib.fix (
       meta = {
         description =
           "TeX Live environment"
-          + lib.optionalString withDocs " with documentation"
-          + lib.optionalString (withDocs && withSources) " and"
-          + lib.optionalString withSources " with sources";
+          + lib.optionalString finalAttrs.withDocs " with documentation"
+          + lib.optionalString (finalAttrs.withDocs && finalAttrs.withSources) " and"
+          + lib.optionalString finalAttrs.withSources " with sources";
         platforms = lib.platforms.all;
         longDescription =
           "Contains the following packages and their transitive dependencies:\n - "
@@ -508,6 +505,10 @@ lib.fix (
         languageLua = assembleConfigLines langLuaLines pkgList.sortedHyphenPatterns;
 
         postactionScripts = builtins.catAttrs "postactionScript" pkgList.tlpkg;
+
+        # whethe to include doc, source containers
+        withDocs = false;
+        withSources = false;
 
         allowSubstitutes = true;
         preferLocalBuild = false;

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -1,7 +1,6 @@
 {
   # texlive package set
   tl,
-  bin,
 
   tlpdbVersion,
 
@@ -12,9 +11,7 @@
   makeWrapper,
   runCommand,
   writeShellScript,
-  writeText,
   toTLPkgSets,
-  bash,
   perl,
 
   # common runtime dependencies

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -23,12 +23,9 @@
 }:
 
 lib.fix (
-  self:
+  buildTeXEnv:
   {
-    withDocs ? false,
-    withSources ? false,
     requiredTeXPackages ? ps: [ ps.scheme-infraonly ],
-
     ### texlive.combine backward compatibility
     __extraName ? "combined",
     __extraVersion ? "",
@@ -38,448 +35,484 @@ lib.fix (
     __fromCombineWrapper ? false,
     # build only the formats of a package (for internal use!)
     __formatsOf ? null,
-  }@args:
+  }:
+  buildEnv (
+    finalAttrs:
 
-  let
-    ### texlive.combine backward compatibility
-    # if necessary, convert old style { pkgs = [ ... ]; } packages to attribute sets
-    isOldPkgList = p: !p.outputSpecified or false && p ? pkgs && builtins.all (p: p ? tlType) p.pkgs;
-    ensurePkgSets =
-      ps:
-      if !__fromCombineWrapper && builtins.any isOldPkgList ps then
-        let
-          oldPkgLists = builtins.partition isOldPkgList ps;
-        in
-        oldPkgLists.wrong ++ lib.concatMap toTLPkgSets oldPkgLists.right
-      else
-        ps;
+    let
+      withDocs = finalAttrs.passthru.withDocs or false;
+      withSources = finalAttrs.passthru.withSources or false;
 
-    pkgList = rec {
-      # resolve dependencies of the packages that affect the runtime
-      all =
-        let
-          packages = ensurePkgSets (requiredTeXPackages tl);
-          runtime = builtins.partition (
-            p:
-            p.outputSpecified or false
-            -> builtins.elem (p.tlOutputName or p.outputName) [
-              "out"
-              "tex"
-              "tlpkg"
-            ]
-          ) packages;
-          keySet = p: {
-            key =
-              p.pname or p.name
-              + lib.optionalString (p.outputSpecified or false) ("-" + p.tlOutputName or p.outputName or "");
-            inherit p;
-            tlDeps = if p ? tlDeps then ensurePkgSets p.tlDeps else (p.requiredTeXPackages or (_: [ ]) tl);
-          };
-        in
-        # texlive.combine: the wrapper already resolves all dependencies
-        if __fromCombineWrapper then
-          requiredTeXPackages null
+      # if necessary, convert old style { pkgs = [ ... ]; } packages to attribute sets
+      isOldPkgList = p: !p.outputSpecified or false && p ? pkgs && builtins.all (p: p ? tlType) p.pkgs;
+      ensurePkgSets =
+        ps:
+        if !finalAttrs.passthru.__fromCombineWrapper && builtins.any isOldPkgList ps then
+          let
+            oldPkgLists = builtins.partition isOldPkgList ps;
+          in
+          oldPkgLists.wrong ++ lib.concatMap toTLPkgSets oldPkgLists.right
         else
-          builtins.catAttrs "p" (
-            builtins.genericClosure {
-              startSet = map keySet runtime.right;
-              operator = p: map keySet p.tlDeps;
-            }
-          )
-          ++ runtime.wrong;
+          ps;
 
-      # group the specified outputs
-      specified = builtins.partition (p: p.outputSpecified or false) all;
-      specifiedOutputs = lib.groupBy (p: p.tlOutputName or p.outputName) specified.right;
-      otherOutputNames = builtins.catAttrs "key" (
-        builtins.genericClosure {
-          startSet = map (key: { inherit key; }) (
-            lib.concatLists (builtins.catAttrs "outputs" specified.wrong)
-          );
-          operator = _: [ ];
-        }
-      );
-      otherOutputs = lib.genAttrs otherOutputNames (n: builtins.catAttrs n specified.wrong);
-      outputsToInstall = builtins.catAttrs "key" (
-        builtins.genericClosure {
-          startSet = map (key: { inherit key; }) (
-            [ "out" ]
-            ++ lib.optional (otherOutputs ? man) "man"
-            ++ lib.concatLists (builtins.catAttrs "outputsToInstall" (builtins.catAttrs "meta" specified.wrong))
-          );
-          operator = _: [ ];
-        }
-      );
+      pkgList = rec {
+        # resolve dependencies of the packages that affect the runtime
+        all =
+          let
+            packages = ensurePkgSets (finalAttrs.passthru.requiredTeXPackages tl);
+            runtime = builtins.partition (
+              p:
+              p.outputSpecified or false
+              -> builtins.elem (p.tlOutputName or p.outputName) [
+                "out"
+                "tex"
+                "tlpkg"
+              ]
+            ) packages;
+            keySet = p: {
+              key =
+                p.pname or p.name
+                + lib.optionalString (p.outputSpecified or false) ("-" + p.tlOutputName or p.outputName or "");
+              inherit p;
+              tlDeps = if p ? tlDeps then ensurePkgSets p.tlDeps else (p.requiredTeXPackages or (_: [ ]) tl);
+            };
+          in
+          # texlive.combine: the wrapper already resolves all dependencies
+          if finalAttrs.passthru.__fromCombineWrapper then
+            finalAttrs.passthru.requiredTeXPackages null
+          else
+            builtins.catAttrs "p" (
+              builtins.genericClosure {
+                startSet = map keySet runtime.right;
+                operator = p: map keySet p.tlDeps;
+              }
+            )
+            ++ runtime.wrong;
 
-      # split binary and tlpkg from tex, texdoc, texsource
-      bin =
-        if __fromCombineWrapper then
-          builtins.filter (p: p.tlType == "bin") all # texlive.combine: legacy filter
-        else
-          otherOutputs.out or [ ] ++ specifiedOutputs.out or [ ];
-      tlpkg =
-        if __fromCombineWrapper then
-          builtins.filter (p: p.tlType == "tlpkg") all # texlive.combine: legacy filter
-        else
-          otherOutputs.tlpkg or [ ] ++ specifiedOutputs.tlpkg or [ ];
-
-      nonbin =
-        if __fromCombineWrapper then
-          builtins.filter (p: p.tlType != "bin" && p.tlType != "tlpkg") all # texlive.combine: legacy filter
-        else
-          (
-            if __combine then # texlive.combine: emulate old input ordering to avoid rebuilds
-              lib.concatMap (
-                p:
-                lib.optional (p ? tex) p.tex
-                ++ lib.optional ((withDocs || p ? man) && p ? texdoc) p.texdoc
-                ++ lib.optional (withSources && p ? texsource) p.texsource
-              ) specified.wrong
-            else
-              otherOutputs.tex or [ ]
-              ++ lib.optionals withDocs (otherOutputs.texdoc or [ ])
-              ++ lib.optionals withSources (otherOutputs.texsource or [ ])
-          )
-          ++ specifiedOutputs.tex or [ ]
-          ++ specifiedOutputs.texdoc or [ ]
-          ++ specifiedOutputs.texsource or [ ];
-
-      # outputs that do not become part of the environment
-      nonEnvOutputs = lib.subtractLists [ "out" "tex" "texdoc" "texsource" "tlpkg" ] otherOutputNames;
-
-      # packages that contribute to config files and formats
-      fontMaps = lib.filter (p: p ? fontMaps && (p.tlOutputName or p.outputName == "tex")) nonbin;
-      sortedFontMaps = builtins.sort (a: b: a.pname < b.pname) fontMaps;
-      hyphenPatterns = lib.filter (
-        p: p ? hyphenPatterns && (p.tlOutputName or p.outputName == "tex")
-      ) nonbin;
-      sortedHyphenPatterns = builtins.sort (a: b: a.pname < b.pname) hyphenPatterns;
-      formatPkgs = lib.filter (
-        p:
-        p ? formats
-        && (p.outputSpecified or false -> p.tlOutputName or p.outputName == "tex")
-        && builtins.any (f: f.enabled or true) p.formats
-      ) all;
-      sortedFormatPkgs =
-        if __formatsOf != null then [ __formatsOf ] else builtins.sort (a: b: a.pname < b.pname) formatPkgs;
-      formats = map (
-        p:
-        self {
-          requiredTeXPackages =
-            ps:
-            [
-              ps.scheme-infraonly
-              p
-            ]
-            ++ hyphenPatterns;
-          __formatsOf = p;
-        }
-      ) sortedFormatPkgs;
-    };
-
-    # list generated by inspecting `grep -IR '\([^a-zA-Z]\|^\)gs\( \|$\|"\)' "$TEXMFDIST"/scripts`
-    # and `grep -IR rungs "$TEXMFDIST"`
-    # and ignoring luatex, perl, and shell scripts (those must be patched using postFixup)
-    needsGhostscript = lib.any (
-      p:
-      lib.elem p.pname [
-        "context"
-        "dvipdfmx"
-        "latex-papersize"
-        "lyluatex"
-      ]
-    ) pkgList.bin;
-
-    pname =
-      if __combine then
-        "texlive-${__extraName}" # texlive.combine: old name
-      else
-        "texlive";
-    version =
-      if __combine then
-        "${toString tlpdbVersion.year}${__extraVersion}" # texlive.combine: old version
-      else
-        "${toString tlpdbVersion.year}-r${toString tlpdbVersion.revision}-"
-        + (lib.optionalString tlpdbVersion.frozen "final-")
-        + (if __formatsOf != null then "${__formatsOf.pname}-fmt" else "env");
-
-    name = "${pname}-${version}";
-
-    texmfdist = buildEnv {
-      name = "${name}-texmfdist";
-
-      # remove fake derivations (without 'outPath') to avoid undesired build dependencies
-      paths = builtins.catAttrs "outPath" pkgList.nonbin;
-
-      # mktexlsr
-      nativeBuildInputs = [
-        tl.texlive-scripts # for mktexlsr.pl with --sort support
-        perl
-      ];
-
-      postBuild = # generate ls-R database
-        ''
-          perl ${tl.texlive-scripts.tex}/scripts/texlive/mktexlsr.pl --sort "$out"
-        '';
-    };
-
-    tlpkg = buildEnv {
-      name = "${name}-tlpkg";
-
-      # remove fake derivations (without 'outPath') to avoid undesired build dependencies
-      paths = builtins.catAttrs "outPath" pkgList.tlpkg;
-    };
-
-    # the 'non-relocated' packages must live in $TEXMFROOT/texmf-dist
-    # and sometimes look into $TEXMFROOT/tlpkg (notably fmtutil, updmap look for perl modules in both)
-    texmfroot =
-      runCommand "${name}-texmfroot"
-        {
-          inherit texmfdist tlpkg;
-        }
-        ''
-          mkdir -p "$out"
-          ln -s "$texmfdist" "$out"/texmf-dist
-          ln -s "$tlpkg" "$out"/tlpkg
-        '';
-
-    # texlive.combine: expose info and man pages in usual /share/{info,man} location
-    doc = buildEnv {
-      name = "${name}-doc";
-
-      paths = [ (texmfdist.outPath + "/doc") ];
-      extraPrefix = "/share";
-
-      pathsToLink = [
-        "/info"
-        "/man"
-      ];
-    };
-
-    meta = {
-      description =
-        "TeX Live environment"
-        + lib.optionalString withDocs " with documentation"
-        + lib.optionalString (withDocs && withSources) " and"
-        + lib.optionalString withSources " with sources";
-      platforms = lib.platforms.all;
-      longDescription =
-        "Contains the following packages and their transitive dependencies:\n - "
-        + lib.concatMapStringsSep "\n - " (
-          p:
-          p.pname + (lib.optionalString (p.outputSpecified or false) " (${p.tlOutputName or p.outputName})")
-        ) (requiredTeXPackages tl);
-    };
-
-    # other outputs
-    nonEnvOutputs = lib.genAttrs pkgList.nonEnvOutputs (
-      outName:
-      buildEnv {
-        inherit name;
-        paths = builtins.catAttrs "outPath" (
-          pkgList.otherOutputs.${outName} or [ ] ++ pkgList.specifiedOutputs.${outName} or [ ]
-        );
-        derivationArgs = {
-          outputs = [ outName ];
-          nativeBuildInputs = [
-            # force the output to be ${outName} or nix-env will not work
-            (writeShellScript "force-output.sh" ''
-              export out="''${${outName}-}"
-            '')
-          ];
-          inherit meta passthru;
-        };
-      }
-    );
-
-    passthru = {
-      # This is set primarily to help find-tarballs.nix to do its job
-      requiredTeXPackages = builtins.filter lib.isDerivation (
-        pkgList.bin
-        ++ pkgList.nonbin
-        ++ lib.optionals (!__fromCombineWrapper) (
-          lib.concatMap (
-            n: (pkgList.otherOutputs.${n} or [ ] ++ pkgList.specifiedOutputs.${n} or [ ])
-          ) pkgList.nonEnvOutputs
-        )
-      );
-      # useful for inclusion in the `fonts.packages` nixos option or for use in devshells
-      fonts = "${texmfroot}/texmf-dist/fonts";
-      # support variants attrs, (prev: attrs)
-      __overrideTeXConfig =
-        newArgs:
-        let
-          appliedArgs = if builtins.isFunction newArgs then newArgs args else newArgs;
-        in
-        self (args // { __fromCombineWrapper = false; } // appliedArgs);
-      withPackages =
-        reqs:
-        self (
-          args
-          // {
-            requiredTeXPackages = ps: reqs ps ++ requiredTeXPackages ps;
-            __fromCombineWrapper = false;
+        # group the specified outputs
+        specified = builtins.partition (p: p.outputSpecified or false) all;
+        specifiedOutputs = lib.groupBy (p: p.tlOutputName or p.outputName) specified.right;
+        otherOutputNames = builtins.catAttrs "key" (
+          builtins.genericClosure {
+            startSet = map (key: { inherit key; }) (
+              lib.concatLists (builtins.catAttrs "outputs" specified.wrong)
+            );
+            operator = _: [ ];
           }
         );
-    };
+        otherOutputs = lib.genAttrs otherOutputNames (n: builtins.catAttrs n specified.wrong);
+        outputsToInstall = builtins.catAttrs "key" (
+          builtins.genericClosure {
+            startSet = map (key: { inherit key; }) (
+              [ "out" ]
+              ++ lib.optional (otherOutputs ? man) "man"
+              ++ lib.concatLists (builtins.catAttrs "outputsToInstall" (builtins.catAttrs "meta" specified.wrong))
+            );
+            operator = _: [ ];
+          }
+        );
 
-    # TeXLive::TLOBJ::fmtutil_cnf_lines
-    fmtutilLine =
-      {
-        name,
-        engine,
-        enabled ? true,
-        patterns ? [ "-" ],
-        options ? "",
-        ...
-      }:
-      lib.optionalString (!enabled) "#! "
-      + "${name} ${engine} ${lib.concatStringsSep "," patterns} ${options}";
-    fmtutilLines =
-      { pname, formats, ... }:
-      [
-        "#"
-        "# from ${pname}:"
-      ]
-      ++ map fmtutilLine formats;
+        # split binary and tlpkg from tex, texdoc, texsource
+        bin =
+          if finalAttrs.passthru.__fromCombineWrapper then
+            builtins.filter (p: p.tlType == "bin") all # texlive.combine: legacy filter
+          else
+            otherOutputs.out or [ ] ++ specifiedOutputs.out or [ ];
+        tlpkg =
+          if finalAttrs.passthru.__fromCombineWrapper then
+            builtins.filter (p: p.tlType == "tlpkg") all # texlive.combine: legacy filter
+          else
+            otherOutputs.tlpkg or [ ] ++ specifiedOutputs.tlpkg or [ ];
 
-    # TeXLive::TLOBJ::language_dat_lines
-    langDatLine =
-      {
-        name,
-        file,
-        synonyms ? [ ],
-        ...
-      }:
-      [ "${name} ${file}" ] ++ map (s: "=" + s) synonyms;
-    langDatLines =
-      { pname, hyphenPatterns, ... }:
-      [ "% from ${pname}:" ] ++ builtins.concatMap langDatLine hyphenPatterns;
+        nonbin =
+          if finalAttrs.passthru.__fromCombineWrapper then
+            builtins.filter (p: p.tlType != "bin" && p.tlType != "tlpkg") all # texlive.combine: legacy filter
+          else
+            (
+              if finalAttrs.__combine then # texlive.combine: emulate old input ordering to avoid rebuilds
+                lib.concatMap (
+                  p:
+                  lib.optional (p ? tex) p.tex
+                  ++ lib.optional ((withDocs || p ? man) && p ? texdoc) p.texdoc
+                  ++ lib.optional (withSources && p ? texsource) p.texsource
+                ) specified.wrong
+              else
+                otherOutputs.tex or [ ]
+                ++ lib.optionals withDocs (otherOutputs.texdoc or [ ])
+                ++ lib.optionals withSources (otherOutputs.texsource or [ ])
+            )
+            ++ specifiedOutputs.tex or [ ]
+            ++ specifiedOutputs.texdoc or [ ]
+            ++ specifiedOutputs.texsource or [ ];
 
-    # TeXLive::TLOBJ::language_def_lines
-    # see TeXLive::TLUtils::parse_AddHyphen_line for default values
-    langDefLine =
-      {
-        name,
-        file,
-        lefthyphenmin ? "",
-        righthyphenmin ? "",
-        synonyms ? [ ],
-        ...
-      }:
-      map (
-        n:
-        "\\addlanguage{${n}}{${file}}{}{${if lefthyphenmin == "" then "2" else lefthyphenmin}}{${
-          if righthyphenmin == "" then "3" else righthyphenmin
-        }}"
-      ) ([ name ] ++ synonyms);
-    langDefLines =
-      { pname, hyphenPatterns, ... }:
-      [ "% from ${pname}:" ] ++ builtins.concatMap langDefLine hyphenPatterns;
+        # outputs that do not become part of the environment
+        nonEnvOutputs = lib.subtractLists [ "out" "tex" "texdoc" "texsource" "tlpkg" ] otherOutputNames;
 
-    # TeXLive::TLOBJ::language_lua_lines
-    # see TeXLive::TLUtils::parse_AddHyphen_line for default values
-    langLuaLine =
-      {
-        name,
-        file,
-        lefthyphenmin ? "",
-        righthyphenmin ? "",
-        synonyms ? [ ],
-        ...
-      }@args:
-      ''
-        ''\t['${name}'] = {
-        ''\t''\tloader = '${file}',
-        ''\t''\tlefthyphenmin = ${if lefthyphenmin == "" then "2" else lefthyphenmin},
-        ''\t''\trighthyphenmin = ${if righthyphenmin == "" then "3" else righthyphenmin},
-        ''\t''\tsynonyms = { ${lib.concatStringsSep ", " (map (s: "'${s}'") synonyms)} },
-      ''
-      + lib.optionalString (args ? file_patterns) "\t\tpatterns = '${args.file_patterns}',\n"
-      + lib.optionalString (args ? file_exceptions) "\t\thyphenation = '${args.file_exceptions}',\n"
-      + lib.optionalString (args ? luaspecial) "\t\tspecial = '${args.luaspecial}',\n"
-      + "\t},";
-    langLuaLines =
-      { pname, hyphenPatterns, ... }: [ "-- from ${pname}:" ] ++ map langLuaLine hyphenPatterns;
+        # packages that contribute to config files and formats
+        fontMaps = lib.filter (p: p ? fontMaps && (p.tlOutputName or p.outputName == "tex")) nonbin;
+        sortedFontMaps = builtins.sort (a: b: a.pname < b.pname) fontMaps;
+        hyphenPatterns = lib.filter (
+          p: p ? hyphenPatterns && (p.tlOutputName or p.outputName == "tex")
+        ) nonbin;
+        sortedHyphenPatterns = builtins.sort (a: b: a.pname < b.pname) hyphenPatterns;
+        formatPkgs = lib.filter (
+          p:
+          p ? formats
+          && (p.outputSpecified or false -> p.tlOutputName or p.outputName == "tex")
+          && builtins.any (f: f.enabled or true) p.formats
+        ) all;
+        sortedFormatPkgs =
+          if __formatsOf != null then [ __formatsOf ] else builtins.sort (a: b: a.pname < b.pname) formatPkgs;
+        formats = map (
+          p:
+          buildTeXEnv {
+            requiredTeXPackages =
+              ps:
+              [
+                ps.scheme-infraonly
+                p
+              ]
+              ++ hyphenPatterns;
+            __formatsOf = p;
+          }
+        ) sortedFormatPkgs;
+      };
 
-    assembleConfigLines = f: packages: builtins.concatStringsSep "\n" (builtins.concatMap f packages);
+      # list generated by inspecting `grep -IR '\([^a-zA-Z]\|^\)gs\( \|$\|"\)' "$TEXMFDIST"/scripts`
+      # and `grep -IR rungs "$TEXMFDIST"`
+      # and ignoring luatex, perl, and shell scripts (those must be patched using postFixup)
+      needsGhostscript = lib.any (
+        p:
+        lib.elem p.pname [
+          "context"
+          "dvipdfmx"
+          "latex-papersize"
+          "lyluatex"
+        ]
+      ) pkgList.bin;
 
-    updmapLines = { pname, fontMaps, ... }: [ "# from ${pname}:" ] ++ fontMaps;
+      pname =
+        if finalAttrs.__combine then
+          "texlive-${finalAttrs.passthru.__extraName}" # texlive.combine: old name
+        else
+          "texlive";
+      version =
+        if finalAttrs.__combine then
+          "${toString tlpdbVersion.year}${finalAttrs.passthru.__extraVersion}" # texlive.combine: old version
+        else
+          "${toString tlpdbVersion.year}-r${toString tlpdbVersion.revision}-"
+          + (lib.optionalString tlpdbVersion.frozen "final-")
+          + (if __formatsOf != null then "${__formatsOf.pname}-fmt" else "env");
 
-  in
-  buildEnv {
+      name = "${pname}-${version}";
 
-    inherit name;
+      texmfdist = buildEnv {
+        name = "${name}-texmfdist";
 
-    # remove fake derivations (without 'outPath') to avoid undesired build dependencies
-    paths =
-      builtins.catAttrs "outPath" pkgList.bin
-      ++ lib.optionals (!__combine && __formatsOf == null) pkgList.formats
-      ++ lib.optional __combine doc;
-    pathsToLink = [
-      "/"
-      "/share/texmf-var/scripts"
-      "/share/texmf-var/tex/generic/config"
-      "/share/texmf-var/web2c"
-      "/share/texmf-config"
-      "/bin" # ensure these are writeable directories
-    ];
+        # remove fake derivations (without 'outPath') to avoid undesired build dependencies
+        paths = builtins.catAttrs "outPath" pkgList.nonbin;
 
-    postBuild = ''
-      . "${./build-tex-env.sh}"
-    '';
+        # mktexlsr
+        nativeBuildInputs = [
+          tl.texlive-scripts # for mktexlsr.pl with --sort support
+          perl
+        ];
 
-    derivationArgs = {
-      # use attrNames, attrValues to ensure the two lists are sorted in the same way
-      outputs = [
-        "out"
-      ]
-      ++ lib.optionals (!__combine && __formatsOf == null) (builtins.attrNames nonEnvOutputs);
-      otherOutputs = lib.optionals (!__combine && __formatsOf == null) (
-        builtins.attrValues nonEnvOutputs
+        postBuild = # generate ls-R database
+          ''
+            perl ${tl.texlive-scripts.tex}/scripts/texlive/mktexlsr.pl --sort "$out"
+          '';
+      };
+
+      tlpkg = buildEnv {
+        name = "${name}-tlpkg";
+
+        # remove fake derivations (without 'outPath') to avoid undesired build dependencies
+        paths = builtins.catAttrs "outPath" pkgList.tlpkg;
+      };
+
+      # the 'non-relocated' packages must live in $TEXMFROOT/texmf-dist
+      # and sometimes look into $TEXMFROOT/tlpkg (notably fmtutil, updmap look for perl modules in both)
+      texmfroot =
+        runCommand "${name}-texmfroot"
+          {
+            inherit texmfdist tlpkg;
+          }
+          ''
+            mkdir -p "$out"
+            ln -s "$texmfdist" "$out"/texmf-dist
+            ln -s "$tlpkg" "$out"/tlpkg
+          '';
+
+      # texlive.combine: expose info and man pages in usual /share/{info,man} location
+      doc = buildEnv {
+        name = "${name}-doc";
+
+        paths = [ (texmfdist.outPath + "/doc") ];
+        extraPrefix = "/share";
+
+        pathsToLink = [
+          "/info"
+          "/man"
+        ];
+      };
+
+      meta = {
+        description =
+          "TeX Live environment"
+          + lib.optionalString withDocs " with documentation"
+          + lib.optionalString (withDocs && withSources) " and"
+          + lib.optionalString withSources " with sources";
+        platforms = lib.platforms.all;
+        longDescription =
+          "Contains the following packages and their transitive dependencies:\n - "
+          + lib.concatMapStringsSep "\n - " (
+            p:
+            p.pname + (lib.optionalString (p.outputSpecified or false) " (${p.tlOutputName or p.outputName})")
+          ) (finalAttrs.passthru.requiredTeXPackages tl);
+      };
+
+      # other outputs
+      nonEnvOutputs = lib.genAttrs pkgList.nonEnvOutputs (
+        outName:
+        buildEnv {
+          inherit name;
+          paths = builtins.catAttrs "outPath" (
+            pkgList.otherOutputs.${outName} or [ ] ++ pkgList.specifiedOutputs.${outName} or [ ]
+          );
+          derivationArgs = {
+            outputs = [ outName ];
+            nativeBuildInputs = [
+              # force the output to be ${outName} or nix-env will not work
+              (writeShellScript "force-output.sh" ''
+                export out="''${${outName}-}"
+              '')
+            ];
+            inherit meta passthru;
+          };
+        }
       );
 
-      nativeBuildInputs = [
-        makeWrapper
-        libfaketime
-        tl."texlive.infra" # mktexlsr
-        tl.texlive-scripts # fmtutil, updmap
-        tl.texlive-scripts-extra # texlinks
-        perl
+      passthru = {
+        inherit
+          requiredTeXPackages
+          __fromCombineWrapper
+          __extraName
+          __extraVersion
+          ;
+        # This is set primarily to help find-tarballs.nix to do its job
+        includedTeXPackages = builtins.filter lib.isDerivation (
+          pkgList.bin
+          ++ pkgList.nonbin
+          ++ lib.optionals (!finalAttrs.passthru.__fromCombineWrapper) (
+            lib.concatMap (
+              n: (pkgList.otherOutputs.${n} or [ ] ++ pkgList.specifiedOutputs.${n} or [ ])
+            ) pkgList.nonEnvOutputs
+          )
+        );
+        # useful for inclusion in the `fonts.packages` nixos option or for use in devshells
+        fonts = "${texmfroot}/texmf-dist/fonts";
+        __overrideTeXConfig = lib.warn "__overrideTeXConfig is deprecated, please switch to overrideAttrs" (
+          newArgs:
+          let
+            # arguments of buildTeXEnv before deprecation of __overrideTeXConfig
+            prevArgs = {
+              withDocs = finalAttrs.passthru.withDocs or false;
+              withSources = finalAttrs.passthru.withSources or false;
+              inherit (finalAttrs)
+                __combine
+                ;
+              inherit (finalAttrs.passthru)
+                requiredTeXPackages
+                __extraName
+                __extraVersion
+                __fromCombineWrapper
+                ;
+            };
+            appliedArgs = prevArgs // (if builtins.isFunction newArgs then newArgs prevArgs else newArgs);
+          in
+          finalAttrs.finalPackage.overrideAttrs (prevAttrs: {
+            passthru = prevAttrs.passthru // {
+              inherit (appliedArgs)
+                withDocs
+                withSources
+                requiredTeXPackages
+                __extraName
+                __extraVersion
+                ;
+              __fromCombineWrapper = false;
+            };
+            inherit (appliedArgs) __combine;
+          })
+        );
+        withPackages =
+          reqs:
+          finalAttrs.finalPackage.overrideAttrs (prevAttrs: {
+            passthru = prevAttrs.passthru // {
+              requiredTeXPackages = ps: reqs ps ++ prevAttrs.passthru.requiredTeXPackages ps;
+              __fromCombineWrapper = false;
+            };
+          });
+      };
+
+      # TeXLive::TLOBJ::fmtutil_cnf_lines
+      fmtutilLine =
+        {
+          name,
+          engine,
+          enabled ? true,
+          patterns ? [ "-" ],
+          options ? "",
+          ...
+        }:
+        lib.optionalString (!enabled) "#! "
+        + "${name} ${engine} ${lib.concatStringsSep "," patterns} ${options}";
+      fmtutilLines =
+        { pname, formats, ... }:
+        [
+          "#"
+          "# from ${pname}:"
+        ]
+        ++ map fmtutilLine formats;
+
+      # TeXLive::TLOBJ::language_dat_lines
+      langDatLine =
+        {
+          name,
+          file,
+          synonyms ? [ ],
+          ...
+        }:
+        [ "${name} ${file}" ] ++ map (s: "=" + s) synonyms;
+      langDatLines =
+        { pname, hyphenPatterns, ... }:
+        [ "% from ${pname}:" ] ++ builtins.concatMap langDatLine hyphenPatterns;
+
+      # TeXLive::TLOBJ::language_def_lines
+      # see TeXLive::TLUtils::parse_AddHyphen_line for default values
+      langDefLine =
+        {
+          name,
+          file,
+          lefthyphenmin ? "",
+          righthyphenmin ? "",
+          synonyms ? [ ],
+          ...
+        }:
+        map (
+          n:
+          "\\addlanguage{${n}}{${file}}{}{${if lefthyphenmin == "" then "2" else lefthyphenmin}}{${
+            if righthyphenmin == "" then "3" else righthyphenmin
+          }}"
+        ) ([ name ] ++ synonyms);
+      langDefLines =
+        { pname, hyphenPatterns, ... }:
+        [ "% from ${pname}:" ] ++ builtins.concatMap langDefLine hyphenPatterns;
+
+      # TeXLive::TLOBJ::language_lua_lines
+      # see TeXLive::TLUtils::parse_AddHyphen_line for default values
+      langLuaLine =
+        {
+          name,
+          file,
+          lefthyphenmin ? "",
+          righthyphenmin ? "",
+          synonyms ? [ ],
+          ...
+        }@args:
+        ''
+          ''\t['${name}'] = {
+          ''\t''\tloader = '${file}',
+          ''\t''\tlefthyphenmin = ${if lefthyphenmin == "" then "2" else lefthyphenmin},
+          ''\t''\trighthyphenmin = ${if righthyphenmin == "" then "3" else righthyphenmin},
+          ''\t''\tsynonyms = { ${lib.concatStringsSep ", " (map (s: "'${s}'") synonyms)} },
+        ''
+        + lib.optionalString (args ? file_patterns) "\t\tpatterns = '${args.file_patterns}',\n"
+        + lib.optionalString (args ? file_exceptions) "\t\thyphenation = '${args.file_exceptions}',\n"
+        + lib.optionalString (args ? luaspecial) "\t\tspecial = '${args.luaspecial}',\n"
+        + "\t},";
+      langLuaLines =
+        { pname, hyphenPatterns, ... }: [ "-- from ${pname}:" ] ++ map langLuaLine hyphenPatterns;
+
+      assembleConfigLines = f: packages: builtins.concatStringsSep "\n" (builtins.concatMap f packages);
+
+      updmapLines = { pname, fontMaps, ... }: [ "# from ${pname}:" ] ++ fontMaps;
+
+    in
+    {
+
+      inherit name;
+
+      # remove fake derivations (without 'outPath') to avoid undesired build dependencies
+      paths =
+        builtins.catAttrs "outPath" pkgList.bin
+        ++ lib.optionals (!finalAttrs.__combine && __formatsOf == null) pkgList.formats
+        ++ lib.optional finalAttrs.__combine doc;
+      pathsToLink = [
+        "/"
+        "/share/texmf-var/scripts"
+        "/share/texmf-var/tex/generic/config"
+        "/share/texmf-var/web2c"
+        "/share/texmf-config"
+        "/bin" # ensure these are writeable directories
       ];
 
-      buildInputs = [
-        coreutils
-        gawk
-        gnugrep
-        gnused
-      ]
-      ++ lib.optional needsGhostscript ghostscript;
+      postBuild = ''
+        . "${./build-tex-env.sh}"
+      '';
 
-      inherit passthru __combine;
-      __formatsOf = __formatsOf.pname or null;
+      derivationArgs = {
+        # use attrNames, attrValues to ensure the two lists are sorted in the same way
+        outputs = [
+          "out"
+        ]
+        ++ lib.optionals (!finalAttrs.__combine && __formatsOf == null) (builtins.attrNames nonEnvOutputs);
+        otherOutputs = lib.optionals (!finalAttrs.__combine && __formatsOf == null) (
+          builtins.attrValues nonEnvOutputs
+        );
 
-      inherit texmfdist texmfroot;
+        nativeBuildInputs = [
+          makeWrapper
+          libfaketime
+          tl."texlive.infra" # mktexlsr
+          tl.texlive-scripts # fmtutil, updmap
+          tl.texlive-scripts-extra # texlinks
+          perl
+        ];
 
-      fontconfigFile = makeFontsConf { fontDirectories = [ "${texmfroot}/texmf-dist/fonts" ]; };
+        buildInputs = [
+          coreutils
+          gawk
+          gnugrep
+          gnused
+        ]
+        ++ lib.optional needsGhostscript ghostscript;
 
-      fmtutilCnf = assembleConfigLines fmtutilLines pkgList.sortedFormatPkgs;
-      updmapCfg = assembleConfigLines updmapLines pkgList.sortedFontMaps;
+        inherit passthru __combine;
+        __formatsOf = __formatsOf.pname or null;
 
-      languageDat = assembleConfigLines langDatLines pkgList.sortedHyphenPatterns;
-      languageDef = assembleConfigLines langDefLines pkgList.sortedHyphenPatterns;
-      languageLua = assembleConfigLines langLuaLines pkgList.sortedHyphenPatterns;
+        inherit texmfdist texmfroot;
 
-      postactionScripts = builtins.catAttrs "postactionScript" pkgList.tlpkg;
+        fontconfigFile = makeFontsConf { fontDirectories = [ "${texmfroot}/texmf-dist/fonts" ]; };
 
-      allowSubstitutes = true;
-      preferLocalBuild = false;
+        fmtutilCnf = assembleConfigLines fmtutilLines pkgList.sortedFormatPkgs;
+        updmapCfg = assembleConfigLines updmapLines pkgList.sortedFontMaps;
 
-      meta =
-        meta
-        // lib.optionalAttrs (!__combine && __formatsOf == null) {
-          inherit (pkgList) outputsToInstall;
-        };
-    };
-  }
+        languageDat = assembleConfigLines langDatLines pkgList.sortedHyphenPatterns;
+        languageDef = assembleConfigLines langDefLines pkgList.sortedHyphenPatterns;
+        languageLua = assembleConfigLines langLuaLines pkgList.sortedHyphenPatterns;
+
+        postactionScripts = builtins.catAttrs "postactionScript" pkgList.tlpkg;
+
+        allowSubstitutes = true;
+        preferLocalBuild = false;
+
+        meta =
+          meta
+          // lib.optionalAttrs (!finalAttrs.__combine && __formatsOf == null) {
+            inherit (pkgList) outputsToInstall;
+          };
+      };
+    }
+  )
 )

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -10,7 +10,6 @@
   makeFontsConf,
   makeWrapper,
   runCommand,
-  writeShellScript,
   toTLPkgSets,
   perl,
 
@@ -279,12 +278,12 @@ lib.fix (
           );
           derivationArgs = {
             outputs = [ outName ];
-            nativeBuildInputs = [
-              # force the output to be ${outName} or nix-env will not work
-              (writeShellScript "force-output.sh" ''
-                export out="''${${outName}-}"
-              '')
-            ];
+
+            # force the output to be ${outName} or nix-env will not work
+            preHook = ''
+              export out="''${${outName}}"
+            '';
+
             inherit meta passthru;
           };
         }

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -40,8 +40,8 @@ lib.fix (
     finalAttrs:
 
     let
-      withDocs = finalAttrs.passthru.withDocs or false;
-      withSources = finalAttrs.passthru.withSources or false;
+      withDocs = finalAttrs.withDocs or false;
+      withSources = finalAttrs.withSources or false;
 
       # if necessary, convert old style { pkgs = [ ... ]; } packages to attribute sets
       isOldPkgList = p: !p.outputSpecified or false && p ? pkgs && builtins.all (p: p ? tlType) p.pkgs;
@@ -317,8 +317,6 @@ lib.fix (
           let
             # arguments of buildTeXEnv before deprecation of __overrideTeXConfig
             prevArgs = {
-              withDocs = finalAttrs.passthru.withDocs or false;
-              withSources = finalAttrs.passthru.withSources or false;
               inherit (finalAttrs)
                 __combine
                 ;
@@ -328,22 +326,27 @@ lib.fix (
                 __extraVersion
                 __fromCombineWrapper
                 ;
-            };
+            }
+            // lib.optionalAttrs (finalAttrs ? withDocs) { inherit (finalAttrs) withDocs; }
+            // lib.optionalAttrs (finalAttrs ? withSources) { inherit (finalAttrs) withSources; };
             appliedArgs = prevArgs // (if builtins.isFunction newArgs then newArgs prevArgs else newArgs);
           in
-          finalAttrs.finalPackage.overrideAttrs (prevAttrs: {
-            passthru = prevAttrs.passthru // {
-              inherit (appliedArgs)
-                withDocs
-                withSources
-                requiredTeXPackages
-                __extraName
-                __extraVersion
-                ;
-              __fromCombineWrapper = false;
-            };
-            inherit (appliedArgs) __combine;
-          })
+          finalAttrs.finalPackage.overrideAttrs (
+            prevAttrs:
+            {
+              passthru = prevAttrs.passthru // {
+                inherit (appliedArgs)
+                  requiredTeXPackages
+                  __extraName
+                  __extraVersion
+                  ;
+                __fromCombineWrapper = false;
+              };
+              inherit (appliedArgs) __combine;
+            }
+            // lib.optionalAttrs (appliedArgs ? withDocs) { inherit (appliedArgs) withDocs; }
+            // lib.optionalAttrs (appliedArgs ? withSources) { inherit (appliedArgs) withSources; }
+          )
         );
         withPackages =
           reqs:

--- a/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
@@ -2,7 +2,6 @@
 {
   lib,
   toTLPkgList,
-  toTLPkgSets,
   buildTeXEnv,
 }:
 args@{

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -231,7 +231,7 @@ let
 
   # function for creating a working environment
   buildTeXEnv = import ./build-tex-env.nix {
-    inherit bin tl;
+    inherit tl;
     inherit tlpdbVersion;
     ghostscript = ghostscript_headless;
     inherit
@@ -242,9 +242,7 @@ let
       makeWrapper
       runCommand
       writeShellScript
-      writeText
       toTLPkgSets
-      bash
       perl
       coreutils
       gawk

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -241,7 +241,6 @@ let
       makeFontsConf
       makeWrapper
       runCommand
-      writeShellScript
       toTLPkgSets
       perl
       coreutils

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1767,6 +1767,7 @@ with pkgs;
     texliveSmall
     texliveTeTeX
     ;
+  texliveFullWithDocs = texliveFull.overrideAttrs { withDocs = true; };
   texlivePackages = recurseIntoAttrs (lib.mapAttrs (_: v: v.build) texlive.pkgs);
 
   futhark = haskell.lib.compose.justStaticExecutables haskellPackages.futhark;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1757,6 +1757,7 @@ with pkgs;
     texliveSmall
     texliveTeTeX
     ;
+  texliveFullWithDocs = texliveFull.overrideAttrs { withDocs = true; };
   texlivePackages = recurseIntoAttrs (lib.mapAttrs (_: v: v.build) texlive.pkgs);
 
   futhark = haskell.lib.compose.justStaticExecutables haskellPackages.futhark;


### PR DESCRIPTION
Leverage the new fixed-point style `buildEnv` to allow sensible overrides like:
```nix
texliveSmall.overrideAttrs { withDocs = true; }
```
This supercedes #497867, #247364, #312945. Massive thanks to @ShamrockLee for upgrading `buildEnv`, this wouldn't be possible otherwise.

I split the core change into two commits:
- the first one switches to `finalAttrs` without changing evaluation, to make testing trivial; however, one would have to run `texliveSmall.overrideAttrs (prev: { passthru = prev.passthru // { withDocs = true; }; }` to get the documentation packages
- the second one moves `withDocs`, `withSources` to normal derivation attributes (outside of `passthru`), which changes the evaluation, but gives you the much more ergonomic `texliveSmall.overrideAttrs { withDocs = true; }`

It took me a few tries not to break `__overrideTeXConfig`, but the theory is that it should evaluate the same as before, modulo the `withDocs` attribute.

I removed `__overrideTeXConfig` from the documentation.

PS: unfortunately build-tex-env.nix requires reformatting. Please look at non-whitespace changes only.

**EDIT:** this also enables `strictDeps`.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
