### PR TITLE
emissary: add wayland dependencies

### DIFF
--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -2,9 +2,14 @@
   rustPlatform,
   fetchFromGitHub,
   lib,
+  stdenv,
   pkg-config,
   openssl,
   fontconfig,
+
+  libGL,
+  libxkbcommon,
+  wayland,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "emissary";
@@ -26,6 +31,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
     fontconfig
   ];
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/bin/emissary-cli \
+      --add-rpath ${
+        lib.makeLibraryPath [
+          libxkbcommon
+          wayland
+          libGL
+        ]
+      }
+  '';
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<details>
<summary>
Fixes startup crash when running <code>emissary-cli</code> on Linux Wayland
</summary>

```
thread 'main' (130817) panicked at /build/emissary-0.3.1-vendor/source-registry-0/iced_winit-0.13.0/src/program.rs:192:10:
Create event loop: Os(OsError { line: 81, file: "/build/emissary-0.3.1-vendor/source-registry-0/winit-0.30.5/src/platform_impl/linux/wayland/event_loop/mod.rs", error: WaylandError(Connection(NoWaylandLib)) })
```

</details>

Solution is inspired by 

https://github.com/NixOS/nixpkgs/blob/bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e/pkgs/by-name/sn/sniffnet/package.nix#L76-L86

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
