### PR TITLE
pioasm: 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/by-name/pi/pioasm/package.nix
+++ b/pkgs/by-name/pi/pioasm/package.nix
@@ -2,32 +2,21 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   ninja,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pioasm";
-  version = "2.1.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "pico-sdk";
-    rev = finalAttrs.version;
-    hash = "sha256-epO7yw6/21/ess3vMCkXvXEqAn6/4613zmH/hbaBbUw=";
+    tag = finalAttrs.version;
+    hash = "sha256-hQdEZD84/cnLSzP5Xr9vbOGROQz4BjeVOnvbyhe6rfM=";
   };
-
-  patches = [
-    # Pull upstream fix for gcc-15:
-    #   https://github.com/raspberrypi/pico-sdk/pull/2468
-    (fetchpatch {
-      name = "gcc-15.patch";
-      url = "https://github.com/raspberrypi/pico-sdk/commit/66540fe88e86a9f324422b7451a3b5dff4c0449f.patch";
-      hash = "sha256-KwTED7/IWorgRTw1XMU2ILJhf6DAioGuVIunlC1QdNE=";
-      stripLen = 2;
-    })
-  ];
 
   sourceRoot = "${finalAttrs.src.name}/tools/pioasm";
 
@@ -36,17 +25,16 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
-  installPhase = ''
-    runHook preInstall
+  cmakeFlags = [
+    (lib.cmakeFeature "PIOASM_VERSION_STRING" finalAttrs.version)
+  ];
 
-    install -D pioasm $out/bin/pioasm
-
-    runHook postInstall
-  '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Assemble PIO programs for Raspberry Pi Pico";
     homepage = "https://github.com/raspberrypi/pico-sdk";
+    changelog = "https://github.com/raspberrypi/pico-sdk/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
- Use cmake's built-in install targets instead of manually installing only the binary. This installs cmake config files (pioasmConfig.cmake, pioasmConfigVersion.cmake, pioasmTargets.cmake) to lib/cmake/pioasm/, enabling find_package(pioasm CONFIG) to work. Without these files, projects using pico-sdk fall back to rebuilding pioasm from source via ExternalProject_Add for every build target.
- Remove gcc-15 patch (included upstream)
- Add updateScript and changelog


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
