### PR TITLE
gccrs, gcobol, ga68: improve support and package

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -157,6 +157,8 @@
 
 - `minio_legacy_fs` has been removed. If you used that package, migrate your data to be compatible with the newest minio and use the package `minio`.
 
+- `gcc` now supports building its `cobol` compiler front-end, with `langCobol = true`. This has been packaged as `gcobol` or `gcobol15`. Alongside this, the rust compiler front-end has also be packaged, as `gccrs`, `gccrs14` and `gccrs15`
+
 - `mercure` has been update to `0.21.4` (or later). Version [0.21.0](https://github.com/dunglas/mercure/releases/v0.21.0) and [0.21.2](https://github.com/dunglas/mercure/releases/tag/v0.21.2) introduce breaking changes to the package.
 
 - `mozc` and `mozc-ut` no longer contains the IBus front-end, which are now provided by `ibus-engines.mozc` and `ibus-engines.mozc-ut`.

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -582,6 +582,10 @@ stdenvNoCC.mkDerivation {
   + optionalString cc.langGo or false ''
     wrap ${targetPrefix}gccgo $wrapper $ccPath/${targetPrefix}gccgo
     wrap ${targetPrefix}go ${./go-wrapper.sh} $ccPath/${targetPrefix}go
+  ''
+
+  + optionalString cc.langRust or false ''
+    wrap ${targetPrefix}gccrs $wrapper $ccPath/${targetPrefix}gccrs
   '';
 
   strictDeps = true;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -586,6 +586,10 @@ stdenvNoCC.mkDerivation {
 
   + optionalString cc.langRust or false ''
     wrap ${targetPrefix}gccrs $wrapper $ccPath/${targetPrefix}gccrs
+  ''
+
+  + optionalString cc.langCobol or false ''
+    wrap ${targetPrefix}gcobol $wrapper $ccPath/${targetPrefix}gcobol
   '';
 
   strictDeps = true;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -587,6 +587,10 @@ stdenvNoCC.mkDerivation {
 
   + optionalString cc.langRust or false ''
     wrap ${targetPrefix}gccrs $wrapper $ccPath/${targetPrefix}gccrs
+  ''
+
+  + optionalString cc.langCobol or false ''
+    wrap ${targetPrefix}gcobol $wrapper $ccPath/${targetPrefix}gcobol
   '';
 
   strictDeps = true;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -591,6 +591,10 @@ stdenvNoCC.mkDerivation {
 
   + optionalString cc.langCobol or false ''
     wrap ${targetPrefix}gcobol $wrapper $ccPath/${targetPrefix}gcobol
+  ''
+
+  + optionalString cc.langAlgol68 or false ''
+    wrap ${targetPrefix}ga68 $wrapper $ccPath/${targetPrefix}ga68
   '';
 
   strictDeps = true;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -583,6 +583,10 @@ stdenvNoCC.mkDerivation {
   + optionalString cc.langGo or false ''
     wrap ${targetPrefix}gccgo $wrapper $ccPath/${targetPrefix}gccgo
     wrap ${targetPrefix}go ${./go-wrapper.sh} $ccPath/${targetPrefix}go
+  ''
+
+  + optionalString cc.langRust or false ''
+    wrap ${targetPrefix}gccrs $wrapper $ccPath/${targetPrefix}gccrs
   '';
 
   strictDeps = true;

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -32,6 +32,7 @@
   langObjCpp,
   langJit,
   langRust ? false,
+  langCobol ? false,
   disableBootstrap ? (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform),
 }:
 
@@ -215,6 +216,7 @@ let
           ]
           ++ lib.optional langJit "jit"
           ++ lib.optional langRust "rust"
+          ++ lib.optional langCobol "cobol"
         )
       }"
     ]

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -33,6 +33,7 @@
   langJit,
   langRust ? false,
   langCobol ? false,
+  langAlgol68 ? false,
   hostIsTarget,
   disableBootstrap ? (!hostIsTarget),
 }:
@@ -216,6 +217,7 @@ let
           ++ lib.optional langJit "jit"
           ++ lib.optional langRust "rust"
           ++ lib.optional langCobol "cobol"
