### PR TITLE
stdenv, trivial-builders: replace `// optionalAttrs` with nullable attr names

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -80,8 +80,8 @@ rec {
         inherit buildCommand name;
         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);
       }
-      // lib.optionalAttrs (!derivationArgs ? meta) {
-        pos =
+      // {
+        ${if !derivationArgs ? meta then "pos" else null} =
           let
             args = builtins.attrNames derivationArgs;
           in
@@ -89,11 +89,9 @@ rec {
             builtins.unsafeGetAttrPos (builtins.head args) derivationArgs
           else
             null;
+        ${if runLocal then "preferLocalBuild" else null} = true;
+        ${if runLocal then "allowSubstitutes" else null} = false;
       }
-      // (lib.optionalAttrs runLocal {
-        preferLocalBuild = true;
-        allowSubstitutes = false;
-      })
       // removeAttrs derivationArgs [ "passAsFile" ]
     );
 
@@ -567,8 +565,8 @@ rec {
           ${postBuild}
         '';
       }
-      // lib.optionalAttrs (!args ? meta) {
-        pos =
+      // {
+        ${if !args ? meta then "pos" else null} =
           if args ? pname then
             builtins.unsafeGetAttrPos "pname" args
           else

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -1,3 +1,11 @@
+# PERF: This file is evaluated for every derivation in the build closure.
+# Avoid `// optionalAttrs` — each call allocates a closure, an intermediate
+# attrset, and a `//` merge.  Use nullable attribute names instead:
+#
+#   ${if cond then "name" else null} = value;
+#
+# See https://github.com/NixOS/nixpkgs/pull/430969 for measurements.
+
 { lib, config }:
 
 stdenv:
@@ -28,7 +36,6 @@ let
     mapAttrs
     mapNullable
     optional
-    optionalAttrs
     optionalString
     optionals
     pipe
@@ -530,220 +537,228 @@ let
           ]
         ];
 
-        derivationArg =
-          removeAttrs attrs removedOrReplacedAttrNames
-          // {
-            ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
-              let
-                # Indicate the host platform of the derivation if cross compiling.
-                # Fixed-output derivations like source tarballs shouldn't get a host
-                # suffix. But we have some weird ones with run-time deps that are
-                # just used for their side-affects. Those might as well since the
-                # hash can't be the same. See #32986.
-                hostSuffix = optionalString (!dontAddHostSuffix) stdenvHostSuffix;
+        derivationArg = removeAttrs attrs removedOrReplacedAttrNames // {
+          ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
+            let
+              # Indicate the host platform of the derivation if cross compiling.
+              # Fixed-output derivations like source tarballs shouldn't get a host
+              # suffix. But we have some weird ones with run-time deps that are
+              # just used for their side-affects. Those might as well since the
+              # hash can't be the same. See #32986.
+              hostSuffix = optionalString (!dontAddHostSuffix) stdenvHostSuffix;
 
