### PR TITLE
rust-ui-cli: package init at 0.3.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28772,6 +28772,12 @@
     githubId = 230381;
     name = "Daniel Nilsson";
   };
+  vrashabh-sontakke = {
+    email = "vrashabhsontakke@outlook.com";
+    github = "Vrashabh-Sontakke";
+    githubId = 86019029;
+    name = "Vrashabh Sontakke";
+  };
   vrinek = {
     email = "vrinek@hey.com";
     github = "vrinek";

--- a/pkgs/by-name/ru/rust-ui-cli/package.nix
+++ b/pkgs/by-name/ru/rust-ui-cli/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchCrate,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rust-ui-cli";
+  version = "0.3.12";
+
+  src = fetchCrate {
+    pname = "ui-cli";
+    inherit (finalAttrs) version;
+    hash = "sha256-z1XbZ4dU5pdFhhdUVKbfmcnPKuqYkwE4AivRks9t+fc=";
+  };
+
+  cargoHash = "sha256-CyYhfG5a8DBetIPA+C7X4ZfkxI9dfCqOP1jMd3TlD4o=";
+
+  # Integration tests make HTTP requests to the rust-ui registry
+  doCheck = false;
+
+  meta = {
+    description = "CLI to add rust-ui components to your Leptos project";
+    longDescription = ''
+      A command-line tool for the rust-ui component library. Provides commands
+      to initialise projects, browse and install components, diff installed
+      components against the registry, and start an MCP server for AI editor
+      integration (Claude Code, Cursor, VS Code).
+    '';
+    homepage = "https://rust-ui.com/docs/components/cli";
+    changelog = "https://github.com/rust-ui/ui/blob/main/crates/ui-cli/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vrashabh-sontakke ];
+    mainProgram = "ui";
+  };
+})


### PR DESCRIPTION
Adds rust-ui-cli to nixpkgs (new package at 0.3.12).

rust-ui-cli is a CLI for rust-ui/Leptos projects. It can initialize project config, browse/search/install components, diff installed components against the registry, and run an MCP server for AI editor integration.

Homepage: https://rust-ui.com/docs/components/cli
Changelog: https://github.com/rust-ui/cli/blob/master/CHANGELOG.md
Crate: https://crates.io/crates/ui-cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
