### PR TITLE
frawk: fix build

### DIFF
--- a/pkgs/by-name/fr/frawk/fix-prefetch-read-data.patch
+++ b/pkgs/by-name/fr/frawk/fix-prefetch-read-data.patch
@@ -1,0 +1,13 @@
+diff --git a/src/runtime/splitter/batch.rs b/src/runtime/splitter/batch.rs
+index 9b1bc21..d7eeaa0 100644
+--- a/src/runtime/splitter/batch.rs
++++ b/src/runtime/splitter/batch.rs
+@@ -1137,7 +1137,7 @@ mod generic {
+         macro_rules! iterate {
+             ($buf:expr) => {{
+                 #[cfg(feature = "unstable")]
+-                std::intrinsics::prefetch_read_data($buf.offset(128), 3);
++                std::intrinsics::prefetch_read_data::<_, 3>($buf.offset(128));
+                 let (s, mask, nl) = f(state, $buf);
+                 state = s;
+                 (mask, nl)

--- a/pkgs/by-name/fr/frawk/package.nix
+++ b/pkgs/by-name/fr/frawk/package.nix
@@ -27,8 +27,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-VraFR3Mp4mPh+39hw88R0q1p5iNkcQzvhRVNPwSxzU0=";
 
   patches = [
-    # This patch comes from https://github.com/ezrosent/frawk/pull/120, which was squash-merged.
+    # Remove these two patches after frawk is updated to a version including this fix
+    # This patch comes from https://github.com/ezrosent/frawk/pull/120
     ./fix-some-compiler-warnings-errors.patch
+    # From https://github.com/ezrosent/frawk/commit/35a79dc04933f38f98a7c8f6fc89ca09724702ab
+    ./fix-prefetch-read-data.patch
   ];
 
   buildInputs = [


### PR DESCRIPTION
- https://hydra.nixos.org/build/322289392

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
