### PR TITLE
Add grove, tick, pike-md, and wen packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30099,6 +30099,12 @@
     githubId = 908716;
     name = "Zach Coyle";
   };
+  zachthieme = {
+    email = "zach@techsage.org";
+    github = "zachthieme";
+    githubId = 590418;
+    name = "Zach Thieme";
+  };
   ZachDavies = {
     name = "Zach Davies";
     email = "zdmalta@proton.me";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30099,17 +30099,17 @@
     githubId = 908716;
     name = "Zach Coyle";
   };
-  zachthieme = {
-    email = "zach@techsage.org";
-    github = "zachthieme";
-    githubId = 590418;
-    name = "Zach Thieme";
-  };
   ZachDavies = {
     name = "Zach Davies";
     email = "zdmalta@proton.me";
     github = "ZachDavies";
     githubId = 131615861;
+  };
+  zachthieme = {
+    email = "zach@techsage.org";
+    github = "zachthieme";
+    githubId = 590418;
+    name = "Zach Thieme";
   };
   Zaczero = {
     name = "Kamil Monicz";

--- a/pkgs/by-name/gr/grove/package.nix
+++ b/pkgs/by-name/gr/grove/package.nix
@@ -50,7 +50,7 @@ buildGoModule {
     description = "Interactive web-based org chart planner with CSV/XLSX import and drag-and-drop editing";
     homepage = "https://github.com/zachthieme/grove";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ zachthieme ];
     mainProgram = "grove";
   };
 }

--- a/pkgs/by-name/gr/grove/package.nix
+++ b/pkgs/by-name/gr/grove/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+let
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "zachthieme";
+    repo = "grove";
+    tag = "v${version}";
+    hash = "sha256-EgAsgV4LrnvWMvfElkzDERv9Ih0E7ALBMoqFZH0IGcY=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "grove-frontend";
+    inherit version src;
+
+    sourceRoot = "${src.name}/web";
+
+    npmDepsHash = "sha256-b2B6e2nW0tzrNCMGgUOoVNOP3umLh86viHKQ8OPMd44=";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/* $out/
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule {
+  pname = "grove";
+  inherit version src;
+
+  vendorHash = "sha256-s5odRE+tm4K7dEDJVKVF/3882c6dCygOldJCMqt0wNM=";
+
+  preBuild = ''
+    mkdir -p web/dist
+    cp -r ${frontend}/* web/dist/
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Interactive web-based org chart planner with CSV/XLSX import and drag-and-drop editing";
+    homepage = "https://github.com/zachthieme/grove";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "grove";
+  };
+}

--- a/pkgs/by-name/pi/pike-md/package.nix
+++ b/pkgs/by-name/pi/pike-md/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pike-md";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "zachthieme";
+    repo = "pike";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YGYmsbpmDBN0rYlUi7Xrpf+bCW0B9criOaFbazPQe94=";
+  };
+
+  vendorHash = "sha256-tN+9O4Z1Gtm1AwHTgjM3jJNk4jAhdlb6oOwdaGYpM6o=";
+
+  subPackages = [ "cmd/pike" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/pike $out/bin/pike-md
+  '';
+
+  meta = {
+    description = "Task extraction tool that scans markdown files for checkboxes and tagged items";
+    homepage = "https://github.com/zachthieme/pike";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "pike-md";
+  };
+})

--- a/pkgs/by-name/pi/pike-md/package.nix
+++ b/pkgs/by-name/pi/pike-md/package.nix
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
     description = "Task extraction tool that scans markdown files for checkboxes and tagged items";
     homepage = "https://github.com/zachthieme/pike";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ zachthieme ];
     mainProgram = "pike-md";
   };
 })

--- a/pkgs/by-name/ti/tick/package.nix
+++ b/pkgs/by-name/ti/tick/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "tick";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "zachthieme";
+    repo = "tick";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dnAsyGjVcLjmSe0Go1mJWhzuSpMnq8tUYmfXiOdRVOQ=";
+  };
+
+  vendorHash = "sha256-3AGoHAxfwXaano2hYf0wa/VoYQmjZuRnpCr6QXTILMc=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Terminal dashboard showing nightly host upgrade quota to hit a deadline";
+    homepage = "https://github.com/zachthieme/tick";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "tick";
+  };
+})

--- a/pkgs/by-name/ti/tick/package.nix
+++ b/pkgs/by-name/ti/tick/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
     description = "Terminal dashboard showing nightly host upgrade quota to hit a deadline";
     homepage = "https://github.com/zachthieme/tick";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ zachthieme ];
     mainProgram = "tick";
   };
 })

--- a/pkgs/by-name/we/wen/package.nix
+++ b/pkgs/by-name/we/wen/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     description = "Natural language date parser and interactive terminal calendar";
     homepage = "https://github.com/zachthieme/wen";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ zachthieme ];
     mainProgram = "wen";
   };
 })

--- a/pkgs/by-name/we/wen/package.nix
+++ b/pkgs/by-name/we/wen/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "wen";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "zachthieme";
+    repo = "wen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Cue+Tw5/yGID41lnyY6yFh3f3W/fjfEUltMVo7hEKjE=";
+  };
+
+  vendorHash = "sha256-PI8k21Wiy2XgecmdZVUIzEF/l4FzfTtvuJIHqoeVufU=";
+
+  subPackages = [ "cmd/wen" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Natural language date parser and interactive terminal calendar";
+    homepage = "https://github.com/zachthieme/wen";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "wen";
+  };
+})


### PR DESCRIPTION
## Summary

Add four new Go CLI tools by [@zachthieme](https://github.com/zachthieme):

- **grove** (v0.13.0) — Interactive web-based org chart planner with CSV/XLSX import and drag-and-drop editing. Go backend with embedded React frontend via `go:embed`.
- **tick** (v0.1.1) — Terminal dashboard showing nightly host upgrade quota to hit a deadline. Bubble Tea TUI.
- **pike-md** (v1.8.1) — Task extraction tool that scans markdown files for checkboxes and tagged items. Named `pike-md` to avoid conflict with the existing `pike` (Pike programming language) package.
- **wen** (v1.10.0) — Natural language date parser and interactive terminal calendar.

All four are MIT-licensed, build with `buildGoModule`, and have been verified to build and run successfully.

## Build verification

All packages tested locally:

```
$ nix-build -A tick && result/bin/tick --version
tick v0.1.1

$ nix-build -A pike-md && result/bin/pike-md --version
pike v1.8.1

$ nix-build -A wen && result/bin/wen --version
wen dev

$ nix-build -A grove && result/bin/grove --version
grove version dev
```

## Checklist

- [x] Builds on x86_64-linux
- [x] All Go tests pass during build
- [x] `meta.license` set to MIT
- [x] `meta.mainProgram` set
- [x] Uses `pkgs/by-name/` convention
- [x] `pike-md` avoids name conflict with existing `pike` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)