### PR TITLE
lib.systems.equals: hardcode function attr names

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -3,11 +3,9 @@
 let
   inherit (lib)
     any
-    filterAttrs
     foldl
     hasInfix
     isAttrs
-    isFunction
     isList
     mapAttrs
     optional
@@ -43,9 +41,16 @@ let
   */
   equals =
     let
-      # perf: avoid lib.isFunction because system attrs are never __functor-style attrsets.
-      removeFunctions =
-        a: removeAttrs a (builtins.filter (n: builtins.isFunction a.${n}) (builtins.attrNames a));
+      # Elaborated systems have a fixed set of function-valued attrs.
+      # Listing them explicitly avoids iterating over all attr names.
+      functionNames = [
+        "canExecute"
+        "emulator"
+        "emulatorAvailable"
+        "isCompatible"
+        "staticEmulatorAvailable"
+      ];
+      removeFunctions = a: removeAttrs a functionNames;
     in
     a: b: removeFunctions a == removeFunctions b;
 

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -254,6 +254,27 @@ lib.runTests (
     };
   }
 
+  // {
+    # equals.functionNames must list exactly the function-valued attrs of an
+    # elaborated system, so that removeFunctions stays correct without iterating.
+    test_equals_functionNames_in_sync =
+      let
+        sys = lib.systems.elaborate "x86_64-linux";
+        actual = lib.filter (n: builtins.isFunction sys.${n}) (builtins.attrNames sys);
+        expected = lib.sort lib.lessThan [
+          "canExecute"
+          "emulator"
+          "emulatorAvailable"
+          "isCompatible"
+          "staticEmulatorAvailable"
+        ];
+      in
+      {
+        expr = lib.sort lib.lessThan actual;
+        inherit expected;
+      };
+  }
+
   # Generate test cases to assert that a change in any non-function attribute makes a platform unequal
   //
     lib.concatMapAttrs


### PR DESCRIPTION
Elaborated systems have a fixed set of function-valued attrs:
canExecute, emulator, emulatorAvailable, isCompatible,
staticEmulatorAvailable. Listing them explicitly in removeFunctions
avoids iterating over all attr names and testing each with isFunction.

A test in lib/tests/systems.nix asserts the list stays in sync.

Repro:

  EXPR='let pkgs = import ./. { localSystem = "x86_64-linux"; crossSystem = "aarch64-linux"; }; in (pkgs.python3.withPackages (ps: [ ps.requests ])).drvPath'
  NIX_SHOW_STATS=1 nix-instantiate --eval -E "$EXPR"

drvPath byte-exact (mb82vdkqafg9i8x0makrgxw8xcc4y8lz both ways).

Before:

  nrFunctionCalls: 651343
  nrPrimOpCalls: 404173
  nrLookups: 448195
  nrThunks: 2018744
  values: 5061740
  gc totalBytes: 320504688

After:

  nrFunctionCalls: 602961
  nrPrimOpCalls: 354971
  nrLookups: 350613
  nrThunks: 1969129
  values: 5011927
  gc totalBytes: 318344896


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
