### PR TITLE
rsyslog,rsyslog-light: migrate to by-name, hardcode pname

### DIFF
--- a/pkgs/by-name/rs/rsyslog-light/package.nix
+++ b/pkgs/by-name/rs/rsyslog-light/package.nix
@@ -1,0 +1,30 @@
+{
+  rsyslog,
+}:
+
+rsyslog.override {
+  withKrb5 = false;
+  withSystemd = false;
+  withJemalloc = false;
+  withMysql = false;
+  withPostgres = false;
+  withDbi = false;
+  withNetSnmp = false;
+  withUuid = false;
+  withCurl = false;
+  withGnutls = false;
+  withGcrypt = false;
+  withLognorm = false;
+  withMaxminddb = false;
+  withOpenssl = false;
+  withRelp = false;
+  withKsi = false;
+  withLogging = false;
+  withNet = false;
+  withHadoop = false;
+  withRdkafka = false;
+  withMongo = false;
+  withCzmq = false;
+  withRabbitmq = false;
+  withHiredis = false;
+}

--- a/pkgs/by-name/rs/rsyslog/package.nix
+++ b/pkgs/by-name/rs/rsyslog/package.nix
@@ -39,13 +39,13 @@
   openssl,
   withRelp ? true,
   librelp,
-  withKsi ? true,
+  withKsi ? false, # Currently Broken
   libksi,
   withLogging ? true,
   liblogging,
   withNet ? true,
   libnet,
-  withHadoop ? true,
+  withHadoop ? false, # Currently Broken
   hadoop,
   withRdkafka ? true,
   rdkafka,

--- a/pkgs/by-name/rs/rsyslog/package.nix
+++ b/pkgs/by-name/rs/rsyslog/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "8.2512.0";
 
   src = fetchurl {
-    url = "https://www.rsyslog.com/files/download/rsyslog/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    url = "https://www.rsyslog.com/files/download/rsyslog/rsyslog-${finalAttrs.version}.tar.gz";
     hash = "sha256-k8UAJdkLbHlfo1DVaj2DK/zkUEPqm9aCQNnCqTlLxik=";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1935,33 +1935,6 @@ with pkgs;
 
   roundcubePlugins = recurseIntoAttrs (callPackage ../servers/roundcube/plugins { });
 
-  rsyslog-light = rsyslog.override {
-    withKrb5 = false;
-    withSystemd = false;
-    withJemalloc = false;
-    withMysql = false;
-    withPostgres = false;
-    withDbi = false;
-    withNetSnmp = false;
-    withUuid = false;
-    withCurl = false;
-    withGnutls = false;
-    withGcrypt = false;
-    withLognorm = false;
-    withMaxminddb = false;
-    withOpenssl = false;
-    withRelp = false;
-    withKsi = false;
-    withLogging = false;
-    withNet = false;
-    withHadoop = false;
-    withRdkafka = false;
-    withMongo = false;
-    withCzmq = false;
-    withRabbitmq = false;
-    withHiredis = false;
-  };
-
   xmlsort = perlPackages.XMLFilterSort;
 
   mcelog = callPackage ../os-specific/linux/mcelog {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1935,11 +1935,6 @@ with pkgs;
 
   roundcubePlugins = recurseIntoAttrs (callPackage ../servers/roundcube/plugins { });
 
-  rsyslog = callPackage ../tools/system/rsyslog {
-    withHadoop = false; # Currently Broken
-    withKsi = false; # Currently Broken
-  };
-
   rsyslog-light = rsyslog.override {
     withKrb5 = false;
     withSystemd = false;


### PR DESCRIPTION
This pull request refactors how the `rsyslog` and `rsyslog-light` packages are defined and managed, improving maintainability and clarity. The main changes involve moving package definitions to a more appropriate location, updating configuration defaults, and simplifying the top-level package file.

**Refactoring and package management:**

* Moved the `rsyslog` package definition from `pkgs/tools/system/rsyslog/default.nix` to `pkgs/by-name/rs/rsyslog/package.nix`, and updated all references accordingly.
* Created a new `rsyslog-light` package in `pkgs/by-name/rs/rsyslog-light/package.nix` that provides a minimal build by disabling a wide range of optional features via overrides.

**Configuration and maintenance improvements:**

* Changed the default values of `withKsi` and `withHadoop` options to `false` in the `rsyslog` package, as these features are currently broken.
* Fixed the source URL in the `rsyslog` package derivation to use the correct filename format (`rsyslog-${version}.tar.gz`).
* Removed the direct definitions and overrides of `rsyslog` and `rsyslog-light` from `pkgs/top-level/all-packages.nix`, delegating their configuration to the new package files for better modularity.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
