### PR TITLE
python3Packages.lojack-api: init at 0.7.2 

### DIFF
--- a/pkgs/development/python-modules/lojack-api/default.nix
+++ b/pkgs/development/python-modules/lojack-api/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  aioresponses,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "lojack-api";
+  version = "0.7.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "devinslick";
+    repo = "lojack_api";
+    tag = finalAttrs.version;
+    hash = "sha256-QVXiIN+gb/jm5H49ByT8+jVgl3RVKPSgpwca04C6Keo=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    aioresponses
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "lojack_api" ];
+
+  meta = {
+    description = "Async Python client library for the Spireon LoJack API";
+    homepage = "https://github.com/devinslick/lojack_api";
+    changelog = "https://github.com/devinslick/lojack_api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3587,7 +3587,8 @@
       ];
     "lojack" =
       ps: with ps; [
-      ]; # missing inputs: lojack-api
+        lojack-api
+      ];
     "london_air" =
       ps: with ps; [
       ];
@@ -7877,6 +7878,7 @@
     "logbook"
     "logentries"
     "logger"
+    "lojack"
     "london_air"
     "london_underground"
     "lookin"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9281,6 +9281,8 @@ self: super: with self; {
 
   logzero = callPackage ../development/python-modules/logzero { };
 
+  lojack-api = callPackage ../development/python-modules/lojack-api { };
+
   lomond = callPackage ../development/python-modules/lomond { };
 
   london-tube-status = callPackage ../development/python-modules/london-tube-status { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/lojack/
- https://pypi.org/project/lojack-api/
- https://github.com/devinslick/lojack_api

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
