### PR TITLE
ghgrab: enable tests on darwin

### DIFF
--- a/pkgs/by-name/gh/ghgrab/package.nix
+++ b/pkgs/by-name/gh/ghgrab/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  stdenv,
+  versionCheckHook,
 }:
 
 # note: upstream has a flake
@@ -19,18 +19,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-S1wkdPYVvH+4rfCQ/IohrqvHsiVWlb9OW5Dva3jNeis=";
 
-  # fails on darwin
-  # https://github.com/abhixdd/ghgrab/issues/31
-  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    "--skip=agent_tree_invalid_url_returns_json_error"
-  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     changelog = "https://github.com/abhixdd/ghgrab/releases/tag/v${finalAttrs.version}";
     description = "Simple, pretty terminal tool that lets you search and download files from GitHub without leaving your CLI";
     homepage = "https://github.com/abhixdd/ghgrab";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "ghgrab";
+    maintainers = with lib.maintainers; [ phanirithvij ];
   };
 })


### PR DESCRIPTION
The upstream has fixed the failing test. and a new release has been merged
#506776

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
