### PR TITLE
androidenv: fix new "37.0" packages with API version ranges

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -298,7 +298,8 @@ let
   # Returns true if the given version exists.
   hasVersion =
     packages: package: version:
-    lib.hasAttrByPath [ package (toString version) ] packages;
+    lib.hasAttrByPath [ package (toString version) ] packages
+    || lib.hasAttrByPath [ package "${(toString version)}.0" ] packages;
 
   # Displays a nice error message that includes the available options if a version doesn't exist.
   # Note that allPackages can be a list of package sets, or a single package set. Pass a list if
@@ -322,7 +323,7 @@ let
         }.
       ''
     else
-      packageSet.${package}.${toString version};
+      packageSet.${package}.${toString version} or packageSet.${package}."${toString version}.0";
 
   # Returns true if we should link the specified plugins.
   shouldLink =
@@ -546,12 +547,25 @@ lib.recurseIntoAttrs rec {
     }
   ) platformVersions';
 
-  sources = map (
-    version:
-    deployAndroidPackage {
-      package = checkVersion allArchives.packages "sources" version;
-    }
-  ) platformVersions';
+  # Google is not including sources for API 37+. If the user requests them, don't fail.
+  sources = lib.filter (source: source != null) (
+    map (
+      version:
+      let
+        package =
+          let
+            version' = builtins.tryEval (checkVersion allArchives.packages "sources" version);
+          in
+          if version'.success then version'.value else null;
+      in
+      if package == null then
+        null
+      else
+        deployAndroidPackage {
+          inherit package;
+        }
+    ) platformVersions'
+  );
 
   system-images = lib.flatten (
     map (

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -37,6 +37,7 @@ deployAndroidPackage {
         nspr
         alsa-lib
         waylandpp.lib
+        libgbm
       ]
     )
     ++ (with pkgs; [

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -128,7 +128,7 @@ pkgs.mkShell rec {
           packages=(
             "build-tools" "cmdline-tools" \
             "platform-tools" "platforms;android-${toString latestSdkVersion}" \
-            "system-images;android-${toString latestSdkVersion};google_apis;x86_64"
+            "system-images;android-${toString latestSdkVersion};google_apis_ps16k;x86_64"
           )
           ${lib.optionalString emulatorSupported ''packages+=("emulator")''}
 
@@ -158,7 +158,6 @@ pkgs.mkShell rec {
           for x in $(seq 1 ${lib.versions.major (toString latestSdkVersion)}); do
             excluded_packages+=(
               "platforms;android-$x"
-              "sources;android-$x"
               "system-images;android-$x"
             )
           done
@@ -188,7 +187,7 @@ pkgs.mkShell rec {
             mkdir -p $ANDROID_USER_HOME
 
             avdmanager delete avd -n testAVD || true
-            echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-${toString latestSdkVersion};google_apis;x86_64'
+            { echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-${toString latestSdkVersion};google_apis_ps16k;x86_64'; }
             result=$(avdmanager list avd)
 
             if [[ ! $result =~ "Name: testAVD" ]]; then

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -187,10 +187,6 @@ pkgs.mkShell rec {
             "extras;google;gcm"
           )
 
-          for x in $(seq ${toString firstSdkVersion} ${toString latestSdkVersion}); do
-            packages+=("sources;android-$x")
-          done
-
           ${lib.optionalString includeAuto ''packages+=("extras;google;auto")''}
 
           for package in "''${packages[@]}"; do

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -91,7 +91,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -156,7 +156,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -233,7 +233,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -280,7 +280,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -357,7 +357,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -404,7 +404,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -483,7 +483,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -576,7 +576,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -669,7 +669,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -762,7 +762,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -855,7 +855,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -948,7 +948,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -1041,7 +1041,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1134,7 +1134,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -1227,7 +1227,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1320,7 +1320,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1413,7 +1413,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1478,7 +1478,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1543,7 +1543,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1608,7 +1608,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1673,7 +1673,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1738,7 +1738,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1803,7 +1803,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1869,7 +1869,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1900,7 +1900,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1931,7 +1931,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1960,7 +1960,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -2010,7 +2010,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2036,7 +2036,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2072,7 +2072,7 @@
         }
       },
       "displayName": "Google Play services",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2101,7 +2101,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2130,7 +2130,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK (Deprecated)",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2168,7 +2168,7 @@
         }
       },
       "displayName": "Google Repository",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2197,7 +2197,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2226,7 +2226,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2256,7 +2256,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2285,7 +2285,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2314,7 +2314,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20429,
+      "last-available-day": 20549,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2984,7 +2984,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -3030,7 +3030,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -3078,7 +3078,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -3130,7 +3130,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -3179,7 +3179,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -3229,7 +3229,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -3275,7 +3275,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -3323,7 +3323,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -3375,7 +3375,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -3431,7 +3431,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -3470,7 +3470,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -3516,7 +3516,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -3564,7 +3564,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -3616,7 +3616,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -3672,7 +3672,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3711,7 +3711,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3757,7 +3757,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3811,7 +3811,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3863,7 +3863,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3919,7 +3919,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3965,7 +3965,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -4013,7 +4013,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -4065,7 +4065,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -4121,7 +4121,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -4167,7 +4167,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -4215,7 +4215,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -4267,7 +4267,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -4316,7 +4316,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -4353,7 +4353,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -4392,7 +4392,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -4438,7 +4438,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -4484,7 +4484,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -4530,7 +4530,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -4571,7 +4571,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -4623,7 +4623,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -4675,7 +4675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -4727,7 +4727,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4776,7 +4776,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4815,7 +4815,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4861,7 +4861,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4907,7 +4907,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4953,7 +4953,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4994,7 +4994,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -5046,7 +5046,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -5098,7 +5098,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -5150,7 +5150,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -5199,7 +5199,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -5243,7 +5243,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -5282,7 +5282,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -5328,7 +5328,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -5374,7 +5374,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -5420,7 +5420,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -5461,7 +5461,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -5513,7 +5513,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -5565,7 +5565,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -5617,7 +5617,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -5673,7 +5673,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -5712,7 +5712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5758,7 +5758,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5804,7 +5804,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5850,7 +5850,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5898,7 +5898,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5950,7 +5950,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -6002,7 +6002,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -6056,7 +6056,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -6112,7 +6112,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -6158,7 +6158,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -6202,7 +6202,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -6241,7 +6241,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -6287,7 +6287,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -6333,7 +6333,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -6374,7 +6374,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -6426,7 +6426,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -6478,7 +6478,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -6530,7 +6530,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -6584,7 +6584,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -6655,7 +6655,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -6701,7 +6701,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -6752,7 +6752,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6796,7 +6796,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6840,7 +6840,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6891,7 +6891,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6958,7 +6958,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -7025,7 +7025,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -7094,7 +7094,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -7150,7 +7150,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -7201,7 +7201,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -7245,7 +7245,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -7289,7 +7289,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -7340,7 +7340,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -7407,7 +7407,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -7476,7 +7476,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -7537,7 +7537,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -7582,7 +7582,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -7628,7 +7628,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -7679,7 +7679,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -7716,7 +7716,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7753,7 +7753,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7804,7 +7804,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7871,7 +7871,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7938,7 +7938,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7997,7 +7997,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -8064,7 +8064,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -8131,7 +8131,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -8192,7 +8192,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -8252,7 +8252,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -8291,7 +8291,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -8354,7 +8354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -8417,7 +8417,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -8468,7 +8468,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -8525,7 +8525,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -8582,7 +8582,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -8641,7 +8641,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -8722,7 +8722,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -8803,7 +8803,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -8864,7 +8864,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8924,7 +8924,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8970,7 +8970,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear-cn/arm64-v8a",
@@ -9014,7 +9014,7 @@
             }
           },
           "displayName": "China version of Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear-cn/x86",
@@ -9053,7 +9053,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -9102,7 +9102,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -9153,7 +9153,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -9220,7 +9220,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -9287,7 +9287,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -9353,7 +9353,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -9434,7 +9434,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -9515,7 +9515,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -9586,7 +9586,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -9645,7 +9645,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -9696,7 +9696,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -9745,7 +9745,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9806,7 +9806,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9873,7 +9873,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9949,7 +9949,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -10016,7 +10016,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -10077,7 +10077,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -10130,7 +10130,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -10185,7 +10185,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -10234,7 +10234,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -10295,7 +10295,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -10362,7 +10362,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -10438,7 +10438,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -10519,7 +10519,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -10580,7 +10580,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -10633,7 +10633,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -10698,7 +10698,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -10757,7 +10757,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10803,7 +10803,7 @@
             }
           },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10847,7 +10847,7 @@
             }
           },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10898,7 +10898,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10947,7 +10947,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -11008,7 +11008,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -11075,7 +11075,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -11144,7 +11144,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -11211,7 +11211,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -11286,7 +11286,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -11335,7 +11335,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -11398,7 +11398,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -11458,7 +11458,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -11498,7 +11498,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -11535,7 +11535,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -11586,7 +11586,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -11635,7 +11635,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -11696,7 +11696,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -11764,7 +11764,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11834,7 +11834,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11903,7 +11903,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11966,7 +11966,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -12019,7 +12019,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -12088,7 +12088,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -12137,7 +12137,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -12178,7 +12178,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -12210,7 +12210,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -12256,7 +12256,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -12301,7 +12301,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -12348,7 +12348,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -12406,7 +12406,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -12466,7 +12466,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -12524,7 +12524,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -12584,7 +12584,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -12646,7 +12646,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -12688,6 +12688,114 @@
       }
     },
     "35x": {
+      "android-automotive": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "7062de5c4d849728d9e5e06b1f189c1dd1e341e4",
+              "size": 1485616113,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/arm64-v8a-35-ext15_playstore_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "1",
+                "minor:1": "3"
+              }
+            }
+          },
+          "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-35x-android-automotive-arm64-v8a",
+          "path": "system-images/android-35-ext15/android-automotive/arm64-v8a",
+          "revision": "35x-android-automotive-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "35x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "15",
+            "tag:3": {
+              "display:1": "Automotive",
+              "id:0": "android-automotive"
+            },
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "7487c1fca63109186fdbce4f50e67c228b6a0db1",
+              "size": 1537658008,
+              "url": "https://dl.google.com/android/repository/sys-img/android-automotive/x86_64-35-ext15_playstore_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "36",
+                "micro:2": "1",
+                "minor:1": "3"
+              }
+            }
+          },
+          "displayName": "Android Automotive with Google APIs x86_64 System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-35x-android-automotive-x86_64",
+          "path": "system-images/android-35-ext15/android-automotive/x86_64",
+          "revision": "35x-android-automotive-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "35x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "15",
+            "tag:3": {
+              "display:1": "Automotive",
+              "id:0": "android-automotive"
+            },
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
       "android-wear": {
         "arm64-v8a": {
           "archives": [
@@ -12700,7 +12808,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-arm64-v8a",
           "path": "system-images/android-35-ext15/android-wear/arm64-v8a",
@@ -12733,7 +12841,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35x-android-wear-x86_64",
           "path": "system-images/android-35-ext15/android-wear/x86_64",
@@ -12780,7 +12888,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis/arm64-v8a",
@@ -12829,7 +12937,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis-x86_64",
           "path": "system-images/android-35-ext15/google_apis/x86_64",
@@ -12880,7 +12988,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext15/google_apis_playstore/arm64-v8a",
@@ -12929,7 +13037,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext15/google_apis_playstore/x86_64",
@@ -12982,7 +13090,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-arm64-v8a",
           "path": "system-images/android-36/android-tv/arm64-v8a",
@@ -13027,7 +13135,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-android-tv-x86",
           "path": "system-images/android-36/android-tv/x86",
@@ -13062,7 +13170,7 @@
             }
           ],
           "displayName": "Wear OS 6.0 ARM 64 v8a System Image (signed)",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-arm64-v8a",
           "path": "system-images/android-36/android-wear-signed/arm64-v8a",
@@ -13095,7 +13203,7 @@
             }
           ],
           "displayName": "Wear OS 6.0 Intel x86_64 Atom System Image (signed)",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-android-wear-x86_64",
           "path": "system-images/android-36/android-wear-signed/x86_64",
