### PR TITLE
gtk3: fall back to packaged schemas for internal settings

### DIFF
--- a/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
@@ -31,6 +31,10 @@
     if optional schema exists. Its invocation will be replaced with TRUE
     for known schemas.
 
+  - `preferDefaultSchemaSource`: when true, generated patches will first
+    look up the schema in the default schema source and only fall back to
+    the hardcoded schema directory if it is missing there.
+
   - `patches`: A list of patches to apply before generating the patch.
 
   Example:
@@ -59,8 +63,16 @@
   patches ? [ ],
   schemaIdToVariableMapping,
   schemaExistsFunction ? null,
+  preferDefaultSchemaSource ? false,
 }:
 
+let
+  spFile =
+    if preferDefaultSchemaSource then
+      ./hardcode-gsettings-default-first.cocci
+    else
+      ./hardcode-gsettings.cocci;
+in
 runCommand "hardcode-gsettings.patch"
   {
     inherit src patches;
@@ -79,6 +91,6 @@ runCommand "hardcode-gsettings.patch"
     cp ${builtins.toFile "glib-schema-exists-function.json" (builtins.toJSON schemaExistsFunction)} ./glib-schema-exists-function.json
     git init
     git add -A
-    spatch --sp-file "${./hardcode-gsettings.cocci}" --dir . --in-place
+    spatch --sp-file "${spFile}" --dir . --in-place
     git diff > "$out"
   ''

--- a/pkgs/build-support/make-hardcode-gsettings-patch/hardcode-gsettings-default-first.cocci
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/hardcode-gsettings-default-first.cocci
@@ -1,0 +1,192 @@
+/**
+ * Since Nix does not have a standard location like /usr/share where GSettings system
+ * could look for schemas, we need to point the software to a correct location somehow.
+ * For executables, we handle this using wrappers but this is not an option for libraries like e-d-s.
+ * Instead, we patch the source code to look for the schema in a schema source
+ * through a hardcoded path to the schema.
+ *
+ * This variant keeps the default schema source first and only falls back to a hardcoded
+ * directory when the schema is missing there.
+ *
+ * For each schema id referenced in the source code (e.g. org.gnome.evolution),
+ * a variable name such as `EVOLUTION` must be provided in the ./glib-schema-to-var.json JSON file.
+ * It will end up in the resulting patch as `@EVOLUTION@` placeholder, which should be replaced at build time
+ * with a path to the directory containing a `gschemas.compiled` file that includes the schema.
+ */
+
+@initialize:python@
+@@
+import json
+
+cpp_constants = {}
+
+def register_cpp_constant(const_name, val):
+    cpp_constants[const_name] = val.strip()
+
+def resolve_cpp_constant(const_name):
+    return cpp_constants.get(const_name, const_name)
+
+with open("./glib-schema-to-var.json") as mapping_file:
+    schema_to_var = json.load(mapping_file);
+
+def get_schema_directory(schema_id):
+    # Sometimes the schema id is referenced using C preprocessor #define constant in the same file
+    # let’s try to resolve it first.
+    schema_id = resolve_cpp_constant(schema_id.strip()).strip('"')
+    if schema_id in schema_to_var:
+        return f'"@{schema_to_var[schema_id]}@"'
+    raise Exception(f"Unknown schema path {schema_id!r}, please add it to ./glib-schema-to-var.json")
+
+
+@script:python schema_exists_fn@
+fn;
+@@
+import json
+
+with open("./glib-schema-exists-function.json") as fn_file:
+    if (fn := json.load(fn_file)):
+        coccinelle.fn = fn
+
+
+@find_cpp_constants@
+identifier const_name;
+expression val;
+@@
+
+#define const_name val
+
+@script:python record_cpp_constants depends on find_cpp_constants@
+const_name << find_cpp_constants.const_name;
+val << find_cpp_constants.val;
+@@
+
+register_cpp_constant(const_name, val)
+
+
+@depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_ID;
+expression settings;
+// Coccinelle does not like autocleanup macros in + sections,
+// let’s use fresh id with concatenation to produce the code as a string.
+fresh identifier schema_source_decl = "g_autoptr(GSettingsSchemaSource) " ## "schema_source = NULL";
+fresh identifier schema_decl = "g_autoptr(GSettingsSchema) " ## "schema = NULL";
+fresh identifier SCHEMA_DIRECTORY = script:python(SCHEMA_ID) { get_schema_directory(SCHEMA_ID) };
+@@
+-settings = g_settings_new(SCHEMA_ID);
++{
++	GSettingsSchemaSource *default_schema_source;
++	schema_source_decl;
++	schema_decl;
++	default_schema_source = g_settings_schema_source_get_default();
++	if (default_schema_source != NULL)
++		schema = g_settings_schema_source_lookup(default_schema_source, SCHEMA_ID, TRUE);
++	if (schema == NULL) {
++		schema_source = g_settings_schema_source_new_from_directory(SCHEMA_DIRECTORY,
++		                                                            default_schema_source,
++		                                                            TRUE,
++		                                                            NULL);
++		schema = g_settings_schema_source_lookup(schema_source, SCHEMA_ID, FALSE);
++	}
++	settings = g_settings_new_full(schema, NULL, NULL);
++}
+
+
+@depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_ID;
+expression settings;
+expression BACKEND;
+// Coccinelle does not like autocleanup macros in + sections,
+// let’s use fresh id with concatenation to produce the code as a string.
+fresh identifier schema_source_decl = "g_autoptr(GSettingsSchemaSource) " ## "schema_source = NULL";
+fresh identifier schema_decl = "g_autoptr(GSettingsSchema) " ## "schema = NULL";
+fresh identifier SCHEMA_DIRECTORY = script:python(SCHEMA_ID) { get_schema_directory(SCHEMA_ID) };
+@@
+-settings = g_settings_new_with_backend(SCHEMA_ID, BACKEND);
++{
++   GSettingsSchemaSource *default_schema_source;
++   schema_source_decl;
++   schema_decl;
++   default_schema_source = g_settings_schema_source_get_default();
++   if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source, SCHEMA_ID, TRUE);
++   if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory(SCHEMA_DIRECTORY,
++		                                                            default_schema_source,
++		                                                            TRUE,
++		                                                            NULL);
++      schema = g_settings_schema_source_lookup(schema_source, SCHEMA_ID, FALSE);
++   }
++   settings = g_settings_new_full(schema, BACKEND, NULL);
++}
+
+
+@depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_ID;
+expression settings;
+expression BACKEND;
+expression PATH;
+// Coccinelle does not like autocleanup macros in + sections,
+// let’s use fresh id with concatenation to produce the code as a string.
+fresh identifier schema_source_decl = "g_autoptr(GSettingsSchemaSource) " ## "schema_source = NULL";
+fresh identifier schema_decl = "g_autoptr(GSettingsSchema) " ## "schema = NULL";
+fresh identifier SCHEMA_DIRECTORY = script:python(SCHEMA_ID) { get_schema_directory(SCHEMA_ID) };
+@@
+-settings = g_settings_new_with_backend_and_path(SCHEMA_ID, BACKEND, PATH);
++{
++   GSettingsSchemaSource *default_schema_source;
++   schema_source_decl;
++   schema_decl;
++   default_schema_source = g_settings_schema_source_get_default();
++   if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source, SCHEMA_ID, TRUE);
++   if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory(SCHEMA_DIRECTORY,
++		                                                            default_schema_source,
++		                                                            TRUE,
++		                                                            NULL);
++      schema = g_settings_schema_source_lookup(schema_source, SCHEMA_ID, FALSE);
++   }
++   settings = g_settings_new_full(schema, BACKEND, PATH);
++}
+
+
+@depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_ID;
+expression settings;
+expression PATH;
+// Coccinelle does not like autocleanup macros in + sections,
+// let’s use fresh id with concatenation to produce the code as a string.
+fresh identifier schema_source_decl = "g_autoptr(GSettingsSchemaSource) " ## "schema_source = NULL";
+fresh identifier schema_decl = "g_autoptr(GSettingsSchema) " ## "schema = NULL";
+fresh identifier SCHEMA_DIRECTORY = script:python(SCHEMA_ID) { get_schema_directory(SCHEMA_ID) };
+@@
+-settings = g_settings_new_with_path(SCHEMA_ID, PATH);
++{
++   GSettingsSchemaSource *default_schema_source;
++   schema_source_decl;
++   schema_decl;
++   default_schema_source = g_settings_schema_source_get_default();
++   if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source, SCHEMA_ID, TRUE);
++   if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory(SCHEMA_DIRECTORY,
++		                                                            default_schema_source,
++		                                                            TRUE,
++		                                                            NULL);
++      schema = g_settings_schema_source_lookup(schema_source, SCHEMA_ID, FALSE);
++   }
++   settings = g_settings_new_full(schema, NULL, PATH);
++}
+
+
+@replace_schema_exists_fns depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_ID;
+identifier schema_exists_fn.fn;
+@@
+-fn(SCHEMA_ID)
++TRUE

