### PR TITLE
﻿home-assistant-custom-components: disable socket-dependent tests

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
@@ -26,6 +26,12 @@ buildHomeAssistantComponent rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # tests try to open sockets
+    "test_manual_flow_ac_device"
+    "test_manual_flow_cc_device"
+  ];
+
   meta = {
     changelog = "https://github.com/mill1000/midea-ac-py/releases/tag/${src.tag}";
     description = "Home Assistant custom integration to control Midea (and associated brands) air conditioners via LAN";

--- a/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
@@ -30,6 +30,13 @@ buildHomeAssistantComponent rec {
     pytest-homeassistant-custom-component
   ];
 
+  disabledTests = [
+    # tests try to open sockets
+    "test_form_success"
+    "test_form_already_configured"
+    "test_form_with_options"
+  ];
+
   meta = {
     description = "Home Assistant Mitsubishi Air Conditioner Integration";
     changelog = "https://github.com/pymitsubishi/homeassistant-mitsubishi/releases/tag/v${version}";

--- a/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
@@ -34,6 +34,12 @@ buildHomeAssistantComponent rec {
   ]
   ++ home-assistant.getPackages "camera" home-assistant.python.pkgs;
 
+  disabledTests = [
+    # tests try to open sockets
+    "test_thumbnail_camera_from_img_to_none"
+    "test_bad_connection_config_flow"
+  ];
+
   #skip phases with nothing to do
   dontConfigure = true;
 


### PR DESCRIPTION
﻿Three custom components have tests that try to open real sockets during config flow validation. These fail in the Nix build sandbox.

Affected components:

 - midea_ac: `test_manual_flow_ac_device`, `test_manual_flow_cc_device` - `msmart-ng` opens a TCP connection to the AC unit
 - mitsubishi: `test_form_success`, `test_form_already_configured`, `test_form_with_options` - `pymitsubishi` makes HTTP requests
 - moonraker: `test_thumbnail_camera_from_img_to_none`, `test_bad_connection_config_flow` - `moonraker-api` attempts websocket connections

The tests pass fine when sockets are allowed, they just aren't properly mocked. Disabled them for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
