### PR TITLE
python3Packages.pydantic{,-core}: 2.12.5 -> 2.13.0b3, repo move

### DIFF
--- a/pkgs/development/python-modules/pydantic-core/default.nix
+++ b/pkgs/development/python-modules/pydantic-core/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   cargo,
   rustPlatform,
   rustc,
@@ -21,19 +21,18 @@
 let
   pydantic-core = buildPythonPackage rec {
     pname = "pydantic-core";
-    version = "2.41.5";
+    version = "2.45.0";
     pyproject = true;
 
-    src = fetchFromGitHub {
-      owner = "pydantic";
-      repo = "pydantic-core";
-      tag = "v${version}";
-      hash = "sha256-oIYHLSep8tWOXEaUybXG8Gv9WBoPGQ1Aj7QyqYksvMw=";
+    src = fetchPypi {
+      pname = "pydantic_core";
+      inherit version;
+      hash = "sha256-o/9lkhfcs9E0Qu00jhLhLtbIdnkRVKV13vH+qbtmfY4=";
     };
 
     cargoDeps = rustPlatform.fetchCargoVendor {
       inherit pname version src;
-      hash = "sha256-Kvc0a34C6oGc9oS/iaPaazoVUWn5ABUgrmPa/YocV+Y=";
+      hash = "sha256-OD2nw4tf5Xt75tfp5faaWz5BjEVsFSyLSqSeEXIZWl4=";
     };
 
     nativeBuildInputs = [
@@ -64,7 +63,6 @@ let
     ];
 
     meta = {
-      changelog = "https://github.com/pydantic/pydantic-core/releases/tag/${src.tag}";
       description = "Core validation logic for pydantic written in rust";
       homepage = "https://github.com/pydantic/pydantic-core";
       license = lib.licenses.mit;

--- a/pkgs/development/python-modules/pydantic/default.nix
+++ b/pkgs/development/python-modules/pydantic/default.nix
@@ -19,7 +19,9 @@
   cloudpickle,
   email-validator,
   dirty-equals,
+  hypothesis,
   jsonschema,
+  pytest-timeout,
   pytestCheckHook,
   pytest-mock,
   pytest-run-parallel,
@@ -27,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "pydantic";
-  version = "2.12.5";
+  version = "2.13.0b3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic";
     tag = "v${version}";
-    hash = "sha256-9TRLtVNBw2WHQnS0XFHg16Q7FdpTf3e2nb5qE5rlLUA=";
+    hash = "sha256-zxooO1fMqtD8Vy59odEcKBHaD6b7sSL4vScn0Z2+/Rs=";
   };
 
   patches = lib.optionals (lib.versionAtLeast python.version "3.14.1") [
@@ -68,15 +70,19 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     cloudpickle
     dirty-equals
+    hypothesis
     jsonschema
     pytest-mock
     pytest-run-parallel
+    pytest-timeout
     pytestCheckHook
   ]
   ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     "tests/benchmarks"
+    "tests/pydantic_core/benchmarks"
+    "tests/pydantic_core/validators/test_allow_partial.py"
 
     # avoid cyclic dependency
     "tests/test_docs.py"


### PR DESCRIPTION
Update `pydantic-core`, fetch from PyPI instead of GitHub since upstream has archived the `pydantic/pydantic-core` repo and merged the code into `pydantic/pydantic`. So far the Pydantic repo has no tags that point to pydantic-core releases.

If they start tagging GitHub commits or making releases in the main repo for pydantic-core updates, we can switch back to fetching from GitHub.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
