### PR TITLE
python3Packages.onvif-parsers: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/onvif-parsers/default.nix
+++ b/pkgs/development/python-modules/onvif-parsers/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  lxml,
+  onvif-zeep-async,
+  zeep,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "onvif-parsers";
+  version = "2.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openvideolibs";
+    repo = "onvif-parsers";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ukwcyycK3YFk0qHUPBD7Aoy3F3itXn0zUGq9I65b3Ns=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    lxml
+    onvif-zeep-async
+    zeep
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "onvif_parsers" ];
+
+  meta = {
+    description = "Parsers for ONVIF events";
+    homepage = "https://github.com/openvideolibs/onvif-parsers";
+    changelog = "https://github.com/openvideolibs/onvif-parsers/blob/main/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4483,9 +4483,10 @@
     "onvif" =
       ps: with ps; [
         ha-ffmpeg
+        onvif-parsers
         onvif-zeep-async
         wsdiscovery
-      ]; # missing inputs: onvif_parsers
+      ];
     "open_meteo" =
       ps: with ps; [
         open-meteo
@@ -8012,6 +8013,7 @@
     "onedrive_for_business"
     "onewire"
     "onkyo"
+    "onvif"
     "open_meteo"
     "open_router"
     "openai_conversation"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11464,6 +11464,8 @@ self: super: with self; {
 
   onnxslim = callPackage ../development/python-modules/onnxslim { };
 
+  onvif-parsers = callPackage ../development/python-modules/onvif-parsers { };
+
   onvif-zeep = callPackage ../development/python-modules/onvif-zeep { };
 
   onvif-zeep-async = callPackage ../development/python-modules/onvif-zeep-async { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/onvif
- https://pypi.org/project/onvif-parsers/
- https://github.com/openvideolibs/onvif-parsers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
