### PR TITLE
nixos/limine: pass distroName using JSON

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -491,13 +491,13 @@ def install_bootloader() -> None:
     config_file += option_from_config('term_margin', ['style', 'graphicalTerminal', 'margin'])
     config_file += option_from_config('term_margin_gradient', ['style', 'graphicalTerminal', 'marginGradient'])
 
-    config_file += textwrap.dedent('''
-        # @distroName@ boot entries start here
+    config_file += textwrap.dedent(f'''
+        # {config('distroName')} boot entries start here
     ''')
 
     for (profile, gens) in profiles:
         group_name = 'default profile' if profile == 'system' else f"profile '{profile}'"
-        config_file += f'/+@distroName@ {group_name}\n'
+        config_file += f'/+{config('distroName')} {group_name}\n'
 
         isFirst = True
 
@@ -506,7 +506,7 @@ def install_bootloader() -> None:
             isFirst = False
 
     config_file_path = os.path.join(limine_install_dir, 'limine.conf')
-    config_file += '\n# @distroName@ boot entries end here\n\n'
+    config_file += f'\n# {config('distroName')} boot entries end here\n\n'
 
     config_file += str(config('extraEntries'))
 

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -9,6 +9,7 @@ let
   efi = config.boot.loader.efi;
   limineInstallConfig = pkgs.writeText "limine-install.json" (
     builtins.toJSON {
+      inherit (config.system.nixos) distroName;
       nixPath = config.nix.package;
       efiBootMgrPath = pkgs.efibootmgr;
       liminePath = cfg.package;
@@ -432,7 +433,6 @@ in
           replacements = {
             python3 = pkgs.python3.withPackages (python-packages: [ python-packages.psutil ]);
             configPath = limineInstallConfig;
-            inherit (config.system.nixos) distroName;
           };
         };
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This refactors distroName to be passed via JSON instead of using `pkgs.replaceVars`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
