### PR TITLE
jellyfin{,-web}: 10.11.7 -> 10.11.8

### DIFF
--- a/pkgs/by-name/je/jellyfin-web/package.nix
+++ b/pkgs/by-name/je/jellyfin-web/package.nix
@@ -13,7 +13,7 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "jellyfin-web";
-  version = "10.11.7";
+  version = "10.11.8";
 
   src =
     assert finalAttrs.version == jellyfin.version;
@@ -21,7 +21,7 @@ buildNpmPackage (finalAttrs: {
       owner = "jellyfin";
       repo = "jellyfin-web";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-DA3UDAcaHyxJmLfw8mRgRNxwOiGu6QIm9QHDrMAaG1w=";
+      hash = "sha256-Nrh4BNlhJyzj9cXQ6Yr7349r5H+4r9W3aldcg9+J6dU=";
     };
 
   nodejs = nodejs_20; # does not build with 22
@@ -31,7 +31,7 @@ buildNpmPackage (finalAttrs: {
       --replace-fail "git describe --always --dirty" "echo ${finalAttrs.src.rev}" \
   '';
 
-  npmDepsHash = "sha256-U90aZ3Kym0yxcsNUSAdm3P3XU6Nb2GjEru64wODrm8M=";
+  npmDepsHash = "sha256-oxytp6n/4X1bhpfFqpqMAji86sbjV669F324zY3hoK4=";
 
   preBuild = ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart

--- a/pkgs/by-name/je/jellyfin/package.nix
+++ b/pkgs/by-name/je/jellyfin/package.nix
@@ -14,13 +14,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "jellyfin";
-  version = "10.11.7"; # ensure that jellyfin-web has matching version
+  version = "10.11.8"; # ensure that jellyfin-web has matching version
 
   src = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u2J55xGjjHwT+nrGvmO01JUS9edaxzYcTdoau3xqnDM=";
+    hash = "sha256-wBf561mZvC65Hu4MHHSu8YeILQDp/WN9vGA+JxGXwE8=";
   };
 
   propagatedBuildInputs = [ sqlite ];


### PR DESCRIPTION
Non-security critical but fixes several regressions in 10.11.7

Upstream release notes:

- https://github.com/jellyfin/jellyfin/releases/tag/v10.11.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
