### PR TITLE
freetype: refactor derivation, remove unused let binding

### DIFF
--- a/pkgs/by-name/fr/freetype/package.nix
+++ b/pkgs/by-name/fr/freetype/package.nix
@@ -12,7 +12,6 @@
   brotli,
   libpng,
   gnumake,
-  glib,
 
   # FreeType supports LCD filtering (colloquially referred to as sub-pixel rendering).
   # LCD filtering is also known as ClearType and covered by several Microsoft patents.
@@ -41,14 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "freetype";
   version = "2.13.3";
 
-  src =
-    let
-      inherit (finalAttrs) pname version;
-    in
-    fetchurl {
-      url = "mirror://savannah/freetype/freetype-${version}.tar.xz";
-      sha256 = "sha256-BVA1BmbUJ8dNrrhdWse7NTrLpfdpVjlZlTEanG8GMok=";
-    };
+  src = fetchurl {
+    url = "mirror://savannah/freetype/freetype-${finalAttrs.version}.tar.xz";
+    hash = "sha256-BVA1BmbUJ8dNrrhdWse7NTrLpfdpVjlZlTEanG8GMok=";
+  };
 
   propagatedBuildInputs = [
     zlib

--- a/pkgs/by-name/fr/freetype/package.nix
+++ b/pkgs/by-name/fr/freetype/package.nix
@@ -12,7 +12,6 @@
   brotli,
   libpng,
   gnumake,
-  glib,
 
   # FreeType supports LCD filtering (colloquially referred to as sub-pixel rendering).
   # LCD filtering is also known as ClearType and covered by several Microsoft patents.
@@ -42,11 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.14.2";
 
   src =
-    let
-      inherit (finalAttrs) pname version;
-    in
     fetchurl {
-      url = "mirror://savannah/freetype/freetype-${version}.tar.xz";
+      url = "mirror://savannah/freetype/freetype-${finalAttrs.version}.tar.xz";
       sha256 = "sha256-S2Lcq0ySChqGA2mTMiGBQ2LmmeJvVXklFtZx5v9VteE=";
     };
 


### PR DESCRIPTION
This pull request makes minor cleanup and modernization changes to the `freetype` package definition. The most notable changes are the removal of an unused dependency and updating the way the source is fetched for clarity and consistency.

Dependency cleanup:

* Removed the unused `glib` dependency from the package inputs in `package.nix`.

Modernization and simplification:

* Simplified the `src` attribute by removing unnecessary variable inheritance and updating the attribute names to use `hash` instead of `sha256` in the `fetchurl` call.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
