### PR TITLE
qiling: 1.4.6 -> 1.4.7

### DIFF
--- a/pkgs/development/python-modules/qiling/default.nix
+++ b/pkgs/development/python-modules/qiling/default.nix
@@ -1,8 +1,10 @@
 {
   lib,
   buildPythonPackage,
+  unittestCheckHook,
+  poetry-core,
   capstone,
-  fetchPypi,
+  fetchFromGitHub,
   gevent,
   keystone-engine,
   multiprocess,
@@ -15,18 +17,21 @@
   termcolor,
   unicorn,
 }:
-
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "qiling";
-  version = "1.4.6";
-  format = "setuptools";
+  version = "1.4.7";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-l3WQBlJic4lXCe5Z1FmoxaqOblE7uAaW2gG/nTn84Kc=";
+  src = fetchFromGitHub {
+    owner = "qilingframework";
+    repo = "qiling";
+    tag = finalAttrs.version;
+    hash = "sha256-B3p3Ve/mZvKZLbVlEjItS+O4tSYwJV7wSsj0gV/CZq8=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ poetry-core ];
+
+  dependencies = [
     capstone
     gevent
     keystone-engine
@@ -41,18 +46,21 @@ buildPythonPackage rec {
     unicorn
   ];
 
-  # Tests are broken (attempt to import a file that tells you not to import it,
-  # amongst other things)
-  doCheck = false;
+  pythonRelaxDeps = [
+    "capstone"
+    "unicorn"
+  ];
 
   pythonImportsCheck = [ "qiling" ];
+  # to be enabled in the future, when we figure out how to exclude tests from unittestCheckHook
+  # nativeCheckInputs = [ unittestCheckHook ];
+  # doCheck = false;
 
   meta = {
     description = "Qiling Advanced Binary Emulation Framework";
     homepage = "https://qiling.io/";
-    changelog = "https://github.com/qilingframework/qiling/releases/tag/${version}";
+    changelog = "https://github.com/qilingframework/qiling/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
-    broken = true;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ BonusPlay ];
   };
-}
+})


### PR DESCRIPTION
Step up as a maintainer and no longer mark the package as broken.
I updated build system to poetry (since that's what qiling now uses) and relaxed dependencies a bit so that we can use libs from nixpkgs. From my quick (~20 minutes) of testing everything seems to work just fine.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test