### PR TITLE
grails: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/gr/grails/package.nix
+++ b/pkgs/by-name/gr/grails/package.nix
@@ -24,13 +24,13 @@ let
     ++ lib.optional (grailsJdk != null) grailsJdk
   );
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "grails";
   version = "7.0.0-M3";
 
   src = fetchurl {
-    url = "https://github.com/grails/grails-core/releases/download/v${version}/grails-${version}.zip";
-    sha256 = "sha256-BM3fxmf86o+Ob63bE9aSCBh2MlkIS4AsYj7CZr/PVWU=";
+    url = "https://github.com/grails/grails-core/releases/download/v${finalAttrs.version}/grails-${finalAttrs.version}.zip";
+    hash = "sha256-BM3fxmf86o+Ob63bE9aSCBh2MlkIS4AsYj7CZr/PVWU=";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -67,4 +67,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.bjornfor ];
   };
-}
+})

--- a/pkgs/by-name/gr/grails/package.nix
+++ b/pkgs/by-name/gr/grails/package.nix
@@ -3,9 +3,10 @@
   stdenv,
   fetchurl,
   unzip,
-  # If jdk is null, require JAVA_HOME in runtime environment, else store
-  # JAVA_HOME=${jdk.home} into grails.
-  jdk ? null,
+  # Renamed from 'jdk' to avoid callPackage auto-injecting pkgs.jdk.
+  # If grailsJdk is null, require JAVA_HOME in runtime environment,
+  # else store JAVA_HOME=${grailsJdk.home} into grails.
+  grailsJdk ? null,
   coreutils,
   ncurses,
   gnused,
@@ -20,7 +21,7 @@ let
       gnused
       gnugrep
     ]
-    ++ lib.optional (jdk != null) jdk
+    ++ lib.optional (grailsJdk != null) grailsJdk
   );
 in
 stdenv.mkDerivation rec {
@@ -44,9 +45,9 @@ stdenv.mkDerivation rec {
     # Improve purity
     sed -i -e '2iPATH=${binpath}:\$PATH' "$out"/bin/grails
   ''
-  + lib.optionalString (jdk != null) ''
+  + lib.optionalString (grailsJdk != null) ''
     # Inject JDK path into grails
-    sed -i -e '2iJAVA_HOME=${jdk.home}' "$out"/bin/grails
+    sed -i -e '2iJAVA_HOME=${grailsJdk.home}' "$out"/bin/grails
   '';
 
   preferLocalBuild = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2541,8 +2541,6 @@ with pkgs;
 
   gprof2dot = with python3Packages; toPythonApplication gprof2dot;
 
-  grails = callPackage ../development/web/grails { jdk = null; };
-
   graylog-6_0 = callPackage ../tools/misc/graylog/6.0.nix { };
 
   inherit


### PR DESCRIPTION
This pull request reorganizes and refactors the packaging for the `grails` package in Nixpkgs. The main focus is on moving the package to the new by-name directory structure and improving the clarity and purity of its JDK dependency handling. The most important changes are:

**Refactoring and Directory Restructuring:**
* Moved the `grails` package from `pkgs/development/web/grails/default.nix` to `pkgs/by-name/gr/grails/package.nix` to follow the by-name directory convention.

**JDK Dependency Handling Improvements:**
* Renamed the `jdk` argument to `grailsJdk` to avoid unintentional injection of `pkgs.jdk` and clarified its usage throughout the package. All references to `jdk` are updated to `grailsJdk`, and the logic for setting `JAVA_HOME` in the wrapper script is updated accordingly.

**Derivation Modernization:**
* Updated the derivation to use the argument form `stdenv.mkDerivation (finalAttrs: { ... })` instead of the deprecated `rec` form, and used `finalAttrs.version` in the `src` URL for better maintainability.

**Top-level Package List Cleanup:**
* Removed the old reference to `grails` from `pkgs/top-level/all-packages.nix`, as part of the migration to the new directory structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
