### PR TITLE
python3Packages.aiolichess: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/aiolichess/default.nix
+++ b/pkgs/development/python-modules/aiolichess/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  aiohttp,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aiolichess";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aryanhasgithub";
+    repo = "aiolichess";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WCrvDNlq0i2FBD6Ouiue3BQcTuIV80Z8MT/5mOjTr3w=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
+
+  # upstream tests are empty
+  doCheck = false;
+
+  pythonImportsCheck = [ "aiolichess" ];
+
+  meta = {
+    description = "Async Python client for the Lichess REST API";
+    homepage = "https://github.com/aryanhasgithub/aiolichess";
+    changelog = "https://github.com/aryanhasgithub/aiolichess/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3476,7 +3476,8 @@
       ];
     "lichess" =
       ps: with ps; [
-      ]; # missing inputs: aiolichess
+        aiolichess
+      ];
     "lidarr" =
       ps: with ps; [
         aiopyarr
@@ -7849,6 +7850,7 @@
     "lg_soundbar"
     "lg_thinq"
     "libre_hardware_monitor"
+    "lichess"
     "lidarr"
     "liebherr"
     "life360"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -380,6 +380,8 @@ self: super: with self; {
 
   aiokem = callPackage ../development/python-modules/aiokem { };
 
+  aiolichess = callPackage ../development/python-modules/aiolichess { };
+
   aiolifx = callPackage ../development/python-modules/aiolifx { };
 
   aiolifx-connection = callPackage ../development/python-modules/aiolifx-connection { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/lichess/
- https://pypi.org/project/aiolichess/
- https://github.com/aryanhasgithub/aiolichess

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