@@ -13114,6 +13222,98 @@
             "tag:3": {
               "display:1": "Wear OS 6.0",
               "id:0": "android-wear"
+            }
+          }
+        }
+      },
+      "default": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "62ad6714df790f89c8a8ad32552ffe20bb16fe87",
+              "size": 810736863,
+              "url": "https://dl.google.com/android/repository/sys-img/android/arm64-v8a-36_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "ARM 64 v8a System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-36-default-arm64-v8a",
+          "path": "system-images/android-36/default/arm64-v8a",
+          "revision": "36-default-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "829c076e8ff448a336097ae25a355b495ba36e2c",
+              "size": 844217077,
+              "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-36_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-36-default-x86_64",
+          "path": "system-images/android-36/default/x86_64",
+          "revision": "36-default-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:4": "x86_64",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Default Android System Image",
+              "id:0": "default"
             }
           }
         }
@@ -13142,7 +13342,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis-arm64-v8a",
           "path": "system-images/android-36/google_apis/arm64-v8a",
@@ -13191,7 +13391,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis-x86_64",
           "path": "system-images/android-36/google_apis/x86_64",
@@ -13242,7 +13442,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore/arm64-v8a",
@@ -13291,7 +13491,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-google_apis_playstore-x86_64",
           "path": "system-images/android-36/google_apis_playstore/x86_64",
