### PR TITLE
sonic-pi: fix sema-unused-def-lambda-witharg-formal, fix boost error

### DIFF
--- a/pkgs/by-name/so/sonic-pi/package.nix
+++ b/pkgs/by-name/so/sonic-pi/package.nix
@@ -32,14 +32,15 @@
   gl3w,
   SDL2,
   fmt,
-}@args:
+}:
 
 let
-  ruby = args.ruby.withPackages (ps: [
+  rubyEnv = ruby.withPackages (ps: [
     ps.prime
     ps.racc
     ps.rake
     ps.rexml
+    ps.mutex_m
   ]);
 in
 
@@ -70,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
     cmake
     pkg-config
-    ruby
+    rubyEnv
     beamPackages.erlang
     beamPackages.elixir
     beamPackages.hex
@@ -122,6 +123,10 @@ stdenv.mkDerivation (finalAttrs: {
   # Fix shebangs on files in app and bin scripts
   postPatch = ''
     patchShebangs app bin
+
+    # Boost 1.89+ dropped the dummy compiled boost_system library.
+    # We need to remove references to it so CMake doesn't fail.
+    sed -i 's/COMPONENTS filesystem system thread/COMPONENTS filesystem thread/g' app/api/CMakeLists.txt
   '';
 
   preConfigure =


### PR DESCRIPTION
This pull request updates the Sonic Pi package definition to improve Ruby dependency handling and fix a build issue with newer Boost versions. The main changes are grouped below:

**Ruby environment improvements:**
* Replaces the direct use of `ruby` with a new `rubyEnv` that includes the `mutex_m` package, ensuring all required Ruby packages are available.

**Build compatibility fixes:**
* Adds a patch in the `postPatch` phase to remove references to the removed `boost_system` library from `app/api/CMakeLists.txt`, resolving build failures with Boost 1.89 and newer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
