### PR TITLE
qradiolink: 0.9.1-3 -> 0.10.2-1

### DIFF
--- a/pkgs/by-name/qr/qradiolink/package.nix
+++ b/pkgs/by-name/qr/qradiolink/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
-  fetchpatch,
+  fetchFromCodeberg,
   libpulseaudio,
   libconfig,
   pkg-config,
@@ -28,27 +27,14 @@
 
 gnuradio.pkgs.mkDerivation rec {
   pname = "qradiolink";
-  version = "0.9.1-3";
+  version = "0.10.2-1";
 
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "qradiolink";
     repo = "qradiolink";
     tag = version;
-    hash = "sha256-0inXfeOSVmJYtNhD6WBExjT43STfBjePomKILxoHO6Q=";
+    hash = "sha256-pouOFi0w5QW3Wn6C5k+JB5wO+tX79rD+SshH+OitsDw=";
   };
-
-  patches = [
-    # dmr: add explicit cstdint import
-    (fetchpatch {
-      url = "https://github.com/qradiolink/qradiolink/pull/131/commits/bdd3b47708edf42b281fb9e5507d356d475f3df9.patch";
-      hash = "sha256-Uoi8/IK8yBmfPL7RAkCGuyHdcdJZ+YMxccviY7Z+hXs=";
-    })
-    # qmake: find protobuf via pkg-config
-    (fetchpatch {
-      url = "https://github.com/qradiolink/qradiolink/pull/132/commits/cd3e4bc188a60bc85693fe3de4540c48f325deb4.patch";
-      hash = "sha256-ufSStm0pyDkCUIx0SjVVHZhA4gW7Ip6PiexPg34DsCo=";
-    })
-  ];
 
   preBuild = ''
     cd src/ext


### PR DESCRIPTION
- #485826 
- #507271
- https://hydra.nixos.org/build/325810790
- Changelog: https://codeberg.org/qradiolink/qradiolink/releases/tag/0.10.2-1
- Diff: https://codeberg.org/qradiolink/qradiolink/compare/0.9.1-3...0.10.2-1



Upstream repository migrated to codeberg.

Only verified the GUI loads up.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
