### PR TITLE
stac-validator: 3.11.0 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/stac-validator/default.nix
+++ b/pkgs/development/python-modules/stac-validator/default.nix
@@ -1,32 +1,41 @@
 {
   lib,
   fetchFromGitHub,
-  python3Packages,
-}:
+  buildPythonPackage,
 
-python3Packages.buildPythonPackage rec {
+  # build systems
+  setuptools,
+  # runtime deps
+  click,
+  jsonschema,
+  pyyaml,
+  requests,
+  tqdm,
+}:
+buildPythonPackage rec {
   pname = "stac-validator";
-  version = "3.11.0";
+  version = "4.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stac-utils";
     repo = "stac-validator";
     tag = "v${version}";
-    hash = "sha256-5wcnEdk8+/stdJVQ97Me/+H3GrS7DA+Nd0OQtPEXDl4=";
+    hash = "sha256-qO1DRYpPn+zarHTj2mZQ2LJ2uhmS1bax6Yxy035ZEUA=";
   };
 
-  build-system = [ python3Packages.setuptools ];
+  build-system = [ setuptools ];
 
   pythonRelaxDeps = [
     "click"
   ];
 
-  dependencies = with python3Packages; [
+  dependencies = [
     click
     jsonschema
     pyyaml
     requests
+    tqdm
   ];
 
   pythonImportsCheck = [ "stac_validator" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1636,6 +1636,8 @@ with pkgs;
     haskellPackages.generateOptparseApplicativeCompletions [ "cabal2nix" ] haskellPackages.cabal2nix
   );
 
+  stac-validator = with python3Packages; toPythonApplication stac-validator;
+
   stack2nix =
     with haskell.lib;
     overrideCabal (justStaticExecutables haskellPackages.stack2nix) (_: {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18468,6 +18468,8 @@ self: super: with self; {
 
   stable-baselines3 = callPackage ../development/python-modules/stable-baselines3 { };
 
+  stac-validator = callPackage ../development/python-modules/stac-validator { };
+
   stack-data = callPackage ../development/python-modules/stack-data { };
 
   stackprinter = callPackage ../development/python-modules/stackprinter { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update stac-validator.

As newer version exposes a python API, I added it to python3Packages instead.

I'd love to enable tests, but most of them actually needs network access, and excluding them in a fine-grained fashion is cumbersome.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
