### PR TITLE
lib/services: expose portable service lib as `lib.services`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -89,6 +89,7 @@ let
 
       # domain-specific
       fetchers = callLibs ./fetchers.nix;
+      services = callLibs ./services/lib.nix;
 
       # Eval-time filesystem handling
       path = callLibs ./path;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -89,6 +89,7 @@ let
 
       # domain-specific
       fetchers = callLibs ./fetchers.nix;
+      services = callLibs ./services/lib.nix;
 
       # Modules that are not specific to a module class
       genericModules = {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -90,6 +90,12 @@ let
       # domain-specific
       fetchers = callLibs ./fetchers.nix;
 
+      # Modules that are not specific to a module class
+      genericModules = {
+        meta-maintainers = ./modules/generic/meta-maintainers.nix;
+        assertions = ./modules/generic/assertions.nix;
+      };
+
       # Eval-time filesystem handling
       path = callLibs ./path;
       filesystem = callLibs ./filesystem.nix;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -90,6 +90,7 @@ let
       # domain-specific
       fetchers = callLibs ./fetchers.nix;
       services = callLibs ./services/lib.nix;
+      importService = self.modules.importApply ./services/service.nix;
 
       # Modules that are not specific to a module class
       genericModules = {

--- a/lib/modules/generic/assertions.nix
+++ b/lib/modules/generic/assertions.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+{
+  _class = null; # not specific to NixOS
+
+  options = {
+
+    assertions = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      internal = true;
+      default = [ ];
+      example = [
+        {
+          assertion = false;
+          message = "you can't enable this for that reason";
+        }
+      ];
+      description = ''
+        This option allows modules to express conditions that must
+        hold for the evaluation of the system configuration to
+        succeed, along with associated error messages for the user.
+      '';
+    };
+
+    warnings = lib.mkOption {
+      internal = true;
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+      example = [ "The `foo' service is deprecated and will go away soon!" ];
+      description = ''
+        This option allows modules to show warnings to users during
+        the evaluation of the system configuration.
+      '';
+    };
+
+  };
+  # impl of assertions is in
+  # - <nixpkgs/nixos/modules/system/activation/top-level.nix>
+  # - <nixpkgs/lib/services/lib.nix>
+}

--- a/lib/modules/generic/meta-maintainers.nix
+++ b/lib/modules/generic/meta-maintainers.nix
@@ -1,0 +1,59 @@
+# Test:
+#   ../../../modules/generic/meta-maintainers/test.nix
+{ lib, ... }:
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+
+  # The resulting value of this type shows where all values were defined
+  sourceList = types.listOf types.raw // {
+    merge = loc: defs: lib.listToAttrs (lib.map ({ file, value }: lib.nameValuePair file value) defs);
+  };
+in
+{
+  _class = null; # not specific to NixOS
+  options = {
+    meta = {
+      maintainers = mkOption {
+        type =
+          let
+            allMaintainers = lib.attrValues lib.maintainers;
+          in
+          lib.types.addCheck sourceList (lib.all (v: lib.elem v allMaintainers))
+          // {
+            description = "list of lib.maintainers";
+          };
+        default = [ ];
+        example = lib.literalExpression "[ lib.maintainers.alice lib.maintainers.bob ]";
+        description = ''
+          List of maintainers of each module.
+          This option should be defined at most once per module.
+
+          The option value is not a list of maintainers, but an attribute set that maps module file names to lists of maintainers.
+        '';
+      };
+      teams = mkOption {
+        type =
+          let
+            allTeams = lib.attrValues lib.teams;
+          in
+          lib.types.addCheck sourceList (lib.all (v: lib.elem v allTeams))
+          // {
+            description = "list of lib.teams";
+          };
+        default = [ ];
+        example = lib.literalExpression "[ lib.teams.acme lib.teams.haskell ]";
+        description = ''
+          List of team maintainers of each module.
+          This option should be defined at most once per module.
+        '';
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    pierron
+    roberth
+  ];
+}