-                # Disambiguate statically built packages. This was originally
-                # introduce as a means to prevent nix-env to get confused between
-                # nix and nixStatic. This should be also achieved by moving the
-                # hostSuffix before the version, so we could contemplate removing
-                # it again.
-                staticMarker = stdenvStaticMarker;
-              in
-              lib.strings.sanitizeDerivationName (
-                if attrs ? name then
-                  attrs.name + hostSuffix
-                else
-                  # we cannot coerce null to a string below
-                  assert assertMsg (
-                    attrs ? version && attrs.version != null
-                  ) "The `version` attribute cannot be null.";
-                  "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
-              );
-
-            builder = attrs.realBuilder or stdenvShell;
-            args =
-              attrs.args or [
-                "-e"
-                ./source-stdenv.sh
-                (attrs.builder or ./default-builder.sh)
-              ];
-            inherit stdenv;
-
-            # The `system` attribute of a derivation has special meaning to Nix.
-            # Derivations set it to choose what sort of machine could be used to
-            # execute the build, The build platform entirely determines this,
-            # indeed more finely than Nix knows or cares about. The `system`
-            # attribute of `buildPlatform` matches Nix's degree of specificity.
-            # exactly.
-            system = buildPlatformSystem;
-
-            inherit userHook;
-            __ignoreNulls = true;
-            inherit __structuredAttrs strictDeps;
-
-            depsBuildBuild = elemAt (elemAt dependencies 0) 0;
-            nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
-            depsBuildTarget = elemAt (elemAt dependencies 0) 2;
-            depsHostHost = elemAt (elemAt dependencies 1) 0;
-            buildInputs = elemAt (elemAt dependencies 1) 1;
-            depsTargetTarget = elemAt (elemAt dependencies 2) 0;
-
-            depsBuildBuildPropagated = elemAt (elemAt propagatedDependencies 0) 0;
-            propagatedNativeBuildInputs = elemAt (elemAt propagatedDependencies 0) 1;
-            depsBuildTargetPropagated = elemAt (elemAt propagatedDependencies 0) 2;
-            depsHostHostPropagated = elemAt (elemAt propagatedDependencies 1) 0;
-            propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
-            depsTargetTargetPropagated = elemAt (elemAt propagatedDependencies 2) 0;
-
-            # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
-            configureFlags =
-              configureFlags
-              ++ (
-                if configurePlatforms == defaultConfigurePlatforms then
-                  defaultConfigurePlatformsFlags
-                else
-                  optional (elem "build" configurePlatforms) buildPlatformConfigureFlag
-                  ++ optional (elem "host" configurePlatforms) hostPlatformConfigureFlag
-                  ++ optional (elem "target" configurePlatforms) targetPlatformConfigureFlag
-              );
-
-            inherit patches;
-
-            inherit doCheck doInstallCheck;
-
-            inherit outputs;
-
-            # When the derivations is content addressed provide default values
-            # for outputHashMode and outputHashAlgo because most people won't
-            # care about these anyways
-            ${if __contentAddressed then "__contentAddressed" else null} = __contentAddressed;
-            ${if __contentAddressed then "outputHashAlgo" else null} = attrs.outputHashAlgo or "sha256";
-            ${if __contentAddressed then "outputHashMode" else null} = attrs.outputHashMode or "recursive";
-
-            ${if enableParallelBuilding then "enableParallelBuilding" else null} = enableParallelBuilding;
-            ${if enableParallelBuilding then "enableParallelChecking" else null} =
-              attrs.enableParallelChecking or true;
-            ${if enableParallelBuilding then "enableParallelInstalling" else null} =
-              attrs.enableParallelInstalling or true;
-
-            ${
-              if (hardeningDisable != [ ] || hardeningEnable != [ ] || isMusl) then
-                "NIX_HARDENING_ENABLE"
+              # Disambiguate statically built packages. This was originally
+              # introduce as a means to prevent nix-env to get confused between
+              # nix and nixStatic. This should be also achieved by moving the
+              # hostSuffix before the version, so we could contemplate removing
+              # it again.
+              staticMarker = stdenvStaticMarker;
+            in
+            lib.strings.sanitizeDerivationName (
+              if attrs ? name then
+                attrs.name + hostSuffix
               else
-                null
-            } =
-              lib.warnIf ((builtins.elem "pie" hardeningEnable) || (builtins.elem "pie" hardeningDisable))
-                "The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future."
-                (builtins.concatStringsSep " " enabledHardeningOptions);
+                # we cannot coerce null to a string below
+                assert assertMsg (
+                  attrs ? version && attrs.version != null
+                ) "The `version` attribute cannot be null.";
+                "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
+            );
 
