### PR TITLE
pkgs/README: Use one set of guidelines for `pname`s, attribute names and filenames

### DIFF
--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -420,38 +420,36 @@ For instance, the package `e2fsprogs` has a `pname` attribute `"e2fsprogs"`, is 
 
 Follow these guidelines:
 
-- For the `pname` attribute:
+- All three names (the `pname` value, the attribute name and the filename for the Nix expression) _should_ be the same.
 
-  - It _should_ be identical to the upstream package name.
+- All three names _should_ be identical to the upstream package name.
 
-  - It _must not_ contain uppercase letters.
+- All three names _should not_ contain uppercase letters.
 
-    Example: Use `"mplayer"` instead of `"MPlayer"`
+  Example: Use `"mplayer"` instead of `"MPlayer"`
 
-- For the package attribute name:
+- All three names _should_ be a valid identifier in Nix.
 
-  - It _must_ be a valid identifier in Nix.
+- If any of the names would otherwise begin with a digit, then that name _should_ be prefixed with an underscore.
+  Otherwise that name _should not_ be prefixed with an underscore.
 
-  - If the `pname` starts with a digit, the attribute name _should_ be prefixed with an underscore.
-    Otherwise the attribute name _should not_ be prefixed with an underscore.
+  Example: Use `_0ad` instead of `0ad`.
 
-    Example: The corresponding attribute name for `0ad` should be `_0ad`.
+- Hyphenated names _should_ be used instead of [snake case](https://en.wikipedia.org/wiki/Snake_case) or [camel case](https://en.wikipedia.org/wiki/Camel_case)
 
-  - New attribute names _should_ be the same as the value in `pname`.
+  Hyphenated names _should not_ be converted to snake case or camel case.
+  This was done historically, but is not necessary any more.
+  [The Nix language allows dashes in identifiers since 2012](https://github.com/NixOS/nix/commit/95c74eae269b2b9e4bc514581b5caa1d80b54acc).
 
-    Hyphenated names _should not_ be converted to [snake case](https://en.wikipedia.org/wiki/Snake_case) or [camel case](https://en.wikipedia.org/wiki/Camel_case).
-    This was done historically, but is not necessary any more.
-    [The Nix language allows dashes in identifiers since 2012](https://github.com/NixOS/nix/commit/95c74eae269b2b9e4bc514581b5caa1d80b54acc).
+- If there are multiple versions of a package, this _should_ be reflected in all three names.
 
-  - If there are multiple versions of a package, this _should_ be reflected in the attribute names in `all-packages.nix`.
+  Example: `json-c_0_9` and `json-c_0_11`
 
-    Example: `json-c_0_9` and `json-c_0_11`
+  If there is an obvious “default” version, make an extra attribute.
 
-    If there is an obvious “default” version, make an extra attribute.
+  Example: `json-c = json-c_0_9;`
 
-    Example: `json-c = json-c_0_9;`
-
-    See also [versioning][versioning].
+  See also [versioning][versioning].
 
 ## Versioning
 [versioning]: #versioning


### PR DESCRIPTION
The goal of this change is to hopefully make it easier for contributors to follow Nixpkgs’s guidelines for naming packages. It was inspired by [this NixOS Discourse thread](https://discourse.nixos.org/t/are-spaces-and-dots-supposed-to-be-allowed-in-pname-values/76661?u=jasonyundt) where I was confused about Nixpkgs’s guidelines for naming packages.

Guidelines for naming packages were first added to Nixpkgs in 2009. At the time, each package had three different names: the value of the `name` attribute, the attribute name, and the filename. A different set of guidelines was added for each of the different names that packages had. It made sense to have different guidelines for each of the different names because each of the different types of names had different limitations. It’s now 2026. We still have different guidelines for three different different types of package names, but we’re no longer constrained by the same limitations that we were in 2009. At this point, there are very few technical limitations for each of the three different types of names. Additionally, the current sets of guidelines for each of the different types of names are all almost identical. As a result, I don’t think that it makes sense for use to have three different sets of guidelines for each of the three different types of names anymore.

See the commit message for details.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `9aac5dfe5a561ca3750683516e13b4d8626bc4e4`

---
### `x86_64-linux`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
