### PR TITLE
bazel_9: fix linux-sandbox

### DIFF
--- a/pkgs/by-name/ba/bazel_9/package.nix
+++ b/pkgs/by-name/ba/bazel_9/package.nix
@@ -211,6 +211,11 @@ stdenv.mkDerivation rec {
     (replaceVars ./patches/usr_bin_env.patch {
       usrBinEnv = "${coreutils}/bin/env";
     })
+
+    # Bazel tries to run "/bin/true" to test if linux-sandbox works.
+    (replaceVars ./patches/linux_sandbox.patch {
+      binTrue = "${coreutils}/bin/true";
+    })
   ];
 
   meta = {

--- a/pkgs/by-name/ba/bazel_9/patches/linux_sandbox.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/linux_sandbox.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+index dc188b4ce2..46d338c9af 100644
+--- a/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
++++ b/src/main/java/com/google/devtools/build/lib/sandbox/LinuxSandboxedSpawnRunner.java
+@@ -106,7 +106,7 @@ final class LinuxSandboxedSpawnRunner extends AbstractSandboxSpawnRunner {
+     ImmutableList<String> linuxSandboxArgv =
+         LinuxSandboxCommandLineBuilder.commandLineBuilder(linuxSandbox)
+             .setTimeout(options.getLocalSigkillGraceSeconds())
+-            .buildForCommand(ImmutableList.of("/bin/true"));
++            .buildForCommand(ImmutableList.of("@binTrue@"));
+     ImmutableMap<String, String> env = ImmutableMap.of();
+     Path execRoot = cmdEnv.getExecRoot();
+     File cwd = execRoot.getPathFile();


### PR DESCRIPTION
Applying PR #461754 to bazel_9.

I want to merge the bazel 8 and 9 packages eventually. Before doing so, we need to align them as much as possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
