### PR TITLE
windscribe: init at 2.23.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26348,6 +26348,12 @@
     githubId = 12595971;
     name = "Guillaume Girol";
   };
+  syntheit = {
+    email = "daniel@matv.io";
+    github = "syntheit";
+    githubId = 96559325;
+    name = "Daniel Miller";
+  };
   sysedwinistrator = {
     email = "edwin.mowen@gmail.com";
     github = "sysedwinistrator";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27378,6 +27378,12 @@
     githubId = 12595971;
     name = "Guillaume Girol";
   };
+  syntheit = {
+    email = "daniel@matv.io";
+    github = "syntheit";
+    githubId = 96559325;
+    name = "Daniel Miller";
+  };
   sysedwinistrator = {
     email = "edwin.mowen@gmail.com";
     github = "sysedwinistrator";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1445,6 +1445,7 @@
   ./services/networking/wg-quick.nix
   ./services/networking/wgautomesh.nix
   ./services/networking/whoogle-search.nix
+  ./services/networking/windscribe.nix
   ./services/networking/wireguard-networkd.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1475,6 +1475,7 @@
   ./services/networking/wg-quick.nix
   ./services/networking/wgautomesh.nix
   ./services/networking/whoogle-search.nix
+  ./services/networking/windscribe.nix
   ./services/networking/wireguard-networkd.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix

--- a/nixos/modules/services/networking/windscribe.nix
+++ b/nixos/modules/services/networking/windscribe.nix
@@ -1,0 +1,122 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.windscribe;
+in
+{
+  options.services.windscribe = {
+    enable = lib.mkEnableOption "Windscribe VPN";
+
+    package = lib.mkPackageOption pkgs "windscribe" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # The bundled Go binaries (wstunnel, amneziawg, ctrld) cannot be patched
+    # by autoPatchelf without crashing, so they retain their original
+    # /lib64/ld-linux-x86-64.so.2 interpreter. nix-ld provides this path.
+    programs.nix-ld.enable = true;
+
+    # The GUI and CLI need cap_setgid to switch to the windscribe group for
+    # helper socket access. security.wrappers creates setcap copies in
+    # /run/wrappers/bin/ which is early in PATH and takes precedence.
+    security.wrappers = {
+      windscribe = {
+        source = "${cfg.package}/opt/windscribe/Windscribe";
+        capabilities = "cap_setgid+ep";
+        owner = "root";
+        group = "root";
+      };
+      windscribe-cli = {
+        source = "${cfg.package}/opt/windscribe/windscribe-cli";
+        capabilities = "cap_setgid+ep";
+        owner = "root";
+        group = "root";
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /etc/windscribe 0755 root root -"
+      "f /etc/windscribe/platform 0644 root root - linux_deb_x64"
+      "d /etc/windscribe/autostart 0755 root root -"
+      "L+ /etc/windscribe/autostart/windscribe.desktop - - - - ${cfg.package}/etc/xdg/autostart/windscribe.desktop"
+      "d /var/log/windscribe 0755 root root -"
+      "d /var/tmp/windscribe 0755 root root -"
+      # The update-systemd-resolved DNS script writes config here
+      "d /usr/local/lib/systemd/resolved.conf.d 0755 root root -"
+    ];
+
+    # The helper creates these imperatively via groupadd/useradd at startup;
+    # declare them so they exist before the helper starts.
+    users.groups.windscribe = { };
+    users.users.windscribe = {
+      isSystemUser = true;
+      group = "windscribe";
+      home = "/var/lib/windscribe";
+      createHome = true;
+    };
+
+    # Windscribe helper daemon - runs as root, manages firewall rules and
+    # VPN tunnels. The GUI/CLI connects via /var/run/windscribe/helper.sock.
+    systemd.services.windscribe-helper = {
+      description = "Windscribe helper service";
+      before = [ "network-pre.target" ];
+      wants = [ "network-pre.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        # Bind mount /opt/windscribe from the nix store before starting.
+        # MUST be a bind mount, not a symlink: the helper uses realpath() to
+        # validate sub-process paths start with "/opt/windscribe". Symlinks
+        # resolve to /nix/store/... which fails the check and blocks all VPN
+        # connections. Bind mounts are transparent to realpath().
+        ExecStartPre = pkgs.writeShellScript "setup-windscribe-mount" ''
+          # Remove any stale symlink from previous configs
+          if [ -L /opt/windscribe ]; then
+            ${pkgs.coreutils}/bin/rm /opt/windscribe
+          fi
+          ${pkgs.coreutils}/bin/mkdir -p /opt/windscribe
+          # Always unmount and remount to pick up new store paths after rebuilds.
+          # Without this, a stale mount serves old (possibly broken) binaries.
+          if ${pkgs.util-linux}/bin/mountpoint -q /opt/windscribe; then
+            ${pkgs.util-linux}/bin/umount /opt/windscribe
+          fi
+          ${pkgs.util-linux}/bin/mount --bind ${cfg.package}/opt/windscribe /opt/windscribe
+          ${pkgs.util-linux}/bin/mount -o remount,bind,ro /opt/windscribe
+        '';
+        ExecStart = "/opt/windscribe/helper";
+        Restart = "on-failure";
+      };
+      # /run/wrappers/bin provides sudo, which the helper uses to drop
+      # privileges when starting stunnel/wstunnel for Stealth and WStunnel protocols.
+      environment.PATH = lib.mkForce (
+        "/run/wrappers/bin:"
+        + lib.makeBinPath (
+          with pkgs;
+          [
+            iptables
+            iproute2
+            systemd
+            util-linux
+            kmod
+            gnused
+            gawk
+            gnugrep
+            coreutils
+            e2fsprogs
+            wireguard-tools
+            shadow
+          ]
+        )
+      );
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ syntheit ];
+}

--- a/nixos/modules/services/networking/windscribe.nix
+++ b/nixos/modules/services/networking/windscribe.nix
@@ -1,0 +1,148 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.windscribe;
+in
+{
+  options.services.windscribe = {
+    enable = lib.mkEnableOption "Windscribe VPN";
+
+    package = lib.mkPackageOption pkgs "windscribe" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # The bundled Go binaries (windscribewstunnel, windscribeamneziawg,
+    # windscribectrld) are Windscribe-specific forks and ship with the standard
+    # /lib64/ld-linux-x86-64.so.2 interpreter. They are restored unpatched after
+    # autoPatchelf because the Go runtime crashes when the dynamic linker is
+    # rewritten; nix-ld provides the interpreter path so they can be exec'd.
+    programs.nix-ld.enable = true;
+
+    # The helper listens on a 0770 root:windscribe unix socket
+    # (/var/run/windscribe/helper.sock). The GUI/CLI reach it by running
+    # setgid "windscribe" so they inherit egid=windscribe - exactly what the
+    # upstream .deb does in its postinst:
+    #   chgrp windscribe /opt/windscribe/Windscribe && chmod 2755 ...
+    # The app connects with the inherited group, then drops it (dropHelperGroup).
+    #
+    # cap_setgid does NOT work here: the app never calls setgid() to *raise*
+    # into the windscribe group before connecting (it only ever drops the
+    # group), so the capability is never exercised and connect() gets EACCES,
+    # which surfaces as "Timed out connecting to helper socket" / "app did not
+    # start in time".
+    security.wrappers = {
+      windscribe = {
+        source = "${cfg.package}/opt/windscribe/Windscribe";
+        owner = "root";
+        group = "windscribe";
+        setgid = true;
+      };
+      windscribe-cli = {
+        source = "${cfg.package}/opt/windscribe/windscribe-cli";
+        owner = "root";
+        group = "windscribe";
+        setgid = true;
+      };
+    };
+
+    systemd.tmpfiles.settings."10-windscribe" = {
+      "/etc/windscribe".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/etc/windscribe/platform".f = {
+        mode = "0644";
+        user = "root";
+        group = "root";
+        argument = "linux_deb_x64";
+      };
+      "/etc/windscribe/autostart".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/etc/windscribe/autostart/windscribe.desktop"."L+".argument =
+        "${cfg.package}/etc/xdg/autostart/windscribe.desktop";
+      "/var/log/windscribe".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      "/var/tmp/windscribe".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      # The update-systemd-resolved DNS script writes config here.
+      "/usr/local/lib/systemd/resolved.conf.d".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+      # Bind-mount target for the helper service.
+      "/opt/windscribe".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+    };
+
+    # The helper creates these imperatively via groupadd/useradd at startup;
+    # declare them so they exist before the helper starts.
+    users.groups.windscribe = { };
+    users.users.windscribe = {
+      isSystemUser = true;
+      group = "windscribe";
+      home = "/var/lib/windscribe";
+      createHome = true;
+    };
+
+    # Windscribe helper daemon - runs as root, manages firewall rules and
+    # VPN tunnels. The GUI/CLI connects via /var/run/windscribe/helper.sock.
+    systemd.services.windscribe-helper = {
+      description = "Windscribe helper service";
+      before = [ "network-pre.target" ];
+      wants = [ "network-pre.target" ];
+      wantedBy = [ "multi-user.target" ];
+      # /run/wrappers provides setuid sudo, which the helper invokes to drop
+      # privileges when starting stunnel/wstunnel for Stealth and WStunnel protocols.
+      path = [
+        "/run/wrappers"
+      ]
+      ++ (with pkgs; [
+        iptables
+        iproute2
+        systemd
+        util-linux
+        kmod
+        gnused
+        gawk
+        gnugrep
+        coreutils
+        e2fsprogs
+        wireguard-tools
+        shadow
+      ]);
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "/opt/windscribe/helper";
+        Restart = "on-failure";
+        # The helper validates child-process paths via realpath() against
+        # /opt/windscribe. realpath() is transparent to mount points but
+        # resolves through symlinks, so a bind mount is required (a symlink
+        # to the store path would resolve to /nix/store/... and fail the check).
+        BindReadOnlyPaths = [ "${cfg.package}/opt/windscribe:/opt/windscribe" ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ syntheit ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1754,6 +1754,7 @@ in
     inherit pkgs runTest;
     inherit (pkgs) lib;
   };
+  windscribe = runTest ./windscribe.nix;
   wine = handleTest ./wine.nix { };
   wireguard = import ./wireguard {
     inherit pkgs runTest;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1870,6 +1870,7 @@ in
     inherit pkgs runTest;
     inherit (pkgs) lib;
   };
+  windscribe = runTest ./windscribe.nix;
   wine = handleTest ./wine.nix { };
   wireguard = import ./wireguard {
     inherit pkgs runTest;

--- a/nixos/tests/windscribe.nix
+++ b/nixos/tests/windscribe.nix
@@ -1,0 +1,21 @@
+{
+  name = "windscribe";
+
+  meta.maintainers = with (import ../../maintainers/maintainer-list.nix); [ syntheit ];
+
+  nodes.machine = {
+    services.windscribe.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("windscribe-helper.service")
+    machine.succeed("test -S /var/run/windscribe/helper.sock")
+    machine.succeed("test -f /etc/windscribe/platform")
+    machine.succeed("test -d /opt/windscribe")
+    machine.succeed("mountpoint -q /opt/windscribe")
+    machine.succeed("test -x /opt/windscribe/helper")
+    machine.succeed("test -x /opt/windscribe/windscribeopenvpn")
+    machine.succeed("test -x /opt/windscribe/windscribewstunnel")
+    machine.succeed("/opt/windscribe/windscribeopenvpn --version")
+  '';
+}

--- a/nixos/tests/windscribe.nix
+++ b/nixos/tests/windscribe.nix
@@ -1,0 +1,100 @@
+{ lib, ... }:
+
+{
+  name = "windscribe";
+
+  meta.maintainers = with lib.maintainers; [ syntheit ];
+
+  nodes.machine =
+    { pkgs, config, ... }:
+    let
+      # Connects to the helper's unix socket. Exits 0 on success, 1 on any
+      # error (EACCES for a caller not in the windscribe group, ECONNREFUSED if
+      # nothing is listening, ...). Written in Python, not shell: a setgid bash
+      # would drop egid back to the real gid (its privileged-mode guard),
+      # masking the very group the setgid wrapper grants - the real GUI is a
+      # compiled binary and keeps the group.
+      helperProbe = pkgs.writeScript "windscribe-helper-probe" ''
+        #!${pkgs.python3}/bin/python3
+        import socket, sys
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            s.connect("/var/run/windscribe/helper.sock")
+        except OSError as e:
+            print("connect failed:", e)
+            sys.exit(1)
+        print("connected")
+      '';
+    in
+    {
+      services.windscribe.enable = true;
+
+      # A desktop user who is NOT in the windscribe group - mirrors how someone
+      # actually launches the GUI.
+      users.users.alice.isNormalUser = true;
+
+      # At runtime the bundled binaries live only inside the helper service's
+      # BindReadOnlyPaths mount namespace (/opt/windscribe is an empty dir in
+      # the global namespace). Expose the package tree at a stable path so the
+      # test can exercise those binaries directly.
+      environment.etc."windscribe-package".source = config.services.windscribe.package;
+
+      # Plain (no setgid) copy of the probe, to confirm the helper socket is
+      # genuinely group-gated for a non-member.
+      environment.etc."windscribe-helper-probe" = {
+        source = helperProbe;
+        mode = "0755";
+      };
+
+      # setgid-"windscribe" copy of the same probe, built with the very
+      # security.wrappers mechanism the module uses for the GUI. Proves a
+      # non-member gains egid=windscribe and can reach the socket.
+      security.wrappers.windscribe-helper-probe = {
+        source = helperProbe;
+        owner = "root";
+        group = "windscribe";
+        setgid = true;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("windscribe-helper.service")
+    machine.wait_for_file("/var/run/windscribe/helper.sock")
+
+    pkg = "/etc/windscribe-package/opt/windscribe"
+
+    # The bundled OpenVPN binary must actually load and run - this exercises
+    # the autoPatchelf'd interpreter, rpath, and the bundled libcrypto/libssl
+    # in $out/opt/windscribe/lib.
+    machine.succeed(f"{pkg}/windscribeopenvpn --version")
+
+    # The Go wstunnel is intentionally unpatched and relies on nix-ld for
+    # /lib64/ld-linux-x86-64.so.2. Regression check for the segfault that
+    # autoPatchelf would otherwise introduce in the Go runtime.
+    machine.succeed(f"{pkg}/windscribewstunnel --version")
+
+    # The CLI wrapper resolves through security.wrappers (setgid'd copy in
+    # /run/wrappers/bin). --help exits 0 without requiring an account or display.
+    machine.succeed("windscribe-cli --help")
+
+    # --- Helper socket access (regression guard for the GUI startup hang) ---
+    # The helper socket is 0770 root:windscribe; the GUI/CLI reach it by running
+    # setgid "windscribe" (as the upstream .deb does with `chmod 2755 && chgrp
+    # windscribe`). cap_setgid does NOT work here: the app never raises into the
+    # group, it only ever drops it, so connect() gets EACCES, surfacing as
+    # "Timed out connecting to helper socket" / "app did not start in time".
+
+    # The GUI and CLI wrappers must carry the setgid bit and group "windscribe".
+    for prog in ["windscribe", "windscribe-cli"]:
+        machine.succeed(f"test -g /run/wrappers/bin/{prog}")
+        gid = machine.succeed(f"stat -c %G /run/wrappers/bin/{prog}").strip()
+        assert gid == "windscribe", f"{prog} wrapper group is {gid!r}, expected windscribe"
+
+    # A non-member connecting directly is denied - proves the socket is really
+    # group-gated (otherwise the check below would pass vacuously).
+    machine.fail("su alice -c /etc/windscribe-helper-probe")
+
+    # The same user, launched through a setgid-"windscribe" wrapper, connects.
+    machine.succeed("su alice -c /run/wrappers/bin/windscribe-helper-probe")
+  '';
+}

--- a/pkgs/by-name/wi/windscribe/package.nix
+++ b/pkgs/by-name/wi/windscribe/package.nix
@@ -47,6 +47,9 @@ stdenv.mkDerivation rec {
   pname = "windscribe";
   version = "2.21.7";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchurl {
     url = "https://github.com/Windscribe/Desktop-App/releases/download/v${version}/windscribe_${version}_amd64.deb";
     hash = "sha256-ADzN5RH3hLcgvOW5Ix0n44cIslezrM9s1z8uum/Qd1c=";

--- a/pkgs/by-name/wi/windscribe/package.nix
+++ b/pkgs/by-name/wi/windscribe/package.nix
@@ -194,6 +194,7 @@ stdenv.mkDerivation rec {
     homepage = "https://windscribe.com";
     license = licenses.gpl2;
     sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    maintainers = with maintainers; [ syntheit ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "windscribe";
   };

--- a/pkgs/by-name/wi/windscribe/package.nix
+++ b/pkgs/by-name/wi/windscribe/package.nix
@@ -1,0 +1,200 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  nixosTests,
+  autoPatchelfHook,
+  makeWrapper,
+  # GUI dependencies (linked)
+  dbus,
+  glib,
+  brotli,
+  libdrm,
+  libxcb,
+  libx11,
+  libxcb-wm,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxcb-cursor,
+  libxkbcommon,
+  wayland,
+  libglvnd,
+  harfbuzz,
+  freetype,
+  fontconfig,
+  zstd,
+  pcre2,
+  # OpenVPN dependencies
+  libnl,
+  libcap_ng,
+  # Runtime tools used by helper scripts
+  iptables,
+  iproute2,
+  systemd,
+  util-linux,
+  kmod,
+  gnused,
+  gawk,
+  gnugrep,
+  coreutils,
+  e2fsprogs,
+  wireguard-tools,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "windscribe";
+  version = "2.21.7";
+
+  src = fetchurl {
+    url = "https://github.com/Windscribe/Desktop-App/releases/download/v${version}/windscribe_${version}_amd64.deb";
+    hash = "sha256-ADzN5RH3hLcgvOW5Ix0n44cIslezrM9s1z8uum/Qd1c=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glib
+    brotli
+    libdrm
+    libxcb
+    libx11
+    libxcb-wm
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxcb-cursor
+    libxkbcommon
+    wayland
+    libglvnd
+    harfbuzz
+    freetype
+    fontconfig
+    zstd
+    pcre2
+    libnl
+    libcap_ng
+    stdenv.cc.cc.lib
+  ];
+
+  # Qt loads libdbus-1 via dlopen() - not detected by autoPatchelfHook
+  runtimeDependencies = [
+    (lib.getLib dbus)
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  installPhase =
+    let
+      scriptPath = lib.makeBinPath [
+        iptables
+        iproute2
+        systemd
+        util-linux
+        kmod
+        gnused
+        gawk
+        gnugrep
+        coreutils
+        e2fsprogs
+        wireguard-tools
+      ];
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/opt
+      cp -r opt/windscribe $out/opt/
+
+      # Save original Go binaries BEFORE any patching. autoPatchelf corrupts
+      # them (segfault in ld-linux) - we restore the originals in postFixup.
+      mkdir -p $TMPDIR/go-originals
+      for bin in windscribewstunnel windscribeamneziawg windscribectrld; do
+        cp "opt/windscribe/$bin" "$TMPDIR/go-originals/" 2>/dev/null || true
+      done
+
+      # Inject PATH into helper scripts so they find iptables, ip, wg, etc.
+      for script in $out/opt/windscribe/scripts/*; do
+        if [ -f "$script" ] && head -1 "$script" | grep -q "^#!"; then
+          sed -i "2i export PATH=\"${scriptPath}:\$PATH\"" "$script"
+        fi
+      done
+
+      # Replace self-update script (calls apt/dnf/pacman which don't exist on NixOS)
+      cat > $out/opt/windscribe/scripts/install-update << 'EOF'
+      #!/bin/bash
+      echo "Windscribe updates on NixOS are managed through the windscribe-nix flake."
+      echo "Update the flake input and rebuild your system."
+      exit 0
+      EOF
+      chmod +x $out/opt/windscribe/scripts/install-update
+
+      # Systemd unit (installed for reference; the NixOS module creates its own)
+      mkdir -p $out/lib/systemd/system
+      cp usr/lib/systemd/system/windscribe-helper.service $out/lib/systemd/system/
+
+      # Polkit policy
+      mkdir -p $out/share/polkit-1/actions
+      cp usr/polkit-1/actions/com.windscribe.authhelper.policy $out/share/polkit-1/actions/
+      sed -i "s|/opt/windscribe|$out/opt/windscribe|g" \
+        $out/share/polkit-1/actions/com.windscribe.authhelper.policy
+
+      # Desktop entry and icons
+      mkdir -p $out/share/applications
+      cp usr/share/applications/windscribe.desktop $out/share/applications/
+      sed -i "s|/opt/windscribe/Windscribe|windscribe|g" \
+        $out/share/applications/windscribe.desktop
+      cp -r usr/share/icons $out/share/
+
+      # Autostart entry (app checks /etc/windscribe/autostart/ for "Launch on Startup")
+      mkdir -p $out/etc/xdg/autostart
+      if [ -f etc/windscribe/autostart/windscribe.desktop ]; then
+        cp etc/windscribe/autostart/windscribe.desktop $out/etc/xdg/autostart/
+        sed -i "s|/opt/windscribe/Windscribe|windscribe|g" \
+          $out/etc/xdg/autostart/windscribe.desktop
+      fi
+
+      # CLI and GUI wrappers
+      mkdir -p $out/bin
+      makeWrapper $out/opt/windscribe/Windscribe $out/bin/windscribe \
+        --prefix PATH : "${scriptPath}"
+      makeWrapper $out/opt/windscribe/windscribe-cli $out/bin/windscribe-cli \
+        --prefix PATH : "${scriptPath}"
+
+      runHook postInstall
+    '';
+
+  # Bundled libs (libwsnet, libcrypto, libssl) live in $out/opt/windscribe/lib
+  preFixup = ''
+    addAutoPatchelfSearchPath $out/opt/windscribe/lib
+
+    # Register a hook that runs AFTER autoPatchelf (which is also a
+    # postFixupHook). This restores the original Go binaries from the .deb
+    # that were saved during installPhase. autoPatchelf corrupts Go binaries
+    # (segfault in ld-linux), so we overwrite them with the unpatched originals.
+    restoreGoBinaries() {
+      for bin in "$TMPDIR/go-originals"/*; do
+        cp "$bin" "$out/opt/windscribe/$(basename "$bin")"
+      done
+    }
+    postFixupHooks+=(restoreGoBinaries)
+  '';
+
+  passthru.tests.windscribe = nixosTests.windscribe;
+
+  meta = with lib; {
+    description = "Windscribe VPN client";
+    homepage = "https://windscribe.com";
+    license = licenses.gpl2;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "windscribe";
+  };
+}

--- a/pkgs/by-name/wi/windscribe/package.nix
+++ b/pkgs/by-name/wi/windscribe/package.nix
@@ -1,0 +1,217 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  nixosTests,
+  autoPatchelfHook,
+  makeWrapper,
+  # GUI dependencies (linked)
+  dbus,
+  glib,
+  brotli,
+  libdrm,
+  libxcb,
+  libx11,
+  libxcb-wm,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxcb-cursor,
+  libxcb-util,
+  libxkbcommon,
+  wayland,
+  libglvnd,
+  harfbuzz,
+  freetype,
+  fontconfig,
+  zstd,
+  pcre2,
+  # OpenVPN dependencies
+  libnl,
+  libcap_ng,
+  acl,
+  # Runtime tools used by helper scripts
+  iptables,
+  iproute2,
+  systemd,
+  util-linux,
+  kmod,
+  gnused,
+  gawk,
+  gnugrep,
+  coreutils,
+  e2fsprogs,
+  wireguard-tools,
+}:
+
+let
+  # Upstream ships per-arch .deb builds under identical layouts. The GUI, CLI,
+  # helper and openvpn binaries are dynamically linked on both arches (aarch64
+  # uses /lib/ld-linux-aarch64.so.1; amd64 uses /lib64/ld-linux-x86-64.so.2 —
+  # nix-ld provides both). The bundled Go binaries are dynamically linked on
+  # amd64 (so restoreGoBinaries below matters) and statically linked on
+  # aarch64 (autoPatchelf ignores them; the restore is a harmless no-op).
+  sources = {
+    x86_64-linux = {
+      urlArch = "amd64";
+      hash = "sha256-YySYUm5URisCVyO9RL+89gMkQn7C3nToVwujAfArIy4=";
+    };
+    aarch64-linux = {
+      urlArch = "arm64";
+      hash = "sha256-ZpO9BT9xXMXiqGtSrgx7ghTyiDsLUhq7PpgGw8be4Ak=";
+    };
+  };
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "windscribe: unsupported system ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation rec {
+  pname = "windscribe";
+  version = "2.23.12";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/Windscribe/Desktop-App/releases/download/v${version}/windscribe_${version}_${source.urlArch}.deb";
+    inherit (source) hash;
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glib
+    brotli
+    libdrm
+    libxcb
+    libx11
+    libxcb-wm
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxcb-cursor
+    libxcb-util
+    libxkbcommon
+    wayland
+    libglvnd
+    harfbuzz
+    freetype
+    fontconfig
+    zstd
+    pcre2
+    libnl
+    libcap_ng
+    acl
+    stdenv.cc.cc.lib
+  ];
+
+  # Qt loads libdbus-1 via dlopen() - not detected by autoPatchelfHook
+  runtimeDependencies = [
+    (lib.getLib dbus)
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  installPhase =
+    let
+      scriptPath = lib.makeBinPath [
+        iptables
+        iproute2
+        systemd
+        util-linux
+        kmod
+        gnused
+        gawk
+        gnugrep
+        coreutils
+        e2fsprogs
+        wireguard-tools
+      ];
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/opt
+      cp -r opt/windscribe $out/opt/
+
+      # Save original Go binaries BEFORE any patching. autoPatchelf corrupts
+      # them (segfault in ld-linux) - we restore the originals in postFixup.
+      mkdir -p $TMPDIR/go-originals
+      for bin in windscribewstunnel windscribeamneziawg windscribectrld; do
+        cp "opt/windscribe/$bin" "$TMPDIR/go-originals/" 2>/dev/null || true
+      done
+
+      # Inject PATH into helper scripts so they find iptables, ip, wg, etc.
+      for script in $out/opt/windscribe/scripts/*; do
+        if [ -f "$script" ] && head -1 "$script" | grep -q "^#!"; then
+          sed -i "2i export PATH=\"${scriptPath}:\$PATH\"" "$script"
+        fi
+      done
+
+      # Replace self-update script (calls apt/dnf/pacman which don't exist on NixOS)
+      cat > $out/opt/windscribe/scripts/install-update << 'EOF'
+      #!/bin/bash
+      echo "Windscribe updates on NixOS are managed through the windscribe-nix flake."
+      echo "Update the flake input and rebuild your system."
+      exit 0
+      EOF
+      chmod +x $out/opt/windscribe/scripts/install-update
+
+      # Desktop entry and icons
+      mkdir -p $out/share/applications
+      cp usr/share/applications/windscribe.desktop $out/share/applications/
+      substituteInPlace $out/share/applications/windscribe.desktop \
+        --replace-fail "/opt/windscribe/Windscribe" "windscribe"
+      cp -r usr/share/icons $out/share/
+
+      # Autostart entry (app checks /etc/windscribe/autostart/ for "Launch on Startup")
+      mkdir -p $out/etc/xdg/autostart
+      cp etc/windscribe/autostart/windscribe.desktop $out/etc/xdg/autostart/
+      substituteInPlace $out/etc/xdg/autostart/windscribe.desktop \
+        --replace-fail "/opt/windscribe/Windscribe" "windscribe"
+
+      # CLI and GUI wrappers
+      mkdir -p $out/bin
+      makeWrapper $out/opt/windscribe/Windscribe $out/bin/windscribe \
+        --prefix PATH : "${scriptPath}"
+      makeWrapper $out/opt/windscribe/windscribe-cli $out/bin/windscribe-cli \
+        --prefix PATH : "${scriptPath}"
+
+      runHook postInstall
+    '';
+
+  # Bundled libs (libwsnet, libcrypto, libssl) live in $out/opt/windscribe/lib
+  preFixup = ''
+    addAutoPatchelfSearchPath $out/opt/windscribe/lib
+
+    # Register a hook that runs AFTER autoPatchelf (which is also a
+    # postFixupHook). This restores the original Go binaries from the .deb
+    # that were saved during installPhase. autoPatchelf corrupts Go binaries
+    # (segfault in ld-linux), so we overwrite them with the unpatched originals.
+    restoreGoBinaries() {
+      for bin in "$TMPDIR/go-originals"/*; do
+        cp "$bin" "$out/opt/windscribe/$(basename "$bin")"
+      done
+    }
+    postFixupHooks+=(restoreGoBinaries)
+  '';
+
+  passthru.tests.windscribe = nixosTests.windscribe;
+
+  meta = with lib; {
+    description = "Windscribe VPN client";
+    homepage = "https://windscribe.com";
+    license = licenses.gpl2;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    maintainers = with maintainers; [ syntheit ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "windscribe";
+  };
+}


### PR DESCRIPTION
Package and NixOS module for the Windscribe VPN client. Upstream source: https://github.com/Windscribe/Desktop-App (GPL-2.0)

The helper binary validates sub-process paths via realpath() against /opt/windscribe, so a bind mount is used instead of a symlink (realpath resolves symlinks but not mount points). The GUI and CLI require cap_setgid for helper socket access, handled via security.wrappers.

Go binaries (wstunnel, amneziawg, ctrld) are restored to their original unpatched state after autoPatchelf, as the Go runtime segfaults when the dynamic linker is modified. These binaries use the standard /lib64/ld-linux-x86-64.so.2 interpreter via programs.nix-ld.

Closes #158368

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