+          ++ lib.optional langAlgol68 "algol68"
         )
       }"
     ]

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -32,6 +32,7 @@
   langObjCpp,
   langJit,
   langRust ? false,
+  langCobol ? false,
   hostIsTarget,
   disableBootstrap ? (!hostIsTarget),
 }:
@@ -214,6 +215,7 @@ let
           ]
           ++ lib.optional langJit "jit"
           ++ lib.optional langRust "rust"
+          ++ lib.optional langCobol "cobol"
         )
       }"
     ]

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -19,8 +19,8 @@ in
   description = "GNU Compiler Collection, version ${version}";
   longDescription = ''
     The GNU Compiler Collection includes compiler front ends for C, C++,
-    Objective-C, Fortran, OpenMP for C/C++/Fortran, and Ada, as well as
-    libraries for these languages (libstdc++, libgomp,...).
+    Objective-C, Fortran, OpenMP for C/C++/Fortran, Ada, Go, Rust and Cobol,
+    as well as libraries for these languages (libstdc++, libgomp,...).
 
     GCC development is a part of the GNU Project, aiming to improve the
     compiler used in the GNU system including the GNU/Linux variant.

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -19,8 +19,8 @@ in
   description = "GNU Compiler Collection, version ${version}";
   longDescription = ''
     The GNU Compiler Collection includes compiler front ends for C, C++,
-    Objective-C, Fortran, OpenMP for C/C++/Fortran, and Ada, as well as
-    libraries for these languages (libstdc++, libgomp,...).
+    Objective-C, Fortran, OpenMP for C/C++/Fortran, Ada, Go, Rust, Cobol
+    and Algol68 as well as libraries for these languages (libstdc++, libgomp,...).
 
     GCC development is a part of the GNU Project, aiming to improve the
     compiler used in the GNU system including the GNU/Linux variant.

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -12,11 +12,10 @@
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langGo ? false,
+  langRust ? false,
   reproducibleBuild ? true,
   profiledCompiler ? false,
   langJit ? false,
-  langRust ? false,
-  cargo,
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
   enableDefaultPie ? stdenv.targetPlatform.hasSharedLibraries,
@@ -54,6 +53,7 @@
   majorMinorVersion,
   apple-sdk,
   darwin,
+  cargo,
 }:
 
 let
@@ -194,6 +194,9 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 # The go frontend is written in c++
 assert langGo -> langCC;
 assert langAda -> gnat-bootstrap != null;
+
+# Rust support requires libstdc++
+assert langRust -> atLeast14 && langCC;
 
 # threadsCross is just for MinGW
 assert threadsCross != { } -> stdenv.targetPlatform.isWindows;
@@ -396,6 +399,7 @@ pipe
           langAda
           langFortran
           langGo
+          langRust
           version
           ;
         isGNU = true;

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -13,6 +13,7 @@
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langGo ? false,
   langRust ? false,
+  langCobol ? false,
   reproducibleBuild ? true,
   profiledCompiler ? false,
   langJit ? false,
@@ -80,6 +81,7 @@ let
 
   majorVersion = versions.major version;
   atLeast14 = versionAtLeast version "14";
+  atLeast15 = versionAtLeast version "15";
   is14 = majorVersion == "14";
   is13 = majorVersion == "13";
 
@@ -156,6 +158,7 @@ let
       langAda
       langC
       langCC
+      langCobol
       langFortran
       langGo
       langJit
@@ -195,8 +198,9 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 assert langGo -> langCC;
 assert langAda -> gnat-bootstrap != null;
 
-# Rust support requires libstdc++
+# Rust and Cobol support requires libstdc++
 assert langRust -> atLeast14 && langCC;
+assert langCobol -> atLeast15 && langCC;
 
 # threadsCross is just for MinGW
 assert threadsCross != { } -> stdenv.targetPlatform.isWindows;
@@ -400,6 +404,7 @@ pipe
           langFortran
           langGo
           langRust
+          langCobol
           version
           ;
         isGNU = true;

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -14,6 +14,7 @@
   langGo ? false,
   langRust ? false,
   langCobol ? false,
