### PR TITLE
indilib, indi-3rdparty: 2.1.9 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/science/astronomy/indilib/default.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "indilib";
-  version = "2.1.9";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "indilib";
     repo = "indi";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-L3qZ1VgL4J4TYYdgeSrWuVC2Xy+iBxIU9GBx8cllm1o=";
+    hash = "sha256-XTb+etafMRTP/Arb087s+kZoqFT50RT1fpVDeHaGdmY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
+++ b/pkgs/development/libraries/science/astronomy/indilib/indi-3rdparty.nix
@@ -41,13 +41,13 @@
 }:
 
 let
-  thirdparty_version = "2.1.9";
+  thirdparty_version = "2.2.0";
   fxload = libusb1.override { withExamples = true; };
   src-3rdparty = fetchFromGitHub {
     owner = "indilib";
     repo = "indi-3rdparty";
     rev = "v${thirdparty_version}";
-    hash = "sha256-zHcJDbi+xsI1xDnZTFmUbk4GNGD8WqZUzf3hfSCmvpU=";
+    hash = "sha256-JGDaRlKYgHADMC3C2kiRmTqoL0dHuJKXiUVAYknQsGA=";
   };
 
   buildIndi3rdParty =
@@ -241,7 +241,7 @@ let
     pname = "libfishcamp";
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace-fail "/lib/firmware" "lib/firmware"
+      substituteInPlace CMakeLists.txt --replace-fail "/usr/lib/firmware" "lib/firmware"
     '';
 
     buildInputs = [
@@ -426,7 +426,7 @@ let
     postPatch = ''
       sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
       substituteInPlace CMakeLists.txt \
-        --replace-fail "/lib/firmware" "lib/firmware"
+        --replace-fail "/usr/lib/firmware" "lib/firmware"
 
       substituteInPlace 85-qhyccd.rules \
         --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
@@ -487,7 +487,7 @@ let
 
     postPatch = ''
       sed -i '/FIX_MACOS_LIBRARIES/d' CMakeLists.txt
-      substituteInPlace CMakeLists.txt --replace-fail "/lib/firmware" "lib/firmware"
+      substituteInPlace CMakeLists.txt --replace-fail "/usr/lib/firmware" "lib/firmware"
       substituteInPlace 51-sbig-debian.rules \
         --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
         --replace-fail "/lib/firmware" "$out/lib/firmware"
@@ -635,7 +635,7 @@ in
       libnova
     ];
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/usr/lib/udev/rules.d" "lib/udev/rules.d"
     '';
   };
 
@@ -745,8 +745,8 @@ in
 
     postPatch = ''
       substituteInPlace CMakeLists.txt \
-        --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d" \
-        --replace-fail "/lib/firmware" "lib/firmware"
+        --replace-fail "/usr/lib/udev/rules.d" "lib/udev/rules.d" \
+        --replace-fail "/usr/lib/firmware" "lib/firmware"
       substituteInPlace 99-meadedsi.rules \
         --replace-fail "/sbin/fxload" "${fxload}/sbin/fxload" \
         --replace-fail "/lib/firmware" "$out/lib/firmware"
@@ -979,7 +979,7 @@ in
     ];
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/usr/lib/udev/rules.d" "lib/udev/rules.d"
     '';
   };
 
@@ -1036,7 +1036,7 @@ in
     ];
 
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/usr/lib/udev/rules.d" "lib/udev/rules.d"
     '';
 
     meta.platforms = libqsi.meta.platforms;
@@ -1109,6 +1109,7 @@ in
     buildInputs = [
       cfitsio
       indilib
+      libusb1
       zlib
     ];
     propagatedBuildInputs = [ libsvbony ];
@@ -1124,7 +1125,7 @@ in
       libusb1
     ];
     postPatch = ''
-      substituteInPlace CMakeLists.txt --replace-fail "/lib/udev/rules.d" "lib/udev/rules.d"
+      substituteInPlace CMakeLists.txt --replace-fail "/usr/lib/udev/rules.d" "lib/udev/rules.d"
     '';
   };
 


### PR DESCRIPTION
Updated to latest version, updated substitutes since upstream changed the paths.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
