### PR TITLE
[Backport release-25.11] signal-cli: 0.13.24 -> 0.14.2

### DIFF
--- a/pkgs/by-name/si/signal-cli/package.nix
+++ b/pkgs/by-name/si/signal-cli/package.nix
@@ -12,12 +12,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "signal-cli";
-  version = "0.14.1";
+  version = "0.14.2";
 
   # Building from source would be preferred, but is much more involved.
   src = fetchurl {
     url = "https://github.com/AsamK/signal-cli/releases/download/v${finalAttrs.version}/signal-cli-${finalAttrs.version}.tar.gz";
-    hash = "sha256-zs2ksSxCwYhEZ/Oh8BN3U2ISwqXPshCl82HoL4wWNug=";
+    hash = "sha256-riu8b8ZomoqyPVfmN9fpzbtDQpN72xtU1M9rVkDfHg0=";
   };
 
   buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [

--- a/pkgs/by-name/si/signal-cli/package.nix
+++ b/pkgs/by-name/si/signal-cli/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchurl,
   makeWrapper,
-  openjdk21_headless,
+  openjdk25_headless,
   libmatthew_java,
   dbus,
   dbus_java,
@@ -12,12 +12,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "signal-cli";
-  version = "0.13.24";
+  version = "0.14.1";
 
   # Building from source would be preferred, but is much more involved.
   src = fetchurl {
     url = "https://github.com/AsamK/signal-cli/releases/download/v${finalAttrs.version}/signal-cli-${finalAttrs.version}.tar.gz";
-    hash = "sha256-Xg43pmLi5k+H58UYOhtzYogjuJWQcHxU5IsIS+Zd1D8=";
+    hash = "sha256-zs2ksSxCwYhEZ/Oh8BN3U2ISwqXPshCl82HoL4wWNug=";
   };
 
   buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
@@ -36,8 +36,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   + (
     if stdenvNoCC.hostPlatform.isLinux then
       ''
-        makeWrapper ${openjdk21_headless}/bin/java $out/bin/signal-cli \
-          --set JAVA_HOME "${openjdk21_headless}" \
+        makeWrapper ${openjdk25_headless}/bin/java $out/bin/signal-cli \
+          --set JAVA_HOME "${openjdk25_headless}" \
           --add-flags "-classpath '$out/lib/*:${libmatthew_java}/lib/jni'" \
           --add-flags "-Djava.library.path=${libmatthew_java}/lib/jni:${dbus_java}/share/java/dbus:$out/lib" \
           --add-flags "org.asamk.signal.Main"
@@ -45,8 +45,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     else
       ''
         wrapProgram $out/bin/signal-cli \
-          --prefix PATH : ${lib.makeBinPath [ openjdk21_headless ]} \
-          --set JAVA_HOME ${openjdk21_headless}
+          --prefix PATH : ${lib.makeBinPath [ openjdk25_headless ]} \
+          --set JAVA_HOME ${openjdk25_headless}
       ''
   )
   + ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of #501468 #506706 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
