### PR TITLE
python3Packages.helion: 0.3.2 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/helion/default.nix
+++ b/pkgs/development/python-modules/helion/default.nix
@@ -10,13 +10,12 @@
 
   # dependencies
   filecheck,
+  numpy,
   psutil,
   rich,
   scikit-learn,
-  torch,
-  tqdm,
-  triton,
   typing-extensions,
+  torch,
 
   # tests
   pytestCheckHook,
@@ -26,14 +25,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "helion";
-  version = "0.3.2";
+  version = "1.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "helion";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MR8fo6MhMSAXlBsx//ODIprXPXFhMy6K5Mno9BnZGHc=";
+    hash = "sha256-3Iam+1FUg9I9kKmkQBZp9/FTZpEjf4Ba+cKRo5eLEzw=";
   };
 
   build-system = [
@@ -43,13 +42,15 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     filecheck
+    numpy
     psutil
     rich
     scikit-learn
-    torch
-    tqdm
-    triton
     typing-extensions
+
+    # torch is not listed as a dependency, but is actually required at import time
+    # https://github.com/pytorch/helion/blob/v1.0.0/helion/_compat.py#L13
+    torch
   ];
 
   pythonImportsCheck = [ "helion" ];
@@ -67,11 +68,9 @@ buildPythonPackage (finalAttrs: {
 
   # Tests require GPU access
   doCheck = false;
-  passthru.gpuChecks = {
-    pytest = helion.overridePythonAttrs {
-      doCheck = true;
-      requiredSystemFeatures = [ "cuda" ];
-    };
+  passthru.gpuCheck = helion.overridePythonAttrs {
+    doCheck = true;
+    requiredSystemFeatures = [ "cuda" ];
   };
 
   meta = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pytorch/helion/compare/v0.3.2...v1.0.0
Changelog: https://github.com/pytorch/helion/releases/tag/v1.0.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test