### PR TITLE
context7-mcp: 2.1.6 -> 2.1.7

### DIFF
--- a/pkgs/by-name/co/context7-mcp/package.nix
+++ b/pkgs/by-name/co/context7-mcp/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   nix-update-script,
+  versionCheckHook,
 
   nodejs,
   pnpm,
@@ -62,25 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
-  installCheckPhase = ''
-    runHook preInstallCheck
-
-    echo "Executing custom version check for MCP stdio server..."
-
-    output=$(< /dev/null $out/bin/context7-mcp 2>&1 || true)
-
-    if echo "$output" | grep -Fq "v${finalAttrs.version}"; then
-      echo "versionCheckPhase: found version v${finalAttrs.version}"
-    else
-      echo "versionCheckPhase: failed to find version v${finalAttrs.version}"
-      echo "Output was:"
-      echo "$output"
-      exit 1
-    fi
-
-    runHook postInstallCheck
-  '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version-regex '${tag-prefix}@(.*)'" ];

--- a/pkgs/by-name/co/context7-mcp/package.nix
+++ b/pkgs/by-name/co/context7-mcp/package.nix
@@ -67,7 +67,10 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex '${tag-prefix}@(.*)'" ];
+    extraArgs = [
+      "--version-regex"
+      "${tag-prefix}@(.*)"
+    ];
   };
 
   meta = {

--- a/pkgs/by-name/co/context7-mcp/package.nix
+++ b/pkgs/by-name/co/context7-mcp/package.nix
@@ -15,13 +15,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "context7-mcp";
-  version = "2.1.4";
+  version = "2.1.7";
 
   src = fetchFromGitHub {
     owner = "upstash";
     repo = "context7";
     tag = "${tag-prefix}@${finalAttrs.version}";
-    hash = "sha256-bQXmKY4I5k5uaQ2FVEOPkym5X3mR87nALf3+jqJjJjE=";
+    hash = "sha256-u0sFNX19ZBWvA7HYWdM4iI9AvEVz/CK6dLfZ80Rxa9c=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
-    hash = "sha256-EjEdbPKXJbxaDBuAg/j+BSjI/W3HdsqbtDky0TPUB88=";
+    hash = "sha256-8RRHfCTZVC91T1Qx+ACCo2oG4ZwMNy5WYakCjmBhe3Q=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
context7-mcp now provides a --version flag which enables the usage of the `versoinCheckHook`. I upadted the version and replace the old `installCheckPhase` with the hook.
I also replaced the `linux ++ darwin` entry with `unix` and split the `extraArgs` entry for the `nix-update-script` (would result in not updating the package, similar to ctx7).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
