### PR TITLE
[WIP] audio-share: new module and package init a v0.3.4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -425,6 +425,7 @@
   ./services/amqp/activemq/default.nix
   ./services/amqp/rabbitmq.nix
   ./services/audio/alsa.nix
+  ./services/audio/audio-share.nix
   ./services/audio/botamusique.nix
   ./services/audio/gmediarender.nix
   ./services/audio/gonic.nix

--- a/nixos/modules/services/audio/audio-share.nix
+++ b/nixos/modules/services/audio/audio-share.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.audio-share;
+  inherit
+    (lib)
+    maintainers
+    getExe
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    mkOption
+    ;
+  inherit
+    (lib.types)
+    bool
+    listOf
+    str
+    ;
+in {
+  options.services.audio-share = {
+    enable = mkEnableOption "audio-share";
+    package = mkPackageOption pkgs "audio-share" {};
+    openFirewall = mkOption {
+      description = "Open port in the firewall.";
+      type = bool;
+      default = false;
+    };
+    extraArgs = mkOption {
+      type = listOf str;
+      default = [];
+      description = "Extra command-line arguments.";
+    };
+  };
+  config = mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+    systemd.user.services."audio-share" = {
+      description = "audio-share";
+      after = ["pipewire.service" "sound.target"];
+      wants = ["sound.target"];
+      wantedBy = ["default.target"];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${getExe cfg.package} -b";
+        Restart = "on-failure";
+      };
+    };
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [65530];
+    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [65530];
+  };
+  meta.maintainers = with maintainers; [wetrustinprize];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -235,6 +235,7 @@ in
   attr = pkgs.callPackage ./attr.nix { };
   atuin = runTest ./atuin.nix;
   audiobookshelf = runTest ./audiobookshelf.nix;
+  audio-share = runTest ./audio-share.nix;
   audit = runTest ./audit.nix;
   audit-testsuite = runTest ./audit-testsuite.nix;
   auth-mysql = runTest ./auth-mysql.nix;

--- a/nixos/tests/audio-share.nix
+++ b/nixos/tests/audio-share.nix
@@ -1,0 +1,36 @@
+{lib, ...}: {
+  name = "audio-share";
+  nodes = {
+    machine_default = {...}: {
+      imports = [./common/x11.nix];
+
+      users.users.alice = {
+        isNormalUser = true;
+        extraGroups = ["audio" "video"];
+      };
+
+      services.pipewire = {
+        enable = true;
+        pulse.enable = true;
+        alsa.enable = true;
+      };
+
+      security.rtkit.enable = true;
+
+      services.audio-share.enable = true;
+    };
+  };
+  testScript = ''
+    machine_default.start()
+    machine_default.wait_for_x()
+
+    # Start a user session for alice so PipeWire has a session bus
+    machine_default.succeed("loginctl enable-linger alice")
+    machine_default.succeed("su - alice -c 'systemctl --user start pipewire pipewire-pulse'")
+    machine_default.wait_for_unit("pipewire.service", user="alice")
+
+    machine_default.wait_for_unit("audio-share.service")
+    machine_default.wait_for_open_port(65530)
+  '';
+  meta.maintainers = with lib.maintainers; [wetrustinprize];
+}

--- a/pkgs/by-name/au/audio-share/package.nix
+++ b/pkgs/by-name/au/audio-share/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  pipewire,
+}:
+stdenv.mkDerivation rec {
+  pname = "audio-share";
+  version = "0.3.4";
+
+  src = fetchurl {
+    url = "https://github.com/mkckr0/audio-share/releases/download/v${version}/audio-share-server-cmd-linux.tar.gz";
+    hash = "sha256-3PJculwZ8L7YwS7Hw3RSHlx9mL5Q0M6YhiUWELtDUk8=";
+  };
+
+  nativeBuildInputs = [autoPatchelfHook];
+  buildInputs = [pipewire stdenv.cc.cc.lib];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/as-cmd $out/bin/as-cmd
+    chmod +x $out/bin/as-cmd
+  '';
+
+  meta = with lib; {
+    description = "Share Linux audio to an Android phone over the network";
+    homepage = "https://github.com/mkckr0/audio-share";
+    license = licenses.asl20;
+    maintainers = with maintainers; [wetrustinprize];
+    platforms = ["x86_64-linux"];
+    mainProgram = "as-cmd";
+  };
+}

--- a/pkgs/by-name/au/audio-share/package.nix
+++ b/pkgs/by-name/au/audio-share/package.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp bin/as-cmd $out/bin/as-cmd
-    chmod +x $out/bin/as-cmd
+    cp bin/as-cmd $out/bin/audio-share
+    chmod +x $out/bin/audio-share
   '';
 
   meta = with lib; {
@@ -31,6 +31,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     maintainers = with maintainers; [wetrustinprize];
     platforms = ["x86_64-linux"];
-    mainProgram = "as-cmd";
+    mainProgram = "audio-share";
   };
 }


### PR DESCRIPTION
Added a new NixOS module and package [audio-share](https://github.com/mkckr0/audio-share), is shares the main audio device audio from PipeWire to an [Android app](https://f-droid.org/packages/io.github.mkckr0.audio_share_app/).

This is my first real contribution for the `nixpkgs`, learned a lot but reached an block which are stated below in the "todo list".

## Todo list: (need help)
- [ ] systemd service currently is not starting correctly;
- [ ] tests are not working because of this ^;

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
