### PR TITLE
gnfinder: init at 1.1.6

### DIFF
--- a/pkgs/by-name/gn/gnfinder/package.nix
+++ b/pkgs/by-name/gn/gnfinder/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gnfinder";
+  version = "1.1.6";
+
+  src = fetchFromGitHub {
+    owner = "gnames";
+    repo = "gnfinder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-huv9NnFQAZwzjZ7EYF0XNDXWBHA3F9yOjLRqxEvLzd0=";
+  };
+
+  vendorHash = "sha256-28+KOS5qeSvhkC5QgzwzOKyqqFlbtnUHTsBgZj8vBa0=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/gnames/gnfinder/ent/version.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Find and verify scientific names in text";
+    homepage = "https://github.com/gnames/gnfinder";
+    changelog = "https://github.com/gnames/gnfinder/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "gnfinder";
+    maintainers = with lib.maintainers; [ attila ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
