### PR TITLE
prometheus-podman-exporter: init at 1.21.2

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -280,6 +280,8 @@
 
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 
+- Added `prometheus-podman-exporter` package and `prometheus.exporters.podman` service.
+
 - the `autossh-ng` NixOS module was introduced as a simpler alternative to the existing `autossh` module.
 
 - `gnuradio`: Overriding the `.pkgs` package set is now possible with a `packageOverrides` function, like with `python.pkgs` and other language-specific package sets.

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -142,6 +142,8 @@
   They were missing before because Ceph omitted logs when this directory was missing.
   Ceph logs can grow large, so you may want to configure rotation of these logs.
 
+- Added `prometheus-podman-exporter` package and `prometheus.exporters.podman` service.
+
 ## Nixpkgs Library {#sec-nixpkgs-release-26.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -103,6 +103,7 @@ let
         "pihole"
         "ping"
         "postfix"
+        "podman"
         "postgres"
         "process"
         "pve"

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -106,6 +106,7 @@ let
         "pihole"
         "ping"
         "postfix"
+        "podman"
         "postgres"
         "process"
         "pve"

--- a/nixos/modules/services/monitoring/prometheus/exporters/podman.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/podman.nix
@@ -63,13 +63,13 @@ in
 
     collector = {
       cacheDuration = mkOption {
-        type = types.nullOr types.int;
+        type = types.nullOr types.ints.positive;
         default = null;
         description = "Duration (seconds) to retrieve container, size and refresh the cache";
       };
       enableAll = mkOption {
         type = types.nullOr types.bool;
-        default = null;
+        default = false;
         description = "Enable all collectors by default";
       };
       enhanceMetrics = mkOption {
@@ -132,7 +132,7 @@ in
         description = "Exclude metrics about the exporter itself (promhttp_*, process_*, go_*)";
       };
       maxRequests = lib.mkOption {
-        type = types.nullOr types.int;
+        type = types.nullOr types.ints.unsigned;
         default = null;
         description = "Maximum number of parallel scrape requests. Use 0 to disable";
       };

--- a/nixos/modules/services/monitoring/prometheus/exporters/podman.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/podman.nix
@@ -1,0 +1,164 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.podman;
+  boolFlag = name: value: lib.optional (value == true) name;
+  inherit (lib)
+    mkOption
+    types
+    ;
+
+  args = lib.flatten [
+    (lib.optional (cfg.collector.cacheDuration != null) [
+      "--collector.cache_duration"
+      (toString cfg.collector.cacheDuration)
+    ])
+    (lib.optional (cfg.web.maxRequests != null) [
+      "--web.max-requests"
+      (toString cfg.web.maxRequests)
+    ])
+    (lib.optional (cfg.web.telemetryPath != null) [
+      "--web.telemetry-path"
+      cfg.web.telemetryPath
+    ])
+    [
+      "--web.listen-address"
+      "${cfg.listenAddress}:${toString cfg.port}"
+    ]
+    (boolFlag "--collector.enable-all" cfg.collector.enableAll)
+    (boolFlag "--collector.enhance-metrics" cfg.collector.enhanceMetrics)
+    (boolFlag "--collector.image" cfg.collector.image)
+    (boolFlag "--collector.network" cfg.collector.network)
+    (boolFlag "--collector.pod" cfg.collector.pod)
+    (boolFlag "--collector.store_labels" cfg.collector.storeLabels)
+    (boolFlag "--collector.system" cfg.collector.system)
+    (boolFlag "--collector.volume" cfg.collector.volume)
+    (boolFlag "--debug" cfg.debug)
+    (boolFlag "--web.disable-exporter-metrics" cfg.web.disableExporterMetrics)
+    (lib.optional (cfg.collector.whitelistedLabels != null) [
+      "--collector.whitelisted_labels"
+      cfg.collector.whitelistedLabels
+    ])
+    (lib.optional (cfg.web.configFile != null) [
+      "--web.config.file"
+      (toString cfg.web.configFile)
+    ])
+  ];
+in
+{
+  port = 9156;
+  extraOpts = {
+    package = lib.mkPackageOption pkgs "prometheus-podman-exporter" { };
+
+    podmanSocket = mkOption {
+      type = types.str;
+      default = "unix:///var/run/podman/podman.sock";
+      description = "path to podman UNIX or network socket for connection";
+    };
+
+    collector = {
+      cacheDuration = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "Duration (seconds) to retrieve container, size and refresh the cache";
+      };
+      enableAll = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable all collectors by default";
+      };
+      enhanceMetrics = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enhance all metrics with the same field as their podman_<...>_info metrics";
+      };
+      image = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable image collector";
+      };
+      network = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable network collector";
+      };
+      pod = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable pod collector";
+      };
+      storeLabels = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Convert pod/container/image labels to labels on prometheus metrics";
+      };
+      system = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable system collector";
+      };
+      volume = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable volume collector";
+      };
+      whitelistedLabels = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Comma separated list of pod/container/image labels to be converted";
+      };
+    };
+
+    debug = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = "Set log level to debug";
+    };
+
+    web = {
+      configFile = lib.mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Path to configuration file that can enable TLS or authentication";
+      };
+      disableExporterMetrics = lib.mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Exclude metrics about the exporter itself (promhttp_*, process_*, go_*)";
+      };
+      maxRequests = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "Maximum number of parallel scrape requests. Use 0 to disable";
+      };
+      telemetryPath = lib.mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Path under which to expose metrics";
+      };
+    };
+  };
+  serviceOpts = {
+    # NOTE: this is based on contrib/systemd/system/prometheus-podman-exporter.service
+    # It was overwritten to pass the custom shellArgs and env variables
+    serviceConfig = {
+      DynamicUser = false;
+      ExecStart = lib.escapeShellArgs ([ (lib.getExe cfg.package) ] ++ args);
+      TimeoutStopSec = "20s";
+      SendSIGKILL = false;
+      Restart = "on-failure";
+    };
+
+    environment.CONTAINER_HOST = cfg.podmanSocket;
+
+    path = [ config.virtualisation.podman.package.helpersBin ];
+
+    after = lib.optional config.virtualisation.podman.enable "podman.service";
+    wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/nixos/modules/services/monitoring/prometheus/exporters/podman.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/podman.nix
@@ -1,0 +1,175 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.podman;
+  boolFlag = name: value: lib.optional (value == true) name;
+  inherit (lib)
+    mkOption
+    types
+    ;
+
+  args = lib.flatten [
+    (lib.optional (cfg.collector.cacheDuration != null) [
+      "--collector.cache_duration"
+      (toString cfg.collector.cacheDuration)
+    ])
+    (lib.optional (cfg.web.maxRequests != null) [
+      "--web.max-requests"
+      (toString cfg.web.maxRequests)
+    ])
+    (lib.optional (cfg.web.telemetryPath != null) [
+      "--web.telemetry-path"
+      cfg.web.telemetryPath
+    ])
+    [
+      "--web.listen-address"
+      "${cfg.listenAddress}:${toString cfg.port}"
+    ]
+    (boolFlag "--collector.enable-all" cfg.collector.enableAll)
+    (boolFlag "--collector.enhance-metrics" cfg.collector.enhanceMetrics)
+    (boolFlag "--collector.image" cfg.collector.image)
+    (boolFlag "--collector.network" cfg.collector.network)
+    (boolFlag "--collector.pod" cfg.collector.pod)
+    (boolFlag "--collector.store_labels" cfg.collector.storeLabels)
+    (boolFlag "--collector.system" cfg.collector.system)
+    (boolFlag "--collector.volume" cfg.collector.volume)
+    (boolFlag "--debug" cfg.debug)
+    (boolFlag "--web.disable-exporter-metrics" cfg.web.disableExporterMetrics)
+    (lib.optional (cfg.collector.whitelistedLabels != null) [
+      "--collector.whitelisted_labels"
+      cfg.collector.whitelistedLabels
+    ])
+    (lib.optional (cfg.web.configFile != null) [
+      "--web.config.file"
+      (toString cfg.web.configFile)
+    ])
+  ];
+in
+{
+  port = 9156;
+  extraOpts = {
+    package = lib.mkPackageOption pkgs "prometheus-podman-exporter" { };
+
+    podmanSocket = mkOption {
+      type = types.str;
+      default = "unix:///var/run/podman/podman.sock";
+      description = "path to podman UNIX or network socket for connection";
+    };
+
+    collector = {
+      cacheDuration = mkOption {
+        type = types.nullOr types.ints.positive;
+        default = null;
+        description = "Duration (seconds) to retrieve container, size and refresh the cache";
+      };
+      enableAll = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable all collectors by default";
+      };
+      enhanceMetrics = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enhance all metrics with the same field as their podman_<...>_info metrics";
+      };
+      image = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable image collector";
+      };
+      network = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable network collector";
+      };
+      pod = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable pod collector";
+      };
+      storeLabels = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Convert pod/container/image labels to labels on prometheus metrics";
+      };
+      system = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable system collector";
+      };
+      volume = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Enable volume collector";
+      };
+      whitelistedLabels = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Comma separated list of pod/container/image labels to be converted";
+      };
+    };
+
+    debug = lib.mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = "Set log level to debug";
+    };
+
+    web = {
+      configFile = lib.mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = "Path to configuration file that can enable TLS or authentication";
+      };
+      disableExporterMetrics = lib.mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Exclude metrics about the exporter itself (promhttp_*, process_*, go_*)";
+      };
+      maxRequests = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        description = "Maximum number of parallel scrape requests. Use 0 to disable";
+      };
+      telemetryPath = lib.mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Path under which to expose metrics";
+      };
+    };
+  };
+  serviceOpts = {
+    # NOTE: this is based on contrib/systemd/system/prometheus-podman-exporter.service
+    # It was overwritten to pass the custom shellArgs and env variables
+    serviceConfig = {
+      DynamicUser = false;
+      ExecStart = lib.escapeShellArgs ([ (lib.getExe cfg.package) ] ++ args);
+      StateDirectory = "prometheus-podman-exporter";
+      SupplementaryGroups = lib.optional config.virtualisation.podman.enable "podman";
+      TimeoutStopSec = "20s";
+      SendSIGKILL = false;
+      Restart = "on-failure";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+    };
+
+    environment = {
+      CONTAINER_HOST = cfg.podmanSocket;
+      HOME = "/var/lib/prometheus-podman-exporter";
+      XDG_CONFIG_HOME = "/var/lib/prometheus-podman-exporter";
+    };
+
+    path = [ config.virtualisation.podman.package.helpersBin ];
+
+    after = lib.optional config.virtualisation.podman.enable "podman.service";
+    wantedBy = [ "multi-user.target" ];
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1370,6 +1370,22 @@ let
         '';
       };
 
