### PR TITLE
terminal-oscilloscope: init at 0.1.0-unstable-2026-04-07

### DIFF
--- a/pkgs/by-name/te/terminal-oscilloscope/lock.json
+++ b/pkgs/by-name/te/terminal-oscilloscope/lock.json
@@ -1,0 +1,14 @@
+{
+  "depends": [
+    {
+      "method": "fetchzip",
+      "packages": ["illwill"],
+      "path": "",
+      "rev": "v0.4.1",
+      "sha256": "0hiic5yjsaw6sgl1jzmfpm5g6a5ckzmd29c3pzg30glchn2g94sk",
+      "srcDir": "",
+      "subDir": "",
+      "url": "https://github.com/johnnovak/illwill/archive/v0.4.1.tar.gz"
+    }
+  ]
+}

--- a/pkgs/by-name/te/terminal-oscilloscope/package.nix
+++ b/pkgs/by-name/te/terminal-oscilloscope/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildNimPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  ffmpeg,
+  wireplumber,
+}:
+
+buildNimPackage (finalAttrs: {
+  pname = "terminal-oscilloscope";
+  version = "0.1.0-unstable-2026-04-07";
+
+  src = fetchFromGitHub {
+    owner = "rolandnsharp";
+    repo = "terminal-oscilloscope";
+    rev = "f2a94befaa4b9de1c01a410f132e08032b447844";
+    hash = "sha256-L1/1Hg7ig286KbNuo9ED5mJxpUIVBFdH5KHnVdBm390=";
+  };
+
+  lockFile = ./lock.json;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/osc \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ ffmpeg ]}" \
+      --prefix PATH : "${lib.makeBinPath [ wireplumber ]}"
+  '';
+
+  meta = {
+    description = "Terminal oscilloscope with CRT phosphor physics";
+    homepage = "https://github.com/rolandnsharp/terminal-oscilloscope";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.linux;
+    mainProgram = "osc";
+  };
+})


### PR DESCRIPTION
Terminal-based oscilloscope with CRT phosphor physics written in Nim. Captures live system audio via PipeWire/PulseAudio and renders waveforms with phosphor persistence, bloom, and decay trails. Supports Y-T (time-domain) and X-Y (Lissajous) display modes using Unicode half-block characters for 2x vertical resolution.

Homepage: https://github.com/rolandnsharp/terminal-oscilloscope

Runtime dependencies: ffmpeg (dlopen'd libavformat/libavdevice for audio capture), wireplumber (wpctl for audio source discovery).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
