### PR TITLE
nixos-rebuild-ng: introduce --run0 flag

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -172,6 +172,9 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         "--sudo", action="store_true", help="Prefixes activation commands with sudo"
     )
     main_parser.add_argument(
+        "--run0", action="store_true", help="Prefixes activation commmands with run0"
+    )
+    main_parser.add_argument(
         "--use-remote-sudo",
         action="store_true",
         help="Deprecated, use '--sudo' instead",
@@ -298,6 +301,9 @@ def parse_args(
     if args.flake and (args.file or args.attr):
         parser.error("--flake cannot be used with --file or --attr")
 
+    if args.sudo and args.run0:
+        parser.error(f"--run0 and --sudo are mutually exclusive")
+
     if args.store_path:
         if args.rollback:
             parser.error("--store-path and --rollback are mutually exclusive")
@@ -321,7 +327,7 @@ def execute(argv: list[str]) -> None:
     args, grouped_nix_args = parse_args(argv)
 
     if args.upgrade or args.upgrade_all:
-        nix.upgrade_channels(args.upgrade_all, args.sudo)
+        nix.upgrade_channels(args.upgrade_all, args.sudo, args.run0)
 
     action = Action(args.action)
     # Only run shell scripts from the Nixpkgs tree if the action is

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -454,6 +454,7 @@ def get_generations_from_nix_env(
     profile: Profile,
     target_host: Remote | None = None,
     sudo: bool = False,
+    run0: bool = False,
 ) -> list[Generation]:
     """Get all NixOS generations from profile with nix-env. Needs root.
 
@@ -469,6 +470,7 @@ def get_generations_from_nix_env(
         stdout=PIPE,
         remote=target_host,
         sudo=sudo,
+        run0=run0,
     )
 
     def parse_line(line: str) -> Generation:
@@ -600,12 +602,15 @@ def repl_flake(flake: Flake, flake_flags: Args | None = None) -> None:
     )
 
 
-def rollback(profile: Profile, target_host: Remote | None, sudo: bool) -> Path:
+def rollback(
+    profile: Profile, target_host: Remote | None, sudo: bool, run0: bool
+) -> Path:
     "Rollback Nix profile, like one created by `nixos-rebuild switch`."
     run_wrapper(
         ["nix-env", "--rollback", "-p", profile.path],
         remote=target_host,
         sudo=sudo,
+        run0=run0,
     )
     # Rollback config PATH is the own profile
     return profile.path
@@ -615,10 +620,11 @@ def rollback_temporary_profile(
     profile: Profile,
     target_host: Remote | None,
     sudo: bool,
+    run0: bool,
 ) -> Path | None:
     "Rollback a temporary Nix profile, like one created by `nixos-rebuild test`."
     generations = get_generations_from_nix_env(
-        profile, target_host=target_host, sudo=sudo
+        profile, target_host=target_host, sudo=sudo, run0=run0
     )
     previous_gen_id = None
     for generation in generations:
@@ -636,6 +642,7 @@ def set_profile(
     path_to_config: Path,
     target_host: Remote | None,
     sudo: bool,
+    run0: bool,
 ) -> None:
     "Set a path as the current active Nix profile."
     if not os.environ.get(
@@ -669,6 +676,7 @@ def set_profile(
         ["nix-env", "-p", profile.path, "--set", path_to_config],
         remote=target_host,
         sudo=sudo,
+        run0=run0,
     )
 
 
@@ -677,6 +685,7 @@ def switch_to_configuration(
     action: Literal[Action.SWITCH, Action.BOOT, Action.TEST, Action.DRY_ACTIVATE],
     target_host: Remote | None,
     sudo: bool,
+    run0: bool,
     install_bootloader: bool = False,
     specialisation: str | None = None,
 ) -> None:
@@ -717,6 +726,7 @@ def switch_to_configuration(
         },
         remote=target_host,
         sudo=sudo,
+        run0=run0,
         # switch-to-configuration is not expected to produce meaningful
         # stdout, but if it (or any of its children) does, it would leak
         # into our stdout and break the "only the store path on stdout"
@@ -726,16 +736,18 @@ def switch_to_configuration(
     )
 
 
-def upgrade_channels(all_channels: bool = False, sudo: bool = False) -> None:
+def upgrade_channels(
+    all_channels: bool = False, sudo: bool = False, run0: bool = False
+) -> None:
     """Upgrade channels for classic Nix.
 
     It will either upgrade just the `nixos` channel (including any channel
     that has a `.update-on-nixos-rebuild` file) or all.
     """
-    if not sudo and os.geteuid() != 0:
+    if not sudo and not run0 and os.geteuid() != 0:
         raise NixOSRebuildError(
             "if you pass the '--upgrade' or '--upgrade-all' flag, you must "
-            "also pass '--sudo' or run the command as root (e.g., with sudo)"
+            "also pass '--sudo', '--run0', or run the command as root (e.g., with sudo)"
         )
 
     for channel_path in Path("/nix/var/nix/profiles/per-user/root/channels/").glob("*"):
@@ -748,4 +760,5 @@ def upgrade_channels(all_channels: bool = False, sudo: bool = False) -> None:
                 ["nix-channel", "--update", channel_path.name],
                 check=False,
                 sudo=sudo,
+                run0=run0,
             )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -131,6 +131,7 @@ def run_wrapper(
     append_local_env: Mapping[str, str] | None = None,
     remote: Remote | None = None,
     sudo: bool = False,
+    run0: bool = False,
     **kwargs: Unpack[RunKwargs],
 ) -> subprocess.CompletedProcess[str]:
     "Wrapper around `subprocess.run` that supports extra functionality."
@@ -163,6 +164,8 @@ def run_wrapper(
                 process_input = remote.sudo_password + "\n"
             else:
                 remote_run_args = ["sudo", *sudo_args, *remote_run_args]
+        if run0:
+            remote_run_args = ["run0", *remote_run_args]
 
         ssh_args: list[Arg] = [
             "ssh",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -132,12 +132,15 @@ def _rollback_system(
 ) -> Path:
     match action:
         case Action.SWITCH | Action.BOOT:
-            path_to_config = nix.rollback(profile, target_host, sudo=args.sudo)
+            path_to_config = nix.rollback(
+                profile, target_host, sudo=args.sudo, run0=args.run0
+            )
         case Action.TEST | Action.BUILD:
             maybe_path_to_config = nix.rollback_temporary_profile(
                 profile,
                 target_host,
                 sudo=args.sudo,
+                run0=args.run0,
             )
             if maybe_path_to_config:
                 path_to_config = maybe_path_to_config
@@ -232,12 +235,14 @@ def _activate_system(
                 path_to_config,
                 target_host=target_host,
                 sudo=args.sudo,
+                run0=args.run0,
             )
             nix.switch_to_configuration(
                 path_to_config,
                 action,
                 target_host=target_host,
                 sudo=args.sudo,
+                run0=args.run0,
                 specialisation=args.specialisation,
                 install_bootloader=args.install_bootloader,
             )
@@ -248,6 +253,7 @@ def _activate_system(
                 action,
                 target_host=target_host,
                 sudo=args.sudo,
+                run0=args.run0,
                 specialisation=args.specialisation,
                 install_bootloader=args.install_bootloader,
             )

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -532,6 +532,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             stdout=PIPE,
             remote=None,
             sudo=False,
+            run0=False,
         )
 
     remote = m.Remote("user@host", [], "password", "ssh")
@@ -550,6 +551,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             stdout=PIPE,
             remote=remote,
             sudo=True,
+            run0=False,
         )
 
 
@@ -640,19 +642,21 @@ def test_rollback(mock_run: Mock, tmp_path: Path) -> None:
 
     profile = m.Profile("system", path)
 
-    assert n.rollback(profile, None, False) == profile.path
+    assert n.rollback(profile, None, False, False) == profile.path
     mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
         remote=None,
         sudo=False,
+        run0=False,
     )
 
     target_host = m.Remote("user@localhost", [], None, "ssh")
-    assert n.rollback(profile, target_host, True) == profile.path
+    assert n.rollback(profile, target_host, True, False) == profile.path
     mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
         remote=target_host,
         sudo=True,
+        run0=False,
     )
 
 
@@ -672,7 +676,7 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
                 """),
         )
         assert (
-            n.rollback_temporary_profile(m.Profile("system", path), None, False)
+            n.rollback_temporary_profile(m.Profile("system", path), None, False, False)
             == path.parent / "system-2083-link"
         )
         mock_run.assert_called_with(
@@ -685,11 +689,14 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             stdout=PIPE,
             remote=None,
             sudo=False,
+            run0=False,
         )
 
         target_host = m.Remote("user@localhost", [], None, "ssh")
         assert (
-            n.rollback_temporary_profile(m.Profile("foo", path), target_host, True)
+            n.rollback_temporary_profile(
+                m.Profile("foo", path), target_host, True, False
+            )
             == path.parent / "foo-2083-link"
         )
         mock_run.assert_called_with(
@@ -702,11 +709,12 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             stdout=PIPE,
             remote=target_host,
             sudo=True,
+            run0=False,
         )
 
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         mock_run.return_value = CompletedProcess([], 0, stdout="")
-        assert n.rollback_temporary_profile(profile, None, False) is None
+        assert n.rollback_temporary_profile(profile, None, False, False) is None
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
@@ -720,12 +728,14 @@ def test_set_profile(mock_run: Mock) -> None:
         config_path,
         target_host=None,
         sudo=False,
