### PR TITLE
verilator: 5.044 -> 5.046

### DIFF
--- a/pkgs/by-name/ve/verilator/package.nix
+++ b/pkgs/by-name/ve/verilator/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "verilator";
-  version = "5.044";
+  version = "5.046";
 
   src = fetchFromGitHub {
     owner = "verilator";
     repo = "verilator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z3jYNzhnZ+OocDAbmsRBWHNNPXLLvExKK1TLDi9JzPQ=";
+    hash = "sha256-dfZzbQrw/14dFvWnkmCDElwsGm6GdFstNAURujvEIb8=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
https://github.com/verilator/verilator/releases/tag/v5.046

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
