### PR TITLE
various: reduce // merges, optimize ++ chains across hot paths

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -107,8 +107,9 @@ rec {
         passthru = if drv ? passthru then drv.passthru else { };
       }
       // (drv.passthru or { })
-      // optionalAttrs (drv ? __spliced) {
-        __spliced = { } // (mapAttrs (_: sDrv: overrideDerivation sDrv f) drv.__spliced);
+      // {
+        ${if drv ? __spliced then "__spliced" else null} =
+          { } // (mapAttrs (_: sDrv: overrideDerivation sDrv f) drv.__spliced);
       }
     );
 
@@ -165,9 +166,9 @@ rec {
           # Preserve additional attributes for f
           f
           // fDecorated
-          # Decorate f.override if presented
-          // lib.optionalAttrs (f ? override) {
-            override = fdrv: makeOverridable (f.override fdrv);
+          // {
+            # Decorate f.override if presented
+            ${if f ? override then "override" else null} = fdrv: makeOverridable (f.override fdrv);
           }
         else
           id;
@@ -412,43 +413,49 @@ rec {
       outputs = drv.outputs or [ "out" ];
 
       commonAttrs =
-        drv // (listToAttrs outputsList) // { all = map (x: x.value) outputsList; } // passthru;
+        drv
+        // listToAttrs (
+          outputsList
+          ++ [
+            {
+              name = "all";
+              value = map (x: x.value) outputsList;
+            }
+          ]
+        )
+        // passthru
+        // {
+          drvPath =
+            assert condition;
+            drv.drvPath;
+          outPath =
+            assert condition;
+            drv.outPath;
+        };
 
       outputToAttrListElement = outputName: {
         name = outputName;
-        value =
-          commonAttrs
-          // {
-            inherit (drv.${outputName}) type outputName;
-            outputSpecified = true;
-            drvPath =
-              assert condition;
-              drv.${outputName}.drvPath;
-            outPath =
-              assert condition;
-              drv.${outputName}.outPath;
-          }
-          //
-            # TODO: give the derivation control over the outputs.
-            #       `overrideAttrs` may not be the only attribute that needs
-            #       updating when switching outputs.
-            optionalAttrs (passthru ? overrideAttrs) {
-              # TODO: also add overrideAttrs when overrideAttrs is not custom, e.g. when not splicing.
-              overrideAttrs = f: (passthru.overrideAttrs f).${outputName};
-            };
+        value = commonAttrs // {
+          inherit (drv.${outputName}) type outputName;
+          outputSpecified = true;
+          drvPath =
+            assert condition;
+            drv.${outputName}.drvPath;
+          outPath =
+            assert condition;
+            drv.${outputName}.outPath;
+          # TODO: give the derivation control over the outputs.
+          #       `overrideAttrs` may not be the only attribute that needs
+          #       updating when switching outputs.
+          # TODO: also add overrideAttrs when overrideAttrs is not custom, e.g. when not splicing.
+          ${if passthru ? overrideAttrs then "overrideAttrs" else null} =
+            f: (passthru.overrideAttrs f).${outputName};
+        };
       };
 
       outputsList = map outputToAttrListElement outputs;
     in
