### PR TITLE
kibi: 0.3.2 -> 0.3.3

### DIFF
--- a/pkgs/by-name/ki/kibi/package.nix
+++ b/pkgs/by-name/ki/kibi/package.nix
@@ -2,30 +2,39 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  nix-update-script,
   makeWrapper,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kibi";
-  version = "0.3.2";
+  version = "0.3.3";
 
-  cargoHash = "sha256-EOw4iE9MTZVL0vIgPHVr0dggtksS5b8IvrRykblF0vA=";
+  cargoHash = "sha256-lBBIEceZgxwoM2DoD+iFtlNdnO5LkvIf2/8CB2uPH3Y=";
 
   src = fetchFromGitHub {
     owner = "ilai-deutel";
     repo = "kibi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lakx3ZNj9HeLFdRVxYLUh8W6yHXpBXlguQjjFofWl/s=";
+    hash = "sha256-uGCtFS29XVrYXOHAeTT5QmYwCIQWg2SRmgw3CP5O0+c=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
+  passthru.updateScript = nix-update-script { };
+
   postInstall = ''
     install -Dm644 syntax.d/* -t $out/share/kibi/syntax.d
     install -Dm644 kibi.desktop -t $out/share/applications
-    install -Dm0644 assets/logo.svg $out/share/icons/hicolor/scalable/apps/kibi.svg
+    install -Dm644 assets/kibi.svg -t $out/share/icons/hicolor/scalable/apps
     wrapProgram $out/bin/kibi --prefix XDG_DATA_DIRS : "$out/share"
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = {
     description = "Text editor in ≤1024 lines of code, written in Rust";
@@ -34,7 +43,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ robertodr ];
+    maintainers = with lib.maintainers; [
+      robertodr
+      ilai-deutel
+    ];
     mainProgram = "kibi";
   };
 })


### PR DESCRIPTION
https://github.com/ilai-deutel/kibi/releases/tag/v0.3.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