+    podman =
+      { ... }:
+      {
+        exporterConfig = {
+          enable = true;
+        };
+        metricProvider = {
+          virtualisation.podman.enable = true;
+        };
+        exporterTest = ''
+          wait_for_unit("prometheus-postfix-exporter.service")
+          wait_for_open_port(9156)
+          wait_until_succeeds("curl -sSf http://localhost:9156/metrics | grep prometheus_podman_exporter_build_info")
+        '';
+      };
+
     postfix =
       { ... }:
       {
@@ -1380,7 +1396,9 @@ let
           services.postfix.enable = true;
         };
         exporterTest = ''
+          wait_for_unit("prometheus-podman-exporter.service")
           wait_for_unit("prometheus-postfix-exporter.service")
+          wait_for_open_port(8020, "0.0.0.0", 300)
           wait_for_file("/var/lib/postfix/queue/public/showq")
           wait_for_open_port(9154)
           wait_until_succeeds(

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1426,6 +1426,22 @@ let
         '';
       };
 
+    podman =
+      { ... }:
+      {
+        exporterConfig = {
+          enable = true;
+        };
+        metricProvider = {
+          virtualisation.podman.enable = true;
+        };
+        exporterTest = ''
+          wait_for_unit("prometheus-podman-exporter.service")
+          wait_for_open_port(9156)
+          wait_until_succeeds("curl -sSf http://localhost:9156/metrics | grep prometheus_podman_exporter_build_info")
+        '';
+      };
+
     postfix =
       { ... }:
       {
@@ -1437,6 +1453,7 @@ let
         };
         exporterTest = ''
           wait_for_unit("prometheus-postfix-exporter.service")
