### PR TITLE
nixos/power-management: Handle resume correctly with `sleep.target`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -137,6 +137,8 @@
 
 - `services.uptime` has been removed because the package it relies on does not exist anymore in nixpkgs.
 
+- `post-resume.target` has been removed. See {manpage}`systemd.special(7)` about `sleep.target` for instructions on ordering a process after resume with `ExecStop=`.
+
 - `services.kubernetes.addons.dns.coredns` has been renamed to `services.kubernetes.addons.dns.corednsImage` and now expects a
 package instead of attrs. Now, by default, nixpkgs.coredns in conjunction with dockerTools.buildImage is used, instead
 of pulling the upstream container image from Docker Hub. If you want the old behavior, you can set:

--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -90,38 +90,21 @@ in
       https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#sleep.target
     '';
 
-    systemd.targets.post-resume = {
-      description = "Post-Resume Actions";
-      requires = [ "post-resume.service" ];
-      after = [ "post-resume.service" ];
-      wantedBy = [ "sleep.target" ];
-      unitConfig.StopWhenUnneeded = true;
-    };
-
     systemd.services = {
       # Service executed before suspending/hibernating.
-      pre-sleep = {
-        description = "Pre-Sleep Actions";
+      sleep-actions = {
+        description = "Sleep Actions";
         wantedBy = [ "sleep.target" ];
         before = [ "sleep.target" ];
+        unitConfig.StopWhenUnneeded = true;
         script = ''
           # NixOS pre-sleep script
 
           # config.powerManagement.powerDownCommands
           ${cfg.powerDownCommands}
         '';
-        serviceConfig.Type = "oneshot";
-      };
-
-      # Service executed after resuming from suspend/hibernate
-      post-resume = {
-        description = "Post-Resume Actions";
-        # Pulled in by post-resume.service above
-        after = [ "sleep.target" ];
-        script = ''
+        preStop = ''
           # NixOS pre-resume script
-
-          /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
 
           # config.powerManagement.resumeCommands
           ${cfg.resumeCommands}
@@ -129,29 +112,13 @@ in
           # config.powerManagement.powerUpCommands
           ${cfg.powerUpCommands}
         '';
-        serviceConfig.Type = "oneshot";
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
       };
 
-      # Service executed before shutdown
-      pre-shutdown = {
-        description = "Pre-Shutdown Actions";
-        wantedBy = [
-          "shutdown.target"
-        ];
-        before = [
-          "shutdown.target"
-        ];
-        script = ''
-          # NixOS pre-shutdown script
-
-          # config.powerManagement.powerDownCommands
-          ${cfg.powerDownCommands}
-        '';
-        serviceConfig.Type = "oneshot";
-        unitConfig.DefaultDependencies = false;
-      };
-
-      # Service executed after boot
+      # Service executed after boot, and stopped during shutdown
       post-boot = {
         description = "Post-Boot Actions";
         # It's not well defined at what point in the bootup sequence this should run
@@ -166,6 +133,12 @@ in
 
           # config.powerManagement.powerUpCommands
           ${cfg.powerUpCommands}
+        '';
+        preStop = ''
+          # NixOS pre-shutdown script
+
+          # config.powerManagement.powerDownCommands
+          ${cfg.powerDownCommands}
         '';
         serviceConfig = {
           Type = "oneshot";

--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -194,17 +194,27 @@ in
     systemd.services.undervolt = {
       description = "Intel Undervolting Service";
 
-      # Apply undervolt on boot, nixos generation switch and resume
-      wantedBy = [
-        "multi-user.target"
-        "post-resume.target"
-      ];
-      after = [ "post-resume.target" ]; # Not sure why but it won't work without this
+      wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
         Type = "oneshot";
         Restart = "no";
         ExecStart = "${cfg.package}/bin/undervolt ${toString cliArgs}";
+      };
+    };
+
+    systemd.services.undervolt-sleep = {
+      description = "Preserve Intel Undervolting After Sleep";
+
+      wantedBy = [ "sleep.target" ];
+      before = [ "sleep.target" ];
+
+      unitConfig.StopWhenUnneeded = true;
+      serviceConfig = {
+        Type = "oneshot";
+        Restart = "no";
+        RemainAfterExit = true;
+        ExecStop = "${cfg.package}/bin/undervolt ${toString cliArgs}";
       };
     };
 


### PR DESCRIPTION
Fixes `nixos.tests.hibernate` nondeterministic failure.

The documentation in `systemd.special(7)` recommends using this `StopWhenUnneeded` method, rather than using custom unit logic post-resume. This method is sufficiently general, and matches systemd's typical model of using `ExecStart` and `ExecStop` as duals that mirror each others processes across symmetric events in the system's life cycle, e.g. bootup / shutdown.

This involved removing `post-resume.target`. This was introduced in d5604f0b22daf8a0ec341c70607f014dfc9bf207 as a way to notify services of resume events, but as discussed, this is not the typical model.

See: https://github.com/NixOS/nixpkgs/pull/488429/changes#r3038005884


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
