### PR TITLE
nixos/systemd: fix modprobe

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -792,6 +792,10 @@ in
       path = [ pkgs.util-linux ];
       overrideStrategy = "asDropin";
     };
+    systemd.services."modprobe@" = {
+      restartIfChanged = false;
+      serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.kmod ];
+    };
     systemd.services.systemd-random-seed.restartIfChanged = false;
     systemd.services.systemd-remount-fs.restartIfChanged = false;
     systemd.services.systemd-update-utmp.restartIfChanged = false;

--- a/nixos/tests/systemd-misc.nix
+++ b/nixos/tests/systemd-misc.nix
@@ -60,5 +60,10 @@ in
     machine.succeed("systemctl status example.service | grep 'Active: active'")
 
     machine.succeed("systemctl show --property TasksMax --value user-1000.slice | grep 100")
+
+    with subtest("modprobe@ services work"):
+      modprobe_service_status = machine.succeed("systemctl show --property ExecMainStatus modprobe@configfs.service")
+      print(modprobe_service_status)
+      t.assertEqual("ExecMainStatus=0\n", modprobe_service_status)
   '';
 }


### PR DESCRIPTION
Fixes #504407

Upstream systemd changed how modprobe is discovered. It is now searched for on path. Thus, add the kmod package to the ExecSearchPath of the modprobe@.service.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