-            # TODO: remove platform condition
-            # Enabling this check could be a breaking change as it requires to edit nix.conf
-            # NixOS module already sets gccarch, unsure of nix installers and other distributions
-            ${if requiredSystemFeaturesShouldBeSet then "requiredSystemFeatures" else null} =
-              attrs.requiredSystemFeatures or [ ] ++ gccArchFeature;
-          }
-          // optionalAttrs buildIsDarwin (
+          builder = attrs.realBuilder or stdenvShell;
+          args =
+            attrs.args or [
+              "-e"
+              ./source-stdenv.sh
+              (attrs.builder or ./default-builder.sh)
+            ];
+          inherit stdenv;
+
+          # The `system` attribute of a derivation has special meaning to Nix.
+          # Derivations set it to choose what sort of machine could be used to
+          # execute the build, The build platform entirely determines this,
+          # indeed more finely than Nix knows or cares about. The `system`
+          # attribute of `buildPlatform` matches Nix's degree of specificity.
+          # exactly.
+          system = buildPlatformSystem;
+
+          inherit userHook;
+          __ignoreNulls = true;
+          inherit __structuredAttrs strictDeps;
+
+          depsBuildBuild = elemAt (elemAt dependencies 0) 0;
+          nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
+          depsBuildTarget = elemAt (elemAt dependencies 0) 2;
+          depsHostHost = elemAt (elemAt dependencies 1) 0;
+          buildInputs = elemAt (elemAt dependencies 1) 1;
+          depsTargetTarget = elemAt (elemAt dependencies 2) 0;
+
+          depsBuildBuildPropagated = elemAt (elemAt propagatedDependencies 0) 0;
+          propagatedNativeBuildInputs = elemAt (elemAt propagatedDependencies 0) 1;
+          depsBuildTargetPropagated = elemAt (elemAt propagatedDependencies 0) 2;
+          depsHostHostPropagated = elemAt (elemAt propagatedDependencies 1) 0;
+          propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
+          depsTargetTargetPropagated = elemAt (elemAt propagatedDependencies 2) 0;
+
+          # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
+          configureFlags =
+            configureFlags
+            ++ (
+              if configurePlatforms == defaultConfigurePlatforms then
+                defaultConfigurePlatformsFlags
+              else
+                optional (elem "build" configurePlatforms) buildPlatformConfigureFlag
+                ++ optional (elem "host" configurePlatforms) hostPlatformConfigureFlag
+                ++ optional (elem "target" configurePlatforms) targetPlatformConfigureFlag
+            );
+
+          inherit patches;
+
+          inherit doCheck doInstallCheck;
+
+          inherit outputs;
+
+          # When the derivations is content addressed provide default values
+          # for outputHashMode and outputHashAlgo because most people won't
+          # care about these anyways
+          ${if __contentAddressed then "__contentAddressed" else null} = __contentAddressed;
+          ${if __contentAddressed then "outputHashAlgo" else null} = attrs.outputHashAlgo or "sha256";
+          ${if __contentAddressed then "outputHashMode" else null} = attrs.outputHashMode or "recursive";
+
+          ${if enableParallelBuilding then "enableParallelBuilding" else null} = enableParallelBuilding;
+          ${if enableParallelBuilding then "enableParallelChecking" else null} =
+            attrs.enableParallelChecking or true;
+          ${if enableParallelBuilding then "enableParallelInstalling" else null} =
+            attrs.enableParallelInstalling or true;
+
+          ${
+            if (hardeningDisable != [ ] || hardeningEnable != [ ] || isMusl) then
+              "NIX_HARDENING_ENABLE"
+            else
+              null
+          } =
+            lib.warnIf ((builtins.elem "pie" hardeningEnable) || (builtins.elem "pie" hardeningDisable))
+              "The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future."
+              (builtins.concatStringsSep " " enabledHardeningOptions);
+
+          # TODO: remove platform condition
+          # Enabling this check could be a breaking change as it requires to edit nix.conf
+          # NixOS module already sets gccarch, unsure of nix installers and other distributions
+          ${if requiredSystemFeaturesShouldBeSet then "requiredSystemFeatures" else null} =
+            attrs.requiredSystemFeatures or [ ] ++ gccArchFeature;
+
+          # -- Darwin-specific attrs --
+          ${if buildIsDarwin then "__darwinAllowLocalNetworking" else null} = __darwinAllowLocalNetworking;
+          ${if buildIsDarwin then "__sandboxProfile" else null} =
             let
               allDependencies = concatLists (concatLists dependencies);
               allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
-
               computedSandboxProfile = concatMap (input: input.__propagatedSandboxProfile or [ ]) (
                 extraNativeBuildInputs ++ extraBuildInputs ++ allDependencies
               );
-
               computedPropagatedSandboxProfile = concatMap (
                 input: input.__propagatedSandboxProfile or [ ]
               ) allPropagatedDependencies;
