### PR TITLE
sing-box: allow empty settings

### DIFF
--- a/nixos/modules/services/networking/sing-box.nix
+++ b/nixos/modules/services/networking/sing-box.nix
@@ -50,6 +50,7 @@ in
       serviceConfig = {
         User = "sing-box";
         Group = "sing-box";
+        ConfigurationDirectory = "sing-box";
         StateDirectory = "sing-box";
         StateDirectoryMode = "0700";
         RuntimeDirectory = "sing-box";
@@ -62,11 +63,15 @@ in
               chown --reference=/run/sing-box /run/sing-box/config.json
             '';
           in
-          "+${script}";
-        ExecStart = [
-          ""
-          "${lib.getExe cfg.package} -D \${STATE_DIRECTORY} -C \${RUNTIME_DIRECTORY} run"
-        ];
+          lib.mkIf (cfg.settings != { }) "+${script}";
+        ExecStart =
+          let
+            configDir = if cfg.settings != { } then "RUNTIME_DIRECTORY" else "CONFIGURATION_DIRECTORY";
+          in
+          [
+            ""
+            "${lib.getExe cfg.package} -D \${STATE_DIRECTORY} -C \${${configDir}} run"
+          ];
       };
       # After= is specified by upstream
       requires = [ "network-online.target" ];

--- a/nixos/tests/sing-box.nix
+++ b/nixos/tests/sing-box.nix
@@ -511,6 +511,31 @@ in
           };
         };
       };
+
+    empty_settings =
+      { ... }:
+      {
+        environment.etc."sing-box/config.json".text = builtins.toJSON {
+          inbounds = [
+            {
+              type = "mixed";
+              listen = "127.0.0.1";
+              listen_port = 1088;
+            }
+          ];
+          outbounds = [
+            {
+              type = "direct";
+              tag = "outbound:direct";
+            }
+          ];
+        };
+
+        services.sing-box = {
+          enable = true;
+          settings = { };
+        };
+      };
   };
 
   testScript = ''
@@ -558,6 +583,9 @@ in
       fakeip.wait_for_unit("sing-box.service")
       fakeip.wait_until_succeeds("ip route get ${hosts."${target_host}"} | grep 'dev ${tunInbound.interface_name}'")
       fakeip.succeed("dig +short A ${target_host} @${target_host} | grep '^198.18.'")
+
+    with subtest("empty settings"):
+      empty_settings.wait_for_unit("sing-box.service")
   '';
 
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

With `services.sing-box.settings = {}`, `-C` points to the runtime directory. This PR makes it point to the configuration directory so users can manage their configs in `/etc/sing-box` in the traditional way.

Also added a new test. Not sure if it is really needed though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
