### PR TITLE
Upgrade firefox-syncserver to 0.22.1 and expose PostgreSQL support

### DIFF
--- a/nixos/modules/services/networking/firefox-syncserver.nix
+++ b/nixos/modules/services/networking/firefox-syncserver.nix
@@ -3,6 +3,7 @@
   pkgs,
   lib,
   options,
+  utils,
   ...
 }:
 
@@ -12,17 +13,58 @@ let
   defaultDatabase = "firefox_syncserver";
   defaultUser = "firefox-syncserver";
 
+  # unfortunately the default for MySQL to have distinct database name and user names is not
+  # compatible with NixOS PostgreSQL requiring the user and database name to be identical
+  # to grant correct owner permissions
+  dbName =
+    if cfg.database.type == "pgsql" && cfg.database.name == defaultDatabase then
+      defaultUser
+    else
+      cfg.database.name;
+
+  # shorthand for deciding whether to use local UDS access
   dbIsLocal = cfg.database.host == "localhost";
-  dbURL = "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}";
+
+  # escaped database URI
+  dbURL =
+    let
+      dbHostEscaped =
+        if lib.strings.match "[A-Za-z0-9]*:[A-Za-z0-9:%]+" cfg.database.host != null then # IPv6 address
+          "[${cfg.database.host}]"
+        # hostname, IPv4 address or path
+        else
+          lib.strings.escapeURL cfg.database.host;
+      dbNameEscaped = lib.strings.escapeURL dbName;
+      dbUserEscaped = lib.strings.escapeURL cfg.database.user;
+    in
+    if cfg.database.type == "mysql" then
+      "mysql://${dbUserEscaped}@${dbHostEscaped}/${dbNameEscaped}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}"
+    else if cfg.database.type == "pgsql" then
+      "postgres://${dbUserEscaped}@${dbHostEscaped}/${dbNameEscaped}${lib.optionalString dbIsLocal "?host=/run/postgresql"}"
+    else
+      throw "Unexpected database type: ${cfg.database.type}";
 
   format = pkgs.formats.toml { };
   settings = {
     human_logs = true;
     syncstorage = {
+      node_type =
+        if cfg.database.type == "mysql" then
+          "mysql"
+        else if cfg.database.type == "pgsql" then
+          "postgres"
+        else
+          throw "Unexpected database type: ${cfg.database.type}";
       database_url = dbURL;
     };
     tokenserver = {
-      node_type = "mysql";
+      node_type =
+        if cfg.database.type == "mysql" then
+          "mysql"
+        else if cfg.database.type == "pgsql" then
+          "postgres"
+        else
+          throw "Unexpected database type: ${cfg.database.type}";
       database_url = dbURL;
       fxa_email_domain = "api.accounts.firefox.com";
       fxa_oauth_server_url = "https://oauth.accounts.firefox.com/v1";
@@ -41,44 +83,57 @@ let
     };
   };
   configFile = format.generate "syncstorage.toml" (lib.recursiveUpdate settings cfg.settings);
-  setupScript = pkgs.writeShellScript "firefox-syncserver-setup" ''
-    set -euo pipefail
-    shopt -s inherit_errexit
-
-    schema_configured() {
-      mysql ${cfg.database.name} -Ne 'SHOW TABLES' | grep -q services
-    }
-
-    update_config() {
-      mysql ${cfg.database.name} <<"EOF"
-        BEGIN;
-
-        INSERT INTO `services` (`id`, `service`, `pattern`)
-          VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
-          ON DUPLICATE KEY UPDATE service='sync-1.5', pattern='{node}/1.5/{uid}';
-        INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
-                             `capacity`, `downed`, `backoff`)
-          VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
-          0, ${toString cfg.singleNode.capacity}, 0, 0)
-          ON DUPLICATE KEY UPDATE node = '${cfg.singleNode.url}', capacity=${toString cfg.singleNode.capacity};
-
-        COMMIT;
-    EOF
-    }
-
-
-    for (( try = 0; try < 60; try++ )); do
-      if ! schema_configured; then
-        sleep 2
+  setupScript =
+    with if cfg.database.type == "mysql" then
+      {
+        databaseExecCommand = "${config.services.mysql.package}/bin/mysql '${dbName}'";
+        databaseListTables = "${config.services.mysql.package}/bin/mysql '${dbName}' -Ne 'SHOW TABLES'";
+      }
+      else if cfg.database.type == "pgsql" then
+        {
+          databaseExecCommand = "${pkgs.util-linux}/bin/runuser -u postgres -- ${config.services.postgresql.package}/bin/psql -d '${dbName}'";
+          databaseListTables = "${pkgs.util-linux}/bin/runuser -u postgres -- ${config.services.postgresql.package}/bin/psql -d '${dbName}' -tc '\d'";
+        }
       else