@@ -13342,7 +13542,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36/google_apis_playstore_ps16k/arm64-v8a",
@@ -13395,7 +13595,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36-page_size_16kb-x86_64",
           "path": "system-images/android-36/google_apis_playstore_ps16k/x86_64",
@@ -13428,15 +13628,83 @@
       }
     },
     "36.1": {
+      "android-wear": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "745dd39a3a18e59b7636b9cdfc8326de3c42f989",
+              "size": 1258760868,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-36.1_signed_r01.zip"
+            }
+          ],
+          "displayName": "Wear OS 6.1 ARM 64 v8a System Image (signed)",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-36.1-android-wear-arm64-v8a",
+          "path": "system-images/android-36.1/android-wear-signed/arm64-v8a",
+          "revision": "36.1-android-wear-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Wear OS 6.1",
+              "id:0": "android-wear"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "4cf09d620a70295b46de2ad16c0104589f0a4737",
+              "size": 1234838800,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86_64-36.1_signed_r01.zip"
+            }
+          ],
+          "displayName": "Wear OS 6.1 Intel x86_64 Atom System Image (signed)",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-36.1-android-wear-x86_64",
+          "path": "system-images/android-36.1/android-wear-signed/x86_64",
+          "revision": "36.1-android-wear-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:4": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "20",
+            "tag:3": {
+              "display:1": "Wear OS 6.1",
+              "id:0": "android-wear"
+            }
+          }
+        }
+      },
       "google_apis": {
         "arm64-v8a": {
           "archives": [
             {
               "arch": "all",
               "os": "all",
-              "sha1": "4b3c296dfa125a03944317da5c3b9c852e384a95",
-              "size": 1931618675,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.1_r03.zip"
+              "sha1": "da1c7ab56c651637cef86736d2ef59ef2bf52549",
+              "size": 1933985844,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36.1_r04.zip"
             }
           ],
           "dependencies": {
@@ -13451,17 +13719,18 @@
               }
             }
           },
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-google_apis-arm64-v8a",
-          "path": "system-images/android-36.1/google_apis/arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_ps16k/arm64-v8a",
           "revision": "36.1-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
+            "abi:6": "arm64-v8a",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13472,7 +13741,15 @@
               "display:1": "Google APIs",
               "id:0": "google_apis"
             },
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
             "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13483,9 +13760,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "e7c2ee3e0efcdc79e13b8c40d93629c83741c143",
-              "size": 1958060347,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.1_r03.zip"
+              "sha1": "15261872d5f0ae4b5728faefd0380d51b61a5b23",
+              "size": 1960532087,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36.1_r04.zip"
             }
           ],
           "dependencies": {
@@ -13500,17 +13777,18 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36.1-google_apis-x86_64",
-          "path": "system-images/android-36.1/google_apis/x86_64",
+          "path": "system-images/android-36.1/google_apis_ps16k/x86_64",
           "revision": "36.1-google_apis-x86_64",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:5": "x86_64",
+            "abi:6": "x86_64",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13521,7 +13799,15 @@
               "display:1": "Google APIs",
               "id:0": "google_apis"
             },
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
             "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13534,9 +13820,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "240c7164dd250be3c096dd62801e96f7b144bc2f",
-              "size": 1955944487,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.1_r03.zip"
+              "sha1": "193d86bad80d9ff79fe4272304f3193e7c097e1e",
+              "size": 1958370801,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36.1_r04.zip"
             }
           ],
           "dependencies": {
@@ -13551,17 +13837,18 @@
               }
             }
           },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36.1-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-36.1/google_apis_playstore/arm64-v8a",
