### PR TITLE
gnparser: init at 1.14.2

### DIFF
--- a/pkgs/by-name/gn/gnparser/package.nix
+++ b/pkgs/by-name/gn/gnparser/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gnparser";
+  version = "1.14.2";
+
+  src = fetchFromGitHub {
+    owner = "gnames";
+    repo = "gnparser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QqBg0BUbP8p1sqVRVSny0oqBIc4wY0jX8VlivOPn2bg=";
+  };
+
+  vendorHash = "sha256-Oitse5Te35Cs8Ub7ueDw60JM5p8FOsyMsZif8OQQ+uE=";
+
+  subPackages = [ "gnparser" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/gnames/gnparser/ent/version.Version=${finalAttrs.version}"
+  ];
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage man/gnparser.1
+  '';
+  meta = {
+    description = "Parser for scientific names";
+    homepage = "https://github.com/gnames/gnparser";
+    changelog = "https://github.com/gnames/gnparser/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "gnparser";
+    maintainers = with lib.maintainers; [ attila ];
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
