### PR TITLE
metadata-cleaner: 2.5.6 -> 4.0.0

### DIFF
--- a/pkgs/by-name/me/metadata-cleaner/package.nix
+++ b/pkgs/by-name/me/metadata-cleaner/package.nix
@@ -12,7 +12,6 @@
   librsvg,
   meson,
   ninja,
-  nix-update-script,
   pkg-config,
   poppler_gi,
   wrapGAppsHook4,
@@ -20,14 +19,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "metadata-cleaner";
-  version = "2.5.6";
+  version = "4.0.0";
   pyproject = false;
 
   src = fetchFromGitLab {
-    owner = "rmnvgr";
-    repo = "metadata-cleaner";
+    owner = "metadatacleaner";
+    repo = "metadatacleaner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-J+nwgLbAFoh1gq3J4cqQEShZJCSZesyCjT9DfkCWIHs=";
+    hash = "sha256-9e8uH//FtufYUsvule3JirkeHTjDMebruZ3bAYyDVWY=";
   };
 
   nativeBuildInputs = [
@@ -56,15 +55,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pygobject3
   ];
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
-
   meta = {
     description = "Python GTK application to view and clean metadata in files, using mat2";
     mainProgram = "metadata-cleaner";
-    homepage = "https://gitlab.com/rmnvgr/metadata-cleaner";
-    changelog = "https://gitlab.com/rmnvgr/metadata-cleaner/-/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://gitlab.com/metadatacleaner/metadatacleaner";
+    changelog = "https://gitlab.com/metadatacleaner/metadatacleaner/-/releases/${finalAttrs.src.tag}";
     license = with lib.licenses; [
       gpl3Plus
       cc-by-sa-40


### PR DESCRIPTION
Diff: https://gitlab.com/metadatacleaner/metadatacleaner/-/compare/v2.5.6...v4.0.0

Changelog: https://gitlab.com/metadatacleaner/metadatacleaner/-/releases/v4.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
