### PR TITLE
picotool: add missing mbedtls

### DIFF
--- a/pkgs/by-name/pi/picotool/package.nix
+++ b/pkgs/by-name/pi/picotool/package.nix
@@ -22,6 +22,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-kIB/ODAvwWWoAQDq2cMiFuNWjzzLgPuRQv0NluWYU+Y=";
   };
 
+  postPatch = ''
+    # necessary for signing/hashing support. our pico-sdk does not come with
+    # it by default, and it shouldn't due to submodule size. pico-sdk uses
+    # an upstream version of mbedtls 3.x so we patch ours in directly.
+    substituteInPlace lib/CMakeLists.txt \
+      --replace-fail "''$"'{PICO_SDK_PATH}/lib/mbedtls' '${mbedtls.src}'
+  '';
+
   buildInputs = [
     libusb1
     pico-sdk


### PR DESCRIPTION
#450680 tried to update `mbedtls` from 2.x to 3.x, but accidentally removed any reference to `mbedtls`, causing `seal` and `encrypt` commands missing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
