### PR TITLE
python3Packages.senzu: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21102,6 +21102,12 @@
     githubId = 1640697;
     name = "Philipp Hausmann";
   };
+  philip-730 = {
+    email = "philip.amendolia@gmail.com";
+    github = "philip-730";
+    githubId = 116534928;
+    name = "Philip Amendolia";
+  };
   philipdb = {
     email = "philipdb.art110@passmail.com";
     name = "Philip de Bruin";

--- a/pkgs/development/python-modules/senzu/default.nix
+++ b/pkgs/development/python-modules/senzu/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  google-cloud-secret-manager,
+  pydantic-settings,
+  python-dotenv,
+  rich,
+  toml,
+  typer,
+  pytestCheckHook,
+  pytest-mock,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "senzu";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-NQogzZ5xgyhFKC3wjcrgmbmonQ2SIGBBRxC+hIHusm0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    google-cloud-secret-manager
+    pydantic-settings
+    python-dotenv
+    rich
+    toml
+    typer
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "senzu" ];
+
+  meta = {
+    description = "Secret env sync for GCP teams";
+    homepage = "https://github.com/philip-730/senzu";
+    changelog = "https://github.com/philip-730/senzu/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philip-730 ];
+    mainProgram = "senzu";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17479,6 +17479,8 @@ self: super: with self; {
 
   sentry-sdk = callPackage ../development/python-modules/sentry-sdk/default.nix { };
 
+  senzu = callPackage ../development/python-modules/senzu { };
+
   sepaxml = callPackage ../development/python-modules/sepaxml { };
 
   seqdiag = callPackage ../development/python-modules/seqdiag { };


### PR DESCRIPTION
Adds senzu, a CLI tool for syncing secrets between GCP Secret Manager and local `.env` files.

Homepage: https://github.com/philip-730/senzu

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test