### PR TITLE
python3Packages.great-tables: cleanup, skip failing test

### DIFF
--- a/pkgs/development/python-modules/great-tables/default.nix
+++ b/pkgs/development/python-modules/great-tables/default.nix
@@ -33,7 +33,7 @@
   syrupy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "great-tables";
   version = "0.21.0";
   pyproject = true;
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "posit-dev";
     repo = "great-tables";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-d5LKKA6KCkkBGibalWkfOTRzf48YEjdtjCdbGpW2AjE=";
   };
 
@@ -83,6 +83,10 @@ buildPythonPackage rec {
     "test_save_custom_webdriver"
     "test_save_image_file"
     "test_save_non_png"
+
+    # AssertionError: assert [- snapshot] == [+ received]
+    # https://github.com/posit-dev/great-tables/issues/826
+    "test_html_string_generated_inline_css"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Fails due to added newline in HTML output
@@ -95,8 +99,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library for rendering and formatting dataframes";
     homepage = "https://github.com/posit-dev/great-tables";
-    changelog = "https://github.com/posit-dev/great-tables/releases/tag/${src.tag}";
+    changelog = "https://github.com/posit-dev/great-tables/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
