### PR TITLE
Vault agent fixes

### DIFF
--- a/nixos/modules/services/security/vault-agent.nix
+++ b/nixos/modules/services/security/vault-agent.nix
@@ -52,7 +52,7 @@ let
 
                     options = {
                       pid_file = lib.mkOption {
-                        default = "/run/${flavour}/${name}.pid";
+                        default = "/run/${flavour}-${name}/pid";
                         type = types.str;
                         description = ''
                           Path to use for the pid file.
@@ -106,7 +106,7 @@ let
       serviceConfig = {
         User = instance.user;
         Group = instance.group;
-        RuntimeDirectory = flavour;
+        RuntimeDirectory = "${flavour}-${name}";
         ExecStart = "${lib.getExe instance.package} ${
           lib.optionalString (flavour == "vault-agent") "agent"
         } -config ${configFile}";

--- a/nixos/modules/services/security/vault-agent.nix
+++ b/nixos/modules/services/security/vault-agent.nix
@@ -21,7 +21,7 @@ let
         with lib.types;
         attrsOf (
           submodule (
-            { name, ... }:
+            { name, config, ... }:
             {
               options = {
                 enable = lib.mkEnableOption "this ${flavour} instance" // {
@@ -46,13 +46,20 @@ let
                   '';
                 };
 
+                serviceName = lib.mkOption {
+                  type = types.str;
+                  default = "${flavour}-${name}";
+                  defaultText = "${flavour}-<name>";
+                  description = "Systemd service name";
+                };
+
                 settings = lib.mkOption {
                   type = types.submodule {
                     freeformType = format.type;
 
                     options = {
                       pid_file = lib.mkOption {
-                        default = "/run/${flavour}-${name}/pid";
+                        default = "/run/${config.serviceName}/pid";
                         type = types.str;
                         description = ''
                           Path to use for the pid file.
@@ -106,7 +113,7 @@ let
       serviceConfig = {
         User = instance.user;
         Group = instance.group;
-        RuntimeDirectory = "${flavour}-${name}";
+        RuntimeDirectory = instance.serviceName;
         ExecStart = "${lib.getExe instance.package} ${
           lib.optionalString (flavour == "vault-agent") "agent"
         } -config ${configFile}";
@@ -136,7 +143,7 @@ in
         lib.mkIf (cfg.instances != { }) {
           systemd.services = lib.mapAttrs' (
             name: instance:
-            lib.nameValuePair "${flavour}-${name}" (createAgentInstance {
+            lib.nameValuePair instance.serviceName (createAgentInstance {
               inherit name instance flavour;
             })
           ) cfg.instances;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the instance name to `RuntimeDirectory`, because previously different instances used the same `RuntimeDirectory`, and if one instance is stopped, it will delete every other instance `RuntimeDirectory` as well.

Also added `serviceName` (as it is done in `services.oci-containers.containers`) for more convenient overriding, such as doing
```nix
{ config, ... }:
{
  services.vault-agent.instances.myvaultagent = { … };
  systemd.services.${config.services.vault-agent.instances.myvaultagent.serviceName} = {
    serviceConfig.RuntimeDirectoryMode = "0700";
  };
}
``` 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