-    commonAttrs
-    // {
-      drvPath =
-        assert condition;
-        drv.drvPath;
-      outPath =
-        assert condition;
-        drv.outPath;
-    };
+    commonAttrs;
 
   /**
     Strip a derivation of all non-essential attributes, returning

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -401,7 +401,25 @@ rec {
     condition: passthru: drv:
     let
       commonAttrs =
-        drv // (listToAttrs outputsList) // { all = map (x: x.value) outputsList; } // passthru;
+        drv
+        // listToAttrs (
+          outputsList
+          ++ [
+            {
+              name = "all";
+              value = map (x: x.value) outputsList;
+            }
+          ]
+        )
+        // passthru
+        // {
+          drvPath =
+            assert condition;
+            drv.drvPath;
+          outPath =
+            assert condition;
+            drv.outPath;
+        };
 
       outputsList = map (outputName: {
         name = outputName;
@@ -423,15 +441,7 @@ rec {
         };
       }) (drv.outputs or [ "out" ]);
     in
-    commonAttrs
-    // {
-      drvPath =
-        assert condition;
-        drv.drvPath;
-      outPath =
-        assert condition;
-        drv.outPath;
-    };
+    commonAttrs;
 
   /**
     Strip a derivation of all non-essential attributes, returning

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -468,19 +468,14 @@ stdenvNoCC.mkDerivation {
       libc_lib
       ;
     default_hardening_flags_str = toString defaultHardeningFlags;
-  }
-  // lib.mapAttrs (_: lib.optionalString targetPlatform.isDarwin) {
     # These will become empty strings when not targeting Darwin.
-    inherit (targetPlatform)
-      darwinPlatform
-      darwinSdkVersion
-      darwinMinVersion
-      darwinMinVersionVariable
-      ;
-  }
-  // lib.optionalAttrs (stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null) {
+    darwinPlatform = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinPlatform;
+    darwinSdkVersion = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinSdkVersion;
+    darwinMinVersion = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinMinVersion;
+    darwinMinVersionVariable = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinMinVersionVariable;
     # Wrapped compilers should do something useful even when no SDK is provided at `DEVELOPER_DIR`.
-    fallback_sdk = apple-sdk.__spliced.buildTarget or apple-sdk;
+    ${if stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null then "fallback_sdk" else null} =
+      apple-sdk.__spliced.buildTarget or apple-sdk;
   };
 
   meta =

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -85,13 +85,10 @@ lib.makeOverridable (
         buildInputs ? null,
       }@args:
       let
-        compatArgs =
-          lib.optionalAttrs (args ? nativeBuildInputs) {
-            inherit nativeBuildInputs;
-          }
-          // lib.optionalAttrs (args ? buildInputs) {
-            inherit buildInputs;
-          };
+        compatArgs = {
+          ${if args ? nativeBuildInputs then "nativeBuildInputs" else null} = nativeBuildInputs;
+          ${if args ? buildInputs then "buildInputs" else null} = buildInputs;
+        };
       in
       compatArgs
       // derivationArgs

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -86,13 +86,10 @@ lib.makeOverridable (
         buildInputs ? null,
       }@args:
       let
-        compatArgs =
-          lib.optionalAttrs (args ? nativeBuildInputs) {
-            inherit nativeBuildInputs;
-          }
-          // lib.optionalAttrs (args ? buildInputs) {
-            inherit buildInputs;
-          };
+        compatArgs = {
+          ${if args ? nativeBuildInputs then "nativeBuildInputs" else null} = nativeBuildInputs;
+          ${if args ? buildInputs then "buildInputs" else null} = buildInputs;
+        };
       in
       compatArgs
       // derivationArgs

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -451,13 +451,12 @@ stdenvNoCC.mkDerivation {
     inherit nixSupport;
 
     inherit defaultHardeningFlags;
-  }
-  // optionalAttrs cc.langGo or false {
+
     # So gccgo looks more like go for buildGoModule
-
-    inherit (targetPlatform.go) GOOS GOARCH GOARM;
-
-    CGO_ENABLED = 1;
+    ${if cc.langGo or false then "GOOS" else null} = targetPlatform.go.GOOS;
+    ${if cc.langGo or false then "GOARCH" else null} = targetPlatform.go.GOARCH;
+    ${if cc.langGo or false then "GOARM" else null} = targetPlatform.go.GOARM;
+    ${if cc.langGo or false then "CGO_ENABLED" else null} = 1;
   };
 
   dontBuild = true;
@@ -993,14 +992,12 @@ stdenvNoCC.mkDerivation {
     inherit darwinPlatformForCC;
     default_hardening_flags_str = toString defaultHardeningFlags;
     inherit useMacroPrefixMap;
-  }
-  // lib.mapAttrs (_: lib.optionalString targetPlatform.isDarwin) {
     # These will become empty strings when not targeting Darwin.
-    inherit (targetPlatform) darwinMinVersion darwinMinVersionVariable;
-  }
-  // lib.optionalAttrs (stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null) {
+    darwinMinVersion = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinMinVersion;
+    darwinMinVersionVariable = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinMinVersionVariable;
     # Wrapped compilers should do something useful even when no SDK is provided at `DEVELOPER_DIR`.
-    fallback_sdk = apple-sdk.__spliced.buildTarget or apple-sdk;
+    ${if stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null then "fallback_sdk" else null} =
+      apple-sdk.__spliced.buildTarget or apple-sdk;
   };
 
   meta =

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -453,13 +453,12 @@ stdenvNoCC.mkDerivation {
     inherit nixSupport;
 
     inherit defaultHardeningFlags;
-  }
-  // optionalAttrs cc.langGo or false {
+
     # So gccgo looks more like go for buildGoModule
-
-    inherit (targetPlatform.go) GOOS GOARCH GOARM;
-
-    CGO_ENABLED = 1;
+    ${if cc.langGo or false then "GOOS" else null} = targetPlatform.go.GOOS;
+    ${if cc.langGo or false then "GOARCH" else null} = targetPlatform.go.GOARCH;
+    ${if cc.langGo or false then "GOARM" else null} = targetPlatform.go.GOARM;
+    ${if cc.langGo or false then "CGO_ENABLED" else null} = 1;
   };
 
   dontBuild = true;
@@ -995,14 +994,12 @@ stdenvNoCC.mkDerivation {
     inherit darwinPlatformForCC;
     default_hardening_flags_str = toString defaultHardeningFlags;
     inherit useMacroPrefixMap;
-  }
-  // lib.mapAttrs (_: lib.optionalString targetPlatform.isDarwin) {
     # These will become empty strings when not targeting Darwin.
-    inherit (targetPlatform) darwinMinVersion darwinMinVersionVariable;
-  }
-  // lib.optionalAttrs (stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null) {
+    darwinMinVersion = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinMinVersion;
+    darwinMinVersionVariable = lib.optionalString targetPlatform.isDarwin targetPlatform.darwinMinVersionVariable;
     # Wrapped compilers should do something useful even when no SDK is provided at `DEVELOPER_DIR`.
-    fallback_sdk = apple-sdk.__spliced.buildTarget or apple-sdk;
+    ${if stdenvNoCC.targetPlatform.isDarwin && apple-sdk != null then "fallback_sdk" else null} =
+      apple-sdk.__spliced.buildTarget or apple-sdk;
   };
 
   meta =

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -26,9 +26,7 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoBuildHook;
-    }
-    // lib.optionalAttrs (stdenv.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
+      ${if stdenv.isLinux then "testCross" else null} = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
     };
   } ./cargo-build-hook.sh;
 
@@ -40,9 +38,7 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoCheckHook;
-    }
-    // lib.optionalAttrs (stdenv.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
+      ${if stdenv.isLinux then "testCross" else null} = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
     };
   } ./cargo-check-hook.sh;
 
@@ -53,9 +49,8 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoInstallHook;
-    }
-    // lib.optionalAttrs (stdenv.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
+      ${if stdenv.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
     };
   } ./cargo-install-hook.sh;
 
@@ -67,9 +62,8 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoNextestHook;
-    }
-    // lib.optionalAttrs (stdenv.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
+      ${if stdenv.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
     };
   } ./cargo-nextest-hook.sh;
 
@@ -106,9 +100,7 @@
 
     passthru.tests = {
       test = tests.rust-hooks.cargoSetupHook;
-    }
-    // lib.optionalAttrs (stdenv.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
+      ${if stdenv.isLinux then "testCross" else null} = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
     };
   } ./cargo-setup-hook.sh;
 

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -26,9 +26,8 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoBuildHook;
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
+      ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
     };
   } ./cargo-build-hook.sh;
 
@@ -40,9 +39,8 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoCheckHook;
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
+      ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
     };
   } ./cargo-check-hook.sh;
 
@@ -53,9 +51,8 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoInstallHook;
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
+      ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
     };
   } ./cargo-install-hook.sh;
 
@@ -67,9 +64,8 @@
     };
     passthru.tests = {
       test = tests.rust-hooks.cargoNextestHook;
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
+      ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
     };
   } ./cargo-nextest-hook.sh;
 
@@ -106,9 +102,8 @@
 
     passthru.tests = {
       test = tests.rust-hooks.cargoSetupHook;
-    }
-    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
-      testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
+      ${if stdenv.hostPlatform.isLinux then "testCross" else null} =
+        pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
     };
   } ./cargo-setup-hook.sh;
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -94,71 +94,64 @@ let
 
     in
     # The stdenv that we are producing.
-    derivation (
-      lib.optionalAttrs (allowedRequisites != null) {
-        allowedRequisites = allowedRequisites ++ defaultNativeBuildInputs ++ defaultBuildInputs;
-      }
-      // lib.optionalAttrs config.contentAddressedByDefault {
-        __contentAddressed = true;
-        outputHashAlgo = "sha256";
-        outputHashMode = "recursive";
-      }
-      // {
-        inherit name pname version;
-        inherit disallowedRequisites;
+    derivation {
+      ${if allowedRequisites != null then "allowedRequisites" else null} =
+        allowedRequisites ++ defaultNativeBuildInputs ++ defaultBuildInputs;
+      ${if config.contentAddressedByDefault then "__contentAddressed" else null} = true;
+      ${if config.contentAddressedByDefault then "outputHashAlgo" else null} = "sha256";
+      ${if config.contentAddressedByDefault then "outputHashMode" else null} = "recursive";
+      inherit name pname version;
+      inherit disallowedRequisites;
 
-        # Nix itself uses the `system` field of a derivation to decide where to
-        # build it. This is a bit confusing for cross compilation.
-        inherit (buildPlatform) system;
+      # Nix itself uses the `system` field of a derivation to decide where to
+      # build it. This is a bit confusing for cross compilation.
+      inherit (buildPlatform) system;
 
-        builder = shell;
+      builder = shell;
 
-        args = [
-          "-e"
-          ./builder.sh
-        ];
+      args = [
+        "-e"
+        ./builder.sh
+      ];
 
-        setup = setupScript;
+      setup = setupScript;
 
-        # We pretty much never need rpaths on Darwin, since all library path references
-        # are absolute unless we go out of our way to make them relative (like with CF)
-        # TODO: This really wants to be in stdenv/darwin but we don't have hostPlatform
-        # there (yet?) so it goes here until then.
-        preHook =
-          preHook
-          + lib.optionalString buildPlatform.isDarwin ''
-            export NIX_DONT_SET_RPATH_FOR_BUILD=1
-          ''
-          + lib.optionalString (hostPlatform.isDarwin || (!hostPlatform.isElf && !hostPlatform.isMacho)) ''
-            export NIX_DONT_SET_RPATH=1
-            export NIX_NO_SELF_RPATH=1
-          ''
-          + lib.optionalString (hostPlatform.isDarwin && hostPlatform.isMacOS) ''
-            export MACOSX_DEPLOYMENT_TARGET=${hostPlatform.darwinMinVersion}
-          ''
-        # TODO this should be uncommented, but it causes stupid mass rebuilds due to
-        # `pkgsCross.*.buildPackages` not being the same, resulting in cross-compiling
-        # for a target rebuilding all of `nativeBuildInputs` for that target.
-        #
-        # I think the best solution would just be to fixup linux RPATHs so we don't
-        # need to set `-rpath` anywhere.
-        # + lib.optionalString targetPlatform.isDarwin ''
-        #   export NIX_DONT_SET_RPATH_FOR_TARGET=1
-        # ''
+      # We pretty much never need rpaths on Darwin, since all library path references
+      # are absolute unless we go out of our way to make them relative (like with CF)
+      # TODO: This really wants to be in stdenv/darwin but we don't have hostPlatform
+      # there (yet?) so it goes here until then.
+      preHook =
+        preHook
+        + lib.optionalString buildPlatform.isDarwin ''
+          export NIX_DONT_SET_RPATH_FOR_BUILD=1
+        ''
+        + lib.optionalString (hostPlatform.isDarwin || (!hostPlatform.isElf && !hostPlatform.isMacho)) ''
+          export NIX_DONT_SET_RPATH=1
+          export NIX_NO_SELF_RPATH=1
+        ''
+        + lib.optionalString (hostPlatform.isDarwin && hostPlatform.isMacOS) ''
+          export MACOSX_DEPLOYMENT_TARGET=${hostPlatform.darwinMinVersion}
+        ''
+      # TODO this should be uncommented, but it causes stupid mass rebuilds due to
+      # `pkgsCross.*.buildPackages` not being the same, resulting in cross-compiling
+      # for a target rebuilding all of `nativeBuildInputs` for that target.
+      #
+      # I think the best solution would just be to fixup linux RPATHs so we don't
+      # need to set `-rpath` anywhere.
+      # + lib.optionalString targetPlatform.isDarwin ''
+      #   export NIX_DONT_SET_RPATH_FOR_TARGET=1
+      # ''
+      ;
+
+      inherit
+        initialPath
+        shell
+        defaultNativeBuildInputs
+        defaultBuildInputs
         ;
-
-        inherit
-          initialPath
-          shell
-          defaultNativeBuildInputs
-          defaultBuildInputs
-          ;
-      }
-      // lib.optionalAttrs buildPlatform.isDarwin {
-        __sandboxProfile = stdenvSandboxProfile;
-        __impureHostDeps = __stdenvImpureHostDeps;
-      }
-    )
+      ${if buildPlatform.isDarwin then "__sandboxProfile" else null} = stdenvSandboxProfile;
+      ${if buildPlatform.isDarwin then "__impureHostDeps" else null} = __stdenvImpureHostDeps;
+    }
 
     // {
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -46,6 +46,8 @@ let
     zipAttrsWith
     ;
 
+  inherit (lib.strings) sanitizeDerivationName;
+
   inherit (import ../../build-support/lib/cmake.nix { inherit lib stdenv; }) makeCMakeFlags;
   inherit (import ../../build-support/lib/meson.nix { inherit lib stdenv; }) makeMesonFlags;
 
@@ -544,7 +546,7 @@ let
               # it again.
               staticMarker = stdenvStaticMarker;
             in
-            lib.strings.sanitizeDerivationName (
+            sanitizeDerivationName (
               if attrs ? name then
                 attrs.name + hostSuffix
               else

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -397,16 +397,14 @@ let
       outputs' = outputs ++ optional separateDebugInfo' "debug";
 
       noNonNativeDeps =
-        (
-          depsBuildTarget
-          ++ depsBuildTargetPropagated
-          ++ depsHostHost
-          ++ depsHostHostPropagated
-          ++ buildInputs
-          ++ propagatedBuildInputs
-          ++ depsTargetTarget
-          ++ depsTargetTargetPropagated
-        ) == [ ];
+        depsBuildTarget == [ ]
+        && depsBuildTargetPropagated == [ ]
+        && depsHostHost == [ ]
+        && depsHostHostPropagated == [ ]
+        && buildInputs == [ ]
+        && propagatedBuildInputs == [ ]
+        && depsTargetTarget == [ ]
+        && depsTargetTargetPropagated == [ ];
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
 
       concretizeFlagImplications =
@@ -592,7 +590,6 @@ let
           propagatedBuildInputs = propagatedHostTargetOutputs;
           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
 
-          # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
           configureFlags =
             configureFlags
             ++ (

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -801,9 +801,8 @@ let
       );
 
     let
-      env' = env // {
-        ${if meta ? mainProgram then "NIX_MAIN_PROGRAM" else null} = meta.mainProgram;
-      };
+
+      env' = if meta ? mainProgram then env // { NIX_MAIN_PROGRAM = meta.mainProgram; } else env;
 
       derivationArg = makeDerivationArgument (
         removeAttrs attrs [

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -702,7 +702,6 @@ let
           propagatedBuildInputs = propagatedHostTargetOutputs;
           depsTargetTargetPropagated = propagatedTargetTargetOutputs;
 
-          # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
           configureFlags =
             configureFlags
             ++ (

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -54,15 +54,13 @@ in
 
   # `stdenv` without a C compiler. Passing in this helps avoid infinite
   # recursions, and may eventually replace passing in the full stdenv.
-  stdenvNoCC ? stdenv.override (
-    {
-      cc = null;
-      hasCC = false;
-    }
+  stdenvNoCC ? stdenv.override {
+    cc = null;
+    hasCC = false;
     # Darwin doesn’t need an SDK in `stdenvNoCC`.  Dropping it shrinks the closure
     # size down from ~1 GiB to ~83 MiB, which is a considerable reduction.
-    // lib.optionalAttrs stdenv.hostPlatform.isDarwin { extraBuildInputs = [ ]; }
-  ),
+    ${if stdenv.hostPlatform.isDarwin then "extraBuildInputs" else null} = [ ];
+  },
 
   # This is used because stdenv replacement and the stdenvCross do benefit from
   # the overridden configuration provided by the user, as opposed to the normal
@@ -218,26 +216,21 @@ let
       if !config.allowAliases || isSupported then
         nixpkgsFun {
           overlays = [
-            (
-              self': super':
-              {
-                pkgsi686Linux = super';
-              }
-              // lib.optionalAttrs (!isSupported) {
-                # Overrides pkgsi686Linux.stdenv.mkDerivation to produce only broken derivations,
-                # when used on a non x86_64-linux platform in CI.
-                # TODO: Remove this, once pkgsi686Linux can become a variant.
-                stdenv = super'.stdenv // {
-                  mkDerivation =
-                    args:
-                    (super'.stdenv.mkDerivation args).overrideAttrs (prevAttrs: {
-                      meta = prevAttrs.meta or { } // {
-                        broken = true;
-                      };
-                    });
-                };
-              }
-            )
+            (self': super': {
+              pkgsi686Linux = super';
+              # Overrides pkgsi686Linux.stdenv.mkDerivation to produce only broken derivations,
+              # when used on a non x86_64-linux platform in CI.
+              # TODO: Remove this, once pkgsi686Linux can become a variant.
+              ${if !isSupported then "stdenv" else null} = super'.stdenv // {
+                mkDerivation =
+                  args:
+                  (super'.stdenv.mkDerivation args).overrideAttrs (prevAttrs: {
+                    meta = prevAttrs.meta or { } // {
+                      broken = true;
+                    };
+                  });
+              };
+            })
           ]
           ++ overlays;
           ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {


### PR DESCRIPTION
Disclaimer: Co-authored by claude code

Follow-up to #506774, #430969, and #430132. Further eval performance improvements across hot paths. I used Claude to help. Most (95%+) perf gains are from the `lib/customisation` change (item 2); the rest are smaller wrapper/hook/stdenv `optionalAttrs` conversions.

> [!NOTE]
> **Rebased onto current master.** Three commits from earlier revisions of this PR have since landed upstream independently and have been dropped here to avoid duplication:
> - `make-derivation: skip env merge when mainProgram is null` → landed as [`fde4f1c5a058`](https://github.com/NixOS/nixpkgs/commit/fde4f1c5a058) using `attrs ? meta.mainProgram` to avoid forcing the lazy `commonMeta` thunk.
> - Equivalent `optionalAttrs` → nullable-attr conversions in `overrideDerivation` and `makeOverridable` → [`a72cd26ce`](https://github.com/NixOS/nixpkgs/commit/a72cd26ceb15) and [`6a07020e3`](https://github.com/NixOS/nixpkgs/commit/6a07020e3c17).
>
> Headline deltas (notably `nrOpUpdates`) are therefore smaller than earlier benchmark runs in this PR; the remaining wins come from `extendDerivation` restructuring and the wrapper/hook/stdenv conversions in the commits below.

## Changes

1. **make-derivation.nix**: remove no longer valid comment
2. **lib/customisation.nix**: fold the `all` attribute into the `listToAttrs` call alongside the outputs in `extendDerivation`, and inline `drvPath`/`outPath` into `commonAttrs` (4→3 `//` merges per derivation)
3. **stdenv/generic/default.nix**: convert 3 `optionalAttrs` in stdenv `derivation` call
4. **cc-wrapper**: inline Go passthru attrs, Darwin env vars, `fallback_sdk`
5. **bintools-wrapper**: same pattern as cc-wrapper for Darwin env vars and `fallback_sdk`
6. **top-level/stage.nix**: convert Darwin `extraBuildInputs` and `!isSupported` stdenv override
7. **rust/hooks**: convert 5 `optionalAttrs` for `testCross` in cargo hooks
8. **buildenv**: convert `nativeBuildInputs`/`buildInputs` `optionalAttrs` in the `compatArgs` block

## CI eval comparison (mean across 4 platforms, sum of all chunks each)

Source: `comparison` artifact from this PR's latest CI run (head `520089ba8066`). Deterministic metrics only; `time.cpu` omitted because it is noisy across CI runs.

| metric | before | after | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 262,416,023 | 262,329,027 | -86,996 | -0.03% |
| nrOpUpdates | 56,664,964 | 53,433,089 | -3,231,875 | **-5.70%** |
| nrOpUpdateValuesCopied | 603,093,960 | 566,034,360 | -37,059,599 | **-6.14%** |
| envs.number | 300,844,907 | 300,753,876 | -91,032 | -0.03% |
| envs.bytes | 5.93 GB | 5.93 GB | -1.4 MB | -0.02% |
| sets.number | 82,483,031 | 80,874,750 | -1,608,281 | **-1.95%** |
| sets.bytes | 17.29 GB | 16.73 GB | -571 MB | **-3.24%** |
| list.bytes | 0.84 GB | 0.88 GB | +42 MB | **+4.88%** |
| list.concats | 23,800,293 | 25,386,948 | +1,586,655 | **+6.67%** |
| nrThunks | 378,846,671 | 381,936,005 | +3,089,334 | +0.82% |
| gc.totalBytes | 41.54 GB | 40.83 GB | -727 MB | **-1.71%** |

The `list.{bytes,concats}` increase comes from the `extendDerivation` restructuring: `listToAttrs` with `++` builds list elements instead of intermediate attrsets via `//`. This is more than offset by the `sets.bytes` decrease (-571 MB vs +42 MB), for a net allocation savings of ~656 MB / -1.71% `gc.totalBytes`.

`nrThunks` increase is expected: `listToAttrs` with `++` creates thunks for list elements instead of intermediate attrsets via `//`.

<details><summary>Per-platform breakdown (sum across all chunks)</summary>

| metric | x86_64-linux | aarch64-linux | x86_64-darwin | aarch64-darwin |
|---|---|---|---|---|
| nrFunctionCalls | -0.03% (308.4M → 308.3M) | -0.03% (280.6M → 280.5M) | -0.03% (223.7M → 223.6M) | -0.04% (237.0M → 236.9M) |
| nrOpUpdates | **-5.79%** (68.2M → 64.2M) | **-5.58%** (61.4M → 58.0M) | **-5.71%** (47.6M → 44.9M) | **-5.72%** (49.5M → 46.6M) |
| nrOpUpdateValuesCopied | **-6.47%** (666.4M → 623.3M) | **-6.52%** (585.4M → 547.2M) | **-5.78%** (565.9M → 533.2M) | **-5.75%** (594.6M → 560.4M) |
| envs.number | -0.03% (354.6M → 354.5M) | -0.03% (322.5M → 322.4M) | -0.03% (255.7M → 255.6M) | -0.03% (270.5M → 270.4M) |
| envs.bytes | -0.02% (7.00 GB → 7.00 GB) | -0.02% (6.39 GB → 6.38 GB) | -0.02% (5.03 GB → 5.03 GB) | -0.03% (5.30 GB → 5.30 GB) |
| sets.number | **-1.90%** (102.6M → 100.6M) | **-1.84%** (92.4M → 90.7M) | **-2.06%** (66.1M → 64.8M) | **-2.06%** (68.8M → 67.4M) |
| sets.bytes | **-3.27%** (20.00 GB → 19.35 GB) | **-3.27%** (17.65 GB → 17.07 GB) | **-3.21%** (15.41 GB → 14.92 GB) | **-3.21%** (16.09 GB → 15.57 GB) |
| list.bytes | **+5.90%** (0.84 GB → 0.89 GB) | **+5.75%** (0.76 GB → 0.81 GB) | **+4.19%** (0.83 GB → 0.86 GB) | **+3.86%** (0.94 GB → 0.97 GB) |
| list.concats | **+9.24%** (21.0M → 22.9M) | **+8.74%** (19.3M → 21.0M) | **+4.99%** (26.7M → 28.1M) | **+4.92%** (28.2M → 29.6M) |
| nrThunks | +0.84% (448.5M → 452.3M) | +0.81% (405.3M → 408.6M) | +0.80% (324.3M → 326.9M) | +0.80% (337.2M → 339.9M) |
| gc.totalBytes | **-1.75%** (48.10 GB → 47.26 GB) | **-1.74%** (43.02 GB → 42.27 GB) | **-1.65%** (36.76 GB → 36.15 GB) | **-1.66%** (38.28 GB → 37.65 GB) |

</details>

<details><summary>Stale: local benchmark — hello.drvPath (~950 derivations in closure)</summary>

> [!WARNING]
> These local benchmark numbers were captured against an earlier revision of this PR that included commits since absorbed upstream (see top NOTE). They are kept for historical context only — see the CI comparison above for the current state.

| metric | baseline | optimized | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 152,145 | 151,376 | -769 | -0.51% |
| nrOpUpdates | 17,657 | 14,887 | -2,770 | **-15.68%** |
| nrOpUpdateValuesCopied | 1,098,547 | 1,093,331 | -5,216 | -0.47% |
| envs.number | 172,240 | 171,448 | -792 | -0.46% |
| sets.number | 52,526 | 50,923 | -1,603 | **-3.05%** |
| sets.bytes | 26,672,848 | 26,666,424 | -6,424 | -0.02% |
| list.bytes | 695,848 | 763,840 | +67,992 | **+9.77%** |
| list.concats | 3,410 | 4,539 | +1,129 | **+33.11%** |
| nrThunks | 274,672 | 278,506 | +3,834 | +1.40% |
| gc.totalBytes | 48,134,592 | 48,252,192 | +117,600 | +0.24% |

</details>

<details><summary>Stale: local benchmark — forcing all top-level .drvPaths</summary>

> [!WARNING]
> These local benchmark numbers were captured against an earlier revision of this PR that included commits since absorbed upstream (see top NOTE). They are kept for historical context only — see the CI comparison above for the current state.

| metric | baseline | optimized | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 110,225,036 | 109,782,488 | -442,548 | -0.40% |
| nrOpUpdates | 12,278,148 | 10,435,598 | -1,842,550 | **-15.01%** |
| nrOpUpdateValuesCopied | 197,442,016 | 192,017,627 | -5,424,389 | **-2.75%** |
| envs.number | 124,292,235 | 123,848,917 | -443,318 | -0.36% |
| sets.number | 32,884,900 | 31,582,489 | -1,302,411 | **-3.96%** |
| list.concats | 8,803,021 | 7,996,639 | -806,382 | **-9.16%** |
| nrThunks | 187,131,418 | 188,875,088 | +1,743,670 | +0.93% |
| gc.totalBytes | 15,801,516,816 | 15,785,149,168 | -16,367,648 | -0.10% |

</details>

Repro:

```bash
NIX_SHOW_STATS=1 nix-instantiate --eval -E '(import ./. {}).hello.drvPath' 2>stats.json >/dev/null
jq . stats.json
```

## Things done

- [x] Same derivation hash before/after (`hello`, `libgcrypt`, cross-compilation)
- [x] Multi-output packages verified (`openssl.{out,dev,all}`)
- [x] Verified `nodejs.outPath` evaluates without triggering the `Use nodejs-slim.outPath instead` deprecation warning (earlier revision of `extendDerivation` had a precedence bug that let `passthru.outPath` shadow the real `outPath`; fixed by keeping the final `{ drvPath; outPath; }` merge after `passthru`)
- [x] CI eval passes on all 4 platforms with 0 added/removed packages (6 changed: extra-container, nixos-container, nixos-install-tools, nixpkgs-manual, tests.lib-tests, tests.nixos-functions.nixos-test — expected from CI base branch drift)
- [x] `Lint / treefmt` passes (initial revision after rebase had 3 lines exceeding nixfmt's wrap threshold in `pkgs/build-support/rust/hooks/default.nix`; fixed in latest revision)
- [x] No metric regressions except expected list/thunk tradeoffs from `extendDerivation` restructuring

## Split-out changes

- `configureFlags` simplification (dropping `elem`+`optional`+`++` chain for a `concatMap` that respects user-specified `configurePlatforms` order) is split into a separate PR targeting staging because it changes emitted flag order for non-default `configurePlatforms` and causes a mass rebuild.

