### PR TITLE
macvim: add vim common hardeningDisable flags

### DIFF
--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  callPackage,
   fetchFromGitHub,
   apple-sdk_14,
   ncurses,
@@ -24,6 +25,9 @@ let
   ruby = ruby_3_4;
 in
 
+let
+  common = callPackage ./common.nix { inherit stdenv; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "macvim";
 
@@ -182,7 +186,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # macvim obj-c log macro triggers -Wformat-security (seems like a bug? it's a string literal!)
-  hardeningDisable = [ "format" ];
+  hardeningDisable = common.hardeningDisable ++ [ "format" ];
   # os_log also enables -Werror,-Wformat by default
   env.NIX_CFLAGS_COMPILE = "-DOS_LOG_FORMAT_WARNINGS";
 


### PR DESCRIPTION
The other vim derivations all use a common definition of `hardeningDisable` which disables `fortify`. The vim source already sets `-D_FORTIFY_SOURCE=1` so it's not fully disabled, though it's certainly weaker than what we get if we don't disable it.

Disabling `fortify` like this fixes a crash that occurs as a consequence of `strictflexarrays1` now being enabled by default. Arguably we should just disable that instead of disabling `fortify` but this keeps us consistent with the other vim derivations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
