### PR TITLE
pcre2: 10.46 -> 10.47, modernize

### DIFF
--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation rec {
   pname = "pcre2";
-  version = "10.46";
+  version = "10.47";
 
   src = fetchurl {
     url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${version}/pcre2-${version}.tar.bz2";
-    hash = "sha256-FfvFq6a+7gsXrssEYCrjlDI5OroevY45t8q/fbiDKZ8=";
+    hash = "sha256-R/6MmUYSUNQviebo/a66naBXhV0G63/AjZygP9CNe8c=";
   };
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "10.46";
 
   src = fetchurl {
-    url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${version}/pcre2-${version}.tar.bz2";
+    url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${version}/pcre2-${version}.tar.bz2";
     hash = "sha256-FfvFq6a+7gsXrssEYCrjlDI5OroevY45t8q/fbiDKZ8=";
   };
 
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://www.pcre.org/";
+    changelog = "https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-${version}";
     description = "Perl Compatible Regular Expressions";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ ttuegel ];


### PR DESCRIPTION
changelog: https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.47
diff: https://github.com/PCRE2Project/pcre2/compare/pcre2-10.46...pcre2-10.47
news: https://github.com/PCRE2Project/pcre2/blob/pcre2-10.47/ChangeLog

Looking at the older `r-ryantm` PR the packages doesn't *need* to be updated too often so I'm just going to leave this here for now.

The License notice for sljit might be worth adding in `meta.license` (https://github.com/PCRE2Project/pcre2/blob/f454e231fe5006dd7ff8f4693fd2b8eb94333429/ChangeLog#L29-L30).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
