### PR TITLE
python3Packages.py-opendisplay: init at 5.5.0

### DIFF
--- a/pkgs/development/python-modules/epaper-dithering/default.nix
+++ b/pkgs/development/python-modules/epaper-dithering/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  numpy,
+  pillow,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "epaper-dithering";
+  version = "0.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "OpenDisplay";
+    repo = "epaper-dithering";
+    tag = "python-v${finalAttrs.version}";
+    hash = "sha256-h84AgWJR8zVuwoz02A3U82yTOw4MSK9DjaxkYi0nWkM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/python";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    numpy
+    pillow
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "epaper_dithering" ];
+
+  meta = {
+    description = "Dithering algorithms for e-paper/e-ink displays";
+    homepage = "https://github.com/OpenDisplay/epaper-dithering";
+    changelog = "https://github.com/OpenDisplay/epaper-dithering/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/development/python-modules/py-opendisplay/default.nix
+++ b/pkgs/development/python-modules/py-opendisplay/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  bleak,
+  bleak-retry-connector,
+  epaper-dithering,
+  numpy,
+  pillow,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "py-opendisplay";
+  version = "5.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "OpenDisplay";
+    repo = "py-opendisplay";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pPV4Ir9GK++66qq5QGnwyjpBinK7EvI7C7HB14tFDXU=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    bleak
+    bleak-retry-connector
+    epaper-dithering
+    numpy
+    pillow
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "opendisplay" ];
+
+  meta = {
+    description = "Python library for communicating with OpenDisplay BLE e-paper displays";
+    homepage = "https://github.com/OpenDisplay/py-opendisplay";
+    changelog = "https://github.com/OpenDisplay/py-opendisplay/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4535,11 +4535,12 @@
         home-assistant-intents
         ifaddr
         mutagen
+        py-opendisplay
         pymicro-vad
         pyserial
         pyspeex-noise
         zeroconf
-      ]; # missing inputs: py-opendisplay
+      ];
     "openerz" =
       ps: with ps; [
         openerz-api
@@ -8016,6 +8017,7 @@
     "open_router"
     "openai_conversation"
     "openalpr_cloud"
+    "opendisplay"
     "openerz"
     "openevse"
     "openexchangerates"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5054,6 +5054,8 @@ self: super: with self; {
 
   enzyme = callPackage ../development/python-modules/enzyme { };
 
+  epaper-dithering = callPackage ../development/python-modules/epaper-dithering { };
+
   epc = callPackage ../development/python-modules/epc { };
 
   ephem = callPackage ../development/python-modules/ephem { };
@@ -13144,6 +13146,8 @@ self: super: with self; {
   py-nymta = callPackage ../development/python-modules/py-nymta { };
 
   py-ocsf-models = callPackage ../development/python-modules/py-ocsf-models { };
+
+  py-opendisplay = callPackage ../development/python-modules/py-opendisplay { };
 
   py-opensonic = callPackage ../development/python-modules/py-opensonic { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/opendisplay/
- https://pypi.org/project/py-opendisplay/
- https://github.com/OpenDisplay-org/py-opendisplay

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
