### PR TITLE
klayout: 0.30.7 -> 0.30.8 using Qt6

### DIFF
--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -7,40 +7,41 @@
   python3,
   python3Packages,
   ruby,
-  wrapQtAppsHook,
-  qtbase,
-  qtmultimedia,
-  qtsvg,
-  qttools,
-  qtxmlpatterns,
-  qmake,
   which,
   perl,
   libgit2,
   libpng,
   expat,
   curl,
+  zlib,
+  wrapQtAppsHook,
+  qmake,
+  qtbase,
+  qtmultimedia,
+  qtsvg,
+  qttools,
+  qt5compat,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "klayout";
-  version = "0.30.7";
+  version = "0.30.8";
 
   src = fetchFromGitHub {
     owner = "KLayout";
     repo = "klayout";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-W8ry1+wxVOUxg4hXMd0OpcaWcVr6wUBC3eGgDney2Xc=";
+    hash = "sha256-RjMH6hrc0jyCLgG1D6cztBp5Fb3W5HgTxVTfI2bxgCs=";
   };
 
   strictDeps = true;
 
   postPatch = ''
-    substituteInPlace src/klayout.pri --replace "-Wno-reserved-user-defined-literal" ""
-    patchShebangs .
+    patchShebangs --build .
   '';
 
   dontUseQmakeConfigure = true;
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
 
   nativeBuildInputs = [
     (python3.withPackages (ps: [ ps.tomli ]))
@@ -54,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtmultimedia
     qtsvg
     qttools
-    qtxmlpatterns
+    qt5compat
   ];
 
   buildInputs = [
@@ -62,11 +63,12 @@ stdenv.mkDerivation (finalAttrs: {
     qtmultimedia
     qtsvg
     qttools
-    qtxmlpatterns
+    qt5compat
     libgit2
     libpng
     expat
     curl
+    zlib
   ];
 
   buildPhase = ''
@@ -107,7 +109,10 @@ stdenv.mkDerivation (finalAttrs: {
     wrapQtApp "$out/Applications/klayout.app/Contents/MacOS/klayout"
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-parentheses" ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [ "-Wno-parentheses" ];
+    NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
+  };
 
   # Installation is handled manually in buildPhase/postBuild via build.sh -prefix
   dontInstall = true;

--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -4,70 +4,85 @@
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
+  libsForQt5,
+  qt6Packages,
   python3,
   python3Packages,
   ruby,
-  wrapQtAppsHook,
-  qtbase,
-  qtmultimedia,
-  qtsvg,
-  qttools,
-  qtxmlpatterns,
-  qmake,
   which,
   perl,
   libgit2,
   libpng,
   expat,
   curl,
+  zlib,
+  withQt6 ? true,
 }:
 
+let
+  qtPackages = if withQt6 then qt6Packages else libsForQt5;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "klayout";
-  version = "0.30.7";
+  version = "0.30.8";
 
   src = fetchFromGitHub {
     owner = "KLayout";
     repo = "klayout";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-W8ry1+wxVOUxg4hXMd0OpcaWcVr6wUBC3eGgDney2Xc=";
+    hash = "sha256-RjMH6hrc0jyCLgG1D6cztBp5Fb3W5HgTxVTfI2bxgCs=";
   };
 
   strictDeps = true;
 
   postPatch = ''
-    substituteInPlace src/klayout.pri --replace "-Wno-reserved-user-defined-literal" ""
-    patchShebangs .
+    patchShebangs --build .
   '';
 
   dontUseQmakeConfigure = true;
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
 
-  nativeBuildInputs = [
-    (python3.withPackages (ps: [ ps.tomli ]))
-    installShellFiles
-    perl
-    ruby
-    which
-    wrapQtAppsHook
-    qmake
-    qtbase
-    qtmultimedia
-    qtsvg
-    qttools
-    qtxmlpatterns
-  ];
+  nativeBuildInputs =
+    with qtPackages;
+    [
+      (python3.withPackages (ps: [ ps.tomli ]))
+      installShellFiles
+      perl
+      ruby
+      which
+      wrapQtAppsHook
+      qmake
+      qtbase
+      qtmultimedia
+      qtsvg
+      qttools
+    ]
+    ++ lib.optionals withQt6 [
+      qt5compat
+    ]
+    ++ lib.optionals (!withQt6) [
+      qtxmlpatterns
+    ];
 
-  buildInputs = [
-    qtbase
-    qtmultimedia
-    qtsvg
-    qttools
-    qtxmlpatterns
-    libgit2
-    libpng
-    expat
-    curl
-  ];
+  buildInputs =
+    with qtPackages;
+    [
+      qtbase
+      qtmultimedia
+      qtsvg
+      qttools
+      libgit2
+      libpng
+      expat
+      curl
+      zlib
+    ]
+    ++ lib.optionals withQt6 [
+      qt5compat
+    ]
+    ++ lib.optionals (!withQt6) [
+      qtxmlpatterns
+    ];
 
   buildPhase = ''
     runHook preBuild
@@ -107,7 +122,10 @@ stdenv.mkDerivation (finalAttrs: {
     wrapQtApp "$out/Applications/klayout.app/Contents/MacOS/klayout"
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-parentheses" ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [ "-Wno-parentheses" ];
+    NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
+  };
 
   # Installation is handled manually in buildPhase/postBuild via build.sh -prefix
   dontInstall = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9661,7 +9661,7 @@ with pkgs;
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };
 
-  klayout = libsForQt5.callPackage ../applications/misc/klayout { };
+  klayout = qt6Packages.callPackage ../applications/misc/klayout { };
 
   kotatogram-desktop =
     callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9691,7 +9691,7 @@ with pkgs;
 
   k4dirstat = libsForQt5.callPackage ../applications/misc/k4dirstat { };
 
-  klayout = libsForQt5.callPackage ../applications/misc/klayout { };
+  klayout = callPackage ../applications/misc/klayout { withQt6 = true; };
 
   kotatogram-desktop =
     callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
