### PR TITLE
crash: init at 9.0.3

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -424,6 +424,7 @@ in
   };
   coturn = runTest ./coturn.nix;
   couchdb = runTest ./couchdb.nix;
+  crash = runTest ./crash.nix;
   cri-o = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./cri-o.nix;
   croc = runTest ./croc.nix;
   cross-seed = runTest ./cross-seed.nix;

--- a/nixos/tests/crash.nix
+++ b/nixos/tests/crash.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "crash";
+  meta.maintainers = with lib.maintainers; [ al3xtjames ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      boot.crashDump.enable = true;
+
+      environment.systemPackages = with pkgs; [
+        crash
+      ];
+    };
+
+  testScript =
+    let
+      vmlinux = "${config.nodes.machine.boot.kernelPackages.kernel.dev}/vmlinux";
+      crashrc = pkgs.writeText "crashrc" ''
+        print (char *)init_uts_ns.name.release > release.txt
+        exit
+      '';
+    in
+    ''
+      machine.start(allow_reboot=True)
+
+      with subtest("Live debugging succeeds"):
+        machine.succeed("crash /proc/kcore ${vmlinux} -i ${crashrc}")
+        crash_release = machine.succeed("cat release.txt").splitlines()[1].split()[-1].replace("\"", "")
+        uname_release = machine.succeed("uname -r").rstrip()
+        assert crash_release == uname_release
+    '';
+}

