### PR TITLE
copyq: 13.0.0 -> 15.0.0

### DIFF
--- a/pkgs/by-name/co/copyq/package.nix
+++ b/pkgs/by-name/co/copyq/package.nix
@@ -2,26 +2,27 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   cmake,
   ninja,
   qt6,
+  libx11,
   libxfixes,
   libxtst,
   wayland,
+  miniaudio,
   pkg-config,
   kdePackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "CopyQ";
-  version = "13.0.0";
+  version = "15.0.0";
 
   src = fetchFromGitHub {
     owner = "hluk";
     repo = "CopyQ";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-wxjUL5mGXAMNVGP+dAh1NrE9tw71cJW9zmLsaCVphTo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D1huGKvYa/GsVeLQcP69MCWF8p+ytcQxlu0qynmYbGw=";
   };
 
   nativeBuildInputs = [
@@ -37,26 +38,23 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtsvg
     qt6.qttools
     qt6.qtdeclarative
+    libx11
     libxfixes
     libxtst
     qt6.qtwayland
     wayland
+    miniaudio
     kdePackages.kconfig
     kdePackages.kstatusnotifieritem
     kdePackages.knotifications
     kdePackages.kguiaddons
+    kdePackages.qca
+    kdePackages.qtkeychain
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_QT6" true)
-  ];
-
-  patches = [
-    # https://github.com/hluk/CopyQ/pull/3268
-    (fetchpatch2 {
-      url = "https://github.com/hluk/CopyQ/commit/103903593c37c9db5406d276e0097fbf18d2a8c4.patch?full_index=1";
-      hash = "sha256-zywE6ntMw+WvTyilXwvd4lfQRAAB9R/AGpwtwwPFZZE=";
-    })
+    (lib.cmakeFeature "MINIAUDIO_INCLUDE_DIR" "${lib.getInclude miniaudio}/include/miniaudio")
   ];
 
   meta = {


### PR DESCRIPTION
https://github.com/hluk/CopyQ/releases/tag/v15.0.0


## Things done



- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
