### PR TITLE
prrte,pmix: 3.0.13 -> 4.1.0, 5.0.10 -> 6.1.0

### DIFF
--- a/pkgs/by-name/pm/pmix/package.nix
+++ b/pkgs/by-name/pm/pmix/package.nix
@@ -20,21 +20,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pmix";
-  version = "5.0.10";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     repo = "openpmix";
     owner = "openpmix";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-i7DZCJeNwjcRYCp3t0GlKM1V1rU/ws22u5Ct/JZ5P1Q=";
+    hash = "sha256-wMVppqSXpQeBgkwna+jaU5kY03WHbGwMQQrouCyGROo=";
     fetchSubmodules = true;
   };
 
   outputs = [ "out" ] ++ lib.optionals stdenv.hostPlatform.isLinux [ "dev" ];
 
   postPatch = ''
-    patchShebangs ./autogen.pl
-    patchShebangs ./config
+    patchShebangs --build ./autogen.pl
+    patchShebangs --build ./config
+    patchShebangs --build ./contrib
+    patchShebangs --build ./src/util/convert-help.py
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pr/prrte/package.nix
+++ b/pkgs/by-name/pr/prrte/package.nix
@@ -6,6 +6,7 @@
   autoconf,
   automake,
   libtool,
+  pkg-config,
   gitMinimal,
   perl,
   python3,
@@ -18,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "prrte";
-  version = "3.0.13";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "openpmix";
     repo = "prrte";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-T/iHmSO2isyIjsaiTrNYeTiBobM/9eg7gTP12m7ehno=";
+    hash = "sha256-FO2dFqvJ3Ahc7rE2gAiQhmM5GTc7LJ8nE4y5fe+FgDg=";
     fetchSubmodules = true;
   };
 
@@ -46,10 +47,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     ./autogen.pl
+    patchShebangs --build ./src/util/prte-convert-help.py
   '';
 
   postInstall = ''
     moveToOutput "bin/prte_info" "''${!outputDev}"
+    moveToOutput "bin/prte-info" "''${!outputDev}"
     # Fix a broken symlink, created due to FHS assumptions
     rm "$out/bin/pcc"
     ln -s ${lib.getDev pmix}/bin/pmixcc "''${!outputDev}"/bin/pcc
@@ -66,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtool
     flex
     gitMinimal
+    pkg-config
   ];
 
   buildInputs = [


### PR DESCRIPTION
Changelogs:
 https://github.com/openpmix/openpmix/releases/tag/v6.1.0
 https://github.com/openpmix/prrte/releases/tag/v4.1.0

Replaces https://github.com/NixOS/nixpkgs/pull/411370

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
