### PR TITLE
mattermost: fix override for mattermostLatest and mmctl

### DIFF
--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -195,6 +195,7 @@ buildMattermost rec {
   passthru = {
     updateScript = nix-update-script {
       extraArgs = [
+        "--use-github-releases"
         "--version-regex"
         versionInfo.regex
       ]

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -28,6 +28,7 @@
       unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
     '';
   },
+  ...
 }:
 
 let

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -1,23 +1,27 @@
 {
   mattermost,
-}:
+  ...
+}@args:
 
-mattermost.override {
-  versionInfo = {
-    # Latest, non-RC releases only.
-    # If the latest is an ESR (Extended Support Release),
-    # duplicate it here to facilitate the update script.
-    # See https://docs.mattermost.com/about/mattermost-server-releases.html
-    # and make sure the version regex is up to date here.
-    # Ensure you also check ../mattermost/package.nix for ESR releases.
-    regex = "^v(11\\.[0-9]+\\.[0-9]+)$";
-    version = "11.5.1";
-    srcHash = "sha256-3ij6JYGectkAYc2z6caD3L0NUP1UJJ6QaR2qLcTWXoI=";
-    vendorHash = "sha256-ao8jWfrzMTs9JJokaGH0kuoZ0d3VnIDGc5uDN2hCrhk=";
-    npmDepsHash = "sha256-r7iq1pCAJjFyspZBdeNWe00W7A3l73PGC6rrsZ7O6Uw=";
-    lockfileOverlay = ''
-      unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
-    '';
-    autoUpdate = ./package.nix;
-  };
-}
+mattermost.override (
+  {
+    versionInfo = {
+      # Latest, non-RC releases only.
+      # If the latest is an ESR (Extended Support Release),
+      # duplicate it here to facilitate the update script.
+      # See https://docs.mattermost.com/about/mattermost-server-releases.html
+      # and make sure the version regex is up to date here.
+      # Ensure you also check ../mattermost/package.nix for ESR releases.
+      regex = "^v(11\\.[0-9]+\\.[0-9]+)$";
+      version = "11.5.1";
+      srcHash = "sha256-3ij6JYGectkAYc2z6caD3L0NUP1UJJ6QaR2qLcTWXoI=";
+      vendorHash = "sha256-ao8jWfrzMTs9JJokaGH0kuoZ0d3VnIDGc5uDN2hCrhk=";
+      npmDepsHash = "sha256-r7iq1pCAJjFyspZBdeNWe00W7A3l73PGC6rrsZ7O6Uw=";
+      lockfileOverlay = ''
+        unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
+      '';
+      autoUpdate = ./package.nix;
+    };
+  }
+  // args
+)

--- a/pkgs/by-name/mm/mmctl/package.nix
+++ b/pkgs/by-name/mm/mmctl/package.nix
@@ -1,12 +1,16 @@
 {
+  lib,
   mattermost,
 }:
 
-mattermost.withoutTests.server.overrideAttrs (o: {
+mattermost.withoutTests.server.overrideAttrs (prev: {
   pname = "mmctl";
   subPackages = [ "cmd/mmctl" ];
 
-  meta = o.meta // {
+  # `mattermost` or `mattermostLatest` handle it
+  passthru = lib.removeAttrs prev.passthru [ "updateScript" ];
+
+  meta = prev.meta // {
     description = "Remote CLI tool for Mattermost";
     mainProgram = "mmctl";
   };

--- a/pkgs/by-name/mm/mmctl/package.nix
+++ b/pkgs/by-name/mm/mmctl/package.nix
@@ -1,9 +1,10 @@
 {
   lib,
   mattermost,
-}:
+  ...
+}@args:
 
-mattermost.withoutTests.server.overrideAttrs (prev: {
+(mattermost.override args).withoutTests.server.overrideAttrs (prev: {
   pname = "mmctl";
   subPackages = [ "cmd/mmctl" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes .override on mattermostLatest and mmctl.

Backport for update script reasons.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
