### PR TITLE
unixodbc: 2.3.12 -> 2.3.14, adopt

### DIFF
--- a/pkgs/by-name/un/unixodbc/package.nix
+++ b/pkgs/by-name/un/unixodbc/package.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "ODBC driver manager for Unix";
     homepage = "https://www.unixodbc.org/";
     license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ hythera ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/un/unixodbc/package.nix
+++ b/pkgs/by-name/un/unixodbc/package.nix
@@ -1,21 +1,24 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  autoreconfHook,
+  fetchFromGitHub,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unixodbc";
-  version = "2.3.12";
+  version = "2.3.14";
 
-  # TODO: build from source https://github.com/lurcher/unixODBC
-  src = fetchurl {
-    urls = [
-      "ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-${finalAttrs.version}.tar.gz"
-      "https://www.unixodbc.org/unixODBC-${finalAttrs.version}.tar.gz"
-    ];
-    sha256 = "sha256-8hBQFEXOIb9ge6Ue+MEl4Q4i3/3/7Dd2RkYt9fAZFew=";
+  src = fetchFromGitHub {
+    owner = "lurcher";
+    repo = "unixODBC";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2WhUnpiNTtsoOJ4rvdxaadcW1ROWfdoSVA8Crj8rpo8=";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
 
   configureFlags = [
     "--disable-gui"

--- a/pkgs/by-name/un/unixodbc/package.nix
+++ b/pkgs/by-name/un/unixodbc/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
+    changelog = "https://github.com/lurcher/unixODBC/releases/tag/v${finalAttrs.version}";
     description = "ODBC driver manager for Unix";
     homepage = "https://www.unixodbc.org/";
     license = lib.licenses.lgpl2;


### PR DESCRIPTION
changelog: https://github.com/lurcher/unixODBC/releases/tag/v2.3.14
diff: https://github.com/lurcher/unixODBC/compare/2.3.12...v2.3.14

Supersedes #450185.

The amount of resulting files are the same. Only the content differs.
```
Files result/bin/dltest and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/bin/dltest differ
Files result/bin/isql and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/bin/isql differ
Files result/bin/iusql and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/bin/iusql differ
Files result/bin/odbc_config and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/bin/odbc_config differ
Files result/bin/odbcinst and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/bin/odbcinst differ
Files result/bin/slencheck and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/bin/slencheck differ
Files result/include/odbcinstext.h and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/include/odbcinstext.h differ
Files result/include/sql.h and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/include/sql.h differ
Files result/include/sqltypes.h and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/include/sqltypes.h differ
Files result/include/unixODBC/unixodbc_conf.h and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/include/unixODBC/unixodbc_conf.h differ
Files result/lib/libodbccr.la and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbccr.la differ
Files result/lib/libodbccr.so and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbccr.so differ
Files result/lib/libodbccr.so.2 and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbccr.so.2 differ
Files result/lib/libodbccr.so.2.0.0 and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbccr.so.2.0.0 differ
Files result/lib/libodbcinst.la and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbcinst.la differ
Files result/lib/libodbcinst.so and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbcinst.so differ
Files result/lib/libodbcinst.so.2 and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbcinst.so.2 differ
Files result/lib/libodbcinst.so.2.0.0 and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbcinst.so.2.0.0 differ
Files result/lib/libodbc.la and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbc.la differ
Files result/lib/libodbc.so and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbc.so differ
Files result/lib/libodbc.so.2 and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbc.so.2 differ
Files result/lib/libodbc.so.2.0.0 and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/libodbc.so.2.0.0 differ
Files result/lib/pkgconfig/odbccr.pc and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/pkgconfig/odbccr.pc differ
Files result/lib/pkgconfig/odbcinst.pc and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/pkgconfig/odbcinst.pc differ
Files result/lib/pkgconfig/odbc.pc and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/lib/pkgconfig/odbc.pc differ
Files result/share/man/man1/isql.1.gz and /nix/store/yra0v59yiks513j9lszvc0vb5pjxkb56-unixodbc-2.3.14/share/man/man1/isql.1.gz differ
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
