### PR TITLE
u-root: 0.15.0-unstable-2026-02-12 -> 0.16.0

### DIFF
--- a/pkgs/by-name/u-/u-root/package.nix
+++ b/pkgs/by-name/u-/u-root/package.nix
@@ -5,7 +5,7 @@
   coreutils,
   bash,
   nix-update-script,
-  fetchpatch,
+  u-root-cmds,
 
   linuxManualConfig,
   fetchurl,
@@ -14,21 +14,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "u-root";
-  version = "0.15.0-unstable-2026-02-12";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "u-root";
     repo = "u-root";
-    rev = "0f23b8374acf4f00b457c69c13c3fe73dd5bab86";
-    hash = "sha256-RwEegwzBpw0r0fPyNhB35hyaAcqSt8dUmYf2N5WrpQQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QHLVkQJkgTSB9a/QLgl4SKrWje0OhtBpa56zGQK8m+o=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/u-root/u-root/commit/aeeb2aafd6a35416d5941b496e44a94594021424.patch";
-      hash = "sha256-h+b/s9NkreQfFWezEup1DpQjfyiJpHQGTD/RyKmkF8s=";
-    })
-  ];
 
   vendorHash = null;
 
@@ -62,6 +55,7 @@ buildGoModule (finalAttrs: {
       allowImportFromDerivation = true;
     };
     updateScript = nix-update-script { };
+    tests.u-root-cmds = u-root-cmds;
   };
 
   meta = {
@@ -70,6 +64,8 @@ buildGoModule (finalAttrs: {
       u-root can create a one-binary root file system (initramfs) containing a busybox-like set of tools written in Go.
 
       The package exposes `u-root.kernel-amd64` passthru for a minimal and pre-configured kernel to be used locally with QEMU.
+
+      The u-root commands are available as `u-root-cmds`.
     '';
     homepage = "https://u-root.org/";
     downloadPage = "https://github.com/u-root/u-root";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