--- a/pkgs/by-name/gt/gtk3/package.nix
+++ b/pkgs/by-name/gt/gtk3/package.nix
@@ -215,6 +215,14 @@ stdenv.mkDerivation (finalAttrs: {
   # See: https://developer.gnome.org/gtk3/stable/gtk-building.html#extra-configuration-options
   env.NIX_CFLAGS_COMPILE = "-DG_ENABLE_DEBUG -DG_DISABLE_CAST_CHECKS";
 
+  # The patch needs build-time substitution because it hardcodes GTK's own
+  # compiled schema directory in the final $out as a fallback lookup path.
+  prePatch = ''
+    substitute ${./patches/3.0-hardcode-gsettings.patch} hardcode-gsettings.patch \
+      --subst-var-by gtk ${glib.makeSchemaPath "$out" "${finalAttrs.pname}-${finalAttrs.version}"}
+    patches="$patches $PWD/hardcode-gsettings.patch"
+  '';
+
   postPatch = ''
     # See https://github.com/NixOS/nixpkgs/issues/132259
     substituteInPlace meson.build \

--- a/pkgs/by-name/gt/gtk3/package.nix
+++ b/pkgs/by-name/gt/gtk3/package.nix
@@ -57,6 +57,8 @@
   cups,
   broadwaySupport ? true,
   wayland-scanner,
+  _experimental-update-script-combinators,
+  makeHardcodeGsettingsPatch,
   testers,
 }:
 
@@ -281,11 +283,32 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    updateScript = gnome.updateScript {
-      packageName = "gtk";
-      attrPath = "gtk3";
-      freeze = true;
+    hardcodeGsettingsPatch = makeHardcodeGsettingsPatch {
+      schemaIdToVariableMapping = {
+        "org.gtk.Settings.ColorChooser" = "gtk";
+        "org.gtk.Settings.EmojiChooser" = "gtk";
+        "org.gtk.Settings.FileChooser" = "gtk";
+        "org.gtk.Demo" = "gtk";
+        "org.gtk.exampleapp" = "gtk"; # Not actually installed.
+      };
+      inherit (finalAttrs) src;
+      preferDefaultSchemaSource = true;
     };
+
+    updateScript =
+      let
+        updateSource = gnome.updateScript {
+          packageName = "gtk";
+          attrPath = "gtk3";
+          freeze = true;
+        };
+        updatePatch = _experimental-update-script-combinators.copyAttrOutputToFile "gtk3.hardcodeGsettingsPatch" ./patches/3.0-hardcode-gsettings.patch;
+      in
+      _experimental-update-script-combinators.sequence [
+        updateSource
+        updatePatch
+      ];
+
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
   };
 

--- a/pkgs/by-name/gt/gtk3/patches/3.0-hardcode-gsettings.patch
+++ b/pkgs/by-name/gt/gtk3/patches/3.0-hardcode-gsettings.patch
@@ -1,98 +1,493 @@
-diff --git a/gtk/gtkcolorchooserwidget.c b/gtk/gtkcolorchooserwidget.c
-index 9fca31d..b37057b 100644
---- a/gtk/gtkcolorchooserwidget.c
-+++ b/gtk/gtkcolorchooserwidget.c
-@@ -545,7 +545,28 @@ gtk_color_chooser_widget_init (GtkColorChooserWidget *cc)
-   gtk_color_swatch_set_selectable (GTK_COLOR_SWATCH (button), FALSE);
-   gtk_container_add (GTK_CONTAINER (box), button);
-
--  cc->priv->settings = g_settings_new ("org.gtk.Settings.ColorChooser");
+diff --git a/demos/gtk-demo/application.c b/demos/gtk-demo/application.c
+index 289f73a..43491e6 100644
+--- a/demos/gtk-demo/application.c
++++ b/demos/gtk-demo/application.c
+@@ -384,7 +384,23 @@ demo_application_init (DemoApplication *app)
+   GSettings *settings;
+   GAction *action;
+ 
+-  settings = g_settings_new ("org.gtk.Demo");
 +  {
 +    GSettingsSchemaSource *default_schema_source;
 +    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
 +    g_autoptr(GSettingsSchema) schema = NULL;
-+
-+    default_schema_source = g_settings_schema_source_get_default ();
++    default_schema_source = g_settings_schema_source_get_default();
 +    if (default_schema_source != NULL)
-+      schema = g_settings_schema_source_lookup (default_schema_source,
-+                                                "org.gtk.Settings.ColorChooser",
-+                                                TRUE);
-+
-+    if (schema == NULL)
-+      {
-+        schema_source = g_settings_schema_source_new_from_directory ("@gtk@", NULL, TRUE, NULL);
-+        schema = g_settings_schema_source_lookup (schema_source,
-+                                                  "org.gtk.Settings.ColorChooser",
-+                                                  FALSE);
-+      }
-+
-+    cc->priv->settings = g_settings_new_full (schema, NULL, NULL);
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.Demo", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source, "org.gtk.Demo",
++                                               FALSE);
++    }
++    settings = g_settings_new_full(schema, NULL, NULL);
 +  }
