### PR TITLE
schildi-revenge: 26.03.03 -> 26.04.04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29539,6 +29539,13 @@
     githubId = 117323435;
     name = "Andrés Pico";
   };
+  xeni = {
+    name = "xeni";
+    github = "Gernomaly";
+    githubId = 71495036;
+    email = "xeni@koeln.ccc.de";
+    matrix = "@xeni:koeln.ccc.de";
+  };
   xfnw = {
     email = "xfnw+nixos@riseup.net";
     github = "xfnw";

--- a/pkgs/by-name/sc/schildi-revenge/deps.json
+++ b/pkgs/by-name/sc/schildi-revenge/deps.json
@@ -2,19 +2,10 @@
  "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
  "!version": 1,
  "https://dl.google.com/dl/android/maven2/androidx": {
-  "annotation#annotation-jvm/1.8.0": {
-   "jar": "sha256-mqsybZSSgAmRhUNgrCSPSTzn98MYNRkwm3is6eJA9vY=",
-   "module": "sha256-48tFJVOdDtdLsjjvksae7yKoDkIsDSrLxR5hh/67ChM=",
-   "pom": "sha256-2fkI7m1IgSSs7VVv2Ka6nf5kf+AUuFrXIhRhEQ0DI2E="
-  },
   "annotation#annotation-jvm/1.9.1": {
    "jar": "sha256-HjQ5F+vye6lv5NxSscrX/TK3OPvGNVu2zVs7MF1yEtA=",
    "module": "sha256-A/tlkXfIYY5HQlklwRvJHzhHA+omwmW+myXNeSkrURw=",
    "pom": "sha256-ibmcIY1gAZMWtQqreYFnB7whaWyJagMOGxrgOJYby44="
-  },
-  "annotation#annotation/1.8.0": {
-   "module": "sha256-1ZCg2OAvQF3nSejcgLdB3FA8bj5MnAFtYU12tl8LWe8=",
-   "pom": "sha256-fDjBim6KzHvYjvrNfhR6iXqUW5nbci5U4LnOJEYQLVs="
   },
   "annotation#annotation/1.9.1": {
    "jar": "sha256-ODIq+nNFw34pxl7IhSF4rhwm4jCWoGNNB6SjiTkx9Yw=",
@@ -36,108 +27,130 @@
    "module": "sha256-v+t72E8/fdp71ztnCdSh9h9aN/hDcouuCKBn49+aCu8=",
    "pom": "sha256-LWXI0LNtS0+q3ESv+breI9hx1xWe7fKz8C2AKzS3elc="
   },
-  "compose/runtime#runtime-annotation-jvm/1.10.2": {
+  "compose/runtime#runtime-annotation-jvm/1.10.4": {
    "jar": "sha256-+J3ai81zh20PwWVohEsr15RD7nymKBCHTSXH3Ko5S9Y=",
-   "module": "sha256-bcUnp8TRJbJptXdZYt/kJBtwxF9H2CR0v8njCYBbdVw=",
-   "pom": "sha256-rJQC5K2FpjrKyH5sqRXtkneGPS80s74hH3ydnRTr+7Q="
+   "module": "sha256-q7WHXqnbAuulrJKWJTihbFmOj/nYjprWcYhuy5in8zE=",
+   "pom": "sha256-Y4wSOLV9v0CqRpBJbFRP49rEGqIidkA5Ka3J2Kkmp0Q="
   },
   "compose/runtime#runtime-annotation-jvm/1.9.0": {
    "jar": "sha256-mJstoov1unlmwIyi2z9IpgfmhOSrT/DegOnNXsZjwHY=",
    "module": "sha256-BwRUw9jx/YX9sCztcMXdVbnJUGqfHJYwmVrWtUhbweY=",
    "pom": "sha256-kTdIOF0hz/MrNeJZUR7w4mo4lt9+4P8Sv2rGEOreq2A="
   },
-  "compose/runtime#runtime-annotation/1.10.2": {
+  "compose/runtime#runtime-annotation-jvm/1.9.4": {
+   "jar": "sha256-mJstoov1unlmwIyi2z9IpgfmhOSrT/DegOnNXsZjwHY=",
+   "module": "sha256-cdTwQFv/4v7dHZuLZJ63DhuW0HBnQLVjhhhMEhZiALk=",
+   "pom": "sha256-OMb8W3u9UXzgpBSKwe+P1E+GoMLOHmlkm/FXhWDPLpY="
+  },
+  "compose/runtime#runtime-annotation/1.10.4": {
    "jar": "sha256-XUzoJpn1AaDI4eZyZY8fgIlTTgaYm/JTvfqxHixzBZU=",
-   "module": "sha256-ZE41sINE5OSZALN7VJdjnlN9bTXNcvZeSQioSrqCvV8=",
-   "pom": "sha256-vgICQEeT5zicLYyvmpBzcD9ep0TVGwy6VqdKBj0JbLg="
+   "module": "sha256-Q17dAVKhY2ScHpZ8EDwozI/FQV2C/XWa+lTCeVh9aq8=",
+   "pom": "sha256-PcTE2aXh8wzGSmXNFCUH9gBApMCcI2Oe/1JtVFIFIok="
   },
   "compose/runtime#runtime-annotation/1.9.0": {
    "module": "sha256-aI/PepDHx6su4gF+reuc2inzWuF+aq3sct/QdA8C5iQ=",
    "pom": "sha256-0Vin/5qk2CFOCF+dXHndAAKjLRgWoCOqn6omucRtg6c="
   },
-  "compose/runtime#runtime-desktop/1.10.2": {
+  "compose/runtime#runtime-annotation/1.9.4": {
+   "module": "sha256-JmaBc8UooQ3RpzXY0LF6q10ujJYWlTg72PHUSPCHws0=",
+   "pom": "sha256-zrmsMOstfKN8qXafyC3CFsEkeSHLC3eKW2q6YuVbhqI="
+  },
+  "compose/runtime#runtime-desktop/1.10.4": {
    "jar": "sha256-sZWGBUL2Et4FErVKdTU+D21YgV8MlTCgO8Ww5zRHSCk=",
-   "module": "sha256-xBIdemjoROKu7j4I9JMPWhfpvkGGR15YGOXG8ZAI5go=",
-   "pom": "sha256-lwkgQSl9VtBBiG5Wwz5a+l9opCS/QiPRCTa0CV2HaIo="
+   "module": "sha256-rZSsgLckO1eFIbwmkkMtgkNw/k6pZz7Sn032ask1WOc=",
+   "pom": "sha256-3JEGYnjcg1gbyIlv3yw+IMTnpPzs9Giticn7uTsxgqo="
   },
   "compose/runtime#runtime-desktop/1.9.0": {
    "jar": "sha256-rmV+QzL7cvobQ3zlyqSGxrSl4XWIqu8CZ6qSkYu6dFg=",
    "module": "sha256-vVE7iwcDHUB2Y2i/ILOSanNAU3lGxuhXJK1pknOn+g8=",
    "pom": "sha256-4ybvc2sUSnnTBXjuMcSiY0F1U5tcMyZPBcmrxvpl0fo="
   },
-  "compose/runtime#runtime-retain-desktop/1.10.2": {
+  "compose/runtime#runtime-desktop/1.9.4": {
+   "jar": "sha256-tWObLfBAhyh7WIbUfbHveRwnnBB07mKEgXJu2Qz/A+c=",
+   "module": "sha256-9NbvOvLHfjiA2GuAEzw8S2XhAaQTzYhks8FCZW8NZT8=",
+   "pom": "sha256-auYydwtkdmu36sMLZF+AarEk9kLOiFKKg4xsfOXtUkk="
+  },
+  "compose/runtime#runtime-retain-desktop/1.10.4": {
    "jar": "sha256-Rj7pwek9G5E0WL/syW0SijV0qAL0HIyXgdcyDDtV7Ys=",
-   "module": "sha256-w4oMg8g/0xm2HYrK52oLDQTf3bLMGhnNODIdn6Ikejo=",
-   "pom": "sha256-k6wJjf79Vkttnawp1cwR8F8nErnKSnDJZEyWwTqbo9Q="
+   "module": "sha256-Oy0aQGvi72V0m+43OwV9W9ko5pasHUV8svt8Z2ip/7A=",
+   "pom": "sha256-pu9nw3QDxfTIN4o+Jn2A2aNCQCYlgfxLpmxNuvgVZ1U="
   },
-  "compose/runtime#runtime-retain/1.10.2": {
+  "compose/runtime#runtime-retain/1.10.4": {
    "jar": "sha256-rxY11W6En8ruAC2dqeHeZsy3FULLodGWdkRBGU3BVEM=",
-   "module": "sha256-U5Rb39vDDJkOmuM8N/tsO7ye76GqjoeKNm1niQ6vWG0=",
-   "pom": "sha256-pmUgPT/hMcoXbfWCtkMaLjzIXZci9LeWcyJ7BVMb96M="
+   "module": "sha256-LtkHtK1i+r4JZlsdS3+eH1yqJ9qlovCheJWRK97wLVw=",
+   "pom": "sha256-eToadImlk0c8IgbXE/CD3ELxEuUTI2VAFNAR7JOKDzA="
   },
-  "compose/runtime#runtime-saveable-desktop/1.10.2": {
+  "compose/runtime#runtime-saveable-desktop/1.10.4": {
    "jar": "sha256-7yTiTMjJw7mHEAf731ie2aquz5WXmma3SEgG+fDiTZE=",
-   "module": "sha256-buT+7kpqletl6qkncleVHxwSvfpt6Wmvn/C+Zfs1ObM=",
-   "pom": "sha256-lRLMge6XclY+So1XX3qyS4fIL0aa8su91FiZilTovcE="
+   "module": "sha256-osSCCUVzXV/0EO3SPMxGNHCKsXRsJgM2MnGGf7czxRI=",
+   "pom": "sha256-CB5e4eJocN3BraB9WI7iLY8QKCHG/BNGVI3xBV1FGoE="
   },
-  "compose/runtime#runtime-saveable/1.10.2": {
+  "compose/runtime#runtime-saveable-desktop/1.9.4": {
+   "jar": "sha256-35kHo+Zyw/qdp+iAMTZ5zbB+gKfzFB9UrB7IFJ0MW+Y=",
+   "module": "sha256-BwrIv4Rv7/f5a+6uF++WBCvgs10uNdwOPHOv2aXLM4A=",
+   "pom": "sha256-t2I5gDlhPCa1EgSoOGyWicjr8lWD1DiXiG/IQew7aeU="
+  },
+  "compose/runtime#runtime-saveable/1.10.4": {
    "jar": "sha256-+ivj7IPEsSm8t6mxXOH8sNHXYzTn7dt7jzXOmt97CBE=",
-   "module": "sha256-ANG3ryxd7/QdyN+NkHY0dnXQAiwUZ35g51GcecZjBdk=",
-   "pom": "sha256-JVQuFexmeKw+hNsKiMRmXwgdz416E638eWP/ddtXXL0="
+   "module": "sha256-6JWHAAmDgGGgA0WH93kn/h3ZtIgYwyv7BTNssna0Ik0=",
+   "pom": "sha256-9BjpZIDQRAh1D9feJK7gNDBP/2DtcCgrCWrJHKAGZ3Y="
   },
-  "compose/runtime#runtime/1.10.2": {
+  "compose/runtime#runtime-saveable/1.9.4": {
+   "module": "sha256-exsm2uetyGKjS/vYPgoS5x3uI41Bp7pd42bOBVzaKPU=",
+   "pom": "sha256-I8fdOoHs474rqLTm7osX/Nkg3nRpADkkBW1Wltb9RP8="
+  },
+  "compose/runtime#runtime/1.10.4": {
    "jar": "sha256-OTRR9TXSGU2ljqSzu9oNoJu8DeHQQVF2q+AdVnZKDOM=",
-   "module": "sha256-M6hpeeFw8D+nfnkk+VjOZaC7ui8cXchmzOn+g60Mx38=",
-   "pom": "sha256-0cQQlie+6UMcjwjZRWM6IdE1gc9KZypdWepCABI+mAM="
+   "module": "sha256-lnBOQLXh5NpUxwrN0T778wscGcplh7TqbJ4v6NJb21I=",
+   "pom": "sha256-DthwOkiKSVOTMKEbJDWns6Fw2LaMSAOLxhoqbzGRQX4="
   },
   "compose/runtime#runtime/1.9.0": {
    "module": "sha256-sR6bZBtlR39obhm0mdqkNbr0INE7t56Y2wXsAYktsi4=",
    "pom": "sha256-0vrrNhehR8vOsH6B2tI8+wHi/QiJ3hO5kJWQChpe030="
   },
-  "datastore#datastore-core-jvm/1.2.0": {
+  "compose/runtime#runtime/1.9.4": {
+   "module": "sha256-f5pbcCKwprlNXD5LAOYS4Zbw2pkV1qs8Sd8dItFbb1o=",
+   "pom": "sha256-eVGpmylFQxFVtvqEwUoJh6pQXBevj6xvOz/zVQ9xcYw="
+  },
+  "datastore#datastore-core-jvm/1.2.1": {
    "jar": "sha256-3S0ID8FusL6h4C5VUdQ0lvueUXeFXFtyxqr24WqxxcE=",
-   "module": "sha256-DrbQ8S5ImcnX3f/WvCWWoTGnNs0XRaKzpSj5n/aj4GI=",
-   "pom": "sha256-yA6pTBIZGp84KEY/z/f1Saobjr1IbceTs6smWq7nFxQ="
+   "module": "sha256-n5XebiGnr+uq44H79ZKtcX0PipLdfhVISq3z6SUaSoY=",
+   "pom": "sha256-/HfBwerbtG10A85wFKe7JbQ55JuHr1OW24NF5OjQHUg="
   },
-  "datastore#datastore-core-okio-jvm/1.2.0": {
+  "datastore#datastore-core-okio-jvm/1.2.1": {
    "jar": "sha256-et5iOaZ2dINPVyRCjncsQXYintML4lOsflIIKikH7gU=",
-   "module": "sha256-Ct2oBJ8Dj4YutPfmp4y/9exvZukvqjcC2CJQTVrK74w=",
-   "pom": "sha256-bIPenceI0r8Gr5LB3BRBuWMCf92y0NQLvMGgjegILgs="
+   "module": "sha256-h1PfOHGdyVNabVODRmi5E30+EWcQghuya3h6hcn8v8o=",
+   "pom": "sha256-9jvfHz3Gn4wQi57GB8QznRIVm9lbamqtNKNAriG1N+s="
   },
-  "datastore#datastore-core-okio/1.2.0": {
+  "datastore#datastore-core-okio/1.2.1": {
    "jar": "sha256-qqFaAMdoj/Xobp6fbCj4fexa/plcRVA18lEBTSmMNMY=",
-   "module": "sha256-qOoJMo0zIj5WhftCC3UGqOe6CR3B2xCCnJSv7U8ldps=",
-   "pom": "sha256-uG57vBaxG7cxkXa+xPx+/yLwOGI/hGc0DjQsW0edFGo="
+   "module": "sha256-Uio4O9pYJQuWCKnOZ2L8oPVL6aOPlEay0uJhwsnOsqg=",
+   "pom": "sha256-l6IMy9DxVBo743GsqYmHKPZS/hpYg/9SuUg8YSvS5yg="
   },
-  "datastore#datastore-core/1.2.0": {
+  "datastore#datastore-core/1.2.1": {
    "jar": "sha256-724F4UniVvNgr6IJhajKUtjhGXBlfqKSpvu1cT95R9o=",
-   "module": "sha256-+BOlT9CkCpoeI0ZjW2lbn+VgE+4kYrsH6Gv/CywXAi0=",
-   "pom": "sha256-ZElglIl53kcvCeASnrJSeweN0JgFRqfh1N6xMj0somQ="
+   "module": "sha256-PsuQuyXi5OZ09U4VSWSZINGzHPOcjKLCyREV6Pivje0=",
+   "pom": "sha256-xQ8uSECCuGNRBn74OB07ApFTWjzbnlIgiRBZMPhNI7M="
   },
-  "datastore#datastore-preferences-core-jvm/1.2.0": {
+  "datastore#datastore-preferences-core-jvm/1.2.1": {
    "jar": "sha256-vINQxaOCo/aCYBSG9UUdYSLV/YwVr6Maznsi+pgAXqY=",
-   "module": "sha256-VqpMyA88Zyq0Hzt2REqqZtr+aguZOMNNnNz+DYhpwEs=",
-   "pom": "sha256-8KdtdjJK01vbuukzx1+Mf9H8mPKOSiEPwXcUYj+sVcA="
+   "module": "sha256-yO1zm8SUsu88iTP+qBqItqpgNfEu/7R0BAdmYQ//hE0=",
+   "pom": "sha256-I7MC9Tjee7D+DuOTnTBXQVB0rMzb3iubCbi2nOpxuns="
   },
-  "datastore#datastore-preferences-core/1.2.0": {
+  "datastore#datastore-preferences-core/1.2.1": {
    "jar": "sha256-/mJsICueo7bqzo2q6w5pL6XYL1Vx0sA3Wo3RT508ymY=",
-   "module": "sha256-4cJTWSFoSGaw46GMXZ25zek3NGCfy9fAzwBjy5dJEL0=",
-   "pom": "sha256-+mm/iqS2goFO8X9FQfBMWsNHxtvZ+VpbSXsd5pOuYWw="
+   "module": "sha256-RhuLV+aHzDFW7/tPrayde7XadyMm7mo0hE61nrCR2Yw=",
+   "pom": "sha256-lGmC5zev6Fn5A5+6GFdcodTx520Yghu3M9O0C0LeCvk="
   },
-  "datastore#datastore-preferences-external-protobuf/1.2.0": {
+  "datastore#datastore-preferences-external-protobuf/1.2.1": {
    "jar": "sha256-Twm6f8oqBzpcVSeptjdYK5PiYsK2qJl3xYTSjOqDjrw=",
-   "module": "sha256-/I67tB5mN3J1JS3g6JxkbXJeapMqqVZAsslttK+YLQE=",
-   "pom": "sha256-PwO1u6ARxVrzZCC05hX0zAQzKhfICNUgU4ds8g8PLwc="
+   "module": "sha256-AJRV3Ob24zyLPvmkSFn3u+o51JBKUjqibFtmYOAyZrI=",
+   "pom": "sha256-f3iN+Yvsc2EbIW+0vqYl2RMwBUIit4nnYmoUb4b7Iyc="
   },
-  "datastore#datastore-preferences-proto/1.2.0": {
+  "datastore#datastore-preferences-proto/1.2.1": {
    "jar": "sha256-2bvZT3jppskzCO7Sa4p+1GsfEooZwoL+NvloBOnXwYQ=",
-   "module": "sha256-//wGjV0yElIHedu+EL5Qm8K6CoV3jl7Eg1e1uYQBgTo=",
-   "pom": "sha256-Nh/vrjipiSnTvKzeVBnNN0ryoK607zEoGVHxkvJ/xz8="
-  },
-  "lifecycle#lifecycle-common-jvm/2.8.5": {
-   "jar": "sha256-YchzpzJ8lG7AM8MQu5jz+S7qvO3g4aUgCrihiWSDx78=",
-   "module": "sha256-BWg9kQ3FQdBsTJekmSs+KXGueMK1zDX2vx2OB94Olw4=",
-   "pom": "sha256-q5cbvWNFWm6QTCC8Ub19oVOMDAglIx5SvDA94KsenuA="
+   "module": "sha256-XrEsUlySObPJ6F2WsXea3Qy4ZrD7AC+MBvWyh6DvkbQ=",
+   "pom": "sha256-4vhhHTXgwleKQzM84/5eHLXlFo3XNDgQ0QrLZIhWbQY="
   },
   "lifecycle#lifecycle-common-jvm/2.9.2": {
    "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
@@ -148,10 +161,6 @@
    "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
    "module": "sha256-HRg385QrM+owqiMB/c6iY5QIoP1v1DaMIkePqBU6678=",
    "pom": "sha256-MXNemVOq7qtOB/z/pMarNRn5CzMcSx2oFz35EWB9OQY="
-  },
-  "lifecycle#lifecycle-common/2.8.5": {
-   "module": "sha256-AwuN8Z5JeKwb6WnCopoBv8LMVihPUSY5oK00wi2mxPE=",
-   "pom": "sha256-KCYLDQ/KghpeL0Ug1DKLt94SYCGz3c1Hgt1WQRLsn2E="
   },
   "lifecycle#lifecycle-common/2.9.2": {
    "module": "sha256-SDP4jjmhvSZO1eoYciAj6+UedLGaBBEkaqPXQOFukIE=",
@@ -172,11 +181,6 @@
    "module": "sha256-J9hk9AyjC5Z7hdqsa5F7va6mN9Y+EjlIyVBFwhvlhIM=",
    "pom": "sha256-DvP7KPibgLkMeK1ro0UWTVWQiJ7jRZsCfyZpWTYpFXU="
   },
-  "lifecycle#lifecycle-runtime-desktop/2.8.5": {
-   "jar": "sha256-EL/lO7J1L5Z3UaUQLNt4Xu6lTh1N9r3oj7D1CwpJFWw=",
-   "module": "sha256-7xi5Ie9z8pw0yf/rE0+ipKMIR7PgpKWFbABz6b9gBV0=",
-   "pom": "sha256-2RkYuV83/FPzkftWNFV2VlAmOuirwyjp5ry6imIBYqU="
-  },
   "lifecycle#lifecycle-runtime-desktop/2.9.2": {
    "jar": "sha256-L7SfdtECF5L7NZ4KkkbBUJ8vW1VfCkZZHSTVjetovVw=",
    "module": "sha256-LlSqpZmBsgH4wWFd8SOPcCXy/z82H+FNwOcJJhaJOu4=",
@@ -187,10 +191,6 @@
    "module": "sha256-+VLq6Qa8BiePYEGvs8EzPp1rAL5DeIV7zWahulg2eQk=",
    "pom": "sha256-+yriSTRTAzy/Kzp0qh36Z8/bwYmlTRkJg9/RVQLQtuc="
   },
-  "lifecycle#lifecycle-runtime/2.8.5": {
-   "module": "sha256-PnYlwcbHpLz6iHTZ2Xe08VX8M/bwKtbZQaQnAxENxHU=",
-   "pom": "sha256-BvksaPPGjzu339Gs/7yzNLuf+HxjWHQ9XUvCslds87Q="
-  },
   "lifecycle#lifecycle-runtime/2.9.2": {
    "module": "sha256-Tt2F+xoXbKfoOxW0dltc7hqTSqMX5BcQ+grBM0HXODo=",
    "pom": "sha256-C7WGx+arw98w0Xnqn72uhnREwnmoF6IQHAzJQ/ks79w="
@@ -199,11 +199,6 @@
    "jar": "sha256-ulZtD0bcAcIWl3jScjh4ns66oAZVZC4Cwk5Og+fcWQU=",
    "module": "sha256-3LxbW1BmboQlinS/2OUUkYxZOk/87wwDWFYqAvvYDFg=",
    "pom": "sha256-1helGd2zajCCE/W5r5kWOwo6NznOA4G2yND6aBRhOgg="
-  },
-  "lifecycle#lifecycle-viewmodel-desktop/2.8.5": {
-   "jar": "sha256-IewOd9wC7Q1r/m88un9D4lQARG2J3thWjuFlQ34MGSI=",
-   "module": "sha256-Xye5EC2feXeRfxjy6yYelXaxbV1lxIjd8missFVNkQ4=",
-   "pom": "sha256-N2sCiZt+1vZK4rmBfm3S/vNr0cQn9qj+p6vV2iVxq3k="
   },
   "lifecycle#lifecycle-viewmodel-desktop/2.9.2": {
    "jar": "sha256-mPgWvmhpQHyH1GBYdW+XeA+mxs9hrNupchb0E3Ma8V0=",
@@ -233,10 +228,6 @@
    "jar": "sha256-wMw+Mfw1hIbZbwJw3+Kw9E+YXwyrDvp3OipWfVX3YaU=",
    "module": "sha256-Q4nMoKmoAace/664j4nwoD2Zwivgk8U5qcD5w5YpVBY=",
    "pom": "sha256-aRK1XHRcV57G/L6wBl1aF9i18G3QpYeIA31B5A21AgI="
-  },
-  "lifecycle#lifecycle-viewmodel/2.8.5": {
-   "module": "sha256-UjEhedy+2gwntKyQIFdv5BBbBH/0V+dLbaQiRft3RXM=",
-   "pom": "sha256-zzU+toek04gE0IYSpbxV5aO22ZWWdRC9yypfSH91bPY="
   },
   "lifecycle#lifecycle-viewmodel/2.9.2": {
    "module": "sha256-uBT8ApPfHqN+GfIGrRg3A/+bslTdbarvXl59H4V/4Yw=",
@@ -450,25 +441,25 @@
    "module": "sha256-yGECuuKG8zdIIe+H9FO50b3XCQQ4fRWHI6FgyvTtHis=",
    "pom": "sha256-wzXWGRFakyrtcWEKbIAQIssts+vXeWpBf0rgwFyzCAM="
   },
-  "co/touchlab#kermit-core-jvm/2.0.8": {
+  "co/touchlab#kermit-core-jvm/2.1.0": {
    "jar": "sha256-o7+Kg6Q1Pz3UcpMjsojt0bfwR0x9MlHhYbJBodBwVDo=",
-   "module": "sha256-l09bcPms0kvVVKld9ZQtINh5qtuu8XmaqPRtWOLl/DY=",
-   "pom": "sha256-5f9Y8OhqtldqmosT/RqMARb2sznGCU2UX7p9YhiStHA="
+   "module": "sha256-1XB+LtLHU5Q3bjQXEux323nhpW0ouMa/Bt9AJiDyotw=",
+   "pom": "sha256-EbvK7nunAWJYi3FA1uqBGdUArrWoka2w+SJNHYrOfYU="
   },
-  "co/touchlab#kermit-core/2.0.8": {
+  "co/touchlab#kermit-core/2.1.0": {
    "jar": "sha256-I+HZ6s9suxI+J71rHzp/SJ6NefDt0A6xg35YgnNKWv4=",
-   "module": "sha256-FdKxKrNx/0VUxucDVJ4mBK2ySwhhxf6/qm5ErJO4WNs=",
-   "pom": "sha256-lX4+zNyAMBFacunVy2bcyhHHv3utiB8QTd5PD2GaCa0="
+   "module": "sha256-GFS2DlFXadp6mK9ctAzr9SqBmq5VibhMewuxRkCL+eM=",
+   "pom": "sha256-hByDSKnOdSX6ljgb8O7UnLaOCtiK97ag3dJAXT9RSNE="
   },
-  "co/touchlab#kermit-jvm/2.0.8": {
-   "jar": "sha256-huifnylLYW1l/Da6flH7S54/kFzThR39w12SbGWztuk=",
-   "module": "sha256-p09bPKKkIoOcPaRssUxWsH6gCYpDDGCLx0NtfusjYt8=",
-   "pom": "sha256-MqqCxZsHT6ozOArTiKzZtYBZr+Irm2aVIU72nXCO7wk="
+  "co/touchlab#kermit-jvm/2.1.0": {
+   "jar": "sha256-DHD/2yCQVAb9oWyCZYhSvIEyjma3FAF2CWDyEHKTL+0=",
+   "module": "sha256-QQvKCBq8Vr6kGtToDwAlhRIFi49hDpyDqFXwC6tVpKE=",
+   "pom": "sha256-Fg7hxMN89WSMVGxyofD05wgoGmrZYOwNkiFq4pB8lFI="
   },
-  "co/touchlab#kermit/2.0.8": {
-   "jar": "sha256-n9kqbHsDR0q7v//af3KBnnwmJpQanq2b17jyY+yadig=",
-   "module": "sha256-FWYAeowbMj1IllzZRoNT4GL0OdcJ3N2b8eUtWd5IICw=",
-   "pom": "sha256-z5a1kr1pUlwyEPzWiMuyKDlaVOHXciFVcaVVFu+GiWI="
+  "co/touchlab#kermit/2.1.0": {
+   "jar": "sha256-ZgGKM6VfvPiP4jZLXQyk3m8bgi0n+25lgQIfC5nkmnw=",
+   "module": "sha256-j5+C8LO6FjpyFoyjtNDIreZjiYWlSHCmrmxVSiVoDMc=",
+   "pom": "sha256-LttgVDFR0D1gnKQZd/mAyiPCauXJZUdfBIEsCDsWLFI="
   },
   "com/akuleshov7#ktoml-core-jvm/0.7.1": {
    "jar": "sha256-wiy2Ye78deMAB6GwjTfE6ToVf386lQpHglFjLAr2BQ0=",
@@ -478,6 +469,83 @@
   "com/akuleshov7#ktoml-core/0.7.1": {
    "module": "sha256-hRT4XEby1I04dPmzkG/JOIIHPDfb9tFx7+smenVd0mw=",
    "pom": "sha256-7gHJjNR9lVtZmKbK68N8H+SouOI1crHufEylupSd22w="
+  },
+  "com/github/ajalt/clikt#clikt-core-jvm/5.1.0": {
+   "jar": "sha256-f3gEn6gVm6wFzgnd70MTJI1MrQAUp0QhTBFQ0U42Yec=",
+   "module": "sha256-PGmchzr/jisrbNfNIsxUnupCkyePOPUxrDMXYy13tMI=",
+   "pom": "sha256-OKjX8Hz0pmZsFh29e6/uHXqFtKt3eSRsJ2LRbrcA2p4="
+  },
+  "com/github/ajalt/clikt#clikt-core/5.1.0": {
+   "jar": "sha256-Lv9Z62+f9azWNSRtZnN9JYaZW5MqnqrX5wsnESLjfAQ=",
+   "module": "sha256-tkXCUaJtPniCiBtsNH+FzJH/xg72yOwXhJRQLay7gw4=",
+   "pom": "sha256-2/rrFPlGzTHdwJDWvJmXoQTTPLV2oxu/5zWdvIerDSg="
+  },
+  "com/github/ajalt/clikt#clikt-jvm/5.1.0": {
+   "jar": "sha256-dcMwln2xWlxZH7pp/DsY/7aCcdVPkPIcHJxS6G+uudY=",
+   "module": "sha256-stbl8VmP1is31/28VSsNa0x93t+xvEoP7uziO/nFOTs=",
+   "pom": "sha256-LXaI+5VyidIY9du0gIen2aKdIyYKbkI63pFHywb+YnM="
+  },
+  "com/github/ajalt/clikt#clikt/5.1.0": {
+   "jar": "sha256-+oSo1XuQmSGh/WcZzxcU5NqF8UPUePYjR2uzYcwhq9w=",
+   "module": "sha256-CHn2eCFvk4T60/wR2tW1o+sdYyQ3eymlkjL0Vlu6D1A=",
+   "pom": "sha256-r9m7PkSlICN/3zIOYbrwUW6cGFZYEkJA0uDmZmI96og="
+  },
+  "com/github/ajalt/colormath#colormath-jvm/3.6.0": {
+   "jar": "sha256-WfdBrf5iBTBmeC2LGkWv0GaFpLxkszJ35Uh2uZPtiFw=",
+   "module": "sha256-P6dnMPmJ4ChN8YL87IViDZtIrjIhOYhBrGyviEYvYvg=",
+   "pom": "sha256-8Dw11QURDQZzNF9HQOVbzZdqmp+lobE8qirTmPO8Hl0="
+  },
+  "com/github/ajalt/colormath#colormath/3.6.0": {
+   "jar": "sha256-49ox0EqJXlNfXQh2TM9fODQcQr99aNqW6h8ACfclmdY=",
+   "module": "sha256-aQeqSXrbmvY4EsdTZjic7T5ruL7oDnsjmttMU2c/iIQ=",
+   "pom": "sha256-zh3tjA259LxNNjS64Vn9jVu2qWDyzTuWoAyPDnnOZAs="
+  },
+  "com/github/ajalt/mordant#mordant-core-jvm/3.0.2": {
+   "jar": "sha256-ZRw710/06Y201Y49z0sU6Ame4NIg5nL1cfjP7uRJOQU=",
+   "module": "sha256-5ye2C+d8MTeuuy+nqdhdGF+rt5BNlE3CFTnULAEdNZA=",
+   "pom": "sha256-BOsXQTz97is1U2zyHDT5pD/4u/7J7BAURbLuKsnh/7k="
+  },
+  "com/github/ajalt/mordant#mordant-core/3.0.2": {
+   "jar": "sha256-RyqVWswFRZLut06lYmFaaJxnTmPSbRLovo2nqF4bs3w=",
+   "module": "sha256-0flx5bMpTkS//zr6RA1843pR1Yg1aw+vsJDARrDpzgc=",
+   "pom": "sha256-Oh+bdkH+E7uMTwdCaSPmW5iPZqsPK5w5NwYn8qjZGis="
+  },
+  "com/github/ajalt/mordant#mordant-jvm-ffm-jvm/3.0.2": {
+   "jar": "sha256-ECJHhBJcnxeCwdTx0489VCNvzFXAMKKtAMvkMG4WK6Q=",
+   "module": "sha256-S4/mRlOuA7eSFrXFoOwm1Uyg+VMr3HKY3kCCpaOIcZI=",
+   "pom": "sha256-1quALOXImBg+w59ikbupM2s6e19+Hb0uuC++QZ5amjM="
+  },
+  "com/github/ajalt/mordant#mordant-jvm-ffm/3.0.2": {
+   "module": "sha256-G9cU09l4urfa1Wt8lIWwH7ta3brEnUvpyDVKw3bOP3Y=",
+   "pom": "sha256-q57bn0Sq3RRIEnJSwVhKgWIfhFxXKcPZn+JJNO6YpEw="
+  },
+  "com/github/ajalt/mordant#mordant-jvm-graal-ffi-jvm/3.0.2": {
+   "jar": "sha256-bdS+vBZK6s3azI+Y6Phx4A/SHOe8LrDRgjDqg73fyGo=",
+   "module": "sha256-zTCkXAow9xwszIyDuOx+TO7DOHGPZoWT+MN839OYwbA=",
+   "pom": "sha256-jrQ4E5SEKRUjq2iWHlZIJmqu8dHvROHF7n0FBLta33A="
+  },
+  "com/github/ajalt/mordant#mordant-jvm-graal-ffi/3.0.2": {
+   "module": "sha256-5QTKuCsTKnisa5by3i8IjmP1XHiDfPqdoufR3uDp3y0=",
+   "pom": "sha256-+046A/nMtnRJ2FPS40ZX6eComtgiDVEX5Kq91dn9bmU="
+  },
+  "com/github/ajalt/mordant#mordant-jvm-jna-jvm/3.0.2": {
+   "jar": "sha256-QQY0QsiJGyd0U2qbh6UGKn/SDm8ZSZdMbacvSUctb00=",
+   "module": "sha256-Qx5V+e+NeSxaeF4BRtg19MKuDphY+kIPneBgJoKncSY=",
+   "pom": "sha256-HyiNXD3pQTR2DhhZRwlKvWXv2mqNIfk/Mvq+9olO5Is="
+  },
+  "com/github/ajalt/mordant#mordant-jvm-jna/3.0.2": {
+   "module": "sha256-uAoLhp3AhMEeELXnFg6/GJ521ulQgweRanhWf6dnw+U=",
+   "pom": "sha256-uWV/1B1fmGNAXdJ1zzm5PQ+rwJj7lEHAoV3HZcFTaDw="
+  },
+  "com/github/ajalt/mordant#mordant-jvm/3.0.2": {
+   "jar": "sha256-ntO5dvzMx42nRtSYZvqOu48QUwqTxUTqBCAlmmB92V4=",
+   "module": "sha256-ePaERgODJINNruNw9ZfWJIsDz6/pZAWtwrbdZs38P4w=",
+   "pom": "sha256-O3C9sHYLuSTrdwmcb8f0kyLFkbZ39YHvS7i+xYhbnEI="
+  },
+  "com/github/ajalt/mordant#mordant/3.0.2": {
+   "jar": "sha256-CQmE0gJpL/70R+iN/ixjaTpd4pZw2ggxuGO8KE2hR+I=",
+   "module": "sha256-1JvlTnf/S5YQ3C8ij4HcBlaqklvHJYj2JFjbWZiVCVE=",
+   "pom": "sha256-5cbZkBgl3gKJ5J0tt1A+A546FmCq2sY3Oyp2zd9eZRM="
   },
   "com/github/hypfvieh#dbus-java-core/5.2.0": {
    "jar": "sha256-nfrdZb3+whVMzyMDn5rmI53GJXNbkzZT2UA+EcLJzxA=",
@@ -532,10 +600,10 @@
    "module": "sha256-YH4iD/ghW5Kdgpu/VPMyiU8UWbTXlZea6vy8wc6lTPM=",
    "pom": "sha256-fHNwQKlBlSLnxQzAJ0FqcP58dinlKyGZNa3mtBGcfTg="
   },
-  "com/squareup/okio#okio-jvm/3.15.0": {
-   "jar": "sha256-SD3Dg7EEnSIIkjIqDWpDCEJfCbsFtIxD1Oqp/4KxzRY=",
-   "module": "sha256-mJRUqUrvvClwMoiPE1rNoUqf+0aWDn2EYDkl0mkkHuc=",
-   "pom": "sha256-B45C9oykYT/yWX+8VUHFzleM3MSIOdqJ2nynYFGL+3k="
+  "com/squareup/okio#okio-jvm/3.16.4": {
+   "jar": "sha256-IZa5k800272Rnn4B9XpHgbWL7oD4YQYWPih8IDQ6lqc=",
+   "module": "sha256-kAjVopVKBoxoSCdPbuvf9IsUpw28aT0zAuCMVwzKAy8=",
+   "pom": "sha256-ZnePTQWXvOY/kewADFdcwCmzIB990JLLgIh1FVs+hqE="
   },
   "com/squareup/okio#okio-jvm/3.6.0": {
    "jar": "sha256-Z1Q/Bzb8QirpJ+0OUEuYvF4mn9oNNQBXkzfLcT2ihBI=",
@@ -546,10 +614,10 @@
    "module": "sha256-sK+pGSxC18Rj3jjWMlk2xpAdnjtxSXNf/RihHfMQNKs=",
    "pom": "sha256-VXZInO8kBTNoAPxt6VhUU18zVxpO/lpa0OybmwkNIdU="
   },
-  "com/squareup/okio#okio/3.15.0": {
-   "jar": "sha256-DtQSXgSMhq9+zkRtZU8rqLzF500K4fTePF3ArZqXXi0=",
-   "module": "sha256-EWgmBmzrTTM2p05xcqM3UWF+w0S8UKNPmbDSSVmko50=",
-   "pom": "sha256-LXN4VBFATurDLwRzouB6sVFrmFCpKAzGGgi0eXkMzPg="
+  "com/squareup/okio#okio/3.16.4": {
+   "jar": "sha256-yZZPOUxM0yt5vzOK+/ovIpciHu4IMReHBhzqVfh91g4=",
+   "module": "sha256-yEQahybbGk+dTzngaOu0LfalnWR+MqnGHBW1OQ7VklI=",
+   "pom": "sha256-CPvpfh4ugVoUyvFv9ayHCFEb713ec51gwHE5UYdtomM="
   },
   "com/squareup/okio#okio/3.6.0": {
    "module": "sha256-akesUDZOZZhFlAH7hvm2z832N7mzowRbHMM8v0xAghg=",
@@ -563,88 +631,88 @@
    "jar": "sha256-8cwY8VldRBroOc2hRlwIsefbRrcsHX87NzIK4WQexys=",
    "pom": "sha256-tNgod+BwsV0dTmdrQV9qVCnw4i3U75gX2F5MWcU7yr8="
   },
-  "dev/zacsweers/metro#compiler/0.10.4": {
-   "jar": "sha256-tb/mpJT19aKNsuTTHJoKqbkX0S0SP3xZr9f0fw7REks=",
-   "module": "sha256-Lv13j79bExHOiNOA08xhSsZkmAwl4heFpJdECkbDPu8=",
-   "pom": "sha256-MiKcDp7JPbylb0+jiX1XrI4p8+WajpWjACbNgofrCeI="
+  "dev/zacsweers/metro#compiler/0.11.2": {
+   "jar": "sha256-tIQH2AQi2skk/LEQamhLGqWGkVIwIMX3+q1Wib67IvY=",
+   "module": "sha256-SguQAotXkeqXldn14cypoiZLcdYulJfvaudA70EUO5g=",
+   "pom": "sha256-ugkcYZKk7cfS8c373/KNs9wItQk0jU9z9B8WG5DV6xA="
   },
-  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/0.10.4": {
-   "pom": "sha256-2ZzKmEfDT+IuIZZGRR3FIZTMEp33EcAdB9RrGfl3y1U="
+  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/0.11.2": {
+   "pom": "sha256-w9s+Q5EZAh0Xp4DvHIUfoIxtyQXJ7gPB8RYvCZGwjQI="
   },
-  "dev/zacsweers/metro#gradle-plugin/0.10.4": {
-   "jar": "sha256-rM9+X3b/u/SfJ3+tuKVFcaWzx4uO5Oewi1qiFjjDLs0=",
-   "module": "sha256-HZ66IQv61GEU5ZqsjKVxgOv26JtLpiE0Bxp5A6yDyCI=",
-   "pom": "sha256-/gjW0Nb9km1WU5P9bJx6tSjQWoiBI3RlddJ/M6R/BBY="
+  "dev/zacsweers/metro#gradle-plugin/0.11.2": {
+   "jar": "sha256-PXV0LewbBynAVUCU/8QCy11zCqy4fqGWic0sQLyGSGY=",
+   "module": "sha256-P/XNeuQSmiq481gj74j67n34p7y5TmgEn6E9rXdxyt4=",
+   "pom": "sha256-n8XARtTH+57IfE0A+CAB101Y9itdD6agBpDqAGORR+Q="
   },
-  "dev/zacsweers/metro#runtime-jvm/0.10.4": {
-   "jar": "sha256-1oTbZVHE9o9XWoT0/gVBcstvB+4knhb2JU1OkQbXvCg=",
-   "module": "sha256-ttrnD0zd+Xlrg+ScJJ1w1ZZp/Gw99rGmqgyxFG0AQTY=",
-   "pom": "sha256-YoQCrPrd+SjRDmKbprrpUbSrIpvS9qE1nBnj6Qdp30M="
+  "dev/zacsweers/metro#runtime-jvm/0.11.2": {
+   "jar": "sha256-P36CRuwV1anloy6xr4OMcLCbwZ9Gen31N8F30Bxv/zk=",
+   "module": "sha256-yFXdeaLgMp6jWreehpYhmxG/G4iT8MrAktuukM5Z9cg=",
+   "pom": "sha256-Ersigma2XEY79H9OlGcgSzWh5iCnfUoOknmAXHgoP/w="
   },
-  "dev/zacsweers/metro#runtime/0.10.4": {
-   "jar": "sha256-dZZb3y0ib7X0077XvbTPUtVGF6FdDTfFLvKhYY//WWE=",
-   "module": "sha256-jw58TEQkZf92NrJmgZsu5XnleWKDxheyVHCfX7iTfI0=",
-   "pom": "sha256-8D3TPAvYHuZsIapgmDacVRtQRs9bhpmT6yKFouF2+7s="
+  "dev/zacsweers/metro#runtime/0.11.2": {
+   "jar": "sha256-5yTOOGsUo8+yBTfVdvQe69PqgK5GEuG71KbkVhgyeQM=",
+   "module": "sha256-OGxDlATiRBwm4EiyoEPOsFUKJpG3D6YkuJNOk8A28MU=",
+   "pom": "sha256-ic3Yo67a1W24EFJH9axWEiUPbcS2a8eNJz11vnr/hik="
   },
-  "io/coil-kt/coil3#coil-compose-core-jvm/3.3.0": {
-   "jar": "sha256-2YHAj9qk+8qXVJkplCP5UAWGZrQR6uLgPHkVFIPcxh4=",
-   "module": "sha256-2szxqDpzzjc+Fj377+rqQxYvljSGYFjIiM4seQjqwKg=",
-   "pom": "sha256-V/rJ/UPPbLCr0B4fuzQuhlQNkOS9OcgMt8SoTD3kS9s="
+  "io/coil-kt/coil3#coil-compose-core-jvm/3.4.0": {
+   "jar": "sha256-UZpHGiZB7VJW052oUbF4qv8yfJ+iNQYi+utE7rGO05c=",
+   "module": "sha256-DHLibYVA/HN8kFHGhAVQhlM/UTmgcnutc3PWF4knYAg=",
+   "pom": "sha256-jtWVHvZARZs7JFnHxROoqAPg9n4FbZmMZEWJfgwKoLA="
   },
-  "io/coil-kt/coil3#coil-compose-core/3.3.0": {
-   "jar": "sha256-FD/TxmqNFLufVnfGpGMqfqWqSHlffjTBac9rkq0amiU=",
-   "module": "sha256-IobTVf1atg8jI54FbaOH7ZHTDxc0OryszJx6vVkvTb0=",
-   "pom": "sha256-3Zza6ne8JqYFWAo67Jg9AozLIRK6Yhe2eeG1fSQ0RDk="
+  "io/coil-kt/coil3#coil-compose-core/3.4.0": {
+   "jar": "sha256-xgS7FINNhN25VhbBQhMnNSkXyMFMtt8Wdi8fUv562KU=",
+   "module": "sha256-gJP4IwYSR/QTuhN1bF1kCpbXXqjldeHbVNuv0zCF5go=",
+   "pom": "sha256-Bi62HyYVqqmh82FTzVBVA7Z3Xc2ZxHTDAQ8t7+R4TDw="
   },
-  "io/coil-kt/coil3#coil-compose-jvm/3.3.0": {
-   "jar": "sha256-/iw/e9bW5FqyWCvSPvOiEyjU+K8m0ec87e7cH1WvkIo=",
-   "module": "sha256-XeSjnyda0YtndUiHIts8YZ53DHEOAyjYbXSUkevi1bM=",
-   "pom": "sha256-CJfwAdr+kM5SdnKcT9tmNiV8Y57mKD02pPvWJUh6jDE="
+  "io/coil-kt/coil3#coil-compose-jvm/3.4.0": {
+   "jar": "sha256-HYlXkAM5FpVebMW4NXX5YozHN6KaVUhNfDzC86az7WU=",
+   "module": "sha256-6wKPSFt5vp9FXa/dnvnSROYCAhMn3Gk5feu9APpThYA=",
+   "pom": "sha256-qBb2n8Bu8PIG7xXGyrAde8L8nOp5Eikf1+izVYIELxo="
   },
-  "io/coil-kt/coil3#coil-compose/3.3.0": {
-   "jar": "sha256-QRGHLQ+qiCf/RqPSExVMB8fi4VWJ4lobVZFPtMc+DCs=",
-   "module": "sha256-zEfkZ/z3jkvu/cd7JCOFwuRH2OsI033XzKh924BvUKA=",
-   "pom": "sha256-3evuGExa6a2fGVjUH62IG/TKX42OKzLa1IKlMOps9Gs="
+  "io/coil-kt/coil3#coil-compose/3.4.0": {
+   "jar": "sha256-Iz+ZBSm9Ijm6AAockpas3oRMDQFyUGaQw6m6t8ZXByU=",
+   "module": "sha256-gUi96Mu3cTaN6vsPXopXMOjdqnuZd9K/Sa6oW9SZ5f8=",
+   "pom": "sha256-SHmLQ9l293aYHAgR54N279S/jf/aAzvUnh9BLgsHi18="
   },
-  "io/coil-kt/coil3#coil-core-jvm/3.3.0": {
-   "jar": "sha256-RUyCXvUqPOvNTsNHPmtTMj6io0YIar1Y4bofdlEaSNo=",
-   "module": "sha256-KSOw/zMRPqXMuxYacmUr5SrFJ1YlzS6z96mF3jHqkmM=",
-   "pom": "sha256-wvdy8Kt0fdQcH6qr+UMqUo7mAD0U1NMO06VRfaxreUc="
+  "io/coil-kt/coil3#coil-core-jvm/3.4.0": {
+   "jar": "sha256-VcqK14GHwpuZ4eJ9ZL1TSiXPU+ooz3hs1iIESiKqNXE=",
+   "module": "sha256-QubYdwaCSraBNwvlpF1hSbKJNb4rHJ1hEWIbSOYLVdI=",
+   "pom": "sha256-J/jri/iHdHvY3BTRifkdB4DLE8tkx5Emai5wDHoM3ME="
   },
-  "io/coil-kt/coil3#coil-core/3.3.0": {
-   "jar": "sha256-sUdN4K9sMvAV00KzBQ6wg0UcsIK3PoDnWrHmDXhf/DA=",
-   "module": "sha256-c2KNSDYGhdQCraxXHzBtXtTyjEwgPa+RIkCTHt1g0qQ=",
-   "pom": "sha256-0L6GTehC01zkI5tC+zvsD+WORAQ8R41HMYub0naIQTE="
+  "io/coil-kt/coil3#coil-core/3.4.0": {
+   "jar": "sha256-ovFt0ldTnOQQ1G1W5lV6P8l/f1BPe/AVXPI4g234AfA=",
+   "module": "sha256-6iHg7xC2TxMmH8L6aAIU3tSJTjvp+YUy7fsUi1q8Hjc=",
+   "pom": "sha256-cFLwQJso91rDHXBWHDzsHwAMOm4GuITKz36N64nYnj4="
   },
-  "io/coil-kt/coil3#coil-jvm/3.3.0": {
-   "jar": "sha256-vKRiPkNo3/33E20SNs+7EHBV0VezxMbYkJCXZVGOvLQ=",
-   "module": "sha256-rtY1IAqw6aecSdQGP9kWh3fwjPHjkLurXQwWYtkGbUo=",
-   "pom": "sha256-oQYNOHHthLXqJOLAPCtATETvBIiH11yQvkd7wVpy6ug="
+  "io/coil-kt/coil3#coil-jvm/3.4.0": {
+   "jar": "sha256-FuRMFYG9fFczMNTIMUU9gdLKUGWtgZxFyuj/lkExepQ=",
+   "module": "sha256-29d1JoWn9q6dRZp8XGRUIcOc+R82E20DJdrk+6ssOWU=",
+   "pom": "sha256-hwcuI9DzN6vjUFVaW535RMfVn3735cW9meWIGr5BASc="
   },
-  "io/coil-kt/coil3#coil-network-core-jvm/3.3.0": {
-   "jar": "sha256-hT4wBQPUnX3y0dj6ja7Rmigu+YbzL/neF8+ec26cRD4=",
-   "module": "sha256-HQpgFH/Wh3hFnVALRSqbigax3IEHerZCXjVU5MDARjU=",
-   "pom": "sha256-hFWDjPEvKjGZEzEpyWt2le4KAFwwNmZDqvDRQYCG1AQ="
+  "io/coil-kt/coil3#coil-network-core-jvm/3.4.0": {
+   "jar": "sha256-pendnwlGa9qldwAiBk+9nAHP1nIpo1aLFmSpep0TG/8=",
+   "module": "sha256-0PBWjEA2kr76N0ardL4Zhpju247VS5A3JyYTYPKrgeY=",
+   "pom": "sha256-x+h8S7FnrR7QHy6ma+7UU0GrApk/Jzg2Uv57rHBA07w="
   },
-  "io/coil-kt/coil3#coil-network-core/3.3.0": {
-   "jar": "sha256-37nyRUWBHiLH7ri7xUmqZe9WnskDKK2oV4DGjcCtUMw=",
-   "module": "sha256-brQ3m6xJ/tocXBqLqmTfFhgjZN7b3hedyWJ48efqzPQ=",
-   "pom": "sha256-xUCmNHex+Sjq/9pASnDQibR3/q/ecqli+PBiIYLh4bw="
+  "io/coil-kt/coil3#coil-network-core/3.4.0": {
+   "jar": "sha256-UvW4cp8b2QIjmvL3kzz7DHYRLwEO6GYH1EdnAJwrqyQ=",
+   "module": "sha256-HwXhOXxUXmlg9rIsBbP+S0uxWAk+5Zc+n5qu69sCSHU=",
+   "pom": "sha256-98udG+JA0nNXljQLujPmAV9QLxrla6eZXrL4gNCP5io="
   },
-  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.3.0": {
-   "jar": "sha256-MnUP+/WZYSqwkOd9EUqWqOMDSx2YQsF+/+xmLlyiDe8=",
-   "module": "sha256-/tg9gWDhtKJveqAV6SuefGTmGKHP/pwS76FXp8FOZDU=",
-   "pom": "sha256-qTRA3CRrChz06ToevSdvWXA8R2f8PK7GQFxazwvJ2Pg="
+  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.4.0": {
+   "jar": "sha256-lpMYS6Nfve4MrGRNR1FBB2rXieNJ2SEmx63bx7ib3Cs=",
+   "module": "sha256-ANWexH86+CoVVLTaGpLmzcvWxrO6pgyQpfGQRFsakM4=",
+   "pom": "sha256-SgqzKTsP/0a3H3DvLTY4tsqvUXaRiJRBbO5qSS7jdsc="
   },
-  "io/coil-kt/coil3#coil-network-okhttp/3.3.0": {
-   "jar": "sha256-kT1dFf1xzhY+TGmFWqOY+ykO5W0GeUatUqpVfYCK+N4=",
-   "module": "sha256-nu4rauClXXhyH0qoNPQ9hNnMHyh4q4P56YV6WizrCXI=",
-   "pom": "sha256-JH/fiuiQiY7NTb113WPOtdXjAhdqzrjFL8+SDa/fBGU="
+  "io/coil-kt/coil3#coil-network-okhttp/3.4.0": {
+   "jar": "sha256-mUDHZn3QbRihsY0j0ktKlXvXEFif66VLUNlhiEUtHpY=",
+   "module": "sha256-2ob7y0O0kO8ZTUCr78U+bJd1Y8czkwGnaCFff16RvwU=",
+   "pom": "sha256-PLlSeecJZr5qjK4HdZcjKS8p28XbLX3c4K4oMV4a2GQ="
   },
-  "io/coil-kt/coil3#coil/3.3.0": {
-   "jar": "sha256-KtJdjAQtkRdHpIYIWIbhQ3GDTPKvzwKHpCPXlckaYlA=",
-   "module": "sha256-4CIocRU3cyeBEx4o2ej7ixD2GWoFDEFv8gtWdlJMows=",
-   "pom": "sha256-U8IQKP+BBqdUQbw8bdnlefd9qCRaOhcqNrwdPIpJxR4="
+  "io/coil-kt/coil3#coil/3.4.0": {
+   "jar": "sha256-gzU2f+hZSf1wwIaVbiEL3ZPj0o6+diXnjpkLUbBzq/8=",
+   "module": "sha256-0yJb8IXYbZ1kkfEDMEQ24MR7fnvOttkQicqZTvAjg3M=",
+   "pom": "sha256-ehSZzkBhq7uO5z7s7o+cjLpccy1kmMTVXDkrXkeefpY="
   },
   "io/github/java-diff-utils#java-diff-utils-parent/4.12": {
    "pom": "sha256-2BHPnxGMwsrRMMlCetVcF01MCm8aAKwa4cm8vsXESxk="
@@ -662,6 +730,26 @@
    "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
    "module": "sha256-z/+uzKUXit/mqJ1GAk7yeo5fSsF6FFs7UqL9bN+rNTw=",
    "pom": "sha256-L2tgiwlzCiF3e/qVIRtx2cKsOaptSp4cIvP8PC1KBKA="
+  },
+  "io/github/kdroidfilter#knotify-compose-jvm/0.4.3": {
+   "jar": "sha256-T0fvdaCRBa56tibZ30IX1sYnSQVYx0KXKXg+ZxklSw0=",
+   "module": "sha256-g+YNmwvOxe82HhzdBtq2fHeP2Y9E5P0tmib0c6+oBaY=",
+   "pom": "sha256-2OmE0PaDMEb4botuwEH5JcBBJuk6ZI0jXBKwB/lSiFI="
+  },
+  "io/github/kdroidfilter#knotify-compose/0.4.3": {
+   "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
+   "module": "sha256-4Q1RjEtvp1D4RxJ+lN1l0BbxbG61uus3aZJwsI8a6Bc=",
+   "pom": "sha256-h6E8g7jvpSx+m/GqSWh/zotwDh2XSklxzxQ1rotH5VY="
+  },
+  "io/github/kdroidfilter#knotify-jvm/0.4.3": {
+   "jar": "sha256-D6hwk+QGBgzoHJPqQhhHZxJ5fzcdeTmhDsauK0bSqxI=",
+   "module": "sha256-SuVFgHPhhv5xVEzQ8BPTysm5uTXdOKKfI5sUQgF5++8=",
+   "pom": "sha256-/EUOaSyoDkMxadrGSZXLbKQSFahvlmpbdbLC2kLpisw="
+  },
+  "io/github/kdroidfilter#knotify/0.4.3": {
+   "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
+   "module": "sha256-+pkfIQzRj+eh0FF1gsX66EpBXW0V7zHd+FSHtV6ojwQ=",
+   "pom": "sha256-/UIOKxswaQFYJ5W3I8FHAlSLXah9ZjPGa+ZhWsuwEVE="
   },
   "io/github/kdroidfilter#platformtools.core-jvm/0.7.5": {
    "jar": "sha256-9JW3mMkkbWaJ1rmImJcK8u+geEYBK2UfgQ+UBn35ihs=",
@@ -683,114 +771,114 @@
    "module": "sha256-kibzxBq0koDI2ICOdnCGJkvK6Wa2HjjhoZ/Z6DjS+d4=",
    "pom": "sha256-aOCPC4VPlpixFzpkVstualPzc65tzLv3XL/ag0TiRwA="
   },
-  "io/ktor#ktor-client-core-jvm/3.4.0": {
-   "jar": "sha256-nBEGhT2CD/KBVOEr4QEk+jcn/3v0x7eVNbYwfNjX970=",
-   "module": "sha256-IbZ7yOYFHhccpXkjLK71a5Av4kCDUs8AOcBTIfo2m0s=",
-   "pom": "sha256-vf8xSnl3GMbuKGh+Ubsl2RUUYyXSyfnL9Zqbbz49fjA="
+  "io/ktor#ktor-client-core-jvm/3.4.1": {
+   "jar": "sha256-7Jb/nJ1r4mtjDG183xqczPx8HSwOVutGFgIbs17h0Ag=",
+   "module": "sha256-rEYx3yCMYrTwVxu3QP6d/mqyvrrsqxyrbO5ONAkQeb4=",
+   "pom": "sha256-40O4T0U0NVG9V6VDvoR5hDBmgnyAydOMvYfXz/ul9Ng="
   },
-  "io/ktor#ktor-client-core/3.4.0": {
-   "jar": "sha256-718hdQyyVH3y3umPg2gtNyJZ9sMOO+T0R/Z7wtj0G50=",
-   "module": "sha256-vh1s394y5ddVAT+n48xM+1Y2MwYo56Lcp07n5PcZDnY=",
-   "pom": "sha256-JZ1e9f1hjgjb0B1pfVmwMg6dw7IH4tSgXGjHL21GiPI="
+  "io/ktor#ktor-client-core/3.4.1": {
+   "jar": "sha256-izP54cqxNQzS/FU0k14as3pTucpJIIHCI4wu40EPPvQ=",
+   "module": "sha256-H4ygp+vd9gMMeSPWpGXy2eXOh8pspxw0xMRkxR0DgoU=",
+   "pom": "sha256-P26LYYfVDxAdRyJGULY9oUOws7T6ayfdGO+SkCzMWbs="
   },
-  "io/ktor#ktor-events-jvm/3.4.0": {
-   "jar": "sha256-0NWmyY1cgweDQlFwySoT05JZBOjIrFCGU16VIlPLj04=",
-   "module": "sha256-jmf781ztl0Nnmkam5mZR/+r26Fs/ctH534UAJ6TEgoo=",
-   "pom": "sha256-C+xWgEf0WBKz9ohtS9phxJd3YZmhlu+W6CT/8P9LajM="
+  "io/ktor#ktor-events-jvm/3.4.1": {
+   "jar": "sha256-IymMxZ94fl1PD2Gyl6WZAZeRCy02igysIMBaJrl/JBk=",
+   "module": "sha256-lV4BoIgPDfMPI4lfRC4FiGg5DRoqijznDRGxA8m2MTI=",
+   "pom": "sha256-nBVuLFe5gXA0ZqlDZRzH6EhFOJmtERs5rtzBDHIRV4M="
   },
-  "io/ktor#ktor-events/3.4.0": {
+  "io/ktor#ktor-events/3.4.1": {
    "jar": "sha256-AXH8Y+I+z47LsUcn42ohjtCQ13AmIaQGZjDmRa/DKnA=",
-   "module": "sha256-xHdxdnf8Zs22wBuoCjlVHpFuwK09Qm575RL5BvMlXHY=",
-   "pom": "sha256-O3CTzZeLwAEOtvSOBynyLNcSRy8EjWuWVSW37lSIyvA="
+   "module": "sha256-r4EchtIOYX1QjAvorg9mcIK3FiLzeFnuJ6m0VQ9f+h4=",
+   "pom": "sha256-fB1sfgQ/bzrM6dfI4FGNy+iTAqkJp4mphQj7K86bINA="
   },
-  "io/ktor#ktor-http-cio-jvm/3.4.0": {
-   "jar": "sha256-tQQSB32ObbFu8PSPMVaodmkhCsfiSBzOhPdTYrymbA8=",
-   "module": "sha256-CATE1glPiIt4YpTFaB746LtbzSkFBJM0skYCjrtb27E=",
-   "pom": "sha256-Fm6ITOO3xMvaZNBHHImQLAU8jOWtfAKwjSZ2Pk5nBzE="
+  "io/ktor#ktor-http-cio-jvm/3.4.1": {
+   "jar": "sha256-+w/FSkbVLBjGwiW58VrIxX0l9xejG0BalcNp0swwtF4=",
+   "module": "sha256-FxawOP8wJqMnpdr+i5aQrS68OUse8nibA0ajA6Ll2Nw=",
+   "pom": "sha256-YZ6OvRQl7/xzvJDbY8/eojj5kCUsUHDPW0wyCsxe/wU="
   },
-  "io/ktor#ktor-http-cio/3.4.0": {
-   "jar": "sha256-RpM0H0Ip7PuZEeTMSxLR2CKY+Gj5trC59TdfULDCABU=",
-   "module": "sha256-HEp4uigp6RENx0hypkJZQ2mumxTLLIp00kjy1AgqQQM=",
-   "pom": "sha256-Sy5Na+VAkmTaqqGZSdPKxn2W2Nvets8bhuAND57hH/g="
+  "io/ktor#ktor-http-cio/3.4.1": {
+   "jar": "sha256-MlFo99aA+JBzl/87TR+WiNzJILJYyHSpE+OzRfJBYJk=",
+   "module": "sha256-nquCfpP8gHkb61OfF9/w5z4CRpYvkgKANsGzrMqWOtg=",
+   "pom": "sha256-qrzi34/pjYKPQnsb5mkgvsyRtkAdDFVj/zfp+rNCxqw="
   },
-  "io/ktor#ktor-http-jvm/3.4.0": {
-   "jar": "sha256-s40iiIRTgZI227J/wJWH50mqLUb9/oeeQtv9mhONRIQ=",
-   "module": "sha256-rouFtG/4iXdbeU5iOH53xzx/CEfYNeWfSMJUoLihvE4=",
-   "pom": "sha256-1kYvMRLFpi758XDgB962UOm+6ETIgJIKm4s0m0dHUZA="
+  "io/ktor#ktor-http-jvm/3.4.1": {
+   "jar": "sha256-xGDLpLSNxSjGzQOwxuNlFvvYPH64TI0ZUcknOi0+siM=",
+   "module": "sha256-n+jKVnAZUpdGuUiE5U+OfV40Y07KyTeOC4YXwr3Bel8=",
+   "pom": "sha256-4awy/eV2QYb7FsAqk65YhLjnz9fePqNaRYt1TdyKsuk="
   },
-  "io/ktor#ktor-http/3.4.0": {
+  "io/ktor#ktor-http/3.4.1": {
    "jar": "sha256-dELHB5CPgs4lZkz6B3CYx6l+qeuTbMKivhT6kp0XieE=",
-   "module": "sha256-oDGiKVXpdpm/TQM8e+jxxOlYlBM020OjRjhPTVTAWrs=",
-   "pom": "sha256-WVIygBV5zPJcLKItaGgT/ztKYtign04oyqT+TQ5V7V4="
+   "module": "sha256-0wt0352clpI/1gTssDb+nL3V1ak2awNSaWvsI2nf06Y=",
+   "pom": "sha256-7IxGDgx0cGP/y/yd1cJa947RenGeBsKOvvDaITsFaA8="
   },
-  "io/ktor#ktor-io-jvm/3.4.0": {
-   "jar": "sha256-xqOqi8a/UqpA9tDC6iLUwwVGY23tYYMi3ZYd/+q5fm8=",
-   "module": "sha256-GN0hyu006NgHAfgVlkj+oMQJLifDDeJ1nmIDECL6NQI=",
-   "pom": "sha256-Q97XiljFpfTfv61VJPBFpXnw6JAcyJIPnySP5JSF1qc="
+  "io/ktor#ktor-io-jvm/3.4.1": {
+   "jar": "sha256-y8z0AfFbNXYMUWX76hyFytQsdvIJjvHA7Yn09Y4J+Ck=",
+   "module": "sha256-JpJ1ziinnO1c6FdeIrzjg4a58SRO9vpN+8ioWXzuCP0=",
+   "pom": "sha256-Du3k+anAF0VvnrD5ysTF9iN0CnfESqXQyhiKb+9V2LU="
   },
-  "io/ktor#ktor-io/3.4.0": {
+  "io/ktor#ktor-io/3.4.1": {
    "jar": "sha256-QmqtJ+721Fan9RfL31LRE0prUuICfKpats1xEHorNH4=",
-   "module": "sha256-y90fjdwo5DAxPYV7ngVSdgbD5mSR3EMzr6gwplWloVs=",
-   "pom": "sha256-9JDZ9or3Nnv7VXFfJU6KcekRmlmiBQLg8LXezrUqZQA="
+   "module": "sha256-a/3bszzsoEjA+nqrubJ6yPLI0kKZtnb8E5yOODE2gWY=",
+   "pom": "sha256-s4D/L/qdSqScPfopxgzBqM8o5I2GHHetMt0QQfFOK2o="
   },
-  "io/ktor#ktor-network-jvm/3.4.0": {
-   "jar": "sha256-QAmcpMdQSpz36oUkBLlWXXlSUGhCg540HrAg7ou38pA=",
-   "module": "sha256-+HYQHrbUumBUZVA+T+o38gy+RHBI0ZtpEhVrE031wEQ=",
-   "pom": "sha256-VK3uTQXo0I74GlYDFllg72j7iW20ppDMF/foo7/qEmk="
+  "io/ktor#ktor-network-jvm/3.4.1": {
+   "jar": "sha256-lj5vz+HY7u8x5hS9We0dWaZYErfRu3nTb4zbUjs4vNY=",
+   "module": "sha256-ZjFyWSxggk4FleAmv0UUM8emMlS757smTMsTPdecXlg=",
+   "pom": "sha256-2bGrM8UJpAjc9wYEpXnHgMveGQaZwnB2fxNk0a6CybE="
   },
-  "io/ktor#ktor-network/3.4.0": {
-   "module": "sha256-3s9jLH1FArfVScWnXa/ce+n8uMsKZ9L93YF+qqOEhBE=",
-   "pom": "sha256-yBv1YiBB+vo9anehceJ1krTIQdZbbrYju8mTLNXZ7g0="
+  "io/ktor#ktor-network/3.4.1": {
+   "module": "sha256-Cm8r52yM4J8rYqsmRFHj3QzuDTmdDVF2a6LVgsFdeeE=",
+   "pom": "sha256-gV9GK+YL/H6Yqla/6f7Q74GgAppvdmMx6+UCKXNWX1I="
   },
-  "io/ktor#ktor-serialization-jvm/3.4.0": {
-   "jar": "sha256-jt0KeyNIbPIC8iTefJz4sTK7magmjDYGgO+wAOOIB/I=",
-   "module": "sha256-v9Xz7c1LoVpxoIrEXvj3cPeT0/T0feOmELmS2b/56eg=",
-   "pom": "sha256-phizpaV253vMDj7wU+6FlmdQ3Kf9ZxVucJVfe/q9qXI="
+  "io/ktor#ktor-serialization-jvm/3.4.1": {
+   "jar": "sha256-k9FiBR9hSn6SK0wR0ue6RseMg/WAnOqfrhE01tXRcoY=",
+   "module": "sha256-nZwoYELlw1kypQloEFt5AIZL4Ki3/W01NJp5gbikcsc=",
+   "pom": "sha256-zLGXXxYyKdDQnsqWuBBEPFe7K6STlk634WAwT0k3L0k="
   },
-  "io/ktor#ktor-serialization/3.4.0": {
+  "io/ktor#ktor-serialization/3.4.1": {
    "jar": "sha256-tgY1K6fiKrmbRZjH3UGrk64P8YhvD4/93ZmnmBsyVA0=",
-   "module": "sha256-aLfNY323ZoECQ3tq6ZZr0ToYQ3igPw6UKRnqISJcC1w=",
-   "pom": "sha256-aXLpwM7eSNhvcBqArHpp/Ht1lkRg3bzc1O9RBIiJzRk="
+   "module": "sha256-hpUBB9CkhXTCiDbrw7K75btDV6W0aBU8cWk5UWeVnXA=",
+   "pom": "sha256-dxPXmG/id6HNHG1WIvr0B+TJvG1FpJUumwoHl3aKmPs="
   },
-  "io/ktor#ktor-sse-jvm/3.4.0": {
-   "jar": "sha256-aiHGvWHNyXtYkyHDOVZld4abmdGqrwngxr5LzjOzajo=",
-   "module": "sha256-BgF5nAhyGIot9+lt+aaKbDcICdvkLM5wkUc/zXfxM5I=",
-   "pom": "sha256-USpyh03wDeWrZB6t7vrhLMFurdWxEP0DyygAY223x6A="
+  "io/ktor#ktor-sse-jvm/3.4.1": {
+   "jar": "sha256-8vPDmzjm8RLkUIQWYQBPfwEfC89xwRacwBlXl5lEwX0=",
+   "module": "sha256-4TVbiz1sg2RgDuPmUA5GvdDdQVCeqFrEiW6+mXlhpLs=",
+   "pom": "sha256-YBZg60/Oci7MhOqONqGfjyhY4Mci9GWmVcbOIxnSJMM="
   },
-  "io/ktor#ktor-sse/3.4.0": {
+  "io/ktor#ktor-sse/3.4.1": {
    "jar": "sha256-CyJmwH4hDhfrJAsttWPnvpqcnC96WFdOqqZZOgtlX+0=",
-   "module": "sha256-qsSAFoagYd6SQmFkQ0gDcGJxDEdvRhuyY5gXCo8obmU=",
-   "pom": "sha256-iJldwepdy9nfaOdc2GlPjmln98jAaW9Cxostmjb20qU="
+   "module": "sha256-ePlcpcS+mKPq+JFi6llBZfqvJfdHaJBWRHPbQBG1DW8=",
+   "pom": "sha256-aZnyE7SOsCLFBBZVgt37853yJ7kVVSIoisUZ1q7iaPY="
   },
-  "io/ktor#ktor-utils-jvm/3.4.0": {
-   "jar": "sha256-baZMja0qRwxWEpuBQ/rwuImSOAf4YqfyePX/tPezdcY=",
-   "module": "sha256-0FpAUN7cxZvWGX7uVgKCUf1JCVz+CRN+5KLu3FYeYsI=",
-   "pom": "sha256-44Nicuiwa9GGbgXg4Da7/ko5cLSK2ZpInBFYv/u1oQc="
+  "io/ktor#ktor-utils-jvm/3.4.1": {
+   "jar": "sha256-GXOQCWX5QBrqr/p3VQmIs90tGsvnUeyLFFMEOkxZmRQ=",
+   "module": "sha256-CCF8FjZB49ogI4nps2uJQYIJHR1bkUPtnxMluqh9eto=",
+   "pom": "sha256-Q9dTFfFkHVE3efiDtUGEi1Y5yXVN4sY7Tp+GUuFFlE8="
   },
-  "io/ktor#ktor-utils/3.4.0": {
-   "jar": "sha256-X15pXIF2vW7FKZYyP5+szuUsV9RwHrVVQTAOopMr/cs=",
-   "module": "sha256-jMiU3yrEcQYCek0jdxr7mS/Zqgqt4QlBkRxYlC4MMTk=",
-   "pom": "sha256-+UHXFBgeJkz5iIL+9+MZ655TIOEze0c+iTHezKC292s="
+  "io/ktor#ktor-utils/3.4.1": {
+   "jar": "sha256-48M0tpNfsuVQX6LaMRlVT8Ca/Ao4V4lOMBRmrKLOAOA=",
+   "module": "sha256-1pFVFTfUL4TSdGCU5Y7SswnjMPtji2f1aHsdzvMUP8k=",
+   "pom": "sha256-K1Rkoom6dJ/PGWKxlcURvL7u6+DUhHs8WVk7V6tZuE8="
   },
-  "io/ktor#ktor-websocket-serialization-jvm/3.4.0": {
-   "jar": "sha256-tOGM2Db3bY8Vdphf72+yJdTyVYgN6GnUlxLZMBA/+AY=",
-   "module": "sha256-qaDTYSVNv/2Fub7ossBJVXRlLG2NpvztXFdZQobPBYU=",
-   "pom": "sha256-syw/ob9zp/iQVlo2Byj87L0mwmppV+lwH+2tjPaGdvY="
+  "io/ktor#ktor-websocket-serialization-jvm/3.4.1": {
+   "jar": "sha256-wQw7055poZWENOMyRQ/1tw6do1MaGBjNrJWO4IWj/aw=",
+   "module": "sha256-14lAwvpWVri5tdnPQj8Ow7FqX6vxWe6XWdyOGWpI+BY=",
+   "pom": "sha256-5Lcd0JTOmyiZZdKqA4BaOZwS+Mbq4RKQ5Zg7MwpOCls="
   },
-  "io/ktor#ktor-websocket-serialization/3.4.0": {
+  "io/ktor#ktor-websocket-serialization/3.4.1": {
    "jar": "sha256-PRUs4CTMJjFuJEU3HPhPr+JiECQc13vF58hD17/n0z8=",
-   "module": "sha256-AM4y7NCckx6AG4Pb4kltECILKl4S4EFD9DBpcAP13/E=",
-   "pom": "sha256-xNKuf71ladrSiib+oeOh34YHF8CK5a20HqunuRF6YIU="
+   "module": "sha256-vljQv/t3WupQ6xQtxDTEfQ2HvJSfxbAzQUUCm98ac40=",
+   "pom": "sha256-sVWs3yK3jbfpitnP8cIQmIV8a0oLmBrVURLEIAW4fhI="
   },
-  "io/ktor#ktor-websockets-jvm/3.4.0": {
-   "jar": "sha256-SFFkWRw00qJLojVPPeoSNG4qpdL0c1ceE6pRTy/V6zA=",
-   "module": "sha256-/15J+ThlveVqU1Ia7IN5vDTWhG4SMotER+zOWzKMB4E=",
-   "pom": "sha256-mYZLwHFUHfoXyxJpliuabUa74NBtSoPEt0QZQvAIil8="
+  "io/ktor#ktor-websockets-jvm/3.4.1": {
+   "jar": "sha256-Ija9prgt8L1HIuLoapy2IxhdlEw5kSNTHQM9w9RnLcg=",
+   "module": "sha256-8dtrCIEycJcGY+ZEz9yHIJ7a+YrrXyCZi4yfuBUzci4=",
+   "pom": "sha256-q/nVUcDsRFBkir6Cc7t2PMXcmoYVZTEC6gWq9Woei7w="
   },
-  "io/ktor#ktor-websockets/3.4.0": {
+  "io/ktor#ktor-websockets/3.4.1": {
    "jar": "sha256-t6BMoUFepzA27NCYCn74oZhyVSMMuCRWBu5vVuKrTrE=",
-   "module": "sha256-PZeRBXJBq9vbItiFNjr6jYFzoi/+8T5nL2qvLhAzrOA=",
-   "pom": "sha256-m84hNt++sdNX0KGDE9aZS80wsCTwBo2oe8m/sIAXwho="
+   "module": "sha256-rrECn3SJJjPAZcrBlaZd2X7nhIRW5OKrvw912A2Hcfw=",
+   "pom": "sha256-Sxbc0s7KjR4gWJCLrVujowlW7yhLOj/X6k5kWDl8484="
   },
   "io/sellmair#evas-compose-jvm/1.3.0": {
    "jar": "sha256-z0ANDakJZF+G1zUrr8Fll3ucyZ0KsPhm3Kj21x9D6oA=",
@@ -826,6 +914,10 @@
    "jar": "sha256-t+PUbIe60utAmw5wSRa82BIGFo41cxLf3dDiU2ec2eA=",
    "pom": "sha256-CjC3l622giFH75jLJJ7z+/SiQ1QqqGv59C+tnmgwWkQ="
   },
+  "net/java/dev/jna#jna-platform/5.18.1": {
+   "jar": "sha256-rRTBsexPQ9OWIxIZ36Y16/go9zjqyfiQ6hvAd5WJLZo=",
+   "pom": "sha256-OdU4qVmaRHR3CDiGXtQs+j5rPRMIbLHld7i7QxSNGmU="
+  },
   "net/java/dev/jna#jna/5.17.0": {
    "jar": "sha256-s6lAjnxR4I7w47/MCPRD9uwPYZG6jNfBjVPSsi5b28A=",
    "pom": "sha256-UBoP8F2EpK0Q9t4lvpT0k5i3CjG+jzoO2fTGtE++/uQ="
@@ -853,10 +945,6 @@
    "jar": "sha256-ew8ZckCCy/y8ZuWr6iubySzwih6hHhkZM+1DgB6zzQU=",
    "pom": "sha256-yUkPZVEyMo3yz7z990P1P8ORbWwdEENxdabKbjpndxw="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.8.4": {
-   "module": "sha256-o7yb3i/+/IFT1Sr8WAQms4rWV2yuE0a7jIPbzFBvAPQ=",
-   "pom": "sha256-BjXG8hQBtELWxoStOF6vEfzeJDv7dZbGk62+tZPwobM="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.4": {
    "module": "sha256-S/WE5uBMORPf6cIMGIKiKZ3N3gMgR9YxpqsAZSpRnTM=",
    "pom": "sha256-DRDzDh37izhO+dnYN5kDd+pecAijEujpEINo++ZR67g="
@@ -865,11 +953,6 @@
    "jar": "sha256-shoUn+KMzMfs43tVCY0QAnq6PS4Nsx0S083JB97SNoo=",
    "module": "sha256-gF5FIbAzeYEISMesMUzzyVT8jS3zSlsJEcRW1Djc2iY=",
    "pom": "sha256-0yUq74s29h2gYJD4T+URQCGCA0Tq0dZAw3NXohkYVBk="
-  },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.8.4": {
-   "jar": "sha256-weUaJG5p4jfofSib4Ivr2NQG/+n/YKEl6PIHLbYRmWY=",
-   "module": "sha256-x55RdgcihHN1i5WIkdcSS7CaFZRqXEof+5DvPP+xGfU=",
-   "pom": "sha256-R0gxXXQwmLRVFvSZdM4854w2efSmaOw5tTjBGmRa4Bg="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
    "jar": "sha256-oHi0QUV+wOEAB9zRY/+fLAQ3+bNfvJ7Gzq2C+OmFiU0=",
@@ -881,10 +964,6 @@
    "module": "sha256-h4v4qGH7h4NN834eunP946WSEV/A17pm6iPhkVcoMx4=",
    "pom": "sha256-LUvR/bTef5L9Bdav5YWZCJOLzBXsisNrKfafL1C+1fs="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.8.4": {
-   "module": "sha256-Q7eeNCcX8sx9rQzddNUawtwxbEhmj3jfJsIc8GleED4=",
-   "pom": "sha256-UofDvv5hVYWLH9njHp2UwCQHN3i/fY1Bs4dasp70Gsc="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.4": {
    "module": "sha256-FOsoP3X55Qs7gDCWEi5xO7YX8LZkWntNkUYReBLzmzQ=",
    "pom": "sha256-nTn31/uWEshmNaR9lkulaMrU+K6LD6JpwvNXUR4mC4E="
@@ -893,10 +972,6 @@
    "jar": "sha256-rbdbK4nWjzONlCC4sk3ZulNohypPxw4yKCwvoPGToPw=",
    "module": "sha256-gAMMZAio8gsZVXh+GmE8tp8Fh26vW5GF++FZSAwPZyE=",
    "pom": "sha256-OFjDsK0gsHhobakHitFk7MbF5Y8wlvLS5vpmznPHg98="
-  },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.8.4": {
-   "module": "sha256-t/5oq5S4ncDF1wWltk3LDDyDpITimPNfA2x5cRZgHqQ=",
-   "pom": "sha256-DQ7wsV76yiXtdgT6FB0OjT+6iU0wl511DVBpZrZg0Dk="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.4": {
    "module": "sha256-bu2+0UiG5BVzBDUROa1LtNTvkBxn3AKyJ+6Yvkr2EXs=",
@@ -925,10 +1000,6 @@
    "jar": "sha256-dCOTmMsfIKgROze5PTCfH1dJShT3DWV4ZI6LsIP4D10=",
    "module": "sha256-rQ264j3Z3KujqV0dCCwb+0xASxe7kySQ9ASayTgl3E8=",
    "pom": "sha256-hC0AC7vnoGloZw6B/tCSr3gLhtbjCLaqGo+QwjsrZ2w="
-  },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.8.4": {
-   "module": "sha256-YdkxJsnivTyFp0+XrYFbxhi5A52bFIOz9OXp6Ayc+Bw=",
-   "pom": "sha256-7VnmgyoqJ4xsYcgDMqFxWJmewWE90Cvir6DZ/PMbvfY="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.4": {
    "module": "sha256-RQ5l1bXN5cWq6WwHPkOmA8k3xawekl2V1gX2zAmivoc=",
@@ -967,26 +1038,25 @@
    "module": "sha256-5Z+aDYcs4zt44W18XqY2lgRuYXKTSozo1Cdyawd5GTQ=",
    "pom": "sha256-+01/UV0FOzQ9G+gAao4Ehw3SFbi1L89/DJvIv+7WgMY="
   },
-  "org/jetbrains/compose#compose-gradle-plugin/1.10.1": {
-   "jar": "sha256-MqhD8Tq3rs/iABYVzIHy3+q5Tj9XnTE/EOJ7uz6DKyc=",
-   "module": "sha256-/+D7Pu71jb2Ht1ySco6niIx4zsanWlmEUnQQ83+5bUg=",
-   "pom": "sha256-FH0reVVkXabKL6HP0BHbGnCvML7ArysXoWp2EqGieNc="
+  "org/jetbrains/compose#compose-gradle-plugin/1.10.2": {
+   "jar": "sha256-j5vh0fcJI/k64yOeVPbQvYzoUn+RJa3umoGj+3KlFDI=",
+   "module": "sha256-EAByyO66gf04ywPWr6FSFIfCEZIKMEg2QQ4Lu0Us89o=",
+   "pom": "sha256-32OBsvD8S/8oeUIuKgykhhirIHQ9sAoeKi/Bq5ZQsGA="
   },
-  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.10.1": {
-   "jar": "sha256-oztKHplwob/LKJvHqm3xm5Zy3DJ3XI98PgZEFd388DI=",
-   "module": "sha256-QpO0B8KYMgtbUUH7+9qzCMJxhtYYDJDv0gPNBQEizLI=",
-   "pom": "sha256-cPJ8hD2tvXZ2H9n1H64JQxLqSfRdOYnNSCSx4oWCti0="
+  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.10.2": {
+   "jar": "sha256-BhYZa5LbMvuCO6thLNrPrvrFgch6l3X3CFmBg5ym7yU=",
+   "module": "sha256-TIQspmAy4+ajV4Cgqc74jsuY5a9S3W87AAbmkZALAvo=",
+   "pom": "sha256-DPuWh6dYdEX+kqxBsx2hByW0pjxUBGPdPAFbhLGm9K0="
   },
-  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.10.1": {
-   "pom": "sha256-MQ52I2X5rJ14cLvm31lJblH0a4h1e0227VxBvBMOnck="
+  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.10.2": {
+   "pom": "sha256-CkcekViHcKJTzJumsaIg7EOAH0tgl92O2vsiFcnhvP4="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.10.1": {
+  "org/jetbrains/compose/animation#animation-core-desktop/1.10.2": {
    "jar": "sha256-QcAiDdvFXLiX/rDVgWt0j5wRFiFx8SdDwEtQ0NhNtig=",
-   "module": "sha256-fu+UOd1Qo+EvF1wRrfF1+L3A5cBw8CO9Nzumes2Di3c=",
-   "pom": "sha256-h5kCm4r8XeaflPAVscX/EgRyR7o2SrLIjNjgb+lQmE8="
+   "module": "sha256-WudDzo3osmZZ0YvBaFZQA9UBfCm3jCKDZR6hYO4fR80=",
+   "pom": "sha256-MtID6VdKp0VLUPvhCsZeWrpIIYu+E1FmCCZMEzCs/qs="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.8.2": {
-   "jar": "sha256-cQ7rkf2FUuELZ+yuErHcMasxfrblvOsE1MIePzQlJAc=",
    "module": "sha256-qxOVOtDhVv+Au9EXooS4EVYN46LMXQKvjWGDKM5xbIg=",
    "pom": "sha256-5BZ9JA37PUEKkRee2wCWUkkSqkdZLOk/SqbirF0g6uY="
   },
@@ -999,10 +1069,15 @@
    "module": "sha256-hgdAqi8Icj+Iq5y9pDwTI/0Dbvfdw11tURa0ZDnAROc=",
    "pom": "sha256-1VVL+PdDa479M8WdaENtV8T0woD2wK+oqBRDrGtGV78="
   },
-  "org/jetbrains/compose/animation#animation-core/1.10.1": {
+  "org/jetbrains/compose/animation#animation-core-desktop/1.9.3": {
+   "jar": "sha256-ds9NCbUxL5qeRugKJwx2pxV6k4GUk/63B2+cjJhhBgU=",
+   "module": "sha256-hNnSyX8aeeZyRZntDqAd1wQCURcArCGP9V79qZ6j2CE=",
+   "pom": "sha256-4y8Cfj983nDxLtkxt92SO9s6VuoYYKSZhmtAu3YEqiI="
+  },
+  "org/jetbrains/compose/animation#animation-core/1.10.2": {
    "jar": "sha256-v8T0PWZFdawQ22FkkhL0U5L5aCR/lq6R4ac+S9CiBPM=",
-   "module": "sha256-cqV8oeW9K5ICYT3F3xcdnK3Yi1O1HBn0tlL0afnFmlQ=",
-   "pom": "sha256-H2KpZGr8xnG+6hy21HwCYTRKN8IE8fJscBYZ5H1k1jo="
+   "module": "sha256-0m08JhoRUO1MBv+iwrtBbZDNdlFtYx8QY1k/3HG4JEA=",
+   "pom": "sha256-non1Hu5lhJ7xUtA7bLlOagLIZqgpRwxPmn5/WXhIcB0="
   },
   "org/jetbrains/compose/animation#animation-core/1.8.2": {
    "module": "sha256-tRGby7/TKMDcD8yKRynXk6g3vz4naSP1bRCtvifGSMk=",
@@ -1016,42 +1091,42 @@
    "module": "sha256-sLNcaXIN2EWqMr9DTUyMalYOE4elIAh0jvlGeJSOoyQ=",
    "pom": "sha256-u3hZBa0EmVIiHZzNxcJFY5ri9TfiEICldU/YZ0UhvK0="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.10.1": {
-   "jar": "sha256-PsUlQoix6HImMAkiH2dwY+pyj5CWlZjzmaWwJQDrwBQ=",
-   "module": "sha256-aKxwO4ACtpfS5TT8zLpi9TWyBnnt9QjGxe38chmKOYU=",
-   "pom": "sha256-yAdhrYTkFJBqefjbk/H4+plO1lWwPLF81Rna9OiNIpY="
+  "org/jetbrains/compose/animation#animation-core/1.9.3": {
+   "module": "sha256-//2Jmf4MeqLGL+F2pGRbxxslH4+JK8fBwcbZFV6vLLI=",
+   "pom": "sha256-HxktalvHdmP3EGHKkbD+RaiwF56b5c52GInkx5ics9c="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.8.2": {
-   "jar": "sha256-gK89a/MF8LbAz76Bda5+xGv3swJ6m6wWFuBbDiFCJDI=",
-   "module": "sha256-vPH6Ul9Vl5pujum2UCMjOhSnfrY/4byJQwiTZTJm2I0=",
-   "pom": "sha256-nef9zQzxwa0CmSS0INRqCxyz60RYwq8QhKxPs0+bv60="
+  "org/jetbrains/compose/animation#animation-desktop/1.10.2": {
+   "jar": "sha256-GIHFV1RABV1UpnlBj3rX6GwDSXQziTYL7Q9qNq8WujQ=",
+   "module": "sha256-DEoL9Is7hj1v8jzT73kS97SpqHb3F3TPwiQKJ1YxKrg=",
+   "pom": "sha256-o95ZtfTcd97jt5+shtFQ9gDiLORGcjj7WCIpX4UWKV8="
   },
   "org/jetbrains/compose/animation#animation-desktop/1.9.0": {
    "jar": "sha256-+LkLWR0fjCyLVHzd2uo3CpmJsLLHG0IDi2f9so8SC30=",
    "module": "sha256-GZi9Zn+D8JNWo5xob3hS7RVvjCqNuJKVo6w56UYkukM=",
    "pom": "sha256-cdJ8weEaTONaDDWYjPFMHqDlygRz9hm+3augjRl0v8Y="
   },
-  "org/jetbrains/compose/animation#animation/1.10.1": {
-   "jar": "sha256-l0dDbPFjO25lUFn+vd58JJECvV/zx72Nu0lsCpwtk20=",
-   "module": "sha256-B4eA5z8jZBSVDCzubbZQiLLG8RL9pArvzKgu6Fv64+s=",
-   "pom": "sha256-FuH/GivVQAJ62xrtFiO0K8AlMrD59Zl334yE6gSh0Cc="
+  "org/jetbrains/compose/animation#animation-desktop/1.9.3": {
+   "jar": "sha256-u8XhmPe4FZ+nFwr/LvvJxhJKbamn+quIiekiQio7Ils=",
+   "module": "sha256-W9cMeWQRQOm3sLdHlW8yj2tiayvu/unikOy/OkJQ28w=",
+   "pom": "sha256-L99kHu+ToKOvR4Aslk0Wagvx6GZvd8yVUjW77jXxf6s="
   },
-  "org/jetbrains/compose/animation#animation/1.8.2": {
-   "module": "sha256-7RvWvOaffnnQdwZqUo1qKbH89/lh8CxTR5HrMl+BRmE=",
-   "pom": "sha256-LNRhOg+sfyT5fbtCc3UTyge0NnCNnPgygVt+92XCeCg="
+  "org/jetbrains/compose/animation#animation/1.10.2": {
+   "jar": "sha256-wk2FqQJHt64x7m5du+xicV7QRoEqSIhhQq/YjVaD9GQ=",
+   "module": "sha256-+iKKI8T5Q7ofGF6xToAI0hWA/nrj9WoC2Vz5+Qt2ScM=",
+   "pom": "sha256-31BKS/NoUN9sxyz5OhMh0d0eBh4ye36jKm5YiWP/YzU="
   },
   "org/jetbrains/compose/animation#animation/1.9.0": {
    "module": "sha256-RiS7LSOr9KRgyluQd1oG53UoTk2gnYOYl5hpjgVDM1g=",
    "pom": "sha256-zNUgtBuPHxNkX8e2txcG0ochLUQ26E5L4ETRKGtKlIE="
   },
-  "org/jetbrains/compose/annotation-internal#annotation/1.10.1": {
-   "jar": "sha256-WaDpt3s+H2HT4/Dfj5ntKhKxaN7YCeo55v117v+UvhI=",
-   "module": "sha256-We811efy58zvGNxPIhW4j5tg/qqfZmQOGuw3hoH96SQ=",
-   "pom": "sha256-D6Kh5POUM3dE5hiY64KA2kvZQfDdZ8vmjF2XsSX1y0k="
+  "org/jetbrains/compose/animation#animation/1.9.3": {
+   "module": "sha256-qj5kBl1T2z8KenRJ/2HKb5QfXzKKddHldItIZ/8ElTE=",
+   "pom": "sha256-BYvPS8fjYOus8vHvLRoQu1XP+7cIMzfD81ZRKt1iFTM="
   },
-  "org/jetbrains/compose/annotation-internal#annotation/1.6.11": {
-   "module": "sha256-9txJXZJVCe3GwMVcdR2oaytNDL2VYz7aIxe4XBsON54=",
-   "pom": "sha256-Rppb+yjQ15aoR93X1dggwc10TgLXOl8zBPh5kN+utbg="
+  "org/jetbrains/compose/annotation-internal#annotation/1.10.2": {
+   "jar": "sha256-WaDpt3s+H2HT4/Dfj5ntKhKxaN7YCeo55v117v+UvhI=",
+   "module": "sha256-rTK9m51To1cEEk7mahhdrMHeW0lf7qS179P4TlyrBqY=",
+   "pom": "sha256-JOmLEkwqWBnrOTa60j2FZ/HdyoHNKk0kLtRgO4UE5cw="
   },
   "org/jetbrains/compose/annotation-internal#annotation/1.8.2": {
    "module": "sha256-6tQ9Tmx0RuQ3H8KpGRhBKUJXKCApYhbsE/hAOj0w9Ww=",
@@ -1061,10 +1136,14 @@
    "module": "sha256-wuNy4DRqo8B0a94IDEAFIb0zdicuXVTBc2pkuji8dZc=",
    "pom": "sha256-hOGFqg90Z7GfToFxQY0FRr2MpJMIfhPFXoUWeHoq/V4="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.10.1": {
+  "org/jetbrains/compose/annotation-internal#annotation/1.9.3": {
+   "module": "sha256-XJA8onJ3P/ZifQO8vgh0IwV+kKYfYpNxyYupGQ04DDA=",
+   "pom": "sha256-zC5CIiLwOdJa9TeVsBO6syHZG7HothhYNuG4sWbo9wk="
+  },
+  "org/jetbrains/compose/collection-internal#collection/1.10.2": {
    "jar": "sha256-NnuOooSW3AJFMaD+l1dt12hkuwZv+gm6IUH3PHm/PD0=",
-   "module": "sha256-4TarBGhqy+dK/kL5zWPVEo/Y71kFyAQsNkY0Y74YNfQ=",
-   "pom": "sha256-lX7zmU0b4K5kFEl6ItEnZDpAKix4EuIrH2CSrQMpWUE="
+   "module": "sha256-G5h+t7JPWODCSQgeWJfcPAptBc8QpDTLM1ROLFHJScU=",
+   "pom": "sha256-MnsZTtJ8OiG2UW0/+1GS5qcGMaSkP+og9sV5Z4BraRM="
   },
   "org/jetbrains/compose/collection-internal#collection/1.8.2": {
    "module": "sha256-et7z8txM7WiKbJz7YNYGu2K0A2nvic2yr+l2NCiuoYk=",
@@ -1074,82 +1153,78 @@
    "module": "sha256-gDAK5xf3KEo4h5SKEX94kRnvukfy0fZIiwCv0Mt0rx8=",
    "pom": "sha256-boJ19whECuea8VxYRdIUy2liiMRyyokyV3q7VsER5ic="
   },
-  "org/jetbrains/compose/components#components-resources-desktop/1.10.1": {
+  "org/jetbrains/compose/collection-internal#collection/1.9.3": {
+   "module": "sha256-DG395u8H/Lkr6q4j5SO4yLOBaYYd7HKyT3+urnVT6iA=",
+   "pom": "sha256-uMEk0N0L89C3jdKlGvWBtzsy20VZGtmbb/scmo9o1L4="
+  },
+  "org/jetbrains/compose/components#components-resources-desktop/1.10.2": {
    "jar": "sha256-fbvgZoO++oEQtKySanQyt+LuRG7RVq31WtF+nIaK4OI=",
-   "module": "sha256-y6Qgbkwb1tkbQ8ZMgrOrg7uCt/yjtWfgEX3lFfo9Hvs=",
-   "pom": "sha256-u0W4KzhT0Xnebtqzpv3qX9v6/gYhIBDeH6eNX5n2TPg="
+   "module": "sha256-w4muk8LSXLs6jmIyDwwiX+YlVkWWNdYsVopNH1TyvAE=",
+   "pom": "sha256-l+t+W/RJOsX3HW/f8ToyZB+W3/x8OQTIDdMVckLFxps="
   },
   "org/jetbrains/compose/components#components-resources-desktop/1.9.0": {
    "jar": "sha256-87jzMba7QxKnTtFte7NlRCfPpzcopYF63b/2TG533+w=",
    "module": "sha256-OTHh694xwO+VJYKEJkOrT7yKQa3f8LMQN/y5HJnRjtE=",
    "pom": "sha256-JiFTqaOp09D+2PS88PlLDk9Xzx31156V6JGGiUE3kA0="
   },
-  "org/jetbrains/compose/components#components-resources/1.10.1": {
+  "org/jetbrains/compose/components#components-resources/1.10.2": {
    "jar": "sha256-w8pVlHgcoFydarBZbX9OvcZKdE63TXvCwQ5Yxo1E65Q=",
-   "module": "sha256-w6f+ozx3h+7/p4JhqPhyHUXlsvE2kM72aT5VzwgVVlY=",
-   "pom": "sha256-Cx/MUiKkvb7gstEdzrIT0e4fN4eFwvDGVKyK8BqjCzQ="
+   "module": "sha256-G9/wHZHJWzgctW5XQmyQwE68l2MF6mCL89mBNCYxUqc=",
+   "pom": "sha256-bNGpnt14uOPI5i7axUFSgYV+/8t2097jnCt5Q2KCpkk="
   },
   "org/jetbrains/compose/components#components-resources/1.9.0": {
    "module": "sha256-O/zJJv65jlZXAEXvnMLXKH+swiWJNEQlTENGSEM42P0=",
    "pom": "sha256-4UJBU1Q55uEIKLERKX1Ot/9QIR+JR81kx0nKck4BmmE="
   },
-  "org/jetbrains/compose/components#components-ui-tooling-preview-desktop/1.10.1": {
-   "jar": "sha256-bS///FHOSNObRwj7UgpgsXD5+zmZONMJLi4J59w6IMc=",
-   "module": "sha256-JMiUBPW9R9HdaVnqd7S9firuxnrdMd9NMbfA22LPXQg=",
-   "pom": "sha256-xb02dxmhVKn4Jl37bXVkq8EEF4So38wPd9qSOKUzecQ="
-  },
-  "org/jetbrains/compose/components#components-ui-tooling-preview/1.10.1": {
-   "jar": "sha256-FV/wCdJ24ifBpaWafNco1OtYnQvkZpoLlxcCiZ6m1+w=",
-   "module": "sha256-HLVOOaMUF6ERhwE55pvzSZGFDWg0QU159JyjTo5vV5Y=",
-   "pom": "sha256-g4RElP4IUdwBgIjckMTTaP8qksDrtul1ZIj9cr0k9zc="
-  },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.10.1": {
-   "pom": "sha256-bjLjyd7muCPLODtVsyG4HnleEdXeoNzR8lJxYX/FKEs="
+  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.10.2": {
+   "pom": "sha256-Z3gsYyj7rnrmXv5Pv4ceT+6Ch4aoZPYcdVSrREB4MRo="
   },
   "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.9.0": {
    "pom": "sha256-ikrzKPIGw40cwII7kzDaHHM/HAY2dIVgzPk8T6u9JcM="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.10.1": {
+  "org/jetbrains/compose/desktop#desktop-jvm-macos-arm64/1.9.0": {
+   "pom": "sha256-JiGp36CoFnnMhSVjEflgjoMQj5zRlDvQa1F/fblo1kw="
+  },
+  "org/jetbrains/compose/desktop#desktop-jvm/1.10.2": {
    "jar": "sha256-/bY95Mm9xlcMU1XusPAT1GNe/9pCkHwtCErMd+CNT4o=",
-   "module": "sha256-ioRsFxvvJB0fZ5u+42uTFKajTsY4wK4SJulWvbIa7mo=",
-   "pom": "sha256-RrXjgwHpiKL37IHhHNei3LEUBNZtGNPp/6tDxI6WUXs="
+   "module": "sha256-ZqqpinkbjNWvAFSGL4CympiEJ7a6YZuHXrw+kgScyTk=",
+   "pom": "sha256-u9QQTdoyEOhuWNIuqwf3OZi68GtUoEIAAkaeWxwlGOM="
   },
   "org/jetbrains/compose/desktop#desktop-jvm/1.9.0": {
    "jar": "sha256-winFLJW0xNc5hMiPQPhHXAfRPSkI003wKeQktroambI=",
    "module": "sha256-XZKFY3U+ZqsA1zpMgxAoYUt5SubNnt3BykvxdziQ2Eo=",
    "pom": "sha256-Fa1qgZfJUB2LTvKsCnkU7SOK4KSU+Gq5dYdlaYjticc="
   },
-  "org/jetbrains/compose/desktop#desktop/1.10.1": {
+  "org/jetbrains/compose/desktop#desktop/1.10.2": {
    "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
-   "module": "sha256-LA4EZizXCBuoAzLN7N1g3Mov7a60iaAtp1JMOJwCfNQ=",
-   "pom": "sha256-0tHx5wEUkDbm7iXag2wMQRMgNXXqqo8qh0szYCpmjOc="
+   "module": "sha256-Z0ImirOZpCPDvDcrd2DfheY1eRLqEtpeiADJAZyRSmc=",
+   "pom": "sha256-+qUCgGCIwtRHqLmE8pSVhp7cVz2ysFYC4hQ53nPWVbM="
   },
   "org/jetbrains/compose/desktop#desktop/1.9.0": {
    "module": "sha256-kiCLVt2h9QQPgOmufi3pZ9az1UY2gorrwFYVBa6weLk=",
    "pom": "sha256-6pFZD1PxYbxeT/rjAVVXsG7zGcLme+lPiHuDPGEIPw8="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.10.1": {
+  "org/jetbrains/compose/foundation#foundation-desktop/1.10.2": {
    "jar": "sha256-Opt7+ucvGpKoEj0ykLt9f2HZLlzeh3r1Nzw+XCys6ys=",
-   "module": "sha256-XZ61wQDphwdQ+VUGPNmgzC02VUK+YUO4AuWIJcO8gV4=",
-   "pom": "sha256-AcvtTRSMFy0uFH6AE/iQOZnUAlPVzwC5psN1kcyuO7Y="
-  },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.8.2": {
-   "jar": "sha256-BxXcfvs+ptUXSoSSFKghKqrEmJw+Mb6D2oLTJxKlT54=",
-   "module": "sha256-Pxu5mKbbqReLHxTm7L2bjvPl8AyJB0DNO8/V4FsS6eY=",
-   "pom": "sha256-R+o9s1H7v3Bbb5mxqcyfpWGl/6gDH1nePI88f616uSc="
+   "module": "sha256-GtcRJ3IxUcgIKERF6k1V9p70QzHjgZnL6R3L3wqG1VU=",
+   "pom": "sha256-SaIiA9UP7LqMhyzyjIQm2MjcsUXA/pyrUdqjXbJNGHY="
   },
   "org/jetbrains/compose/foundation#foundation-desktop/1.9.0": {
    "jar": "sha256-CzobXwhb5sDOlTVKRzmzXp6oLgD3kEl8H1PHLqUTQvk=",
    "module": "sha256-vpZlZzRb+0wg8vNOWSVdBKRhvAXF4fia/qyOrD9kqro=",
    "pom": "sha256-Dy5t7Bgcjq7IznOIHLJIaC+c9Z+rl/iuDFevTBkGyNY="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.1": {
-   "jar": "sha256-vQhqn1zkU5Z+oRJLtwlhK8oUpPu2UipgIwkqiGbuTvA=",
-   "module": "sha256-LpDXk0nRCwGNGT1k2zQn2T1QJRdH6hJoRQz6yVTZesw=",
-   "pom": "sha256-Ao29tgTRpbQLu+HPZP0gd+VSk9SaqZ2fnJr0yNKDXX0="
+  "org/jetbrains/compose/foundation#foundation-desktop/1.9.3": {
+   "jar": "sha256-08V6qBjAEjNAju7wc09RsLwWh7ceTPhj3fkrk6fMhhI=",
+   "module": "sha256-/nKrfJWvH+8AgrxOYWlG4VBQ3gZRA/UA1FSweqM4Tpg=",
+   "pom": "sha256-+HCWU6qwkonNNgeG8mwcJ8+UL5g9Xkj0GhGREzdC2AU="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.2": {
+   "jar": "sha256-jY4ABiqDoUdAn0L5F5g5TDwiHSKHeVPv99CoF2e10Pw=",
+   "module": "sha256-Fam90mZVDBithCo+tNEtM0yW6JMZgxcJiPSYqj9V8bY=",
+   "pom": "sha256-gZvxKbJiBFQpL8KMAspBLbAO7gCwGga3JVM+Lnx6jBk="
   },
   "org/jetbrains/compose/foundation#foundation-layout-desktop/1.8.2": {
-   "jar": "sha256-l5Y2h2yr1rvNf7t28DEegLGzGbQg4FfkaHIhgOnKAHk=",
    "module": "sha256-FLYe6xVeaN7rIikWXb9OsXxYDoUZHVWAImCESRfwnrc=",
    "pom": "sha256-Fed6HT2iHROf8shLGg6t+xGr5NZq+nMO47Tdbgm/9Yk="
   },
@@ -1158,10 +1233,15 @@
    "module": "sha256-5wXUw8YaJQC9BmkMhIGkjjl/PzyEaPEVYX1p6szzcTs=",
    "pom": "sha256-KxoFyZeJ69iDa5wc73P09K6FUqWN5SvNu0iDlLy2ASM="
   },
-  "org/jetbrains/compose/foundation#foundation-layout/1.10.1": {
-   "jar": "sha256-I5Lm4DC/WdAxYWnwF9vcN8TsT4p+971M5VHCegfCCRI=",
-   "module": "sha256-qPSOSOZWi8G0D+54DKtDVqzKR/qbnchICDF2c2V2E9g=",
-   "pom": "sha256-kl0kuFgh9WARp9+FeCWocLry9bnjfqHa0qkSRce+624="
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.9.3": {
+   "jar": "sha256-WVDOHhAlmuIZikbhaB2Vnxa81k2LXQKJ4XxQhjrz+O0=",
+   "module": "sha256-gtXkFCxeZpJWvZH2owJ7+crJKATmi9Rfdaj0dbysts4=",
+   "pom": "sha256-noSi2dPlxYmIFRKUkjFU1dyxh9oF1mM8Q8XtHD54Zgg="
+  },
+  "org/jetbrains/compose/foundation#foundation-layout/1.10.2": {
+   "jar": "sha256-XCmtk/BVfEeKvT/N/5wZXF6EvajJfwIu98WPSSMyFHU=",
+   "module": "sha256-z9jjcq0V1Wccv6bOg9DEDDiceJUNIZ66hYYRSrBXzig=",
+   "pom": "sha256-QEqj1YahXNZU8q4eA8zTRILYl3kpFJOjmRRlBLpCfko="
   },
   "org/jetbrains/compose/foundation#foundation-layout/1.8.2": {
    "module": "sha256-4ZO0QesgCnPcerN0hgMczkKibiznAPp53WsxZut6R5Q=",
@@ -1171,18 +1251,22 @@
    "module": "sha256-YwrZaw97aT69sY9aXgKPZxaM4paL08yz8VflSqRjG7s=",
    "pom": "sha256-Y0v0YLAjBNxJWl1pTxHeKYZeCdgHzZ7q1hPTxgXmkEc="
   },
-  "org/jetbrains/compose/foundation#foundation/1.10.1": {
-   "jar": "sha256-4ZIu0qgQtBnlPztiGgnSJ4Ohu4U9b0J9qfMgEglxKx8=",
-   "module": "sha256-Wuza7Y1FKv92kqrPBdbVBEcIH72yt8ISXLgMVhy28ao=",
-   "pom": "sha256-+D+56uQri/d3pUzyu8N99UG1p1vfXQCPuGDUAuDipog="
+  "org/jetbrains/compose/foundation#foundation-layout/1.9.3": {
+   "module": "sha256-BC1gYzk28D+86dvOi66DXG3mR/ZWaqtlUhmveApPB4o=",
+   "pom": "sha256-SGJ1Sxcpg8FGGKEesl328Sfx8gVXHKMa4CQ1NmDBbD0="
   },
-  "org/jetbrains/compose/foundation#foundation/1.8.2": {
-   "module": "sha256-PREXcV6bF6jtYAOaNBWbXivYHSnu5mGwPT7c7ceFVlU=",
-   "pom": "sha256-IJQCKpfsF6/uApRy2HWKDfQmxqVmkUeW9AvxJb50Yes="
+  "org/jetbrains/compose/foundation#foundation/1.10.2": {
+   "jar": "sha256-4ZIu0qgQtBnlPztiGgnSJ4Ohu4U9b0J9qfMgEglxKx8=",
+   "module": "sha256-Smr5jULzXCALfuumMz1YBIrS/Y6tmWt6lPRe9Y99rZg=",
+   "pom": "sha256-12Fnv8j9fjSfHMX3nIkDC39Q0rbQWIKhKTsTBKBvmtQ="
   },
   "org/jetbrains/compose/foundation#foundation/1.9.0": {
    "module": "sha256-/6+3yasG25hJJDhAlTja6o9Y3Bydh0TsSgMCn6b4Ky0=",
    "pom": "sha256-KdYEVx22XMXYrruz8VeeiDBr1SxG2dh203PpYauoQW8="
+  },
+  "org/jetbrains/compose/foundation#foundation/1.9.3": {
+   "module": "sha256-XMLCtU13nZlCjZcgjf9mclJe8PBY0b+3F7s8cNopVr4=",
+   "pom": "sha256-1uFzEB2DhAZQMlv2jdRpOdznvuXzPos6/j1fx3DgdEI="
   },
   "org/jetbrains/compose/hot-reload#hot-reload-agent/1.0.0": {
    "jar": "sha256-MmtA0vfH40G4B2hGA7ji9XUMOdj5yfZ6ShjCJMjDGX0=",
@@ -1247,10 +1331,10 @@
   "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.0.0": {
    "pom": "sha256-buCnhcd6o2l4sJSDyk0zJ68TS6ZjktF4Tr109dyD/NM="
   },
-  "org/jetbrains/compose/material#material-desktop/1.10.1": {
+  "org/jetbrains/compose/material#material-desktop/1.10.2": {
    "jar": "sha256-7kr6M6JBHgbPG+xolmd2f/uZH/AiaeBApO9k5245IRk=",
-   "module": "sha256-fvSMDyM0Fecs01asTGzZQRxJ05EygBY1+muSevnltSc=",
-   "pom": "sha256-2+olR4NblvFMcckESgAYHa4m7sz5l+nBxZLh/pY18KA="
+   "module": "sha256-H62oIjmxyCiXG4/Mn5Ng6VK0gtSk756KsoZ+MOpbm3c=",
+   "pom": "sha256-tbB9LsGnwb1eDkl4C1mwdC4jtHOEuJnK/ltcaZmmfK4="
   },
   "org/jetbrains/compose/material#material-desktop/1.9.0": {
    "jar": "sha256-WgTR4pWWAj/dXK/e20UQpKb6ZRIuhBm1ogSlFtyJR4c=",
@@ -1277,10 +1361,10 @@
    "module": "sha256-sfqa12veAdmGn5uwxxKc0rByeU8jfgTRXj73yKZqSHI=",
    "pom": "sha256-3NyiJy7t6vlAZmO5s4zMl8cXnoWqHKeJMuxhIuVZlYw="
   },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.10.1": {
+  "org/jetbrains/compose/material#material-ripple-desktop/1.10.2": {
    "jar": "sha256-MldpehpYGI7D3DHzGGfxw4IJkAuH3xJh66yeahOH24M=",
-   "module": "sha256-QqHPa2C2TnN61Aupsjw34plulnIFYt0nRmdlH43k67I=",
-   "pom": "sha256-2MQPfRTqQl/Mrl6aA7K2cLtgLnnzUai/hV0awIgKns0="
+   "module": "sha256-aPcwbpcyiZ6SlsRhRnreEO5ZOkDZO8FRxhdhibqbh8c=",
+   "pom": "sha256-s+X047ly7FxNF2n6v+yLk1jYfNgMSEBDfliiQ7SPsX8="
   },
   "org/jetbrains/compose/material#material-ripple-desktop/1.8.2": {
    "module": "sha256-qonDHtpLPCdfECYdvgaC7a5j/N66IKNauEDsZIsQH7w=",
@@ -1295,10 +1379,10 @@
    "module": "sha256-BlaiK1iKg5uADqwoWqPrTQNd89VSIccGxdNfpil+bYk=",
    "pom": "sha256-T5wpVlxWK/sQxbeoEGzHkuJZp2z3iJnemi71R4cADBM="
   },
-  "org/jetbrains/compose/material#material-ripple/1.10.1": {
+  "org/jetbrains/compose/material#material-ripple/1.10.2": {
    "jar": "sha256-ce62zqnl/PPpPoRj4YjOseRIhxg6AgId0ML0JKWrHEo=",
-   "module": "sha256-SPUuOFZZpQTFU8pUMtTc/kzVhcxEfilYzQNwLFqJFf8=",
-   "pom": "sha256-4x27Zeb/dL0wAmqGCfBoIooq1stR7rSGYPjATqJzRr0="
+   "module": "sha256-gXnwkWKOxmEEx9jmUPUtyKsUwNQi7msi43/UcEgQG9o=",
+   "pom": "sha256-f+wi7IDbjG1LbzcaX767fksLHYGO6uxKWKnWEeEqtO4="
   },
   "org/jetbrains/compose/material#material-ripple/1.8.2": {
    "module": "sha256-sPjhBmZdFZ5A5QpkLm/L4voyjv7tdZ073Js89SZ8nQk=",
@@ -1313,10 +1397,10 @@
    "module": "sha256-iY2+mg5iyco5GzdewaJ7SZZXQ7dKBq2F9ucQoLu0o9o=",
    "pom": "sha256-9S84Kui5GL5SNnYUELp9jdEuC2rJkjB5fFOyQLoaMeg="
   },
-  "org/jetbrains/compose/material#material/1.10.1": {
+  "org/jetbrains/compose/material#material/1.10.2": {
    "jar": "sha256-LSEY93unibj6F5gDhWp64ex1P5/5ko70jyB3VAq4MgU=",
-   "module": "sha256-qXV8BaYCfcrhuqJ11bFlFkHvFFTqvxIo0btpKBRoMrg=",
-   "pom": "sha256-eh+kROY+sPBR0Bd12ZDkwmSiCq1FVkZyIRB8Zars3aE="
+   "module": "sha256-w9oVgKADamzTzJdLOL0awdsrbmz8pqm+m5u3ju5bYMg=",
+   "pom": "sha256-SIqluVGoPnwcspszffDdBvtXMQPgjAWyiShpXUcbxJA="
   },
   "org/jetbrains/compose/material#material/1.9.0": {
    "module": "sha256-UyLG9xJ+ZTOuU8dQ+TmDz7ww6kiJTOc72bKqUIzby/g=",
@@ -1341,69 +1425,68 @@
    "module": "sha256-+np0XfkXBZHZjzdzMDvPU4KTE6z7Q8csGqT4+5m6RaQ=",
    "pom": "sha256-lyjwhwOCTgT6yPhOZuHn8obuQwiQ8yf/ix51Qx3fGto="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.10.1": {
+  "org/jetbrains/compose/runtime#runtime-desktop/1.10.2": {
    "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-0vukIO+Pmq4ul1mYHi9+tb/ErWF3hjnF5I6yWnFy5y4=",
-   "pom": "sha256-HSX+fkdC51oDqMYXGuJDwSyrQ7ovwQTh84PDlyZiBgA="
-  },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.8.2": {
-   "jar": "sha256-l/3nRA1zQFM1Uo9TrNSg3GDuz9uyHmfbwWbV+8vC4/Y=",
-   "module": "sha256-17f3ATBctjiDhaFJqs/pQy1FlE+Dywmn0+qHbFDbDHY=",
-   "pom": "sha256-/3iTtXN3ijxMvDfSRGzi6gaDNteTFNrYObz4aRwAcXw="
+   "module": "sha256-oaKNowIUkoW1jRVCJP1QXiop6FNh8/u91dWHgns7wS8=",
+   "pom": "sha256-jZnPVbQT89n+PiMDcnTfkr02QqHc4YuMc4YmD6ZeC3w="
   },
   "org/jetbrains/compose/runtime#runtime-desktop/1.9.0": {
    "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
    "module": "sha256-kszIipLLMPWv1OBsHU/jkKBCEDbOzUD7jL6ntnEp8Pc=",
    "pom": "sha256-hRQIp7xApYgt3rUY0HU/c42x0birWJP3U1mmYfmArSk="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.1": {
-   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
-   "module": "sha256-hAeNGHbIAVlIgG+MmHW3mI2hzt6U9K84plpMF4DPtYo=",
-   "pom": "sha256-Kgp0R25rxYssFh0m9LAxutmgN1W3meorWSnJ0N32u48="
+  "org/jetbrains/compose/runtime#runtime-desktop/1.9.3": {
+   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
+   "module": "sha256-PTuLjN+aMF8bQuIKiUjw6NkHoyLbktmEmdCg4d18TyE=",
+   "pom": "sha256-r0eMxiql29JF+HIbQEpFZp7pk6zxaTXs7CGdq65uoZI="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.8.2": {
-   "jar": "sha256-qyI297YSoXb+MgnD2X+66zgxESwPQd3GWfy3d2L67hg=",
-   "module": "sha256-P/OoOpzKK+Oz+2OEL/ghAJyrom1anJqs3i2U4LJgfGc=",
-   "pom": "sha256-457OQgbrcIObfFSWlwC6SLu9JtIxR9Nk0vmPgk1yR0k="
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.2": {
+   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
+   "module": "sha256-k+wd3rthKyfIH6GrBbrds8bFH6Dk4YGdQaNKnase8OI=",
+   "pom": "sha256-ddPbmiWEYr8pHbOTbRfootxmpFyCe2vgZwjivHLZQFs="
   },
   "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.0": {
    "jar": "sha256-lgpiL9h17cPFmPJpIQHm+STvePuvvpQR50nRhK+49i8=",
    "module": "sha256-QT66RZ1ktkSR4mtYEPCXk5OX52278IvGKf2kYE+GR/w=",
    "pom": "sha256-pIix1dT0+gTMEUVKX1YnmoDbgV5wv8poOu6gmovY0Wg="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.10.1": {
-   "jar": "sha256-3R9FlRnD00QOtXjsQSrQaRnJ02ucF+XNs5jWv7CMIvs=",
-   "module": "sha256-GcnQ4jA6NJ8FJnwjYh8x2XlwO1wp97GdotuyKYJSYGA=",
-   "pom": "sha256-XGX8fK/tedTLD2khZpI5AnfXS1tXV6xUT4VzVd74A2k="
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.3": {
+   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
+   "module": "sha256-G9YdH5y8eupNKWgKQnuusT4/7swkssYyusJI/TqHL/k=",
+   "pom": "sha256-0WllLahBVRQ34G/mvsJ04QodSziMT40nQuehJF0re9k="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.8.2": {
-   "module": "sha256-tjnYq55mE/H7t10NXTxcy3eVJHcHl16mbLqfToNiV24=",
-   "pom": "sha256-OHs4L1azx/e/s6VyTt4ibrJ/ezcZDA7PRKQT0h9RHdA="
+  "org/jetbrains/compose/runtime#runtime-saveable/1.10.2": {
+   "jar": "sha256-3R9FlRnD00QOtXjsQSrQaRnJ02ucF+XNs5jWv7CMIvs=",
+   "module": "sha256-poH+PLFenw1lbTnNgrzJmddypX0PMjikCABIrsnlt8E=",
+   "pom": "sha256-p2H4BiSjjPDd/tR+CNkJlPsqP2zkJWMbE/6fOCm7DRA="
   },
   "org/jetbrains/compose/runtime#runtime-saveable/1.9.0": {
    "module": "sha256-vND9YwqwZNKdv3HahqLATVX1lXiM+doOB8G+YZdAQlI=",
    "pom": "sha256-0TBzcL6/xy7vRmUgeBvnPskoxvHzur2HfozlRl47Xb0="
   },
-  "org/jetbrains/compose/runtime#runtime/1.10.1": {
-   "jar": "sha256-uj5+kVsZvOBaHnQzWlRijrzuRssjihu2hHrT+wRaVr0=",
-   "module": "sha256-lSWoQMQNt2cKZAbreAzIFGPSniYDnSe6bATJSSwG60A=",
-   "pom": "sha256-im5yiIjzljDjXj5zGRFN8MbUiRRlNML+8287o2Fwlqs="
+  "org/jetbrains/compose/runtime#runtime-saveable/1.9.3": {
+   "module": "sha256-r8hC/ovdMqXOdBMrta6H9ziiCXUGkW0W4orbGIgFfpU=",
+   "pom": "sha256-8b9Fr9nQV0k5nvAqwnbC3LZWVz3USSdTD66/L7u7R7M="
   },
-  "org/jetbrains/compose/runtime#runtime/1.8.2": {
-   "module": "sha256-5p1YuRjSmBWJgWzJxDuGJqdNmz1DDNgxR6zEPazVtt8=",
-   "pom": "sha256-QKUQ52/bvkweT8ISMjsfCtJSb+tuKr/eAAzRlmZ98EQ="
+  "org/jetbrains/compose/runtime#runtime/1.10.2": {
+   "jar": "sha256-uj5+kVsZvOBaHnQzWlRijrzuRssjihu2hHrT+wRaVr0=",
+   "module": "sha256-YVvm9uNuWeiDhCSGqspbi1NTFq+r8ltTi3nlyy74is8=",
+   "pom": "sha256-sF8oFym4GxiwX0jHBRlWKPPEDIV1XsbTkeJNXLbp8us="
   },
   "org/jetbrains/compose/runtime#runtime/1.9.0": {
    "module": "sha256-FuTMFfw9DaBRlitd4t2codlJqQ6TBF4nOCvdozGjiqM=",
    "pom": "sha256-NYdEukMSFIl1/n0TqPnnQV1BRTdTSkFG2YDJSIBrSQA="
   },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.10.1": {
+  "org/jetbrains/compose/runtime#runtime/1.9.3": {
+   "module": "sha256-RoPOYaDjW2fnQuNTqNRlcXglAxwQgc+7+zojate9s9o=",
+   "pom": "sha256-4yJMwKXBCThxJVp+fmcbXoXsxKLloEg1Q7o3Tc9awq4="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.10.2": {
    "jar": "sha256-G6v2j1oFy+G6jPk08OV1uw0LGEREUU5qp+wfgATJzjM=",
-   "module": "sha256-WWWr2SZuDJcXpab+blODCLkgnGJowFf9IFkavDkiJQg=",
-   "pom": "sha256-T9S8MPSt+5EGh9u/djFQlKdDs92FReFY3QTOTLgY894="
+   "module": "sha256-NUQQGI+gWv+e/pFjTbecIGD7K2BqtVxpSygfJkcr6Rg=",
+   "pom": "sha256-u9s/eEMI12yAkH3c5MBK5NquYiR+/WxNCvgkWQn/FY4="
   },
   "org/jetbrains/compose/ui#ui-backhandler-desktop/1.8.2": {
-   "jar": "sha256-pFuf06l8YKNtrH0hjykNEn+eVX5NUZ72E018I7luWZE=",
    "module": "sha256-+oKZkW+3Mr9DcgP4srNf2cfIX64H4I6qh4bVYM4eo1w=",
    "pom": "sha256-FyT0XKYO3FXhUT1ePE6xpveCcBRMREpO2aEB1Jxolpc="
   },
@@ -1412,10 +1495,15 @@
    "module": "sha256-9gHX8qF1m8UoF9XSmX62b7zXZWPAkHeWJzr/dTE0FAE=",
    "pom": "sha256-qFojKagc8fJgF5STGQ9zxBByptHZJjn3MwFvCMJyAoQ="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.10.1": {
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.9.3": {
+   "jar": "sha256-N9Npc3xo770nsUuDXOKIzK5FaTzBUCy161gxo09Eo9A=",
+   "module": "sha256-dGExx/cfhC4n5QGSwyrcJeiH1EoLbCKVXP6787UpLPI=",
+   "pom": "sha256-wc4wH0ViEhDEOp9TSQ0itmQcRDVo+laE9LCzlKCt0iw="
+  },
+  "org/jetbrains/compose/ui#ui-backhandler/1.10.2": {
    "jar": "sha256-oyMxtIaU52eRz0Gx4WGUfs1zscw29iksG7vHPMQRd2s=",
-   "module": "sha256-1MpaAIvNb7kOcAa/LK195C7FKXhwTNMafcMsWq2k3uQ=",
-   "pom": "sha256-MGqBdbegMDRQjpeRS2OtkxurHG9xvwvhFS1PG67s8Jc="
+   "module": "sha256-i8tV6CFr7vjQd9qdMAYnHf6CmpsHnWQ9sslBYmGwr/Y=",
+   "pom": "sha256-IVXYtatyujYXnFG+LQVz+r+Cet6YDB0mmVZfPAaHcQQ="
   },
   "org/jetbrains/compose/ui#ui-backhandler/1.8.2": {
    "module": "sha256-WR18EZK6Ag6G3DevzSi/QzFyT+bE+kfO2XWQkKrp6EU=",
@@ -1429,56 +1517,59 @@
    "module": "sha256-Md+hhs1xs1XLG+eGB//VJW3Mg8/xFaJg6k1pdJIJJYI=",
    "pom": "sha256-jKkBhNsSyAgoKenTNle2BzBOI6o2nTbfy7sQjib+DuI="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.10.1": {
-   "jar": "sha256-7IiHwDozP6N00LTEa7n7cAk3hX9AiOrqTEzA7INfdJg=",
-   "module": "sha256-tkbz2vKqoTaqbaP8b5+Io6slD5NLDSLUbwPcyv4cIWc=",
-   "pom": "sha256-xl8OxPSlepgQCa+zOAGhmwdbkGVLhA1Dir7wrGQ34Uw="
+  "org/jetbrains/compose/ui#ui-backhandler/1.9.3": {
+   "module": "sha256-dDCSIM9OhiXxSAUduWL3g+4E87ZCatgbEXKeaD8JcYE=",
+   "pom": "sha256-IRNOf+Gko/ke6PDfdCFGTa/zjLv32D1qx80oWvg+QjE="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.8.2": {
-   "jar": "sha256-Gkput7Hp6nxYosdVpYNRaijSvWBzpC5XX+hW0CFLYyg=",
-   "module": "sha256-MElSHvBNgexPU2S97JnDlyiUMlpXEAl8KgMbJreuVRk=",
-   "pom": "sha256-tWlrrXTxNF01+mThDCaWhMkv/phvTXPX8dA2pGXSSm0="
+  "org/jetbrains/compose/ui#ui-desktop/1.10.2": {
+   "jar": "sha256-7IiHwDozP6N00LTEa7n7cAk3hX9AiOrqTEzA7INfdJg=",
+   "module": "sha256-pz8PMFGumNYbhDaN1zA3MsuAVm3cEmsxVEMJlIqCniI=",
+   "pom": "sha256-NNV1LmK2ZShOnucR5LKLjRRHxkrY9pmAOrcxRwKRq1Q="
   },
   "org/jetbrains/compose/ui#ui-desktop/1.9.0": {
    "jar": "sha256-c5clOZPo1RLGE7dyOeIOUFLaghj2sLZMzeLDexS1QNw=",
    "module": "sha256-nShr23AMBOUQ6rfv8xcalPsS21In3UmIVjy2/JQAuCk=",
    "pom": "sha256-N8qab9bThJ5l+UCCMjH05oycfYfAt19zSLSPIeU+NPw="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.10.1": {
-   "jar": "sha256-zb/avMrIq+8tm8BCDsDEvnqID20mstHMTiMXwNJS7ic=",
-   "module": "sha256-A9O8AQ5sDx3Vs0TtcfIA5R15Yp8Gq1sGHuL5cRKeBCw=",
-   "pom": "sha256-b4r6BrMqH6fbRnBgVoezZm0oc98bnymiLtGlI0YQYG4="
+  "org/jetbrains/compose/ui#ui-desktop/1.9.3": {
+   "jar": "sha256-nJIUT23ylm1319Fmv4ktjF3ao1jAr47IJ2515CZgevQ=",
+   "module": "sha256-b7sxOjIcHw/GgZFKPgHUmydYgTTakLrXHrEsow0a5+0=",
+   "pom": "sha256-6ZxZIdDUmtwX6Xl4CPHoyT36g9Y09wef/nbT1XLGHB4="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.8.2": {
-   "jar": "sha256-Wq+LeL7W5Wt07okxcszi4xaBO2HYoizdwFh6Unxcqic=",
-   "module": "sha256-pvFbmQWoxewqbQfxIKUkmtFCdC4SRIWSBYY9K5c0BUY=",
-   "pom": "sha256-NVLl25MJZMNpnXWUJJn5iv864bPQZRa5ufRLo1xPN9w="
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.10.2": {
+   "jar": "sha256-zb/avMrIq+8tm8BCDsDEvnqID20mstHMTiMXwNJS7ic=",
+   "module": "sha256-S3oEoInF5gbe3rV/JfraruH29fEZnKOKrf9PSfqFeaE=",
+   "pom": "sha256-yqzXKSxBwBvNdswGKuZSiLLFJgDezA6+wZ9eB/CLHM0="
   },
   "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.0": {
    "jar": "sha256-3qD2dSTkNJY3yYXg+iIE/zVJIvOMZcyPgQZJ0Njp+uo=",
    "module": "sha256-mZqXUb2oQ+LV/S6ZVq3Fd+FxVP5SrH6Q7LdaqTd+WUY=",
    "pom": "sha256-ajUF56SiSisNnJqjxSFMQ5M0mQljcpLjvPjvjDR/9EM="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.10.1": {
-   "jar": "sha256-Fu6RG4s+UdacwImB2VcjoWgtV4/vr3+OilTVVVv4WSU=",
-   "module": "sha256-H3IYS0VZAg54JLle/VayR73hhSVhZLXYryp+kS5OD6A=",
-   "pom": "sha256-rvoyV36SY/A3GIbYX9zR4o/ZJXbU5GaU7fcb5Pz7ofY="
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.3": {
+   "jar": "sha256-3qD2dSTkNJY3yYXg+iIE/zVJIvOMZcyPgQZJ0Njp+uo=",
+   "module": "sha256-BR1eOV0OB305IVxbnXP3I+xEBjK2leBZD52i07kdnpk=",
+   "pom": "sha256-Vsnm4VvcVVQNaroiYKvRSwXw7AKbSeUvw/6EUkyAOqI="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.8.2": {
-   "module": "sha256-XvOmPmVDkBp9sfcU1z04HFdzPj8urHznMb86gm3xHVk=",
-   "pom": "sha256-NUMPxIKUipkyQhXSIoxtXwl0bKAu/briL+/X1Q5+qsQ="
+  "org/jetbrains/compose/ui#ui-geometry/1.10.2": {
+   "jar": "sha256-Fu6RG4s+UdacwImB2VcjoWgtV4/vr3+OilTVVVv4WSU=",
+   "module": "sha256-vYvW4J7X2RFnV+LkBPdlIE0BzYbBBGENmNxcWQSUMnY=",
+   "pom": "sha256-5sLqw9AJX+xLyzxteXyJpq5u0ai/QksLjV/uKLLSnoA="
   },
   "org/jetbrains/compose/ui#ui-geometry/1.9.0": {
    "module": "sha256-MrCoE8bMfwFQv+MYCKP9uAm4g7Xp+yODOZ2OCbxzAvQ=",
    "pom": "sha256-6D3wiP53lSdwbdxB5T6g/o+aE0fLCZ79FGskisUtbEc="
   },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.10.1": {
+  "org/jetbrains/compose/ui#ui-geometry/1.9.3": {
+   "module": "sha256-BjMaYYvV3QXSIEF7anPoQjtaluNNU4vZ9Cp80eVvl4M=",
+   "pom": "sha256-WBN7lJhIqew1/8/4sjM1kZTp19/c7GlpRY61KYllCYM="
+  },
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.10.2": {
    "jar": "sha256-0XEKShWxFfxMN4eLMrEKR2oOw7g5n6H7WIGB26g9vdI=",
-   "module": "sha256-f1h2jvtgvUfqbSQRMTifBmWi4XizbGa0oLedrtrP3f4=",
-   "pom": "sha256-+u3ij8ZEUBTRkFPjG7EwX3no1o6po/4IK/i+bricenc="
+   "module": "sha256-CFcMjjI6EABPgKnS7ipeLUdipi/tDPigoO6nE6WFnxg=",
+   "pom": "sha256-LphiN571KINNhnkbN7kxKbXJtdK6jT9ROtCh7SEHb6w="
   },
   "org/jetbrains/compose/ui#ui-graphics-desktop/1.8.2": {
-   "jar": "sha256-P8SBZWxsloXPWTqb6CLFdZtwCKzHOVh1yvbi7lpON2w=",
    "module": "sha256-VKdWGvFbAenj1reymZfgvN5/VhMgTzwWaaYhBdZ5b4s=",
    "pom": "sha256-Q8xiGyDTZPIimJ4bva2fkSoice/WjDX5SJlczGX6emo="
   },
@@ -1487,10 +1578,15 @@
    "module": "sha256-zhOcM8R+fBaIL+Wg9x/ybsIgf0nbXkQs8dLsZjBYls8=",
    "pom": "sha256-dnVmTZ/ahP6rPQ3AJn1nzNraBKiSlTzQsCY3BejgIsI="
   },
-  "org/jetbrains/compose/ui#ui-graphics/1.10.1": {
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.9.3": {
+   "jar": "sha256-D4vlJjaE3TrgPCPoIhoejmlypQjsmuzXd/iYR5jxUfg=",
+   "module": "sha256-mTvTBodaBfZ31NpkMS0ryg+77/wTXstcr8HsORgVTho=",
+   "pom": "sha256-+OREs7Vl2nYYWQqdu8K9+EJFrtTSdhNjWfwEP7drSzc="
+  },
+  "org/jetbrains/compose/ui#ui-graphics/1.10.2": {
    "jar": "sha256-N3HQ3yUMCeDpONBwc8CJ6utmEsuMqGFTvbDXBEPgS5c=",
-   "module": "sha256-8vNAx/zcTn/aLNhWWRABQj/5UuHCw57uFtYww6YvN1A=",
-   "pom": "sha256-sEnO7xj389phm8m6JRaIftSJ0TYt1LSCUZHx0RSLZ2s="
+   "module": "sha256-2xH9irbb/6LwyvHePZsz2OEfDTykOKtD0+dzcf+J/Tc=",
+   "pom": "sha256-mOwWWj83D8Ko+Q2cqadjLZqjgGkuLTH3ZV/ZaVW8TSY="
   },
   "org/jetbrains/compose/ui#ui-graphics/1.8.2": {
    "module": "sha256-ah9EbiXhhsXFXUOG42zKGnadejS0QSN6vWxmSrPrPiU=",
@@ -1504,13 +1600,16 @@
    "module": "sha256-ttJkrI5cSN1PbxPZ/YGQeA8aOG5KEL2Qw7sFVlLUdAE=",
    "pom": "sha256-Fg1bjrRrnNaYMU32OM+sNDC5aC3fm1RAG3kWxjd7z6c="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.10.1": {
+  "org/jetbrains/compose/ui#ui-graphics/1.9.3": {
+   "module": "sha256-WZRUxCZS+cyjOPEzwWLfV8sOZ2EgroZFl0FrFHXmVyM=",
+   "pom": "sha256-kGv0hbcgzxNRbm4UTNyU/cVfIcF2UIfZeIWqXWWxrFA="
+  },
+  "org/jetbrains/compose/ui#ui-text-desktop/1.10.2": {
    "jar": "sha256-+8pNuUW+KGuE91wMnHhCGEcL6++oMfc/CO37MpS2yOg=",
-   "module": "sha256-PvKr7R4vWzijjzJRnnvYs89PkbXX74rjiavITneiyPo=",
-   "pom": "sha256-3L88b4dEKUFcSOSibwrZuhXCy0+suQ3Tg+uCaQ7G0iM="
+   "module": "sha256-A75v+wlgJnbiHNlHE3TrdkFEdyeYSHm9ijEKDu7gxr0=",
+   "pom": "sha256-9zDcqn8MeN/2Jz+nTCNQGuI++OA2PK1gfenswQC7wC0="
   },
   "org/jetbrains/compose/ui#ui-text-desktop/1.8.2": {
-   "jar": "sha256-efyvlzfco4Xka8bwnQePLmMFUkiR/uU5wxxm08GDU+c=",
    "module": "sha256-M/9uYPm7rQMunqnxIZir/MD5H0dLeclIh0NK//DE4xY=",
    "pom": "sha256-rQhacC7enMbO4cCujRFRO1stHpu0BTJ52RjGvqZf5R0="
   },
@@ -1519,10 +1618,15 @@
    "module": "sha256-zVME5EaA/wXyqzYNOiRrCCIwhRfjAFfmYnBr15waBtk=",
    "pom": "sha256-XEZdule7t8YccSEaS2jRBr/HRoguZBReio7Z3jwzix4="
   },
-  "org/jetbrains/compose/ui#ui-text/1.10.1": {
+  "org/jetbrains/compose/ui#ui-text-desktop/1.9.3": {
+   "jar": "sha256-M3cgBxAUajU1hOtz6/6t19ZBANNWuvW/hgh24Rgij0I=",
+   "module": "sha256-UFCQKbJeoFDYbnL2wv9p3lp8j+INsjgkMs+0YVmam8A=",
+   "pom": "sha256-ltaW+gUBBy569mpdyzbuhhDyzDq0WOsCJviEuWD/ueA="
+  },
+  "org/jetbrains/compose/ui#ui-text/1.10.2": {
    "jar": "sha256-tTfQs7sj7HlaGzVifeqpNwPP0HM7x7LcNGQV3wYkOpE=",
-   "module": "sha256-NqYyyb4ZN89lZVvcKRe7Y+sm+RZ/IDu+ZnrVcLIY+aI=",
-   "pom": "sha256-js6+nL1gDzrQnVxZzUqJihJ8Xgml6n+gjhcLFA0fWi4="
+   "module": "sha256-hpXh98XBFalX3BE+yL2aorudCu8gvBdMvPtCw7JqT10=",
+   "pom": "sha256-IiQCYEAv/yytGD5vDzvokhJb21ukWkj/Z4CGnzyI5P0="
   },
   "org/jetbrains/compose/ui#ui-text/1.8.2": {
    "module": "sha256-6MI81LMwHQAVpsgJYVty7dTJPCKarirtmfAVgJ6K56k=",
@@ -1536,106 +1640,110 @@
    "module": "sha256-lEvw4Xg0uVarRga3jgXG90MxqSVAcnYJ0Qq1cjd6F9k=",
    "pom": "sha256-jEFrj59tZfdBvaLWzwySOJjfJyA99Q2alHSiLNDhQig="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.10.1": {
+  "org/jetbrains/compose/ui#ui-text/1.9.3": {
+   "module": "sha256-ExDZIq34+r97g8qO6Z1bNCJnWSscNvjdANkDp/y8eUc=",
+   "pom": "sha256-7kAj5T1Z2i94hfKhuON4lhALRv/QHXrpQ9kqT10EmAo="
+  },
+  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.10.2": {
    "jar": "sha256-tfpvu+6l+JatKo53A71+tXTTobWrbUTb4KB1Nr1q9sQ=",
-   "module": "sha256-X/d6OnitBLTsL/COuprlWL5qYWpBYHM/tc0L6Yq5qBU=",
-   "pom": "sha256-EaFvpsCqTgF+nfmnMncQ/m76eXpNR5leiGwKT21N8jY="
+   "module": "sha256-i32BdZvAdDTOlTqBgGlqjMKSIFEnu7bNQliEnTn3goE=",
+   "pom": "sha256-1bBLUv5+Md7OMe8lySOASgyAd1XPuN5VnDuYM1spjZg="
   },
   "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.9.0": {
    "jar": "sha256-qyghEVDLh8RtZzfiyGyb9E2sZCqV7SbbLCAKDi2vJQ0=",
    "module": "sha256-4tbglF3zQSeXbYCB7PrQm8Rja5mpceQbd1Z5xZXaWR4=",
    "pom": "sha256-WhRl70I5MpG2qcNZ97Hkl///onhZKPDkvS8PI10diI0="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.10.1": {
+  "org/jetbrains/compose/ui#ui-tooling-preview/1.10.2": {
    "jar": "sha256-YlyeD/k7ko5YYPEcUQiizVEXl7m0Om3MuznXydowUjM=",
-   "module": "sha256-YPCHVdzAI/08bzKYlhJvcARndiuNOp792XFKhBi+SCY=",
-   "pom": "sha256-RtNpoJBXF8BrM1/ZMxTiF3l+NW6I1whLAHlpo5Ny+yc="
+   "module": "sha256-O/MFSmG+bo7fIug35U+FqiYC0fKiZ6hrkxUQcTqEky4=",
+   "pom": "sha256-I4iSSLGo2du/G20EPbByJml8iqvQ8DE+pQ30OQqN6Z4="
   },
   "org/jetbrains/compose/ui#ui-tooling-preview/1.9.0": {
    "module": "sha256-qLznna0FAdzZ4hCg0TrDGpiYtn0fDfJoNJuwP/RYgM0=",
    "pom": "sha256-3Sx+EPRlVAIyJVl4J+n4B79+UEq30vkjp6C8pEffiD0="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.10.1": {
+  "org/jetbrains/compose/ui#ui-uikit/1.10.2": {
    "jar": "sha256-GhOzmt860nZ/ln92S6Cg0u0qLQnu8xDyLSwDBNe9pss=",
-   "module": "sha256-xpO76jqvcOHCjCWNamWSMgmnv2HuLJ1jweq59tzl6rg=",
-   "pom": "sha256-OhNf4Y7zfx/XBJVe1ITxOErOXJAA4qhDhxkN1nJ6zSc="
+   "module": "sha256-+1aUkmM71+JIB3reKqs07wnR30Sy7V9de6zToP41SF8=",
+   "pom": "sha256-Lc7VuwUVNo2BEcj9hfuUrmzdEYSmhfTApLXOaooqiUc="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.10.1": {
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.10.2": {
    "jar": "sha256-8PNDmSiz2RMvB8steoYJFpY3LryDVNFrSIMLbOFegWE=",
-   "module": "sha256-YRE98lDllZ9mBwa9AjmRhA7xR8rn682K5/T3RIiGrgw=",
-   "pom": "sha256-qTiIieU/w9X8fD2RjNYrh+DVWz8wxJAlTy+liraB054="
+   "module": "sha256-4Oz+MQYjgPPmGXrebtOctXgVgruj9HN9XnIQhMr4scE=",
+   "pom": "sha256-Zu8qHLFkkcYXqOIb9jtMqzBd3CdPyVjF554NILwBWA8="
   },
   "org/jetbrains/compose/ui#ui-unit-desktop/1.7.3": {
    "module": "sha256-Tscp7nc71qd6x6bKCayPqPUFejgJjclUnYSm44ml7pw=",
    "pom": "sha256-n/eV5ZtaFbFZMYar9pUyNlEbMkb6s9lAhURyUxTDcKs="
-  },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.8.2": {
-   "jar": "sha256-KW0j3qp4tQjPldFM9b2lik861bQthfzIvs9uEv+9A34=",
-   "module": "sha256-8dmVveiTQj6I8eFIunCLOP/FbZTXXMdLO5Fy2Laf0XE=",
-   "pom": "sha256-bgTgmIh+hmyLZZGa+ui2yrqEnBrgcQbcql0hrCr7y0w="
   },
   "org/jetbrains/compose/ui#ui-unit-desktop/1.9.0": {
    "jar": "sha256-EV99ATZ/4ddX9G8+WIJXzBLTmiIiprOXVIfKDuqGFuY=",
    "module": "sha256-9LjQy4GaPPqID16h6LxxPe4439uRa8P1vdjd1Cp2TmY=",
    "pom": "sha256-CwR/GlukxA3i2aels9nBgZ6rNW9kvNxUAqr8dvsiUwE="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.10.1": {
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.9.3": {
+   "jar": "sha256-EV99ATZ/4ddX9G8+WIJXzBLTmiIiprOXVIfKDuqGFuY=",
+   "module": "sha256-U1s9qLc15uzRKRSAOfr/FKJHar0D+kFCTObt1f7GI6w=",
+   "pom": "sha256-h/R7VdAMyoj2UW6FqESUCfBf63fPszdnoq7vYhYDJRI="
+  },
+  "org/jetbrains/compose/ui#ui-unit/1.10.2": {
    "jar": "sha256-khB/iX1tho/DPn5O3cPodMqa6yLYcSdkasjtK2drxHo=",
-   "module": "sha256-Qa16Vdgl3znnJKO5Z2lRXsla1JQ/Ft43/XJWpsAtEAI=",
-   "pom": "sha256-RJPs7/7JMFiFT7NQQaG2SCD2r2Uz8S41gsLd8izRxFg="
+   "module": "sha256-u07ZBvqCfVLfh4aVsrHmwSWN23EutwNQFtEx+4KBIR8=",
+   "pom": "sha256-8d38LKNUpnCATK1oNWqI5/EN7lAhcUcEBkEb03L9fIg="
   },
   "org/jetbrains/compose/ui#ui-unit/1.7.3": {
    "module": "sha256-12BSTnbgmCj0oa3tvG89ZGZ+g4GP9A2G8MXOANlIrWg=",
    "pom": "sha256-DA7+AYbpUYP+JYBBmDJNLy8xdwSEV0qQlrmLrAzZ/9E="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.8.2": {
-   "module": "sha256-vWHQGMwjQpCjuiSvwmev6vkM/4QQfbvSVhqhB/mYLqQ=",
-   "pom": "sha256-Y9sio4iZUyWqG08ENNIkM4ukwnzAknEp8AQTVcmbuLA="
-  },
   "org/jetbrains/compose/ui#ui-unit/1.9.0": {
    "module": "sha256-swHbwckV5ClwaGLg09Q7DrG+0xkkd1Vns+7t2SH0g84=",
    "pom": "sha256-xE2RKziWVTv7+ZXmf+uJZtpP1QNGm4j048Ea/KyS3HU="
   },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.10.1": {
-   "jar": "sha256-e/yTqMrSl0zf1aLIF+MIPg48SO+Z5Nu6UeuYoUyS7S0=",
-   "module": "sha256-y7c3PqODuh7cL11lOpe1xagoD5zvvris4Q5IA4WEZSg=",
-   "pom": "sha256-h6VntOLXfd7CE+W1n7HPqG3vnmgUnMl3NtED1R+ttBE="
+  "org/jetbrains/compose/ui#ui-unit/1.9.3": {
+   "module": "sha256-+rgCJR75HGHb76FqSNupF/yVt9sJzQohLXn6XdRCgts=",
+   "pom": "sha256-SvveVAHDpEDevrSvcszIknHUA9uL0Osi41xUW2ZhT84="
   },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.8.2": {
-   "jar": "sha256-47HEObTqgChb6Q6u2OcFZDf2cc+v5LGKOpy1OHyAvko=",
-   "module": "sha256-r5IyPLGSvw2NEVb7UuLp+1tnm4z0urpyfCuLtBH62J8=",
-   "pom": "sha256-swyKVwwd1IKFyCvtydGsadt3dqna13PvnH2jhnNzaHk="
+  "org/jetbrains/compose/ui#ui-util-desktop/1.10.2": {
+   "jar": "sha256-e/yTqMrSl0zf1aLIF+MIPg48SO+Z5Nu6UeuYoUyS7S0=",
+   "module": "sha256-9q8Cs99OROENdxjTW5RtIIn8TmUv5Z5Dj8SKBoKNL08=",
+   "pom": "sha256-ngqYKDtuUXOjSUY5LeVE2TDOMGcuZYxqjU+5nv8rRuQ="
   },
   "org/jetbrains/compose/ui#ui-util-desktop/1.9.0": {
    "jar": "sha256-nLACuJI3L6IDCX6hHSFz3z4nEPZAzPeK2NBfPprx9xY=",
    "module": "sha256-SUw37O+HE6n4UoBX6BbaPW3UD/kRcMZfygX7MlStozI=",
    "pom": "sha256-6jmJnKSbL2BgJpcaZsbJcLNcpcyDNzWBssu7JcFaPtA="
   },
-  "org/jetbrains/compose/ui#ui-util/1.10.1": {
-   "jar": "sha256-8K3Lk6F/J7VUgxQgfbiq+Y+u1i49stIsqYxJnqK8I+0=",
-   "module": "sha256-uG5tE5YZATcAmTwXVCQCjHypSEIbELCqvtXHWkXCB6Y=",
-   "pom": "sha256-Fnb794tdB+XXzx68+7hyWLiY7zvT6OKj8ANY0mOmnxA="
+  "org/jetbrains/compose/ui#ui-util-desktop/1.9.3": {
+   "jar": "sha256-nLACuJI3L6IDCX6hHSFz3z4nEPZAzPeK2NBfPprx9xY=",
+   "module": "sha256-ouuTFJGMuOIn404uuvSTcRsPSv8nwZ+zGrr43b+8SU0=",
+   "pom": "sha256-PdzaSnSoiB1TJHwCG4oLRtpP+nnw3ISfCouvbedXCSI="
   },
-  "org/jetbrains/compose/ui#ui-util/1.8.2": {
-   "module": "sha256-+ZuWex/wIFJWfUxNG9A6O0GBvX9X2ljgSjBiY+hh8Pg=",
-   "pom": "sha256-RX/A+m1EwZgcCPdSrqDoS5QKgnyPeUUX1OOVjoYFO8Y="
+  "org/jetbrains/compose/ui#ui-util/1.10.2": {
+   "jar": "sha256-8K3Lk6F/J7VUgxQgfbiq+Y+u1i49stIsqYxJnqK8I+0=",
+   "module": "sha256-XioCtD/IMsL75T+jK36xE6Ip7xGPFAGqp663vSBvnwc=",
+   "pom": "sha256-bGFGUqw3hReC69GpPUMj+az7ZZrtlYsp9zFmpfjcxNU="
   },
   "org/jetbrains/compose/ui#ui-util/1.9.0": {
    "module": "sha256-y6I6SuhwblUOxPj3BW225t4Q7oGB9ZEYtUGyzTWrP/g=",
    "pom": "sha256-FXiSH0ZOLYUd47smQi7VTeiet5Tz/3Ufu4HmqbOxLW0="
   },
-  "org/jetbrains/compose/ui#ui/1.10.1": {
-   "jar": "sha256-rKMrBWibtBFqwQ7usoOlfQy36h782XYh1GQ/XLRP7Gw=",
-   "module": "sha256-32F1jPHHj4Wv8lmbB6oQ8FCuNJ4x38MLmxfVJkqOlRw=",
-   "pom": "sha256-wDwaG7N6uDnOBrP3kT/+nNm7A13MGXy40nqRTZ4rCwM="
+  "org/jetbrains/compose/ui#ui-util/1.9.3": {
+   "module": "sha256-vzxx0r1FrCKQFidq+zp/V58XWAUuNsv00DA7E9nb6zA=",
+   "pom": "sha256-Qko43+7YsGYRZPE8YgfwrFMJ/0zU4oSxOqJ4tqRvUvY="
   },
-  "org/jetbrains/compose/ui#ui/1.8.2": {
-   "module": "sha256-fI8CBQvAcwJreqZQYw1y7xyaluJrzmABgnvemem28PE=",
-   "pom": "sha256-rmWkRWgrtqPr5k5NdVwwQHvXXUtakfBJH5u5wcBy4c4="
+  "org/jetbrains/compose/ui#ui/1.10.2": {
+   "jar": "sha256-rKMrBWibtBFqwQ7usoOlfQy36h782XYh1GQ/XLRP7Gw=",
+   "module": "sha256-C2mrbyFVI2ZiNK3Uv5fvcehRpHBEpjWKpqAMsdyNc9E=",
+   "pom": "sha256-uEivWz0+RMqetWSrIM1HUva7VZe4zsNHFDRgI8Kb8N8="
   },
   "org/jetbrains/compose/ui#ui/1.9.0": {
    "module": "sha256-M6lOgXRyk5JvQ5FMDB0G1LFrSfTKwX1geTXHLjD8yEc=",
    "pom": "sha256-Pd5Fl2AoE2rkmsrdr7O6oWT8wpTv6sGqjaoRI0EdPPI="
+  },
+  "org/jetbrains/compose/ui#ui/1.9.3": {
+   "module": "sha256-g6n1tIgz3apLwOxywHUn9kIUMehcuMtKYjHt18kIhDE=",
+   "pom": "sha256-1BliLw4IiJAwNstVd/dor/6jEbk4+KjHNhcTfM7sqs4="
   },
   "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
    "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
@@ -2124,6 +2232,10 @@
    "jar": "sha256-7Hlt8TXZgLuxdA54n+hmioGE3yQ+TRw5mXdQMDx28Ts=",
    "pom": "sha256-OdTTs4n7AZEljgICt7DeawkhBQm81haLJ3Slsk8u1qI="
   },
+  "org/jetbrains/skiko#skiko-awt-runtime-macos-arm64/0.9.22.2": {
+   "jar": "sha256-iaMVIfr5mFu9SFjIYyg9HDjqXXjRd72zmqMgMoXy/QQ=",
+   "pom": "sha256-sqCj8EKIL9aGPFpynw1S3TpVTWpxCYfW8PNVifDY3oY="
+  },
   "org/jetbrains/skiko#skiko-awt/0.9.22.2": {
    "jar": "sha256-jMftbErik0zd9lAtF98w89HCNYmMggtQYrkw/qS51jw=",
    "module": "sha256-LeiBcFkeTTs4BM1Mdr2I5XUGBjUyOyHCiXGqw9dkBk4=",
@@ -2134,11 +2246,6 @@
    "module": "sha256-GsTVhATzIPDdifbMoV+Bj048iehjiATfjgHtTYDFyHo=",
    "pom": "sha256-jMcrhU+iv+z2j79TB66ZLxP+wxa6hQksYsiJswNopa8="
   },
-  "org/jetbrains/skiko#skiko-awt/0.9.4.2": {
-   "jar": "sha256-fQxhrXQp0vnBbaGMtAi5PIOiO9iE57JdICJcEjsUWQs=",
-   "module": "sha256-QLtd1spRZwbFeF6FWNzouZquZt+jOqW3SrgtJdpF6QM=",
-   "pom": "sha256-nFBlTp2Mzx1vR/53vsHXPObqcGI0Li13AdnKF49e1Is="
-  },
   "org/jetbrains/skiko#skiko/0.9.22.2": {
    "module": "sha256-++zojoxrB/L+lPgSKs9AfjnTsMFUzHf+OLZoPfNn9Ks=",
    "pom": "sha256-FVBgFtv1/RvtYYDWpVe7dyeX1N2woKzKLu0OVkf69fw="
@@ -2147,10 +2254,6 @@
    "jar": "sha256-cnPbKwiENaMKptPPRl8cgtCR4cU43r13F6OXirP4l9o=",
    "module": "sha256-cCCSHsd+yhXxDs3xbMt1fOUToR9e1KKHPh3FYJ4EYok=",
    "pom": "sha256-yGEgoPxWVhXsdLgBnP65EnsqzDAgpx+qn3DdUswmtBk="
-  },
-  "org/jetbrains/skiko#skiko/0.9.4.2": {
-   "module": "sha256-6jCa+fvM7wsStVetEF9GVXgxEhYgMLvwXkYYc79SPSc=",
-   "pom": "sha256-JJZxEpDExjiEPbjjXqPm8dWXBlshEhYCvsAEQE7+3dA="
   },
   "org/jsoup#jsoup/1.22.1": {
    "jar": "sha256-z9MpjYcgzd+wVFEJzMbqDvOe/36cQKEK2VyTpl8ByRY=",
@@ -2201,10 +2304,10 @@
   }
  },
  "https://www.jitpack.io": {
-  "com/github/beeper/matrix-messageformat-compose#messageformat-jvm/625f17508b966606cfbfcee5e3ea8bc106c2077c": {
-   "jar": "sha256-JQcbSHANH82sMdLKui0URVJyBtxsif+95xTZK4gBKmc=",
-   "module": "sha256-MQO7WFh7M+vlOZZ/2xWxFPipdoyOWfIGpTck+zbSAL8=",
-   "pom": "sha256-tCB+GDe7UIeASDaU0niXlOiSfY5v/npmjDOGeN70QSQ="
+  "com/github/beeper/matrix-messageformat-compose#messageformat-jvm/9c24e92ba36252e33a8d19a045874ec76d168e26": {
+   "jar": "sha256-fWUy6SSLWfn9aEolGUII/xlvUFLgf8XsFewF0AoHcYc=",
+   "module": "sha256-ZYsZdiYuUUvQ/0wzScsqakrhmFYmjNHj5Ki4JywVwpU=",
+   "pom": "sha256-LM66SIdRz8xuQdvBURwLd4u6wVfA7/e6Xhz7mPPYxAQ="
   }
  }
 }

--- a/pkgs/by-name/sc/schildi-revenge/package.nix
+++ b/pkgs/by-name/sc/schildi-revenge/package.nix
@@ -14,20 +14,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "schildi-revenge";
-  version = "26.03.03";
+  version = "26.04.04";
 
   src = fetchFromGitHub {
     owner = "SchildiChat";
     repo = "schildi-revenge";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9peDC4NCa/cJ3eljs/2eyM9yMTBa7w2ddcuQOKjX5Ts=";
+    hash = "sha256-B3UOCcEWPt+kejK6mJZkYnVoSfzx1m28DM+Oco6iFJ8=";
     fetchSubmodules = true;
   };
 
   cargoRoot = "matrix-rust-sdk";
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-NWxop42zsSGtI2H2itwRdgkgbOBXe3po5MKb47BWbcQ=";
+    hash = "sha256-1BUBOBOsQ+I3bKUMnzwtqCd/uh/gEWW9THhjaDXWWeg=";
   };
 
   nativeBuildInputs = [
@@ -83,12 +83,14 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "SchildiChatRevenge";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Only;
+    homepage = "https://schildi.chat/revenge";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       binaryBytecode # mitm cache
     ];
     maintainers = with lib.maintainers; [
       _71rd
+      xeni
     ];
   };
 })


### PR DESCRIPTION
## Changelog
 https://github.com/SchildiChat/schildi-revenge/releases/tag/v26.04.04


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
