### PR TITLE
rocmPackages.rocprofiler-sdk: init at 7.2.1

### DIFF
--- a/pkgs/by-name/el/elfio/package.nix
+++ b/pkgs/by-name/el/elfio/package.nix
@@ -4,24 +4,45 @@
   fetchFromGitHub,
   cmake,
   boost,
+  gtest,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "elfio";
-  version = "3.10";
+  version = "3.12";
 
   src = fetchFromGitHub {
     owner = "serge1";
     repo = "elfio";
     rev = "Release_${finalAttrs.version}";
-    sha256 = "sha256-DuZhkiHXdCplRiOy1Gsu7voVPdCbFt+4qFqlOeOeWQw=";
+    sha256 = "sha256-tDRBscs2L/3gYgLQvb1+8nNxqkr8v1xBkeDXuOqShX4=";
   };
+
+  patches = [
+    # Add missing #include <stdint.h> for gcc 15
+    (fetchpatch {
+      url = "https://github.com/serge1/ELFIO/commit/34d2c64237bb40f09879e7421db120e50e7e2923.patch";
+      hash = "sha256-HD+rOwqkuvu4lgeIHhiORNxpuowDfy94i0OgUVqbhJ8=";
+    })
+    # Replace including of <stdint.h> by <cstdint>
+    (fetchpatch {
+      url = "https://github.com/serge1/ELFIO/commit/575bfdb12cd90fa8913660295103549f151d116a.patch";
+      hash = "sha256-9N/NC5U+zs9eFKYLw/kVdrMGySWakWH7HG4fsK0mvNw=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
-  nativeCheckInputs = [ boost ];
+  nativeCheckInputs = [
+    boost
+    gtest
+  ];
 
-  cmakeFlags = [ "-DELFIO_BUILD_TESTS=ON" ];
+  cmakeFlags = [
+    "-DELFIO_BUILD_TESTS=ON"
+    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/rocm-modules/clr/default.nix
+++ b/pkgs/development/rocm-modules/clr/default.nix
@@ -17,6 +17,7 @@
   roctracer,
   rocminfo,
   rocm-smi,
+  rocprofiler-register,
   symlinkJoin,
   numactl,
   libffi,
@@ -112,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     libffi
     zstd
     zlib
+    rocprofiler-register
   ];
 
   propagatedBuildInputs = [
@@ -136,7 +138,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DPROF_API_HEADER_PATH=${roctracer.src}/inc/ext"
     "-DROCM_PATH=${rocminfo}"
     "-DBUILD_ICD=ON"
-    "-DHIP_ENABLE_ROCPROFILER_REGISTER=OFF" # circular dep - may need -minimal and -full builds?
     "-DAMD_ICD_LIBRARY_DIR=${khronos-ocl-icd-loader}"
 
     # Temporarily set variables to work around upstream CMakeLists issue

--- a/pkgs/development/rocm-modules/default.nix
+++ b/pkgs/development/rocm-modules/default.nix
@@ -87,6 +87,7 @@ let
       rocprofiler-register = self.callPackage ./rocprofiler-register {
         inherit (llvm) clang;
       };
+      rocprofiler-sdk = self.callPackage ./rocprofiler-sdk { };
 
       rocprof-trace-decoder = self.callPackage ./rocprof-trace-decoder { };
 

--- a/pkgs/development/rocm-modules/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/rocm-runtime/default.nix
@@ -8,6 +8,7 @@
   cmake,
   xxd,
   rocm-device-libs,
+  rocprofiler-register,
   elfutils,
   libdrm,
   numactl,
@@ -48,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     elfutils
     libdrm
     numactl
+    rocprofiler-register
   ];
 
   cmakeFlags = [

--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   stdenv,
-  rocm-runtime,
-  rocprofiler,
   numactl,
   libpciaccess,
   libxml2,
@@ -36,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     clang
-    clr
   ];
 
   # TODO(@LunNova): use system fmt&glog once upstream fixes flag to not vendor
@@ -45,9 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     libpciaccess
     libxml2
     elfutils
-    rocm-runtime
-
-    rocprofiler.rocmtoolkit-merged
 
     python3Packages.lxml
     python3Packages.cppheaderparser
@@ -56,8 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pandas
   ];
   cmakeFlags = [
-    "-DCMAKE_MODULE_PATH=${clr}/lib/cmake/hip"
-    "-DHIP_ROOT_DIR=${clr}"
     "-DGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
     "-DBUILD_TEST=OFF"
     "-DROCPROFILER_BUILD_TESTS=0"

--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -5,11 +5,14 @@
   libpciaccess,
   libxml2,
   elfutils,
+  glog,
+  fmt,
   fetchFromGitHub,
   rocmUpdateScript,
   cmake,
   clang,
   python3Packages,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,22 +27,37 @@ stdenv.mkDerivation (finalAttrs: {
       "projects/rocprofiler-register"
       "shared"
     ];
-    fetchSubmodules = true;
-    hash = "sha256-2u5rLLT4Aif0jwAqqlIzrzh9kICJG15nZAslbiL7H9g=";
+    hash = "sha256-XhxED3LHIjxBcSVyyEC3pgg0fyKyfKtHkF7umExSboM=";
   };
   sourceRoot = "${finalAttrs.src.name}/projects/rocprofiler-register";
+
+  patches = [
+    (fetchpatch {
+      # [rocprofiler-sdk][rocprofiler-register] add CPackComponent
+      url = "https://github.com/ROCm/rocm-systems/commit/ef7253365c420ca486f074b9e9119a222e30fea0.patch";
+      hash = "sha256-dwqvZ4AaTcOk2mSnxgHp/NbhjlD8W6KVz1H5ZF4i/Tw=";
+      relative = "projects/rocprofiler-register";
+    })
+    (fetchpatch {
+      # [rocprofiler-register] Fix compilation with system fmt/glog
+      url = "https://github.com/ROCm/rocm-systems/commit/c8ad2522083c6e00539ce5c1c22df766c20084fb.patch";
+      hash = "sha256-VloRKV6kUzIfIInltx/bV1EM0FUfeQZrVAx6qgdsLyg=";
+      relative = "projects/rocprofiler-register";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
     clang
   ];
 
-  # TODO(@LunNova): use system fmt&glog once upstream fixes flag to not vendor
   buildInputs = [
     numactl
     libpciaccess
     libxml2
     elfutils
+    glog
+    fmt
 
     python3Packages.lxml
     python3Packages.cppheaderparser
@@ -48,9 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pandas
   ];
   cmakeFlags = [
-    "-DBUILD_TEST=OFF"
-    "-DROCPROFILER_BUILD_TESTS=0"
-    "-DROCPROFILER_BUILD_SAMPLES=0"
+    "-DROCPROFILER_REGISTER_BUILD_TESTS=0"
+    "-DROCPROFILER_REGISTER_BUILD_SAMPLES=0"
+    "-DROCPROFILER_REGISTER_BUILD_GLOG=OFF"
+    "-DROCPROFILER_REGISTER_BUILD_FMT=OFF"
     # Manually define CMAKE_INSTALL_<DIR>
     # See: https://github.com/NixOS/nixpkgs/pull/197838
     "-DCMAKE_INSTALL_BINDIR=bin"

--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -9,9 +9,7 @@
   rocmUpdateScript,
   cmake,
   clang,
-  clr,
   python3Packages,
-  gpuTargets ? clr.gpuTargets,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pandas
   ];
   cmakeFlags = [
-    "-DGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
     "-DBUILD_TEST=OFF"
     "-DROCPROFILER_BUILD_TESTS=0"
     "-DROCPROFILER_BUILD_SAMPLES=0"

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0001-rocprofiler-sdk-rename-consumer-test-for-dependent-c.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0001-rocprofiler-sdk-rename-consumer-test-for-dependent-c.patch
@@ -1,0 +1,42 @@
+From 2868bcf8a340ecd4c564c1bd3210753fbd6aad8c Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sun, 5 Apr 2026 15:14:12 +0000
+Subject: [PATCH] [rocprofiler-sdk] rename consumer-test for dependent change
+
+This target has been renamed on the develop branch in
+https://github.com/ROCm/rocm-systems/commit/a2288eb50bd805e5d6d7dfa98834972083e4356a,
+however, that commit requires additional commits in order to apply properly. For now
+it is easier to fix this by renaming this target so that the other patch applies
+cleanly.
+---
+ .../lib/rocprofiler-sdk/counters/tests/CMakeLists.txt     | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt b/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+index 66fd9efa5b..d3b5fbe378 100644
+--- a/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
++++ b/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+@@ -104,16 +104,16 @@ set_tests_properties(
+ 
+ set(ROCPROFILER_LIB_CONSUMER_TEST_SOURCES consumer_test.cpp)
+ 
+-add_executable(consumer-test)
+-target_sources(consumer-test PRIVATE ${ROCPROFILER_LIB_CONSUMER_TEST_SOURCES})
++add_executable(consumer-tests)
++target_sources(consumer-tests PRIVATE ${ROCPROFILER_LIB_CONSUMER_TEST_SOURCES})
+ 
+ target_link_libraries(
+-    consumer-test rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
++    consumer-tests rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+     rocprofiler-sdk::rocprofiler-sdk-hip rocprofiler-sdk::rocprofiler-sdk-common-library
+     rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest GTest::gtest_main)
+ 
+ gtest_add_tests(
+-    TARGET consumer-test
++    TARGET consumer-tests
+     SOURCES ${ROCPROFILER_LIB_CONSUMER_TEST_SOURCES}
+     TEST_LIST consumer-tests_TESTS
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0002-rocprofiler-sdk-add-missing-stl-headers.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0002-rocprofiler-sdk-add-missing-stl-headers.patch
@@ -1,0 +1,69 @@
+From af363337240fb6e4976004900b610317ba459165 Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 21:01:33 +0000
+Subject: [PATCH] [rocprofiler-sdk] add missing stl headers
+
+These missing includes became apparent when building with
+ROCPROFILER_BUILD_GHC_FS=OFF.
+---
+ source/lib/att-tool/att_lib_wrapper.hpp                | 2 ++
+ source/lib/rocprofiler-sdk-rocpd/sql.cpp               | 1 +
+ source/lib/rocprofiler-sdk/counters/metrics.cpp        | 1 +
+ source/lib/rocprofiler-sdk/tests/status.cpp            | 1 +
+ 4 files changed, 5 insertions(+)
+
+diff --git a/source/lib/att-tool/att_lib_wrapper.hpp b/source/lib/att-tool/att_lib_wrapper.hpp
+index e7e58c5991..7dcd000a43 100644
+--- a/source/lib/att-tool/att_lib_wrapper.hpp
++++ b/source/lib/att-tool/att_lib_wrapper.hpp
+@@ -28,9 +28,11 @@
+ #include <rocprofiler-sdk/experimental/thread-trace/trace_decoder.h>
+ 
+ #include <algorithm>
++#include <array>
+ #include <fstream>
+ #include <iostream>
+ #include <map>
++#include <memory>
+ #include <vector>
+ 
+ namespace rocprofiler
+diff --git a/source/lib/rocprofiler-sdk-rocpd/sql.cpp b/source/lib/rocprofiler-sdk-rocpd/sql.cpp
+index b052ec51c3..7e8742686e 100644
+--- a/source/lib/rocprofiler-sdk-rocpd/sql.cpp
++++ b/source/lib/rocprofiler-sdk-rocpd/sql.cpp
+@@ -39,6 +39,7 @@
+ #include <fmt/ranges.h>
+ 
+ #include <dlfcn.h>
++#include <fstream>
+ #include <initializer_list>
+ #include <unordered_map>
+ 
+diff --git a/source/lib/rocprofiler-sdk/counters/metrics.cpp b/source/lib/rocprofiler-sdk/counters/metrics.cpp
+index 8adcf0f991..ee3391e904 100644
+--- a/source/lib/rocprofiler-sdk/counters/metrics.cpp
++++ b/source/lib/rocprofiler-sdk/counters/metrics.cpp
+@@ -46,6 +46,7 @@
+ #include <dlfcn.h>  // for dladdr
+ #include <cstdint>
+ #include <cstdlib>
++#include <fstream>
+ #include <memory>
+ #include <system_error>
+ #include <vector>
+diff --git a/source/lib/rocprofiler-sdk/tests/status.cpp b/source/lib/rocprofiler-sdk/tests/status.cpp
+index a5a492101d..b01f511b99 100644
+--- a/source/lib/rocprofiler-sdk/tests/status.cpp
++++ b/source/lib/rocprofiler-sdk/tests/status.cpp
+@@ -25,6 +25,7 @@
+ 
+ #include <gtest/gtest.h>
+ 
++#include <iomanip>
+ #include <string_view>
+ 
+ TEST(rocprofiler_lib, error_string)
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0003-rocprofiler-sdk-add-missing-rocprofiler-sdk-rocprofi.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0003-rocprofiler-sdk-add-missing-rocprofiler-sdk-rocprofi.patch
@@ -1,0 +1,190 @@
+From c767eafb393294214e9d25142a9eebebf234892b Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 21:20:32 +0000
+Subject: [PATCH] [rocprofiler-sdk] add missing
+ rocprofiler-sdk::rocprofiler-sdk-amd-comgr dependencies
+
+These targets, mostly tests, were missing dependencies on amd comgr.
+---
+ .../lib/att-tool/waitcnt/tests/CMakeLists.txt |  1 +
+ source/lib/python/utilities.cmake             |  3 ++-
+ .../counters/tests/CMakeLists.txt             | 13 +++++++++---
+ .../pc_sampling/parser/tests/CMakeLists.txt   | 20 ++++++++++++++-----
+ .../pc_sampling/tests/CMakeLists.txt          |  4 +++-
+ .../lib/rocprofiler-sdk/tests/CMakeLists.txt  |  2 ++
+ .../thread_trace/tests/CMakeLists.txt         |  1 +
+ 7 files changed, 34 insertions(+), 10 deletions(-)
+
+diff --git a/source/lib/att-tool/waitcnt/tests/CMakeLists.txt b/source/lib/att-tool/waitcnt/tests/CMakeLists.txt
+index 4cc800600e..88dbeaf15a 100644
+--- a/source/lib/att-tool/waitcnt/tests/CMakeLists.txt
++++ b/source/lib/att-tool/waitcnt/tests/CMakeLists.txt
+@@ -17,6 +17,7 @@ target_link_libraries(
+             rocprofiler-sdk::rocprofiler-sdk-common-library
+             rocprofiler-sdk::rocprofiler-sdk-glog
+             rocprofiler-sdk::rocprofiler-sdk-static-library
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+             GTest::gtest
+             GTest::gtest_main)
+ 
+diff --git a/source/lib/python/utilities.cmake b/source/lib/python/utilities.cmake
+index 8f51fe971b..e527278f38 100644
+--- a/source/lib/python/utilities.cmake
++++ b/source/lib/python/utilities.cmake
+@@ -211,7 +211,8 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
+                 rocprofiler-sdk::rocprofiler-sdk-gotcha
+                 rocprofiler-sdk::rocprofiler-sdk-dw
+                 rocprofiler-sdk::rocprofiler-sdk-static-library
+-                rocprofiler-sdk::rocprofiler-sdk-rocpd-library)
++                rocprofiler-sdk::rocprofiler-sdk-rocpd-library
++                rocprofiler-sdk::rocprofiler-sdk-amd-comgr)
+ 
+     # if "Development" is specified instead of "Development.Module", we need to link to
+     # python libraries
+diff --git a/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt b/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+index 824a5c7ae0..5f0bdf313f 100644
+--- a/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
++++ b/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+@@ -55,6 +55,7 @@ target_sources(
+ target_link_libraries(
+     counter_test_constants
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+             rocprofiler-sdk::rocprofiler-sdk-static-library
+             rocprofiler-sdk::rocprofiler-sdk-hip
+             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime)
+@@ -77,6 +78,7 @@ target_link_libraries(
+             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+             rocprofiler-sdk::rocprofiler-sdk-hip
+             rocprofiler-sdk::rocprofiler-sdk-common-library
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+             rocprofiler-sdk::rocprofiler-sdk-static-library
+             GTest::gtest
+             GTest::gtest_main)
+@@ -111,9 +113,14 @@ add_executable(consumer-tests)
+ target_sources(consumer-tests PRIVATE ${ROCPROFILER_LIB_CONSUMER_TEST_SOURCES})
+ 
+ target_link_libraries(
+-    consumer-tests rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+-    rocprofiler-sdk::rocprofiler-sdk-hip rocprofiler-sdk::rocprofiler-sdk-common-library
+-    rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest GTest::gtest_main)
++    consumer-tests
++    rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
++    rocprofiler-sdk::rocprofiler-sdk-hip
++    rocprofiler-sdk::rocprofiler-sdk-common-library
++    rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++    rocprofiler-sdk::rocprofiler-sdk-static-library
++    GTest::gtest
++    GTest::gtest_main)
+ 
+ rocprofiler_add_unit_test(
+     TARGET consumer-tests
+diff --git a/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/CMakeLists.txt b/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/CMakeLists.txt
+index 46feb0cf51..8a8168186e 100644
+--- a/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/CMakeLists.txt
++++ b/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/CMakeLists.txt
+@@ -30,7 +30,9 @@ target_include_directories(pcs_gfx9_test PRIVATE ${PCTEST_INCLUDE_DIR})
+ target_link_libraries(
+     pcs_gfx9_test
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+-            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++            rocprofiler-sdk::rocprofiler-sdk-static-library
++            GTest::gtest
+             GTest::gtest_main)
+ 
+ rocprofiler_add_unit_test(
+@@ -50,7 +52,9 @@ target_include_directories(pcs_id_test PRIVATE ${PCTEST_INCLUDE_DIR})
+ target_link_libraries(
+     pcs_id_test
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+-            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++            rocprofiler-sdk::rocprofiler-sdk-static-library
++            GTest::gtest
+             GTest::gtest_main)
+ 
+ rocprofiler_add_unit_test(
+@@ -72,7 +76,9 @@ target_include_directories(pcs_bench_test PRIVATE ${PCTEST_INCLUDE_DIR})
+ target_link_libraries(
+     pcs_bench_test
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+-            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++            rocprofiler-sdk::rocprofiler-sdk-static-library
++            GTest::gtest
+             GTest::gtest_main)
+ 
+ add_executable(pcs_thread_test)
+@@ -85,7 +91,9 @@ target_include_directories(pcs_thread_test PRIVATE ${PCTEST_INCLUDE_DIR})
+ target_link_libraries(
+     pcs_thread_test
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+-            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++            rocprofiler-sdk::rocprofiler-sdk-static-library
++            GTest::gtest
+             GTest::gtest_main)
+ 
+ rocprofiler_add_unit_test(
+@@ -106,7 +114,9 @@ target_include_directories(pcs_gfx12_test PRIVATE ${PCTEST_INCLUDE_DIR})
+ target_link_libraries(
+     pcs_gfx12_test
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+-            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++            rocprofiler-sdk::rocprofiler-sdk-static-library
++            GTest::gtest
+             GTest::gtest_main)
+ 
+ rocprofiler_add_unit_test(
+diff --git a/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt b/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
+index 4f91344f06..2268cd9eba 100644
+--- a/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
++++ b/source/lib/rocprofiler-sdk/pc_sampling/tests/CMakeLists.txt
+@@ -16,7 +16,9 @@ target_sources(pcs-test PRIVATE ${ROCPROFILER_LIB_PC_SAMPLING_TEST_SOURCES}
+ target_link_libraries(
+     pcs-test
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-common-library
+-            rocprofiler-sdk::rocprofiler-sdk-static-library GTest::gtest
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
++            rocprofiler-sdk::rocprofiler-sdk-static-library
++            GTest::gtest
+             GTest::gtest_main)
+ 
+ rocprofiler_add_unit_test(
+diff --git a/source/lib/rocprofiler-sdk/tests/CMakeLists.txt b/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
+index 3a33b6b547..15f1728955 100644
+--- a/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
++++ b/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
+@@ -30,6 +30,7 @@ target_link_libraries(
+     rocprofiler-sdk-lib-tests
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-static-library
+             rocprofiler-sdk::rocprofiler-sdk-common-library
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+             rocprofiler-sdk::counter-test-constants
+             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+             rocprofiler-sdk::rocprofiler-sdk-drm
+@@ -64,6 +65,7 @@ target_link_libraries(
+     rocprofiler-sdk-lib-tests-shared
+     PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
+             rocprofiler-sdk::rocprofiler-sdk-common-library
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+             rocprofiler-sdk::rocprofiler-sdk-drm
+             rocprofiler-sdk::rocprofiler-sdk-roctx-shared-library
+diff --git a/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt b/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
+index 410fa84eb4..7ce4c73e20 100644
+--- a/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
++++ b/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
+@@ -15,6 +15,7 @@ target_link_libraries(
+             rocprofiler-sdk::rocprofiler-sdk-hsa-runtime
+             rocprofiler-sdk::rocprofiler-sdk-hip
+             rocprofiler-sdk::rocprofiler-sdk-common-library
++            rocprofiler-sdk::rocprofiler-sdk-amd-comgr
+             GTest::gtest
+             GTest::gtest_main
+             rocprofiler-sdk::counter-test-constants)
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0004-rocprofiler-sdk-fix-find_package-dependency-scoping-.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0004-rocprofiler-sdk-fix-find_package-dependency-scoping-.patch
@@ -1,0 +1,89 @@
+From 33058e85d1ee985f9b622bbb2a48199eb55afc20 Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 21:34:58 +0000
+Subject: [PATCH] [rocprofiler-sdk] fix find_package dependency scoping issues
+
+By default, find_package() packages are only made visible to the current
+scope. add_subdirectory() enters a new scope, so the packages searched for
+in external/CMakeLists.txt are not visible in any other CMake files. This
+causes dependency errors for these dependencies. find_package() packages can
+be made visible to the entire project by supplying the GLOBAL argument.
+
+The GLOBAL keyword was added in CMake version 3.24, hence the minimum required
+version is also bumped. Other projects across rocm-systems (rocprofiler-register)
+also already require CMake 3.24, so that should not cause any problems.
+
+See https://github.com/ROCm/rocm-systems/pull/1243, that change fixes the
+same problem in rocprofiler-register.
+---
+ CMakeLists.txt          | 2 +-
+ external/CMakeLists.txt | 8 ++++----
+ requirements.txt        | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 25f335afb3..0d86e05170 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+ 
+ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND CMAKE_CURRENT_SOURCE_DIR STREQUAL
+                                                   CMAKE_SOURCE_DIR)
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index cab59c07bd..fcc872d118 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -64,7 +64,7 @@ if(ROCPROFILER_BUILD_TESTS)
+         mark_as_advanced(BUILD_GMOCK)
+         mark_as_advanced(GTEST_HAS_ABSL)
+     else()
+-        find_package(GTest REQUIRED)
++        find_package(GTest REQUIRED GLOBAL)
+         target_link_libraries(rocprofiler-sdk-gtest INTERFACE GTest::gtest)
+     endif()
+ endif()
+@@ -90,7 +90,7 @@ if(ROCPROFILER_BUILD_GLOG)
+         INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/external/glog>
+                   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/glog/src>)
+ else()
+-    find_package(glog REQUIRED)
++    find_package(glog REQUIRED GLOBAL)
+     target_link_libraries(rocprofiler-sdk-glog INTERFACE glog::glog)
+ endif()
+ 
+@@ -111,7 +111,7 @@ if(ROCPROFILER_BUILD_FMT)
+         rocprofiler-sdk-fmt SYSTEM
+         INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/fmt/include>)
+ else()
+-    find_package(fmt REQUIRED)
++    find_package(fmt REQUIRED GLOBAL)
+     target_link_libraries(rocprofiler-sdk-fmt INTERFACE fmt::fmt)
+ endif()
+ 
+@@ -147,7 +147,7 @@ if(ROCPROFILER_BUILD_YAML_CPP)
+         rocprofiler-sdk-yaml-cpp
+         INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/yaml-cpp/include>)
+ else()
+-    find_package(yaml-cpp 0.8.0 REQUIRED)
++    find_package(yaml-cpp 0.8.0 REQUIRED GLOBAL)
+     target_link_libraries(rocprofiler-sdk-yaml-cpp INTERFACE yaml-cpp::yaml-cpp)
+ endif()
+ 
+diff --git a/requirements.txt b/requirements.txt
+index de7421da0d..3eb60c088b 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,7 +1,7 @@
+ black
+ clang-format>=11.0.0,<12.0.0
+ clang-tidy>=15.0.0,<20.0.0
+-cmake>=3.21.0
++cmake>=3.24.0
+ cmake-format
+ dataclasses
+ flake8
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0005-rocprofiler-sdk-allow-using-system-elfio-dependency.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0005-rocprofiler-sdk-allow-using-system-elfio-dependency.patch
@@ -1,0 +1,76 @@
+From 40b1abf9d3ec8eb3f798946263f144988fa3a416 Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 21:50:57 +0000
+Subject: [PATCH] [rocprofiler-sdk] allow using system elfio dependency
+
+This adds a new option, ROCPROFILER_BUILD_ELFIO, which can be set to OFF to
+make rocprofiler use a system dependency for ELFIO instead of trying to build
+it manually. To mimick old behavior, ROCPROFILER_BUILD_ELFIO is set to ON by
+default.
+
+Related: https://github.com/ROCm/rocm-systems/pull/2319
+---
+ cmake/rocprofiler_options.cmake |  2 ++
+ external/CMakeLists.txt         | 33 +++++++++++++++++++--------------
+ 2 files changed, 21 insertions(+), 14 deletions(-)
+
+diff --git a/cmake/rocprofiler_options.cmake b/cmake/rocprofiler_options.cmake
+index c29311cc8c..da9ee9ad29 100644
+--- a/cmake/rocprofiler_options.cmake
++++ b/cmake/rocprofiler_options.cmake
+@@ -67,6 +67,8 @@ rocprofiler_add_option(ROCPROFILER_BUILD_GOTCHA
+                        "Enable building gotcha library internally" ON)
+ rocprofiler_add_option(ROCPROFILER_BUILD_YAML_CPP
+                        "Enable building yaml-cpp library internally" ON)
++rocprofiler_add_option(ROCPROFILER_BUILD_ELFIO "Enable building ELFIO library internally"
++                       ON)
+ if(ROCPROFILER_BUILD_TESTS)
+     rocprofiler_add_option(
+         ROCPROFILER_BUILD_GTEST
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index fcc872d118..ade8d25c1b 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -201,20 +201,25 @@ target_link_libraries(
+     INTERFACE $<BUILD_INTERFACE:rocprofiler-sdk-perfetto-static-library>)
+ 
+ # ELFIO
+-rocprofiler_checkout_git_submodule(
+-    RECURSIVE
+-    RELATIVE_PATH external/elfio
+-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-    REPO_URL https://github.com/serge1/ELFIO.git
+-    REPO_BRANCH "Release_3.12")
+-
+-set(ELFIO_BUILD_EXAMPLES OFF)
+-set(ELFIO_BUILD_TESTS OFF)
+-add_subdirectory(elfio EXCLUDE_FROM_ALL)
+-if(TARGET rocprofiler-sdk-elfio)
+-    get_target_property(ELFIO_INCLUDE_DIR elfio::elfio INTERFACE_INCLUDE_DIRECTORIES)
+-    target_include_directories(rocprofiler-sdk-elfio SYSTEM
+-                               INTERFACE ${ELFIO_INCLUDE_DIR})
++if(ROCPROFILER_BUILD_ELFIO)
++    rocprofiler_checkout_git_submodule(
++        RECURSIVE
++        RELATIVE_PATH external/elfio
++        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
++        REPO_URL https://github.com/serge1/ELFIO.git
++        REPO_BRANCH "Release_3.12")
++
++    set(ELFIO_BUILD_EXAMPLES OFF)
++    set(ELFIO_BUILD_TESTS OFF)
++    add_subdirectory(elfio EXCLUDE_FROM_ALL)
++    if(TARGET rocprofiler-sdk-elfio)
++        get_target_property(ELFIO_INCLUDE_DIR elfio::elfio INTERFACE_INCLUDE_DIRECTORIES)
++        target_include_directories(rocprofiler-sdk-elfio SYSTEM
++                                   INTERFACE ${ELFIO_INCLUDE_DIR})
++    endif()
++else()
++    find_package(elfio REQUIRED GLOBAL)
++    target_link_libraries(rocprofiler-sdk-elfio INTERFACE elfio::elfio)
+ endif()
+ 
+ #
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0006-rocprofiler-sdk-allow-using-system-otf2-dependency.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0006-rocprofiler-sdk-allow-using-system-otf2-dependency.patch
@@ -1,0 +1,53 @@
+From 0f81ad1a46df9da7c9653812eded2165d0cd794d Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 21:58:13 +0000
+Subject: [PATCH] [rocprofiler-sdk] allow using system otf2 dependency
+
+This adds a new option, ROCPROFILER_BUILD_OTF2, which can be set to OFF to
+make rocprofiler-sdk use a system dependency for OTF2 instead of trying to
+build it manually. To mimick old behavior, ROCPROFILER_BUILD_OTF2 is set to
+ON by default.
+
+Related: https://github.com/ROCm/rocm-systems/pull/2319
+---
+ cmake/rocprofiler_options.cmake |  2 ++
+ external/CMakeLists.txt         | 10 +++++++++-
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/rocprofiler_options.cmake b/cmake/rocprofiler_options.cmake
+index da9ee9ad29..077898a520 100644
+--- a/cmake/rocprofiler_options.cmake
++++ b/cmake/rocprofiler_options.cmake
+@@ -69,6 +69,8 @@ rocprofiler_add_option(ROCPROFILER_BUILD_YAML_CPP
+                        "Enable building yaml-cpp library internally" ON)
+ rocprofiler_add_option(ROCPROFILER_BUILD_ELFIO "Enable building ELFIO library internally"
+                        ON)
++rocprofiler_add_option(ROCPROFILER_BUILD_OTF2 "Enable building OTF2 library internally"
++                       ON)
+ if(ROCPROFILER_BUILD_TESTS)
+     rocprofiler_add_option(
+         ROCPROFILER_BUILD_GTEST
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index ade8d25c1b..0c5d4e5fe5 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -225,7 +225,15 @@ endif()
+ #
+ # OTF2
+ #
+-add_subdirectory(otf2)
++if(ROCPROFILER_BUILD_OTF2)
++    add_subdirectory(otf2)
++else()
++    find_package(PkgConfig REQUIRED)
++    pkg_check_modules(OTF2 REQUIRED IMPORTED_TARGET otf2)
++    add_library(otf2 INTERFACE)
++    add_library(otf2::otf2 ALIAS otf2)
++    target_link_libraries(otf2 INTERFACE PkgConfig::OTF2)
++endif()
+ 
+ rocprofiler_checkout_git_submodule(
+     RECURSIVE
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0007-rocprofiler-sdk-Allow-using-system-json-dependency.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0007-rocprofiler-sdk-Allow-using-system-json-dependency.patch
@@ -1,0 +1,73 @@
+From fda4ff3c2389a5a8b57d44fd9be715ade37d576e Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 22:01:44 +0000
+Subject: [PATCH] [rocprofiler-sdk] Allow using system json dependency
+
+This adds a new option, ROCPROFILER_BUILD_JSON, which can be set to OFF to
+make rocprofiler-sdk use a system dependency for nlohmann_json instead of trying
+to build it manually. To mimick old behavior, ROCPROFILER_BUILD_JSON is set to
+ON by default.
+
+Related: https://github.com/ROCm/rocm-systems/pull/2319
+---
+ cmake/rocprofiler_options.cmake |  2 ++
+ external/CMakeLists.txt         | 27 ++++++++++++++++-----------
+ 2 files changed, 18 insertions(+), 11 deletions(-)
+
+diff --git a/cmake/rocprofiler_options.cmake b/cmake/rocprofiler_options.cmake
+index 077898a520..e35a41c95c 100644
+--- a/cmake/rocprofiler_options.cmake
++++ b/cmake/rocprofiler_options.cmake
+@@ -71,6 +71,8 @@ rocprofiler_add_option(ROCPROFILER_BUILD_ELFIO "Enable building ELFIO library in
+                        ON)
+ rocprofiler_add_option(ROCPROFILER_BUILD_OTF2 "Enable building OTF2 library internally"
+                        ON)
++rocprofiler_add_option(ROCPROFILER_BUILD_JSON "Enable building JSON library internally"
++                       ON)
+ if(ROCPROFILER_BUILD_TESTS)
+     rocprofiler_add_option(
+         ROCPROFILER_BUILD_GTEST
+diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
+index 0c5d4e5fe5..b943be5ad6 100644
+--- a/external/CMakeLists.txt
++++ b/external/CMakeLists.txt
+@@ -235,20 +235,25 @@ else()
+     target_link_libraries(otf2 INTERFACE PkgConfig::OTF2)
+ endif()
+ 
+-rocprofiler_checkout_git_submodule(
+-    RECURSIVE
+-    RELATIVE_PATH external/json
+-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-    REPO_URL https://github.com/nlohmann/json.git
+-    REPO_BRANCH "develop")
+-
+ #
+ # JSON
+ #
+-add_subdirectory(json)
+-target_include_directories(
+-    rocprofiler-sdk-json SYSTEM
+-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/json/include>)
++if(ROCPROFILER_BUILD_JSON)
++    rocprofiler_checkout_git_submodule(
++        RECURSIVE
++        RELATIVE_PATH external/json
++        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
++        REPO_URL https://github.com/nlohmann/json.git
++        REPO_BRANCH "develop")
++
++    add_subdirectory(json)
++    target_include_directories(
++        rocprofiler-sdk-json SYSTEM
++        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/json/include>)
++else()
++    find_package(nlohmann_json REQUIRED GLOBAL)
++    target_link_libraries(rocprofiler-sdk-json INTERFACE nlohmann_json::nlohmann_json)
++endif()
+ 
+ #
+ # SQLite3
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/0008-rocprofiler-sdk-stop-manually-setting-warning-flags-.patch
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/0008-rocprofiler-sdk-stop-manually-setting-warning-flags-.patch
@@ -1,0 +1,269 @@
+From ae4cffc06a368893d91be2739bb6482182681efc Mon Sep 17 00:00:00 2001
+From: Robin Voetter <rvoetter@amd.com>
+Date: Sat, 4 Apr 2026 22:22:56 +0000
+Subject: [PATCH] [rocprofiler-sdk] stop manually setting warning flags on
+ integration tests
+
+The primary motivation for this change is that -Werror is added to the compiler
+options unconditionally, which causes problems when compiling these tests during
+downstream packaging builds. The rocprofiler-sdk::tests-build-flags and
+rocprofiler-sdk::tests-common targets already include these warning flags, and this
+target also already handles setting -Werror conditionally based on ROCPROF_BUILD_WERROR.
+Some integration tests also set -Wpedantic, these have been left as-is. When
+ROCPROF_BUILD_WERROR is set to ON (default), behavior is the same as before this commit.
+---
+ tests/bin/attachment-test/CMakeLists.txt                  | 6 +++---
+ tests/bin/hip-graph/CMakeLists.txt                        | 5 +++--
+ tests/bin/hip-in-libraries/CMakeLists.txt                 | 6 +++---
+ tests/bin/hsa-code-object/CMakeLists.txt                  | 1 -
+ tests/bin/hsa-memory-allocation/CMakeLists.txt            | 3 +--
+ tests/bin/hsa-queue-dependency/CMakeLists.txt             | 1 -
+ tests/bin/multistream/CMakeLists.txt                      | 5 +++--
+ .../bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt | 6 +++---
+ tests/bin/reproducible-dispatch-count/CMakeLists.txt      | 8 ++++----
+ tests/bin/reproducible-runtime/CMakeLists.txt             | 8 ++++----
+ tests/bin/scratch-memory/CMakeLists.txt                   | 3 +--
+ tests/bin/simple-transpose/CMakeLists.txt                 | 8 ++++----
+ tests/bin/transpose/CMakeLists.txt                        | 2 +-
+ tests/bin/vector-operations/CMakeLists.txt                | 2 +-
+ 14 files changed, 31 insertions(+), 33 deletions(-)
+
+diff --git a/tests/bin/attachment-test/CMakeLists.txt b/tests/bin/attachment-test/CMakeLists.txt
+index 332f5e551a..50c644942d 100644
+--- a/tests/bin/attachment-test/CMakeLists.txt
++++ b/tests/bin/attachment-test/CMakeLists.txt
+@@ -42,8 +42,8 @@ find_package(rocprofiler-sdk-roctx REQUIRED)
+ set_source_files_properties(attachment_test.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(attachment-test)
+ target_sources(attachment-test PRIVATE attachment_test.cpp)
+-target_compile_options(attachment-test PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow
+-                                               -Werror)
++target_compile_options(attachment-test PRIVATE -Wpedantic)
+ 
+ target_link_libraries(
+-    attachment-test PRIVATE Threads::Threads rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
++    attachment-test PRIVATE Threads::Threads rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
++                            rocprofiler-sdk::tests-build-flags)
+diff --git a/tests/bin/hip-graph/CMakeLists.txt b/tests/bin/hip-graph/CMakeLists.txt
+index e4d984b68a..dfa9233097 100644
+--- a/tests/bin/hip-graph/CMakeLists.txt
++++ b/tests/bin/hip-graph/CMakeLists.txt
+@@ -35,10 +35,11 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(hip-graph.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(hip-graph)
+ target_sources(hip-graph PRIVATE hip-graph.cpp)
+-target_compile_options(hip-graph PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror)
++target_compile_options(hip-graph PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+-target_link_libraries(hip-graph PRIVATE Threads::Threads)
++target_link_libraries(hip-graph PRIVATE Threads::Threads
++                                        rocprofiler-sdk::tests-build-flags)
+ 
+ # find_package(rocprofiler-sdk-roctx REQUIRED) target_link_libraries(hip-graph PRIVATE
+ # rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
+diff --git a/tests/bin/hip-in-libraries/CMakeLists.txt b/tests/bin/hip-in-libraries/CMakeLists.txt
+index d908704604..5f5d92b80a 100644
+--- a/tests/bin/hip-in-libraries/CMakeLists.txt
++++ b/tests/bin/hip-in-libraries/CMakeLists.txt
+@@ -11,8 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+ add_executable(hip-in-libraries)
+ target_sources(hip-in-libraries PRIVATE hip-in-libraries.cpp)
+-target_compile_options(hip-in-libraries PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow
+-                                                -Werror)
++target_compile_options(hip-in-libraries PRIVATE -Wpedantic)
+ target_link_libraries(hip-in-libraries PRIVATE transpose-shared-library
+                                                vector-ops-shared-library)
+ 
+@@ -20,7 +19,8 @@ find_package(hip REQUIRED)
+ target_link_libraries(hip-in-libraries PRIVATE hip::host)
+ 
+ find_package(Threads REQUIRED)
+-target_link_libraries(hip-in-libraries PRIVATE Threads::Threads)
++target_link_libraries(hip-in-libraries PRIVATE Threads::Threads
++                                               rocprofiler-sdk::tests-build-flags)
+ 
+ if(TRANSPOSE_USE_MPI)
+     find_package(MPI REQUIRED)
+diff --git a/tests/bin/hsa-code-object/CMakeLists.txt b/tests/bin/hsa-code-object/CMakeLists.txt
+index 2e11314509..099606dc26 100644
+--- a/tests/bin/hsa-code-object/CMakeLists.txt
++++ b/tests/bin/hsa-code-object/CMakeLists.txt
+@@ -72,7 +72,6 @@ add_custom_target(generate_hsaco_targets_code_object DEPENDS ${HSACO_TARGET_LIST
+ 
+ add_executable(hsa_code_object_testapp)
+ target_sources(hsa_code_object_testapp PRIVATE hsa_code_object_app.cpp)
+-target_compile_options(hsa_code_object_testapp PRIVATE -W -Wall -Wextra -Wshadow -Werror)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(hsa_code_object_testapp PRIVATE stdc++fs Threads::Threads)
+diff --git a/tests/bin/hsa-memory-allocation/CMakeLists.txt b/tests/bin/hsa-memory-allocation/CMakeLists.txt
+index 485b866209..b0d12490b6 100644
+--- a/tests/bin/hsa-memory-allocation/CMakeLists.txt
++++ b/tests/bin/hsa-memory-allocation/CMakeLists.txt
+@@ -35,8 +35,7 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(hsa-memory-allocation.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(hsa-memory-allocation)
+ target_sources(hsa-memory-allocation PRIVATE hsa-memory-allocation.cpp)
+-target_compile_options(hsa-memory-allocation PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow
+-                                                     -Werror)
++target_compile_options(hsa-memory-allocation PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(hsa-memory-allocation PRIVATE Threads::Threads hsa-runtime64
+diff --git a/tests/bin/hsa-queue-dependency/CMakeLists.txt b/tests/bin/hsa-queue-dependency/CMakeLists.txt
+index 6753da98f2..e02b57f802 100644
+--- a/tests/bin/hsa-queue-dependency/CMakeLists.txt
++++ b/tests/bin/hsa-queue-dependency/CMakeLists.txt
+@@ -49,7 +49,6 @@ add_custom_target(generate_hsaco_targets DEPENDS ${HSACO_TARGET_LIST})
+ 
+ add_executable(multiqueue_testapp)
+ target_sources(multiqueue_testapp PRIVATE multiqueue_app.cpp)
+-target_compile_options(multiqueue_testapp PRIVATE -W -Wall -Wextra -Wshadow -Werror)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(multiqueue_testapp PRIVATE stdc++fs Threads::Threads)
+diff --git a/tests/bin/multistream/CMakeLists.txt b/tests/bin/multistream/CMakeLists.txt
+index 13ef8dee31..37c837976d 100644
+--- a/tests/bin/multistream/CMakeLists.txt
++++ b/tests/bin/multistream/CMakeLists.txt
+@@ -35,7 +35,8 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(multistream_app.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(multistream)
+ target_sources(multistream PRIVATE multistream_app.cpp)
+-target_compile_options(multistream PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror)
++target_compile_options(multistream PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+-target_link_libraries(multistream PRIVATE Threads::Threads)
++target_link_libraries(multistream PRIVATE Threads::Threads
++                                          rocprofiler-sdk::tests-build-flags)
+diff --git a/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt b/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
+index 1e84318f63..aa5d9c88a0 100644
+--- a/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
++++ b/tests/bin/pc-sampling/exec-mask-manipulation/CMakeLists.txt
+@@ -36,8 +36,8 @@ set_source_files_properties(exec_mask_manipulation.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(exec-mask-manipulation)
+ target_sources(exec-mask-manipulation PRIVATE exec_mask_manipulation.cpp)
+ # debug symbols required for PC sampling decoding validation
+-target_compile_options(exec-mask-manipulation PRIVATE -W -Wall -Wextra -Wpedantic
+-                                                      -Wshadow -Werror -g)
++target_compile_options(exec-mask-manipulation PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+-target_link_libraries(exec-mask-manipulation PRIVATE Threads::Threads)
++target_link_libraries(exec-mask-manipulation PRIVATE Threads::Threads
++                                                     rocprofiler-sdk::tests-build-flags)
+diff --git a/tests/bin/reproducible-dispatch-count/CMakeLists.txt b/tests/bin/reproducible-dispatch-count/CMakeLists.txt
+index df10dd7e3f..40fd04cdfc 100644
+--- a/tests/bin/reproducible-dispatch-count/CMakeLists.txt
++++ b/tests/bin/reproducible-dispatch-count/CMakeLists.txt
+@@ -42,15 +42,15 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(reproducible-dispatch-count.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(reproducible-dispatch-count)
+ target_sources(reproducible-dispatch-count PRIVATE reproducible-dispatch-count.cpp)
+-target_compile_options(reproducible-dispatch-count PRIVATE -W -Wall -Wextra -Wpedantic
+-                                                           -Wshadow -Werror)
++target_compile_options(reproducible-dispatch-count PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(reproducible-dispatch-count PRIVATE Threads::Threads)
+ 
+ find_package(rocprofiler-sdk-roctx REQUIRED)
+-target_link_libraries(reproducible-dispatch-count
+-                      PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
++target_link_libraries(
++    reproducible-dispatch-count PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
++                                        rocprofiler-sdk::tests-build-flags)
+ 
+ if(REPRODUCIBLE_DISPATCH_COUNT_USE_MPI)
+     find_package(MPI REQUIRED)
+diff --git a/tests/bin/reproducible-runtime/CMakeLists.txt b/tests/bin/reproducible-runtime/CMakeLists.txt
+index 721b1e190b..4a65e9d60d 100644
+--- a/tests/bin/reproducible-runtime/CMakeLists.txt
++++ b/tests/bin/reproducible-runtime/CMakeLists.txt
+@@ -41,15 +41,15 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(reproducible-runtime.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(reproducible-runtime)
+ target_sources(reproducible-runtime PRIVATE reproducible-runtime.cpp)
+-target_compile_options(reproducible-runtime PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow
+-                                                    -Werror)
++target_compile_options(reproducible-runtime PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(reproducible-runtime PRIVATE Threads::Threads)
+ 
+ find_package(rocprofiler-sdk-roctx REQUIRED)
+-target_link_libraries(reproducible-runtime
+-                      PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
++target_link_libraries(
++    reproducible-runtime PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
++                                 rocprofiler-sdk::tests-build-flags)
+ 
+ if(REPRODUCIBLE_RUNTIME_USE_MPI)
+     find_package(MPI REQUIRED)
+diff --git a/tests/bin/scratch-memory/CMakeLists.txt b/tests/bin/scratch-memory/CMakeLists.txt
+index 06ba7ddadb..419830ec51 100644
+--- a/tests/bin/scratch-memory/CMakeLists.txt
++++ b/tests/bin/scratch-memory/CMakeLists.txt
+@@ -35,8 +35,7 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(scratch-memory.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(scratch-memory)
+ target_sources(scratch-memory PRIVATE scratch-memory.cpp)
+-target_compile_options(scratch-memory PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow
+-                                              -Werror)
++target_compile_options(scratch-memory PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(scratch-memory PRIVATE Threads::Threads hsa-runtime64
+diff --git a/tests/bin/simple-transpose/CMakeLists.txt b/tests/bin/simple-transpose/CMakeLists.txt
+index 41f4954e79..6370289c4a 100644
+--- a/tests/bin/simple-transpose/CMakeLists.txt
++++ b/tests/bin/simple-transpose/CMakeLists.txt
+@@ -35,12 +35,12 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(simple-transpose.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(simple-transpose)
+ target_sources(simple-transpose PRIVATE simple-transpose.cpp)
+-target_compile_options(simple-transpose PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow
+-                                                -Werror)
++target_compile_options(simple-transpose PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(simple-transpose PRIVATE Threads::Threads)
+ 
+ find_package(rocprofiler-sdk-roctx REQUIRED)
+-target_link_libraries(simple-transpose
+-                      PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
++target_link_libraries(
++    simple-transpose PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
++                             rocprofiler-sdk::tests-build-flags)
+diff --git a/tests/bin/transpose/CMakeLists.txt b/tests/bin/transpose/CMakeLists.txt
+index 7d85195a9a..8c98307329 100644
+--- a/tests/bin/transpose/CMakeLists.txt
++++ b/tests/bin/transpose/CMakeLists.txt
+@@ -40,7 +40,7 @@ function(transpose_build_target _NAME _COMPILE_DEFS _LINK_TARGETS)
+     add_executable(${_NAME})
+     target_sources(${_NAME} PRIVATE transpose.cpp)
+     target_compile_definitions(${_NAME} PRIVATE ${_COMPILE_DEFS})
+-    target_compile_options(${_NAME} PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror)
++    target_compile_options(${_NAME} PRIVATE -Wpedantic)
+     target_link_libraries(
+         ${_NAME} PRIVATE Threads::Threads rocprofiler-sdk::tests-build-flags
+                          ${_LINK_TARGETS})
+diff --git a/tests/bin/vector-operations/CMakeLists.txt b/tests/bin/vector-operations/CMakeLists.txt
+index efd16ab04d..9fa1d8fb96 100644
+--- a/tests/bin/vector-operations/CMakeLists.txt
++++ b/tests/bin/vector-operations/CMakeLists.txt
+@@ -35,7 +35,7 @@ set(CMAKE_HIP_STANDARD_REQUIRED ON)
+ set_source_files_properties(vector-ops.cpp PROPERTIES LANGUAGE HIP)
+ add_executable(vector-ops)
+ target_sources(vector-ops PRIVATE vector-ops.cpp)
+-target_compile_options(vector-ops PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror)
++target_compile_options(vector-ops PRIVATE -Wpedantic)
+ 
+ find_package(Threads REQUIRED)
+ target_link_libraries(vector-ops PRIVATE Threads::Threads
+-- 
+2.43.0
+

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/default.nix
@@ -1,0 +1,210 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  clr,
+  rocm-cmake,
+  rocm-runtime,
+  rocprofiler-register,
+  rocprof-trace-decoder,
+  aqlprofile,
+  rocm-comgr,
+  rccl,
+  python3,
+  python3Packages,
+  libdrm,
+  elfutils,
+  sqlite,
+  otf2,
+  zlib,
+  zstd,
+  xz,
+  numactl,
+  fmt,
+  glog,
+  gtest,
+  fetchpatch,
+  yaml-cpp,
+  elfio,
+  nlohmann_json,
+  makeWrapper,
+  gpuTargets ? (clr.localGpuTargets or clr.gpuTargets),
+  buildTests ? false,
+  buildSamples ? false,
+}:
+
+# FIXME: devendor remaining git submodules:
+#   external/cereal     -> https://github.com/jrmadsen/cereal
+#   external/gotcha     -> https://github.com/jrmadsen/GOTCHA
+#   external/perfetto   -> https://github.com/google/perfetto
+#   external/ptl        -> https://github.com/jrmadsen/PTL
+
+# rocprofiler-sdk is the home of rocprofv3
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rocprofiler-sdk";
+  version = "7.2.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "rocm-systems";
+    rev = "rocm-${finalAttrs.version}";
+    hash = "sha256-P8c1/HtkdLlZRTMaOFhFF7a/0SlsOabnUwci1w1Svfc=";
+    fetchSubmodules = true;
+    sparseCheckout = [
+      "projects/rocprofiler-sdk"
+    ];
+  };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocprofiler-sdk";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    clr
+    python3
+    makeWrapper
+  ];
+
+  buildInputs = [
+    clr
+    rocm-cmake
+    rocm-runtime
+    rocprofiler-register
+    aqlprofile
+    rocm-comgr
+    libdrm
+    elfutils
+    sqlite
+    otf2
+    zlib
+    zstd
+    xz
+    numactl
+    fmt
+    glog
+    gtest
+    yaml-cpp
+    elfio
+    nlohmann_json
+    rccl
+    python3Packages.pybind11
+  ];
+
+  patches = [
+    (fetchpatch {
+      # [rocprofiler-sdk] Improve build with system libraries.
+      # https://github.com/ROCm/rocm-systems/pull/2319
+      # Merged in develop branch, but not yet in ROCm 7.2.1.
+      url = "https://github.com/ROCm/rocm-systems/commit/86ee7b2eb2273adaf1181ef9a6b2091465c6f0c7.patch";
+      hash = "sha256-PRmv8SI90jmO6MgJmk1DWf/WVmFy18nUTZClfOvI6a8=";
+      excludes = [ "external/fmt" ];
+      relative = "projects/rocprofiler-sdk";
+    })
+    (fetchpatch {
+      # Users/mkuriche/rocprofiler sdk fmt build fix memory header
+      url = "https://github.com/ROCm/rocm-systems/commit/36d9d33d90879bfbd406498011070ebd929a56b1.patch";
+      hash = "sha256-yRy5pmCX9hd4eeZIz/g3B5VFCL9idkEaGK+S5+2sOsk=";
+      relative = "projects/rocprofiler-sdk";
+    })
+    (fetchpatch {
+      # Fix missing amd_comgr linkage in pc-sampling integration test
+      url = "https://github.com/ROCm/rocm-systems/commit/94a4595a5d02bc066f7a32e1b2134a99a5231213.patch";
+      hash = "sha256-86Fx0bKL0pvXTwVN8QJL+yzCbMYkmMaKzcU4PYcW6ig=";
+      relative = "projects/rocprofiler-sdk";
+    })
+    # See https://github.com/ROCm/rocm-systems/pull/4721
+    # First change is separate and required to make the patches from that pull request
+    # apply cleanly. Its something that was changed on the develop branch, but requires
+    # more effort to backport.
+    ./0001-rocprofiler-sdk-rename-consumer-test-for-dependent-c.patch
+    ./0002-rocprofiler-sdk-add-missing-stl-headers.patch
+    ./0003-rocprofiler-sdk-add-missing-rocprofiler-sdk-rocprofi.patch
+    ./0004-rocprofiler-sdk-fix-find_package-dependency-scoping-.patch
+    ./0005-rocprofiler-sdk-allow-using-system-elfio-dependency.patch
+    ./0006-rocprofiler-sdk-allow-using-system-otf2-dependency.patch
+    ./0007-rocprofiler-sdk-Allow-using-system-json-dependency.patch
+    ./0008-rocprofiler-sdk-stop-manually-setting-warning-flags-.patch
+  ];
+
+  postPatch = ''
+    # NixOS' ROCm distribution does not support libomptarget yet
+    substituteInPlace samples/CMakeLists.txt \
+      --replace-fail 'add_subdirectory(openmp_target)' '# add_subdirectory(openmp_target)'
+    substituteInPlace tests/CMakeLists.txt \
+      --replace-fail 'add_subdirectory(openmp-tools)' '# add_subdirectory(openmp-tools)'
+    substituteInPlace tests/bin/CMakeLists.txt \
+      --replace-fail 'add_subdirectory(openmp)' '# add_subdirectory(openmp)'
+
+    # This requires building perfetto's trace-processor-shell via a weird external script
+    substituteInPlace tests/CMakeLists.txt \
+      --replace-fail 'add_subdirectory(pytest-packages)' ""
+
+    patchShebangs source/libexec/rocprofiler-sdk/rocprofiler-sdk-launch-compiler/rocprofiler-sdk-launch-compiler.sh
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "ROCPROFILER_BUILD_GHC_FS" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_FMT" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_GLOG" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_GTEST" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_PYBIND11" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_YAML_CPP" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_ELFIO" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_OTF2" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_JSON" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_TESTS" buildTests)
+    (lib.cmakeBool "ROCPROFILER_BUILD_SAMPLES" buildSamples)
+    (lib.cmakeBool "ROCPROFILER_BUILD_BENCHMARK" false)
+    (lib.cmakeBool "ROCPROFILER_BUILD_WERROR" false)
+    # rocprofiler-sdk's CMake file doesn't add this dependency properly.
+    "-DCMAKE_HIP_FLAGS=-I${rocm-runtime}/include"
+    "-DCMAKE_INSTALL_BINDIR=bin"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    # Required for rocprofiler-sdk-launch-compiler.sh
+    "-DCMAKE_INSTALL_LIBEXECDIR=libexec"
+    "--debug-find-pkg=amd_comgr"
+    "--trace-source=tests/pc_sampling/CMakeLists.txt"
+    "--trace-expand"
+  ]
+  ++ lib.optionals (buildTests || buildSamples) [
+    # rocprofiler-sdk normally doesn't depend on which GPU is in the system, only when
+    # building tests or samples.
+    (lib.cmakeFeature "GPU_TARGETS" (lib.concatStringsSep ";" gpuTargets))
+  ];
+
+  doCheck = false; # Requires GPU
+
+  postFixup = ''
+    patchelf $out/lib/*.so \
+      --add-rpath ${aqlprofile}/lib \
+      --add-needed libhsa-amd-aqlprofile64.so
+
+    wrapProgram $out/bin/rocprofv3 --add-flags "--att-library-path ${
+      lib.makeLibraryPath [ rocprof-trace-decoder ]
+    }"
+  '';
+
+  postInstall = ''
+    mkdir -p $dev/lib $dev/share/rocprofiler-sdk
+    mv $out/lib/cmake $dev/lib/
+    mv $out/share/rocprofiler-sdk/{samples,tests} $dev/share/rocprofiler-sdk/
+  '';
+
+  meta = {
+    description = "ROCm GPU performance analysis SDK";
+    homepage = "https://github.com/ROCm/rocprofiler-sdk";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Summary of Changes

This is a new attempt at https://github.com/NixOS/nixpkgs/pull/501337.

rocprofv3 is a profiler for AMD which supersedes rocprof and rocprofv2. This package is provided by rocprofiler-sdk. Several fixes to rocprofiler-sdk were required to make this buildable and to devendor as many dependencies as I could, I pushed them [here](https://github.com/ROCm/rocm-systems/commits/users/Snektron/rocprofiler-sdk-build-fixes/) and applied them using `patches`.

I couldn't really devendor all dependencies: Some are forks with random changes applied, some are a bit more complex (perfetto). Not really sure what to do about those, but at least the relatively low-hanging fruits have all been done.

I've also bumped a related dependency (elfio). I didn't see any other packages that use this, so I don't think there should be too much trouble with that.

In order for rocprofv3 to properly work, rocprofiler-register support is needed in CLR and rocm-runtime. Previously, this was disabled, due to a circular dependency. It seems like CLR is no longer needed to build rocprofiler-register though, so I've cleaned up the package (including devendoring its glog and fmt dependencies).

Changing CLR and rocm-runtime causes many ROCm packages to rebuilt. I doubt that it would cause any problems, I don't have the computational capacity to rebuild everything...

Please let me know if I should split these changes up into multiple pull requests.

## Testing

In order to test that rocprofiler-sdk works, you can use something like this:
```cpp
#include <hip/hip_runtime.h>

__global__ void test() {}

int main() {
    test<<<1, 1>>>();
    hipDeviceSynchronize();
}
```
```
$ clang++ -otest-nix ./test.hip
$ rocprofv3 --log-level trace --hip-trace --hsa-trace --kernel-trace -d out --output-format csv -- ./test-nix
```
This should produce `out/x_kernel_trace.csv`, `out/x_hsa_api_trace.csv`, `out/x_hip_api_trace.csv`, and `out/x_agent_info.csv` with some data.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - I've tested rocprofiler-sdk as well as some test ROCm programs.
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
