### PR TITLE
﻿home-assistant.tests.components.conversation: re-enable test_error_no_device_on_floor

### DIFF
--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -208,10 +208,6 @@ let
   };
 
   extraDisabledTests = {
-    conversation = [
-      # intent fixture mismatch
-      "test_error_no_device_on_floor"
-    ];
     ecovacs = [
       # Translation not found for vacuum
       "test_raise_segment_changed_issue"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -139,10 +139,6 @@ let
   };
 
   extraDisabledTests = {
-    conversation = [
-      # intent fixture mismatch
-      "test_error_no_device_on_floor"
-    ];
     ecovacs = [
       # Translation not found for vacuum
       "test_raise_segment_changed_issue"


### PR DESCRIPTION
The `test_error_no_device_on_floor` test was disabled due to an intent fixture mismatch introduced by a bad intents bump (home-assistant/core#162205), which was reverted in home-assistant/core#162226 and properly re-landed in home-assistant/core#162959 with intents 2026.2.13. Our intents package is at 2026.3.24, so the test passes now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
