### PR TITLE
mediawiki: do not clear session cache on every start

### DIFF
--- a/pkgs/by-name/me/mediawiki/keep-session-object-cache.diff
+++ b/pkgs/by-name/me/mediawiki/keep-session-object-cache.diff
@@ -1,0 +1,13 @@
+diff --git a/includes/Installer/DatabaseUpdater.php b/includes/Installer/DatabaseUpdater.php
+index 8ed996b9dee..733a3210096 100644
+--- a/includes/Installer/DatabaseUpdater.php
++++ b/includes/Installer/DatabaseUpdater.php
+@@ -1380,7 +1380,7 @@ public function purgeCache() {
+ 		// ObjectCache
+ 		$this->db->newDeleteQueryBuilder()
+ 			->deleteFrom( 'objectcache' )
+-			->where( ISQLPlatform::ALL_ROWS )
++			->where( "keyname NOT LIKE '%:MWSession:%'" )
+ 			->caller( __METHOD__ )
+ 			->execute();
+ 

--- a/pkgs/by-name/me/mediawiki/package.nix
+++ b/pkgs/by-name/me/mediawiki/package.nix
@@ -26,6 +26,10 @@ stdenvNoCC.mkDerivation rec {
       '';
       hash = "sha256-bhfw5CW4EEpr2GTGda3va+EmM/vK6AqBfyoCcsSiqNQ=";
     })
+
+    # NixOS runs the update script on every start as we might need to run some migrations.
+    # Normally this clears all active sessions, for usability we do not do that.
+    ./keep-session-object-cache.diff
   ];
 
   postPatch = ''

--- a/pkgs/by-name/me/mediawiki/package.nix
+++ b/pkgs/by-name/me/mediawiki/package.nix
@@ -14,6 +14,12 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-XqjB8yHJ+Nuk0aweTsoYJ/sTUZ1KIZDiOfUUMgWKQmk=";
   };
 
+  patches = [
+    # NixOS runs the update script on every start as we might need to run some migrations.
+    # Normally this clears all active sessions, for usability we do not do that.
+    ./keep-session-object-cache.diff
+  ];
+
   postPatch = ''
     substituteInPlace includes/installer/CliInstaller.php \
       --replace-fail '$vars = Installer::getExistingLocalSettings();' '$vars = null;'


### PR DESCRIPTION
Closes #476338

Tested a similar patch on stable (casing of the filename changes)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
