### PR TITLE
python3Packages.jmmpl_evaluator: init at 0.16.0

### DIFF
--- a/pkgs/development/python-modules/jpmml-evaluator-python/default.nix
+++ b/pkgs/development/python-modules/jpmml-evaluator-python/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  jpype1,
+  pandas,
+  py4j,
+  pyjnius,
+  jre_minimal,
+}:
+
+let
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.desktop"
+      "java.instrument"
+      "java.logging"
+      "java.net.http"
+      "java.sql"
+      "java.xml"
+    ];
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "jpmml-evaluator-python";
+  version = "0.16.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jpmml";
+    repo = "jpmml-evaluator-python";
+    tag = finalAttrs.version;
+    hash = "sha256-6B59C1bdHIwvKfI5/3WfP3tFq226vpeAMU0DlwTHhNQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    jpype1
+    pandas
+    py4j
+    pyjnius
+  ];
+
+  nativeBuildInputs = [ jre ];
+
+  pythonImportsCheck = [ "jpmml_evaluator" ];
+
+  meta = {
+    description = "PMML evaluator library for Python";
+    homepage = "https://github.com/jpmml/jpmml-evaluator-python";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.b-rodrigues ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7915,6 +7915,8 @@ self: super: with self; {
 
   jplephem = callPackage ../development/python-modules/jplephem { };
 
+  jpmml-evaluator-python = callPackage ../development/python-modules/jpmml-evaluator-python { };
+
   jproperties = callPackage ../development/python-modules/jproperties { };
 
   jpylyzer = callPackage ../development/python-modules/jpylyzer { };


### PR DESCRIPTION
Adds jpmml_evaluator, PMML evaluator library for Python

Changelog: https://github.com/jpmml/jpmml-evaluator-python/releases/tag/0.16.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
