### PR TITLE
buttplug-lite: init at 2.5.5

### DIFF
--- a/pkgs/by-name/bu/buttplug-lite/package.nix
+++ b/pkgs/by-name/bu/buttplug-lite/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeDesktopItem,
+  versionCheckHook,
+  pkg-config,
+  git,
+  makeWrapper,
+  copyDesktopItems,
+  libx11,
+  libGL,
+  libxcb,
+  libxkbcommon,
+  dbus,
+  udev,
+  openssl,
+  wayland,
+  stdenv,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "buttplug-lite";
+  version = "2.5.5";
+
+  src = fetchFromGitHub {
+    owner = "runtime-shady-backroom";
+    repo = "buttplug-lite";
+    tag = finalAttrs.version;
+    hash = "sha256-Z7xf+507rTWWygPV4p0+Q3e2rFIVgn1Ktu/W1P0FOfw=";
+  };
+
+  cargoHash = "sha256-XGfHJAlv1B+tFKhLqMWiUaVyCUnyuyVZmYz3wvwITQI=";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "buttplug-lite";
+      exec = "buttplug-lite";
+      desktopName = "Buttplug Lite";
+      comment = "Simplified buttplug.io API for when JSON is infeasible";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    git
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libx11
+    libGL
+    libxcb
+    libxkbcommon
+    dbus
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    udev
+    wayland
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/buttplug-lite --suffix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath (
+        [
+          libx11
+          libGL
+          libxcb
+          libxkbcommon
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [ wayland ]
+      )
+    }
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Simplified buttplug.io API for when JSON is infeasible";
+    homepage = "https://github.com/runtime-shady-backroom/buttplug-lite";
+    changelog = "https://github.com/runtime-shady-backroom/buttplug-lite/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ toasteruwu ];
+  };
+})


### PR DESCRIPTION
Created a package for https://github.com/runtime-shady-backroom/buttplug-lite

This one was a bit more complex to get working, i copied the homework of others as good as i can to follow convention, but this is a first for me in terms of things i needed to do to make it work, so please let me know if something isnt up to nixplgs standards and i will fix it asap.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
