### PR TITLE
sheets: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16292,6 +16292,12 @@
     githubId = 85435692;
     name = "Maxwell Berg";
   };
+  maaslalani = {
+    email = "maas@lalani.dev";
+    github = "maaslalani";
+    githubId = 42545625;
+    name = "Maas Lalani";
+  };
   mahe = {
     email = "matthias.mh.herrmann@gmail.com";
     github = "2chilled";

--- a/pkgs/by-name/sh/sheets/package.nix
+++ b/pkgs/by-name/sh/sheets/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sheets";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "maaslalani";
+    repo = "sheets";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P+Teehs0LE4drbTPBvz3BNKCSKhQVR/QezsHxpWysDY=";
+  };
+
+  vendorHash = "sha256-WWtAt0+W/ewLNuNgrqrgho5emntw3rZL9JTTbNo4GsI=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Terminal based spreadsheet tool";
+    homepage = "https://github.com/maaslalani/sheets";
+    changelog = "https://github.com/maaslalani/sheets/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.maaslalani ];
+    mainProgram = "sheets";
+  };
+})


### PR DESCRIPTION
Add [sheets](https://github.com/maaslalani/sheets), a terminal based spreadsheet tool with vim-like keybindings for navigating, editing CSV files.

### Things done

- [x] Built on `x86_64-linux`
- [x] `nix-build -A sheets`
- [x] Tested via `nix-shell -p sheets --run 'sheets --help'`
- [x] Checked formatting with `nixfmt`
- [x] Added to `pkgs/by-name/sh/sheets/package.nix`