-        update_config
-        exit 0
-      fi
-    done
+        throw "Unexpected database type: ${cfg.database.type}";
+    pkgs.writeShellScript "firefox-syncserver-setup" ''
+      set -euo pipefail
+      shopt -s inherit_errexit
 
-    echo "Single-node setup failed"
-    exit 1
-  '';
+      schema_configured() {
+        ${databaseListTables} | grep -q services
+      }
+
+      update_config() {
+        # Please use only standard SQL here (no MySQL-isms!)
+        ${databaseExecCommand} <<"EOF"
+          BEGIN;
+
+          INSERT INTO services (id, service, pattern)
+            VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
+            ON DUPLICATE KEY UPDATE service='sync-1.5', pattern='{node}/1.5/{uid}';
+          INSERT INTO nodes (id, service, node, available, current_load,
+                               capacity, downed, backoff)
+            VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
+            0, ${toString cfg.singleNode.capacity}, 0, 0)
+            ON DUPLICATE KEY UPDATE node='${cfg.singleNode.url}', capacity=${toString cfg.singleNode.capacity};
+
+          COMMIT;
+      EOF
+      }
+
+      for (( try = 0; try < 60; try++ )); do
+        if ! schema_configured; then
+          sleep 2
+        else
+          update_config
+          exit 0
+        fi
+      done
+
+      echo "Single-node setup failed"
+      exit 1
+    '';
 in
 
 {
@@ -92,16 +147,44 @@ in
         by running
 
         ```
-          INSERT INTO `services` (`id`, `service`, `pattern`) VALUES ('1', 'sync-1.5', '{node}/1.5/{uid}');
-          INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
-              `capacity`, `downed`, `backoff`)
+          INSERT INTO services (id, service, pattern) VALUES ('1', 'sync-1.5', '{node}/1.5/{uid}');
+          INSERT INTO nodes (id, service, node, available, current_load,
+              capacity, downed, backoff)
             VALUES ('1', '1', 'https://mydomain.tld', '1', '0', '10', '0', '0');
         ```
 
         {option}`${opt.singleNode.enable}` does this automatically when enabled
       '';
 
-      package = lib.mkPackageOption pkgs "syncstorage-rs" { };
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        description = ''
+          Syncstorage server package.
+        '';
+        default = null;
+        defaultText = lib.literalExpression ''
+          if services.firefox-syncserver.database.type == "mysql" then
+            pkgs.syncstorage-rs-mysql
+          else
+            pkgs.syncstorage-rs-pgsql
+        '';
+      };
+
+      database.type = lib.mkOption (
+        {
+          type = lib.types.enum [
+            "mysql"
+            "pgsql"
+          ];
+          description = ''
+            Database system to use for storage.
+          '';
+        }
+        // lib.optionalAttrs (builtins.compareVersions config.system.stateVersion "26.05" < 0) {
+          # before 26.05 mysql was the only supported backend and assumed by default
+          default = "mysql";
+        }
+      );
 
       database.name = lib.mkOption {
         # the mysql module does not allow `-quoting without resorting to shell
@@ -237,75 +320,117 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.mysql = lib.mkIf cfg.database.createLocally {
+    services.mysql =
+      lib.mkIf (cfg.database.createLocally && dbIsLocal && cfg.database.type == "mysql")
+        {
+          enable = true;
+          ensureDatabases = [ dbName ];
+          ensureUsers = [
+            {
+              name = cfg.database.user;
+              ensurePermissions = {
+                "${dbName}.*" = "all privileges";
+              };
+            }
+          ];
+        };
+
+    services.postgresql = lib.mkIf (dbIsLocal && cfg.database.type == "pgsql") {
       enable = true;
-      ensureDatabases = [ cfg.database.name ];
-      ensureUsers = [
+      ensureDatabases = lib.mkIf cfg.database.createLocally [ dbName ];
+      ensureUsers = lib.mkIf cfg.database.createLocally [
         {
           name = cfg.database.user;
-          ensurePermissions = {
-            "${cfg.database.name}.*" = "all privileges";
-          };
+          ensureDBOwnership = true;
         }
       ];
     };
 
     systemd.services.firefox-syncserver = {
       wantedBy = [ "multi-user.target" ];
-      requires = lib.mkIf dbIsLocal [ "mysql.service" ];
-      after = lib.mkIf dbIsLocal [ "mysql.service" ];
+      requires = lib.mkIf dbIsLocal (
+        if cfg.database.type == "mysql" then
+          [ "mysql.service" ]
+        else if cfg.database.type == "pgsql" then
+          [ "postgresql.service" ]
+        else
+          throw "Unexpected database type: ${cfg.database.type}"
+      );
+      after = lib.mkIf dbIsLocal (
+        if cfg.database.type == "mysql" then
+          [ "mysql.service" ]
+        else if cfg.database.type == "pgsql" then
+          [ "postgresql.target" ]
+        else
+          throw "Unexpected database type: ${cfg.database.type}"
+      );
       restartTriggers = lib.optional cfg.singleNode.enable setupScript;
       environment.RUST_LOG = cfg.logLevel;
-      serviceConfig = {
-        User = defaultUser;
-        Group = defaultUser;
-        ExecStart = "${cfg.package}/bin/syncserver --config ${configFile}";
-        EnvironmentFile = lib.mkIf (cfg.secrets != null) "${cfg.secrets}";
+      serviceConfig =
+        let
+          package =
+            if cfg.package != null then
+              cfg.package
+            else if cfg.database.type == "mysql" then
+              pkgs.syncstorage-rs-mysql
+            else if cfg.database.type == "pgsql" then
+              pkgs.syncstorage-rs-pgsql
+            else
+              throw "Unexpected database type: ${cfg.database.type}";
+        in
+        {
+          User = defaultUser;
+          Group = defaultUser;
+          ExecStart = utils.escapeSystemdExecArgs [
+            "${package}/bin/syncserver"
+            "--config"
+            configFile
+          ];
+          EnvironmentFile = lib.mkIf (cfg.secrets != null) "${cfg.secrets}";
 
-        # hardening
-        RemoveIPC = true;
-        CapabilityBoundingSet = [ "" ];
-        DynamicUser = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        ProtectClock = true;
-        ProtectKernelLogs = true;
-        ProtectControlGroups = true;
-        ProtectKernelModules = true;
-        SystemCallArchitectures = "native";
-        # syncstorage-rs uses python-cffi internally, and python-cffi does not
-        # work with MemoryDenyWriteExecute=true
-        MemoryDenyWriteExecute = false;
-        RestrictNamespaces = true;
-        RestrictSUIDSGID = true;
-        ProtectHostname = true;
-        LockPersonality = true;
-        ProtectKernelTunables = true;
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
-        RestrictRealtime = true;
-        ProtectSystem = "strict";
-        ProtectProc = "invisible";
-        ProcSubset = "pid";
-        ProtectHome = true;
-        PrivateUsers = true;
-        PrivateTmp = true;
-        SystemCallFilter = [
-          "@system-service"
-          "~ @privileged @resources"
-        ];
-        UMask = "0077";
-      };
+          # hardening
+          RemoveIPC = true;
+          CapabilityBoundingSet = [ "" ];
+          DynamicUser = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          ProtectClock = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          ProtectKernelModules = true;
+          SystemCallArchitectures = "native";
+          # syncstorage-rs uses python-cffi internally, and python-cffi does not
+          # work with MemoryDenyWriteExecute=true
+          MemoryDenyWriteExecute = false;
+          RestrictNamespaces = true;
+          RestrictSUIDSGID = true;
+          ProtectHostname = true;
+          LockPersonality = true;
+          ProtectKernelTunables = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictRealtime = true;
+          ProtectSystem = "strict";
+          ProtectProc = "invisible";
+          ProcSubset = "pid";
+          ProtectHome = true;
+          PrivateUsers = true;
+          PrivateTmp = true;
+          SystemCallFilter = [
+            "@system-service"
+            "~ @privileged @resources"
+          ];
+          UMask = "0077";
+        };
     };
 
     systemd.services.firefox-syncserver-setup = lib.mkIf cfg.singleNode.enable {
       wantedBy = [ "firefox-syncserver.service" ];
-      requires = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal "mysql.service";
-      after = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal "mysql.service";
-      path = [ config.services.mysql.package ];
+      requires = [ "firefox-syncserver.service" ];
+      after = [ "firefox-syncserver.service" ];
       serviceConfig.ExecStart = [ "${setupScript}" ];
     };
 
@@ -322,6 +447,17 @@ in
         };
       };
     };
