### PR TITLE
pika-backup: 0.7.6 -> 0.8.2

### DIFF
--- a/pkgs/by-name/pi/pika-backup/borg-path.patch
+++ b/pkgs/by-name/pi/pika-backup/borg-path.patch
@@ -1,8 +1,8 @@
-diff --git a/src/borg/process.rs b/src/borg/process.rs
-index 9af8da7..85bcbf8 100644
---- a/src/borg/process.rs
-+++ b/src/borg/process.rs
-@@ -278,7 +278,7 @@ impl BorgCall {
+diff --git a/pika-backup-common/src/borg/process.rs b/pika-backup-common/src/borg/process.rs
+index eb97eef9..5e8fad65 100644
+--- a/pika-backup-common/src/borg/process.rs
++++ b/pika-backup-common/src/borg/process.rs
+@@ -284,7 +284,7 @@ impl BorgCall {
      }
  
      pub(super) fn command(&self) -> Result<(async_process::Command, UnixStream)> {

--- a/pkgs/by-name/pi/pika-backup/package.nix
+++ b/pkgs/by-name/pi/pika-backup/package.nix
@@ -23,19 +23,19 @@
 
 stdenv.mkDerivation rec {
   pname = "pika-backup";
-  version = "0.7.6";
+  version = "0.8.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "pika-backup";
     tag = version;
-    hash = "sha256-tWTINRYCAhPV2srZWIYJeH4NAQIv/ED0bBdeKKgkC78=";
+    hash = "sha256-Ee++3EQcfM5/x3QJtsq4UBV6LiKN45WLQVgAVqU8pic=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-Ut7dFhm67tcpELZzQPwyIs9/3YNHofi2VF9RxQCD7qo=";
+    hash = "sha256-gfO+R9jj5mPcpWukp84yqg+iKKE+qrIdNzOHCa7oQpU=";
   };
 
   patches = [

--- a/pkgs/by-name/pi/pika-backup/package.nix
+++ b/pkgs/by-name/pi/pika-backup/package.nix
@@ -18,24 +18,25 @@
   gtk4,
   libadwaita,
   libsecret,
+  openssl,
   nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "pika-backup";
-  version = "0.7.6";
+  version = "0.8.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "pika-backup";
     tag = version;
-    hash = "sha256-tWTINRYCAhPV2srZWIYJeH4NAQIv/ED0bBdeKKgkC78=";
+    hash = "sha256-02ChjIXjTos3jm6UR37tFWhRlUvyh/1r6zLsd6fQsyc=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-Ut7dFhm67tcpELZzQPwyIs9/3YNHofi2VF9RxQCD7qo=";
+    hash = "sha256-e6hep/aTpC5HDI/UoSJONGZRP3rjA2eVh9G4DE3HJpE=";
   };
 
   patches = [
@@ -66,6 +67,7 @@ stdenv.mkDerivation rec {
     gtk4
     libadwaita
     libsecret
+    openssl
   ];
 
   passthru = {


### PR DESCRIPTION
Diff: https://gitlab.gnome.org/World/pika-backup/-/compare/0.7.6...0.8.2

Changelog: https://gitlab.gnome.org/World/pika-backup/-/blob/0.8.2/CHANGELOG.md

depends on https://github.com/NixOS/nixpkgs/pull/501286
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
