### PR TITLE
blst: fix incorrect pkg-config flags

### DIFF
--- a/pkgs/by-name/bl/blst/package.nix
+++ b/pkgs/by-name/bl/blst/package.nix
@@ -53,8 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     URL: ${finalAttrs.meta.homepage}
     Version: ${finalAttrs.version}
 
-    Cflags: -I \''${includedir}
-    Libs: -L \''${libdir} -lblst
+    Cflags: -I\''${includedir}
+    Libs: -L\''${libdir} -lblst
     Libs.private:
     EOF
 


### PR DESCRIPTION
## Problem

The generated `libblst.pc` file contains invalid `Cflags` and `Libs` entries:
```
Cflags: -I ${includedir}
Libs: -L ${libdir} -lblst
```
The space between the flag (`-I`, `-L`) and the path causes `pkg-config` to emit malformed arguments:
```
/nix/store/.../include -I
-L /nix/store/.../lib -lblst
```
This leads to broken compiler/linker invocations, for example:

- include path not recognized correctly
- library directory passed as a positional argument instead of a search path
- linker errors such as:
```
library not found for -lblst
can't map file .../lib for architecture
```
## Root cause

`pkg-config` expects flags to be concatenated with their values:

`-I/path` (not `-I /path`)
`-L/path` (not `-L /path`)

When separated by a space, the flag and argument are treated as independent tokens, which breaks downstream tooling like Cabal and the system linker.

## Fix

Removed the space between the flag and the variable

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
