### PR TITLE
whatsie: 5.0.0 -> 6.1.0

### DIFF
--- a/pkgs/by-name/wh/whatsie/package.nix
+++ b/pkgs/by-name/wh/whatsie/package.nix
@@ -10,13 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "whatsie";
-  version = "5.0.0";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "keshavbhatt";
     repo = "whatsie";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GVXwZZFfPqAmBrP95zleHc2PpMMBj/8xZdW4JpFdYVs=";
+    fetchSubmodules = true;
+    hash = "sha256-tSBbEwc5+tALBmqB8E9kW25hdS8pXtjIgee8+SDMrSY=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/wh/whatsie/package.nix
+++ b/pkgs/by-name/wh/whatsie/package.nix
@@ -3,36 +3,68 @@
   lib,
   stdenv,
   cmake,
-  libx11,
-  libxcb,
   qt6,
+  linkFarm,
+  hunspellDictsChromium,
+  dictionaries ? [
+    hunspellDictsChromium.en-us
+  ],
 }:
 
+let
+  qtwebengineDictionaries = linkFarm "whatsie-qtwebengine-dictionaries" (
+    map (d: {
+      name = d.dictFileName;
+      path = d;
+    }) dictionaries
+  );
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "whatsie";
-  version = "5.0.0";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "keshavbhatt";
     repo = "whatsie";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GVXwZZFfPqAmBrP95zleHc2PpMMBj/8xZdW4JpFdYVs=";
+    hash = "sha256-aOhMov7P3zFeWfnDXzBL0pIQu+G2D4tPhBIlY9cuYKQ=";
   };
 
   buildInputs = [
-    libx11
-    libxcb
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
     qt6.qtwebengine
   ];
 
   nativeBuildInputs = [
     cmake
+    qt6.qttools
     qt6.wrapQtAppsHook
   ];
 
   strictDeps = true;
 
   enableParallelBuilding = true;
+
+  doCheck = true;
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    ctest --output-on-failure --exclude-regex '^tst_(permissions|freedesktop_notifier)$'
+
+    runHook postCheck
+  '';
+
+  postInstall = lib.optionalString (dictionaries != [ ]) ''
+    install -Dm444 -t $out/share/whatsie/qtwebengine_dictionaries \
+      ${qtwebengineDictionaries}/*.bdic
+  '';
 
   meta = {
     homepage = "https://github.com/keshavbhatt/whatsie";


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
