### PR TITLE
python3Packages.pypmml: init at 1.5.8

### DIFF
--- a/pkgs/development/python-modules/pypmml/default.nix
+++ b/pkgs/development/python-modules/pypmml/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  py4j,
+  jpype1,
+  jre_minimal,
+  jdk,
+  numpy,
+  pandas,
+  pytestCheckHook,
+  pythonOlder,
+}:
+
+let
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.logging"
+      "java.net.http"
+      "java.desktop"
+    ];
+    jdk = jdk;
+  };
+in
+
+buildPythonPackage (finalAttrs: {
+  pname = "pypmml";
+  version = "1.5.8";
+  pyproject = true;
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "autodeployai";
+    repo = "pypmml";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PNgwSlYyjOCuvIdqwJ7m62oD8GKF5U94qVMpUyuXRg0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    py4j
+    jpype1
+  ];
+
+  makeWrapperArgs = [
+    "--set JAVA_HOME ${jre}"
+  ];
+
+  preCheck = ''
+    export JAVA_HOME=${jre}
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+    pandas
+    jre
+  ];
+
+  disabledTests = [
+    "test_jpype"
+  ];
+
+  pythonImportsCheck = [ "pypmml" ];
+
+  meta = {
+    description = "Python PMML scoring library, Python API for PMML4S";
+    homepage = "https://github.com/autodeployai/pypmml";
+    changelog = "https://github.com/autodeployai/pypmml/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14589,6 +14589,8 @@ self: super: with self; {
 
   pyplatec = callPackage ../development/python-modules/pyplatec { };
 
+  pypmml = callPackage ../development/python-modules/pypmml { };
+
   pypng = callPackage ../development/python-modules/pypng { };
 
   pypoint = callPackage ../development/python-modules/pypoint { };


### PR DESCRIPTION
Adds pypmml, a python pmml scoring library.

Changelog: https://github.com/autodeployai/pypmml/releases/tag/v1.5.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
