### PR TITLE
nixpkgs-vet: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-vet/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-vet/package.nix
@@ -7,16 +7,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixpkgs-vet";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs-vet";
     tag = finalAttrs.version;
-    hash = "sha256-TxQkD9jPoONec87qGXOIQNh+lZ7kyFM6q1RtlgxEqy4=";
+    hash = "sha256-Rk1p6qAqAtl5bwg9dNZ0yc4m1yOOxybWvTwfuNcOkFQ=";
   };
 
-  cargoHash = "sha256-Wx8AwgUENVbxv9GgB/DTH5aGIRznAslABjxRu/X0l2s=";
+  cargoHash = "sha256-GaQ2ldsGabsDMx1bHuZwnSvtPp1LgPkj2C07cnEBdDY=";
 
   doCheck = false;
 


### PR DESCRIPTION
Changelog: https://github.com/NixOS/nixpkgs-vet/pull/214
Diff: https://github.com/NixOS/nixpkgs-vet/compare/0.2.0...0.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
