### PR TITLE
antlr: respect JAVA_HOME

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -149,6 +149,8 @@
 
 - `iroh` has been removed and split up into `iroh-dns-server` and `iroh-relay`.
 
+- `antlr` now respects `JAVA_HOME`. As it is built with jdk11, it will fail if `JAVA_HOME` points to jdk8. You can unset `JAVA_HOME` (e.g. `env -u JAVA_HOME antlr`) or override `jre` / `installPhase`.
+
 - the `xorg` package set has been deprecated, packages have moved to the top level.
 
 - `python3Packages.pygame` has been been renamed to `python3Packages.pygame-original`, the attribute `python3Packages.pygame` will from python 3.14 default to the more actively maintained `python3Packages.pygame-ce`

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -219,6 +219,7 @@ in
   angie-api = runTest ./angie-api.nix;
   angrr = runTest ./angrr.nix;
   anki-sync-server = runTest ./anki-sync-server.nix;
+  antlr = runTest ./antlr.nix;
   anubis = runTest ./anubis.nix;
   anuko-time-tracker = runTest ./anuko-time-tracker.nix;
   apcupsd = runTest ./apcupsd.nix;

--- a/nixos/tests/antlr.nix
+++ b/nixos/tests/antlr.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+{
+  name = "antlr";
+
+  containers.container =
+    { pkgs, ... }:
+    {
+      programs.java = {
+        enable = true;
+        package = pkgs.jdk11_headless;
+      };
+      environment.systemPackages = [ pkgs.antlr ];
+    };
+
+  testScript = ''
+    container.succeed('if [ -z "$JAVA_HOME" ]; then exit 1; fi')
+    container.succeed("antlr")
+  '';
+}

--- a/pkgs/development/tools/parsing/antlr/3.4.nix
+++ b/pkgs/development/tools/parsing/antlr/3.4.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
     cp "$src" "$out/lib/antlr/antlr-${version}-complete.jar"
 
     echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
-    echo "'${jre}/bin/java' -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
+    echo "if [ -n \"\$JAVA_HOME\" ]; then JAVA_BIN=\"\$JAVA_HOME/bin/java\"; else JAVA_BIN=\"${jre}/bin/java\"; fi" >> "$out/bin/antlr"
+    echo "\"\$JAVA_BIN\" -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
 
     chmod a+x "$out/bin/antlr"
     ln -s "$out/bin/antlr"{,3}

--- a/pkgs/development/tools/parsing/antlr/3.5.nix
+++ b/pkgs/development/tools/parsing/antlr/3.5.nix
@@ -34,7 +34,8 @@ stdenv.mkDerivation rec {
     cp runtime/Cpp/include/* $out/include/
 
     echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
-    echo "'${jre}/bin/java' -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
+    echo "if [ -n \"\$JAVA_HOME\" ]; then JAVA_BIN=\"\$JAVA_HOME/bin/java\"; else JAVA_BIN=\"${jre}/bin/java\"; fi" >> "$out/bin/antlr"
+    echo "\"\$JAVA_BIN\" -cp '$out/lib/antlr/antlr-${version}-complete.jar' -Xms200M -Xmx400M org.antlr.Tool \"\$@\"" >> "$out/bin/antlr"
 
     chmod a+x "$out/bin/antlr"
     ln -s "$out/bin/antlr"{,3}

--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -50,13 +50,16 @@ let
           ln -s "$src" "$out/share/java/antlr-${version}-complete.jar"
 
           echo "#! ${stdenv.shell}" >> "$out/bin/antlr"
-          echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.Tool \"\$@\"" >> "$out/bin/antlr"
+          echo "if [ -n \"\$JAVA_HOME\" ]; then JAVA_BIN=\"\$JAVA_HOME/bin/java\"; else JAVA_BIN=\"${jre}/bin/java\"; fi" >> "$out/bin/antlr"
+          echo "\"\$JAVA_BIN\" -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.Tool \"\$@\"" >> "$out/bin/antlr"
 
           echo "#! ${stdenv.shell}" >> "$out/bin/antlr-parse"
-          echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.gui.Interpreter \"\$@\"" >> "$out/bin/antlr-parse"
+          echo "if [ -n \"\$JAVA_HOME\" ]; then JAVA_BIN=\"\$JAVA_HOME/bin/java\"; else JAVA_BIN=\"${jre}/bin/java\"; fi" >> "$out/bin/antlr-parse"
+          echo "\"\$JAVA_BIN\" -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' -Xmx500M org.antlr.v4.gui.Interpreter \"\$@\"" >> "$out/bin/antlr-parse"
 
           echo "#! ${stdenv.shell}" >> "$out/bin/grun"
-          echo "'${jre}/bin/java' -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' org.antlr.v4.gui.TestRig \"\$@\"" >> "$out/bin/grun"
+          echo "if [ -n \"\$JAVA_HOME\" ]; then JAVA_BIN=\"\$JAVA_HOME/bin/java\"; else JAVA_BIN=\"${jre}/bin/java\"; fi" >> "$out/bin/grun"
+          echo "\"\$JAVA_BIN\" -cp '$out/share/java/antlr-${version}-complete.jar:$CLASSPATH' org.antlr.v4.gui.TestRig \"\$@\"" >> "$out/bin/grun"
 
           chmod a+x "$out/bin/antlr" "$out/bin/antlr-parse" "$out/bin/grun"
           ln -s "$out/bin/antlr"{,4}


### PR DESCRIPTION
The antlr package and its generated scripts (antlr, antlr-parse, grun) currently ignore the $JAVA_HOME environment variable and always use the bundled JRE (version 21 as of 25.11). This can cause failures for users running code compiled with newer Java versions, because the class file version may be incompatible with the bundled JRE.

With this change, the scripts first check if $JAVA_HOME is set and use the Java binary from there. If $JAVA_HOME is not defined, they fall back to the original behavior and use the bundled JRE.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
