### PR TITLE
python3Packages.logical-unification: fix build on python 3.14

### DIFF
--- a/pkgs/development/python-modules/logical-unification/default.nix
+++ b/pkgs/development/python-modules/logical-unification/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
+  fetchpatch,
   toolz,
   multipledispatch,
   py,
@@ -13,7 +13,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "logical-unification";
   version = "0.4.7";
   pyproject = true;
@@ -21,9 +21,16 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pythological";
     repo = "unification";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-m1wB7WOGb/io4Z7Zfl/rckh08j6IKSiiwFKMvl5UzHg=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/pythological/unification/pull/49.patch";
+      hash = "sha256-0y1DHxxjQ19upOlstf/zihP1b6iQ4A/WqyWNpirW/kg=";
+    })
+  ];
 
   build-system = [
     setuptools
@@ -42,11 +49,6 @@ buildPythonPackage rec {
     pytest-benchmark # Needed for the `--benchmark-skip` flag
   ];
 
-  disabledTests = lib.optionals (pythonAtLeast "3.12") [
-    # Failed: DID NOT RAISE <class 'RecursionError'>
-    "test_reify_recursion_limit"
-  ];
-
   pytestFlags = [
     "--benchmark-skip"
     "--html=testing-report.html"
@@ -62,4 +64,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ Etjean ];
   };
-}
+})


### PR DESCRIPTION
Pulls a patch from upstream to fix the failing tests. Stops disabling the test that is broken on 3.12+ because upstream has done that for us.

Tracking: #475732
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