+        run0=False,
     )
 
     mock_run.assert_called_with(
         ["nix-env", "-p", profile_path, "--set", config_path],
         remote=None,
         sudo=False,
+        run0=False,
     )
 
     mock_run.return_value = CompletedProcess([], 1)
@@ -736,6 +746,7 @@ def test_set_profile(mock_run: Mock) -> None:
             config_path,
             target_host=None,
             sudo=False,
+            run0=False,
         )
     assert str(e.value).startswith(
         "error: your NixOS configuration path seems to be missing essential files."
@@ -757,6 +768,7 @@ def test_switch_to_configuration_without_systemd_run(
             profile_path,
             m.Action.SWITCH,
             sudo=False,
+            run0=False,
             target_host=None,
             specialisation=None,
             install_bootloader=False,
@@ -769,6 +781,7 @@ def test_switch_to_configuration_without_systemd_run(
             "NIXOS_INSTALL_BOOTLOADER": "0",
         },
         sudo=False,
+        run0=False,
         remote=None,
         stdout=sys.stderr,
     )
@@ -778,6 +791,7 @@ def test_switch_to_configuration_without_systemd_run(
             config_path,
             m.Action.BOOT,
             sudo=False,
+            run0=False,
             target_host=None,
             specialisation="special",
         )
@@ -796,6 +810,7 @@ def test_switch_to_configuration_without_systemd_run(
             Path("/path/to/config"),
             m.Action.TEST,
             sudo=True,
+            run0=False,
             target_host=target_host,
             install_bootloader=True,
             specialisation="special",
@@ -811,6 +826,7 @@ def test_switch_to_configuration_without_systemd_run(
             "NIXOS_INSTALL_BOOTLOADER": "1",
         },
         sudo=True,
+        run0=False,
         remote=target_host,
         stdout=sys.stderr,
     )
@@ -831,6 +847,7 @@ def test_switch_to_configuration_with_systemd_run(
             profile_path,
             m.Action.SWITCH,
             sudo=False,
+            run0=False,
             target_host=None,
             specialisation=None,
             install_bootloader=False,
@@ -847,6 +864,7 @@ def test_switch_to_configuration_with_systemd_run(
             "NIXOS_INSTALL_BOOTLOADER": "0",
         },
         sudo=False,
+        run0=False,
         remote=None,
         stdout=sys.stderr,
     )
@@ -861,6 +879,7 @@ def test_switch_to_configuration_with_systemd_run(
             Path("/path/to/config"),
             m.Action.TEST,
             sudo=True,
+            run0=False,
             target_host=target_host,
             install_bootloader=True,
             specialisation="special",
@@ -877,6 +896,7 @@ def test_switch_to_configuration_with_systemd_run(
             "NIXOS_INSTALL_BOOTLOADER": "1",
         },
         sudo=True,
+        run0=False,
         remote=target_host,
         stdout=sys.stderr,
     )
@@ -901,25 +921,41 @@ def test_upgrade_channels(
     mock_glob: Mock,
 ) -> None:
     with pytest.raises(m.NixOSRebuildError) as e:
-        n.upgrade_channels(all_channels=False, sudo=False)
+        n.upgrade_channels(all_channels=False, sudo=False, run0=False)
     assert str(e.value) == (
         "error: if you pass the '--upgrade' or '--upgrade-all' flag, you must "
-        "also pass '--sudo' or run the command as root (e.g., with sudo)"
+        "also pass '--sudo', '--run0', or run the command as root (e.g., with sudo)"
     )
 
-    n.upgrade_channels(all_channels=False, sudo=True)
+    n.upgrade_channels(all_channels=False, sudo=True, run0=False)
     mock_run.assert_called_once_with(
-        ["nix-channel", "--update", "nixos"], check=False, sudo=True
+        ["nix-channel", "--update", "nixos"],
+        check=False,
+        sudo=True,
+        run0=False,
     )
 
     mock_geteuid.return_value = 0
-    n.upgrade_channels(all_channels=True, sudo=False)
+    n.upgrade_channels(all_channels=True, sudo=False, run0=False)
     mock_run.assert_has_calls(
         [
-            call(["nix-channel", "--update", "nixos"], check=False, sudo=False),
             call(
-                ["nix-channel", "--update", "nixos-hardware"], check=False, sudo=False
+                ["nix-channel", "--update", "nixos"],
+                check=False,
+                sudo=False,
+                run0=False,
             ),
-            call(["nix-channel", "--update", "home-manager"], check=False, sudo=False),
+            call(
+                ["nix-channel", "--update", "nixos-hardware"],
+                check=False,
+                sudo=False,
+                run0=False,
+            ),
+            call(
+                ["nix-channel", "--update", "home-manager"],
+                check=False,
+                sudo=False,
+                run0=False,
+            ),
         ]
     )


### PR DESCRIPTION
adds a `--run0` flag to nixos-rebuild-ng, it simply prepends `run0` to `remote_run_args`, similarly to `--sudo`:

```
if run0:
    remote_run_args = ["run0", *remote_run_args]
```

The only limitation of run0 is that it doesn't accept passwords on stdin like sudo does, so I currently have to force pty allocation using `NIX_SSHOPTS='-t'`. That does leave me with the following warning:

```
warning: detected option '-t' in NIX_SSHOPTS. SSH's TTY may cause issues, it is recommended to remove this option
warning: if you want to prompt for sudo password use '--ask-sudo-password' option instead
```

but I haven't noticed any issues in my testing (though I'd love a better solution than that, if anyone has ideas please lmk).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