-+
+ 
+   g_action_map_add_action_entries (G_ACTION_MAP (app),
+                                    app_entries, G_N_ELEMENTS (app_entries),
+@@ -411,7 +427,23 @@ demo_application_window_store_state (DemoApplicationWindow *win)
+ {
+   GSettings *settings;
+ 
+-  settings = g_settings_new ("org.gtk.Demo");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.Demo", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source, "org.gtk.Demo",
++                                               FALSE);
++    }
++    settings = g_settings_new_full(schema, NULL, NULL);
++  }
+   g_settings_set (settings, "window-size", "(ii)", win->width, win->height);
+   g_settings_set_boolean (settings, "maximized", win->maximized);
+   g_settings_set_boolean (settings, "fullscreen", win->fullscreen);
+@@ -423,7 +455,23 @@ demo_application_window_load_state (DemoApplicationWindow *win)
+ {
+   GSettings *settings;
+ 
+-  settings = g_settings_new ("org.gtk.Demo");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.Demo", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source, "org.gtk.Demo",
++                                               FALSE);
++    }
++    settings = g_settings_new_full(schema, NULL, NULL);
++  }
+   g_settings_get (settings, "window-size", "(ii)", &win->width, &win->height);
+   win->maximized = g_settings_get_boolean (settings, "maximized");
+   win->fullscreen = g_settings_get_boolean (settings, "fullscreen");
+diff --git a/examples/application10/exampleappprefs.c b/examples/application10/exampleappprefs.c
+index 9b3cc33..6c646aa 100644
+--- a/examples/application10/exampleappprefs.c
++++ b/examples/application10/exampleappprefs.c
+@@ -27,7 +27,23 @@ example_app_prefs_init (ExampleAppPrefs *prefs)
+ 
+   priv = example_app_prefs_get_instance_private (prefs);
+   gtk_widget_init_template (GTK_WIDGET (prefs));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "font",
+                    priv->font, "font",
+diff --git a/examples/application10/exampleappwin.c b/examples/application10/exampleappwin.c
+index 294650f..7d9c37b 100644
+--- a/examples/application10/exampleappwin.c
++++ b/examples/application10/exampleappwin.c
+@@ -203,7 +203,23 @@ example_app_window_init (ExampleAppWindow *win)
+ 
+   priv = example_app_window_get_instance_private (win);
+   gtk_widget_init_template (GTK_WIDGET (win));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "transition",
+                    priv->stack, "transition-type",
+diff --git a/examples/application5/exampleappwin.c b/examples/application5/exampleappwin.c
+index d716f2a..db256e6 100644
+--- a/examples/application5/exampleappwin.c
++++ b/examples/application5/exampleappwin.c
+@@ -25,7 +25,23 @@ example_app_window_init (ExampleAppWindow *win)
+ 
+   priv = example_app_window_get_instance_private (win);
+   gtk_widget_init_template (GTK_WIDGET (win));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "transition",
+                    priv->stack, "transition-type",
+diff --git a/examples/application6/exampleappprefs.c b/examples/application6/exampleappprefs.c
+index 9b3cc33..6c646aa 100644
+--- a/examples/application6/exampleappprefs.c
++++ b/examples/application6/exampleappprefs.c
+@@ -27,7 +27,23 @@ example_app_prefs_init (ExampleAppPrefs *prefs)
+ 
+   priv = example_app_prefs_get_instance_private (prefs);
+   gtk_widget_init_template (GTK_WIDGET (prefs));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "font",
+                    priv->font, "font",
+diff --git a/examples/application6/exampleappwin.c b/examples/application6/exampleappwin.c
+index 45e7de4..1b3b90e 100644
+--- a/examples/application6/exampleappwin.c
++++ b/examples/application6/exampleappwin.c
+@@ -25,7 +25,23 @@ example_app_window_init (ExampleAppWindow *win)
+ 
+   priv = example_app_window_get_instance_private (win);
+   gtk_widget_init_template (GTK_WIDGET (win));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "transition",
+                    priv->stack, "transition-type",
+diff --git a/examples/application7/exampleappprefs.c b/examples/application7/exampleappprefs.c
+index 9b3cc33..6c646aa 100644
+--- a/examples/application7/exampleappprefs.c
++++ b/examples/application7/exampleappprefs.c
+@@ -27,7 +27,23 @@ example_app_prefs_init (ExampleAppPrefs *prefs)
+ 
+   priv = example_app_prefs_get_instance_private (prefs);
+   gtk_widget_init_template (GTK_WIDGET (prefs));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "font",
+                    priv->font, "font",
+diff --git a/examples/application7/exampleappwin.c b/examples/application7/exampleappwin.c
+index 2980393..0fb293d 100644
+--- a/examples/application7/exampleappwin.c
++++ b/examples/application7/exampleappwin.c
+@@ -77,7 +77,23 @@ example_app_window_init (ExampleAppWindow *win)
+ 
+   priv = example_app_window_get_instance_private (win);
+   gtk_widget_init_template (GTK_WIDGET (win));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "transition",
+                    priv->stack, "transition-type",
+diff --git a/examples/application8/exampleappprefs.c b/examples/application8/exampleappprefs.c
+index 9b3cc33..6c646aa 100644
+--- a/examples/application8/exampleappprefs.c
++++ b/examples/application8/exampleappprefs.c
+@@ -27,7 +27,23 @@ example_app_prefs_init (ExampleAppPrefs *prefs)
+ 
+   priv = example_app_prefs_get_instance_private (prefs);
+   gtk_widget_init_template (GTK_WIDGET (prefs));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "font",
+                    priv->font, "font",
+diff --git a/examples/application8/exampleappwin.c b/examples/application8/exampleappwin.c
+index 3570d45..f6258e6 100644
+--- a/examples/application8/exampleappwin.c
++++ b/examples/application8/exampleappwin.c
+@@ -166,7 +166,23 @@ example_app_window_init (ExampleAppWindow *win)
+ 
+   priv = example_app_window_get_instance_private (win);
+   gtk_widget_init_template (GTK_WIDGET (win));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "transition",
+                    priv->stack, "transition-type",
+diff --git a/examples/application9/exampleappprefs.c b/examples/application9/exampleappprefs.c
+index 9b3cc33..6c646aa 100644
+--- a/examples/application9/exampleappprefs.c
++++ b/examples/application9/exampleappprefs.c
+@@ -27,7 +27,23 @@ example_app_prefs_init (ExampleAppPrefs *prefs)
+ 
+   priv = example_app_prefs_get_instance_private (prefs);
+   gtk_widget_init_template (GTK_WIDGET (prefs));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "font",
+                    priv->font, "font",
+diff --git a/examples/application9/exampleappwin.c b/examples/application9/exampleappwin.c
+index 15ceb1e..945b930 100644
+--- a/examples/application9/exampleappwin.c
++++ b/examples/application9/exampleappwin.c
+@@ -203,7 +203,23 @@ example_app_window_init (ExampleAppWindow *win)
+ 
+   priv = example_app_window_get_instance_private (win);
+   gtk_widget_init_template (GTK_WIDGET (win));
+-  priv->settings = g_settings_new ("org.gtk.exampleapp");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++    default_schema_source = g_settings_schema_source_get_default();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.exampleapp", TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.exampleapp", FALSE);
++    }
++    priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
+ 
+   g_settings_bind (priv->settings, "transition",
+                    priv->stack, "transition-type",
+diff --git a/gtk/gtkcolorchooserwidget.c b/gtk/gtkcolorchooserwidget.c
+index 9fca31d..62a916d 100644
+--- a/gtk/gtkcolorchooserwidget.c
++++ b/gtk/gtkcolorchooserwidget.c
+@@ -545,7 +545,26 @@ gtk_color_chooser_widget_init (GtkColorChooserWidget *cc)
+   gtk_color_swatch_set_selectable (GTK_COLOR_SWATCH (button), FALSE);
+   gtk_container_add (GTK_CONTAINER (box), button);
+ 
+-  cc->priv->settings = g_settings_new ("org.gtk.Settings.ColorChooser");
++  {
++      GSettingsSchemaSource *default_schema_source;
++      g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++      g_autoptr(GSettingsSchema) schema = NULL;
++      default_schema_source = g_settings_schema_source_get_default();
++      if (default_schema_source != NULL)
++        schema = g_settings_schema_source_lookup(default_schema_source,
++                                                 "org.gtk.Settings.ColorChooser",
++                                                 TRUE);
++      if (schema == NULL) {
++        schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                    default_schema_source,
++                                                                    TRUE,
++                                                                    NULL);
++        schema = g_settings_schema_source_lookup(schema_source,
++                                                 "org.gtk.Settings.ColorChooser",
++                                                 FALSE);
++      }
++      cc->priv->settings = g_settings_new_full(schema, NULL, NULL);
++  }
    variant = g_settings_get_value (cc->priv->settings, "custom-colors");
    g_variant_iter_init (&iter, variant);
    i = 0;
 diff --git a/gtk/gtkemojichooser.c b/gtk/gtkemojichooser.c
