### PR TITLE
python3Packages.whisperx: 3.8.1 -> 3.8.5

### DIFF
--- a/pkgs/development/python-modules/whisperx/default.nix
+++ b/pkgs/development/python-modules/whisperx/default.nix
@@ -18,12 +18,17 @@
   pyannote-audio,
   torch,
   torchaudio,
+  torchcodec,
+  torchvision,
   transformers,
   triton,
 
   # native packages
   ffmpeg,
   ctranslate2-cpp, # alias for `pkgs.ctranslate2`, required due to colliding with the `ctranslate2` Python module.
+
+  # tests
+  versionCheckHook,
 
   # enable GPU support
   cudaSupport ? torch.cudaSupport,
@@ -39,14 +44,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "whisperx";
-  version = "3.8.1";
+  version = "3.8.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "m-bain";
     repo = "whisperX";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2HjQtb8k3px0kqXowKtCXkiG2GuKLCuCtDOPYYa/tbc=";
+    hash = "sha256-dFjB0X7JUqv7r64QLbsQwJNRWti+xGUOWKkhOxJE1tg=";
   };
 
   # As `makeWrapperArgs` does not apply to the module, and whisperx depends on `ffmpeg`,
@@ -61,6 +66,7 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   pythonRelaxDeps = [
+    "huggingface-hub"
     "torch"
     "torchaudio"
   ];
@@ -75,14 +81,18 @@ buildPythonPackage (finalAttrs: {
     pyannote-audio
     torch
     torchaudio
+    torchcodec
+    torchvision
     transformers
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
     triton
   ];
 
-  # No tests in repository
-  doCheck = false;
+  # No python tests in repository
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
 
   pythonImportsCheck = [ "whisperx" ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/m-bain/whisperX/compare/v3.8.1...v3.8.5
Changelog: https://github.com/m-bain/whisperX/releases/tag/v3.8.5

cc @bengsparks

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test