### PR TITLE
vim: enable fortify when using clang

### DIFF
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -1,4 +1,8 @@
-{ lib, fetchFromGitHub }:
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+}:
 rec {
   version = "9.2.0106";
 
@@ -17,7 +21,7 @@ rec {
   enableParallelBuilding = true;
   enableParallelInstalling = false;
 
-  hardeningDisable = [ "fortify" ];
+  hardeningDisable = if stdenv.cc.isClang then [ "strictflexarrays1" ] else [ "fortify" ];
 
   # Use man from $PATH; escape sequences are still problematic.
   postPatch = ''

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -17,7 +17,7 @@
 }:
 
 let
-  common = callPackage ./common.nix { };
+  common = callPackage ./common.nix { inherit stdenv; };
 in
 stdenv.mkDerivation {
   pname = "vim";

--- a/pkgs/applications/editors/vim/full.nix
+++ b/pkgs/applications/editors/vim/full.nix
@@ -81,7 +81,7 @@ let
     endif
   '';
 
-  common = callPackage ./common.nix { };
+  common = callPackage ./common.nix { inherit stdenv; };
 
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Our vim derivations have been disabling fortify for 10 years, due to a crash at the time that had yet to be fixed upstream. The vim configure script tries to strip out any `_FORTIFY_SOURCE` definition provided by the caller in favor of setting `-D_FORTIFY_SOURCE=1` itself and cites a crash introduced in gcc 4.0 as the reason, but our MacVim package has been running with fortify enabled without any known issues. After testing it seems that compiling vim with clang works just fine with fortify, but compiling it with gcc detects a buffer overflow and aborts.

We do still need to disable `strictflexarrays1` though, as vim's `ufunc_S` struct ends with a `uf_name[4]` field that is treated as a flexible array with a minimum length of 4.

I tested `pkgs.vim` on `aarch64-darwin` by running it and letting it process my vimrc files. I also tested enabling `fortify` on `aarch64-linux` but that aborted on launch, and that's why this commit only changes the hardening flags for clang. I subsequently tested building vim with clang on `aarch64-linux` and that worked fine.

I also submitted https://github.com/NixOS/nixpkgs/pull/506844 which makes the MacVim derivation use the same `common.nix` file for hardening flags; if that PR gets merged first, this one will need to be rebased and updated to tweak `macvim.nix` as well for the `stdenv` arg.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