+          "path": "system-images/android-36.1/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "36.1-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:5": "arm64-v8a",
+            "abi:6": "arm64-v8a",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13569,10 +13856,18 @@
             },
             "extension-level:1": "20",
             "tag:3": {
-              "display:1": "Google Play",
+              "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
             "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13583,9 +13878,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "4931dd84c74db66b29c934b313d407faf3298921",
-              "size": 1998865059,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.1_r03.zip"
+              "sha1": "ab58abb8dbbc8a00c9437c30c210e8b6a5286795",
+              "size": 2001299692,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36.1_r04.zip"
             }
           ],
           "dependencies": {
@@ -13600,17 +13895,18 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36.1-google_apis_playstore-x86_64",
-          "path": "system-images/android-36.1/google_apis_playstore/x86_64",
+          "path": "system-images/android-36.1/google_apis_playstore_ps16k/x86_64",
           "revision": "36.1-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:5": "x86_64",
+            "abi:6": "x86_64",
             "api-level:0": "36.1",
             "base-extension:2": "true",
             "element-attributes": {
@@ -13618,10 +13914,18 @@
             },
             "extension-level:1": "20",
             "tag:3": {
-              "display:1": "Google Play",
+              "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
             "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13762,7 +14066,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis/arm64-v8a",
@@ -13811,7 +14115,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis-x86_64",
           "path": "system-images/android-36-ext19/google_apis/x86_64",
@@ -13862,7 +14166,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-36x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36-ext19/google_apis_playstore/arm64-v8a",
@@ -13911,7 +14215,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-36x-google_apis_playstore-x86_64",
           "path": "system-images/android-36-ext19/google_apis_playstore/x86_64",
@@ -13932,6 +14236,240 @@
               "id:0": "google_apis_playstore"
             },
             "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "37.0": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "04ed7e1ab0cde1397365cc44b711686797e14d29",
+              "size": 2106860933,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-37.0_r03.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-37.0-google_apis-arm64-v8a",
+          "path": "system-images/android-37.0/google_apis_ps16k/arm64-v8a",
+          "revision": "37.0-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "b89a6686f9a9e9942d596bed45d422cbccb70c98",
+              "size": 2097719373,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-37.0_r03.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-37.0-google_apis-x86_64",
+          "path": "system-images/android-37.0/google_apis_ps16k/x86_64",
+          "revision": "37.0-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:4": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "af41f56168a8a0f8a8018b2afd9423b2f1303d35",
+              "size": 2221330318,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-37.0_r03.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-37.0-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-37.0/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "37.0-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:7": "arm64-v8a",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "f3f64bbefb58a681614f61de5a752795eff74b95",
+              "size": 2225510754,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-37.0_r03.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-37.0-google_apis_playstore-x86_64",
+          "path": "system-images/android-37.0/google_apis_playstore_ps16k/x86_64",
+          "revision": "37.0-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "3"
+          },
+          "type-details": {
+            "abi:7": "x86_64",
+            "api-level:0": "37.0",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "22",
+            "tag:3": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:4": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:5": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:6": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -13964,7 +14502,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
           "path": "system-images/android-36.0-Baklava/google_apis/arm64-v8a",
@@ -14014,7 +14552,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
           "path": "system-images/android-36.0-Baklava/google_apis/x86_64",
@@ -14066,7 +14604,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore/arm64-v8a",
@@ -14116,7 +14654,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore/x86_64",
@@ -14168,7 +14706,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/arm64-v8a",
@@ -14222,7 +14760,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
           "path": "system-images/android-36.0-Baklava/google_apis_playstore_ps16k/x86_64",
@@ -14279,29 +14817,42 @@
               }
             }
           },
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-google_apis-arm64-v8a",
-          "path": "system-images/android-CANARY/google_apis/arm64-v8a",
+          "path": "system-images/android-CANARY/google_apis_ps16k/arm64-v8a",
           "revision": "CANARY-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "5"
+            "major:0": "9"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
+            "abi:8": "arm64-v8a",
             "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "20",
+            "extension-level:2": "21",
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
             },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
             "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -14329,29 +14880,42 @@
               }
             }
           },
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-CANARY-google_apis-x86_64",
-          "path": "system-images/android-CANARY/google_apis/x86_64",
+          "path": "system-images/android-CANARY/google_apis_ps16k/x86_64",
           "revision": "CANARY-google_apis-x86_64",
           "revision-details": {
-            "major:0": "5"
+            "major:0": "9"
           },
           "type-details": {
             "abi:6": "x86_64",
+            "abi:8": "x86_64",
             "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "20",
+            "extension-level:2": "21",
             "tag:4": {
               "display:1": "Google APIs",
               "id:0": "google_apis"
             },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
             "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -14381,29 +14945,42 @@
               }
             }
           },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-CANARY/google_apis_playstore/arm64-v8a",
+          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "CANARY-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "5"
+            "major:0": "9"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
+            "abi:8": "arm64-v8a",
             "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "20",
+            "extension-level:2": "21",
             "tag:4": {
-              "display:1": "Google Play",
+              "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
             "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -14431,29 +15008,42 @@
               }
             }
           },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
+          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
           "license": "android-sdk-license",
           "name": "system-image-CANARY-google_apis_playstore-x86_64",
-          "path": "system-images/android-CANARY/google_apis_playstore/x86_64",
+          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/x86_64",
           "revision": "CANARY-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "5"
