### PR TITLE
spoof-mac: migrate to by-name, switch to hash, use 0-unstable

### DIFF
--- a/pkgs/by-name/sp/spoof-mac/package.nix
+++ b/pkgs/by-name/sp/spoof-mac/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  buildPythonPackage,
+  python3Packages,
   fetchFromGitHub,
-  docopt,
 }:
 
-buildPythonPackage {
+python3Packages.buildPythonPackage {
   pname = "spoof-mac";
   version = "unstable-2018-01-27";
   format = "setuptools";
@@ -17,7 +16,7 @@ buildPythonPackage {
     sha256 = "sha256-Qiu0URjUyx8QDVQQUFGxPax0J80e2m4+bPJeqFoKxX8=";
   };
 
-  propagatedBuildInputs = [ docopt ];
+  propagatedBuildInputs = [ python3Packages.docopt ];
 
   # No tests
   doCheck = false;

--- a/pkgs/by-name/sp/spoof-mac/package.nix
+++ b/pkgs/by-name/sp/spoof-mac/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonPackage {
   pname = "spoof-mac";
-  version = "unstable-2018-01-27";
+  version = "0-unstable-2018-01-27";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "feross";
     repo = "SpoofMAC";
     rev = "2cfc796150ef48009e9b765fe733e37d82c901e0";
-    sha256 = "sha256-Qiu0URjUyx8QDVQQUFGxPax0J80e2m4+bPJeqFoKxX8=";
+    hash = "sha256-Qiu0URjUyx8QDVQQUFGxPax0J80e2m4+bPJeqFoKxX8=";
   };
 
   propagatedBuildInputs = [ python3Packages.docopt ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3436,8 +3436,6 @@ with pkgs;
   spire-agent = spire.agent;
   spire-server = spire.server;
 
-  spoof-mac = python3Packages.callPackage ../tools/networking/spoof-mac { };
-
   stirling-pdf-desktop = callPackage ../by-name/st/stirling-pdf/package.nix {
     isDesktopVariant = true;
   };


### PR DESCRIPTION
This pull request refactors the packaging of the `spoof-mac` Python tool to align with the new package organization and modern Nixpkgs conventions. The package definition is moved and updated, and its inclusion in `all-packages.nix` is removed, likely as part of a migration to the new by-name package structure.

**Package migration and modernization:**

* Moved the `spoof-mac` package definition from `pkgs/tools/networking/spoof-mac/default.nix` to `pkgs/by-name/sp/spoof-mac/package.nix`, updating it to use `python3Packages.buildPythonPackage` and referencing dependencies from `python3Packages` for improved consistency and maintainability.

**Top-level package list update:**

* Removed the explicit `spoof-mac` entry from `pkgs/top-level/all-packages.nix`, reflecting its migration to the by-name packaging system.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
