### PR TITLE
nix-index: 0.1.9-unstable-2026-04-20 -> 0.1.10

### DIFF
--- a/pkgs/by-name/ni/nix-index-unwrapped/package.nix
+++ b/pkgs/by-name/ni/nix-index-unwrapped/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nix-index";
-  version = "0.1.9-unstable-2026-04-20";
+  version = "0.1.10";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-index";
-    rev = "0f68b51886bde4014629e43d9be4b66cff450990";
-    hash = "sha256-polUDx4tWFmyxsn83XRrw9YQlDq/ggNY1hq6xw9NOoQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IBVI/4hwq84/vZx7Kr/Ci/P/CzPTsn1/oiCIF2vPHXg=";
   };
 
-  cargoHash = "sha256-2Ar7mj9r5eKdbXDC4+jSWG7HvGFTeowEPt2SBM6a6e4=";
+  cargoHash = "sha256-9xzC5PE2nyEtbhWGagCX2yZ0/tfo2v3fatnNU+GdVH8=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [

--- a/pkgs/by-name/ni/nix-index-unwrapped/package.nix
+++ b/pkgs/by-name/ni/nix-index-unwrapped/package.nix
@@ -6,6 +6,7 @@
   openssl,
   curl,
   sqlite,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -36,6 +37,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --subst-var out
     install -Dm555 command-not-found.nu -t $out/etc/profile.d
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Files database for nixpkgs";

--- a/pkgs/by-name/ni/nix-index/package.nix
+++ b/pkgs/by-name/ni/nix-index/package.nix
@@ -4,6 +4,7 @@
   nix-index-unwrapped,
   makeWrapper,
   nix,
+  versionCheckHook,
 }:
 
 symlinkJoin {
@@ -11,10 +12,15 @@ symlinkJoin {
 
   paths = [ nix-index-unwrapped ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    versionCheckHook
+  ];
 
   postBuild = ''
     wrapProgram $out/bin/nix-index \
       --prefix PATH : ${lib.makeBinPath [ nix ]}
+
+    versionCheckHook
   '';
 }


### PR DESCRIPTION
Changelog: https://github.com/nix-community/nix-index/releases/tag/v0.1.10

In particular, this prevents nix-index from failing due to #496365 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
