### PR TITLE
nixos/bazarr: add settings option

### DIFF
--- a/nixos/modules/services/misc/bazarr.nix
+++ b/nixos/modules/services/misc/bazarr.nix
@@ -6,6 +6,9 @@
 }:
 let
   cfg = config.services.bazarr;
+
+  settingsFormat = pkgs.formats.yaml { };
+  configFile = settingsFormat.generate "bazarr-config.yaml" cfg.settings;
 in
 {
   options = {
@@ -43,6 +46,51 @@ in
         default = "bazarr";
         description = "Group under which bazarr runs.";
       };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+          options = {
+            general.hostname = lib.mkOption {
+              type = lib.types.str;
+              default = config.networking.hostName;
+              defaultText = lib.literalExpression "config.networking.hostName";
+              description = "Hostname for Bazarr.";
+            };
+
+            analytics.enabled = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "Enable Bazarr analytics.";
+            };
+          };
+        };
+        default = { };
+        example = lib.literalExpression ''
+          {
+            general = {
+              instance_name = "NixOS Bazarr";
+            };
+          }
+        '';
+        description = ''
+          Bazarr configuration.
+
+          ::: {.note}
+          On start and if {option}`mutableSettings` is `true`,
+          these options are merged into the configuration file on start, taking
+          precedence over configuration changes made on the web interface.
+          :::
+        '';
+      };
+
+      mutableSettings = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Allow changes made on the Bazarr web interface to persist between service restarts.
+        '';
+      };
     };
   };
 
@@ -56,6 +104,17 @@ in
       description = "Bazarr";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        mkdir -p '${cfg.dataDir}/config'
+        if [ -e '${cfg.dataDir}/config/config.yaml' ] && [ "${toString cfg.mutableSettings}" = "1" ]; then
+          ${lib.getExe pkgs.yaml-merge} '${cfg.dataDir}/config/config.yaml' '${configFile}' > '${cfg.dataDir}/config/config.yaml.tmp'
+          mv '${cfg.dataDir}/config/config.yaml.tmp' '${cfg.dataDir}/config/config.yaml'
+        else
+          cp -f '${configFile}' '${cfg.dataDir}/config/config.yaml'
+        fi
+        chmod 600 '${cfg.dataDir}/config/config.yaml'
+      '';
 
       serviceConfig = {
         Type = "simple";

--- a/nixos/tests/bazarr.nix
+++ b/nixos/tests/bazarr.nix
@@ -12,12 +12,17 @@ in
       services.bazarr = {
         enable = true;
         listenPort = port;
+        settings.general.hostname = "localhost";
       };
+
+      environment.systemPackages = [ pkgs.yq-go ];
     };
 
   testScript = ''
     machine.wait_for_unit("bazarr.service")
     machine.wait_for_open_port(${toString port})
+    machine.succeed("test $(yq '.general.hostname' /var/lib/bazarr/config/config.yaml) = localhost")
+    machine.succeed("test $(yq '.analytics.enabled' /var/lib/bazarr/config/config.yaml) = false")
     machine.succeed("curl --fail http://localhost:${toString port}/")
   '';
 }


### PR DESCRIPTION
The yaml merging logic is taken from https://github.com/NixOS/nixpkgs/blob/6201e203d09599479a3b3450ed24fa81537ebc4e/nixos/modules/services/networking/adguardhome.nix#L179-L194

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
