### PR TITLE
nixos/netdata: upstream allignment and add pkg to path

### DIFF
--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -266,8 +266,17 @@ in
     services.netdata.configDir.".opt-out-from-anonymous-statistics" = lib.mkIf (
       !cfg.enableAnalyticsReporting
     ) (pkgs.writeText ".opt-out-from-anonymous-statistics" "");
-    environment.etc."netdata/netdata.conf".source = configFile;
-    environment.etc."netdata/conf.d".source = configDirectory;
+
+    environment = {
+      etc = {
+        "netdata/netdata.conf".source = configFile;
+        "netdata/conf.d".source = configDirectory;
+      };
+
+      systemPackages = [
+        cfg.package
+      ];
+    };
 
     systemd.tmpfiles.settings = lib.mkIf cfg.package.withNdsudo {
       "95-netdata-ndsudo" = {
@@ -293,6 +302,7 @@ in
       };
     };
 
+    # nix repackaged variant of https://github.com/netdata/netdata/blob/0b04755a1039cb1d5651e19af35650feb71577a0/system/systemd/netdata.service.in
     systemd.services.netdata = {
       description = "Real time performance monitoring";
       after = [
@@ -335,20 +345,27 @@ in
         config.environment.etc."netdata/netdata.conf".source
         config.environment.etc."netdata/conf.d".source
       ];
+      script = lib.concatLines [
+        (lib.optionalString (cfg.claimTokenFile != null) ''
+          set -euo pipefail
+          export NETDATA_CLAIM_TOKEN
+          NETDATA_CLAIM_TOKEN="$(cat "$CREDENTIALS_DIRECTORY/token")"
+          echo "Loaded NETDATA_CLAIM_TOKEN into env"
+        '')
+        "exec ${cfg.package}/bin/netdata -D"
+      ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/netdata -P /run/netdata/netdata.pid -D -c /etc/netdata/netdata.conf";
         ExecReload = "${pkgs.util-linux}/bin/kill -s HUP -s USR1 -s USR2 $MAINPID";
-        ExecStartPost = pkgs.writeShellScript "wait-for-netdata-up" ''
-          while [ "$(${cfg.package}/bin/netdatacli ping)" != pong ]; do sleep 0.5; done
-        '';
 
         TimeoutStopSec = cfg.deadlineBeforeStopSec;
+        CPUSchedulingPolicy = "batch";
         Restart = "on-failure";
         # User and group
         User = cfg.user;
         Group = cfg.group;
         # Performance
         LimitNOFILE = "30000";
+        Nice = 0;
         # Runtime directory and mode
         RuntimeDirectory = "netdata";
         RuntimeDirectoryMode = "0750";
@@ -391,25 +408,23 @@ in
         PrivateTmp = true;
         ProtectControlGroups = true;
         PrivateMounts = true;
+        ReadWriteDirectories = lib.optional config.services.postfix.enable [
+          "-/var/spool/postfix/maildrop"
+        ];
+        # https://github.com/netdata/netdata/issues/14238
+        BindReadOnlyPaths = map (p: "-/proc/" + p) [
+          "cpuinfo"
+          "diskstats"
+          "loadavg"
+          "meminfo"
+          "slabinfo"
+          "stat"
+          "swapsstat"
+          "uptime"
+        ];
       }
       // (lib.optionalAttrs (cfg.claimTokenFile != null) {
-        LoadCredential = [
-          "netdata_claim_token:${cfg.claimTokenFile}"
-        ];
-
-        ExecStartPre = pkgs.writeShellScript "netdata-claim" ''
-          set -euo pipefail
-
-          if [[ -f /var/lib/netdata/cloud.d/claimed_id ]]; then
-            # Already registered
-            exit
-          fi
-
-          exec ${cfg.package}/bin/netdata-claim.sh \
-            -token="$(< "$CREDENTIALS_DIRECTORY/netdata_claim_token")" \
-            -url=https://app.netdata.cloud \
-            -daemon-not-running
-        '';
+        LoadCredential = [ "token:${cfg.claimTokenFile}" ];
       });
     };
 

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -266,8 +266,17 @@ in
     services.netdata.configDir.".opt-out-from-anonymous-statistics" = lib.mkIf (
       !cfg.enableAnalyticsReporting
     ) (pkgs.writeText ".opt-out-from-anonymous-statistics" "");
