### PR TITLE
datovka: migrate to by-name and modernize derivation

### DIFF
--- a/pkgs/by-name/da/datovka/package.nix
+++ b/pkgs/by-name/da/datovka/package.nix
@@ -3,13 +3,9 @@
   stdenv,
   fetchurl,
   pkg-config,
-  wrapQtAppsHook,
   libxml2,
   libdatovka,
-  qmake,
-  qtbase,
-  qtwebsockets,
-  qtsvg,
+  libsForQt5,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,16 +19,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     libdatovka
-    qmake
-    qtbase
-    qtsvg
+    libsForQt5.qmake
+    libsForQt5.qtbase
+    libsForQt5.qtsvg
     libxml2
-    qtwebsockets
+    libsForQt5.qtwebsockets
   ];
 
   meta = {

--- a/pkgs/by-name/da/datovka/package.nix
+++ b/pkgs/by-name/da/datovka/package.nix
@@ -8,13 +8,13 @@
   libsForQt5,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "datovka";
   version = "4.28.0";
 
   src = fetchurl {
-    url = "https://gitlab.nic.cz/datovka/datovka/-/archive/v${version}/datovka-v${version}.tar.gz";
-    sha256 = "sha256-vTfmJEwbfaPFnZE8o3YnZhjwfMZ0At7eZ0iMoh4/HQE=";
+    url = "https://gitlab.nic.cz/datovka/datovka/-/archive/v${finalAttrs.version}/datovka-v${finalAttrs.version}.tar.gz";
+    hash = "sha256-vTfmJEwbfaPFnZE8o3YnZhjwfMZ0At7eZ0iMoh4/HQE=";
   };
 
   nativeBuildInputs = [
@@ -39,4 +39,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "datovka";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1694,8 +1694,6 @@ with pkgs;
 
   datasette = with python3Packages; toPythonApplication datasette;
 
-  datovka = libsForQt5.callPackage ../applications/networking/datovka { };
-
   diagrams-builder = callPackage ../tools/graphics/diagrams-builder {
     inherit (haskellPackages) ghcWithPackages diagrams-builder;
   };


### PR DESCRIPTION
This pull request refactors the packaging of the `datovka` application in Nixpkgs. The main focus is on migrating the package definition to the new package set layout, updating dependencies to use the `libsForQt5` attribute set, and cleaning up references in the top-level package list.

Key changes:

**Package migration and refactoring:**

* Renamed and moved the `datovka` package definition from `pkgs/applications/networking/datovka/default.nix` to `pkgs/by-name/da/datovka/package.nix`, updating the function signature to use the `finalAttrs` convention.
* Updated all Qt5 dependencies in `buildInputs` and `nativeBuildInputs` to use the `libsForQt5` attribute set, ensuring consistent and modern dependency management.

**Top-level package list cleanup:**

* Removed the old reference to `datovka` from `pkgs/top-level/all-packages.nix`, as it is now handled by the new package set.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