--- a/pkgs/by-name/cr/crash/crash-replace-hardcoded-paths.patch
+++ b/pkgs/by-name/cr/crash/crash-replace-hardcoded-paths.patch
@@ -1,0 +1,448 @@
+diff --git a/cmdline.c b/cmdline.c
+index 7e7b81d..14067d3 100644
+--- a/cmdline.c
++++ b/cmdline.c
+@@ -362,7 +362,7 @@ dump_history(void)
+  */
+ 
+ static char *less_argv[5] = {
+-	"/usr/bin/less",
++	"@less@",
+ 	"-E",
+ 	"-X",
+         "-Ps -- MORE --  forward\\: <SPACE>, <ENTER> or j  backward\\: b or k  quit\\: q",
+@@ -370,7 +370,7 @@ static char *less_argv[5] = {
+ };
+ 
+ static char *more_argv[2] = {
+-	"/bin/more",
++	"@more@",
+ 	NULL
+ };
+ 
+@@ -2109,8 +2109,8 @@ set_my_tty(void)
+ 
+         strcpy(pc->my_tty, "?");
+ 
+-	if (file_exists("/usr/bin/tty", NULL)) {
+-	        sprintf(buf, "/usr/bin/tty");
++	if (file_exists("@tty@", NULL)) {
++	        sprintf(buf, "@tty@");
+ 	        if ((pipe = popen(buf, "r")) == NULL) 
+ 	                return;
+ 	
+@@ -2124,7 +2124,7 @@ set_my_tty(void)
+ 		return;
+ 	}
+ 
+-        sprintf(buf, "ps -ef | grep ' %d '", getpid());
++        sprintf(buf, "@ps@ -ef | @grep@ ' %d '", getpid());
+ 
+ 	if (CRASHDEBUG(1))
+ 		fprintf(fp, "popen(%s)\n", buf);
+diff --git a/crash.8 b/crash.8
+index f1a3d8f..cc088f4 100644
+--- a/crash.8
++++ b/crash.8
+@@ -436,9 +436,9 @@ Set the initial context to that of the "swapper" task on cpu 0.
+ .TP
+ .B --more
+ Use 
+-.I /bin/more 
++.I more 
+ as the command output scroller, overriding the default of 
+-.I /usr/bin/less
++.I less
+ and any settings in either 
+ .I ./.crashrc 
+ or
+@@ -446,7 +446,7 @@ or
+ .TP
+ .B --less
+ Use 
+-.I /usr/bin/less 
++.I less 
+ as the command output scroller, overriding 
+ any settings in either 
+ .I ./.crashrc 
+@@ -859,7 +859,7 @@ If
+ .B CRASHPAGER
+ is set, its value is used as the name of the program to which command output will be sent. 
+ If not, then command output is sent to 
+-.B /usr/bin/less -E -X 
++.B less -E -X 
+ by default.
+ .TP
+ .B CRASH_MODULE_PATH
+diff --git a/extensions/snap.c b/extensions/snap.c
+index 04b9c60..359d644 100644
+--- a/extensions/snap.c
++++ b/extensions/snap.c
+@@ -143,7 +143,7 @@ cmd_snap(void)
+ 
+         fprintf(stderr, "\r%s: [100%%] ", filename);
+ 	fprintf(fp, "\n");
+-	sprintf(buf, "/bin/ls -l %s\n", filename);
++	sprintf(buf, "@ls@ -l %s\n", filename);
+ 	system(buf);
+ 
+ 	FREEBUF(elf_header);
+diff --git a/filesys.c b/filesys.c
+index 34944e2..0a8b208 100644
+--- a/filesys.c
++++ b/filesys.c
+@@ -1024,14 +1024,14 @@ search_directory_tree(char *directory, char *file, int follow_links)
+ 	regex_t regex;
+ 	int regex_used, done;
+ 
+-	if (!file_exists("/usr/bin/find", NULL) || 
+-	    !file_exists("/bin/echo", NULL) ||
++	if (!file_exists("@find@", NULL) || 
++	    !file_exists("@echo@", NULL) ||
+ 	    !is_directory(directory) ||
+ 	    (*file == '(')) 
+ 		return NULL;
+ 
+ 	sprintf(command, 
+-            "/usr/bin/find %s %s -name %s -print; /bin/echo search done",
++            "@find@ %s %s -name %s -print; @echo@ search done",
+ 		follow_links ? "-L" : "", directory, file);
+ 
+         if ((pipe = popen(command, "r")) == NULL) {
+@@ -4377,7 +4377,7 @@ match_file_string(char *filename, char *string, char *buffer)
+ 	FILE *pipe;
+ 
+ 
+-	sprintf(command, "/usr/bin/strings %s", filename);
++	sprintf(command, "@strings@ %s", filename);
+         if ((pipe = popen(command, "r")) == NULL) {
+                 error(INFO, "%s: %s\n", filename, strerror(errno));
+                 return FALSE;
+diff --git a/help.c b/help.c
+index 810075b..d344bef 100644
+--- a/help.c
++++ b/help.c
+@@ -302,12 +302,12 @@ char *program_usage_info[] = {
+     "    on cpu 0.",
+     "",
+     "  --more ",
+-    "    Use /bin/more as the command output scroller, overriding the",
+-    "    default of /usr/bin/less and any settings in either ./.crashrc",
++    "    Use more as the command output scroller, overriding the",
++    "    default of less and any settings in either ./.crashrc",
+     "    or $HOME/.crashrc.",
+     "",
+     "  --less ",
+-    "    Use /usr/bin/less as the command output scroller, overriding any",
++    "    Use less as the command output scroller, overriding any",
+     "    settings in either ./.crashrc or $HOME/.crashrc.",
+     "",
+     "  --CRASHPAGER",
+@@ -394,7 +394,7 @@ char *program_usage_info[] = {
+     "  CRASHPAGER",
+     "    If CRASHPAGER is set, its value is used as the name of the program",
+     "    to which command output will be sent.  If not, then command output",
+-    "    output is sent to \"/usr/bin/less -E -X\" by default.",
++    "    output is sent to \"/less -E -X\" by default.",
+     "",
+     "  CRASH_MODULE_PATH",
+     "    Specifies an alternative directory tree to search for kernel",
+@@ -1166,7 +1166,7 @@ char *help_set[] = {
+ "  argument is entered, the current value of the %s variable is shown.  These",
+ "  are the %s variables, acceptable arguments, and purpose:\n",
+ "          scroll  on | off     controls output scrolling.",
+-"          scroll  less         /usr/bin/less as the output scrolling program.",
++"          scroll  less         less as the output scrolling program.",
+ "          scroll  more         /bin/more as the output scrolling program.",
+ "          scroll  CRASHPAGER   use CRASHPAGER environment variable as the",
+ "                               output scrolling program.",
+@@ -1249,11 +1249,11 @@ char *help_set[] = {
+ "       STATE: TASK_RUNNING (PANIC)\n",
+ "  Turn off output scrolling:\n",
+ "    %s> set scroll off",
+-"    scroll: off (/usr/bin/less)",
++"    scroll: off (less)",
+ " ",
+ "  Show the current state of %s internal variables:\n", 
+ "    %s> set -v",
+-"            scroll: on (/usr/bin/less)",
++"            scroll: on (less)",
+ "             radix: 10 (decimal)",
+ "           refresh: on",
+ "         print_max: 256",
+@@ -8495,7 +8495,7 @@ display_input_info(void)
+ static
+ char *output_info[] = {
+ 
+-"\nBy default, %s command output is piped to \"/usr/bin/less -E -X\" along",
++"\nBy default, %s command output is piped to \"less -E -X\" along",
+ "with a prompt line.  This behavior can be turned off in two ways:\n",
+ "  1. During runtime, enter \"set scroll off\" or the alias \"sf\".",
+ "  2. Enter \"set scroll off\" in a .%src file, which can be located either",
+diff --git a/kernel.c b/kernel.c
+index 8781d6a..4a8dd4f 100644
+--- a/kernel.c
++++ b/kernel.c
+@@ -1374,7 +1374,7 @@ verify_namelist()
+ 		goto found;
+ 	}
+ 
+-        sprintf(command, "/usr/bin/strings %s", namelist);
++        sprintf(command, "@strings@ %s", namelist);
+         if ((pipe = popen(command, "r")) == NULL) {
+                 error(INFO, "%s: %s\n", namelist, strerror(errno));
+                 return;
+@@ -1496,7 +1496,7 @@ source_tree_init(void)
+ 		return;
+ 	}
+ 
+-	sprintf(command, "/usr/bin/ls -d %s/arch/*/include/asm 2>/dev/null", 
++	sprintf(command, "@ls@ -d %s/arch/*/include/asm 2>/dev/null", 
+ 		kt->source_tree);
+ 	if ((pipe = popen(command, "r"))) {
+ 		if (fgets(buf, BUFSIZE-1, pipe)) {
+@@ -5962,7 +5962,7 @@ debug_kernel_version(char *namelist)
+ 	if (debug_kernel_version_string)
+ 		return debug_kernel_version_string;
+ 
+-        sprintf(command, "/usr/bin/strings %s", namelist);
++        sprintf(command, "@strings@ %s", namelist);
+ 
+         if ((pipe = popen(command, "r")) == NULL) { 
+ 		debug_kernel_version_string = " ";
+diff --git a/main.c b/main.c
+index d5f8486..1aab271 100644
+--- a/main.c
++++ b/main.c
+@@ -198,13 +198,13 @@ main(int argc, char **argv)
+ 
+ 		        else if (STREQ(long_options[option_index].name, "more")) {
+ 				if ((pc->scroll_command != SCROLL_NONE) &&
+-				    file_exists("/bin/more", NULL))
++				    file_exists("@more@", NULL))
+ 					pc->scroll_command = SCROLL_MORE;
+ 			}
+ 
+ 		        else if (STREQ(long_options[option_index].name, "less")) {
+ 				if ((pc->scroll_command != SCROLL_NONE) &&
+-				    file_exists("/usr/bin/less", NULL))
++				    file_exists("@less@", NULL))
+ 					pc->scroll_command = SCROLL_LESS;
+ 			}
+ 
+@@ -1184,10 +1184,10 @@ setup_environment(int argc, char **argv)
+ 		if (CRASHPAGER_valid()) {
+ 			pc->flags |= SCROLL;
+ 			pc->scroll_command = SCROLL_CRASHPAGER;
+-		} else if (file_exists("/usr/bin/less", NULL)) {
++		} else if (file_exists("@less@", NULL)) {
+ 			pc->flags |= SCROLL;
+ 			pc->scroll_command = SCROLL_LESS;
+-		} else if (file_exists("/bin/more", NULL)) {
++		} else if (file_exists("@more@", NULL)) {
+ 			pc->flags |= SCROLL;
+ 			pc->scroll_command = SCROLL_MORE;
+ 		} else {
+diff --git a/makedumpfile.c b/makedumpfile.c
+index ee03199..ffe84a0 100644
+--- a/makedumpfile.c
++++ b/makedumpfile.c
+@@ -391,7 +391,7 @@ flattened_format_get_common(char *file, char *key, ulonglong flag)
+ 
+ 	sprintf(keybuf, "%s=", key);
+ 	c = strlen(keybuf);
+-	sprintf(buf, "/usr/bin/strings -n %d %s", c, file);
++	sprintf(buf, "@strings@ -n %d %s", c, file);
+ 			
+ 	if ((pipe = popen(buf, "r")) == NULL)
+ 		return;
+diff --git a/remote.c b/remote.c
+index 50a5e14..5ebef84 100644
+--- a/remote.c
++++ b/remote.c
+@@ -466,7 +466,7 @@ handle_connection(int sock)
+                         file = strtok(NULL, " ");    /* filename */
+ 
+ 			sprintf(readbuf, 
+-			    "/usr/bin/strings %s | grep 'Linux version'", 
++			    "@strings@ %s | grep 'Linux version'", 
+ 				file);
+ 
+         		if ((pipe = popen(readbuf, "r"))) {
+@@ -496,7 +496,7 @@ handle_connection(int sock)
+ 			errno = 0;
+ 			reqsize = bufsize - DATA_HDRSIZE;
+ 
+-                        sprintf(readbuf, "/usr/bin/gzip -c %s", file);
++                        sprintf(readbuf, "@gzip@ -c %s", file);
+ 
+                         if ((pipe = popen(readbuf, "r")) == NULL) {
+ 				sprintf(readbuf, "%s%07ld", FAILMSG, 
+@@ -1085,7 +1085,7 @@ no_debugging_symbols_found(char *file)
+ 	FILE *pipe;
+ 	char buf[BUFSIZE];
+ 
+-	sprintf(buf, "echo 'q' | /usr/bin/gdb %s", file);
++	sprintf(buf, "echo 'q' | @gdb@ %s", file);
+ 	if ((pipe = popen(buf, "r")) == NULL)
+ 		return "NO_GDB";
+ 
+@@ -1112,7 +1112,7 @@ daemon_proc_version(char *buf)
+         if (stat("/proc/version", &sbuf) == -1)
+                 return FALSE;
+ 
+-        if ((pipe = popen("/bin/cat /proc/version", "r")) == NULL)
++        if ((pipe = popen("@cat@ /proc/version", "r")) == NULL)
+                 return FALSE;
+ 
+         if (fread(buf, sizeof(char),
+@@ -1188,9 +1188,9 @@ daemon_is_elf_file(char *s)
+         if (!STREQ(magic, ELFMAG))
+                 return FALSE;
+ 
+-	sprintf(buf, "/usr/bin/file -L %s", s);
++	sprintf(buf, "@file@ -L %s", s);
+         if ((pipe = popen(buf, "r")) == NULL) {
+-        	console("/usr/bin/strings popen failed\n");
++        	console("file popen failed\n");
+                 return TRUE;
+         } 
+ 
+@@ -1316,9 +1316,9 @@ daemon_find_booted_kernel(char *namelist)
+                             !daemon_is_elf_file(kernel))
+ 				continue;
+ 
+-			sprintf(command, "/usr/bin/strings %s", kernel);
++			sprintf(command, "@strings@ %s", kernel);
+ 	        	if ((pipe = popen(command, "r")) == NULL) {
+-				console("/usr/bin/strings popen failed\n");
++				console("strings popen failed\n");
+ 				continue;
+ 			}
+ 
+@@ -1453,9 +1453,9 @@ daemon_mount_point(char *name)
+ 		found = mount_points_gathered = 0; 
+ 
+         	if (stat("/proc/mounts", &sbuf) == 0)
+-			sprintf(cmd, "/bin/cat /proc/mounts");
++			sprintf(cmd, "@cat@ /proc/mounts");
+ 		else if (stat("/etc/mtab", &sbuf) == 0)
+-			sprintf(cmd, "/bin/cat /etc/mtab");
++			sprintf(cmd, "@cat@ /etc/mtab");
+ 		else
+                 	return FALSE;
+ 
+@@ -1723,13 +1723,13 @@ daemon_search_directory_tree(char *directory, char *file, char *retbuf)
+ 	FILE *pipe;
+ 	int found;
+ 
+-	if (!daemon_file_exists("/usr/bin/find", NULL) || 
+-	    !daemon_file_exists("/bin/echo", NULL) ||
++	if (!daemon_file_exists("@find@", NULL) || 
++	    !daemon_file_exists("@echo@", NULL) ||
+ 	    !daemon_is_directory(directory)) 
+ 		return FALSE;
+ 
+ 	sprintf(command, 
+-            "/usr/bin/find %s -name %s -print; /bin/echo search done",
++            "@find@ %s -name %s -print; @echo@ search done",
+ 		directory, file);
+ 
+         if ((pipe = popen(command, "r")) == NULL) 
+@@ -2783,7 +2783,7 @@ identical_namelist(char *file, struct remote_file *rfp)
+ 
+         vers = recvbuf;
+ 
+-        sprintf(readbuf, "/usr/bin/strings %s | grep 'Linux version'", 
++        sprintf(readbuf, "@strings@ %s | grep 'Linux version'", 
+ 		file);
+         if ((pipe = popen(readbuf, "r"))) {
+         	BZERO(readbuf, BUFSIZE);
+@@ -3368,7 +3368,7 @@ copy_remote_gzip_file(struct remote_file *rfp, char *file, char *ttystr)
+ 	struct stat sbuf;
+         ulong pct, ret, req, tot, total;
+ 
+-	sprintf(readbuf, "/usr/bin/gunzip > %s", pc->namelist);
++	sprintf(readbuf, "@gunzip@ > %s", pc->namelist);
+         if ((pipe = popen(readbuf, "w")) == NULL)
+ 		error(FATAL, "cannot open pipe to create %s\n", pc->namelist);
+ 
+diff --git a/symbols.c b/symbols.c
+index e6865ca..622e6f3 100644
+--- a/symbols.c
++++ b/symbols.c
+@@ -4461,21 +4461,15 @@ is_compressed_kernel(char *file, char **tmp)
+ 	switch (type)
+ 	{
+ 	case GZIP:
+-		sprintf(command, "%s -c %s > %s", 
+-			file_exists("/bin/gunzip", NULL) ?
+-			"/bin/gunzip" : "/usr/bin/gunzip",
++		sprintf(command, "@gunzip@ -c %s > %s", 
+ 			file, tempname);
+ 		break;
+ 	case BZIP2:
+-		sprintf(command, "%s -c %s > %s", 
+-			file_exists("/bin/bunzip2", NULL) ?
+-			"/bin/bunzip2" : "/usr/bin/bunzip2",
++		sprintf(command, "@bunzip2@ -c %s > %s", 
+ 			file, tempname);
+ 		break;
+ 	case XZ:
+-		sprintf(command, "%s -c %s > %s", 
+-			file_exists("/bin/unxz", NULL) ?
+-			"/bin/unxz" : "/usr/bin/unxz",
++		sprintf(command, "@unxz@ -c %s > %s", 
+ 			file, tempname);
+ 		break;
+ 	}
+@@ -14725,15 +14719,15 @@ dump_trace(void **retaddr)
+         }
+ 	fflush(stderr);
+ 
+-	if (!file_exists("/usr/bin/nm", NULL)) {
+-		fprintf(stderr, "crash: /usr/bin/nm: no such file\n");
++	if (!file_exists("@nm@", NULL)) {
++		fprintf(stderr, "crash: @nm@: no such file\n");
+ 		return;
+ 	}
+ 
+ 	if (is_binary_stripped(thisfile))
+-		nm_call = "/usr/bin/nm -DSBn %s";
++		nm_call = "@nm@ -DSBn %s";
+ 	else
+-		nm_call = "/usr/bin/nm -BSn %s";
++		nm_call = "@nm@ -BSn %s";
+ 
+ 	last_size = 0;
+ 
+diff --git a/tools.c b/tools.c
+index 69250c4..7f5092f 100644
+--- a/tools.c
++++ b/tools.c
+@@ -2136,10 +2136,10 @@ cmd_set(void)
+ 				switch (pc->scroll_command)
+ 				{
+ 				case SCROLL_LESS:
+-					fprintf(fp, "(/usr/bin/less)\n");
++					fprintf(fp, "(less)\n");
+ 					break;
+ 				case SCROLL_MORE:
+-					fprintf(fp, "(/bin/more)\n");
++					fprintf(fp, "(more)\n");
+ 					break;
+ 				case SCROLL_NONE:
+ 					fprintf(fp, "(none)\n");
+@@ -2614,10 +2614,10 @@ show_options(void)
+ 	switch (pc->scroll_command)
+ 	{
+ 	case SCROLL_LESS:
+-		fprintf(fp, "(/usr/bin/less)\n");
++		fprintf(fp, "(less)\n");
+ 		break;
+ 	case SCROLL_MORE:
+-		fprintf(fp, "(/bin/more)\n");
++		fprintf(fp, "(more)\n");
+ 		break;
+ 	case SCROLL_NONE:
+ 		fprintf(fp, "(none)\n");

--- a/pkgs/by-name/cr/crash/package.nix
+++ b/pkgs/by-name/cr/crash/package.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchFromGitHub,
+  replaceVars,
+  bison,
+  installShellFiles,
+  texinfo,
+  bintools,
+  bzip2,
+  coreutils,
+  file,
+  findutils,
+  gdb,
+  gmp,
+  gnugrep,
+  gzip,
+  less,
+  lzo,
+  more,
+  mpfr,
+  ncurses,
+  procps,
+  snappy,
+  xz,
+  zlib,
+  zstd,
+  nix-update-script,
+}:
+
+let
+  gdbVersion = "16.2";
+  gdbSrc = fetchurl {
+    url = "mirror://gnu/gdb/gdb-${gdbVersion}.tar.gz";
+    hash = "sha256-vcHaSgMygKx1Ln00sEGO+qRb7QkyNcuI5i6pYXUqN/g=";
+  };
+
+  crashPathsPatch = replaceVars ./crash-replace-hardcoded-paths.patch {
+    bunzip2 = lib.getExe' bzip2 "bunzip2";
+    cat = lib.getExe' coreutils "cat";
+    echo = lib.getExe' coreutils "echo";
+    file = lib.getExe file;
+    find = lib.getExe findutils;
+    gdb = lib.getExe gdb;
+    grep = lib.getExe gnugrep;
+    gunzip = lib.getExe' gzip "gunzip";
+    gzip = lib.getExe gzip;
+    less = lib.getExe less;
+    ls = lib.getExe' coreutils "ls";
+    more = lib.getExe more;
+    nm = lib.getExe' bintools "nm";
+    ps = lib.getExe' procps "ps";
+    strings = lib.getExe' bintools "strings";
+    tty = lib.getExe' coreutils "tty";
+    unxz = lib.getExe' xz "unxz";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "crash";
+  version = "9.0.2";
+
+  outputs = [
+    "bin"
+    "man"
+    "out"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "crash-utility";
+    repo = "crash";
+    tag = finalAttrs.version;
+    hash = "sha256-6FxPBAFFTO3lZXYkp02Nj5HytGEcqswqRoof0cmHNKU=";
+  };
+
+  patches = [
+    crashPathsPatch
+  ];
+
+  postPatch = ''
+    substituteInPlace gdb-${gdbVersion}.patch --replace-fail "/bin/cat" "cat"
+    substituteInPlace Makefile --replace-fail "/usr/bin/install" "install"
+    ln -s ${gdbSrc} ${builtins.baseNameOf gdbSrc.url}
+  '';
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    bison
+    installShellFiles
+    texinfo
+  ];
+
+  buildInputs = [
+    gmp
+    lzo
+    mpfr
+    ncurses
+    snappy
+    zlib
+    zstd
+  ];
+
+  enableParallelBuilding = true;
+
+  buildFlags = [
+    "lzo"
+    "snappy"
+    "zstd"
+  ];
+
+  enableParallelInstalling = true;
+
+  installFlags = [
+    "INSTALLDIR=${placeholder "bin"}/bin"
+  ];
+
+  postInstall = ''
+    installManPage crash.8
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux kernel crash utility";
+    homepage = "https://crash-utility.github.io/";
+    downloadPage = "https://github.com/crash-utility/crash/releases/${finalAttrs.version}";
+    changelog = "https://crash-utility.github.io/changelog/ChangeLog-${finalAttrs.version}.txt";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ al3xtjames ];
+    mainProgram = "crash";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR packages the [Linux kernel crash utility](https://github.com/crash-utility/crash), which is used to analyze kernel coredumps using an integrated version of GDB. Unfortunately crash hardcodes paths to various command line tools in a bunch of places so these had to be patched out (which is why the patch is somewhat large). The default search paths for debug symbols and kernel sources were not modified, so these paths must be manually specified by the user.

I also added a basic NixOS test to verify that live debugging works (i.e., crash can dump the contents of global symbols from the running kernel using `/proc/kcore`). I would like to eventually extend this test with a subtest that uses kdump to generate a core which gets analyzed by crash after a reboot.

Basic functionality (live debugging and loading a coredump) works. I do not know if the (deprecated) daemon functionality works properly on NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
