### PR TITLE
vpp: 25.10 -> 26.02

### DIFF
--- a/pkgs/by-name/vp/vpp/package.nix
+++ b/pkgs/by-name/vp/vpp/package.nix
@@ -50,13 +50,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vpp";
-  version = "25.10";
+  version = "26.02";
 
   src = fetchFromGitHub {
     owner = "FDio";
     repo = "vpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-J+aJXzq9jKzcFKpUNBskX3KccwKtZhK+m8NTbrGjsXw=";
+    hash = "sha256-z9yh1ZMP28SSzHNBdO7UnvVqsIqtXUcwYZUH1UdBUB0=";
   };
 
   postPatch = ''
@@ -78,9 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
   sourceRoot = "${finalAttrs.src.name}/src";
 
   enableParallelBuilding = true;
-  # -Wno-incompatible-pointer-types can be removed in 26.02 (https://github.com/NixOS/nixpkgs/pull/479794)
-  env.NIX_CFLAGS_COMPILE = "-Wno-error -Wno-array-bounds -Wno-maybe-uninitialized -Wno-incompatible-pointer-types";
-
   cmakeFlags = [
     "-DVPP_PLATFORM=default"
     "-DVPP_LIBRARY_DIR=lib"

--- a/pkgs/by-name/vp/vpp/use-dynamic-libs.patch
+++ b/pkgs/by-name/vp/vpp/use-dynamic-libs.patch
@@ -14,14 +14,21 @@
 
 --- a/plugins/rdma/CMakeLists.txt
 +++ b/plugins/rdma/CMakeLists.txt
-@@ -18,8 +18,8 @@ if (NOT IBVERBS_INCLUDE_DIR)
+@@ -18,7 +18,7 @@ if (NOT IBVERBS_INCLUDE_DIR)
    return()
  endif()
  
 -vpp_plugin_find_library(rdma IBVERBS_LIB libibverbs.a)
--vpp_plugin_find_library(rdma MLX5_LIB libmlx5.a)
 +vpp_plugin_find_library(rdma IBVERBS_LIB ibverbs)
-+vpp_plugin_find_library(rdma MLX5_LIB mlx5)
+ if (NOT IBVERBS_LIB)
+   vpp_plugin_find_library(rdma IBVERBS_LIB libibverbs.so)
+   if (NOT IBVERBS_LIB)
+@@ -28,7 +28,7 @@ if (NOT IBVERBS_LIB)
+   message(WARNING "-- linking rdma plugin against ibverbs shared libs")
+ endif()
  
- if (NOT IBVERBS_LIB OR NOT MLX5_LIB)
-   message(WARNING "rdma plugin - ibverbs not found - rdma plugin disabled")
+-vpp_plugin_find_library(rdma MLX5_LIB libmlx5.a)
++vpp_plugin_find_library(rdma MLX5_LIB mlx5)
+ if (MLX5_LIB)
+   string_append(RDMA_LINK_FLAGS "-Wl,--whole-archive,${MLX5_LIB},--no-whole-archive -Wl,--exclude-libs,ALL")
+ else()


### PR DESCRIPTION
https://s3-docs.fd.io/vpp/26.02/aboutvpp/releasenotes/v26.02.html

Tested with #461159's module test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
