### PR TITLE
termframe: init at 0.8.5

### DIFF
--- a/pkgs/by-name/te/termframe/package.nix
+++ b/pkgs/by-name/te/termframe/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  runCommand,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "termframe";
+  version = "0.8.5";
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-Ws+0L752D/ESOZJe9RU63TGlKfpGsS2DxKy+8uYmCfw=";
+
+  src = fetchFromGitHub {
+    owner = "pamburus";
+    repo = "termframe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7+odV1mkUtObSV8LiDJn5MmT3xBm42XScHulFk23KB4=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installManPage --name termframe.1 <($out/bin/termframe --man-page)
+
+    installShellCompletion --cmd termframe \
+     --bash <($out/bin/termframe --shell-completions bash) \
+     --fish <($out/bin/termframe --shell-completions fish) \
+     --zsh <($out/bin/termframe --shell-completions zsh)
+  '';
+
+  passthru = {
+    tests = {
+      echo = runCommand "${finalAttrs.pname}-tests-echo" { } ''
+        mkdir $out
+        ${finalAttrs.finalPackage}/bin/termframe --mode dark --font-family "My Test Font" --output "$out/hello.svg" -- echo 'Hello, World!'
+        grep --quiet 'Hello, World' "$out/hello.svg"
+        grep --quiet 'My Test Font' "$out/hello.svg"
+      '';
+    };
+    updateScript = nix-update-script { };
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Terminal output SVG screenshot tool";
+    longDescription = "A non-interactive terminal emulator that executes a single command, renders its output in an internal virtual session, and exports a screenshot as an SVG file.";
+    homepage = "https://github.com/pamburus/termframe";
+    changelog = "https://github.com/pamburus/termframe/releases";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ ilai-deutel ];
+    mainProgram = "termframe";
+  };
+})


### PR DESCRIPTION
> This tool is a non-interactive terminal emulator that executes a single command, renders its output in an internal virtual session, and exports a screenshot as an SVG file.

https://github.com/pamburus/termframe

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
