### PR TITLE
suitesparse: remove ? null, remove empty list; suitesparse_5_3: drop alias

### DIFF
--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -12,7 +12,7 @@
   config,
   enableCuda ? config.cudaSupport,
   cudaPackages,
-  openmp ? null,
+  llvmPackages,
 }@inputs:
 
 let
@@ -36,14 +36,13 @@ effectiveStdenv.mkDerivation rec {
     sha256 = "sha256-Anen1YtXsSPhk8DpA4JtADIz9m8oXFl9umlkb4iImf8=";
   };
 
-  nativeBuildInputs = [
-  ]
-  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-    fixDarwinDylibNames
-  ]
-  ++ lib.optionals enableCuda [
-    cudaPackages.cuda_nvcc
-  ];
+  nativeBuildInputs =
+    lib.optionals effectiveStdenv.hostPlatform.isDarwin [
+      fixDarwinDylibNames
+    ]
+    ++ lib.optionals enableCuda [
+      cudaPackages.cuda_nvcc
+    ];
 
   # Use compatible indexing for lapack and blas used
   buildInputs =
@@ -57,7 +56,7 @@ effectiveStdenv.mkDerivation rec {
       mpfr
     ]
     ++ lib.optionals effectiveStdenv.cc.isClang [
-      openmp
+      llvmPackages.openmp
     ]
     ++ lib.optionals enableCuda [
       cudaPackages.cuda_cudart

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11627,8 +11627,7 @@ with pkgs;
     lapack = lapack-ilp64;
   };
 
-  suitesparse_5_3 = callPackage ../development/libraries/science/math/suitesparse { };
-  suitesparse = suitesparse_5_3;
+  suitesparse = callPackage ../development/libraries/science/math/suitesparse { };
 
   trilinos-mpi = trilinos.override { withMPI = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11627,9 +11627,7 @@ with pkgs;
     lapack = lapack-ilp64;
   };
 
-  suitesparse_5_3 = callPackage ../development/libraries/science/math/suitesparse {
-    inherit (llvmPackages) openmp;
-  };
+  suitesparse_5_3 = callPackage ../development/libraries/science/math/suitesparse { };
   suitesparse = suitesparse_5_3;
 
   trilinos-mpi = trilinos.override { withMPI = true; };

--- a/pkgs/top-level/release-alternatives.nix
+++ b/pkgs/top-level/release-alternatives.nix
@@ -18,7 +18,7 @@ let
     "rspamd"
     "octopus"
     "superlu"
-    "suitesparse_5_3"
+    "suitesparse"
     "scs"
     "scalapack"
     "petsc"
@@ -94,7 +94,7 @@ let
   blas64Users = [
     "rspamd"
     "sundials"
-    "suitesparse_5_3"
+    "suitesparse"
     "petsc"
     "cholmod-extra"
     "arpack"


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