+            "major:0": "9"
           },
           "type-details": {
             "abi:6": "x86_64",
+            "abi:8": "x86_64",
             "api-level:0": "36.1",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "20",
+            "extension-level:2": "21",
             "tag:4": {
-              "display:1": "Google Play",
+              "display:1": "Google APIs PlayStore",
               "id:0": "google_apis_playstore"
             },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
             "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            },
+            "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -14484,23 +15074,23 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20429,
+          "last-available-day": 20549,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-CANARY-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/arm64-v8a",
+          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "CANARY-page_size_16kb-arm64-v8a",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "3"
           },
           "type-details": {
             "abi:7": "arm64-v8a",
-            "api-level:0": "36.1",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "20",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -14538,23 +15128,23 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20429,
-          "license": "android-sdk-license",
+          "last-available-day": 20549,
+          "license": "android-sdk-preview-license",
           "name": "system-image-CANARY-page_size_16kb-x86_64",
-          "path": "system-images/android-CANARY/google_apis_playstore_ps16k/x86_64",
+          "path": "system-images/android-36.0-CANARY/google_apis_playstore_ps16k/x86_64",
           "revision": "CANARY-page_size_16kb-x86_64",
           "revision-details": {
-            "major:0": "6"
+            "major:0": "3"
           },
           "type-details": {
             "abi:7": "x86_64",
-            "api-level:0": "36.1",
+            "api-level:0": "36.0",
             "base-extension:3": "true",
             "codename:1": "CANARY",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
-            "extension-level:2": "20",
+            "extension-level:2": "19",
             "tag:4": {
               "display:1": "16 KB Page Size",
               "id:0": "page_size_16kb"
@@ -14564,6 +15154,244 @@
               "id:0": "google_apis_playstore"
             },
             "vendor:6": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "CinnamonBun": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "f86850ed7f5f6f8833ead78c6eec75eeb23ddea4",
+              "size": 2083840044,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-ps16k-CinnamonBun_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CinnamonBun-google_apis-arm64-v8a",
+          "path": "system-images/android-CinnamonBun/google_apis_ps16k/arm64-v8a",
+          "revision": "CinnamonBun-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:8": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:3": "true",
+            "codename:1": "CinnamonBun",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "21",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:7": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "99f81267df3c5c0d978609a5b2b286034bd93d3e",
+              "size": 2073828390,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-ps16k-CinnamonBun_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-CinnamonBun-google_apis-x86_64",
+          "path": "system-images/android-CinnamonBun/google_apis_ps16k/x86_64",
+          "revision": "CinnamonBun-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:8": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:3": "true",
+            "codename:1": "CinnamonBun",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "21",
+            "tag:4": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "tag:5": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:7": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "ba064e28780a5a156a85116d741234eac4e7bb37",
+              "size": 2171953354,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-playstore-ps16k-CinnamonBun_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-CinnamonBun-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-CinnamonBun/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "CinnamonBun-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:8": "arm64-v8a",
+            "api-level:0": "36.1",
+            "base-extension:3": "true",
+            "codename:1": "CinnamonBun",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "21",
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:7": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "dc918be7e86d342ed7e3e174bbb62223ac8a06a9",
+              "size": 2173131758,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-playstore-ps16k-CinnamonBun_r02.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "9",
+                "minor:1": "4"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20549,
+          "license": "android-sdk-license",
+          "name": "system-image-CinnamonBun-google_apis_playstore-x86_64",
+          "path": "system-images/android-CinnamonBun/google_apis_playstore_ps16k/x86_64",
+          "revision": "CinnamonBun-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "2"
+          },
+          "type-details": {
+            "abi:8": "x86_64",
+            "api-level:0": "36.1",
+            "base-extension:3": "true",
+            "codename:1": "CinnamonBun",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:2": "21",
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "tag:5": {
+              "display:1": "Page Size 16KB",
+              "id:0": "page_size_16kb"
+            },
+            "tag:6": {
+              "display:1": "AI Glasses Compatible",
+              "id:0": "ai_glasses_compatible"
+            },
+            "vendor:7": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -15145,18 +15973,18 @@
     }
   },
   "latest": {
-    "build-tools": "36.1.0",
+    "build-tools": "37.0.0",
     "cmake": "4.1.2",
-    "cmdline-tools": "19.0",
-    "emulator": "36.3.10",
+    "cmdline-tools": "20.0",
+    "emulator": "36.5.10",
     "ndk": "29.0.14206865",
     "ndk-bundle": "22.1.7171670",
-    "platform-tools": "36.0.0",
-    "platforms": "36.1",
+    "platform-tools": "37.0.0",
+    "platforms": "37.0",
     "skiaparser": "8",
     "sources": "36.1",
     "tools": "26.1.1",
-    "fingerprint": "aeb6a1bcc1fd6600"
+    "fingerprint": "bf29939be4d269fd"
   },
   "licenses": {
     "android-googletv-license": [
@@ -15224,7 +16052,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15273,7 +16101,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15322,7 +16150,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15371,7 +16199,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15420,7 +16248,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15469,7 +16297,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15518,7 +16346,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15567,7 +16395,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15616,7 +16444,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -15664,7 +16492,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -15712,7 +16540,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15761,7 +16589,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15810,7 +16638,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15859,7 +16687,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15908,7 +16736,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15957,7 +16785,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -16005,7 +16833,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16054,7 +16882,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -16102,7 +16930,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16151,7 +16979,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -16199,7 +17027,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -16247,7 +17075,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -16295,7 +17123,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -16343,7 +17171,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -16391,7 +17219,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -16439,7 +17267,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -16487,7 +17315,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -16535,7 +17363,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -16583,7 +17411,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -16631,7 +17459,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -16679,7 +17507,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -16727,7 +17555,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -16775,7 +17603,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -16823,7 +17651,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -16871,7 +17699,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -16919,7 +17747,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -16967,7 +17795,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -17015,7 +17843,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -17063,7 +17891,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -17111,7 +17939,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17161,7 +17989,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17211,7 +18039,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -17259,7 +18087,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -17307,7 +18135,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -17355,7 +18183,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -17403,7 +18231,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17453,7 +18281,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17503,7 +18331,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -17553,7 +18381,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -17601,7 +18429,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -17649,7 +18477,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -17697,7 +18525,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -17745,7 +18573,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -17793,7 +18621,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -17841,7 +18669,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -17882,7 +18710,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -17923,7 +18751,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -17964,7 +18792,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -18006,7 +18834,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -18047,7 +18875,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -18088,7 +18916,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -18129,7 +18957,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -18170,7 +18998,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -18211,7 +19039,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -18253,7 +19081,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -18295,7 +19123,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -18337,7 +19165,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -18378,7 +19206,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -18420,7 +19248,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -18462,7 +19290,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -18504,7 +19332,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -18546,7 +19374,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -18587,7 +19415,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0",
@@ -18628,7 +19456,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -18670,7 +19498,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -18712,7 +19540,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -18754,7 +19582,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc5",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc5",
@@ -18796,7 +19624,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/36.1.0",
@@ -18837,7 +19665,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36.1-rc1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.1.0-rc1",
@@ -18847,6 +19675,131 @@
           "micro:2": "0",
           "minor:1": "1",
           "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "37.0.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "70954e99f4c3d9d46ee70fa32624672fe7cd6ebe",
+            "size": 66135704,
+            "url": "https://dl.google.com/android/repository/build-tools_r37_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "e9c97e26b5b5678002e9d3fed632c841ae62d99f",
+            "size": 61077164,
+            "url": "https://dl.google.com/android/repository/build-tools_r37_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "eb080751b2b2028eb3604f571027d6f7b3c46321",
+            "size": 81933386,
+            "url": "https://dl.google.com/android/repository/build-tools_r37_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 37",
+        "last-available-day": 20549,
+        "license": "android-sdk-license",
+        "name": "build-tools",
+        "path": "build-tools/37.0.0",
+        "revision": "37.0.0",
+        "revision-details": {
+          "major:0": "37",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "37.0.0-rc1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "c036221340ef6d39ad7adae6befc260beaa54085",
+            "size": 64355745,
+            "url": "https://dl.google.com/android/repository/build-tools_r37-rc1_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "70447369a17f8b4687e7237733d024dfb8c5a797",
+            "size": 59343079,
+            "url": "https://dl.google.com/android/repository/build-tools_r37-rc1_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "0e6aad38e1ad4d4c6ac24332942a2007f4b50779",
+            "size": 80130907,
+            "url": "https://dl.google.com/android/repository/build-tools_r37-rc1_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 37-rc1",
+        "last-available-day": 20549,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/37.0.0-rc1",
+        "revision": "37.0.0-rc1",
+        "revision-details": {
+          "major:0": "37",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "37.0.0-rc2": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "3ffc47b1aefa6b7c457e0d84958a804ba5b8fc83",
+            "size": 64585510,
+            "url": "https://dl.google.com/android/repository/build-tools_r37-rc2_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "c76a22fee5b2f04b355ecd13e84abd594f83841f",
+            "size": 59571314,
+            "url": "https://dl.google.com/android/repository/build-tools_r37-rc2_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "88c354b73d57df160d59b5935e2716bbb570c60e",
+            "size": 80361572,
+            "url": "https://dl.google.com/android/repository/build-tools_r37-rc2_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 37-rc2",
+        "last-available-day": 20549,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/37.0.0-rc2",
+        "revision": "37.0.0-rc2",
+        "revision-details": {
+          "major:0": "37",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "2"
         },
         "type-details": {
           "element-attributes": {
@@ -18888,7 +19841,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -18929,7 +19882,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -18970,7 +19923,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -19011,7 +19964,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -19052,7 +20005,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -19093,7 +20046,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -19134,7 +20087,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -19175,7 +20128,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -19216,7 +20169,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -19257,7 +20210,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -19298,7 +20251,7 @@
           }
         ],
         "displayName": "CMake 3.31.6",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.6",
@@ -19346,7 +20299,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -19387,7 +20340,7 @@
           }
         ],
         "displayName": "CMake 4.0.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.2",
@@ -19428,7 +20381,7 @@
           }
         ],
         "displayName": "CMake 4.0.3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.0.3",