-index 1ef9e51..16de780 100644
+index 1ef9e51..7fd8c7b 100644
 --- a/gtk/gtkemojichooser.c
 +++ b/gtk/gtkemojichooser.c
 @@ -851,7 +851,25 @@ gtk_emoji_chooser_init (GtkEmojiChooser *chooser)
  {
    GtkAdjustment *adj;
-
+ 
 -  chooser->settings = g_settings_new ("org.gtk.Settings.EmojiChooser");
 +  {
 +    GSettingsSchemaSource *default_schema_source;
 +    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
 +    g_autoptr(GSettingsSchema) schema = NULL;
-+
-+    default_schema_source = g_settings_schema_source_get_default ();
++    default_schema_source = g_settings_schema_source_get_default();
 +    if (default_schema_source != NULL)
-+      schema = g_settings_schema_source_lookup (default_schema_source,
-+                                                "org.gtk.Settings.EmojiChooser",
-+                                                TRUE);
-+
-+    if (schema == NULL)
-+      {
-+        schema_source = g_settings_schema_source_new_from_directory ("@gtk@", NULL, TRUE, NULL);
-+        schema = g_settings_schema_source_lookup (schema_source, "org.gtk.Settings.EmojiChooser", FALSE);
-+      }
-+
-+    chooser->settings = g_settings_new_full (schema, NULL, NULL);
++      schema = g_settings_schema_source_lookup(default_schema_source,
++                                               "org.gtk.Settings.EmojiChooser",
++                                               TRUE);
++    if (schema == NULL) {
++      schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                  default_schema_source,
++                                                                  TRUE, NULL);
++      schema = g_settings_schema_source_lookup(schema_source,
++                                               "org.gtk.Settings.EmojiChooser",
++                                               FALSE);
++    }
++    chooser->settings = g_settings_new_full(schema, NULL, NULL);
 +  }
  
    gtk_widget_init_template (GTK_WIDGET (chooser));
