### PR TITLE
kloak: init at 0.7.8-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25801,6 +25801,12 @@
     githubId = 6277322;
     name = "Wei Tang";
   };
+  sotormd = {
+    email = "sotormd@proton.me";
+    github = "sotormd";
+    githubId = 201147279;
+    name = "sotormd";
+  };
   soupglasses = {
     email = "sofi+git@mailbox.org";
     github = "soupglasses";

--- a/pkgs/by-name/kl/kloak/package.nix
+++ b/pkgs/by-name/kl/kloak/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  which,
+  wayland-scanner,
+  ronn,
+  installShellFiles,
+  libevdev,
+  libsodium,
+  libinput,
+  wayland,
+  libxkbcommon,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kloak";
+  version = "0.7.8-1";
+
+  src = fetchFromGitHub {
+    owner = "Whonix";
+    repo = "kloak";
+    tag = finalAttrs.version;
+    hash = "sha256-V9t7fQ3K5OIWKhvFiX5Hsf0WzAQUWiZojgbjc38Z1Nk=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+    wayland-scanner
+    ronn
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libevdev
+    libsodium
+    libinput
+    wayland
+    libxkbcommon
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D kloak $out/bin/kloak
+
+    ronn --roff man/kloak.8.ronn
+    installManPage man/kloak.8
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Privacy tool for anonymizing keyboard and mouse use";
+    homepage = "https://github.com/Whonix/kloak";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ sotormd ];
+    mainProgram = "kloak";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds [kloak](<https://github.com/Whonix/kloak>), an anti keystroke deanonymization tool from the Whonix project.

I've tested and ensured full functionality on `x86_64-linux` Debian stable and sid. Additionally, also builds on `x86_64-linux` NixOS.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
