### PR TITLE
makemkv: Fix icon in GNOME dash.

### DIFF
--- a/pkgs/by-name/ma/makemkv/fix-app-id.patch
+++ b/pkgs/by-name/ma/makemkv/fix-app-id.patch
@@ -1,0 +1,14 @@
+diff --git a/makemkvgui/src/main.cpp b/makemkvgui/src/main.cpp
+index 73ce457..71f822c 100644
+--- a/makemkvgui/src/main.cpp
++++ b/makemkvgui/src/main.cpp
+@@ -65,6 +65,9 @@ int qMain(int argc, char **argv)
+ #if (QT_VERSION > 0x050000)
+     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+ #endif
++    // Ensure the app-id ('makemkv') is set, so that GNOME can show
++    // the correct icon in the dash.
++    QGuiApplication::setDesktopFileName("makemkv");
+ 
+     CApClient::ITransport*  p_trans = NULL;
+ 

--- a/pkgs/by-name/ma/makemkv/package.nix
+++ b/pkgs/by-name/ma/makemkv/package.nix
@@ -43,7 +43,10 @@ stdenv.mkDerivation (
 
     srcs = lib.attrValues finalAttrs.passthru.srcs;
     sourceRoot = "makemkv-oss-${version}";
-    patches = [ ./r13y.patch ];
+    patches = [
+      ./r13y.patch
+      ./fix-app-id.patch
+    ];
 
     enableParallelBuilding = true;
     nativeBuildInputs = [


### PR DESCRIPTION
Fixes: #481571
