### PR TITLE
python3Packages.homekit-audio-proxy: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/homekit-audio-proxy/default.nix
+++ b/pkgs/development/python-modules/homekit-audio-proxy/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cryptography,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-timeout,
+  pytestCheckHook,
+  sybil,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "homekit-audio-proxy";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bdraco";
+    repo = "homekit-audio-proxy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9vC6atYdHvJ/Pkq8n4Amh557GRWLvPofhgnfQJPSBx0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ cryptography ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-timeout
+    pytestCheckHook
+    sybil
+  ];
+
+  pythonImportsCheck = [ "homekit_audio_proxy" ];
+
+  meta = {
+    description = "SRTP audio proxy for HomeKit camera streaming";
+    homepage = "https://github.com/bdraco/homekit-audio-proxy";
+    changelog = "https://github.com/bdraco/homekit-audio-proxy/blob/main/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2527,11 +2527,12 @@
         fnv-hash-fast
         ha-ffmpeg
         hap-python
+        homekit-audio-proxy
         ifaddr
         pyqrcode
         pyturbojpeg
         zeroconf
-      ]; # missing inputs: homekit-audio-proxy
+      ];
     "homekit_controller" =
       ps: with ps; [
         aioesphomeapi
@@ -7733,6 +7734,7 @@
     "homeassistant_sky_connect"
     "homeassistant_yellow"
     "homee"
+    "homekit"
     "homekit_controller"
     "homematic"
     "homematicip_cloud"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7106,6 +7106,8 @@ self: super: with self; {
 
   homeconnect = callPackage ../development/python-modules/homeconnect { };
 
+  homekit-audio-proxy = callPackage ../development/python-modules/homekit-audio-proxy { };
+
   homelink-integration-api = callPackage ../development/python-modules/homelink-integration-api { };
 
   homematicip = callPackage ../development/python-modules/homematicip { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/homekit/
- https://pypi.org/project/homekit-audio-proxy/
- https://github.com/bdraco/homekit-audio-proxy

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