-    environment.etc."netdata/netdata.conf".source = configFile;
-    environment.etc."netdata/conf.d".source = configDirectory;
+
+    environment = {
+      etc = {
+        "netdata/netdata.conf".source = configFile;
+        "netdata/conf.d".source = configDirectory;
+      };
+
+      systemPackages = [
+        cfg.package
+      ];
+    };
 
     systemd.tmpfiles.settings = lib.mkIf cfg.package.withNdsudo {
       "95-netdata-ndsudo" = {
@@ -293,6 +302,7 @@ in
       };
     };
 
+    # nix repackaged variant of https://github.com/netdata/netdata/blob/0b04755a1039cb1d5651e19af35650feb71577a0/system/systemd/netdata.service.in
     systemd.services.netdata = {
       description = "Real time performance monitoring";
       after = [
@@ -335,20 +345,30 @@ in
         config.environment.etc."netdata/netdata.conf".source
         config.environment.etc."netdata/conf.d".source
       ];
+      script = lib.concatLines [
+        (lib.optionalString (cfg.claimTokenFile != null) ''
+          set -euo pipefail
+          export NETDATA_CLAIM_TOKEN
+          NETDATA_CLAIM_TOKEN="$(cat "$CREDENTIALS_DIRECTORY/token")"
+          echo "Loaded NETDATA_CLAIM_TOKEN into env"
+        '')
+        "exec ${cfg.package}/bin/netdata -D"
+      ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/netdata -P /run/netdata/netdata.pid -D -c /etc/netdata/netdata.conf";
         ExecReload = "${pkgs.util-linux}/bin/kill -s HUP -s USR1 -s USR2 $MAINPID";
         ExecStartPost = pkgs.writeShellScript "wait-for-netdata-up" ''
           while [ "$(${cfg.package}/bin/netdatacli ping)" != pong ]; do sleep 0.5; done
         '';
 
         TimeoutStopSec = cfg.deadlineBeforeStopSec;
+        CPUSchedulingPolicy = "batch";
         Restart = "on-failure";
         # User and group
         User = cfg.user;
         Group = cfg.group;
         # Performance
         LimitNOFILE = "30000";
+        Nice = 0;
         # Runtime directory and mode
         RuntimeDirectory = "netdata";
         RuntimeDirectoryMode = "0750";
@@ -391,25 +411,23 @@ in
         PrivateTmp = true;
         ProtectControlGroups = true;
         PrivateMounts = true;
+        ReadWriteDirectories = lib.optional config.services.postfix.enable [
+          "-/var/spool/postfix/maildrop"
+        ];
+        # https://github.com/netdata/netdata/issues/14238
+        BindReadOnlyPaths = map (p: "-/proc/" + p) [
+          "cpuinfo"
+          "diskstats"
+          "loadavg"
+          "meminfo"
+          "slabinfo"
+          "stat"
+          "swapsstat"
+          "uptime"
+        ];
       }
       // (lib.optionalAttrs (cfg.claimTokenFile != null) {
-        LoadCredential = [
-          "netdata_claim_token:${cfg.claimTokenFile}"
-        ];
-
-        ExecStartPre = pkgs.writeShellScript "netdata-claim" ''
-          set -euo pipefail
-
-          if [[ -f /var/lib/netdata/cloud.d/claimed_id ]]; then
-            # Already registered
-            exit
-          fi
-
-          exec ${cfg.package}/bin/netdata-claim.sh \
-            -token="$(< "$CREDENTIALS_DIRECTORY/netdata_claim_token")" \
-            -url=https://app.netdata.cloud \
-            -daemon-not-running
-        '';
+        LoadCredential = [ "token:${cfg.claimTokenFile}" ];
       });
     };
 

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -267,8 +267,17 @@ in
     services.netdata.configDir.".opt-out-from-anonymous-statistics" = lib.mkIf (
       !cfg.enableAnalyticsReporting
     ) (pkgs.writeText ".opt-out-from-anonymous-statistics" "");
