### PR TITLE
nixos/ghorg: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5643,6 +5643,11 @@
     githubId = 148147150;
     name = "Curran McConnell";
   };
+  CuSO4Deposit = {
+    github = "CuSO4Deposit";
+    githubId = 87959312;
+    name = "cuso4d";
+  };
   cust0dian = {
     email = "serg@effectful.software";
     github = "cust0dian";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -62,6 +62,15 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-ghorg": [
+    "index.html#module-services-ghorg"
+  ],
+  "module-services-ghorg-basic-usage": [
+    "index.html#module-services-ghorg-basic-usage"
+  ],
+  "module-services-ghorg-multiple-jobs-and-credentials": [
+    "index.html#module-services-ghorg-multiple-jobs-and-credentials"
+  ],
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -104,6 +104,8 @@
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
+- [ghorg](https://github.com/gabrie30/ghorg), a tool for cloning and mirroring repositories from GitHub, GitLab, Gitea, and other supported SCM providers. Available as [services.ghorg](#opt-services.ghorg.enable).
+
 - [perses](https://perses.dev/), the open dashboard tool for Prometheus and other data sources. Available as [services.perses](#opt-services.perses.enable).
 
 - [Drasl](https://github.com/unmojang/drasl), an alternative authentication server for Minecraft. Available as [services.drasl](#opt-services.drasl.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -863,6 +863,7 @@
   ./services/misc/fstrim.nix
   ./services/misc/gammu-smsd.nix
   ./services/misc/geoipupdate.nix
+  ./services/misc/ghorg.nix
   ./services/misc/gitea.nix
   ./services/misc/gitlab.nix
   ./services/misc/gitolite.nix

--- a/nixos/modules/services/misc/ghorg.md
+++ b/nixos/modules/services/misc/ghorg.md
@@ -1,0 +1,72 @@
+# ghorg {#module-services-ghorg}
+
+`services.ghorg` manages scheduled [`ghorg`](https://github.com/gabrie30/ghorg)
+`reclone` jobs on NixOS.
+
+It is intended for repository mirroring workflows such as cloning all
+repositories from a GitHub organization, a GitLab group, or a self-hosted SCM
+instance into a local directory tree.
+
+## Basic usage {#module-services-ghorg-basic-usage}
+
+```nix
+{
+  services.ghorg = {
+    enable = true;
+    startAt = "daily";
+
+    jobs.nixpkgs = {
+      args = [
+        "clone"
+        "NixOS"
+      ];
+      settings = {
+        scmType = "github";
+        cloneType = "org";
+        cloneProtocol = "https";
+      };
+    };
+  };
+}
+```
+
+## Multiple jobs and credentials {#module-services-ghorg-multiple-jobs-and-credentials}
+
+```nix
+{
+  services.ghorg = {
+    enable = true;
+    environmentFile = "/run/secrets/ghorg-common.env";
+
+    jobs = {
+      github = {
+        args = [
+          "clone"
+          "my-org"
+        ];
+        tokenFile = "/run/secrets/github-token";
+        settings = {
+          scmType = "github";
+          cloneType = "org";
+          cloneToPath = "/var/lib/ghorg";
+          preserveScmHostname = true;
+        };
+      };
+
+      gitlab = {
+        args = [
+          "clone"
+          "my-group"
+        ];
+        tokenFile = "/run/secrets/gitlab-token";
+        settings = {
+          scmType = "gitlab";
+          cloneType = "org";
+          baseUrl = "https://gitlab.example.com";
+          cloneProtocol = "ssh";
+        };
+      };
+    };
+  };
+}
+```

--- a/nixos/modules/services/misc/ghorg.nix
+++ b/nixos/modules/services/misc/ghorg.nix
@@ -1,0 +1,503 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.ghorg;
+  yaml = pkgs.formats.yaml { };
+
+  hasInlineConfig =
+    job:
+    job.rawSettings != { }
+    || builtins.any (value: value != null) [
+      job.settings.scmType
+      job.settings.cloneType
+      job.settings.sshHostname
+      job.settings.baseUrl
+      job.settings.cloneProtocol
+      job.settings.outputDir
+      job.settings.concurrency
+      job.settings.preserveScmHostname
+      job.settings.preserveDir
+      job.settings.skipArchived
+      job.settings.skipForks
+      job.settings.branch
+      job.settings.cloneToPath
+    ];
+
+  renderJobSettings =
+    job:
+    let
+      typedSettings =
+        lib.optionalAttrs (job.settings.scmType != null) { GHORG_SCM_TYPE = job.settings.scmType; }
+        // lib.optionalAttrs (job.settings.cloneType != null) { GHORG_CLONE_TYPE = job.settings.cloneType; }
+        // lib.optionalAttrs (job.settings.sshHostname != null) {
+          GHORG_SSH_HOSTNAME = job.settings.sshHostname;
+        }
+        // lib.optionalAttrs (job.settings.baseUrl != null) {
+          GHORG_SCM_BASE_URL = job.settings.baseUrl;
+        }
+        // lib.optionalAttrs (job.settings.cloneProtocol != null) {
+          GHORG_CLONE_PROTOCOL = job.settings.cloneProtocol;
+        }
+        // lib.optionalAttrs (job.settings.outputDir != null) { GHORG_OUTPUT_DIR = job.settings.outputDir; }
+        // lib.optionalAttrs (job.settings.concurrency != null) {
+          GHORG_CONCURRENCY = job.settings.concurrency;
+        }
+        // lib.optionalAttrs (job.settings.preserveScmHostname != null) {
+          GHORG_PRESERVE_SCM_HOSTNAME = job.settings.preserveScmHostname;
+        }
+        // lib.optionalAttrs (job.settings.preserveDir != null) {
+          GHORG_PRESERVE_DIRECTORY_STRUCTURE = job.settings.preserveDir;
+        }
+        // lib.optionalAttrs (job.settings.skipArchived != null) {
+          GHORG_SKIP_ARCHIVED = job.settings.skipArchived;
+        }
+        // lib.optionalAttrs (job.settings.skipForks != null) { GHORG_SKIP_FORKS = job.settings.skipForks; }
+        // lib.optionalAttrs (job.settings.branch != null) { GHORG_BRANCH = job.settings.branch; }
+        // {
+          GHORG_ABSOLUTE_PATH_TO_CLONE_TO =
+            if job.settings.cloneToPath != null then job.settings.cloneToPath else cfg.dataDir;
+        };
+    in
+    typedSettings // job.rawSettings;
+
+  jobConfigFile =
+    name: job:
+    if job.configFile != null then
+      job.configFile
+    else
+      yaml.generate "ghorg-${name}.yaml" (renderJobSettings job);
+
+  jobCommand =
+    name: job:
+    lib.escapeShellArgs (
+      [ "ghorg" ]
+      ++ job.args
+      ++ [
+        "--config"
+        (jobConfigFile name job)
+      ]
+      ++ lib.optionals (job.tokenFile != null) [
+        "--token"
+        job.tokenFile
+      ]
+      ++ job.extraArgs
+    );
+
+  recloneConfig = yaml.generate "ghorg-reclone.yaml" (
+    lib.mapAttrs (
+      name: job:
+      {
+        cmd = jobCommand name job;
+      }
+      // lib.optionalAttrs (job.description != null) { description = job.description; }
+      // lib.optionalAttrs (job.postExecScript != null) {
+        post_exec_script = toString job.postExecScript;
+      }
+    ) cfg.jobs
+  );
+in
+{
+  options.services.ghorg = {
+    enable = lib.mkEnableOption "ghorg mirror jobs managed through ghorg reclone";
+
+    package = lib.mkPackageOption pkgs "ghorg" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "ghorg";
+      description = "User account that runs ghorg.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "ghorg";
+      description = "Primary group for the ghorg service.";
+    };
+
+    createUser = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to create the ghorg system user automatically.";
+    };
+
+    createGroup = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to create the ghorg system group automatically.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/ghorg";
+      description = ''
+        Working directory for ghorg and the default clone destination for jobs
+        that do not override `settings.cloneToPath`.
+      '';
+    };
+
+    dataDirMode = lib.mkOption {
+      type = lib.types.str;
+      default = "0750";
+      example = "0700";
+      description = "Permissions mode used when creating `dataDir` via systemd-tmpfiles.";
+    };
+
+    startAt = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "daily";
+      description = ''
+        Optional systemd timer schedule in `OnCalendar=` format. Leave `null`
+        to manage execution manually.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Optional shared environment file for the ghorg reclone service. This is
+        appropriate for GHORG_* variables that may be reused across multiple
+        jobs.
+      '';
+    };
+
+    jobs = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, ... }:
+          {
+            options = {
+              description = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Optional description written into the generated reclone entry.";
+              };
+
+              postExecScript = lib.mkOption {
+                type = lib.types.nullOr (lib.types.either lib.types.path lib.types.str);
+                default = null;
+                description = "Optional `post_exec_script` value for this reclone entry.";
+              };
+
+              args = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [
+                  "clone"
+                  name
+                ];
+                example = [
+                  "clone"
+                  "my-org"
+                ];
+                description = ''
+                  ghorg subcommand and arguments for this job, excluding the
+                  executable name. `--config` is appended automatically.
+                '';
+              };
+
+              extraArgs = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                example = [
+                  "--preserve-dir"
+                ];
+                description = ''
+                  Additional command-line arguments appended after `args`.
+                  These override equivalent settings from `settings` or
+                  `rawSettings`, because ghorg prefers CLI flags over `conf.yaml`.
+                '';
+              };
+
+              configFile = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = ''
+                  Existing ghorg configuration file for this job. When set, the
+                  module will not generate a config from `settings` or
+                  `rawSettings`.
+                '';
+              };
+
+              tokenFile = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                example = "/run/agenix/ghorg-github-token";
+                description = ''
+                  Optional token file path appended as `--token` for this job.
+                  Use this for per-provider secrets when a single shared
+                  `environmentFile` is not appropriate.
+                '';
+              };
+
+              settings = {
+                scmType = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "github";
+                  description = ''
+                    Which provider to clone from, for example `github`,
+                    `gitlab`, `gitea`, or `bitbucket`. This corresponds to the
+                    `--scm` flag and defaults to `github` in ghorg.
+                  '';
+                };
+
+                cloneType = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "user";
+                  description = ''
+                    Type of entity to clone, typically `user` or `org`. This
+                    corresponds to `--clone-type` and is important for targets
+                    like GitHub users, which otherwise default to org mode.
+                  '';
+                };
+
+                sshHostname = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "github.com";
+                  description = ''
+                    Override the SSH hostname used in clone URLs. This is useful
+                    when your `~/.ssh/config` defines aliases for the same SCM
+                    provider. It only applies when `cloneProtocol = "ssh"`.
+                  '';
+                };
+
+                baseUrl = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "https://gitlab.example.com";
+                  description = ''
+                    Override the SCM API base URL. This is intended for
+                    self-hosted SCM instances such as self-hosted GitLab or
+                    Gitea.
+                  '';
+                };
+
+                cloneProtocol = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "ssh";
+                  description = ''
+                    Which protocol ghorg should use for clone URLs. ghorg
+                    supports `https` or `ssh` and defaults to `https`.
+                  '';
+                };
+
+                outputDir = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  example = "github";
+                  description = ''
+                    Subdirectory created under `cloneToPath`. ghorg clones into
+                    `absolute_path_to_clone_to/output_dir/repo`; by default it
+                    uses the org or user name you are cloning.
+                  '';
+                };
+
+                concurrency = lib.mkOption {
+                  type = lib.types.nullOr lib.types.ints.positive;
+                  default = null;
+                  description = ''
+                    Maximum number of goroutines ghorg uses while cloning. The
+                    upstream default is `25`.
+                  '';
+                };
+
+                preserveScmHostname = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Append the SCM hostname to `cloneToPath` so clones are
+                    organized by provider host, for example
+                    `/data/ghorg/github.com/...`.
+                  '';
+                };
+
+                preserveDir = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Preserve provider-specific directory structure instead of
+                    flattening everything under one output directory. For GitLab
+                    this keeps namespace paths such as `group/subgroup/repo`.
+                  '';
+                };
+
+                skipArchived = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Skip archived repositories. Upstream notes this currently
+                    applies to GitHub, GitLab, and Gitea.
+                  '';
+                };
+
+                skipForks = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Skip repositories that are forks. Upstream notes this
+                    currently applies to GitHub, GitLab, and Gitea.
+                  '';
+                };
+
+                branch = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = ''
+                    Branch ghorg resets to and leaves checked out after sync.
+                    When unset, ghorg uses the repository default branch and
+                    falls back to `master` if no default branch is found.
+                  '';
+                };
+
+                cloneToPath = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = ''
+                    Absolute path where ghorg creates its clone directory tree.
+                    Shell expansions do not work. When unset, this module uses
+                    the service `dataDir`.
+                  '';
+                };
+              };
+
+              rawSettings = lib.mkOption {
+                type = lib.types.attrsOf lib.types.anything;
+                default = { };
+                example = {
+                  GHORG_BITBUCKET_SERVER = true;
+                };
+                description = ''
+                  Additional ghorg config keys written directly into the
+                  generated `conf.yaml`. Use upstream `GHORG_*` key names here.
+                  This layer overrides keys produced from `settings`.
+                '';
+              };
+            };
+          }
+        )
+      );
+      default = { };
+      description = ''
+        Set of ghorg jobs. Each job is rendered into a dedicated config and a
+        generated reclone entry. A single ordinary clone run is modeled as a
+        single job.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/" cfg.dataDir;
+        message = "services.ghorg.dataDir must be an absolute path.";
+      }
+      {
+        assertion = builtins.match "[0-7]{4}" cfg.dataDirMode != null;
+        message = "services.ghorg.dataDirMode must be a four-digit octal mode string such as 0750.";
+      }
+      {
+        assertion = cfg.environmentFile == null || lib.hasPrefix "/" cfg.environmentFile;
+        message = "services.ghorg.environmentFile must be null or an absolute path.";
+      }
+      {
+        assertion = cfg.jobs != { };
+        message = "services.ghorg.jobs must define at least one job.";
+      }
+    ]
+    ++ lib.flatten (
+      lib.mapAttrsToList (name: job: [
+        {
+          assertion = job.args != [ ];
+          message = "services.ghorg.jobs.${name}.args must not be empty.";
+        }
+        {
+          assertion = lib.head job.args == "clone";
+          message = "services.ghorg.jobs.${name}.args must begin with `clone` for ghorg reclone.";
+        }
+        {
+          assertion = job.configFile == null || lib.hasPrefix "/" job.configFile;
+          message = "services.ghorg.jobs.${name}.configFile must be null or an absolute path.";
+        }
+        {
+          assertion = job.tokenFile == null || lib.hasPrefix "/" job.tokenFile;
+          message = "services.ghorg.jobs.${name}.tokenFile must be null or an absolute path.";
+        }
+        {
+          assertion = job.settings.cloneToPath == null || lib.hasPrefix "/" job.settings.cloneToPath;
+          message = "services.ghorg.jobs.${name}.settings.cloneToPath must be null or an absolute path.";
+        }
+        {
+          assertion = job.configFile == null || !(hasInlineConfig job);
+          message = "services.ghorg.jobs.${name} cannot set configFile together with settings or rawSettings.";
+        }
+      ]) cfg.jobs
+    );
+
+    users.groups = lib.mkIf cfg.createGroup {
+      ${cfg.group} = { };
+    };
+
+    users.users = lib.mkIf cfg.createUser {
+      ${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+        createHome = false;
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} ${cfg.dataDirMode} ${cfg.user} ${cfg.group} -"
+    ];
+
+    systemd.services.ghorg = {
+      description = "Mirror repositories with ghorg";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = [
+        cfg.package
+        pkgs.git
+        pkgs.openssh
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        Environment = [
+          "HOME=${cfg.dataDir}"
+          "GHORG_RECLONE_PATH=${recloneConfig}"
+        ];
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStart = lib.escapeShellArgs [
+          (lib.getExe cfg.package)
+          "reclone"
+        ];
+      };
+    };
+
+    systemd.timers.ghorg = lib.mkIf (cfg.startAt != null) {
+      description = "Run ghorg on a schedule";
+      wantedBy = [ "timers.target" ];
+      partOf = [ "ghorg.service" ];
+      timerConfig = {
+        OnCalendar = cfg.startAt;
+        Unit = "ghorg.service";
+      };
+    };
+  };
+
+  meta = {
+    doc = ./ghorg.md;
+    maintainers = with lib.maintainers; [ CuSO4Deposit ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -637,6 +637,7 @@ in
   gerrit = runTest ./gerrit.nix;
   getaddrinfo = runTest ./getaddrinfo.nix;
   geth = runTest ./geth.nix;
+  ghorg = runTest ./ghorg.nix;
   ghostunnel = runTest ./ghostunnel.nix;
   ghostunnel-modular = runTest ./ghostunnel-modular.nix;
   gitdaemon = runTest ./gitdaemon.nix;

--- a/nixos/tests/ghorg.nix
+++ b/nixos/tests/ghorg.nix
@@ -1,0 +1,88 @@
+{ pkgs, ... }:
+{
+  name = "ghorg";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.etc = {
+        "ghorg.env".text = ''
+          GHORG_TOKEN=shared-token
+        '';
+        "ghorg-token".text = "per-job-token";
+      };
+
+      services.ghorg = {
+        enable = true;
+        startAt = "daily";
+        environmentFile = "/etc/ghorg.env";
+        package = pkgs.writeShellScriptBin "ghorg" ''
+          set -eu
+          printf '%s\n' "$@" > "$HOME/invocation.args"
+          printf '%s\n' "$GHORG_RECLONE_PATH" > "$HOME/invocation.reclone-path"
+          ${pkgs.coreutils}/bin/cp "$GHORG_RECLONE_PATH" "$HOME/reclone.yaml"
+        '';
+        jobs.nixos = {
+          description = "Mirror NixOS repositories";
+          postExecScript = "/bin/true";
+          args = [
+            "clone"
+            "NixOS"
+          ];
+          tokenFile = "/etc/ghorg-token";
+          settings = {
+            scmType = "github";
+            cloneType = "org";
+            sshHostname = "github.com";
+            baseUrl = "https://github.example.com";
+            cloneProtocol = "ssh";
+            outputDir = "github";
+            concurrency = 4;
+            preserveScmHostname = true;
+            preserveDir = true;
+            skipArchived = true;
+            skipForks = true;
+            branch = "main";
+            cloneToPath = "/var/lib/ghorg/mirrors";
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("ghorg.timer")
+    machine.succeed("systemctl cat ghorg.timer | grep -F 'OnCalendar=daily'")
+
+    machine.succeed("systemctl start ghorg.service")
+    machine.succeed("systemctl show ghorg.service --property=Result --value | grep -Fx success")
+
+    machine.succeed("test -d /var/lib/ghorg")
+    machine.succeed("stat -c '%U:%G' /var/lib/ghorg | grep -Fx 'ghorg:ghorg'")
+    machine.succeed("grep -Fx reclone /var/lib/ghorg/invocation.args")
+    machine.succeed("test -s /var/lib/ghorg/reclone.yaml")
+    machine.succeed("grep -F 'description: Mirror NixOS repositories' /var/lib/ghorg/reclone.yaml")
+    machine.succeed("grep -F 'post_exec_script: /bin/true' /var/lib/ghorg/reclone.yaml")
+    machine.succeed("grep -F -- '--token /etc/ghorg-token' /var/lib/ghorg/reclone.yaml")
+
+    job_config = machine.succeed(
+        "grep -oE '/nix/store/[^ ]+-ghorg-nixos\\.yaml' /var/lib/ghorg/reclone.yaml | head -n1"
+    ).strip()
+    assert job_config, "missing generated ghorg job config path"
+
+    machine.succeed(f"grep -F 'GHORG_SCM_TYPE: github' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_CLONE_TYPE: org' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_SSH_HOSTNAME: github.com' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_SCM_BASE_URL: https://github.example.com' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_CLONE_PROTOCOL: ssh' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_OUTPUT_DIR: github' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_CONCURRENCY: 4' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_PRESERVE_SCM_HOSTNAME: true' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_PRESERVE_DIRECTORY_STRUCTURE: true' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_SKIP_ARCHIVED: true' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_SKIP_FORKS: true' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_BRANCH: main' {job_config}")
+    machine.succeed(f"grep -F 'GHORG_ABSOLUTE_PATH_TO_CLONE_TO: /var/lib/ghorg/mirrors' {job_config}")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a NixOS module for [ghorg](https://github.com/gabrie30/ghorg) as `services.ghorg`. `ghorg` is already packaged in nixpkgs, but it currently lacks declarative configuration through a NixOS module.

The module provides a declarative way to configure and run `ghorg reclone` jobs on NixOS, including generated per-job config files, optional timer-based execution, and basic service user/data directory management.

The test uses a stub `ghorg` executable. It intentionally does not exercise real SCM API access or upstream clone behavior, so it remains deterministic and offline.

The test validates the NixOS integration layer:
- generated systemd service/timer units
- generated reclone/job config
- invocation wiring and service execution
- user/group/data directory setup


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
