### PR TITLE
osmocom: update osmocom GSM suite.

### DIFF
--- a/pkgs/by-name/li/libosmo-netif/package.nix
+++ b/pkgs/by-name/li/libosmo-netif/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libosmo-netif";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "libosmo-netif";
     rev = finalAttrs.version;
-    hash = "sha256-0INgJV5fS6VdMsJqjlVc3lGMBdLP7cI+Ghc4WEh6AuU=";
+    hash = "sha256-4VDXqi5tK3zaCDQgsWlN34m/odgE6xWXgNaKpG0SpnU=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/li/libosmo-sigtran/package.nix
+++ b/pkgs/by-name/li/libosmo-sigtran/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libosmo-sigtran";
-  version = "2.1.2";
+  version = "2.2.1";
 
   # fetchFromGitea hangs
   src = fetchgit {
     url = "https://gitea.osmocom.org/osmocom/libosmo-sigtran.git";
     rev = finalAttrs.version;
-    hash = "sha256-/TxD7lc/htm1c24rKfnlYxGsVpxawi3nh7m34mRRhUA=";
+    hash = "sha256-EBBSoSX5tImTLRP7Klhjj/YM8+4RyyJClymIXQK8DgE=";
   };
 
   configureFlags = [ "--with-systemdsystemunitdir=$out" ];

--- a/pkgs/by-name/li/libosmoabis/package.nix
+++ b/pkgs/by-name/li/libosmoabis/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libosmoabis";
-  version = "2.0.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "libosmo-abis";
     rev = finalAttrs.version;
-    hash = "sha256-OdmegQXdbpwNBepY+7MeUjaEguVo2q9b8lSkRmlXHEc=";
+    hash = "sha256-jJD7XvwOBisN6womVSrY+V78KpFZ7WBvvh757dAS8y0=";
   };
 
   configureFlags = [ "enable_dahdi=false" ];

--- a/pkgs/by-name/li/libosmocore/package.nix
+++ b/pkgs/by-name/li/libosmocore/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libosmocore";
-  version = "1.11.3";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "libosmocore";
     rev = finalAttrs.version;
-    hash = "sha256-4fb7vmA3iQuQZ+T2Gp0B7bc5+CYE1cTR3IoFwOde7SE=";
+    hash = "sha256-lHPpV3wmsJFzanMUF6dhhmKTVCIz5MOfqr8U23sm6eI=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-bsc/package.nix
+++ b/pkgs/by-name/os/osmo-bsc/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-bsc";
-  version = "1.13.3";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-bsc";
     rev = finalAttrs.version;
-    hash = "sha256-2Go+93h1Z4FV9sESfjwCaee1m4jUq2eO8fxlZAwZVfM=";
+    hash = "sha256-8Fli6LGzOt6/0xQTRQ5X9I+0UkIAb1pAtX1xYSxOE2U=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-bts/package.nix
+++ b/pkgs/by-name/os/osmo-bts/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-bts";
-  version = "1.9.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-bts";
     rev = finalAttrs.version;
-    hash = "sha256-SvlkIvdyrXlaSJl+LbHovhIlnxsxpufJCy1wVCZbjWM=";
+    hash = "sha256-eqra1dh84c3mv4ISqrwe7dbhlawWNGvuYd1CDLAfwNk=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-ggsn/package.nix
+++ b/pkgs/by-name/os/osmo-ggsn/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-ggsn";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-ggsn";
     rev = finalAttrs.version;
-    hash = "sha256-qsBjoLyMlRgUjhX1tyI/MoHGmww1XUT3OMH4dVZzLU4=";
+    hash = "sha256-/t5BqZYbeQb2Aea7fSJSJ4ZY2kG/6BtqHeCfFdfo4VA=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-hlr/package.nix
+++ b/pkgs/by-name/os/osmo-hlr/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-hlr";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-hlr";
     rev = finalAttrs.version;
-    hash = "sha256-yi4sgcX8WOWz7qw/jGvVCtIYe867uBzLps8gdG6ziOA=";
+    hash = "sha256-SYyL7evxxmXGwv2TLr8ZuIrbu+GliAyuz/sKTIveQvc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-mgw/package.nix
+++ b/pkgs/by-name/os/osmo-mgw/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-mgw";
-  version = "1.14.0";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-mgw";
     rev = finalAttrs.version;
-    hash = "sha256-Y/98K81US6McNu+JEJtMluJTvsv0DHJiyjMPJz8/35o=";
+    hash = "sha256-rRjr3Mw3ELp1o7QYDuU7mqZEeL2seo0xEONXpkP14SQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-msc/package.nix
+++ b/pkgs/by-name/os/osmo-msc/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-msc";
-  version = "1.14.0";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-msc";
     rev = finalAttrs.version;
-    hash = "sha256-+Z49TqXLEeCy7Yj0qVg1hPFOD/x+4HnwDZxZoxoUjqI=";
+    hash = "sha256-kRPGtMVNODh03oCqqo/AbApWasxiLYo/A9GrD3ECfaE=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-sgsn/package.nix
+++ b/pkgs/by-name/os/osmo-sgsn/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-sgsn";
-  version = "1.13.0";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-sgsn";
     rev = finalAttrs.version;
-    hash = "sha256-ht8ejeD2whV0Ww5G3coUntLrIp2S0gZBRS6kF7w9KZY=";
+    hash = "sha256-POitmYZNSGlnIm65VmqneDOyoN+OaB69Fk3iG7L1UXQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/os/osmo-sip-connector/package.nix
+++ b/pkgs/by-name/os/osmo-sip-connector/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmo-sip-connector";
-  version = "1.7.1";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-sip-connector";
     rev = finalAttrs.version;
-    hash = "sha256-NmjaN28NnAIpMwUHCUS+7LJBwvCp48kyhmHRf6cU5WE=";
+    hash = "sha256-JOTUa1buj9qR8dnMZMLaxjSIrsLnr9g1yylkTgPcL4k=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Collective update of libraries and service packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
