### PR TITLE
ankiAddons.anki-contanki: init at 1.0

### DIFF
--- a/pkgs/by-name/an/anki/addons/anki-contanki/config.patch
+++ b/pkgs/by-name/an/anki/addons/anki-contanki/config.patch
@@ -1,0 +1,13 @@
+diff --git i/contanki/funcs.py w/contanki/funcs.py
+index ad54c72..7fb0a2c 100644
+--- i/contanki/funcs.py
++++ w/contanki/funcs.py
+@@ -72,7 +72,7 @@ def get_config() -> dict:
+     else:
+         config.update(loaded_config)
+ 
+-    mw.addonManager.writeConfig(__name__, config)
++    # mw.addonManager.writeConfig(__name__, config)
+     return config
+ 
+ 

--- a/pkgs/by-name/an/anki/addons/anki-contanki/default.nix
+++ b/pkgs/by-name/an/anki/addons/anki-contanki/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "anki-contanki";
+  version = "1.0";
+  src = fetchFromGitHub {
+    owner = "roxgib";
+    repo = "anki-contanki";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-a8EbCQVuxJv04RVtiGUz5ypRdqFUIqK8Uqz5Zf0XkqI=";
+  };
+  patches = [ ./config.patch ];
+  patchFlags = [
+    "-p1"
+    "-d"
+    ".."
+  ];
+  sourceRoot = "${finalAttrs.src.name}/contanki";
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "An add-on for Anki which allows users to control Anki using a gamepad or other controller device.";
+    homepage = "https://github.com/roxgib/anki-contanki";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ hey2022 ];
+  };
+})

--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -8,6 +8,8 @@
 
   anki-connect = callPackage ./anki-connect { };
 
+  anki-contanki = callPackage ./anki-contanki { };
+
   anki-quizlet-importer-extended = callPackage ./anki-quizlet-importer-extended { };
 
   fsrs4anki-helper = callPackage ./fsrs4anki-helper { };

--- a/pkgs/by-name/an/anki/with-addons.nix
+++ b/pkgs/by-name/an/anki/with-addons.nix
@@ -54,9 +54,15 @@ let
       pname = "nixos";
       version = "1.0";
       src = writeTextDir "__init__.py" ''
+        import builtins
+        import io
+        import json
+        from pathlib import Path
         import aqt
         from aqt.qt import QMessageBox
-        import json
+
+        ADDONS_PATH = Path(aqt.mw.addonManager.addonsFolder()).expanduser().absolute()
+
 
         def addons_dialog_will_show(dialog: aqt.addons.AddonsDialog) -> None:
           dialog.setEnabled(False)
@@ -80,8 +86,56 @@ let
           message_box.setDetailedText(json.dumps(conf))
           message_box.exec()
 
+
+        class _InterceptedWrite(io.StringIO):
+          def __init__(self, path: str):
+            super().__init__()
+            self.path = path
+
+          def close(self):
+            if self.closed:
+              return
+            text = self.getvalue()
+            super().close()
+            message_box = QMessageBox(
+              QMessageBox.Icon.Warning,
+              "NixOS Info",
+              (f"An attempt was made to write to the user_file at {self.path}<br>"
+                "See <a href='https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/an/anki/with-addons.nix'>"
+                "github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/an/anki/with-addons.nix</a>"
+                " for how to configure add-ons managed by NixOS."
+              ),
+            )
+            message_box.setDetailedText(text)
+            message_box.exec()
+
+
+        def open_hook(real_open, file, mode="r", *args, **kwargs):
+          target = Path(file).expanduser().absolute()
+          base_path = Path(ADDONS_PATH).expanduser().absolute()
+          if target.is_relative_to(base_path):
+            parts = target.relative_to(base_path).parts
+            is_user_file = len(parts) >= 2 and parts[1] == "user_files"
+            if is_user_file and any(m in mode for m in "wax+"):
+              return _InterceptedWrite(file)
+          return real_open(file, mode, *args, **kwargs)
+
+
+        def builtin_open_hook(file, mode="r", *args, **kwargs):
+            return open_hook(_real_builtin_open, file, mode, *args, **kwargs)
+
+
+        def io_open_hook(file, mode="r", *args, **kwargs):
+            return open_hook(_real_io_open, file, mode, *args, **kwargs)
+
+
         aqt.gui_hooks.addons_dialog_will_show.append(addons_dialog_will_show)
         aqt.mw.addonManager.writeConfig = addon_tried_to_write_config
+
+        _real_builtin_open = builtins.open
+        _real_io_open = io.open
+        builtins.open = builtin_open_hook
+        io.open = io_open_hook
       '';
       meta.maintainers = with lib.maintainers; [ junestepp ];
     })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds anki-contanki, an add-on for Anki which allows users to control Anki using a gamepad or other controller device.

~The addons write profiles for controllers in the plugin source directory; in our case, it fails because it is a read-only directory in the Nix store. I patched the addon to write to where the addon user_files directory would be if it weren't installed through nix `~/.local/share/Anki2/addons21/1898790263/user_files`, where `1898790263` is the addon id.~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
