### PR TITLE
fortran-fpm: 0.11.0 -> 0.13.0

### DIFF
--- a/pkgs/by-name/fo/fortran-fpm/package.nix
+++ b/pkgs/by-name/fo/fortran-fpm/package.nix
@@ -10,11 +10,11 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "fortran-fpm";
 
-  version = "0.11.0";
+  version = "0.13.0";
 
   src = fetchurl {
     url = "https://github.com/fortran-lang/fpm/releases/download/v${finalAttrs.version}/fpm-${finalAttrs.version}.F90";
-    hash = "sha256-mIozF+4kSO5yB9CilBDwinnIa92sMxSyoXWAGpz1jSc=";
+    hash = "sha256-ABz/bPEUXyFbqgiIuieswGzqMKibedGovpfbP/+8jNI=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
## Package update

Bump `fortran-fpm` from 0.11.0 to 0.13.0.

Resolves #506814

## Changelog

- [v0.12.0](https://github.com/fortran-lang/fpm/releases/tag/v0.12.0)
- [v0.13.0](https://github.com/fortran-lang/fpm/releases/tag/v0.13.0) (latest, 2026-02-17)

### Highlights
- Custom module install directory
- Custom build folder
- Features and profiles support
- Multiple simultaneous library targets
- flang-new first-class support
- AMD flang compiler support
- macOS ARM64 and Intel x86_64 release artifacts
- Numerous bug fixes

## Things done
- Built on platform: x86_64-linux (hash verified)
- Source: single-file Fortran 90 bootstrap (`fpm-0.13.0.F90`)
- Hash computed via `nix hash path --type sha256`
