### PR TITLE
hdf5: fix sema-unused-def-let warning

### DIFF
--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -90,21 +90,21 @@ stdenv.mkDerivation rec {
     "-DHDF5_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake"
     "-DBUILD_STATIC_LIBS=${lib.boolToString enableStatic}"
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin "-DHDF5_BUILD_WITH_INSTALL_NAME=ON"
-  ++ lib.optional cppSupport "-DHDF5_BUILD_CPP_LIB=ON"
-  ++ lib.optional fortranSupport "-DHDF5_BUILD_FORTRAN=ON"
-  ++ lib.optional szipSupport "-DHDF5_ENABLE_SZIP_SUPPORT=ON"
-  ++ lib.optionals mpiSupport [ "-DHDF5_ENABLE_PARALLEL=ON" ]
-  ++ lib.optional enableShared "-DBUILD_SHARED_LIBS=ON"
-  ++ lib.optional javaSupport "-DHDF5_BUILD_JAVA=ON"
-  ++ lib.optional usev110Api "-DDEFAULT_API_VERSION=v110"
-  ++ lib.optionals threadsafe [
+  ++ optional stdenv.hostPlatform.isDarwin "-DHDF5_BUILD_WITH_INSTALL_NAME=ON"
+  ++ optional cppSupport "-DHDF5_BUILD_CPP_LIB=ON"
+  ++ optional fortranSupport "-DHDF5_BUILD_FORTRAN=ON"
+  ++ optional szipSupport "-DHDF5_ENABLE_SZIP_SUPPORT=ON"
+  ++ optionals mpiSupport [ "-DHDF5_ENABLE_PARALLEL=ON" ]
+  ++ optional enableShared "-DBUILD_SHARED_LIBS=ON"
+  ++ optional javaSupport "-DHDF5_BUILD_JAVA=ON"
+  ++ optional usev110Api "-DDEFAULT_API_VERSION=v110"
+  ++ optionals threadsafe [
     "-DHDF5_ENABLE_THREADSAFE:BOOL=ON"
     "-DHDF5_BUILD_HL_LIB=OFF"
   ]
   # broken in nixpkgs since around 1.14.3 -> 1.14.4.3
   # https://github.com/HDFGroup/hdf5/issues/4208#issuecomment-2098698567
-  ++ lib.optional (
+  ++ optional (
     stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
   ) "-DHDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16=OFF";
 


### PR DESCRIPTION

This pull request updates the way build options are specified in the `hdf5` package derivation. The main change is replacing uses of the `lib.optional` and `lib.optionals` functions with the locally scoped `optional` and `optionals` functions, likely for consistency or to use updated helpers.

Build option specification cleanup:

* Replaced all instances of `lib.optional` and `lib.optionals` with `optional` and `optionals` in the `cmakeFlags` list in `default.nix`, improving consistency and possibly compatibility with updated Nixpkgs conventions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
