### PR TITLE
icinga2-agent: restore backwards compatibility

### DIFF
--- a/pkgs/by-name/ic/icinga2-agent/package.nix
+++ b/pkgs/by-name/ic/icinga2-agent/package.nix
@@ -1,8 +1,17 @@
-{ icinga2 }:
-icinga2.override {
-  nameSuffix = "-agent";
-  withMysql = false;
-  withNotification = false;
-  withIcingadb = false;
-  withPerfdata = false;
-}
+{
+  icinga2,
+  ...
+}@args:
+
+(icinga2.override (
+  {
+    withMysql = false;
+    withNotification = false;
+    withIcingadb = false;
+    withPerfdata = false;
+  }
+  // removeAttrs args [ "icinga2" ]
+)).overrideAttrs
+  (old: {
+    pname = "icinga2-agent";
+  })

--- a/pkgs/by-name/ic/icinga2-agent/package.nix
+++ b/pkgs/by-name/ic/icinga2-agent/package.nix
@@ -1,9 +1,18 @@
-{ icinga2 }:
-icinga2.override {
-  nameSuffix = "-agent";
-  withMysql = false;
-  withNotification = false;
-  withIcingadb = false;
-  withPerfdata = false;
-  withOtel = false;
-}
+{
+  icinga2,
+  ...
+}@args:
+
+(icinga2.override (
+  {
+    withMysql = false;
+    withNotification = false;
+    withIcingadb = false;
+    withPerfdata = false;
+    withOtel = false;
+  }
+  // removeAttrs args [ "icinga2" ]
+)).overrideAttrs
+  (old: {
+    pname = "icinga2-agent";
+  })


### PR DESCRIPTION
This pull request refactors the `icinga2-agent` package definition to make it more flexible and maintainable. The main changes involve updating the function signature to accept additional arguments and ensuring the package name is set correctly.

**Refactoring and flexibility improvements:**

* Changed the function signature in `package.nix` to accept a set of arguments (`{ icinga2, ... }@args`) instead of just `icinga2`, allowing for greater extensibility.
* Used `removeAttrs` to exclude the `icinga2` attribute from the arguments passed to the override, preventing potential conflicts.

**Package naming:**

* Added an `overrideAttrs` block to explicitly set `pname` to `"icinga2-agent"`, ensuring the package name is correct.

before:

guyc@guyc:~/nixpkgs$ nix-build -E '(import ./. {})."icinga2-agent".override { withMysql = true; }'

error:

       … while calling a functor (an attribute set with a '__functor' attribute)
         at «string»:1:1:
            1| (import ./. {})."icinga2-agent".override { withMysql = true; }
             | ^

       … while calling a functor (an attribute set with a '__functor' attribute)
         at /home/guyc/nixpkgs/lib/customisation.nix:193:20:
          192|           */
          193|           newArgs: makeOverridable f (overrideWith newArgs)
             |                    ^
          194|         );

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: function 'anonymous lambda' called with unexpected argument 'withMysql'
       at /home/guyc/nixpkgs/pkgs/by-name/ic/icinga2-agent/package.nix:1:1:
            1| { icinga2 }:
             | ^
            2| icinga2.override {

  after:

guyc@guyc:~/nixpkgs$ nix-build -E '(import ./. {})."icinga2-agent".override { withMysql = true; }'
(after rebuild)
/nix/store/133s8x6f1qvaqs8j4hgyb33r51bns0wr-icinga2-agent-2.15.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
