### PR TITLE
oxicloud: init at 0.5.3

### DIFF
--- a/pkgs/by-name/ox/oxicloud/package.nix
+++ b/pkgs/by-name/ox/oxicloud/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oxicloud";
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "DioCrafts";
+    repo = "OxiCloud";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5OvqXjSTqJuwVSRhL/XcB0v6FLdLldOIclfMHd3OuEs=";
+  };
+
+  cargoHash = "sha256-ImM7jDquzuSdVRTG+JHZb7bTjjob4GGoLA1wRJCjA9c=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast and lightweight self-hosted cloud storage alternative to Nextcloud";
+    homepage = "https://github.com/DioCrafts/OxiCloud";
+    changelog = "https://github.com/DioCrafts/OxiCloud/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "oxicloud";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
# Description

Adding `oxicloud` — a fast and lightweight self-hosted cloud storage alternative to Nextcloud, written in Rust.

- Homepage: https://github.com/DioCrafts/OxiCloud
- License: MIT
- Packaged using `rustPlatform.buildRustPackage`
- Placed in `pkgs/by-name/ox/oxicloud/package.nix` per the by-name convention
- Includes `passthru.updateScript` via `nix-update-script`
- Restricted to `lib.platforms.linux` (upstream only targets Linux)

# Checklist

- [x] package built on `x86_64-linux` via `nix-build -A oxicloud`
- [x] code formatted with `nix fmt`
- [ ] maintainer added (no nixpkgs handle yet)