### PR TITLE
boulder: 0.20251118.0 -> 0.20260331.0; modernize; adopt

### DIFF
--- a/pkgs/by-name/bo/boulder/package.nix
+++ b/pkgs/by-name/bo/boulder/package.nix
@@ -3,19 +3,18 @@
   fetchFromGitHub,
   buildGoModule,
   testers,
-  boulder,
   minica,
   nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "boulder";
   version = "0.20260331.0";
 
   src = fetchFromGitHub {
     owner = "letsencrypt";
     repo = "boulder";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     leaveDotGit = true;
     postFetch = ''
       pushd $out
@@ -44,7 +43,7 @@ buildGoModule rec {
   ];
 
   preBuild = ''
-    ldflags+=" -X \"github.com/letsencrypt/boulder/core.BuildID=${version} +$(cat COMMIT)\""
+    ldflags+=" -X \"github.com/letsencrypt/boulder/core.BuildID=${finalAttrs.version} +$(cat COMMIT)\""
     ldflags+=" -X \"github.com/letsencrypt/boulder/core.BuildTime=$(date -u -d @0)\""
   '';
 
@@ -330,7 +329,7 @@ buildGoModule rec {
   ];
 
   checkFlags = [
-    "-skip ${lib.strings.concatStringsSep "|" disabledTests}"
+    "-skip ${lib.strings.concatStringsSep "|" finalAttrs.disabledTests}"
   ];
 
   postInstall = ''
@@ -341,8 +340,8 @@ buildGoModule rec {
 
   passthru = {
     tests.version = testers.testVersion {
-      package = boulder;
-      inherit version;
+      package = finalAttrs.finalPackage;
+      version = finalAttrs.version;
     };
     updateScript = nix-update-script { };
   };
@@ -361,4 +360,4 @@ buildGoModule rec {
     mainProgram = "boulder";
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/bo/boulder/package.nix
+++ b/pkgs/by-name/bo/boulder/package.nix
@@ -10,7 +10,7 @@
 
 buildGoModule rec {
   pname = "boulder";
-  version = "0.20251118.0";
+  version = "0.20260331.0";
 
   src = fetchFromGitHub {
     owner = "letsencrypt";
@@ -23,7 +23,7 @@ buildGoModule rec {
       find $out -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-JVkIu8Fh5F8WQXa45I0hnSedAaIQIOFidtWVpVHbAWA=";
+    hash = "sha256-2kYZp/cU9OuXmy8EDoX7htqlM7NpAl45Nf2S5MTVn6Y=";
   };
 
   vendorHash = null;
@@ -35,6 +35,8 @@ buildGoModule rec {
 
   subPackages = [ "cmd/boulder" ];
 
+  excludedPackages = [ "test/integration" ];
+
   ldflags = [
     "-s"
     "-w"
@@ -45,6 +47,8 @@ buildGoModule rec {
     ldflags+=" -X \"github.com/letsencrypt/boulder/core.BuildID=${version} +$(cat COMMIT)\""
     ldflags+=" -X \"github.com/letsencrypt/boulder/core.BuildTime=$(date -u -d @0)\""
   '';
+
+  __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [ minica ];
 
@@ -109,6 +113,7 @@ buildGoModule rec {
     "TestCountPendingAuthorizations2"
     "TestCountRegistrationsByIP"
     "TestCountRegistrationsByIPRange"
+    "TestCreateAndFetchRegistrations"
     "TestDbSettings"
     "TestDeactivateAccount"
     "TestDeactivateAuthorization"

--- a/pkgs/by-name/bo/boulder/package.nix
+++ b/pkgs/by-name/bo/boulder/package.nix
@@ -358,6 +358,6 @@ buildGoModule (finalAttrs: {
     '';
     license = lib.licenses.mpl20;
     mainProgram = "boulder";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })


### PR DESCRIPTION
Release: https://github.com/letsencrypt/boulder/releases/tag/v0.20260331.0
Diff: https://github.com/letsencrypt/boulder/compare/v0.20251118.0...v0.20260331.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