+  langAlgol68 ? false,
   reproducibleBuild ? true,
   profiledCompiler ? false,
   langJit ? false,
@@ -85,6 +86,7 @@ let
   majorVersion = versions.major version;
   atLeast14 = lib.versionAtLeast version "14";
   atLeast15 = lib.versionAtLeast version "15";
+  atLeast16 = lib.versionAtLeast version "16";
   is13 = majorVersion == "13";
 
   # releases have a form: MAJOR.MINOR.MICRO, like 14.2.1
@@ -153,6 +155,7 @@ let
       gnused
       isl
       langAda
+      langAlgol68
       langC
       langCC
       langCobol
@@ -197,9 +200,10 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 assert langGo -> langCC;
 assert langAda -> gnat-bootstrap != null;
 
-# Rust and Cobol support requires libstdc++
+# Rust, Cobol and Algol68 support requires libstdc++
 assert langRust -> atLeast14 && langCC;
 assert langCobol -> atLeast15 && langCC;
+assert langAlgol68 -> atLeast16 && langCC;
 
 # threadsCross is just for MinGW
 assert threadsCross != { } -> stdenv.targetPlatform.isWindows;
@@ -400,6 +404,7 @@ pipe
           langGo
           langRust
           langCobol
+          langAlgol68
           version
           ;
         isGNU = true;

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -12,11 +12,10 @@
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langGo ? false,
+  langRust ? false,
   reproducibleBuild ? true,
   profiledCompiler ? false,
   langJit ? false,
-  langRust ? false,
-  cargo,
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
   enableDefaultPie ? stdenv.targetPlatform.hasSharedLibraries,
@@ -60,6 +59,7 @@
   majorMinorVersion,
   apple-sdk,
   darwin,
+  cargo,
 }:
 
 let
@@ -192,6 +192,9 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 # The go frontend is written in c++
 assert langGo -> langCC;
 assert langAda -> gnat-bootstrap != null;
+
+# Rust support requires libstdc++
+assert langRust -> atLeast14 && langCC;
 
 # threadsCross is just for MinGW
 assert threadsCross != { } -> stdenv.targetPlatform.isWindows;
@@ -390,6 +393,7 @@ pipe
           langAda
           langFortran
           langGo
+          langRust
           version
           ;
         isGNU = true;

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -13,6 +13,7 @@
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langGo ? false,
   langRust ? false,
+  langCobol ? false,
   reproducibleBuild ? true,
   profiledCompiler ? false,
   langJit ? false,
@@ -82,6 +83,8 @@ let
   version = gccVersions.fromMajorMinor majorMinorVersion;
 
   majorVersion = versions.major version;
+  atLeast14 = lib.versionAtLeast version "14";
+  atLeast15 = lib.versionAtLeast version "15";
   is13 = majorVersion == "13";
 
   # releases have a form: MAJOR.MINOR.MICRO, like 14.2.1
@@ -152,6 +155,7 @@ let
       langAda
       langC
       langCC
+      langCobol
       langFortran
       langGo
       langJit
@@ -193,8 +197,9 @@ assert stdenv.buildPlatform.isDarwin -> gnused != null;
 assert langGo -> langCC;
 assert langAda -> gnat-bootstrap != null;
 
-# Rust support requires libstdc++
+# Rust and Cobol support requires libstdc++
 assert langRust -> atLeast14 && langCC;
+assert langCobol -> atLeast15 && langCC;
 
 # threadsCross is just for MinGW
 assert threadsCross != { } -> stdenv.targetPlatform.isWindows;
@@ -394,6 +399,7 @@ pipe
           langFortran
           langGo
           langRust
+          langCobol
           version
           ;
         isGNU = true;

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -14,6 +14,7 @@
   langJava ? false,
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
+  langRust ? false,
   langJit ? false,
   enablePlugin ? lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform,
   runCommand,
@@ -205,6 +206,7 @@ stdenv.mkDerivation (finalAttrs: {
           ++ lib.optional langGo "go"
           ++ lib.optional langObjC "objc"
           ++ lib.optional langObjCpp "obj-c++"
+          ++ lib.optional langRust "rust"
           ++ lib.optional langJit "jit"
         )
       )