--- a/lib/services/lib.nix
+++ b/lib/services/lib.nix
@@ -43,9 +43,9 @@ rec {
 
     # Inputs
 
-    `serviceManagerPkgs`: A Nixpkgs instance which will be used for built-in logic such as converting `configData.<path>.text` to a store path.
+    `baseModules`: The portable service base modules (typically `service.nix` via `importApply`). These are loaded into the "root" service submodule and must handle propagation to sub-`services` themselves.
 
-    `extraRootModules`: Modules to be loaded into the "root" service submodule, but not into its sub-`services`. That's the modules' own responsibility.
+    `extraRootModules`: Additional modules to be loaded into the "root" service submodule, but not into its sub-`services`. That's the modules' own responsibility.
 
     `extraRootSpecialArgs`: Fixed module arguments that are provided in a similar manner to `extraRootModules`.
 
@@ -57,17 +57,14 @@ rec {
   */
   configure =
     {
-      serviceManagerPkgs,
+      baseModules ? [ ],
       extraRootModules ? [ ],
       extraRootSpecialArgs ? { },
     }:
     let
-      modules = [
-        (lib.modules.importApply ./service.nix { pkgs = serviceManagerPkgs; })
-      ];
       serviceSubmodule = types.submoduleWith {
         class = "service";
-        modules = modules ++ extraRootModules;
+        modules = baseModules ++ extraRootModules;
         specialArgs = extraRootSpecialArgs;
       };
     in

--- a/lib/services/lib.nix
+++ b/lib/services/lib.nix
@@ -52,6 +52,8 @@ rec {
     let
       modularServiceConfiguration = lib.services.configure {
         serviceManagerPkgs = pkgs;
+        # To load a different portable service base, set `baseModules` instead:
+        #   baseModules = [ (lib.importService { inherit pkgs; }) ];
         extraRootModules = [
           ./launchd-service.nix    # launchd-specific options (plist generation, etc.)
         ];
@@ -80,18 +82,27 @@ rec {
     `serviceManagerPkgs`
 
     : 1\. A Nixpkgs instance used for built-in logic such as converting
-    `configData.<path>.text` to a store path.
+    `configData.<path>.text` to a store path. Required unless `baseModules`
+    is set.
+
+    `baseModules`
+
+    : 2\. Modules that replace the portable service base. They are loaded
+    into the "root" service submodule and must handle propagation to
+    sub-`services` themselves. Defaults to the portable service base of
+    this Nixpkgs. Set it to supply a different one, for example a
+    `service.nix` pinned from another Nixpkgs.
 
     `extraRootModules`
 
-    : 2\. Modules to be loaded into the "root" service submodule, but not
+    : 3\. Modules to be loaded into the "root" service submodule, but not
     into its sub-`services`. That's the modules' own responsibility.
     Typically contains service-manager-specific option modules
     (e.g. systemd unit options, launchd plist options).
 
     `extraRootSpecialArgs`
 
-    : 3\. Fixed module arguments provided alongside `extraRootModules`.
+    : 4\. Fixed module arguments provided alongside `extraRootModules`.
 
     # Output
 
@@ -101,17 +112,15 @@ rec {
   */
   configure =
     {
-      serviceManagerPkgs,
+      serviceManagerPkgs ? throw "lib.services.configure: `serviceManagerPkgs` is required unless `baseModules` is set",
+      baseModules ? [ (lib.importService { pkgs = serviceManagerPkgs; }) ],
       extraRootModules ? [ ],
       extraRootSpecialArgs ? { },
     }:
     let
-      modules = [
-        (lib.modules.importApply ./service.nix { pkgs = serviceManagerPkgs; })
-      ];
       serviceSubmodule = types.submoduleWith {
         class = "service";
-        modules = modules ++ extraRootModules;
+        modules = baseModules ++ extraRootModules;
         specialArgs = extraRootSpecialArgs;
       };
     in

--- a/lib/services/lib.nix
+++ b/lib/services/lib.nix
@@ -50,9 +50,7 @@ rec {
     # darwin/modules/services/system.nix
     { lib, config, pkgs, ... }:
     let
-      portable-lib = import <nixpkgs/lib/services/lib.nix> { inherit lib; };
-
-      modularServiceConfiguration = portable-lib.configure {
+      modularServiceConfiguration = lib.services.configure {
         serviceManagerPkgs = pkgs;
         extraRootModules = [
           ./launchd-service.nix    # launchd-specific options (plist generation, etc.)

--- a/lib/services/service.nix
+++ b/lib/services/service.nix
@@ -42,8 +42,8 @@ in
   # https://nixos.org/manual/nixos/unstable/#modular-services
   _class = "service";
   imports = [
-    ../../modules/generic/meta-maintainers.nix
-    ../../nixos/modules/misc/assertions.nix
+    ../modules/generic/meta-maintainers.nix
+    ../modules/generic/assertions.nix
     (lib.modules.importApply ./config-data.nix { inherit pkgs; })
   ];
   options = {

--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -8,9 +8,11 @@ let
   portable-lib = lib.services;
 
   configured = portable-lib.configure {
-    serviceManagerPkgs = throw "do not use pkgs in this test";
-    extraRootModules = [ ];
-    extraRootSpecialArgs = { };
+    baseModules = [
+      (lib.modules.importApply ./service.nix {
+        pkgs = throw "do not use pkgs in this test";
+      })
+    ];
   };
 
   dummyPkg =

--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -5,7 +5,7 @@ let
 
   inherit (lib) mkOption types;
 
-  portable-lib = import ./lib.nix { inherit lib; };
+  portable-lib = lib.services;
 
   configured = portable-lib.configure {
     serviceManagerPkgs = throw "do not use pkgs in this test";

--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -91,10 +91,16 @@ let
     ];
   };
 
+  # Every service carries some assertions that hold; only the violated ones are of interest here.
+  failures = lib.filter (a: !a.assertion);
+
   filterEval =
     config:
     lib.optionalAttrs (config ? process) {
-      inherit (config) assertions warnings process;
+      inherit (config) warnings;
+      assertions = failures config.assertions;
+      # Only `argv` is relevant here; `process` also carries the reload options.
+      process = { inherit (config.process) argv; };
     }
     // {
       services = lib.mapAttrs (k: filterEval) config.services;
@@ -165,7 +171,7 @@ let
       ];
 
     assert
-      portable-lib.getAssertions [ "service1" ] exampleEval.config.services.service1 == [
+      failures (portable-lib.getAssertions [ "service1" ] exampleEval.config.services.service1) == [
         {
           message = "in service1: you can't enable this for that reason";
           assertion = false;
@@ -177,7 +183,7 @@ let
         "in service3.services.exclacow: The `bar' service is deprecated and will go away soon!"
       ];
     assert
-      portable-lib.getAssertions [ "service3" ] exampleEval.config.services.service3 == [
+      failures (portable-lib.getAssertions [ "service3" ] exampleEval.config.services.service3) == [
         {
           message = "in service3.services.exclacow: you can't enable this for such reason";
           assertion = false;

--- a/modules/generic/meta-maintainers.nix
+++ b/modules/generic/meta-maintainers.nix
@@ -1,59 +1,7 @@
 # Test:
 #   ./meta-maintainers/test.nix
-{ lib, ... }:
-let
-  inherit (lib)
-    mkOption
-    types
-    ;
-
-  # The resulting value of this type shows where all values were defined
-  sourceList = types.listOf types.raw // {
-    merge = loc: defs: lib.listToAttrs (lib.map ({ file, value }: lib.nameValuePair file value) defs);
-  };
-in
 {
-  _class = null; # not specific to NixOS
-  options = {
-    meta = {
-      maintainers = mkOption {
-        type =
-          let
-            allMaintainers = lib.attrValues lib.maintainers;
-          in
-          lib.types.addCheck sourceList (lib.all (v: lib.elem v allMaintainers))
-          // {
-            description = "list of lib.maintainers";
-          };
-        default = [ ];
-        example = lib.literalExpression "[ lib.maintainers.alice lib.maintainers.bob ]";
-        description = ''
-          List of maintainers of each module.
-          This option should be defined at most once per module.
-
-          The option value is not a list of maintainers, but an attribute set that maps module file names to lists of maintainers.
-        '';
-      };
-      teams = mkOption {
-        type =
-          let
-            allTeams = lib.attrValues lib.teams;
-          in
-          lib.types.addCheck sourceList (lib.all (v: lib.elem v allTeams))
-          // {
-            description = "list of lib.teams";
-          };
-        default = [ ];
-        example = lib.literalExpression "[ lib.teams.acme lib.teams.haskell ]";
-        description = ''
-          List of team maintainers of each module.
-          This option should be defined at most once per module.
-        '';
-      };
-    };
-  };
-  meta.maintainers = with lib.maintainers; [
-    pierron
-    roberth
-  ];
+  # Not `lib.genericModules.meta-maintainers`: the `lib` module argument may come
+  # from a different Nixpkgs version than this file.
+  imports = [ ../../lib/modules/generic/meta-maintainers.nix ];
 }

--- a/modules/generic/meta-maintainers/test.nix
+++ b/modules/generic/meta-maintainers/test.nix
@@ -37,7 +37,7 @@ rec {
   test =
     assert
       example.config.meta.maintainers == {
-        ${toString ../meta-maintainers.nix} = [
+        ${toString ../../../lib/modules/generic/meta-maintainers.nix} = [
           lib.maintainers.pierron
           lib.maintainers.roberth
         ];

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -25,7 +25,6 @@ let
     escapeShellArg
     concatMapStringsSep
     sourceFilesBySuffices
-    modules
     ;
 
   common = import ./common.nix;
@@ -134,7 +133,7 @@ let
     inherit
       (evalModules {
         modules = [
-          (modules.importApply ../../../lib/services/service.nix {
+          (pkgs.lib.importService {
             pkgs = throw "nixos docs / portableServiceOptions: Do not reference pkgs in docs";
           })
         ];

--- a/nixos/modules/misc/assertions.nix
+++ b/nixos/modules/misc/assertions.nix
@@ -1,38 +1,5 @@
-{ lib, ... }:
 {
-
-  options = {
-
-    assertions = lib.mkOption {
-      type = lib.types.listOf lib.types.unspecified;
-      internal = true;
-      default = [ ];
-      example = [
-        {
-          assertion = false;
-          message = "you can't enable this for that reason";
-        }
-      ];
-      description = ''
-        This option allows modules to express conditions that must
-        hold for the evaluation of the system configuration to
-        succeed, along with associated error messages for the user.
-      '';
-    };
-
-    warnings = lib.mkOption {
-      internal = true;
-      default = [ ];
-      type = lib.types.listOf lib.types.str;
-      example = [ "The `foo' service is deprecated and will go away soon!" ];
-      description = ''
-        This option allows modules to show warnings to users during
-        the evaluation of the system configuration.
-      '';
-    };
-
-  };
-  # impl of assertions is in
-  # - <nixpkgs/nixos/modules/system/activation/top-level.nix>
-  # - <nixpkgs/lib/services/lib.nix>
+  # Not `lib.genericModules.assertions`: the `lib` module argument may come from a
+  # different Nixpkgs version than this file.
+  imports = [ ../../../lib/modules/generic/assertions.nix ];
 }

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -116,9 +116,7 @@ let
           && (t == "file" -> hasSuffix ".nix" n)
         );
         prefixRegex =
-          "^"
-          + lib.strings.escapeRegex (toString pkgs.path)
-          + "($|/(modules|nixos|lib/services)($|/.*)|/lib)";
+          "^" + lib.strings.escapeRegex (toString pkgs.path) + "($|/(modules|nixos|lib)($|/.*))";
         filteredModules = builtins.path {
           name = "source";
           inherit (pkgs) path;
@@ -132,7 +130,10 @@ let
       in
       pkgs.runCommand "lazy-options.json"
         rec {
-          libPath = filter (pkgs.path + "/lib");
+          # `lib` shares the `filteredModules` tree, so that `declarations` pointing
+          # into it are stripped by the `extraSources` of `../../doc/manual`, just
+          # like the ones pointing into `modules` and `nixos`.
+          libPath = filteredModules + "/lib";
           pkgsLibPath = filter (pkgs.path + "/pkgs/pkgs-lib");
           nixosPath = filteredModules + "/nixos";
           env.NIX_ABORT_ON_WARN = warningsAreErrors;
@@ -142,7 +143,6 @@ let
             + " ]";
           disallowedReferences = [
             filteredModules
-            libPath
             pkgsLibPath
           ];
           __structuredAttrs = true;

--- a/nixos/modules/system/service/systemd/system.nix
+++ b/nixos/modules/system/service/systemd/system.nix
@@ -61,7 +61,9 @@ let
     ) service.services;
 
   modularServiceConfiguration = portable-lib.configure {
-    serviceManagerPkgs = pkgs;
+    baseModules = [
+      (lib.modules.importApply ../../../../../lib/services/service.nix { inherit pkgs; })
+    ];
     extraRootModules = [
       ./service.nix
       ./config-data-path.nix

--- a/nixos/modules/system/service/systemd/system.nix
+++ b/nixos/modules/system/service/systemd/system.nix
@@ -15,7 +15,7 @@ let
     mapAttrsToList
     ;
 
-  portable-lib = import ../../../../../lib/services/lib.nix { inherit lib; };
+  portable-lib = lib.services;
 
   dash =
     before: after:


### PR DESCRIPTION
Followup to #506519. Adds `lib.services` so consumers can reference the portable service infrastructure directly instead of using fragile relative path imports.

fyi I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
