### PR TITLE
guestfs-tools: 1.52.3 -> 1.54.0, add nix+9p based variant

### DIFF
--- a/pkgs/by-name/gu/guestfs-tools-nix/package.nix
+++ b/pkgs/by-name/gu/guestfs-tools-nix/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  guestfs-tools,
+  libguestfs-with-appliance-nix,
+  passt,
+  qemu_kvm,
+}:
+
+# guestfs-tools built against the Nix-built 9p-backed appliance.
+# LIBGUESTFS_NIX_9P=/nix/store is set so the libguestfs launch-direct
+# patch adds the -virtfs share to QEMU.
+# passt is added to PATH so libguestfs uses it as the user-mode network
+# backend instead of falling back to -netdev user (QEMU slirp).
+(guestfs-tools.override {
+  libguestfs-with-appliance = libguestfs-with-appliance-nix;
+  qemu = qemu_kvm;
+}).overrideAttrs
+  (prevAttrs: {
+    extraWrapArgs = prevAttrs.extraWrapArgs ++ [
+      "--set"
+      "LIBGUESTFS_NIX_9P"
+      "/nix/store"
+      "--prefix"
+      "PATH"
+      ":"
+      "${passt}/bin"
+    ];
+
+    meta = prevAttrs.meta // {
+      maintainers = with lib.maintainers; [ illustris ];
+      hydraPlatforms = [ "x86_64-linux" ];
+    };
+  })

--- a/pkgs/by-name/gu/guestfs-tools/fix-app2-spare1.patch
+++ b/pkgs/by-name/gu/guestfs-tools/fix-app2-spare1.patch
@@ -1,0 +1,11 @@
+--- a/common/structs/structs-print.c
++++ b/common/structs/structs-print.c
+@@ -63,7 +63,7 @@
+   fprintf (dest, "%sapp2_source_package: %s%s", indent, application2->app2_source_package, linesep);
+   fprintf (dest, "%sapp2_summary: %s%s", indent, application2->app2_summary, linesep);
+   fprintf (dest, "%sapp2_description: %s%s", indent, application2->app2_description, linesep);
+-  fprintf (dest, "%sapp2_spare1: %s%s", indent, application2->app2_spare1, linesep);
++  fprintf (dest, "%sapp2_class: %s%s", indent, application2->app2_class, linesep);
+   fprintf (dest, "%sapp2_spare2: %s%s", indent, application2->app2_spare2, linesep);
+   fprintf (dest, "%sapp2_spare3: %s%s", indent, application2->app2_spare3, linesep);
+   fprintf (dest, "%sapp2_spare4: %s%s", indent, application2->app2_spare4, linesep);

--- a/pkgs/by-name/gu/guestfs-tools/package.nix
+++ b/pkgs/by-name/gu/guestfs-tools/package.nix
@@ -13,6 +13,7 @@
   gnupg,
   hivex,
   jansson,
+  json_c,
   libguestfs-with-appliance,
   libosinfo,
   libvirt,
@@ -31,11 +32,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "guestfs-tools";
-  version = "1.52.3";
+  version = "1.54.0";
 
   src = fetchurl {
     url = "https://download.libguestfs.org/guestfs-tools/${lib.versions.majorMinor finalAttrs.version}-stable/guestfs-tools-${finalAttrs.version}.tar.gz";
-    hash = "sha256-0xLCwj6TXU5b+tUewhKE9X0E+FN0MpX6+V+WHFxmiEc=";
+    hash = "sha256-m27742X3r+RGSe2YO7RWSYW1I/iLQau4wrDeFZiGj6I=";
   };
 
   nativeBuildInputs = [
@@ -66,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     hivex
     jansson
+    json_c
     libguestfs-with-appliance
     libosinfo
     libvirt
@@ -74,6 +76,12 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     pcre2
     xz
+  ];
+
+  patches = [
+    # Fix build against libguestfs >= 1.58 where app2_spare1 was
+    # renamed to app2_class. https://github.com/libguestfs/guestfs-tools/issues/28
+    ./fix-app2-spare1.patch
   ];
 
   postPatch = ''