+          wait_for_open_port(8020, "0.0.0.0", 300)
           wait_for_file("/var/lib/postfix/queue/public/showq")
           wait_for_open_port(9154)
           wait_until_succeeds(

--- a/pkgs/by-name/pr/prometheus-podman-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-podman-exporter/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  gpgme,
+  libassuan,
+  systemd,
+  withBtrfs ? true,
+  btrfs-progs,
+}:
+buildGoModule (finalAttrs: {
+  pname = "prometheus-podman-exporter";
+  version = "1.21.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HY9ZOooAlIF3vb7ZENpRGvW5074PQS8yrfFXG39/Ycw=";
+  };
+
+  buildInputs = [
+    gpgme
+    libassuan
+    systemd
+  ]
+  ++ (lib.optional withBtrfs btrfs-progs);
+  nativeBuildInputs = [ pkg-config ];
+
+  # NOTE: this is mostly just copied from the Makefile + the scripts in hack/
+  # The .spec file in rpm/ also contains some useful information in the %build section
+  tags = [
+    "remote"
+    "containers_image_openpgp"
+    "systemd"
+  ]
+  ++ (lib.optionals (!withBtrfs) [
+    "exclude_graphdriver_btrfs"
+    "btrfs_noversion"
+  ]);
+
+  ldflags = [
+    # NOTE: upstream manually defines this in a VERSION file
+    "-X github.com/containers/prometheus-podman-exporter/cmd.buildVersion=${finalAttrs.version}"
+    "-X github.com/containers/prometheus-podman-exporter/cmd.buildRevision=${lib.versions.major finalAttrs.version}"
+    # this should be the git ref, for tags it is HEAD
+    "-X github.com/containers/prometheus-podman-exporter/cmd.buildBranch=HEAD"
+  ];
+
+  vendorHash = null;
+
+  __structuredAttrs = true;
+
+  # NOTE: requires a running podman daemon and a $HOME in scripts
+  doCheck = false;
+
+  meta = {
+    description = "Prometheus exporter for podman environments exposing containers, pods, images, volumes and networks information";
+    homepage = "https://github.com/containers/prometheus-podman-exporter";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ cobalt ];
+    mainProgram = "prometheus-podman-exporter";
+  };
+})

