### PR TITLE
twinejs: init at 2.11.1

### DIFF
--- a/pkgs/by-name/tw/twinejs/package.nix
+++ b/pkgs/by-name/tw/twinejs/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  jq,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  desktopToDarwinBundle,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "twine";
+  version = "2.11.1";
+
+  src = fetchFromGitHub {
+    owner = "klembot";
+    repo = "twinejs";
+    tag = finalAttrs.version;
+    hash = "sha256-+y25XxTRxmCKjNL74Wb3hgAkw8yQNznYNzTuDL3uIvg=";
+  };
+
+  npmDepsHash = "sha256-9gMdbFibt6RwMxEsBAQE7nM0rfE7PqgUxTs87+g0Ok8=";
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+  nativeBuildInputs = [
+    jq
+    makeWrapper
+    copyDesktopItems
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm run build:web
+    npm run build:electron-main
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    files="$(node -e 'process.stdout.write(require("./electron-builder.config.js").files.join(" "))')"
+    packageJson="$(jq -s '.[0] * .[1]' package.json <(node -e 'process.stdout.write(JSON.stringify(require("./electron-builder.config.js").extraMetadata))'))"
+
+    # so that dev dependencies will not be installed
+    npm prune --production
+
+    phome="$out/lib/node_modules/$(jq -r .name package.json)"
+    mkdir -p "$phome"
+    tar -cf - --wildcards $files | tar -C "$phome" -xf -
+    echo "$packageJson" > "$phome/package.json"
+
+    makeWrapper ${lib.getExe electron} $out/bin/twine \
+      --add-flags "$phome" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set ELECTRON_FORCE_IS_PACKAGED 1 \
+      --inherit-argv0
+
+    install -Dm644 icons/app-pwa.svg $out/share/icons/hicolor/scalable/apps/twine.svg
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "twine";
+      desktopName = "Twine";
+      comment = finalAttrs.meta.description;
+      exec = "twine %U";
+      icon = "twine";
+      categories = [ "Development" ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open-source tool for telling interactive, nonlinear stories";
+    homepage = "https://twinery.org";
+    changelog = "https://github.com/klembot/twinejs/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = electron.meta.platforms;
+    mainProgram = "twine";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
