### PR TITLE
MakeMKV: add patch to fix application icon on Gnome

### DIFF
--- a/pkgs/by-name/ma/makemkv/app-id.patch
+++ b/pkgs/by-name/ma/makemkv/app-id.patch
@@ -1,0 +1,14 @@
+diff --git a/makemkvgui/src/main.cpp b/makemkvgui/src/main.cpp
+index 73ce457..71f822c 100644
+--- a/makemkvgui/src/main.cpp
++++ b/makemkvgui/src/main.cpp
+@@ -65,6 +65,9 @@ int qMain(int argc, char **argv)
+ #if (QT_VERSION > 0x050000)
+     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+ #endif
++    // Ensure the app-id ('makemkv') is set, so that GNOME can show
++    // the correct icon in the dash.
++    QGuiApplication::setDesktopFileName("makemkv");
+ 
+     CApClient::ITransport*  p_trans = NULL;
+ 

--- a/pkgs/by-name/ma/makemkv/package.nix
+++ b/pkgs/by-name/ma/makemkv/package.nix
@@ -43,7 +43,12 @@ stdenv.mkDerivation (
 
     srcs = lib.attrValues finalAttrs.passthru.srcs;
     sourceRoot = "makemkv-oss-${version}";
-    patches = [ ./r13y.patch ];
+    patches = [
+      ./r13y.patch
+      # This patch is sourced from NonGuix, licensed GPLv3:
+      # https://gitlab.com/nonguix/nonguix/-/blob/2d1f3691546f007c7cd96ae87e4e970fed789182/nongnu/packages/patches/makemkv-app-id.patch
+      ./app-id.patch
+    ];
 
     enableParallelBuilding = true;
     nativeBuildInputs = [


### PR DESCRIPTION
Co-authored-by: apteryks <maxim@guixotic.coop>

Resolves #481571

Currently, while this builds, it does not appear to actually resolve the issue that the patch is intended to fix. I am unsure why, and would appreciate some assistance from someone with more Nix experience with debugging.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