@@ -246,6 +248,7 @@ stdenv.mkDerivation (finalAttrs: {
       langAda
       langFortran
       langGo
+      langRust
       ;
     isGNU = true;
   };

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -15,6 +15,7 @@
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langRust ? false,
+  langCobol ? false,
   langJit ? false,
   enablePlugin ? lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform,
   runCommand,
@@ -207,6 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
           ++ lib.optional langObjC "objc"
           ++ lib.optional langObjCpp "obj-c++"
           ++ lib.optional langRust "rust"
+          ++ lib.optional langCobol "cobol"
           ++ lib.optional langJit "jit"
         )
       )
@@ -249,6 +251,7 @@ stdenv.mkDerivation (finalAttrs: {
       langFortran
       langGo
       langRust
+      langCobol
       ;
     isGNU = true;
   };

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -14,6 +14,7 @@
   langJava ? false,
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
+  langRust ? false,
   langJit ? false,
   enablePlugin ? lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform,
   runCommand,
@@ -210,6 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
           ++ lib.optional langGo "go"
           ++ lib.optional langObjC "objc"
           ++ lib.optional langObjCpp "obj-c++"
+          ++ lib.optional langRust "rust"
           ++ lib.optional langJit "jit"
         )
       )
@@ -251,6 +253,7 @@ stdenv.mkDerivation (finalAttrs: {
       langAda
       langFortran
       langGo
+      langRust
       ;
     isGNU = true;
   };

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -16,6 +16,7 @@
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langRust ? false,
   langCobol ? false,
+  langAlgol68 ? false,
   langJit ? false,
   enablePlugin ? lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform,
   runCommand,
@@ -214,6 +215,7 @@ stdenv.mkDerivation (finalAttrs: {
           ++ lib.optional langObjCpp "obj-c++"
           ++ lib.optional langRust "rust"
           ++ lib.optional langCobol "cobol"
+          ++ lib.optional langAlgol68 "algol68"
           ++ lib.optional langJit "jit"
         )
       )
@@ -257,6 +259,7 @@ stdenv.mkDerivation (finalAttrs: {
       langGo
       langRust
       langCobol
+      langAlgol68
       ;
     isGNU = true;
   };

--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -15,6 +15,7 @@
   langObjC ? stdenv.targetPlatform.isDarwin,
   langObjCpp ? stdenv.targetPlatform.isDarwin,
   langRust ? false,
+  langCobol ? false,
   langJit ? false,
   enablePlugin ? lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform,
   runCommand,
@@ -212,6 +213,7 @@ stdenv.mkDerivation (finalAttrs: {
           ++ lib.optional langObjC "objc"
           ++ lib.optional langObjCpp "obj-c++"
           ++ lib.optional langRust "rust"
+          ++ lib.optional langCobol "cobol"
           ++ lib.optional langJit "jit"
         )
       )
@@ -254,6 +256,7 @@ stdenv.mkDerivation (finalAttrs: {
       langFortran
       langGo
       langRust
+      langCobol
       ;
     isGNU = true;
   };

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -114,6 +114,8 @@ in
   stdenv-inputs = callPackage ./stdenv-inputs { };
   stdenv = recurseIntoAttrs (callPackage ./stdenv { });
 
+  gcc = recurseIntoAttrs (callPackage ./gcc { });
+
   hardeningFlags = recurseIntoAttrs (callPackage ./cc-wrapper/hardening.nix { });
   hardeningFlags-gcc = recurseIntoAttrs (
     callPackage ./cc-wrapper/hardening.nix {

--- a/pkgs/test/gcc/default.nix
+++ b/pkgs/test/gcc/default.nix
@@ -1,0 +1,80 @@
+{
+  gccrs,
+  gcobol,
+  ga68,
+  runCommand,
+  lib,
+}:
+
+let
+  # Compile source file and check that output is "Hello World!"
+  testHelloWorld =
+    {
+      compiler,
+      ext,
+      code,
+    }:
+    runCommand "test-hello-world-${compiler.name}"
+      {
+        nativeBuildInputs = [ compiler ];
+        inherit code ext;
+        passAsFile = [ "code" ];
+      }
+      ''
+        mv $codePath "hello.$ext"
+        ${lib.getExe compiler} -o hello "hello.$ext"
+
+        [[ $(./hello | tee /dev/stderr) = $'Hello World!' ]]
+        touch $out
+      '';
+in
+{
+  gcobol-hello-world = testHelloWorld {
+    compiler = gcobol;
+    ext = "cbl";
+    code = ''
+      *> A SIMPLE HELLO WORLD PROGRAM
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. hello.
+       PROCEDURE DIVISION.
+           DISPLAY "Hello World!".
+           STOP RUN.
+    '';
+  };
+
+  ga68-hello-world = testHelloWorld {
+    compiler = ga68;
+    ext = "a68";
+    code = ''
+      begin
+        puts ("Hello World!'n")
+      end
+    '';
+  };
+
+  gccrs-exit-code =
+    runCommand "test-${gccrs.name}"
+      {
+        env.GCCRS_INCOMPLETE_AND_EXPERIMENTAL_COMPILER_DO_NOT_USE = "1";
+        nativeBuildInputs = [ gccrs ];
+        code = ''
+          fn main() -> isize {
+              let v: isize = 1 + 1;
+              return v;
+          }
+        '';
+        passAsFile = [ "code" ];
+      }
+      ''
+        mv $codePath exit2.rs
+        ${lib.getExe gccrs} -o exit2 exit2.rs
+
+        set +e
+        ./exit2; status=$?
+        set -e
+
+        echo "expected 2, got $status"
+        (( $status == 2 ))
+        touch $out
+      '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4097,6 +4097,35 @@ with pkgs;
     }
   );
 
+  # Cannot override gcc.cc, as this is built at in earlier stdenv bootstrapping
+  # stage (in the native case), which doesn't have a fully-fledged fetchurl.
+  # fetchurl is required to build cargo, and thus evaluation fails as it cannot
+  # properly build the nativeBuildInputs of gccrs. Replace this with a proper
+  # override when cargo is no longer a dependency of gccrs
+  gccrs = pkgs."gccrs${toString default-gcc-version}";
+
+  gccrs14 = wrapCC (
+    gcc14.cc.override {
+      name = "gccrs";
+      langCC = true; # required for rust.
+      langC = true;
+      langJit = true;
+      langRust = true;
+      profiledCompiler = false;
+    }
+  );
+
+  gccrs15 = wrapCC (
+    gcc15.cc.override {
+      name = "gccrs";
+      langCC = true; # required for rust.
+      langC = true;
+      langJit = true;
+      langRust = true;
+      profiledCompiler = false;
+    }
+  );
+
   ghdl-mcode = callPackage ../by-name/gh/ghdl/package.nix { backend = "mcode"; };
 
   ghdl-gcc = callPackage ../by-name/gh/ghdl/package.nix { backend = "gcc"; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4097,6 +4097,28 @@ with pkgs;
     }
   );
 
+  gcobol = wrapCC (
+    gcc.cc.override {
+      name = "gcobol";
+      langCC = true; # required for cobol.
+      langC = true;
+      langJit = true;
+      langCobol = true;
+      profiledCompiler = false;
+    }
+  );
+
+  gcobol15 = wrapCC (
+    gcc15.cc.override {
+      name = "gcobol";
+      langCC = true; # required for cobol.
+      langC = true;
+      langJit = true;
+      langCobol = true;
+      profiledCompiler = false;
+    }
+  );
+
   # Cannot override gcc.cc, as this is built at in earlier stdenv bootstrapping
   # stage (in the native case), which doesn't have a fully-fledged fetchurl.
   # fetchurl is required to build cargo, and thus evaluation fails as it cannot

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3703,6 +3703,46 @@ with pkgs;
     }
   );
 
+  # Cannot override gcc.cc, as this is built at in earlier stdenv bootstrapping
+  # stage (in the native case), which doesn't have a fully-fledged fetchurl.
+  # fetchurl is required to build cargo, and thus evaluation fails as it cannot
+  # properly build the nativeBuildInputs of gccrs. Replace this with a proper
+  # override when cargo is no longer a dependency of gccrs
+  gccrs = pkgs."gccrs${toString default-gcc-version}";
+
+  gccrs14 = wrapCC (
+    gcc14.cc.override {
+      name = "gccrs";
+      langCC = true; # required for rust.
+      langC = true;
+      langJit = true;
+      langRust = true;
+      profiledCompiler = false;
+    }
+  );
+
+  gccrs15 = wrapCC (
+    gcc15.cc.override {
+      name = "gccrs";
+      langCC = true; # required for rust.
+      langC = true;
+      langJit = true;
+      langRust = true;
+      profiledCompiler = false;
+    }
+  );
+
+  gccrs16 = wrapCC (
+    gcc16.cc.override {
+      name = "gccrs";
+      langCC = true; # required for rust.
+      langC = true;
+      langJit = true;
+      langRust = true;
+      profiledCompiler = false;
+    }
+  );
+
   ghdl-mcode = ghdl.override { backend = "mcode"; };
 
   ghdl-gcc = ghdl.override { backend = "gcc"; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3776,6 +3776,22 @@ with pkgs;
     }
   );
 