-
-   adj = gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (chooser->scrolled_window));
+ 
 diff --git a/gtk/gtkfilechooserutils.c b/gtk/gtkfilechooserutils.c
-index 7965ab0..865a4fc 100644
+index 7965ab0..72f8385 100644
 --- a/gtk/gtkfilechooserutils.c
 +++ b/gtk/gtkfilechooserutils.c
 @@ -455,7 +455,26 @@ _gtk_file_chooser_get_settings_for_widget (GtkWidget *widget)
-
+ 
    if (G_UNLIKELY (settings == NULL))
      {
 -      settings = g_settings_new ("org.gtk.Settings.FileChooser");
-+      GSettingsSchemaSource *default_schema_source;
-+      g_autoptr(GSettingsSchemaSource) schema_source = NULL;
-+      g_autoptr(GSettingsSchema) schema = NULL;
-+
-+      default_schema_source = g_settings_schema_source_get_default ();
-+      if (default_schema_source != NULL)
-+        schema = g_settings_schema_source_lookup (default_schema_source,
-+                                                  "org.gtk.Settings.FileChooser",
-+                                                  TRUE);
-+
-+      if (schema == NULL)
-+        {
-+          schema_source = g_settings_schema_source_new_from_directory ("@gtk@", NULL, TRUE, NULL);
-+          schema = g_settings_schema_source_lookup (schema_source,
-+                                                    "org.gtk.Settings.FileChooser",
-+                                                    FALSE);
++      {
++        GSettingsSchemaSource *default_schema_source;
++        g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++        g_autoptr(GSettingsSchema) schema = NULL;
++        default_schema_source = g_settings_schema_source_get_default();
++        if (default_schema_source != NULL)
++          schema = g_settings_schema_source_lookup(default_schema_source,
++                                                   "org.gtk.Settings.FileChooser",
++                                                   TRUE);
++        if (schema == NULL) {
++          schema_source = g_settings_schema_source_new_from_directory("@gtk@",
++                                                                      default_schema_source,
++                                                                      TRUE,
++                                                                      NULL);
++          schema = g_settings_schema_source_lookup(schema_source,
++                                                   "org.gtk.Settings.FileChooser",
++                                                   FALSE);
 +        }
-+
-+      settings = g_settings_new_full (schema, NULL, NULL);
-+
++        settings = g_settings_new_full(schema, NULL, NULL);
++      }
        g_settings_delay (settings);
-
+ 
        g_object_set_qdata_full (G_OBJECT (gtksettings),

--- a/pkgs/by-name/gt/gtk3/patches/3.0-hardcode-gsettings.patch
+++ b/pkgs/by-name/gt/gtk3/patches/3.0-hardcode-gsettings.patch
@@ -1,0 +1,98 @@
+diff --git a/gtk/gtkcolorchooserwidget.c b/gtk/gtkcolorchooserwidget.c
+index 9fca31d..b37057b 100644
+--- a/gtk/gtkcolorchooserwidget.c
++++ b/gtk/gtkcolorchooserwidget.c
+@@ -545,7 +545,28 @@ gtk_color_chooser_widget_init (GtkColorChooserWidget *cc)
+   gtk_color_swatch_set_selectable (GTK_COLOR_SWATCH (button), FALSE);
+   gtk_container_add (GTK_CONTAINER (box), button);
+
+-  cc->priv->settings = g_settings_new ("org.gtk.Settings.ColorChooser");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++
++    default_schema_source = g_settings_schema_source_get_default ();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup (default_schema_source,
++                                                "org.gtk.Settings.ColorChooser",
++                                                TRUE);
++
++    if (schema == NULL)
++      {
++        schema_source = g_settings_schema_source_new_from_directory ("@gtk@", NULL, TRUE, NULL);
++        schema = g_settings_schema_source_lookup (schema_source,
++                                                  "org.gtk.Settings.ColorChooser",
++                                                  FALSE);
++      }
++
++    cc->priv->settings = g_settings_new_full (schema, NULL, NULL);
++  }
++
+   variant = g_settings_get_value (cc->priv->settings, "custom-colors");
+   g_variant_iter_init (&iter, variant);
+   i = 0;
+diff --git a/gtk/gtkemojichooser.c b/gtk/gtkemojichooser.c
+index 1ef9e51..16de780 100644
+--- a/gtk/gtkemojichooser.c
++++ b/gtk/gtkemojichooser.c
+@@ -851,7 +851,25 @@ gtk_emoji_chooser_init (GtkEmojiChooser *chooser)
+ {
+   GtkAdjustment *adj;
+
+-  chooser->settings = g_settings_new ("org.gtk.Settings.EmojiChooser");
++  {
++    GSettingsSchemaSource *default_schema_source;
++    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++    g_autoptr(GSettingsSchema) schema = NULL;
++
++    default_schema_source = g_settings_schema_source_get_default ();
++    if (default_schema_source != NULL)
++      schema = g_settings_schema_source_lookup (default_schema_source,
++                                                "org.gtk.Settings.EmojiChooser",
++                                                TRUE);
++
++    if (schema == NULL)
++      {
++        schema_source = g_settings_schema_source_new_from_directory ("@gtk@", NULL, TRUE, NULL);
++        schema = g_settings_schema_source_lookup (schema_source, "org.gtk.Settings.EmojiChooser", FALSE);
++      }
++
++    chooser->settings = g_settings_new_full (schema, NULL, NULL);
++  }
+ 
+   gtk_widget_init_template (GTK_WIDGET (chooser));
+
+   adj = gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (chooser->scrolled_window));
+diff --git a/gtk/gtkfilechooserutils.c b/gtk/gtkfilechooserutils.c
+index 7965ab0..865a4fc 100644
+--- a/gtk/gtkfilechooserutils.c
++++ b/gtk/gtkfilechooserutils.c
+@@ -455,7 +455,26 @@ _gtk_file_chooser_get_settings_for_widget (GtkWidget *widget)
+
+   if (G_UNLIKELY (settings == NULL))
+     {
+-      settings = g_settings_new ("org.gtk.Settings.FileChooser");
++      GSettingsSchemaSource *default_schema_source;
++      g_autoptr(GSettingsSchemaSource) schema_source = NULL;
++      g_autoptr(GSettingsSchema) schema = NULL;
++
++      default_schema_source = g_settings_schema_source_get_default ();
++      if (default_schema_source != NULL)
++        schema = g_settings_schema_source_lookup (default_schema_source,
++                                                  "org.gtk.Settings.FileChooser",
++                                                  TRUE);
++
++      if (schema == NULL)
++        {
++          schema_source = g_settings_schema_source_new_from_directory ("@gtk@", NULL, TRUE, NULL);
++          schema = g_settings_schema_source_lookup (schema_source,
++                                                    "org.gtk.Settings.FileChooser",
++                                                    FALSE);
++        }
++
++      settings = g_settings_new_full (schema, NULL, NULL);
++
+       g_settings_delay (settings);
+
+       g_object_set_qdata_full (G_OBJECT (gtksettings),

--- a/pkgs/test/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/test/make-hardcode-gsettings-patch/default.nix
@@ -66,6 +66,20 @@ in
     expected = ./fixtures/example-project-patched;
   };
 
+  defaultFirst = mkTest {
+    name = "default-first";
+    src = ./fixtures/example-project;
+    args = {
+      schemaIdToVariableMapping = {
+        "org.gnome.evolution-data-server.addressbook" = "EDS";
+        "org.gnome.evolution.calendar" = "EVO";
+        "org.gnome.seahorse.nautilus.window" = "SEANAUT";
+      };
+      preferDefaultSchemaSource = true;
+    };
+    expected = ./fixtures/example-project-patched-default-first;
+  };
+
   patches = mkTest {
     name = "patches";
     src = ./fixtures/example-project-wrapped-settings-constructor;

--- a/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project-patched-default-first/main.c
+++ b/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project-patched-default-first/main.c
@@ -1,0 +1,183 @@
+#include <gio/gio.h>
+#include <glib-object.h>
+
+void schema_id_literal() {
+  GSettings *settings;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.evolution-data-server.addressbook", TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@EDS@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, "org.gnome.evolution-data-server.addressbook", FALSE);
+    }
+    settings = g_settings_new_full(schema, NULL, NULL);
+  }
+  g_object_unref(settings);
+}
+
+#define SELF_UID_PATH_ID "org.gnome.evolution-data-server.addressbook"
+int schema_id_from_constant() {
+  GSettings *settings;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, SELF_UID_PATH_ID, TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@EDS@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, SELF_UID_PATH_ID, FALSE);
+    }
+    settings = g_settings_new_full(schema, NULL, NULL);
+  }
+  g_object_unref(settings);
+}
+
+void schema_id_autoptr() {
+  g_autoptr(GSettings) settings = NULL;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.evolution.calendar", TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@EVO@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, "org.gnome.evolution.calendar", FALSE);
+    }
+    settings = g_settings_new_full(schema, NULL, NULL);
+  }
+}
+
+void schema_id_with_backend() {
+  GSettings *settings;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.evolution-data-server.addressbook", TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@EDS@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, "org.gnome.evolution-data-server.addressbook", FALSE);
+    }
+    settings = g_settings_new_full(schema, g_settings_backend_get_default(), NULL);
+  }
+  g_object_unref(settings);
+}
+
+void schema_id_with_backend_and_path() {
+  GSettings *settings;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.seahorse.nautilus.window", TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@SEANAUT@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, "org.gnome.seahorse.nautilus.window", FALSE);
+    }
+    settings = g_settings_new_full(schema, g_settings_backend_get_default(), "/org/gnome/seahorse/nautilus/windows/123/");
+  }
+  g_object_unref(settings);
+}
+
+void schema_id_with_path() {
+  GSettings *settings;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.seahorse.nautilus.window", TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@SEANAUT@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, "org.gnome.seahorse.nautilus.window", FALSE);
+    }
+    settings = g_settings_new_full(schema, NULL, "/org/gnome/seahorse/nautilus/windows/123/");
+  }
+  g_object_unref(settings);
+}
+
+void exists_fn_guard() {
+  if (!e_ews_common_utils_gsettings_schema_exists("org.gnome.evolution.calendar")) {
+    return;
+  }
+
+  g_autoptr(GSettings) settings = NULL;
+  {
+    GSettingsSchemaSource *default_schema_source;
+    g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+    g_autoptr(GSettingsSchema) schema = NULL;
+    default_schema_source = g_settings_schema_source_get_default();
+    if (default_schema_source != NULL)
+      schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.evolution.calendar", TRUE);
+    if (schema == NULL) {
+      schema_source = g_settings_schema_source_new_from_directory("@EVO@", default_schema_source, TRUE, NULL);
+      schema = g_settings_schema_source_lookup(schema_source, "org.gnome.evolution.calendar", FALSE);
+    }
+    settings = g_settings_new_full(schema, NULL, NULL);
+  }
+}
+
+void exists_fn_nested() {
+  if (e_ews_common_utils_gsettings_schema_exists("org.gnome.evolution.calendar")) {
+    g_autoptr(GSettings) settings = NULL;
+    {
+      GSettingsSchemaSource *default_schema_source;
+      g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+      g_autoptr(GSettingsSchema) schema = NULL;
+      default_schema_source = g_settings_schema_source_get_default();
+      if (default_schema_source != NULL)
+        schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.evolution.calendar", TRUE);
+      if (schema == NULL) {
+        schema_source = g_settings_schema_source_new_from_directory("@EVO@", default_schema_source, TRUE, NULL);
+        schema = g_settings_schema_source_lookup(schema_source, "org.gnome.evolution.calendar", FALSE);
+      }
+      settings = g_settings_new_full(schema, NULL, NULL);
+    }
+  }
+}
+
+void exists_fn_unknown() {
+  if (e_ews_common_utils_gsettings_schema_exists("org.gnome.foo")) {
+    g_autoptr(GSettings) settings = NULL;
+    {
+      GSettingsSchemaSource *default_schema_source;
+      g_autoptr(GSettingsSchemaSource) schema_source = NULL;
+      g_autoptr(GSettingsSchema) schema = NULL;
+      default_schema_source = g_settings_schema_source_get_default();
+      if (default_schema_source != NULL)
+        schema = g_settings_schema_source_lookup(default_schema_source, "org.gnome.evolution.calendar", TRUE);
+      if (schema == NULL) {
+        schema_source = g_settings_schema_source_new_from_directory("@EVO@", default_schema_source, TRUE, NULL);
+        schema = g_settings_schema_source_lookup(schema_source, "org.gnome.evolution.calendar", FALSE);
+      }
+      settings = g_settings_new_full(schema, NULL, NULL);
+    }
+  }
+}
+
+int main() {
+  schema_id_literal();
+  schema_id_from_constant();
+  schema_id_autoptr();
+  schema_id_with_backend();
+  schema_id_with_backend_and_path();
+  schema_id_with_path();
+  exists_fn_guard();
+  exists_fn_nested();
+  exists_fn_unknown();
+
+  return 0;
+}


