### PR TITLE
plasma6: add qrca support for plasma-nm

### DIFF
--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -170,6 +170,7 @@ in
           kconfig # required for xdg-terminal from xdg-utils
           qtbase # for qtpaths which is required for xdg-mime from xdg-utils
         ]
+        ++ lib.optional config.networking.networkmanager.enable qrca
         ++ lib.optionals config.hardware.sensor.iio.enable [
           # This is required for autorotation in Plasma 6
           qtsensors


### PR DESCRIPTION
- In [this](https://invent.kde.org/plasma/plasma-nm/-/commit/384ccba732daa488a2e3923c0e5855bfca846982) commit, the KDE Plasma network manager applet has gained a feature to scan QR codes to connect to WiFi networks.
- As of now, without adding _qrca_ to `environment.systemPackages` manually, the button is grayed out.
- Due to [the way _qrca_ is discovered](https://invent.kde.org/plasma/plasma-nm/-/commit/384ccba732daa488a2e3923c0e5855bfca846982#f0c86e537e7bc83edcee0a72730070bf441237c8_0_24), modifying `extraBuildInputs` is not enough (I think). Patching _might_ be an alternative, but I am not familiar enough with KDE's codebase.
- I assume `plasma6.nix` is the right place for the change so that the `excludePackages` mechanism can be used.
- Please consider this a draft, as I'm not a Nix-pert yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Maintainer pings (for `kdePackages.plasma-nm`)
@ttuegel @FRidh @K900 @LunNova @NickCao @SuperSandro2000 @bkchr @ilya-fedin @mjm @nyanloutre @peterhoeg
I hope pinging all of you is the right thing to do. :)