### PR TITLE
podman: remove runc from the default extraRuntimes list

### DIFF
--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -122,8 +122,7 @@ in
     extraRuntimes = mkOption {
       type = with types; listOf package;
       # keep the default in sync with the podman package
-      default = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.runc ];
-      defaultText = lib.literalExpression "lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.runc ]";
+      default = [ ];
       example = lib.literalExpression ''
         [
           pkgs.gvisor

--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -32,12 +32,6 @@ import ../make-test-python.nix (
           boot.supportedFilesystems = [ "zfs" ];
           networking.hostId = "00000000";
         };
-      rootful_norunc =
-        { pkgs, ... }:
-        {
-          virtualisation.podman.enable = true;
-          virtualisation.podman.extraRuntimes = [ ];
-        };
       rootless =
         { pkgs, ... }:
         {
@@ -86,20 +80,10 @@ import ../make-test-python.nix (
 
 
       rootful.wait_for_unit("sockets.target")
-      rootful_norunc.wait_for_unit("sockets.target")
       rootless.wait_for_unit("sockets.target")
       dns.wait_for_unit("sockets.target")
       docker.wait_for_unit("sockets.target")
       start_all()
-
-      with subtest("Run container as root with runc"):
-          rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful.succeed(
-              "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-          rootful.succeed("podman ps | grep sleeping")
-          rootful.succeed("podman stop sleeping")
-          rootful.succeed("podman rm sleeping")
 
       with subtest("Run container as root with crun"):
           rootful.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
@@ -119,46 +103,10 @@ import ../make-test-python.nix (
           rootful.succeed("podman stop sleeping")
           rootful.succeed("podman rm sleeping")
 
-      # now without installed runc
-      with subtest("Run runc-less container as root with runc"):
-          rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful_norunc.fail(
-              "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-
-      with subtest("Run runc-less container as root with crun"):
-          rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful_norunc.succeed(
-              "podman run --runtime=crun -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-          rootful_norunc.succeed("podman ps | grep sleeping")
-          rootful_norunc.succeed("podman stop sleeping")
-          rootful_norunc.succeed("podman rm sleeping")
-
-      with subtest("Run runc-less container as root with the default backend"):
-          rootful_norunc.succeed("tar cv --files-from /dev/null | podman import - scratchimg")
-          rootful_norunc.succeed(
-              "podman run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-          )
-          rootful_norunc.succeed("podman ps | grep sleeping")
-          rootful_norunc.succeed("podman stop sleeping")
-          rootful_norunc.succeed("podman rm sleeping")
-
       # start systemd session for rootless
       rootless.succeed("loginctl enable-linger alice")
       rootless.succeed(su_cmd("whoami"))
       rootless.sleep(1)
-
-      with subtest("Run container rootless with runc"):
-          rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))
-          rootless.succeed(
-              su_cmd(
-                  "podman run --runtime=runc -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg /bin/sleep 10"
-              )
-          )
-          rootless.succeed(su_cmd("podman ps | grep sleeping"))
-          rootless.succeed(su_cmd("podman stop sleeping"))
-          rootless.succeed(su_cmd("podman rm sleeping"))
 
       with subtest("Run container rootless with crun"):
           rootless.succeed(su_cmd("tar cv --files-from /dev/null | podman import - scratchimg"))

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -20,10 +20,9 @@
   replaceVars,
   extraPackages ? [ ],
   crun,
-  runc,
   krunkit,
   conmon,
-  extraRuntimes ? lib.optionals stdenv.hostPlatform.isLinux [ runc ], # e.g.: runc, gvisor, youki
+  extraRuntimes ? [ ], # e.g.: runc, gvisor, youki
   fuse-overlayfs,
   util-linuxMinimal,
   nftables,


### PR DESCRIPTION
Podman works perfectly fine with `crun` by default. There is no reason to additionally pull in `runc`, if it's never used by most users. People enabling `virtualisation.podman` without `runc` in extraRuntimes at the moment have to rebuild `podman` locally, since the derivation isn't built and cached on cache.nixos.org.

This PR partially reverts https://github.com/NixOS/nixpkgs/pull/443399. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
