### PR TITLE
libiscsi: Enable -Wno-error flags on riscv

### DIFF
--- a/pkgs/by-name/li/libiscsi/package.nix
+++ b/pkgs/by-name/li/libiscsi/package.nix
@@ -23,16 +23,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  env = lib.optionalAttrs (stdenv.hostPlatform.is32bit || stdenv.hostPlatform.isDarwin) {
-    NIX_CFLAGS_COMPILE = toString [
-      # iscsi-discard.c:223:57: error: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
-      "-Wno-error=format"
-      # multithreading.c:257:16: error: 'sem_init' is deprecated [-Werror,-Wdeprecated-declarations]
-      "-Wno-error=deprecated-declarations"
-      # scsi-lowlevel.c:1244:11: error: cast from 'uint8_t *' (aka 'unsigned char *') to 'uint16_t *' (aka 'unsigned short *') increases required alignment from 1 to 2 [-Werror,-Wcast-align]
-      "-Wno-error=cast-align"
-    ];
-  };
+  env =
+    lib.optionalAttrs
+      (stdenv.hostPlatform.is32bit || stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isRiscV)
+      {
+        NIX_CFLAGS_COMPILE = toString [
+          # iscsi-discard.c:223:57: error: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
+          "-Wno-error=format"
+          # multithreading.c:257:16: error: 'sem_init' is deprecated [-Werror,-Wdeprecated-declarations]
+          "-Wno-error=deprecated-declarations"
+          # scsi-lowlevel.c:1244:11: error: cast from 'uint8_t *' (aka 'unsigned char *') to 'uint16_t *' (aka 'unsigned short *') increases required alignment from 1 to 2 [-Werror,-Wcast-align]
+          "-Wno-error=cast-align"
+        ];
+      };
 
   meta = {
     description = "iSCSI client library and utilities";


### PR DESCRIPTION
The cast-align error also happens on riscv64.

https://hydra.chir.rs/build/64483/nixlog/20/tail


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] [riscv64-linux](https://hydra.chir.rs/build/66761/nixlog/7)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@misuzu @NixOS/risc-v 