@@ -98,6 +106,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  # Extra arguments appended to every wrapProgram call. Overridable by
+  # downstream packages (e.g. guestfs-tools-nix) to inject additional
+  # PATH entries or environment variables without double-wrapping.
+  extraWrapArgs = [ ];
+
   postInstall = ''
     wrapProgram $out/bin/virt-builder \
       --argv0 virt-builder \
@@ -105,10 +118,13 @@ stdenv.mkDerivation (finalAttrs: {
         lib.makeBinPath [
           curl
           gnupg
+          qemu
         ]
       }:$out/bin \
-      --suffix VIRT_BUILDER_DIRS : /etc:$out/etc
+      --suffix VIRT_BUILDER_DIRS : /etc:$out/etc \
+      ${lib.escapeShellArgs finalAttrs.extraWrapArgs}
     wrapProgram $out/bin/virt-win-reg \
+      --prefix PATH : ${qemu}/bin \
       --prefix PERL5LIB : ${
         with perlPackages;
         makeFullPerlPath [
@@ -116,7 +132,17 @@ stdenv.mkDerivation (finalAttrs: {
           libintl-perl
           libguestfs-with-appliance
         ]
-      }
+      } \
+      ${lib.escapeShellArgs finalAttrs.extraWrapArgs}
+
+    # Wrap remaining binaries so libguestfs can find qemu-img at runtime
+    for f in $out/bin/virt-*; do
+      case "$(basename "$f")" in
+        virt-builder|virt-win-reg) continue ;;
+      esac
+      wrapProgram "$f" --prefix PATH : ${qemu}/bin \
+        ${lib.escapeShellArgs finalAttrs.extraWrapArgs}
+    done
   '';
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/by-name/li/libguestfs-appliance-nix/nix-9p-init.patch
+++ b/pkgs/by-name/li/libguestfs-appliance-nix/nix-9p-init.patch
@@ -1,0 +1,21 @@
+--- a/init/init.c	2026-04-01 12:01:30.865154175 +0000
++++ b/init/init.c	2026-04-01 12:01:38.836976937 +0000
+@@ -285,6 +285,18 @@
+   if (!quiet)
+     fprintf (stderr, "supermin: chroot\n");
+
++  /* Mount 9p nix-store share if available (used by Nix-built appliances).
++   * This must happen before chroot so that symlinks into /nix/store resolve.
++   * Silently ignored when no 9p share is configured.
++   */
++  mkdir ("/root/nix", 0755);
++  mkdir ("/root/nix/store", 0755);
++  if (mount ("nix-store", "/root/nix/store", "9p", MS_RDONLY,
++             "trans=virtio,version=9p2000.L,msize=262144") == 0) {
++    if (!quiet)
++      fprintf (stderr, "supermin: mounted 9p nix-store\n");
++  }
++
+   if (chroot ("/root") == -1) {
+     perror ("chroot: /root");
+     exit (EXIT_FAILURE);

--- a/pkgs/by-name/li/libguestfs-appliance-nix/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance-nix/package.nix
@@ -1,0 +1,344 @@
+{
+  lib,
+  stdenv,
+  runCommand,
+  symlinkJoin,
+
+  # Build tools
+  e2fsprogs,
+  cpio,
+  fakeroot,
+  libfaketime,
+
+  # Kernel
+  linuxPackages,
+
+  # Supermin (for static init binary)
+  supermin,
+
+  # libguestfs (for guestfsd binary and init script source)
+  libguestfs,
+
+  # Appliance root filesystem packages
+  augeas,
+  bash,
+  btrfs-progs,
+  bzip2,
+  coreutils,
+  cryptsetup,
+  dhcpcd,
+  diffutils,
+  dosfstools,
+  eudev,
+  file,
+  findutils,
+  gawk,
+  gnugrep,
+  gnused,
+  gnutar,
+  gptfdisk,
+  gzip,
+  hivex,
+  iproute2,
+  kmod,
+  less,
+  libxml2,
+  lsof,
+  lvm2,
+  mdadm,
+  ntfs3g,
+  parted,
+  pciutils,
+  procps,
+  psmisc,
+  rsync,
+  strace,
+  util-linux,
+  xfsprogs,
+  xz,
+  zstd,
+}:
+
+let
+  kernel = linuxPackages.kernel;
+  guestfsd = libguestfs.guestfsd;
+
+  appliancePackages = [
+    augeas
+    bash
+    btrfs-progs
+    bzip2
+    coreutils
+    cryptsetup
+    dhcpcd
+    diffutils
+    dosfstools
+    e2fsprogs
+    eudev
+    file
+    findutils
+    gawk
+    gnugrep
+    gnused
+    gnutar
+    gptfdisk
+    gzip
+    hivex
+    iproute2
+    kmod
+    less
+    libxml2
+    lsof
+    lvm2
+    lvm2.bin
+    mdadm
+    ntfs3g
+    parted
+    pciutils
+    procps
+    psmisc
+    rsync
+    strace
+    util-linux
+    xfsprogs
+    xz
+    zstd
+  ];
+
+  # Merge all appliance packages for FHS symlinks.
+  # The symlinks point into /nix/store; at runtime the VM accesses
+  # them via a 9p mount of the host's store.
+  mergedEnv = symlinkJoin {
+    name = "libguestfs-appliance-nix-env";
+    paths = appliancePackages ++ [ guestfsd ];
+  };
+
+  # Kernel modules needed to boot the appliance VM, in dependency order.
+  # Includes virtio, SCSI, filesystem, device-mapper, and 9p modules.
+  requiredModules = [
+    # virtio transport
+    "virtio_pci_legacy_dev"
+    "virtio_pci_modern_dev"
+    "virtio_ring"
+    "virtio"
+    "virtio_pci"
+    # block devices
+    "virtio_blk"
+    "scsi_common"
+    "scsi_mod"
+    "virtio_scsi"
+    "sd_mod"
+    # communication & network
+    "virtio_console"
+    "failover"
+    "net_failover"
+    "virtio_net"
+    # AF_PACKET (raw sockets) -- needed by dhcpcd for DHCP; CONFIG_PACKET=m
+    "af_packet"
+    # filesystems
+    "mbcache"
+    "ext2"
+    "crc16"
+    "jbd2"
+    "ext4"
+    # FAT/vFAT (for EFI and Windows partitions)
+    # nls_iso8859-1 is the default FAT iocharset; must be present or mount fails
+    "nls_iso8859-1"
+    "nls_utf8"
+    "nls_cp437"
+    "nls_ascii"
+    "fat"
+    "vfat"
+    # device mapper
+    "dax"
+    "dm-mod"
+    # 9p (for mounting host /nix/store)
+    "netfs"
+    "9pnet"
+    "9pnet_virtio"
+    "9p"
+  ];
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libguestfs-appliance-nix";
+  version = libguestfs.version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp ${kernel}/bzImage $out/kernel
+    cp ${finalAttrs.initrd} $out/initrd
+    cp ${finalAttrs.rootImage} $out/root
+    echo "Fixed appliance built from NixOS packages (9p-backed)" > $out/README.fixed
+  '';
+
+  # Supermin with 9p nix-store mount support patched into its init binary.
+  # The base supermin package is unmodified; this override only affects
+  # the appliance built here.
+  superminWithNix9p = supermin.overrideAttrs (prev: {
+    outputs = [
+      "out"
+      "init"
+    ];
+
+    patches = (prev.patches or [ ]) ++ [
+      # Mount a 9p "nix-store" share (if present) before chroot in the
+      # ext2 init.  This lets Nix-built appliances access /nix/store via
+      # virtio-9p instead of baking the full closure into the root image.
+      ./nix-9p-init.patch
+    ];
+
+    postBuild = (prev.postBuild or "") + ''
+      # Build the static init binary used in supermin ext2 initrds.
+      cat > init/config.h <<CONF
+      #define PACKAGE_VERSION "${prev.version}"
+      #define MAJOR_IN_SYSMACROS 1
+      CONF
+      $CC -static -O2 -Iinit -o init/init init/init.c
+    '';
+
+    postInstall = (prev.postInstall or "") + ''
+      install -Dm755 init/init $init/bin/init
+    '';
+  });
+
+  # Initrd: supermin init binary + decompressed kernel modules.
+  initrd =
+    runCommand "libguestfs-appliance-nix-initrd"
+      {
+        nativeBuildInputs = [
+          cpio
+          xz
+          zstd
+        ];
+      }
+      ''
+        mkdir -p initrd/{proc,sys,dev,root}
+        cp ${finalAttrs.superminWithNix9p.init}/bin/init initrd/init
+
+        kmodBase="${kernel.modules}/lib/modules/${kernel.modDirVersion}"
+
+        : > initrd/modules
+        for modName in ${lib.concatStringsSep " " requiredModules}; do
+          modFile=$(find "$kmodBase/kernel" \
+            -name "$modName.ko.xz" -o \
+            -name "$modName.ko.zst" -o \
+            -name "$modName.ko" \
+            2>/dev/null | head -1)
+          if [ -n "$modFile" ]; then
+            case "$modFile" in
+              *.xz) xz -dc "$modFile" > "initrd/$modName.ko" ;;
+              *.zst) zstd -dc "$modFile" > "initrd/$modName.ko" ;;
+              *) cp "$modFile" "initrd/$modName.ko" ;;
+            esac
+            echo "/$modName.ko" >> initrd/modules
+          fi
+        done
+
+        (cd initrd && find . -print0 | sort -z | cpio --null -o -H newc --reproducible) \
+          | gzip -9n > $out
+      '';
+
+  # Root ext2 image: just FHS skeleton + symlinks into /nix/store.
+  # The actual store paths are mounted at runtime via 9p, so this
+  # image is tiny (~1 MiB) and does not contain the Nix closure.
+  rootImage = stdenv.mkDerivation {
+    name = "libguestfs-appliance-nix-root";
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [
+      e2fsprogs.bin
+      fakeroot
+      libfaketime
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      mkdir -p rootfs/{etc/udev/rules.d,proc,sys,dev,tmp,var/tmp,var/lib,var/run,run,sysroot,nix/store,usr}
+      chmod 1777 rootfs/tmp rootfs/var/tmp
+
+      # FHS symlinks to the merged environment (resolved via 9p at runtime)
+      ln -s ${mergedEnv}/bin rootfs/bin
+      if [ -d ${mergedEnv}/sbin ]; then
+        ln -s ${mergedEnv}/sbin rootfs/sbin
+      else
+        ln -s ${mergedEnv}/bin rootfs/sbin
+      fi
+      mkdir -p rootfs/usr
+      ln -s ${mergedEnv}/bin rootfs/usr/bin
+      if [ -d ${mergedEnv}/sbin ]; then
+        ln -s ${mergedEnv}/sbin rootfs/usr/sbin
+      else
+        ln -s ${mergedEnv}/bin rootfs/usr/sbin
+      fi
+
+      for d in lib lib64 libexec share; do
+        if [ -d ${mergedEnv}/$d ]; then
+          ln -s ${mergedEnv}/$d rootfs/$d
+          ln -s ${mergedEnv}/$d rootfs/usr/$d
+        fi
+      done
+
+      install -m755 ${libguestfs.init}/bin/init rootfs/init
+      install -m644 ${libguestfs.udev}/etc/udev/rules.d/99-guestfs-serial.rules rootfs/etc/udev/rules.d/
+      ln -sf /proc/mounts rootfs/etc/mtab
+
+      # eudev stores its rules under $out/var/lib/udev/rules.d, not
+      # $out/lib/udev/rules.d, so udevd would not find them.  Symlink
+      # them into /etc/udev/rules.d (which udevd does scan) so that the
+      # persistent-storage, block, and other built-in rule sets are active.
+      for f in ${mergedEnv}/var/lib/udev/rules.d/*.rules; do
+        ln -s "$f" "rootfs/etc/udev/rules.d/$(basename "$f")"
+      done
+
+      # Image is tiny: just the skeleton, no Nix store closure
+      echo "Creating ext2 image..."
+      numInodes=$(find ./rootfs | wc -l)
+      numDataBlocks=$(du -s -c -B 4096 --apparent-size ./rootfs | tail -1 | awk '{ print int($1 * 1.20) }')
+      bytes=$((2 * 4096 * numInodes + 4096 * numDataBlocks))
+
+      mebibyte=$(( 1024 * 1024 ))
+      if (( bytes % mebibyte )); then
+        bytes=$(( (bytes / mebibyte + 1) * mebibyte ))
+      fi
+
+      truncate -s $bytes root.img
+      faketime -f "1970-01-01 00:00:01" fakeroot mkfs.ext2 -L appliance -d ./rootfs root.img
+
+      export EXT2FS_NO_MTAB_OK=yes
+      resize2fs -M root.img
+      new_size=$(dumpe2fs -h root.img 2>/dev/null | awk -F: \
+        '/Block count/{count=$2} /Block size/{size=$2} END{print (count*size+1*2^20)/size}')
+      resize2fs root.img $new_size
+
+      echo "Root image size: $(($(stat -c%s root.img) / 1024)) KiB"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      cp root.img $out
+    '';
+  };
+
+  passthru = {
+    inherit (finalAttrs) superminWithNix9p initrd rootImage;
+  };
+
+  meta = {
+    description = "Nix-built VM appliance for libguestfs (9p-backed, small output)";
+    homepage = "https://libguestfs.org";
+    license = with lib.licenses; [
+      gpl2Plus
+      lgpl2Plus
+    ];
+    maintainers = with lib.maintainers; [ illustris ];
+    platforms = [ "x86_64-linux" ];
+    # Explicitly set so libguestfs can read appliance.meta.hydraPlatforms
+    hydraPlatforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/li/libguestfs-with-appliance-nix/nix-9p-virtfs.patch
+++ b/pkgs/by-name/li/libguestfs-with-appliance-nix/nix-9p-virtfs.patch
@@ -1,0 +1,26 @@
+--- a/lib/launch-direct.c
++++ b/lib/launch-direct.c
+@@ -735,4 +735,21 @@
+   }
+
+   /* Create the virtio serial bus. */
++
++  /* Share host paths into the appliance via 9p if requested.
++   * Used by the Nix-built appliance to access /nix/store at runtime
++   * instead of baking the full store closure into the root image.
++   */
++  {
++    const char *virtfs_path = getenv ("LIBGUESTFS_NIX_9P");
++    if (virtfs_path && virtfs_path[0]) {
++      start_list ("-virtfs") {
++        append_list ("local");
++        append_list_format ("path=%s", virtfs_path);
++        append_list ("security_model=none");
++        append_list ("mount_tag=nix-store");
++        append_list ("readonly=on");
++      } end_list ();
++    }
++  }
+   arg ("-device", VIRTIO_DEVICE_NAME ("virtio-serial"));
+
+   /* Create the serial console. */

--- a/pkgs/by-name/li/libguestfs-with-appliance-nix/package.nix
+++ b/pkgs/by-name/li/libguestfs-with-appliance-nix/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  libguestfs,
+  libguestfs-appliance-nix,
+  qemu_kvm,
+}:
+
+# Like libguestfs-with-appliance, but uses the Nix-built 9p-backed appliance.
+# Patches libguestfs to share /nix/store into the VM via virtio-9p, and
+# wraps all binaries to set LIBGUESTFS_NIX_9P=/nix/store.
+# Uses qemu_kvm instead of full qemu since the appliance is host-arch only.
+(libguestfs.override {
+  appliance = libguestfs-appliance-nix;
+  qemu = qemu_kvm;
+}).overrideAttrs
+  (prevAttrs: {
+    patches = (prevAttrs.patches or [ ]) ++ [
+      # Adds support for LIBGUESTFS_NIX_9P env var to share a host path
+      # into the appliance VM via virtio-9p.
+      ./nix-9p-virtfs.patch
+    ];
+
+    extraWrapArgs = prevAttrs.extraWrapArgs ++ [
+      "--set"
+      "LIBGUESTFS_NIX_9P"
+      "/nix/store"
+    ];
+
+    meta = prevAttrs.meta // {
+      maintainers = with lib.maintainers; [ illustris ];
+    };
+  })

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -29,6 +29,7 @@
   readline,
   numactl,
   libapparmor,