### PR DESCRIPTION
follow up from: #271037

## Summary

Some Qt applications in nixpkgs crash when Qt loads GTK integration and GTK tries to instantiate its own GSettings schemas, most visibly in the GTK file chooser path.

Typical failures look like:

- `Settings schema 'org.gtk.Settings.FileChooser' is not installed`
- `No GSettings schemas are installed on the system`

The root cause is that GTK 3 library code directly constructs `GSettings` objects for its own schemas, while those schemas live in package-specific paths in nixpkgs instead of a global location like `/usr/share`. `wrapGAppsHook3` often masks the issue by extending `XDG_DATA_DIRS`, but Qt applications wrapped only with `wrapQtAppsHook` can still hit the crash depending on the runtime environment.

## Solution

Patch GTK 3 itself so that when GTK asks for one of its own internal schemas, it:

1. looks in the normal default schema source first
2. if the schema is missing there, falls back to GTK's own packaged schema directory
3. keeps the default schema source as the fallback source's parent so overrides and schema references continue to work

That parent relationship is intentional. It does not change the default-first lookup order, because the target schema is still looked up in the fallback source with `recursive = FALSE`, but it allows fallback-loaded schemas to resolve references through the default source[^1].

[^1]: https://docs.gtk.org/gio/ctor.SettingsSchemaSource.new_from_directory.html#description