-    environment.etc."netdata/netdata.conf".source = configFile;
-    environment.etc."netdata/conf.d".source = configDirectory;
+
+    environment = {
+      etc = {
+        "netdata/netdata.conf".source = configFile;
+        "netdata/conf.d".source = configDirectory;
+      };
+
+      systemPackages = [
+        cfg.package
+      ];
+    };
 
     systemd.tmpfiles.settings = lib.mkIf cfg.package.withNdsudo {
       "95-netdata-ndsudo" = {
@@ -294,6 +303,7 @@ in
       };
     };
 
+    # nix repackaged variant of https://github.com/netdata/netdata/blob/0b04755a1039cb1d5651e19af35650feb71577a0/system/systemd/netdata.service.in
     systemd.services.netdata = {
       description = "Real time performance monitoring";
       after = [
@@ -336,20 +346,30 @@ in
         config.environment.etc."netdata/netdata.conf".source
         config.environment.etc."netdata/conf.d".source
       ];
+      script = lib.concatLines [
+        (lib.optionalString (cfg.claimTokenFile != null) ''
+          set -euo pipefail
+          export NETDATA_CLAIM_TOKEN
+          NETDATA_CLAIM_TOKEN="$(cat "$CREDENTIALS_DIRECTORY/token")"
+          echo "Loaded NETDATA_CLAIM_TOKEN into env"
+        '')
+        "exec ${cfg.package}/bin/netdata -D"
+      ];
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/netdata -P /run/netdata/netdata.pid -D -c /etc/netdata/netdata.conf";
         ExecReload = "${pkgs.util-linux}/bin/kill -s HUP -s USR1 -s USR2 $MAINPID";
         ExecStartPost = pkgs.writeShellScript "wait-for-netdata-up" ''
           while [ "$(${cfg.package}/bin/netdatacli ping)" != pong ]; do sleep 0.5; done
         '';
 
         TimeoutStopSec = cfg.deadlineBeforeStopSec;
+        CPUSchedulingPolicy = "batch";
         Restart = "on-failure";
         # User and group
         User = cfg.user;
         Group = cfg.group;
         # Performance
         LimitNOFILE = "30000";
+        Nice = 0;
         # Runtime directory and mode
         RuntimeDirectory = "netdata";
         RuntimeDirectoryMode = "0750";
@@ -397,25 +417,23 @@ in
         PrivateTmp = true;
         ProtectControlGroups = true;
         PrivateMounts = true;
+        ReadWriteDirectories = lib.optional config.services.postfix.enable [
+          "-/var/spool/postfix/maildrop"
+        ];
+        # https://github.com/netdata/netdata/issues/14238
+        BindReadOnlyPaths = map (p: "-/proc/" + p) [
+          "cpuinfo"
+          "diskstats"
+          "loadavg"
+          "meminfo"
+          "slabinfo"
+          "stat"
+          "swapsstat"
+          "uptime"
+        ];
       }
       // (lib.optionalAttrs (cfg.claimTokenFile != null) {
-        LoadCredential = [
-          "netdata_claim_token:${cfg.claimTokenFile}"
-        ];
-
-        ExecStartPre = pkgs.writeShellScript "netdata-claim" ''
-          set -euo pipefail
-
-          if [[ -f /var/lib/netdata/cloud.d/claimed_id ]]; then
-            # Already registered
-            exit
-          fi
-
-          exec ${cfg.package}/bin/netdata-claim.sh \
-            -token="$(< "$CREDENTIALS_DIRECTORY/netdata_claim_token")" \
-            -url=https://app.netdata.cloud \
-            -daemon-not-running
-        '';
+        LoadCredential = [ "token:${cfg.claimTokenFile}" ];
       });
     };
 


### PR DESCRIPTION
Merge of PRs:
- #433990
- #433994
- #474234

Resolves: #402135

- add the netdata package to `PATH` so you can use the `netdatacli` without needing to figure out the path
- automatically claim netdata instance <https://learn.netdata.cloud/docs/netdata-cloud/connect-agent-to-cloud#automatically-via-environment-variables>
- include more systemd settings of netdata upstream systemd service
  - i chose to not add the journal namespace setting
- improve default type as there are more possible options allowed by systemd -> generally the `TimeoutStopSec` should maybe not be a config option as users can always use `systemd.services.netdata.ServiceConfig.TimeoutStopSec = "200s";` to change the desired
- remove unused `PIDFILE` this is not needed when using `-D`



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
