### PR TITLE
buildVcode: disable update checks and add missing tools

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -2,7 +2,11 @@
   stdenv,
   lib,
   coreutils,
+  gawk,
   gnugrep,
+  gnused,
+  glibc,
+  jq,
   copyDesktopItems,
   makeDesktopItem,
   unzip,
@@ -33,6 +37,7 @@
   openssl,
   webkitgtk_4_1,
   ripgrep,
+  which,
 
   # needed to fix "Save as Root"
   asar,
@@ -269,6 +274,7 @@ stdenv.mkDerivation (
       autoPatchelfHook
       asar
       copyDesktopItems
+      jq
       # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
       # Has to use `makeShellWrapper` from `buildPackages` even though `makeShellWrapper` from the inputs is spliced because `propagatedBuildInputs` would pick the wrong one because of a different offset.
       (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
@@ -352,9 +358,13 @@ stdenv.mkDerivation (
             # for moving files to trash
             glib
 
-            # for launcher script
+            # for launcher and bundled helper scripts
+            gawk
+            glibc.bin
             gnugrep
+            gnused
             coreutils
+            which
           ]
         }
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}"
@@ -365,9 +375,15 @@ stdenv.mkDerivation (
     # See https://github.com/NixOS/nixpkgs/issues/49643#issuecomment-873853897
     # linux only because of https://github.com/NixOS/nixpkgs/issues/138729
     postPatch =
-      # this is a fix for "save as root" functionality
       lib.optionalString stdenv.hostPlatform.isLinux (
+        # disable update checks
         ''
+          tmpProductJson="$(mktemp)"
+          jq 'del(.updateUrl, .backupUpdateUrl)' resources/app/product.json > "$tmpProductJson"
+          mv "$tmpProductJson" resources/app/product.json
+        ''
+        # this is a fix for "save as root" functionality
+        + ''
           packed="resources/app/node_modules.asar"
           unpacked="resources/app/node_modules"
           asar extract "$packed" "$unpacked"

--- a/pkgs/by-name/an/antigravity/package.nix
+++ b/pkgs/by-name/an/antigravity/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildVscode,
   fetchurl,
-  jq,
   writeShellScript,
   coreutils,
   commandLineArgs ? "",
@@ -17,7 +16,7 @@ let
     information.sources."${hostPlatform.system}"
       or (throw "antigravity: unsupported system ${hostPlatform.system}");
 in
-(buildVscode {
+buildVscode {
   inherit commandLineArgs useVSCodeRipgrep;
   inherit (information) version vscodeVersion;
   pname = "antigravity";
@@ -75,15 +74,4 @@ in
       Zaczero
     ];
   };
-}).overrideAttrs
-  (oldAttrs: {
-    # Disable update checks
-    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [ jq ];
-    postPatch = (oldAttrs.postPatch or "") + ''
-      productJson="${
-        if stdenv.hostPlatform.isDarwin then "Contents/Resources" else "resources"
-      }/app/product.json"
-      data=$(jq 'del(.updateUrl)' "$productJson")
-      echo "$data" > "$productJson"
-    '';
-  })
+}

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -11,7 +11,6 @@
 
 let
   inherit (stdenv) hostPlatform;
-  finalCommandLineArgs = "--update=false " + commandLineArgs;
 
   sourcesJson = lib.importJSON ./sources.json;
   sources = lib.mapAttrs (
@@ -24,9 +23,8 @@ let
   source = sources.${hostPlatform.system};
 in
 buildVscode rec {
-  inherit useVSCodeRipgrep;
+  inherit commandLineArgs useVSCodeRipgrep;
   inherit (sourcesJson) version vscodeVersion;
-  commandLineArgs = finalCommandLineArgs;
 
   pname = "cursor";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Improves consistency and fixes https://github.com/NixOS/nixpkgs/issues/440117 because --update=false was passed before any other arguments. Update checks don't make sense in nixpkgs packaging because users can't act on them, the version is bound to the nixos channel they are on. While at that I added some missing PATH tools that are needed for pure mode.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
