### PR TITLE
prosody: Fix httpFileShare options indent

### DIFF
--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -605,20 +605,20 @@ let
       ${lib.optionalString (cfg.httpFileShare != null) ''
         Component ${toLua cfg.httpFileShare.domain} "http_file_share"
           modules_disabled = { "s2s" }
-        ${lib.optionalString (cfg.httpFileShare.http_host != null) ''
-          http_host = "${cfg.httpFileShare.http_host}"
-        ''}
-        ${lib.optionalString (cfg.httpFileShare.http_external_url != null) ''
-          http_external_url = "${cfg.httpFileShare.http_external_url}"
-        ''}
-        ${settingsToLua "  http_file_share_" (
-          cfg.httpFileShare
-          // {
-            domain = null;
-            http_host = null;
-            http_external_url = null;
-          }
-        )}
+          ${lib.optionalString (cfg.httpFileShare.http_host != null) ''
+            http_host = "${cfg.httpFileShare.http_host}"
+          ''}
+          ${lib.optionalString (cfg.httpFileShare.http_external_url != null) ''
+            http_external_url = "${cfg.httpFileShare.http_external_url}"
+          ''}
+          ${settingsToLua "  http_file_share_" (
+            cfg.httpFileShare
+            // {
+              domain = null;
+              http_host = null;
+              http_external_url = null;
+            }
+          )}
       ''}
 
       ${lib.concatStringsSep "\n" (


### PR DESCRIPTION
Otherwise options does not belong to component
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