+  libselinux,
   json_c,
   getopt,
   perlPackages,
@@ -45,11 +46,11 @@ assert appliance == null || lib.isDerivation appliance;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libguestfs";
-  version = "1.56.2";
+  version = "1.58.1";
 
   src = fetchurl {
     url = "https://libguestfs.org/download/${lib.versions.majorMinor finalAttrs.version}-stable/libguestfs-${finalAttrs.version}.tar.gz";
-    hash = "sha256-u0SJGnleC3khPO4sSRSVpt1ksh9ydEVZFzDX94kBaJo=";
+    hash = "sha256-G45bTvQ+hjAsPO3Lb7wBS+W8pehcoode8Xw89nxnEYA=";
   };
 
   strictDeps = true;
@@ -98,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     db
     numactl
     libapparmor
+    libselinux
     perlPackages.ModuleBuild
     python3
     libtirpc
@@ -136,9 +138,16 @@ stdenv.mkDerivation (finalAttrs: {
   installFlags = [ "REALLY_INSTALL=yes" ];
   enableParallelBuilding = true;
 
+  # Extra arguments appended to every wrapProgram call. Overridable by
+  # downstream packages (e.g. libguestfs-with-appliance-nix) to inject
+  # additional PATH entries or environment variables without double-wrapping.
+  extraWrapArgs = [ ];
+
   outputs = [
     "out"
     "guestfsd"
+    "init"
+    "udev"
   ];
 
   postInstall = ''
@@ -151,8 +160,12 @@ stdenv.mkDerivation (finalAttrs: {
     for bin in $out/bin/*; do
       wrapProgram "$bin" \
         --prefix PATH     : "$out/bin:${hivex}/bin:${qemu}/bin" \
-        --prefix PERL5LIB : "$out/${perlPackages.perl.libPrefix}"
+        --prefix PERL5LIB : "$out/${perlPackages.perl.libPrefix}" \
+        ${lib.escapeShellArgs finalAttrs.extraWrapArgs}
     done
+
+    install -Dm755 appliance/init $init/bin/init
+    install -Dm644 appliance/99-guestfs-serial.rules $udev/etc/udev/rules.d/99-guestfs-serial.rules
   '';
 
   postFixup = lib.optionalString (appliance != null) ''


### PR DESCRIPTION
guestfs-tools is currently disabled on Hydra (`hydraPlatforms = []`) because it depends on `libguestfs-with-appliance`, which pulls in a ~4 GiB pre-built appliance image. This PR introduces a lightweight Nix-built appliance that uses virtio-9p to mount the host's `/nix/store` into the VM at runtime, keeping the appliance small. This also avoids filling the Nix store with large rootfs image copies every time any of the appliance's constituent packages change.

### Changes to existing packages

#### libguestfs: 1.56.2 -> 1.58.1
- Add `libselinux` to `buildInputs` (required for >= 1.58; without it the OCaml daemon's C stubs conflict with fallback stubs at link time)
- Add `init` and `udev` outputs exposing the appliance init script and udev rules
- Add `extraWrapArgs` attr for composable wrapper customization by downstream overrides without double-wrapping

#### guestfs-tools: 1.52.3 -> 1.54.0
- Wrap all `virt-*` binaries with `qemu` in PATH (fixes pre-existing bug where `libguestfs` could not find `qemu-img` at runtime when invoked through guestfs-tools binaries)
- Add `json-c` dependency (new in 1.54)
- Patch `app2_spare1 -> app2_class` for libguestfs 1.58 API compatibility ([upstream issue](https://github.com/libguestfs/guestfs-tools/issues/28))
- Add `extraWrapArgs` attr matching libguestfs

### New packages

- libguestfs-appliance-nix: A Nix-built VM appliance for libguestfs. Instead of baking a full root filesystem, it creates a minimal ext2 image (~1 MB) containing only FHS symlinks into `/nix/store`. At runtime, the host's store is mounted into the VM via virtio-9p. Includes a patched supermin init that mounts the 9p share before chroot.
- libguestfs-with-appliance-nix: libguestfs configured with the 9p-backed appliance. Patched to pass a `-virtfs` share to QEMU when `LIBGUESTFS_NIX_9P` is set.
- guestfs-tools-nix: guestfs-tools built against the Nix appliance.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
