### PR TITLE
mistral-rs: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/by-name/mi/mistral-rs/no-native-cpu.patch
+++ b/pkgs/by-name/mi/mistral-rs/no-native-cpu.patch
@@ -1,5 +1,5 @@
 diff --git a/.cargo/config.toml b/.cargo/config.toml
-index dde3bc53f..693808c6e 100644
+index 0ab50ad46..3f5fe0788 100644
 --- a/.cargo/config.toml
 +++ b/.cargo/config.toml
 @@ -1,15 +1,10 @@
@@ -9,7 +9,7 @@ index dde3bc53f..693808c6e 100644
  [target.aarch64-apple-darwin]
  rustflags = [
 -  "-C", "target-cpu=native",
-   "-C", "target-feature=+aes,+sha2,+fp16",
+   "-C", "target-feature=+aes,+sha2,+fp16,+i8mm",
  ]
  
  [target.x86_64-apple-darwin]

--- a/pkgs/by-name/mi/mistral-rs/package.nix
+++ b/pkgs/by-name/mi/mistral-rs/package.nix
@@ -74,13 +74,13 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mistral-rs";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "EricLBuehler";
     repo = "mistral.rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2gE3LRm2oy6H+y6dRNnwYIjlaG67it16bfhfTk4CUTc=";
+    hash = "sha256-WuDvD2ifk0AtB4fpgLqQSiXVfb/50M9oIuz738pdsis=";
   };
 
   patches = [
@@ -96,7 +96,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
           "lto = false"
     '';
 
-  cargoHash = "sha256-nktoMh07PfGJ156XrKa1N/icB634cr9ybsHq/y9zHKo=";
+  cargoHash = "sha256-MzGU62v6ZvVzTN7Ra+zz1uNlk4ul09YG5Hbj2A7hZbY=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/EricLBuehler/mistral.rs/compare/v0.7.0...v0.8.0
Changelog: https://github.com/EricLBuehler/mistral.rs/releases/tag/v0.8.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test