### PR TITLE
libtinfo5: init at 5.9; libtinfo6: init at 6.6

### DIFF
--- a/pkgs/by-name/li/libtinfo5/package.nix
+++ b/pkgs/by-name/li/libtinfo5/package.nix
@@ -1,0 +1,8 @@
+{
+  ncurses5,
+}:
+
+ncurses5.override {
+  unicodeSupport = false;
+  withTermlib = true;
+}

--- a/pkgs/by-name/li/libtinfo6/package.nix
+++ b/pkgs/by-name/li/libtinfo6/package.nix
@@ -1,0 +1,8 @@
+{
+  ncurses6,
+}:
+
+ncurses6.override {
+  unicodeSupport = false;
+  withTermlib = true;
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Creating two packages explicitly naming versions of `libtinfo`. These are further workarounds for #89769, based on the initial workaround in #285347 -- basically just slightly modified rebuilds of `ncurses5` and `ncurses6`. This allows a workaround for the specific variant of #89769 where a program inside of an FHS environment explicitly requires `libtinfo.so.5`. I also included `libtinfo6` for symmetry with ncurses6 and future legacy compatibility.

I don't really like that the numbering is hardcoded, but I don't understand how nixpkgs automatically creates the packages `ncurses5` and `ncurses6`. If anyone wants to lend me a hand with that, it would be nice to have the versions automatically track ncurses versions for future-proofing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
