### PR TITLE
nixos/frp: add 'extraConfig' option

### DIFF
--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -76,6 +76,24 @@ in
                   ];
                 };
               };
+
+              extraConfig = lib.mkOption {
+                type = lib.types.lines;
+                default = "";
+                description = ''
+                  Extra frp TOML configuration included at the end of the generated configuration file.
+                  Especially useful for [port range mapping](https://github.com/fatedier/frp?tab=readme-ov-file#port-range-mapping).
+                '';
+                example = ''
+                  {{- range $_, $v := parseNumberRangePair "6000-6006,6007" "6000-6006,6007" }}
+                  [[proxies]]
+                  name = "tcp-{{ $v.First }}"
+                  type = "tcp"
+                  localPort = {{ $v.First }}
+                  remotePort = {{ $v.Second }}
+                  {{- end }}
+                '';
+              };
             };
           }
         );
@@ -94,7 +112,18 @@ in
       instance: options:
       let
         serviceName = "frp" + lib.optionalString (instance != "") ("-" + instance);
-        configFile = settingsFormat.generate "${serviceName}.toml" options.settings;
+        baseConfigFile = settingsFormat.generate "${serviceName}-base.toml" options.settings;
+        configFile =
+          if options.extraConfig == "" then
+            baseConfigFile
+          else
+            pkgs.writeText "${serviceName}.toml" ''
+              # Nixos Module settings
+              ${builtins.readFile baseConfigFile}
+
+              # Nixos Module extraConfig
+              ${options.extraConfig}
+            '';
         isClient = (options.role == "client");
         isServer = (options.role == "server");
         serviceCapability = lib.optionals isServer [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -175,5 +175,8 @@ in
     ) enabledInstances;
   };
 
-  meta.maintainers = with lib.maintainers; [ zaldnoay ];
+  meta.maintainers = with lib.maintainers; [
+    zaldnoay
+    epireyn
+  ];
 }

--- a/nixos/modules/services/networking/frp.nix
+++ b/nixos/modules/services/networking/frp.nix
@@ -76,6 +76,26 @@ in
                   ];
                 };
               };
+
+              extraConfig = lib.mkOption {
+                type = lib.types.lines;
+                default = "";
+                description = ''
+                  Extra frp TOML configuration included at the end of the generated configuration file.
+                  Especially useful for [port range mapping].
+
+                  [port range mapping]: https://github.com/fatedier/frp#port-range-mapping
+                '';
+                example = ''
+                  {{- range $_, $v := parseNumberRangePair "6000-6006,6007" "6000-6006,6007" }}
+                  [[proxies]]
+                  name = "tcp-{{ $v.First }}"
+                  type = "tcp"
+                  localPort = {{ $v.First }}
+                  remotePort = {{ $v.Second }}
+                  {{- end }}
+                '';
+              };
             };
           }
         );
@@ -94,7 +114,18 @@ in
       instance: options:
       let
         serviceName = "frp" + lib.optionalString (instance != "") ("-" + instance);
-        configFile = settingsFormat.generate "${serviceName}.toml" options.settings;
+        baseConfigFile = settingsFormat.generate "${serviceName}-base.toml" options.settings;
+        configFile =
+          if options.extraConfig == "" then
+            baseConfigFile
+          else
+            pkgs.writeText "${serviceName}.toml" ''
+              # Nixos Module settings
+              ${builtins.readFile baseConfigFile}
+
+              # Nixos Module extraConfig
+              ${options.extraConfig}
+            '';
         isClient = (options.role == "client");
         isServer = (options.role == "server");
         serviceCapability = lib.optionals isServer [ "CAP_NET_BIND_SERVICE" ];

--- a/nixos/tests/frp.nix
+++ b/nixos/tests/frp.nix
@@ -87,6 +87,15 @@ in
             }
           ];
         };
+        extraConfig = ''
+          {{- range $_, $v := parseNumberRangePair "6000-6006,6007" "6000-6006,6007" }}
+          [[proxies]]
+          name = "tcp-{{ $v.First }}"
+          type = "tcp"
+          localPort = {{ $v.First }}
+          remotePort = {{ $v.Second }}
+          {{- end }}
+        '';
       };
     };
   };

--- a/nixos/tests/frp.nix
+++ b/nixos/tests/frp.nix
@@ -13,7 +13,10 @@ let
 in
 {
   name = "frp";
-  meta.maintainers = with lib.maintainers; [ zaldnoay ];
+  meta.maintainers = with lib.maintainers; [
+    zaldnoay
+    epireyn
+  ];
   nodes = {
     frps = {
       networking = {

--- a/nixos/tests/frp.nix
+++ b/nixos/tests/frp.nix
@@ -9,6 +9,7 @@ let
     name = "secrets";
     text = "token=${token}";
   };
+  portRange = 6003;
 in
 {
   name = "frp";
@@ -56,14 +57,25 @@ in
       services.httpd = {
         enable = true;
         adminAddr = "admin@example.com";
-        virtualHosts."test-appication" =
+        virtualHosts =
           let
             testdir = pkgs.writeTextDir "web/index.php" "<?php phpinfo();";
           in
           {
-            documentRoot = "${testdir}/web";
-            locations."/" = {
-              index = "index.php index.html";
+            "test-appication" = {
+              documentRoot = "${testdir}/web";
+              locations."/" = {
+                index = "index.php index.html";
+              };
+            };
+            "test-range" = {
+              documentRoot = "${testdir}/web";
+              listen = [
+                { port = portRange; }
+              ];
+              locations."/" = {
+                index = "index.php index.html";
+              };
             };
           };
         phpPackage = pkgs.php84;
@@ -87,6 +99,15 @@ in
             }
           ];
         };
+        extraConfig = ''
+          {{- range $_, $v := parseNumberRangePair "6000-6006,6007" "6000-6006,6007" }}
+          [[proxies]]
+          name = "tcp-{{ $v.First }}"
+          type = "tcp"
+          localPort = {{ $v.First }}
+          remotePort = {{ $v.Second }}
+          {{- end }}
+        '';
       };
     };
   };
@@ -96,9 +117,17 @@ in
     frps.wait_for_unit("frp-server.service")
     frps.wait_for_open_port(80)
     frpc.wait_for_unit("frp-client.service")
+
+    # Test config written in Nix
     response = frpc.succeed("curl -fvvv -s http://127.0.0.1/")
     assert "PHP Version ${pkgs.php84.version}" in response, "PHP version not detected"
     response = frpc.succeed("curl -fvvv -s http://10.0.0.1/")
+    assert "PHP Version ${pkgs.php84.version}" in response, "PHP version not detected"
+
+    # Test `extraConfig` option with port range
+    response = frpc.succeed("curl -fvvv -s http://127.0.0.1:${toString portRange}/")
+    assert "PHP Version ${pkgs.php84.version}" in response, "PHP version not detected"
+    response = frpc.succeed("curl -fvvv -s http://10.0.0.1:${toString portRange}/")
     assert "PHP Version ${pkgs.php84.version}" in response, "PHP version not detected"
   '';
 }


### PR DESCRIPTION
This feature allows for unparsable settings (by nix) to be used, such as Go templates. It is needed to configure port ranges (https://github.com/fatedier/frp?tab=readme-ov-file#port-range-mapping).

@zaldnoay
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

##### Reviewed points

- [X] changes are backward compatible
- [ ] removed options are declared with `mkRemovedOptionModule`
- [ ] changes that are not backward compatible are documented in release notes
- [ ] module tests succeed on x86_64-linux
- [X] options types are appropriate
- [X] options description is set
- [X] options example is provided
- [ ] documentation affected by the changes is updated

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
