### PR TITLE
catppuccin: add whoogle

### DIFF
--- a/pkgs/by-name/ca/catppuccin/package.nix
+++ b/pkgs/by-name/ca/catppuccin/package.nix
@@ -19,6 +19,7 @@ let
     "starship"
     "thunderbird"
     "waybar"
+    "whoogle"
   ];
 in
 {
@@ -208,6 +209,14 @@ let
       rev = "ee8ed32b4f63e9c417249c109818dcc05a2e25da";
       hash = "sha256-za0y6hcN2rvN6Xjf31xLRe4PP0YyHu2i454ZPjr+lWA=";
     };
+
+    whoogle = fetchFromGitHub {
+      name = "whoogle";
+      owner = "catppuccin";
+      repo = "whoogle";
+      rev = "9d961dc6e2ac405fee18ee1da9a14db1f139db39";
+      hash = "sha256-GyJD/xAF481ZMHOEfwW1SrWW6LT8ARRFizbfjl526XE=";
+    };
   };
 in
 lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListOfEnum
@@ -337,6 +346,11 @@ lib.checkListOfEnum "${pname}: variant" validVariants [ variant ] lib.checkListO
     + lib.optionalString (lib.elem "waybar" themeList) ''
       mkdir -p "$out/waybar"
       cp "${sources.waybar}/themes/${variant}.css" "$out/waybar"
+
+    ''
+    + lib.optionalString (lib.elem "whoogle" themeList) ''
+      mkdir -p "$out/whoogle"
+      cp "${sources.whoogle}/css/${variant}.css" "$out/whoogle"
 
     ''
     + ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the whoogle css theme into this package.

What do you think about renaming the `variant` option into `flavor`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
