### PR TITLE
alacritty{-graphics}: 0.16.1 -> 0.17.0

### DIFF
--- a/pkgs/by-name/al/alacritty/package.nix
+++ b/pkgs/by-name/al/alacritty/package.nix
@@ -49,7 +49,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "alacritty${lib.optionalString withGraphics "-graphics"}";
-  version = "0.16.1";
+  version = "0.17.0";
 
   src =
     # by default we want the official package
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         owner = "alacritty";
         repo = "alacritty";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-IOPhnJ76kZ2djJjxJEUwWPvHDeeXbJAn1ClipTH7nWs=";
+        hash = "sha256-iZtCH2DrSs6o3AG2koI2TyC3116aMlawHFkCd0TYhas=";
       }
     # optionally we want to build the sixels feature fork
     else
@@ -66,14 +66,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
         owner = "ayosec";
         repo = "alacritty";
         tag = "v${finalAttrs.version}-graphics";
-        hash = "sha256-e+o0GLy05qXEY4T57dCuqhukTKBSm1WIHzPUV8uswRI=";
+        hash = "sha256-DdiioNKMVg9u4E4h7AysvaGJ6ys36ykTyJgjHWjIjjY=";
       };
 
   cargoHash =
     if !withGraphics then
-      "sha256-OBhrd4q44LCUGnjDEedhrOuoSC2UFR90IKSQfEPY/Q4="
+      "sha256-BX4PjZXr19SScEZhb0gWkMiJUYq8ByEuVh9RpJSRCHI="
     else
-      "sha256-VR+URXqsB9zCOSow/f/aWXUlrp6j2XeK0zKESQGzMek=";
+      "sha256-xWW0X4dCgnNMT4T6BNsYmxOOFIK8MIHwUMKVtIHAFYc=";
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Changelog: https://github.com/alacritty/alacritty/releases/tag/v0.17.0
Diff: https://github.com/alacritty/alacritty/compare/v0.16.1...v0.17.0

Changelog: https://github.com/ayosec/alacritty/releases/tag/v0.17.0-graphics
Diff: https://github.com/ayosec/alacritty/compare/v0.16.1-graphics...v0.17.0-graphics

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