-
+              profiles = [
+                extraSandboxProfile
+              ]
+              ++ computedSandboxProfile
+              ++ computedPropagatedSandboxProfile
+              ++ [
+                propagatedSandboxProfile
+                sandboxProfile
+              ];
+            in
+            # TODO: remove `unique` once nix has a list canonicalization primitive
+            concatStringsSep "\n" (filter (x: x != "") (unique profiles));
+          ${if buildIsDarwin then "__propagatedSandboxProfile" else null} =
+            let
+              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
+              computedPropagatedSandboxProfile = concatMap (
+                input: input.__propagatedSandboxProfile or [ ]
+              ) allPropagatedDependencies;
+            in
+            unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
+          ${if buildIsDarwin then "__impureHostDeps" else null} =
+            let
+              allDependencies = concatLists (concatLists dependencies);
+              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
               computedImpureHostDeps = unique (
                 concatMap (input: input.__propagatedImpureHostDeps or [ ]) (
                   extraNativeBuildInputs ++ extraBuildInputs ++ allDependencies
                 )
               );
-
               computedPropagatedImpureHostDeps = unique (
                 concatMap (input: input.__propagatedImpureHostDeps or [ ]) allPropagatedDependencies
               );
             in
-            {
-              inherit __darwinAllowLocalNetworking;
-              # TODO: remove `unique` once nix has a list canonicalization primitive
-              __sandboxProfile =
-                let
-                  profiles = [
-                    extraSandboxProfile
-                  ]
-                  ++ computedSandboxProfile
-                  ++ computedPropagatedSandboxProfile
-                  ++ [
-                    propagatedSandboxProfile
-                    sandboxProfile
-                  ];
-                  final = concatStringsSep "\n" (filter (x: x != "") (unique profiles));
-                in
-                final;
-              __propagatedSandboxProfile = unique (
-                computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]
+            computedImpureHostDeps
+            ++ computedPropagatedImpureHostDeps
+            ++ __propagatedImpureHostDeps
+            ++ __impureHostDeps
+            ++ __extraImpureHostDeps
+            ++ [
+              "/dev/zero"
+              "/dev/random"
+              "/dev/urandom"
+              "/bin/sh"
+            ];
+          ${if buildIsDarwin then "__propagatedImpureHostDeps" else null} =
+            let
+              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
+              computedPropagatedImpureHostDeps = unique (
+                concatMap (input: input.__propagatedImpureHostDeps or [ ]) allPropagatedDependencies
               );
-              __impureHostDeps =
-                computedImpureHostDeps
-                ++ computedPropagatedImpureHostDeps
-                ++ __propagatedImpureHostDeps
-                ++ __impureHostDeps
-                ++ __extraImpureHostDeps
-                ++ [
-                  "/dev/zero"
-                  "/dev/random"
-                  "/dev/urandom"
-                  "/bin/sh"
-                ];
-              __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-            }
-          )
-          // optionalAttrs (isWindows || isCygwin) {
-            allowedImpureDLLs =
-              allowedImpureDLLs
-              ++ lib.optionals isCygwin [
-                "KERNEL32.dll"
-              ];
-          }
-          // (
+            in
+            computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
+
+          # -- Windows/Cygwin-specific attrs --
+          ${if isWindows || isCygwin then "allowedImpureDLLs" else null} =
+            allowedImpureDLLs
+            ++ lib.optionals isCygwin [
+              "KERNEL32.dll"
+            ];
+
+          # -- Output reference checks --
+          ${if !__structuredAttrs && attrs ? disallowedReferences then "disallowedReferences" else null} =
+            map unsafeDerivationToUntrackedOutpath attrs.disallowedReferences;
+          ${if !__structuredAttrs && attrs ? disallowedRequisites then "disallowedRequisites" else null} =
+            map unsafeDerivationToUntrackedOutpath attrs.disallowedRequisites;
+          ${if !__structuredAttrs && attrs ? allowedReferences then "allowedReferences" else null} =
+            mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedReferences;
+          ${if !__structuredAttrs && attrs ? allowedRequisites then "allowedRequisites" else null} =
+            mapNullable unsafeDerivationToUntrackedOutpath attrs.allowedRequisites;
+          ${if __structuredAttrs then "outputChecks" else null} =
             let
               attrsOutputChecks = makeOutputChecks attrs;
               attrsOutputChecksFiltered = filterAttrs (_: v: v != null) attrsOutputChecks;
             in
