### PR TITLE
jqjq: init at 0-unstable-2026-03-30

### DIFF
--- a/pkgs/by-name/jq/jqjq/package.nix
+++ b/pkgs/by-name/jq/jqjq/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  jq,
+  jqBootstrap ? jq,
+  lib,
+  makeBinaryWrapper,
+  stdenvNoCC,
+  unstableGitUpdater,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jqjq";
+  version = "0-unstable-2026-03-30";
+
+  src = fetchFromGitHub {
+    owner = "wader";
+    repo = "jqjq";
+    rev = "adfc53104329c4a4ec81ac30552ccddb3a9fc5eb";
+    hash = "sha256-PPYJ8VFhvVUj7WdMdj5HzU23o/oPekfzgNgAdSD9o24=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    jq
+    makeBinaryWrapper
+  ];
+
+  postPatch = ''
+    patchShebangs jqjq.jq
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D jqjq.jq --target-directory="$out"/lib/jqjq
+    mkdir "$out"/bin
+    ln --symbolic \
+      "$out"/{lib/jqjq/jqjq.jq,bin/${finalAttrs.meta.mainProgram}}
+    wrapProgram "$_" --set JQ ${lib.getExe jqBootstrap}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "jq implementation in [jq](https://jqlang.org)";
+    homepage = "https://github.com/wader/jqjq";
+    license = lib.licenses.mit;
+    mainProgram = "jqjq";
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/jq/jqjq/package.nix
+++ b/pkgs/by-name/jq/jqjq/package.nix
@@ -1,0 +1,56 @@
+{
+  fetchFromGitHub,
+  jq,
+  jqBootstrap ? jq,
+  lib,
+  makeBinaryWrapper,
+  stdenvNoCC,
+  unstableGitUpdater,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jqjq";
+  version = "0-unstable-2026-03-30";
+
+  src = fetchFromGitHub {
+    owner = "wader";
+    repo = "jqjq";
+    rev = "adfc53104329c4a4ec81ac30552ccddb3a9fc5eb";
+    hash = "sha256-PPYJ8VFhvVUj7WdMdj5HzU23o/oPekfzgNgAdSD9o24=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    jq
+    makeBinaryWrapper
+  ];
+
+  postPatch = ''
+    patchShebangs jqjq.jq
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D jqjq.jq --target-directory="$out"/lib/jqjq
+    mkdir "$out"/bin
+    ln --symbolic \
+      "$out"/{lib/jqjq/jqjq.jq,bin/${finalAttrs.meta.mainProgram}}
+    wrapProgram "$_" --set JQ ${lib.getExe jqBootstrap}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "jq implementation in [jq](https://jqlang.org)";
+    homepage = "https://github.com/wader/jqjq";
+    license = lib.licenses.mit;
+    mainProgram = "jqjq";
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
