### PR TITLE
android-studio: fix update script substituting incorrect URLs

### DIFF
--- a/pkgs/applications/editors/android-studio/default.nix
+++ b/pkgs/applications/editors/android-studio/default.nix
@@ -16,19 +16,19 @@ let
       inherit tiling_wm;
     };
   stableVersion = {
-    version = "2025.3.2.6"; # "Android Studio Panda 2 | 2025.3.2"
-    sha256Hash = "sha256-MpQtjNdogZLPPNB78oL7EgA1ub2bVubxPFVA5tOYB+k=";
-    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.2.6/android-studio-panda2-linux.tar.gz";
+    version = "2025.3.3.6"; # "Android Studio Panda 3 | 2025.3.3"
+    sha256Hash = "sha256-NBrA/BfbyYfQUw4M+zJxJUgFM9ZzOoifITdja+zUhqU=";
+    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.3.6/android-studio-panda3-linux.tar.gz";
   };
   betaVersion = {
-    version = "2025.3.2.5"; # "Android Studio Panda 2 | 2025.3.2 RC 1"
-    sha256Hash = "sha256-qpmc7MO48GV2nnxEdRstg3ne0Gvlrgk9UX5Dr60gAMM=";
-    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.2.5/android-studio-panda2-rc1-linux.tar.gz";
+    version = "2025.3.3.5"; # "Android Studio Panda 3 | 2025.3.3 RC 1"
+    sha256Hash = "sha256-lKpFKw2Oq7OlDrPjFJhMH3aQsJO7TeOKy7HGUCE0B1U=";
+    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.3.5/android-studio-panda3-rc1-linux.tar.gz";
   };
   latestVersion = {
-    version = "2025.3.3.2"; # "Android Studio Panda 3 | 2025.3.3 Canary 2"
-    sha256Hash = "sha256-z8GpBqyEnbyyBc0XPo5q52WS5d7b4292QgUj0FPW+C0=";
-    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.3.2/android-studio-panda3-canary2-linux.tar.gz";
+    version = "2025.3.4.3"; # "Android Studio Panda 4 | 2025.3.4 Canary 3"
+    sha256Hash = "sha256-8fqHdU6IPuRmcJeCZQOqUPgfild9k98sLnN77dl2Hs8=";
+    url = "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.4.3/android-studio-panda4-canary3-linux.tar.gz";
   };
 in
 {

--- a/pkgs/applications/editors/android-studio/update.sh
+++ b/pkgs/applications/editors/android-studio/update.sh
@@ -16,7 +16,7 @@ getLatest() {
         *) local select=".channel == \"${channel^}\"" ;;
     esac
     local result="$(echo "$RELEASES_JSON" \
-        | jq -r ".content.item[] | select(${select}) | [.version, .${attribute}] | join(\" \")" \
+        | jq -r ".content.item[] | select(${select}) | [.version, (${attribute})] | join(\" \")" \
         | sort --version-sort \
         | cut -d' ' -f 2- \
         | tail -n 1)"
@@ -24,14 +24,14 @@ getLatest() {
     if [[ -n "$result" ]]; then
         echo "$result"
     else
-        echo "could not find the latest $attribute for $channel"
+        echo "could not find the latest $attribute for $channel" >&2
         exit 1
     fi
 }
 
 updateChannel() {
     local channel="$1"
-    local latestVersion="$(getLatest "version" "$channel")"
+    local latestVersion="$(getLatest ".version" "$channel")"
 
     local localVersion="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".version)"
     if [[ "${latestVersion}" == "${localVersion}" ]]; then
@@ -40,15 +40,24 @@ updateChannel() {
     fi
     echo "updating $channel from $localVersion to $latestVersion"
 
-    local latestHash="$(nix-prefetch-url "https://dl.google.com/dl/android/studio/ide-zips/${latestVersion}/android-studio-${latestVersion}-linux.tar.gz")"
-    local latestSri="$(nix --extra-experimental-features nix-command hash to-sri --type sha256 "$latestHash")"
+    local latestUrl="$(getLatest "[.download[] | select(.link | endswith(\"-linux.tar.gz\"))][0].link" "$channel")"
+    local latestHash="$(getLatest "[.download[] | select(.link | endswith(\"-linux.tar.gz\"))][0].checksum" "$channel")"
+
+    if [[ "$latestUrl" != https://edgedl.me.gvt1.com/android/studio/* ]]; then
+        echo "URL '$latestUrl' had an unexpected value, maybe the server changed?" >&2
+        exit 1
+    fi
+
+    local latestSri="$(nix --extra-experimental-features nix-command hash convert --from base16 --hash-algo sha256 "$latestHash")"
+    local localUrl="$(nix --extra-experimental-features nix-command eval --json --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.urls | jq -r '.[0]')"
     local localHash="$(nix --extra-experimental-features nix-command eval --raw --file . androidStudioPackages."${channel}".unwrapped.src.drvAttrs.outputHash)"
     sed -i "s~${localHash}~${latestSri}~g" "${DEFAULT_NIX}"
 
     # Match the formatting of default.nix: `version = "2021.3.1.14"; # "Android Studio Dolphin (2021.3.1) Beta 5"`
-    local versionString="${latestVersion}\"; # \"$(getLatest "name" "${channel}")\""
+    local versionString="${latestVersion}\"; # \"$(getLatest ".name" "${channel}")\""
+    sed -i "s~${localUrl}~${latestUrl}~g" "${DEFAULT_NIX}"
     sed -i "s~${localVersion}.*~${versionString}~g" "${DEFAULT_NIX}"
-    echo "updated ${channel} to ${latestVersion}"
+    echo "updated ${channel} to ${latestVersion}" >&2
 }
 
 if (( $# == 0 )); then
@@ -60,8 +69,10 @@ else
         case "$1" in
             beta|canary|stable)
                 updateChannel "$1" ;;
+            dev)
+                echo "no autoupdate for dev" >&2 && exit 0 ;;
             *)
-                echo "unknown channel: $1" && exit 1 ;;
+                echo "unknown channel: $1" >&2 && exit 1 ;;
         esac
         shift 1
     done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Followup to https://github.com/NixOS/nixpkgs/commit/f31788b40bd4967804ee7a7d26ab0568b8b3dc4e.

We need to substitute the entire URL now, and return 0 for dev.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
