### PR TITLE
octobot-bin: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9991,6 +9991,11 @@
     githubId = 13297896;
     name = "David Isaksson";
   };
+  grandjeanlab = {
+    github = "grandjeanlab";
+    githubId = 22633767;
+    name = "grandjeanlab";
+  };
   gravndal = {
     email = "gaute.ravndal+nixos@gmail.com";
     github = "gravndal";

--- a/pkgs/by-name/oc/octobot-bin/package.nix
+++ b/pkgs/by-name/oc/octobot-bin/package.nix
@@ -1,0 +1,66 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  openssl,
+  stdenvNoCC,
+  zlib,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "octobot-bin";
+  version = "2.1.1";
+  __structuredAttrs = true;
+
+  src = fetchurl (
+    let
+      platform =
+        {
+          "aarch64-linux" = {
+            arch = "arm64";
+            hash = "sha256-nq87HxM5KRbqwJa06hax6gRsDAmHA7m7HcwTe4uR8gk=";
+          };
+          "x86_64-linux" = {
+            arch = "x64";
+            hash = "sha256-nDXWD1jzJtsFT+W8EAs3k+17s/15ZtgDbNqA2Pe2Ed4=";
+          };
+        }
+        .${stdenvNoCC.hostPlatform.system};
+    in
+    {
+      url = "https://github.com/Drakkar-Software/octobot/releases/download/${finalAttrs.version}/octobot_linux_${platform.arch}";
+      inherit (platform) hash;
+    }
+  );
+
+  dontUnpack = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D $src $out/bin/${finalAttrs.meta.mainProgram}
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/Drakkar-Software/OctoBot/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Octobot is a powerful open-source cryptocurrency trading robot.";
+    homepage = "https://www.octobot.cloud";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "octobot";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ grandjeanlab ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Octobot is an open source crypto trading bot.
https://github.com/Drakkar-Software/OctoBot

fourth attempt at a pull request after:
https://github.com/NixOS/nixpkgs/pull/505971 and https://github.com/NixOS/nixpkgs/pull/506114

thanks to @MiniHarinn and @yzhou216 for the initial code review. :-) 

## Things done

- Built on platform:
  - [x ] x86_64-linux
  - [x ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

