### PR TITLE
openshot-qt: 3.3.0 -> 3.5.0

### DIFF
--- a/pkgs/applications/video/openshot-qt/default.nix
+++ b/pkgs/applications/video/openshot-qt/default.nix
@@ -17,12 +17,12 @@
 
 let
   pname = "openshot-qt";
-  version = "3.3.0";
+  version = "3.5.0";
   src = fetchFromGitHub {
     owner = "OpenShot";
     repo = "openshot-qt";
     tag = "v${version}";
-    hash = "sha256-+QI1772ys1Czd+KSVBAdAUjLg9mUcMZs+UhkNljY7nQ=";
+    hash = "sha256-6jQUBnWiqWlLRAa/zUmfq4y+x8SZyCD3g8JGX4x6Gl8=";
   };
 in
 mkDerivationWith python3.pkgs.buildPythonApplication {
@@ -47,9 +47,9 @@ mkDerivationWith python3.pkgs.buildPythonApplication {
   propagatedBuildInputs = with python3.pkgs; [
     httplib2
     libopenshot
-    pyqtwebengine
     pyzmq
     requests
+    pyqt5
     sip
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release announcement: https://github.com/OpenShot/openshot-qt/releases/tag/v3.5.0

Build works but runtime fails due to needing https://github.com/NixOS/nixpkgs/pull/507464.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [s] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


The error in question:
<img width="503" height="151" alt="image" src="https://github.com/user-attachments/assets/b555a290-264f-4a4f-8381-747843a3b435" />
