### PR TITLE
rustpython: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/ru/rustpython/package.nix
+++ b/pkgs/by-name/ru/rustpython/package.nix
@@ -41,7 +41,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Python 3 interpreter in written Rust";
     homepage = "https://rustpython.github.io";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ prusnak ];
+    maintainers = with lib.maintainers; [
+      prusnak
+      miniharinn
+    ];
     mainProgram = "rustpython";
   };
 })

--- a/pkgs/by-name/ru/rustpython/package.nix
+++ b/pkgs/by-name/ru/rustpython/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  libffi,
   rustPlatform,
   fetchFromGitHub,
   python3,
@@ -9,19 +10,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustpython";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "RustPython";
     repo = "RustPython";
     tag = finalAttrs.version;
-    hash = "sha256-BYYqvPJu/eFJ9lt07A0p7pd8pGFccUe/okFqGEObhY4=";
+    hash = "sha256-rjDJXXR1ByFubZtzy70DZKur6nqVmufd3TqwxN1s9kE=";
   };
 
-  cargoHash = "sha256-LuxET01n5drYmPXXhCl0Cs9yoCQKwWah8FWfmKmLdsg=";
+  cargoHash = "sha256-I+yeaMN5wxt+l4I8qUPq2fk+OER8/QxeHAKtvvYIV9Y=";
 
   # freeze the stdlib into the rustpython binary
   cargoBuildFlags = [ "--features=freeze-stdlib" ];
+
+  buildInputs = [ libffi ];
 
   nativeCheckInputs = [ python3 ];
 


### PR DESCRIPTION
Diff: https://github.com/RustPython/RustPython/compare/0.4.0...0.5.0

Ive also added myself as a maintainer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