@@ -19469,7 +20422,7 @@
           }
         ],
         "displayName": "CMake 4.1.0",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.0",
@@ -19510,7 +20463,7 @@
           }
         ],
         "displayName": "CMake 4.1.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.1",
@@ -19551,7 +20504,7 @@
           }
         ],
         "displayName": "CMake 4.1.2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/4.1.2",
@@ -19594,7 +20547,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -19634,7 +20587,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -19674,7 +20627,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -19714,7 +20667,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -19754,7 +20707,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -19794,7 +20747,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -19835,7 +20788,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -19876,7 +20829,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -19916,7 +20869,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -19957,7 +20910,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -19997,7 +20950,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0",
@@ -20037,7 +20990,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -20078,7 +21031,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -20119,7 +21072,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -20127,6 +21080,46 @@
         "revision-details": {
           "major:0": "2",
           "minor:1": "1"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "20.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "48833c34b761c10cb20bcd16582129395d121b27",
+            "size": 172789259,
+            "url": "https://dl.google.com/android/repository/commandlinetools-linux-14742923_latest.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "cc27cca4b84bfdbc7df17e3d0a01d0c640d8ee71",
+            "size": 150703968,
+            "url": "https://dl.google.com/android/repository/commandlinetools-mac-14742923_latest.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "16b3f45ddb3d85ea6bbe6a1c0b47146daf0db450",
+            "size": 150532528,
+            "url": "https://dl.google.com/android/repository/commandlinetools-win-14742923_latest.zip"
+          }
+        ],
+        "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 20549,
+        "license": "android-sdk-license",
+        "name": "cmdline-tools",
+        "path": "cmdline-tools/20.0",
+        "revision": "20.0",
+        "revision-details": {
+          "major:0": "20",
+          "minor:1": "0"
         },
         "type-details": {
           "element-attributes": {
@@ -20159,7 +21152,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -20199,7 +21192,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -20239,7 +21232,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -20279,7 +21272,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -20319,7 +21312,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -20359,7 +21352,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -20399,7 +21392,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -20416,44 +21409,6 @@
       }
     },
     "emulator": {
-      "34.1.19": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "d6cc94109b081c5f6042dcb71a453144f7e62ce7",
-            "size": 249458354,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11525734.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "cc0736b8af11d1e74e03ab13dfc214217d06626b",
-            "size": 324283427,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11525734.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "089de1942b9cc5d96c60c92fdad286434c340124",
-            "size": 363522255,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11525734.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19813,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "34.1.19",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "19",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "34.2.11": {
         "archives": [
           {
@@ -20560,44 +21515,6 @@
         "revision-details": {
           "major:0": "35",
           "micro:2": "19",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.1.2": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "c066c3d65b5a7454e039516ecc6a73b0ab754c17",
-            "size": 298454913,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11616444.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "bf5eaf896dbfdbb832fd38255bace1658e524534",
-            "size": 394769949,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11616444.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "dd37d4ab4e4655aea04b1ecc66fe4e4187b382e9",
-            "size": 423453316,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11616444.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19813,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.1.2",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "2",
           "minor:1": "1"
         },
         "type-details": {
@@ -21775,6 +22692,102 @@
             "xsi:type": "ns5:genericDetailsType"
           }
         }
+      },
+      "36.5.10": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "9f03296214df837c608d0d101e5e03ebcebb4343",
+            "size": 331543272,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15081367.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "3ad9f81115436aed6b4feb76f8e5d3e356f2f6e0",
+            "size": 449808912,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15081367.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "0093f579e798c91b589a8d7bc84e1ca7ee528624",
+            "size": 384550690,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15081367.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "1d5cc76415b9717cec08694d171ceb526b1dedb7",
+            "size": 418622111,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15081367.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20549,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.5.10",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "10",
+          "minor:1": "5"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.6.2": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "dd54bbe318cb070b2f8de3de3ee347de13eab611",
+            "size": 346489008,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-15098414.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "c6b41397c64a05d9cc3b8a0432dbe2a14acd3a8f",
+            "size": 462238423,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-15098414.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "08d485c88de5770f4f36bd06de5d2fc36bbc2620",
+            "size": 395994578,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-15098414.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "f4666edf8e729236ab32221d5a5cad23ee051610",
+            "size": 428574271,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-15098414.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20549,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "36.6.2",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "2",
+          "minor:1": "6"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "extras": {
@@ -21900,7 +22913,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -21962,7 +22975,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -22024,7 +23037,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -22086,7 +23099,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -22149,7 +23162,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -22211,7 +23224,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -22275,7 +23288,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -22339,7 +23352,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -22401,7 +23414,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -22449,7 +23462,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -22498,7 +23511,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -22546,7 +23559,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -22602,7 +23615,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -22658,7 +23671,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -22713,7 +23726,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -22769,7 +23782,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -22824,7 +23837,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -22879,7 +23892,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -22934,7 +23947,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -22990,7 +24003,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -23045,7 +24058,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -23100,7 +24113,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -23156,7 +24169,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -23212,7 +24225,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -23268,7 +24281,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -23317,7 +24330,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -23366,7 +24379,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -23415,7 +24428,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -23463,7 +24476,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -23511,7 +24524,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -23559,7 +24572,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -23608,7 +24621,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -23657,7 +24670,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -23706,7 +24719,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -23754,7 +24767,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -23803,7 +24816,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -23852,7 +24865,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -23901,7 +24914,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -23950,7 +24963,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -23998,7 +25011,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -24046,7 +25059,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -24094,7 +25107,7 @@
           }
         },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -24136,7 +25149,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -24178,7 +25191,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -24219,7 +25232,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -24260,7 +25273,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -24301,7 +25314,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -24342,7 +25355,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -24384,7 +25397,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -24426,7 +25439,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -24467,7 +25480,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -24508,7 +25521,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -24549,7 +25562,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.3.13750724",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.3.13750724",
@@ -24590,7 +25603,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -24632,7 +25645,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -24674,7 +25687,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -24716,7 +25729,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -24757,7 +25770,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.1.13356709",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.1.13356709",
@@ -24798,7 +25811,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.2.13676358",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.2.13676358",
@@ -24839,7 +25852,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13113456",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13113456",
@@ -24881,7 +25894,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13599879",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13599879",
@@ -24923,7 +25936,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.13846066",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.13846066",
@@ -24965,7 +25978,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.14033849",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/29.0.14033849",
@@ -25007,7 +26020,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 29.0.14206865",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/29.0.14206865",
@@ -25016,6 +26029,48 @@
           "major:0": "29",
           "micro:2": "14206865",
           "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "30.0.14904198-rc1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "26b746e5a1e7ac3371f2a862a2f52a7c0740aa8a",
+            "size": 713550176,
+            "url": "https://dl.google.com/android/repository/android-ndk-r30-beta1-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "61f0ae7b4b6fdb732a642560b19e7fd5680fb257",
+            "size": 946331314,
+            "url": "https://dl.google.com/android/repository/android-ndk-r30-beta1-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "ec410335aac74d182b369a62c18079187b191149",
+            "size": 714361038,
+            "url": "https://dl.google.com/android/repository/android-ndk-r30-beta1-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 30.0.14904198",
+        "last-available-day": 20549,
+        "license": "android-sdk-preview-license",
+        "name": "ndk",
+        "path": "ndk/30.0.14904198",
+        "revision": "30.0.14904198-rc1",
+        "revision-details": {
+          "major:0": "30",
+          "micro:2": "14904198",
+          "minor:1": "0",
+          "preview:3": "1"
         },
         "type-details": {
           "element-attributes": {
@@ -25071,7 +26126,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25133,7 +26188,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25195,7 +26250,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25257,7 +26312,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -25320,7 +26375,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25382,7 +26437,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -25446,7 +26501,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -25510,7 +26565,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25572,7 +26627,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25620,7 +26675,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25669,7 +26724,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25717,7 +26772,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25773,7 +26828,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25829,7 +26884,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25884,7 +26939,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25940,7 +26995,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -25995,7 +27050,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26050,7 +27105,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26105,7 +27160,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26161,7 +27216,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26216,7 +27271,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26271,7 +27326,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26327,7 +27382,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26383,7 +27438,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26439,7 +27494,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -26661,6 +27716,47 @@
             "xsi:type": "ns5:genericDetailsType"
           }
         }
+      },
+      "37.0.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "bcf323933980a59dccc3f14c339aed5fb2171163",
+            "size": 9167924,
+            "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "ff8facde137e57994112672a0d0f411a3ca7b201",
+            "size": 16442198,
+            "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "8a8351438a9bde81726129214940e0275f7949c7",
+            "size": 8092184,
+            "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-win.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform-Tools",
+        "last-available-day": 20549,
+        "license": "android-sdk-license",
+        "name": "platform-tools",
+        "path": "platform-tools",
+        "revision": "37.0.0",
+        "revision-details": {
+          "major:0": "37",
+          "micro:2": "0",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
       }
     },
     "platforms": {
@@ -26675,7 +27771,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -26714,7 +27810,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -26753,7 +27849,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -26792,7 +27888,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -26831,7 +27927,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -26870,7 +27966,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -26909,7 +28005,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -26948,7 +28044,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -26987,7 +28083,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -27026,7 +28122,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -27079,7 +28175,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27119,7 +28215,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -27158,7 +28254,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -27197,7 +28293,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -27236,7 +28332,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -27275,7 +28371,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -27314,7 +28410,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -27353,7 +28449,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -27392,7 +28488,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -27431,7 +28527,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -27470,7 +28566,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -27523,7 +28619,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27563,7 +28659,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -27602,7 +28698,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -27641,7 +28737,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -27680,7 +28776,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -27720,7 +28816,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -27755,7 +28851,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -27801,7 +28897,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -27834,7 +28930,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -27872,7 +28968,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext15",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext15",
@@ -27905,7 +29001,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36",
@@ -27938,7 +29034,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36.1",
@@ -27971,7 +29067,7 @@
           }
         ],
         "displayName": "Android SDK Platform 36-ext19",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-36-ext19",
