### PR TITLE
python3Packages.stanza: 1.11.0 -> 1.11.1; python3Packages.udtools: init at 0.2.7; python3Packages.udapi: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/stanza/default.nix
+++ b/pkgs/development/python-modules/stanza/default.nix
@@ -9,23 +9,25 @@
   networkx,
   numpy,
   peft,
+  platformdirs,
   protobuf,
   requests,
   torch,
   tqdm,
   transformers,
+  udtools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "stanza";
-  version = "1.11.0";
+  version = "1.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stanfordnlp";
     repo = "stanza";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zY2+8QuPJTX/HSkE/gKMCWpSanKpYSGZeeYgb4eFuuw=";
+    hash = "sha256-Rq+2DutK46Mc9HeMRsGt26raZiC7zjE9M4A6hLbTINk=";
   };
 
   build-system = [ setuptools ];
@@ -35,11 +37,13 @@ buildPythonPackage (finalAttrs: {
     networkx
     numpy
     peft
+    platformdirs
     protobuf
     requests
     torch
     tqdm
     transformers
+    udtools
   ];
 
   # Most tests require resources from the network (models). Many of the ones that do run are slow

--- a/pkgs/development/python-modules/udapi/default.nix
+++ b/pkgs/development/python-modules/udapi/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  # dependencies
+  colorama,
+  termcolor,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "udapi";
+  version = "0.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "udapi";
+    repo = "udapi-python";
+    tag = finalAttrs.version;
+    hash = "sha256-0h4nfd3QHdZNiT0VFBs6xJ/lpiNPzcJQmV60KoH0Nv0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    colorama
+    termcolor
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "udapi" ];
+
+  meta = {
+    description = "Python framework for processing Universal Dependencies data";
+    homepage = "https://github.com/udapi/udapi-python";
+    license = lib.licenses.gpl3Plus;
+    changelog = "https://github.com/udapi/udapi-python/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [
+      Stebalien
+    ];
+  };
+})

--- a/pkgs/development/python-modules/udtools/default.nix
+++ b/pkgs/development/python-modules/udtools/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  nix-update-script,
+  buildPythonPackage,
+  fetchFromGitHub,
+  python,
+  setuptools,
+  # dependencies
+  regex,
+  udapi,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "udtools";
+  version = "0.2.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "UniversalDependencies";
+    repo = "tools";
+    tag = "py${finalAttrs.version}";
+    hash = "sha256-P1gx6JRq1oWCXzB2uO/eCrw8ZgJ+0Y/0cvlLtj+X7SY=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/udtools";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    udapi
+    regex
+  ];
+
+  # pycheck tests are not enabled because they try to import packages/types
+  # that I can't seem to find anywhere on the internet.
+  # https://github.com/UniversalDependencies/tools/issues/158
+  pythonImportsCheck = [ "udtools" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=py(.*)" ];
+  };
+
+  postInstall = ''
+    install -dm755 $out/${python.sitePackages}/udtools/data
+    cp $src/data/* $out/${python.sitePackages}/udtools/data
+  '';
+
+  meta = {
+    description = "Python tools for Universal Dependencies";
+    homepage = "https://universaldependencies.org/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      Stebalien
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20417,6 +20417,8 @@ self: super: with self; {
 
   ucsmsdk = callPackage ../development/python-modules/ucsmsdk { };
 
+  udapi = callPackage ../development/python-modules/udapi { };
+
   udatetime = callPackage ../development/python-modules/udatetime { };
 
   ueagle = callPackage ../development/python-modules/ueagle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20421,6 +20421,8 @@ self: super: with self; {
 
   udatetime = callPackage ../development/python-modules/udatetime { };
 
+  udtools = callPackage ../development/python-modules/udtools { };
+
   ueagle = callPackage ../development/python-modules/ueagle { };
 
   ueberzug = callPackage ../development/python-modules/ueberzug {


### PR DESCRIPTION
This PR primarily update stanza from 1.11.0 to 1.11.1. Unfortunately, upstream added a dependency on udtools, which has a dependency on udapi, so I had to initialize both of those packages at 0.2.7 and 0.5.2 respectively.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
