### PR TITLE
edmarketconnector: add dependencies for plugins and add way of adding custom dependencies via an override

### DIFF
--- a/pkgs/by-name/ed/edmarketconnector/package.nix
+++ b/pkgs/by-name/ed/edmarketconnector/package.nix
@@ -4,24 +4,15 @@
   stdenv,
   python3,
   makeWrapper,
+  rsync,
+  curlFull,
+  wmctrl,
+  libxcb-cursor,
+  libxkbcommon,
+  xwininfo,
+  xprop,
+  extraPluginDependencies ? [ ],
 }:
-let
-  pythonEnv = python3.buildEnv.override {
-    extraLibs = with python3.pkgs; [
-      tkinter
-      requests
-      pillow
-      (watchdog.overrideAttrs {
-        disabledTests = [
-          "test_select_fd" # Avoid `Too many open files` error. See https://github.com/gorakhargosh/watchdog/issues/1095
-        ];
-      })
-      semantic-version
-      psutil
-      tomli-w
-    ];
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "edmarketconnector";
   version = "6.1.2";
@@ -35,6 +26,41 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  pythonEnv = python3.buildEnv.override {
+    extraLibs = [
+      python3.pkgs.tkinter
+      python3.pkgs.requests
+      python3.pkgs.pillow
+      (python3.pkgs.watchdog.overrideAttrs {
+        disabledTests = [
+          "test_select_fd" # Avoid `Too many open files` error. See https://github.com/gorakhargosh/watchdog/issues/1095
+        ];
+      })
+      python3.pkgs.semantic-version
+      python3.pkgs.psutil
+      python3.pkgs.tomli-w
+
+      # Plugin (from Plugin Browser) dependencies
+      # EDMC-BioScan
+      python3.pkgs.sqlalchemy
+
+      # EDMCHotkeys
+      python3.pkgs.xlib
+      python3.pkgs.six
+      # KeyD cant run via just the package, to use this plugin set "services.keyd.enable" to true in your NixOS config
+
+      # EDMCModernOverlay
+      rsync
+      curlFull
+      wmctrl
+      libxcb-cursor
+      libxkbcommon
+      xwininfo
+      xprop
+    ]
+    ++ extraPluginDependencies;
+  };
+
   installPhase = ''
     runHook preInstall
 
@@ -44,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/share/applications/"
     ln -s "${finalAttrs.src}/io.edcd.EDMarketConnector.desktop" "$out/share/applications/"
 
-    makeWrapper ${pythonEnv}/bin/python $out/bin/edmarketconnector \
+    makeWrapper ${finalAttrs.pythonEnv}/bin/python $out/bin/edmarketconnector \
       --add-flags "${finalAttrs.src}/EDMarketConnector.py"
 
     runHook postInstall

--- a/pkgs/by-name/ed/edmarketconnector/package.nix
+++ b/pkgs/by-name/ed/edmarketconnector/package.nix
@@ -4,24 +4,15 @@
   stdenv,
   python3,
   makeWrapper,
+  rsync,
+  curl,
+  wmctrl,
+  libxcb-cursor,
+  libxkbcommon,
+  xwininfo,
+  xprop,
+  extraPluginDependencies ? [ ],
 }:
-let
-  pythonEnv = python3.buildEnv.override {
-    extraLibs = with python3.pkgs; [
-      tkinter
-      requests
-      pillow
-      (watchdog.overrideAttrs {
-        disabledTests = [
-          "test_select_fd" # Avoid `Too many open files` error. See https://github.com/gorakhargosh/watchdog/issues/1095
-        ];
-      })
-      semantic-version
-      psutil
-      tomli-w
-    ];
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "edmarketconnector";
   version = "6.1.2";
@@ -35,6 +26,41 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  pythonEnv = python3.buildEnv.override {
+    extraLibs = [
+      python3.pkgs.tkinter
+      python3.pkgs.requests
+      python3.pkgs.pillow
+      (python3.pkgs.watchdog.overrideAttrs {
+        disabledTests = [
+          "test_select_fd" # Avoid `Too many open files` error. See https://github.com/gorakhargosh/watchdog/issues/1095
+        ];
+      })
+      python3.pkgs.semantic-version
+      python3.pkgs.psutil
+      python3.pkgs.tomli-w
+
+      # Plugin (from Plugin Browser) dependencies
+      # EDMC-BioScan
+      python3.pkgs.sqlalchemy
+
+      # EDMCHotkeys
+      python3.pkgs.xlib
+      python3.pkgs.six
+      # KeyD cant run via just the package, to use this plugin set "services.keyd.enable" to true in your NixOS config
+
+      # EDMCModernOverlay
+      rsync
+      curl
+      wmctrl
+      libxcb-cursor
+      libxkbcommon
+      xwininfo
+      xprop
+    ]
+    ++ extraPluginDependencies;
+  };
+
   installPhase = ''
     runHook preInstall
 
@@ -44,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/share/applications/"
     ln -s "${finalAttrs.src}/io.edcd.EDMarketConnector.desktop" "$out/share/applications/"
 
-    makeWrapper ${pythonEnv}/bin/python $out/bin/edmarketconnector \
+    makeWrapper ${finalAttrs.pythonEnv}/bin/python $out/bin/edmarketconnector \
       --add-flags "${finalAttrs.src}/EDMarketConnector.py"
 
     runHook postInstall


### PR DESCRIPTION
Added dependencies needed for some Plugins in the official Plugin Browser to work, also added a unused list that users can override if they want to to add extra dependencies for other more obscure plugins.

Supersedes #497541

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
