### PR TITLE
eigenmath: 340-unstable-2025-05-05 -> 350

### DIFF
--- a/pkgs/by-name/ei/eigenmath/package.nix
+++ b/pkgs/by-name/ei/eigenmath/package.nix
@@ -3,18 +3,18 @@
   stdenv,
   fetchFromGitHub,
   buildPackages,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "eigenmath";
-  version = "340-unstable-2025-05-05";
+  version = "350";
 
   src = fetchFromGitHub {
     owner = "georgeweigt";
     repo = "eigenmath";
-    rev = "94fee6b02ebd4cd718dd9ea45583a6af2129dd28";
-    hash = "sha256-2bdO0nRXhDZlEmGRfNf6g9zwc65Ih9Ymlo6PxlpAxes=";
+    tag = finalAttrs.version;
+    hash = "sha256-Depc6mzPK6FEGTUo2BmXoWlyzjQDU8Hiodp5UjxKlQE=";
   };
 
   checkPhase =
@@ -23,13 +23,13 @@ stdenv.mkDerivation {
     in
     ''
       runHook preCheck
-
-      for testcase in selftest1 selftest2; do
-        ${emulator} ./eigenmath "test/$testcase"
-      done
-
+      echo -e "clear\nstatus\nexit" >> test/selftest
+      ${emulator} ./eigenmath "test/selftest"
       runHook postCheck
     '';
+
+  # https://github.com/georgeweigt/eigenmath/issues/32
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
   installPhase = ''
     runHook preInstall
@@ -39,9 +39,7 @@ stdenv.mkDerivation {
 
   doCheck = true;
 
-  passthru = {
-    updateScript = unstableGitUpdater { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Computer algebra system written in C";
@@ -51,4 +49,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ nickcao ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322285353

Upstream have tags for a while, so migrated to that.

Added a workaround for the tests to end properly. However in this current state, if the test fails halfway it will cause the program to output "?" prompts indefinitely. I'm not sure if this is acceptable for check purpose.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
