### PR TITLE
nixos/gatus: improve systemd hardening and set WorkingDirectory

### DIFF
--- a/nixos/modules/services/monitoring/gatus.nix
+++ b/nixos/modules/services/monitoring/gatus.nix
@@ -115,12 +115,16 @@ in
         Restart = "on-failure";
         ExecStart = getExe cfg.package;
         StateDirectory = "gatus";
+        WorkingDirectory = "/var/lib/gatus";
         SyslogIdentifier = "gatus";
         EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
         # see https://github.com/prometheus-community/pro-bing#linux
         AmbientCapabilities = "CAP_NET_RAW";
         CapabilityBoundingSet = "CAP_NET_RAW";
         NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
       };
 
       environment = {


### PR DESCRIPTION

This PR improves the Gatus NixOS module by:

- Setting WorkingDirectory to /var/lib/gatus to match StateDirectory
- Adding systemd hardening options:
  - PrivateTmp
  - ProtectSystem
  - ProtectHome

These changes improve service isolation and align the module with existing nixpkgs service hardening practices.

Tested via nix eval with overridden nixpkgs input to confirm systemd options are correctly applied.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