+
+    assertions = [
+      {
+        assertion =
+          !cfg.database.createLocally
+          || !dbIsLocal
+          || cfg.database.type != "pgsql"
+          || cfg.database.user == dbName;
+        message = "`services.firefox-syncserver.database.name` must match `services.firefox-syncserver.database.user` when creating local database";
+      }
+    ];
   };
 
   meta = {

--- a/nixos/tests/firefox-syncserver-mariadb.nix
+++ b/nixos/tests/firefox-syncserver-mariadb.nix
@@ -1,0 +1,33 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  name = "firefox-syncserver";
+  nodes.machine = {
+    services.mysql = {
+      enable = true;
+      package = pkgs.mariadb;
+    };
+
+    services.firefox-syncserver = {
+      enable = true;
+      secrets = pkgs.writeText "secret" "this-is-a-test";
+      database.type = "mysql";
+      singleNode = {
+        enable = true;
+        hostname = "firefox-syncserver.local";
+        capacity = 1;
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("firefox-syncserver.service")
+    machine.wait_for_open_port(5000)
+
+    machine.wait_until_succeeds("curl --fail http://127.0.0.1:5000")
+
+  '';
+}

--- a/nixos/tests/firefox-syncserver-postgresql.nix
+++ b/nixos/tests/firefox-syncserver-postgresql.nix
@@ -6,14 +6,14 @@
 {
   name = "firefox-syncserver";
   nodes.machine = {
-    services.mysql = {
+    services.postgresql = {
       enable = true;
-      package = pkgs.mariadb;
     };
 
     services.firefox-syncserver = {
       enable = true;
       secrets = pkgs.writeText "secret" "this-is-a-test";
+      database.type = "pgsql";
       singleNode = {
         enable = true;
         hostname = "firefox-syncserver.local";

--- a/pkgs/by-name/sy/syncstorage-rs/01-syncserver-tokenserver-postgres-db.patch
+++ b/pkgs/by-name/sy/syncstorage-rs/01-syncserver-tokenserver-postgres-db.patch
@@ -1,0 +1,26 @@
+diff --git a/syncserver/Cargo.toml b/syncserver/Cargo.toml
+index 3f658f6..461a0df 100644
+--- a/syncserver/Cargo.toml
++++ b/syncserver/Cargo.toml
+@@ -70,7 +70,7 @@ slog-journald = "2.2.0"
+ default = ["mysql", "py_verifier"]
+ no_auth = []
+ py_verifier = ["tokenserver-auth/py", "tokenserver-common/py"]
+-mysql = ["syncstorage-db/mysql"]
+-postgres = ["syncstorage-db/postgres"]
+-spanner = ["syncstorage-db/spanner"]
++mysql = ["syncstorage-db/mysql", "tokenserver-db/mysql"]
++postgres = ["syncstorage-db/postgres", "tokenserver-db/postgres"]
++spanner = ["syncstorage-db/spanner", "tokenserver-db/mysql"]
+ actix-compress = ["actix-web/compress-brotli", "actix-web/compress-gzip", "actix-web/compress-zstd"]
+diff --git a/tokenserver-db/Cargo.toml b/tokenserver-db/Cargo.toml
+index c55b77f..ee68f92 100644
+--- a/tokenserver-db/Cargo.toml
++++ b/tokenserver-db/Cargo.toml
+@@ -25,6 +25,5 @@ temp-env.workspace = true
+ syncserver-settings = { path = "../syncserver-settings" }
+ 
+ [features]
+-default = ["mysql"]
+ mysql = ['tokenserver-mysql']
+ postgres = ['tokenserver-postgres']

--- a/pkgs/by-name/sy/syncstorage-rs/common.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/common.nix
@@ -1,14 +1,16 @@
 {
   fetchFromGitHub,
+  fetchurl,
   rustPlatform,
   pkg-config,
   python3,
   cmake,
-  libmysqlclient,
+  openssl,
   makeBinaryWrapper,
   lib,
   nix-update-script,
   nixosTests,
+  ...
 }:
 
 let
@@ -23,13 +25,25 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "syncstorage-rs";
-  version = "0.21.1-unstable-2026-01-26";
+  version = "0.22.1";
 
   src = fetchFromGitHub {
     owner = "mozilla-services";
     repo = "syncstorage-rs";
-    rev = "11659d98f9c69948a0aab353437ce2036c388711";
-    hash = "sha256-G37QvxTNh/C3gmKG0UYHI6QBr0F+KLGRNI/Sx33uOsc=";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-eo8+6wQQRRjvazE3A7+pJfAtTYKUE3ATTTos/yhqaXI=";
+  };
+
+  # set cargoHash in override
+  #
+  # Has to pull from `finalAttrs` here since overriding using `.overrideAttrs`
+  # does not appear to work for `rustPlatform.buildRustPackage` attributes.
+  cargoHash = finalAttrs.cargoHash;
+
+  # required by utoipa-swagger-ui rust crate as ZIP file
+  swaggerUI = fetchurl {
+    url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip";
+    hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
   };
 
   nativeBuildInputs = [
@@ -39,8 +53,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     python3
   ];
 
+  buildAndTestSubdir = "syncserver";
+  buildNoDefaultFeatures = true;
+
+  # Add database features in override
+  #
+  # Has to pull from `finalAttrs` here since overriding using `.overrideAttrs`
+  # does not appear to work for `rustPlatform.buildRustPackage` attributes.
+  buildFeatures = finalAttrs.buildFeatures ++ [
+    "py_verifier"
+  ];
+
+  # Add database backend dependencies in override
   buildInputs = [
-    libmysqlclient
+    openssl
   ];
 
   preFixup = ''
@@ -48,7 +74,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ pyFxADeps ]}
   '';
 
-  cargoHash = "sha256-9Dcf5mDyK/XjsKTlCPXTHoBkIq+FFPDg1zfK24Y9nHQ=";
+  # cause utoipa-swagger-ui crate to use Swagger UI version downloaded by Nix
+  SWAGGER_UI_DOWNLOAD_URL = "file:${finalAttrs.swaggerUI}";
 
   # almost all tests need a DB to test against
   doCheck = false;

--- a/pkgs/by-name/sy/syncstorage-rs/mysql.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/mysql.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  fetchurl,
+  rustPlatform,
+  pkg-config,
+  python3,
+  cmake,
+  openssl,
+  libmysqlclient,
+  makeBinaryWrapper,
+  lib,
+  nix-update-script,
+  nixosTests,
+}@args:
+
+(import ./common.nix args).overrideAttrs (
+  finalAttrs: prevAttrs: {
+    pname = "${prevAttrs.pname}-mysql";
+
+    cargoHash = "sha256-YgJPDGT0aeCi/x42o6H42ivCiBhP5hhgIEukYfWX1Gg=";
+
+    buildFeatures = [
+      "mysql"
+    ];
+
+    buildInputs = prevAttrs.buildInputs ++ [
+      libmysqlclient
+    ];
+
+    passthru.tests = { inherit (nixosTests) firefox-syncserver-mariadb; };
+
+    meta = prevAttrs.meta // {
+      description = "${prevAttrs.meta.description} (MySQL database build)";
+    };
+  }
+)

--- a/pkgs/by-name/sy/syncstorage-rs/pgsql.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/pgsql.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  fetchurl,
+  rustPlatform,
+  pkg-config,
+  python3,
+  cmake,
+  openssl,
+  libpq,
+  makeBinaryWrapper,
+  lib,
+  nix-update-script,
+  nixosTests,
+}@args:
+
+(import ./common.nix args).overrideAttrs (
+  finalAttrs: prevAttrs: {
+    pname = "${prevAttrs.pname}-pgsql";
+
+    cargoHash = "sha256-YgJPDGT0aeCi/x42o6H42ivCiBhP5hhgIEukYfWX1Gg=";
+
+    patches = [
+      ./01-syncserver-tokenserver-postgres-db.patch
+    ];
+
+    buildFeatures = [
+      "postgres"
+    ];
+
+    buildInputs = prevAttrs.buildInputs ++ [
+      libpq
+    ];
+
+    passthru.tests = { inherit (nixosTests) firefox-syncserver-postgresql; };
+
+    meta = prevAttrs.meta // {
+      description = "${prevAttrs.meta.description} (PostgreSQL database build)";
+    };
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12465,4 +12465,8 @@ with pkgs;
   gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
     releaseChannel = "unstable";
   };
+
+  syncstorage-rs-mysql = callPackage ../by-name/sy/syncstorage-rs/mysql.nix { };
+  syncstorage-rs-pgsql = callPackage ../by-name/sy/syncstorage-rs/pgsql.nix { };
+  syncstorage-rs = callPackage ../by-name/sy/syncstorage-rs/mysql.nix { }; # Compatibility alias
 }


### PR DESCRIPTION
Fixes #484932 

This upgrade the `syncstorage-rs` package to new 0.22.1 version and splits its build into a MySQL and (new) PostgreSQL variant. The NixOS module is upgraded to allow the usage for PostgreSQL with a simple option change.

Existing NixOS installation will continue to use MySQL, new installations will need to explicitly specify the database backend.

@mweinelt @n0rc 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (N/A)
  - [ ] aarch64-darwin (N/A)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking. (PostgreSQL support)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.(PostgreSQL support)
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
