### PR TITLE
python3Packages.ua-parser: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/ua-parser/default.nix
+++ b/pkgs/development/python-modules/ua-parser/default.nix
@@ -6,14 +6,13 @@
   pyyaml,
   pytestCheckHook,
   setuptools,
-  setuptools-scm,
   ua-parser-builtins,
   ua-parser-rs,
 }:
 
 buildPythonPackage rec {
   pname = "ua-parser";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -21,13 +20,12 @@ buildPythonPackage rec {
     repo = "uap-python";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-l8EBQq5Hqw/Vx4zvWy2QQ1m7mrAiqYNK2x3yUmJj8Xw=";
+    hash = "sha256-KKQlM1AonRqanhWlWIqPMoD+AzDCdwAzBsAbhqpZ4cs=";
   };
 
   build-system = [
     pyyaml
     setuptools
-    setuptools-scm
   ];
 
   dependencies = [


### PR DESCRIPTION
Diff: https://github.com/ua-parser/uap-python/compare/1.0.1...1.0.2

Changelog: https://github.com/ua-parser/uap-python/releases/tag/1.0.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