@@ -27987,6 +29083,41 @@
           },
           "extension-level:1": "19",
           "layoutlib:3": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
+      "37.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "1a9a8c2e2a5ab8cd95f2eded7d9da037e62fbc6f",
+            "size": 67204348,
+            "url": "https://dl.google.com/android/repository/platform-37.0_r01.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform 37.0",
+        "last-available-day": 20549,
+        "license": "android-sdk-license",
+        "name": "platforms",
+        "path": "platforms/android-37.0",
+        "revision": "37.0",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "37.0",
+          "base-extension:3": "true",
+          "codename:1": {
+          },
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "extension-level:2": "22",
+          "layoutlib:4": {
             "element-attributes": {
               "api": "15"
             }
@@ -28018,7 +29149,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28072,7 +29203,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28126,7 +29257,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28166,7 +29297,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -28205,7 +29336,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -28244,7 +29375,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -28283,7 +29414,7 @@
           }
         ],
         "displayName": "Android SDK Platform Baklava-ext19",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-Baklava-ext19",
@@ -28311,19 +29442,19 @@
           {
             "arch": "all",
             "os": "all",
-            "sha1": "a8201ba194c5241bf6e80d9c21f981e502f5d69c",
-            "size": 66388262,
-            "url": "https://dl.google.com/android/repository/platform-CANARY_r04.zip"
+            "sha1": "756112dd034ba5c1fbc995a472fb17d196c21a59",
+            "size": 66842057,
+            "url": "https://dl.google.com/android/repository/platform-CANARY_r09.zip"
           }
         ],
         "displayName": "Android SDK Platform CANARY",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-CANARY",
         "revision": "CANARY",
         "revision-details": {
-          "major:0": "6"
+          "major:0": "9"
         },
         "type-details": {
           "api-level:0": "36.1",
@@ -28332,7 +29463,41 @@
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
-          "extension-level:2": "20",
+          "extension-level:2": "21",
+          "layoutlib:4": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
+      "CinnamonBun": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "fc958eeaf4d3075d3f0eb8108df883baba9bb419",
+            "size": 67069204,
+            "url": "https://dl.google.com/android/repository/platform-CinnamonBun_r02.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform CinnamonBun",
+        "last-available-day": 20549,
+        "license": "android-sdk-license",
+        "name": "platforms",
+        "path": "platforms/android-CinnamonBun",
+        "revision": "CinnamonBun",
+        "revision-details": {
+          "major:0": "2"
+        },
+        "type-details": {
+          "api-level:0": "36.1",
+          "base-extension:3": "true",
+          "codename:1": "CinnamonBun",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "extension-level:2": "21",
           "layoutlib:4": {
             "element-attributes": {
               "api": "15"
@@ -28382,7 +29547,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -28500,7 +29665,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -28621,7 +29786,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -28713,7 +29878,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
@@ -28740,7 +29905,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -28770,7 +29935,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -28799,7 +29964,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -28828,7 +29993,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -28857,7 +30022,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -28886,7 +30051,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -28915,7 +30080,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -28944,7 +30109,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -28973,7 +30138,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -29002,7 +30167,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -29031,7 +30196,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -29060,7 +30225,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -29089,7 +30254,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -29118,7 +30283,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -29147,7 +30312,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -29176,7 +30341,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -29205,7 +30370,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -29234,7 +30399,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -29263,7 +30428,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -29292,7 +30457,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -29322,7 +30487,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -29352,7 +30517,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -29382,7 +30547,7 @@
           }
         ],
         "displayName": "Sources for Android 36",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36",
@@ -29410,7 +30575,7 @@
           }
         ],
         "displayName": "Sources for Android 36.1",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-36.1",
@@ -29477,7 +30642,7 @@
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20429,
+        "last-available-day": 20549,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Google has seemed to require this suffix on their newer packages,
and also doesn't provide sources anymore. Fix both issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
