### PR TITLE
bats: work around parallelized test break

### DIFF
--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -246,13 +246,15 @@ resholve.mkDerivation rec {
     # to see when updates would break things, include packages
     # that use nixpkgs' bats for testing (as long as they
     # aren't massive builds)
-    inherit bash-preexec locate-dominating-file packcc;
+    inherit bash-preexec locate-dominating-file;
     resholve = resholve.tests.cli;
   }
   // lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
-    # TODO: kikit's kicad dependency is marked broken on darwin atm
-    # may be able to fold this up if that resolves.
-    inherit kikit;
+    # TODO:
+    # - kikit's kicad dependency is marked broken on darwin atm
+    #   may be able to fold this up if that resolves.
+    # - packcc's tests currently broken on darwin (apr 2026)
+    inherit kikit packcc;
   };
 
   meta = {

--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -208,6 +208,9 @@ resholve.mkDerivation rec {
     upstream = bats.unresholved.overrideAttrs (old: {
       name = "${bats.name}-tests";
       dontInstall = true; # just need the build directory
+      # after 411981, make-symlinks-relative breaks a parallelization test:
+      # "setup_file is not over parallelized"
+      dontRewriteSymlinks = true;
       nativeInstallCheckInputs = [
         ncurses
         parallel # skips some tests if it can't detect


### PR DESCRIPTION
Resist entropy:
- work around test failure induced by update to `make-symlinks-relative` hook: https://github.com/NixOS/nixpkgs/pull/411981#issuecomment-4193060193
- move `packcc` test to !darwin since it is currently broken on macOS https://github.com/NixOS/nixpkgs/pull/501604#issuecomment-4195968503

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