This covers the crash-relevant GTK library schemas:

- `org.gtk.Settings.FileChooser`
- `org.gtk.Settings.ColorChooser`
- `org.gtk.Settings.EmojiChooser`

The fix is deliberately scoped to GTK's own internal schemas rather than arbitrary third-party schemas.

### Default-first approach

A hardcoded-first patch would make GTK's packaged schema win even when the schema is already available through the normal default source, and it could weaken environment-driven override behavior. @jtojnar [called this out](https://github.com/NixOS/nixpkgs/pull/271037#discussion_r1409920197) on the earlier draft PR and suggested checking the default source first, then falling back to the hardcoded path only when needed. This PR follows that approach.

### Automation

The PR also extends `makeHardcodeGsettingsPatch` with an opt-in default-first mode and uses it for `gtk3` so future GTK updates can regenerate the patch without losing these semantics.

The generated patch currently also includes GTK demo and example callsites because the helper runs over the GTK source tree. Those hunks are not needed for the original Qt crash, but they are harmless and kept to avoid adding extra helper complexity in this change.

## Testing

I tested 3 previously crashing applications against the patched `gtk3`:

- `brewtarget`[^2] no longer crashed when run with a deliberately stripped `XDG_DATA_DIRS`, while the unpatched nixpkgs build still did
- `scribus`[^3] also stopped crashing on startup, while the unpatched nixpkgs (nixos-25.11) build still crashed
- `ovito` doesn't crash when launching filechooser with these changes. confirmed the crash on master.

