### PR TITLE
 switch-to-configuration-ng: avoid crashing when fds are closed by dup'ing `stdout` and `stderr`

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1127,6 +1127,9 @@ in
   nixos-rebuild-target-host = runTest {
     imports = [ ./nixos-rebuild-target-host.nix ];
   };
+  nixos-rebuild-target-host-interrupted = runTest {
+    imports = [ ./nixos-rebuild-target-host-interrupted.nix ];
+  };
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
   nixpkgs-config-allow-unfree =
     pkgs.callPackage ../modules/misc/nixpkgs/test-nixpkgs-config-allow-unfree.nix

--- a/nixos/tests/nixos-rebuild-target-host-interrupted.nix
+++ b/nixos/tests/nixos-rebuild-target-host-interrupted.nix
@@ -1,0 +1,226 @@
+{ hostPkgs, ... }:
+
+# This test recreates a remote deployment scenario where the connection
+# between deployer and target is closed during the deployment - in this
+# case because the connection goes over a 'reverse ssh' tunnel service
+# that has changes that are being deployed.
+
+# This is not seamless (the deployer doesn't get to see the logs after
+# the disconnect), but is a lot better than the old behaviour, where
+# the switch was aborted and the connection never restored.
+
+{
+  name = "nixos-rebuild-target-host-interrupted";
+
+  # TODO: remove overlay from  nixos/modules/profiles/installation-device.nix
+  #        make it a _small package instead, then remove pkgsReadOnly = false;.
+  node.pkgsReadOnly = false;
+
+  nodes = {
+    deployer =
+      {
+        nodes,
+        lib,
+        pkgs,
+        ...
+      }:
+      let
+        inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+      in
+      {
+        imports = [
+          ../modules/profiles/installation-device.nix
+        ];
+
+        nix.settings = {
+          substituters = lib.mkForce [ ];
+          hashed-mirrors = null;
+          connect-timeout = 1;
+        };
+
+        system.includeBuildDependencies = true;
+
+        virtualisation = {
+          cores = 2;
+          memorySize = 3072;
+        };
+
+        services.openssh.enable = true;
+        users.users.root.openssh.authorizedKeys.keys = [ nodes.target.system.build.publicKey ];
+
+        system.build.privateKey = snakeOilPrivateKey;
+        system.build.publicKey = snakeOilPublicKey;
+        system.switch.enable = true;
+
+        services.getty.autologinUser = lib.mkForce "root";
+      };
+
+    target =
+      {
+        nodes,
+        lib,
+        pkgs,
+        ...
+      }:
+      let
+        inherit (import ./ssh-keys.nix pkgs) snakeOilPrivateKey snakeOilPublicKey;
+        targetConfig = {
+          documentation.enable = false;
+          services.openssh.enable = true;
+          system.build.privateKey = snakeOilPrivateKey;
+          system.build.publicKey = snakeOilPublicKey;
+
+          users.users.root.openssh.authorizedKeys.keys = [ nodes.deployer.system.build.publicKey ];
+          users.users.alice.openssh.authorizedKeys.keys = [ nodes.deployer.system.build.publicKey ];
+          users.users.bob.openssh.authorizedKeys.keys = [ nodes.deployer.system.build.publicKey ];
+
+          users.users.alice.extraGroups = [ "wheel" ];
+          users.users.bob.extraGroups = [ "wheel" ];
+
+          # Disable sudo for root to ensure sudo isn't called without `--sudo`
+          security.sudo.extraRules = lib.mkForce [
+            {
+              groups = [ "wheel" ];
+              commands = [ { command = "ALL"; } ];
+            }
+            {
+              users = [ "alice" ];
+              commands = [
+                {
+                  command = "ALL";
+                  options = [ "NOPASSWD" ];
+                }
+              ];
+            }
+          ];
+
+          nix.settings.trusted-users = [ "@wheel" ];
+
+          services.autossh-ng.sessions.will-be-interrupted-by-rebuild = {
+            user = "root";
+            destination = "deployer";
+            extraArguments = "-R2222:localhost:22";
+            hostKeyChecking = false;
+          };
+          # Faster retry to avoid slow test
+          systemd.services.autossh-ng-will-be-interrupted-by-rebuild.serviceConfig.RestartSec =
+            lib.mkForce "1s";
+        };
+      in
+      {
+        imports = [ ./common/user-account.nix ];
+
+        config = lib.mkMerge [
+          targetConfig
+          {
+            system.build = {
+              inherit targetConfig;
+            };
+            system.switch.enable = true;
+
+            networking.hostName = "target";
+          }
+        ];
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      sshConfig = builtins.toFile "ssh.conf" ''
+        UserKnownHostsFile=/dev/null
+        StrictHostKeyChecking=no
+      '';
+
+      targetConfigJSON = hostPkgs.writeText "target-configuration.json" (
+        builtins.toJSON nodes.target.system.build.targetConfig
+      );
+
+      targetNetworkJSON = hostPkgs.writeText "target-network.json" (
+        builtins.toJSON nodes.target.system.build.networkConfig
+      );
+
+      configFile =
+        hostname:
+        hostPkgs.writeText "configuration.nix" # nix
+          ''
+            { lib, pkgs, modulesPath, ... }: {
+              imports = [
+                (modulesPath + "/virtualisation/qemu-vm.nix")
+                (modulesPath + "/testing/test-instrumentation.nix")
+                (modulesPath + "/../tests/common/user-account.nix")
+                (lib.modules.importJSON ./target-configuration.json)
+                (lib.modules.importJSON ./target-network.json)
+                ./hardware-configuration.nix
+              ];
+
+              boot.loader.grub = {
+                enable = true;
+                device = "/dev/vda";
+                forceInstall = true;
+              };
+
+              # We're changing the '-E' parameter to the new hostname here,
+              # not because we care about the logs, but because we want to
+              # force the scenario where the connection is broken during the
+              # deployment (because the autossh-ng service is stopped and
+              # started):
+              services.autossh-ng.sessions.will-be-interrupted-by-rebuild.extraArguments = "-R2222:localhost:22 -E ${hostname}";
+
+              # this will be asserted to validate the switch happened:
+              networking.hostName = "${hostname}";
+            }
+          '';
+    in
+    # python
+    ''
+      start_all()
+      target.wait_for_open_port(22)
+
+      deployer.wait_until_succeeds("ping -c1 target")
+      deployer.succeed("install -Dm 600 ${nodes.deployer.system.build.privateKey} ~root/.ssh/id_ecdsa")
+      deployer.succeed("install ${sshConfig} ~root/.ssh/config")
+
+      target.succeed("nixos-generate-config")
+      target.succeed("install -Dm 600 ${nodes.target.system.build.privateKey} ~root/.ssh/id_ecdsa")
+      deployer.succeed("scp alice@target:/etc/nixos/hardware-configuration.nix /root/hardware-configuration.nix")
+      target.wait_for_unit("autossh-ng-will-be-interrupted-by-rebuild.service")
+
+      deployer.copy_from_host("${configFile "config-1-deployed"}", "/root/configuration-1.nix")
+      deployer.copy_from_host("${configFile "config-2-deployed"}", "/root/configuration-2.nix")
+      deployer.copy_from_host("${targetNetworkJSON}", "/root/target-network.json")
+      deployer.copy_from_host("${targetConfigJSON}", "/root/target-configuration.json")
+
+      with subtest("Deploy to alice@target via reverse ssh"):
+        deployer.wait_for_unit("multi-user.target")
+        # Uses TTY/send_chars instead of deployer.succeed to set NIX_SSHOPTS
+        deployer.send_chars("NIX_SSHOPTS=\"-p 2222 -v\" nixos-rebuild switch -I nixos-config=/root/configuration-1.nix --target-host alice@localhost --sudo\n")
+
+        # the connection breaks, but the 'switch' should now continue in the background:
+        deployer.wait_until_tty_matches("1", "error: while running command with remote sudo")
+
+        def deployed(last_try: bool) -> bool:
+            target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname", timeout=20).rstrip()
+            if last_try:
+                print(f"Still seeing hostname {target_hostname}")
+            return target_hostname == "config-1-deployed"
+        retry(deployed)
+
+      with subtest("Deploy to bob@target via reverse ssh with password-based sudo"):
+        deployer.wait_for_unit("multi-user.target")
+        # Uses TTY/send_chars instead of deployer.succeed to set NIX_SSHOPTS and for ask-sudo-password
+        deployer.send_chars("NIX_SSHOPTS=\"-p 2222\" nixos-rebuild switch -I nixos-config=/root/configuration-2.nix --target-host bob@localhost --ask-sudo-password\n")
+        deployer.wait_until_tty_matches("1", "password for bob")
+        deployer.send_chars("${nodes.target.users.users.bob.password}\n")
+
+        # the connection breaks, but the 'switch' should now continue in the background:
+        deployer.wait_until_tty_matches("1", "error: while running command with remote sudo")
+
+        def deployed(last_try: bool) -> bool:
+            target_hostname = deployer.succeed("ssh alice@target cat /etc/hostname", timeout=20).rstrip()
+            if last_try:
+                print(f"Still seeing hostname {target_hostname}")
+            return target_hostname == "config-2-deployed"
+        retry(deployed)
+    '';
+}

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/isolate_stdio.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/isolate_stdio.rs
@@ -1,0 +1,49 @@
+// Wrap writing to stdout and stderr so that write failures
+// do not cause Rust panic. A switch may temporarily break
+// the connection over which it was initiated, and in that
+// case we want the switch to continue, not abort.
+// Such a scenario is tested in
+// nixosTests.nixos-rebuild-target-host-interrupted
+
+use nix::unistd;
+use std::fs::File;
+use std::io::{self, Error, PipeReader, Read, Write};
+use std::os::fd::AsRawFd;
+use std::thread::{self, JoinHandle};
+
+fn pipe(mut reader: PipeReader, mut dest: File) -> JoinHandle<Result<(), Error>> {
+    thread::spawn(move || -> io::Result<()> {
+        let mut buf = [0u8; 8192];
+        loop {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            if dest.write_all(&buf[..n]).is_err() {
+                // Drain and discard the rest
+                io::copy(&mut reader, &mut io::sink())?;
+                break;
+            }
+        }
+        Ok(())
+    })
+}
+
+pub fn init() -> Result<(JoinHandle<Result<(), Error>>, JoinHandle<Result<(), Error>>), Error> {
+    let (out_reader, out_writer) = io::pipe()?;
+    let (err_reader, err_writer) = io::pipe()?;
+    let old_stdout = File::from(unistd::dup(io::stdout())?);
+    let old_stderr = File::from(unistd::dup(io::stderr())?);
+    let out_thread = pipe(out_reader, old_stdout);
+    let err_thread = pipe(err_reader, old_stderr);
+    unistd::dup2_stdout(out_writer)?;
+    unistd::dup2_stderr(err_writer)?;
+    Ok((out_thread, err_thread))
+}
+
+pub fn close(threads: (JoinHandle<Result<(), std::io::Error>>, JoinHandle<Result<(), Error>>)) {
+    let _ = unistd::close(io::stdout().as_raw_fd());
+    let _ = unistd::close(io::stderr().as_raw_fd());
+    let _ = threads.0.join();
+    let _ = threads.1.join();
+}

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -50,6 +50,8 @@ mod logind_manager {
     include!(concat!(env!("OUT_DIR"), "/logind_manager.rs"));
 }
 
+mod isolate_stdio;
+
 use crate::systemd_manager::OrgFreedesktopSystemd1Manager;
 use crate::{
     logind_manager::OrgFreedesktopLogin1Manager,
@@ -995,6 +997,8 @@ dry-activate: show what would be done if this configuration were activated
 
 /// Performs switch-to-configuration functionality for the entire system
 fn do_system_switch(action: Action) -> anyhow::Result<()> {
+    let threads = isolate_stdio::init()?;
+
     log::debug!("Performing system switch");
 
     let out = PathBuf::from(required_env("OUT")?);
@@ -2030,7 +2034,7 @@ won't take effect until you reboot the system.
             exit_code
         );
     }
-
+    isolate_stdio::close(threads);
     std::process::exit(exit_code);
 }
 


### PR DESCRIPTION
New fix for https://github.com/NixOS/nixpkgs/issues/462179

NixOS test confirms the basic concept works, but the shutdown/teardown/error handling still needs to be implemented properly. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
