### PR TITLE
vscode-extensions.yoshi47.selection-path-copier: init at 1.5.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -5374,6 +5374,8 @@ let
         };
       };
 
+      yoshi47.selection-path-copier = callPackage ./yoshi47.selection-path-copier { };
+
       yy0931.vscode-sqlite3-editor = callPackage ./yy0931.vscode-sqlite3-editor { };
 
       yzane.markdown-pdf = callPackage ./yzane.markdown-pdf { };

--- a/pkgs/applications/editors/vscode/extensions/yoshi47.selection-path-copier/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/yoshi47.selection-path-copier/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  vscode-utils,
+  nix-update-script,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
+  mktplcRef = {
+    publisher = "yoshi47";
+    name = "selection-path-copier";
+    version = "1.5.0";
+    hash = "sha256-ip8dsU8B2vghINPSftvfC5OtM0bjIP0V3JAMt5skmdg=";
+  };
+  meta = {
+    description = "Copy file paths with line numbers, code snippets, and GitHub permalinks in multiple formats";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=yoshi47.selection-path-copier";
+    homepage = "https://github.com/yoshi47/selection-path-copier";
+    changelog = "https://github.com/yoshi47/selection-path-copier/releases/tag/release/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aduh95 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

https://marketplace.visualstudio.com/items?itemName=yoshi47.selection-path-copier

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
