### PR TITLE
androidndk-pkgs: add aarch64-darwin support

### DIFF
--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -30,6 +30,14 @@ let
       x86_64-unknown-linux-gnu = {
         double = "linux-x86_64";
       };
+      arm64-apple-darwin = {
+        # the difference in `arm64` attribute vs `x86_64` double is purposeful.
+        # the Android NDK contains a single Universal 2 Darwin binary
+        # which supports arm64 and x86. The NDK was never updated to differentiate
+        # or unify architecture with its folder structure, so the binary supporting both architectures
+        # is stored under a single directory indicating `x86_64` despite also supporting darwin arm64.
+        double = "darwin-x86_64";
+      };
     }
     .${stdenv.buildPlatform.config} or fallback;
 
@@ -90,8 +98,8 @@ else
       inherit (androidndk) version;
       nativeBuildInputs = [
         makeWrapper
-        autoPatchelfHook
-      ];
+      ]
+      ++ lib.optionals stdenv.buildPlatform.isLinux [ autoPatchelfHook ];
       propagatedBuildInputs = [ androidndk ];
       passthru = {
         inherit targetPrefix;
@@ -103,7 +111,7 @@ else
       dontStrip = true;
       dontConfigure = true;
       dontPatch = true;
-      autoPatchelfIgnoreMissingDeps = true;
+      autoPatchelfIgnoreMissingDeps = stdenv.buildPlatform.isLinux;
       installPhase = ''
         # https://developer.android.com/ndk/guides/other_build_systems
         mkdir -p $out


### PR DESCRIPTION

Android NDK r23+ supports building on Apple Silicon using the
  universal darwin binary in the android ndk.
  The toolchain binaries are Mach-O format (not ELF), so we conditionally
  disable autoPatchelfHook on Darwin to avoid ELF parsing errors.

  This enables Android cross-compilation from Apple Silicon Macs.

  See: https://github.com/android/ndk/issues/1299

with these small changes, I was able to cross-compile from `aarch64-darwin` to relevant android targets (`aarch64-unknown-linux-android`, `armv7a-unknown-linux-androideabi`, `x86_64-unknown-linux-android`, `i686-unknown-linux-android`). W/O these changes, I would run into an error, `Android NDK doesn't support building on arm64-apple-darwin, as far as we know` which is incorrect according to the linked issue above.

I tested this by running the android build for xmtp lib targets on a M1 Mac in a oneliner

`nix build github:xmtp/libxmtp/push-rpwzltknwwwt#android-libs`
which will successfully cross-compile all the android library targets on mac silicon with these changes.

the android ndk uses a [Universal 2 binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) since the linked 1299 was merged, which supports apple silicon natively, so this is not using rosetta to cross-compile

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