-            if !__structuredAttrs then
-              attrsOutputChecks
-            else
-              {
-                outputChecks = builtins.listToAttrs (
-                  map (name: {
-                    inherit name;
-                    value =
-                      let
-                        raw = zipAttrsWith (_: builtins.concatLists) [
-                          attrsOutputChecksFiltered
-                          (makeOutputChecks attrs.outputChecks.${name} or { })
-                        ];
-                      in
-                      # separateDebugInfo = true will put all sorts of files in
-                      # the debug output which could carry references, but
-                      # that's "normal". Notably it symlinks to the source.
-                      # So disable reference checking for the debug output
-                      if separateDebugInfo' && name == "debug" then
-                        removeAttrs raw [
-                          "allowedReferences"
-                          "allowedRequisites"
-                          "disallowedReferences"
-                          "disallowedRequisites"
-                        ]
-                      else
-                        raw;
-                  }) outputs
-                );
-              }
-          );
-
+            builtins.listToAttrs (
+              map (name: {
+                inherit name;
+                value =
+                  let
+                    raw = zipAttrsWith (_: builtins.concatLists) [
+                      attrsOutputChecksFiltered
+                      (makeOutputChecks attrs.outputChecks.${name} or { })
+                    ];
+                  in
+                  # separateDebugInfo = true will put all sorts of files in
+                  # the debug output which could carry references, but
+                  # that's "normal". Notably it symlinks to the source.
+                  # So disable reference checking for the debug output
+                  if separateDebugInfo' && name == "debug" then
+                    removeAttrs raw [
+                      "allowedReferences"
+                      "allowedRequisites"
+                      "disallowedReferences"
+                      "disallowedRequisites"
+                    ]
+                  else
+                    raw;
+              }) outputs
+            );
+        };
       in
       derivationArg;
 
@@ -806,7 +821,9 @@ let
 
     let
       mainProgram = meta.mainProgram or null;
-      env' = env // lib.optionalAttrs (mainProgram != null) { NIX_MAIN_PROGRAM = mainProgram; };
+      env' = env // {
+        ${if mainProgram != null then "NIX_MAIN_PROGRAM" else null} = mainProgram;
+      };
 
       derivationArg = makeDerivationArgument (
         removeAttrs attrs [
@@ -815,8 +832,8 @@ let
           "pos"
           "env"
         ]
-        // lib.optionalAttrs __structuredAttrs { env = checkedEnv; }
         // {
+          ${if __structuredAttrs then "env" else null} = checkedEnv;
           cmakeFlags = makeCMakeFlags attrs;
           mesonFlags = makeMesonFlags attrs;
         }


### PR DESCRIPTION
Follow-up to #430969 and #430132. Replace remaining `// optionalAttrs` patterns with `${if cond then "name" else null} = value;` to avoid per-derivation closure allocations and `//` merge operations. Please review diff with whitespace difference disabled

## Changes

- **make-derivation.nix**: inline Darwin, Windows, outputChecks blocks and the `env'`/`__structuredAttrs` patterns in `mkDerivationSimple`
- **trivial-builders/default.nix**: inline `optionalAttrs` in `runCommandWith` and `symlinkJoin`
- Add perf comment at top of `make-derivation.nix` to discourage reintroducing `// optionalAttrs`

## CI eval comparison (full nixpkgs, mean across all 4 platforms)

| metric | before | after | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 25,793,555 | 24,960,472 | -833,082 | **-3.31%** |
| nrOpUpdates | 4,762,810 | 4,373,432 | -389,378 | **-8.27%** |
| envs.number | 28,748,660 | 27,885,846 | -862,814 | **-3.07%** |
| envs.bytes | 579 MB | 565 MB | -14 MB | **-2.52%** |
| sets.number | 6,675,086 | 6,476,370 | -198,716 | **-3.35%** |
| nrThunks | 38,948,662 | 38,425,108 | -523,554 | **-1.31%** |
| values.bytes | 863 MB | 855 MB | -8 MB | **-0.98%** |
| gc.totalBytes | 3,600 MB | 3,594 MB | -7 MB | **-0.16%** |

