### PR TITLE
flightcore: init at 3.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28213,6 +28213,12 @@
     githubId = 17836748;
     name = "Mason Mackaman";
   };
+  username-generic = {
+    name = "username-generic";
+    email = "username-generic@tuta.io";
+    github = "username-generic";
+    githubId = 202454830;
+  };
   usertam = {
     name = "Samuel Tam";
     email = "code@usertam.dev";

--- a/pkgs/by-name/fl/flightcore/override-tauri.conf.json
+++ b/pkgs/by-name/fl/flightcore/override-tauri.conf.json
@@ -1,0 +1,8 @@
+{
+  "build": {
+    "beforeBuildCommand": ""
+  },
+  "bundle":{
+    "createUpdaterArtifacts": false
+  }
+}

--- a/pkgs/by-name/fl/flightcore/package.nix
+++ b/pkgs/by-name/fl/flightcore/package.nix
@@ -1,0 +1,117 @@
+{
+  buildNpmPackage,
+  cargo-tauri,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  glib-networking,
+  lib,
+  makeDesktopItem,
+  nodejs,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "flightcore";
+  version = "3.2.0";
+
+  src = fetchFromGitHub {
+    owner = "R2NorthstarTools";
+    repo = "FlightCore";
+    # tag = "v${finalAttrs.version}";
+    rev = "main";
+    hash = "sha256-NnU7ywJlF8qsU1M7wzlJHc86+0QaiIR6JCdmraPfr68=";
+  };
+
+  # `source/package.json`
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-+xrNKFcCatqbl79j/tSLFNTYjxXANFb3/vgWXYY2PGo=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+    sourceRoot = "source/src-vue";
+
+    # `source/src-vue/package.json`
+    npmDepsHash = "sha256-2PiMB9X/tp1QtTfUgVnH6caE+m2QSKTMYxPUHAUPWhQ=";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -a dist "$out"
+
+      runHook postInstall
+    '';
+  };
+
+  cargoHash = "sha256-ILsRsYHO1OMyfORxrUkr1jyjncLCGag+KefrWHmHpqQ=";
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  # This override does the following:
+  #
+  # * Disables creating updater artifacts - the default behavior causes issues
+  #   with building the package, but since it is going to be distributed via a
+  #   software repository, it won't need to auto-update itself anyways.
+  #
+  # * Empties `beforeBuildCommand` - the upstream Tauri configuration includes
+  #   commands that automatically build the software's front-end, before
+  #   building its back-end. However, since Nixpkgs requires NPM dependencies
+  #   to be hashed, we need to build the front-end in a separate step.
+  #
+  #   This way, we end up fetching the NPM dependencies from both
+  #   `source/package.json`, and `source/src-vue/package.json`.
+  tauriBuildFlags = "-c ${./override-tauri.conf.json}";
+
+  # Copy [frontend] to where it can be picked up by Tauri.
+  preBuild = ''
+    cp -a "${finalAttrs.frontend}"/dist src-vue
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "FlightCore";
+    desktopName = "FlightCore";
+    exec = "flightcore";
+    icon = "flightcore";
+    comment = finalAttrs.meta.description;
+    genericName = finalAttrs.meta.description;
+    categories = [
+      "Game"
+      "Utility"
+      "PackageManager"
+    ];
+    terminal = false;
+  };
+
+  meta = {
+    description = "Updater and mod manager for Northstar";
+    homepage = "https://github.com/R2NorthstarTools/FlightCore";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ username-generic ];
+    mainProgram = "flightcore";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/fl/flightcore/package.nix
+++ b/pkgs/by-name/fl/flightcore/package.nix
@@ -1,0 +1,120 @@
+{
+  buildNpmPackage,
+  cargo-tauri,
+  copyDesktopItems,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  glib-networking,
+  lib,
+  makeDesktopItem,
+  nodejs,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_1,
+  wrapGAppsHook4,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "flightcore";
+  version = "3.2.2";
+
+  src = fetchFromGitHub {
+    owner = "R2NorthstarTools";
+    repo = "FlightCore";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eTRtd616hWHgj3wg+jtrt/tFkaxUeKSN0d+XO1CghsE=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) pname version src;
+
+    # Hash of dependencies fetched from upstream's `package-lock.json` file.
+    hash = "sha256-+xrNKFcCatqbl79j/tSLFNTYjxXANFb3/vgWXYY2PGo=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+    sourceRoot = "source/src-vue";
+
+    # Hash of dependencies fetched from upstream's `src-vue/package-lock.json`
+    # file.
+    npmDepsHash = "sha256-2PiMB9X/tp1QtTfUgVnH6caE+m2QSKTMYxPUHAUPWhQ=";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -a dist "$out"
+
+      runHook postInstall
+    '';
+  };
+
+  cargoHash = "sha256-weidVeEIo3IIV+Xwe1htV46fRymOo5aRzHAEKQwKbvU=";
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  # This override does the following:
+  #
+  # * Disables creating updater artifacts - the default behavior causes issues
+  #   with building the package, but since it is going to be distributed via a
+  #   software repository, it won't need to auto-update itself anyways.
+  #
+  # * Empties `beforeBuildCommand` - the upstream Tauri configuration includes
+  #   commands that automatically build the software's front-end, before
+  #   building its back-end. However, since Nixpkgs requires NPM dependencies
+  #   to be hashed, we need to build the front-end in a separate step.
+  #
+  #   This way, we end up fetching the NPM dependencies from both
+  #   `source/package.json`, and `source/src-vue/package.json`.
+  tauriBuildFlags = "-c ${./override-tauri.conf.json}";
+
+  # Copy [frontend] to where it can be picked up by Tauri.
+  preBuild = ''
+    ln -s "${finalAttrs.frontend}"/dist src-vue
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    copyDesktopItems
+    nodejs
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "FlightCore";
+      desktopName = "FlightCore";
+      exec = "flightcore";
+      icon = "flightcore";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Game"
+        "PackageManager"
+      ];
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    description = "Updater and mod manager for Northstar";
+    homepage = "https://github.com/R2NorthstarTools/FlightCore";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ username-generic ];
+    mainProgram = "flightcore";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
[FlightCore](https://github.com/R2NorthstarTools/FlightCore) is a GUI game launcher, and mod manager, for [Northstar](https://northstar.tf).

The package is built from source since:
* the software is tricky to install on NixOS manually
* for Linux systems, upstream only provides AppImages, which are currently borked
* the software is stable, and updates aren't overly frequent

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
