### PR TITLE
flameshot: 13.3.0 -> 14.0rc1

### DIFF
--- a/pkgs/by-name/fl/flameshot/load-missing-deps.patch
+++ b/pkgs/by-name/fl/flameshot/load-missing-deps.patch
@@ -1,43 +1,43 @@
---- a/CMakeLists.txt	2025-08-21 13:12:55
-+++ b/CMakeLists.txt	2025-08-21 13:16:26
-@@ -24,28 +24,8 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,27 +35,7 @@
  #Needed due to linker error with QtColorWidget
  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
  
-+find_package(QtColorWidgets REQUIRED)
- 
+-
 -# Dependency can be fetched via flatpak builder
 -if(EXISTS "${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets/CMakeLists.txt")
--    add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
+-  add_subdirectory("${CMAKE_SOURCE_DIR}/external/Qt-Color-Widgets" EXCLUDE_FROM_ALL)
 -else()
--    FetchContent_Declare(
--        qtColorWidgets
--        GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
--        GIT_TAG 352bc8f99bf2174d5724ee70623427aa31ddc26a
--    )
+-  FetchContent_Declare(
+-    qtColorWidgets
+-    GIT_REPOSITORY https://gitlab.com/mattbas/Qt-Color-Widgets.git
+-    GIT_TAG 5d52e907e50dc88cf969b41cea44665ff6c475b1
+-  )
 -  #Workaround for duplicate GUID in windows WIX installer
--  if (WIN32)
--      FetchContent_GetProperties(qtColorWidgets)
--      if(NOT qtcolorwidgets_POPULATED)
--          FetchContent_Populate(qtColorWidgets)
--          add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
--      endif()
+-  if(WIN32)
+-    FetchContent_GetProperties(qtColorWidgets)
+-    if(NOT qtcolorwidgets_POPULATED)
+-      FetchContent_Populate(qtColorWidgets)
+-      add_subdirectory(${qtcolorwidgets_SOURCE_DIR} ${qtcolorwidgets_BINARY_DIR} EXCLUDE_FROM_ALL)
+-    endif()
 -  else()
--      FetchContent_MakeAvailable(qtColorWidgets)
+-    FetchContent_MakeAvailable(qtColorWidgets)
 -  endif()
 -endif()
--
++find_package(QtColorWidgets REQUIRED)
+ 
  # This can be read from ${PROJECT_NAME} after project() is called
- if (APPLE)
-   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
-@@ -133,12 +113,7 @@
+ if(APPLE)
+@@ -124,12 +104,7 @@
+ # ToDo: Check if this is used anywhere
  option(BUILD_STATIC_LIBS ON)
  
- if (APPLE)
+ if(WIN32 OR APPLE)
 -  FetchContent_Declare(
--      qHotKey
--      GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
--      GIT_TAG master
+-    qHotKey
+-    GIT_REPOSITORY https://github.com/flameshot-org/QHotkey
+-    GIT_TAG master
 -  )
 -  FetchContent_MakeAvailable(QHotKey)
 +  find_package(QHotKey REQUIRED)

--- a/pkgs/by-name/fl/flameshot/package.nix
+++ b/pkgs/by-name/fl/flameshot/package.nix
@@ -19,13 +19,13 @@ assert stdenv.hostPlatform.isDarwin -> (!enableWlrSupport);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flameshot";
-  version = "13.3.0";
+  version = "14.0.rc1";
 
   src = fetchFromGitHub {
     owner = "flameshot-org";
     repo = "flameshot";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RyoLniRmJRinLUwgmaA4RprYAVHnoPxCP9LyhHfUPe0=";
+    hash = "sha256-7YvmZ9oSYD3VepIml4ixj40IPfTAR0R3MF8DuhdkHUM=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
Updates Flameshot to the first release candidate of v14.
Release notes: https://github.com/flameshot-org/flameshot/releases/tag/v14.0.rc1
Diff: https://github.com/flameshot-org/flameshot/compare/v13.3.0...v14.0.rc1

A notable change is a fix to something that has plagued users on GNOME Wayland, the clipboard copy failure. The capture window now stays briefly alive until the data is properly collected.

~~I am yet to build and run the package on macOS, will do so tomorrow.~~ Builds and runs on **aarch64-darwin**.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