--- a/pkgs/by-name/pr/prometheus-podman-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-podman-exporter/package.nix
@@ -15,7 +15,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "containers";
-    repo = finalAttrs.pname;
+    repo = "prometheus-podman-exporter";
     tag = "v${finalAttrs.version}";
     hash = "sha256-HY9ZOooAlIF3vb7ZENpRGvW5074PQS8yrfFXG39/Ycw=";
   };
@@ -25,7 +25,7 @@ buildGoModule (finalAttrs: {
     libassuan
     systemd
   ]
-  ++ (lib.optional withBtrfs btrfs-progs);
+  ++ lib.optional withBtrfs btrfs-progs;
   nativeBuildInputs = [ pkg-config ];
 
   # NOTE: this is mostly just copied from the Makefile + the scripts in hack/
@@ -35,10 +35,10 @@ buildGoModule (finalAttrs: {
     "containers_image_openpgp"
     "systemd"
   ]
-  ++ (lib.optionals (!withBtrfs) [
+  ++ lib.optionals (!withBtrfs) [
     "exclude_graphdriver_btrfs"
     "btrfs_noversion"
-  ]);
+  ];
 
   ldflags = [
     # NOTE: upstream manually defines this in a VERSION file

--- a/pkgs/by-name/pr/prometheus-podman-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-podman-exporter/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  gpgme,
+  libassuan,
+  systemd,
+  withBtrfs ? true,
+  btrfs-progs,
+}:
+buildGoModule (finalAttrs: {
+  pname = "prometheus-podman-exporter";
+  version = "1.21.2";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "prometheus-podman-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7AU/LWRClwuPEEalhanglMlpXirzFELhdX+6lbu/6zA=";
+  };
+
+  buildInputs = [
+    gpgme
+    libassuan
+    systemd
+  ]
+  ++ lib.optional withBtrfs btrfs-progs;
+  nativeBuildInputs = [ pkg-config ];
+
+  # NOTE: this is mostly just copied from the Makefile + the scripts in hack/
+  # The .spec file in rpm/ also contains some useful information in the %build section
+  tags = [
+    "remote"
+    "containers_image_openpgp"
+    "systemd"
+  ]
+  ++ lib.optionals (!withBtrfs) [
+    "exclude_graphdriver_btrfs"
+    "btrfs_noversion"
+  ];
+
+  ldflags = [
+    # NOTE: upstream manually defines this in a VERSION file
+    "-X github.com/containers/prometheus-podman-exporter/cmd.buildVersion=${finalAttrs.version}"
+    "-X github.com/containers/prometheus-podman-exporter/cmd.buildRevision=${lib.versions.major finalAttrs.version}"
+    # this should be the git ref, for tags it is HEAD
+    "-X github.com/containers/prometheus-podman-exporter/cmd.buildBranch=HEAD"
+  ];
+
+  vendorHash = null;
+
+  __structuredAttrs = true;
+
+  # NOTE: requires a running podman daemon and a $HOME in scripts
+  doCheck = false;
+
+  meta = {
+    description = "Prometheus exporter for podman environments exposing containers, pods, images, volumes and networks information";
+    homepage = "https://github.com/containers/prometheus-podman-exporter";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ cobalt ];
+    mainProgram = "prometheus-podman-exporter";
+  };
+})


### PR DESCRIPTION
Initializes the upstream Prometheus exporter for podman, [containers/prometheus-podman-exporter](https://github.com/containers/prometheus-podman-exporter).

This is a ported version of my packaging in [proveit.nix](https://git.tu-berlin.de/proveit/proveit.nix/), the integration test is also derived from there.

I'm not too sure how to run the integration test from the Prometheus exporter test suite, but it should work. Feedback from the maintainers would be appreciated here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
