### PR TITLE
rgx: 0.9.0 -> 0.10.1, enable PCRE2 engine

### DIFF
--- a/pkgs/by-name/rg/rgx/package.nix
+++ b/pkgs/by-name/rg/rgx/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  pcre2,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -16,6 +17,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-hTR4eZKUOxvib5lAV/l76GZQPQ6s+Hgl3DT2kaGlaGg=";
+
+  buildInputs = [ pcre2 ];
+
+  buildFeatures = [ "pcre2-engine" ];
 
   meta = {
     homepage = "https://github.com/brevity1swos/rgx";

--- a/pkgs/by-name/rg/rgx/package.nix
+++ b/pkgs/by-name/rg/rgx/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rgx";
-  version = "0.9.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "brevity1swos";
     repo = "rgx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-04bnNHpIRMyqvRmXDjzGpeEHgwVDSoBtyunlt03nB5Q=";
+    hash = "sha256-H566bgnf4bNPXS7rPtOFTlqmkwoXKbB1fBmFDZQUjac=";
   };
 
-  cargoHash = "sha256-v7dO2TSCKb+E/jLYPw8Q499qFXmSnbv3/WoS+dZhyBM=";
+  cargoHash = "sha256-hTR4eZKUOxvib5lAV/l76GZQPQ6s+Hgl3DT2kaGlaGg=";
 
   meta = {
     homepage = "https://github.com/brevity1swos/rgx";


### PR DESCRIPTION
Update rgx to v0.10.0 and enable the PCRE2 engine.
[Changelog v0.10.0](https://github.com/brevity1swos/rgx/releases/tag/v0.10.0)
[Changelog v0.10.1](https://github.com/brevity1swos/rgx/releases/tag/v0.10.1)
Diff: [https://github.com/brevity1swos/rgx/compare/v0.9.0...v0.10.1](https://github.com/brevity1swos/rgx/compare/v0.9.0...v0.10.1)

The problem I have is that rgx tells me it uses v10.45 (instead of v10.46) even though v10.46 is in nixpkgs.

> Security note: PCRE2 10.45 is affected by [CVE-2025-58050](https://nvd.nist.gov/vuln/detail/CVE-2025-58050) — a heap-buffer-overflow reachable via patterns that use scan-substring (*scs:) verbs combined with backreferences. If you build rgx with pcre2-engine and link it against PCRE2 10.45, rgx will display a warning in the status bar. Upgrade your system's PCRE2 package to >= 10.46 to resolve.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