[^2]: tested before https://github.com/NixOS/nixpkgs/commit/e7b6af9d4f189e1fc58eec32c01529dc6a05fe43 landed
[^3]: tested before https://github.com/NixOS/nixpkgs/commit/23b5ac11e2181d087c884c6426591d7fdeb0962b

You can download the pre-built `ovito` from this PR to test:
```sh
nix-store -r /nix/store/04czs9mrbmhzdlwspw8i2r0wc1nqn90n-ovito-3.15.2/bin/ovito \
  --option substituters 'https://ilkecan.cachix.org https://cache.nixos.org/' \
  --option trusted-public-keys '
  ilkecan.cachix.org-1:hXb7Vo9EzaXiEb0elvG6Tt5TrP3zrcadyoX8c+lbeCY=
  cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
  '
```

## Follow-up cleanup
After this lands, we should audit recent wrapGAppsHook3 additions on Qt packages and remove the ones that were only added to work around GTK's internal schema lookup failures. This should be done selectively, since some packages may still need wrapGAppsHook3 for unrelated runtime data.

### Relevant issues & PRs (not comprehensive)
- https://github.com/NixOS/nixpkgs/issues/487961
- https://github.com/NixOS/nixpkgs/issues/495741
- https://github.com/NixOS/nixpkgs/issues/507195
- https://github.com/NixOS/nixpkgs/issues/467783
- https://github.com/NixOS/nixpkgs/issues/477406
- https://github.com/NixOS/nixpkgs/issues/275229
- https://github.com/NixOS/nixpkgs/issues/87667
- https://github.com/NixOS/nixpkgs/issues/149812
- https://github.com/NixOS/nixpkgs/issues/494628
- https://github.com/NixOS/nixpkgs/issues/476717
- https://github.com/NixOS/nixpkgs/issues/467263
- https://github.com/NixOS/nixpkgs/issues/469503
- https://github.com/NixOS/nixpkgs/issues/466563
- https://github.com/NixOS/nixpkgs/issues/465126
- https://github.com/NixOS/nixpkgs/issues/481053
- https://github.com/NixOS/nixpkgs/issues/470670
- https://github.com/NixOS/nixpkgs/issues/489056
- https://github.com/NixOS/nixpkgs/issues/456998
- https://github.com/NixOS/nixpkgs/issues/466765
- https://github.com/NixOS/nixpkgs/issues/463087
- https://github.com/NixOS/nixpkgs/issues/463016
- https://github.com/NixOS/nixpkgs/issues/397600
- https://github.com/NixOS/nixpkgs/issues/385645
- https://github.com/NixOS/nixpkgs/issues/192247
- https://github.com/NixOS/nixpkgs/issues/247724
- https://github.com/NixOS/nixpkgs/issues/193985
- https://github.com/NixOS/nixpkgs/issues/101202
- https://github.com/NixOS/nixpkgs/issues/111368
- https://github.com/NixOS/nixpkgs/issues/93246
- https://github.com/NixOS/nixpkgs/issues/83544
- https://github.com/NixOS/nixpkgs/issues/83699
- https://github.com/NixOS/nixpkgs/issues/50985
- https://github.com/NixOS/nixpkgs/issues/2295
- https://github.com/NixOS/nixpkgs/pull/507382
- https://github.com/NixOS/nixpkgs/pull/484819
- https://github.com/NixOS/nixpkgs/pull/307132#issuecomment-2174679234
- https://github.com/NixOS/nixpkgs/pull/493433
- https://github.com/NixOS/nixpkgs/pull/494886
- https://github.com/NixOS/nixpkgs/pull/498106
- https://github.com/NixOS/nixpkgs/pull/482811
- https://github.com/NixOS/nixpkgs/pull/476769
- https://github.com/NixOS/nixpkgs/pull/399610#issuecomment-2816691374
- https://github.com/NixOS/nixpkgs/pull/483099#pullrequestreview-3728782444
- https://github.com/NixOS/nixpkgs/pull/415737
- https://github.com/NixOS/nixpkgs/pull/405950
- https://github.com/NixOS/nixpkgs/pull/368786#issuecomment-2676268692
- https://github.com/NixOS/nixpkgs/pull/372614#issuecomment-2585603202
- https://github.com/NixOS/nixpkgs/pull/357400
- https://github.com/NixOS/nixpkgs/pull/293007
- https://github.com/NixOS/nixpkgs/pull/290977
- https://github.com/NixOS/nixpkgs/pull/300437
- https://github.com/NixOS/nixpkgs/pull/206051#discussion_r1048968232
- https://github.com/NixOS/nixpkgs/pull/208426
- https://github.com/NixOS/nixpkgs/pull/140470
- https://github.com/NixOS/nixpkgs/pull/84449
- https://github.com/NixOS/nixpkgs/pull/210988
- https://github.com/NixOS/nixpkgs/pull/148646#issuecomment-1193370681
- https://github.com/NixOS/nixpkgs/pull/185019
- https://github.com/NixOS/nixpkgs/pull/92630#issuecomment-658431654
- https://github.com/NixOS/nixpkgs/pull/83701#issuecomment-605669787
- https://github.com/NixOS/nixpkgs/pull/6278#discussion_r24401947

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
