### PR TITLE
ccmeter: init at 2.0.0

### DIFF
--- a/pkgs/by-name/cc/ccmeter/package.nix
+++ b/pkgs/by-name/cc/ccmeter/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ccmeter";
+  version = "2.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hmenzagh";
+    repo = "CCMeter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iVPHRV+qfLl77wdyGLycYCYbtMLh3KF+TFwFI8qZPNs=";
+  };
+
+  cargoHash = "sha256-owQwUm8jbi3GItHV7UUfxyNn+htHfXEP/OfJjVLxFzs=";
+
+  # These tests hardcode 2026-04-01 timestamps, but discover_rate_limit_hits()
+  # discards hits older than 30 days, so they only pass within a month of the
+  # release date:
+  # https://github.com/hmenzagh/CCMeter/blob/v2.0.0/src/data/rate_limits.rs#L180-L182
+  checkFlags = [
+    "--skip=data::rate_limits::tests::detects_rate_limit_hit"
+    "--skip=data::rate_limits::tests::deduplicates_same_minute"
+  ];
+
+  meta = {
+    description = "TUI dashboard for tracking Claude Code usage and costs";
+    homepage = "https://github.com/hmenzagh/CCMeter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.unix;
+    mainProgram = "ccmeter";
+  };
+})


### PR DESCRIPTION
TUI dashboard for deep analytics and session insights for Claude Code usage. Tracks per-model cost breakdown (Opus/Sonnet/Haiku), token analytics over time, code metrics (lines suggested/accepted/added/deleted), efficiency scores, and GitHub-style activity heatmaps.

Homepage: https://github.com/hmenzagh/CCMeter


Two upstream unit tests are skipped via `checkFlags`: `data::rate_limits::tests::{detects_rate_limit_hit,deduplicates_same_minute}` hardcode 2026-04-01 timestamps, but `discover_rate_limit_hits()` discards hits older than 30 days ([rate_limits.rs#L180-L182](https://github.com/hmenzagh/CCMeter/blob/v2.0.0/src/data/rate_limits.rs#L180-L182)), so they only pass within a month of release. The other 49 tests pass.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