<details><summary>CI eval comparison: per-platform breakdown (sum of all 14 chunks)</summary>

| metric | x86_64-linux | aarch64-linux | x86_64-darwin | aarch64-darwin |
|---|---|---|---|---|
| nrFunctionCalls | **-3.25%** (434M → 420M) | **-3.38%** (387M → 374M) | **-3.14%** (303M → 293M) | **-3.11%** (320M → 310M) |
| nrOpUpdates | **-7.97%** (79.1M → 72.8M) | **-8.15%** (71.7M → 65.9M) | **-8.30%** (56.8M → 52.1M) | **-8.35%** (59.1M → 54.2M) |
| nrOpUpdateValuesCopied | +2.00% (674M → 687M) | +2.22% (581M → 594M) | +0.97% (574M → 579M) | +0.93% (600M → 605M) |
| envs.number | **-3.13%** (485M → 470M) | **-3.25%** (432M → 418M) | **-2.77%** (337M → 328M) | **-2.74%** (356M → 346M) |
| envs.bytes | -2.59% (9.7 GB → 9.4 GB) | -2.67% (8.7 GB → 8.5 GB) | -2.29% (6.8 GB → 6.7 GB) | -2.26% (7.2 GB → 7.0 GB) |
| sets.number | -1.70% (114M → 112M) | -1.74% (103M → 101M) | **-4.68%** (77M → 74M) | **-4.73%** (80M → 77M) |
| nrThunks | -1.84% (648M → 636M) | -1.89% (585M → 574M) | -0.68% (464M → 461M) | -0.65% (484M → 481M) |
| gc.totalBytes | -0.15% (58.6 GB → 58.5 GB) | -0.13% (52.0 GB → 52.0 GB) | -0.23% (44.6 GB → 44.5 GB) | -0.24% (46.4 GB → 46.3 GB) |

Darwin shows larger `sets.number` reduction (-4.7%) because the Darwin-specific `optionalAttrs` blocks were inlined.
`nrOpUpdateValuesCopied` increases slightly as expected: nullable attrs produce larger attrset literals, so each remaining `//` copies more keys — but far fewer merges total.

</details>

<details><summary>Local benchmark: forcing all top-level .drvPath (~470k function calls)</summary>

| metric | baseline | optimized | delta | % change |
| - | - | - | - | - |
| nrFunctionCalls | 469,589 | 451,788 | -17,801 | **-3.79%** |
| nrOpUpdates | 61,017 | 53,024 | -7,993 | **-13.10%** |
| nrOpUpdateValuesCopied | 2,205,342 | 2,203,290 | -2,052 | -0.09% |
| envs.number | 531,489 | 512,320 | -19,169 | **-3.61%** |
| envs.bytes | 10,823,144 | 10,505,496 | -317,648 | **-2.93%** |
| sets.number | 146,858 | 144,612 | -2,246 | -1.53% |
| nrThunks | 891,393 | 876,318 | -15,075 | -1.69% |
| values.number | 1,599,271 | 1,584,196 | -15,075 | -0.94% |
| gc.totalBytes | 104,538,192 | 104,257,696 | -280,496 | -0.27% |

</details>

<details><summary>Local benchmark: hello.drvPath (~950 derivations in closure)</summary>

| metric | baseline | optimized | delta | % change |
| - | - | - | - | - |
| nrFunctionCalls | 154,429 | 152,145 | -2,284 | **-1.48%** |
| nrOpUpdates | 18,659 | 17,657 | -1,002 | **-5.37%** |
| envs.number | 174,765 | 172,240 | -2,525 | **-1.44%** |

</details>

Repro:

```bash
NIX_SHOW_STATS=1 nix-instantiate --eval \
  -E '(import ./. {}).hello.drvPath' 2>stats.json >/dev/null
jq . stats.json
```

## Things done

- [x] Tested on `hello.drvPath` — same derivation hash before/after
- [x] Tested on `pkgsCross.aarch64-multiplatform.hello.drvPath` — evaluates correctly
- [x] No metric regressions in important benchmarks