### PR TITLE
python3Packages.tensorflow: add missing hash for x86_64-linux GPU

### DIFF
--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -79,11 +79,13 @@ buildPythonPackage (finalAttrs: {
     "test_barker"
     "test_mclmc"
     "test_mcse4"
+    "test_mean_and_std"
     "test_normal_univariate"
     "test_nuts__with_device"
     "test_nuts__with_jit"
     "test_nuts__without_device"
     "test_nuts__without_jit"
+    "test_smc__with_jit"
     "test_smc_waste_free__with_jit"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [

--- a/pkgs/development/python-modules/tensorflow/binary-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/binary-hashes.nix
@@ -29,6 +29,10 @@
     url = "https://storage.googleapis.com/tensorflow/versions/%222.21.0%22/tensorflow-2.21.0-cp312-cp312-manylinux_2_27_x86_64.whl";
     sha256 = "1h0kpc9kflb1xr26ibw4xhbz6hp1rcsznf4rhcjvj3p7qi1mdfdk";
   };
+  x86_64-linux_313_gpu = {
+    url = "https://storage.googleapis.com/tensorflow/versions/%222.21.0%22/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_x86_64.whl";
+    sha256 = "01jljjx1n46x57d6n33fgs86y09gmxqblcph8pxhwrdrra6xmn79";
+  };
   aarch64-linux_310 = {
     url = "https://storage.googleapis.com/tensorflow/versions/%222.21.0%22/tensorflow-2.21.0-cp310-cp310-manylinux_2_27_aarch64.whl";
     sha256 = "0pcskswb7v82282w4mmj5smy5pmwbbw336b1x05chw6g4n5r75vw";

--- a/pkgs/development/python-modules/tensorflow/prefetcher.sh
+++ b/pkgs/development/python-modules/tensorflow/prefetcher.sh
@@ -17,6 +17,7 @@ url_and_key_list=(
 "x86_64-linux_310_gpu $bucket/tensorflow-${version}-cp310-cp310-manylinux_2_27_x86_64.whl"
 "x86_64-linux_311_gpu $bucket/tensorflow-${version}-cp311-cp311-manylinux_2_27_x86_64.whl"
 "x86_64-linux_312_gpu $bucket/tensorflow-${version}-cp312-cp312-manylinux_2_27_x86_64.whl"
+"x86_64-linux_313_gpu $bucket/tensorflow-${version}-cp313-cp313-manylinux_2_27_x86_64.whl"
 "aarch64-linux_310 $bucket/tensorflow-${version}-cp310-cp310-manylinux_2_27_aarch64.whl"
 "aarch64-linux_311 $bucket/tensorflow-${version}-cp311-cp311-manylinux_2_27_aarch64.whl"
 "aarch64-linux_312 $bucket/tensorflow-${version}-cp312-cp312-manylinux_2_27_aarch64.whl"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add missing `x86_64-linux`+GPU hash for tensorflow.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
