### PR TITLE
python313Packages.jh2: 5.0.10 -> 5.0.11

### DIFF
--- a/pkgs/development/python-modules/jh2/default.nix
+++ b/pkgs/development/python-modules/jh2/default.nix
@@ -11,20 +11,20 @@
 
 buildPythonPackage rec {
   pname = "jh2";
-  version = "5.0.10";
+  version = "5.0.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "h2";
     tag = "v${version}";
-    hash = "sha256-zytQ6UFNeIaF7cftp7C/RnXhuRbQxc1jhwVmFwUDF1Y=";
+    hash = "sha256-k69U8O0c7z1TJASOWcndZA/LYTsX7nVfelhaS6FlN5g=";
     fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-W2BfuOhYL56gPd+j9YuJ7Ee3e+jT5m47h8qXihoMu1M=";
+    hash = "sha256-ELZD3CIAv70DGoCgdK8T2yVLtib9ylSvoZPFOge6nIQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/jh2/default.nix
+++ b/pkgs/development/python-modules/jh2/default.nix
@@ -9,7 +9,7 @@
   rustPlatform,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jh2";
   version = "5.0.11";
   pyproject = true;
@@ -17,13 +17,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "h2";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-k69U8O0c7z1TJASOWcndZA/LYTsX7nVfelhaS6FlN5g=";
     fetchSubmodules = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-ELZD3CIAv70DGoCgdK8T2yVLtib9ylSvoZPFOge6nIQ=";
   };
 
@@ -44,11 +44,11 @@ buildPythonPackage rec {
   meta = {
     description = "HTTP/2 State-Machine based protocol implementation";
     homepage = "https://github.com/jawah/h2";
-    changelog = "https://github.com/jawah/h2/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/jawah/h2/blob/${finalAttrs.src.rev}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab
       techknowlogick
     ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/jawah/h2/compare/v5.0.10...v5.0.11

Changelog: https://github.com/jawah/h2/blob/refs/tags/v5.0.11/CHANGELOG.rst

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