+  # Currently the algol68 frontend is only supported on gcc16+
+  # When gcc16 becomes the default gcc version, replace with a gcc.cc.override
+  # like above
+  ga68 = ga68_16;
+
+  ga68_16 = wrapCC (
+    gcc16.cc.override {
+      name = "ga68";
+      langC = true;
+      langCC = true;
+      langJit = true;
+      langAlgol68 = true;
+      profiledCompiler = false;
+    }
+  );
+
   ghdl-mcode = ghdl.override { backend = "mcode"; };
 
   ghdl-gcc = ghdl.override { backend = "gcc"; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3703,6 +3703,39 @@ with pkgs;
     }
   );
 
+  gcobol = wrapCC (
+    gcc.cc.override {
+      name = "gcobol";
+      langCC = true; # required for cobol.
+      langC = true;
+      langJit = true;
+      langCobol = true;
+      profiledCompiler = false;
+    }
+  );
+
+  gcobol15 = wrapCC (
+    gcc15.cc.override {
+      name = "gcobol";
+      langCC = true; # required for cobol.
+      langC = true;
+      langJit = true;
+      langCobol = true;
+      profiledCompiler = false;
+    }
+  );
+
+  gcobol16 = wrapCC (
+    gcc16.cc.override {
+      name = "gcobol";
+      langCC = true; # required for cobol.
+      langC = true;
+      langJit = true;
+      langCobol = true;
+      profiledCompiler = false;
+    }
+  );
+
   # Cannot override gcc.cc, as this is built at in earlier stdenv bootstrapping
   # stage (in the native case), which doesn't have a fully-fledged fetchurl.
   # fetchurl is required to build cargo, and thus evaluation fails as it cannot


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This pr improves the `gcc` build scripts to improve the support for building `gcobol` and `gccrs`, including packaging them for use. Currently I cannot evaluate the `gccrs` package, but I can evaluate the `gccrs15` package, even though they are the same? There's some error in #332738 that I can't fully solve myself so would love help from others.

Edit: thanks to the wonderful explanation of @sternenseemann, `gccrs` now evaluates, and so this pr is ready for review!

Edit 2: This PR has now been added upon to also init the new Algol68 frontend, ga68

For testing, the following is a simple hello world program in cobol, mind the indentation, it is correct, even though it is weird.
```cobol
      *> A SIMPLE HELLO WORLD PROGRAM
       IDENTIFICATION DIVISION.
       PROGRAM-ID. hello.
       PROCEDURE DIVISION.
           DISPLAY "Hello World!".
           STOP RUN.
```
`gccrs` is very incomplete right now on the provided `gcc` versions, it cannot compile `core` or `std`, so no I/O is available, and I haven't been able to properly get the extern bindings to have it call `putstr` to make hello world work properly. Instead, the following program, when compiled with `gccrs`, exits with status code 2:
```rust
fn main() -> isize {
    let v: isize = 1 + 1;
    return v;
}
```
An example algol68 program is below, for testing. Save it as `hello.a68` and compile it with `ga68` to test it's functionality
```algol68
begin
  puts ("Hello World!'n")
end
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
