### PR TITLE
sequoia-chameleon-gnupg: add wrappers to mimic gpg

### DIFF
--- a/pkgs/by-name/se/sequoia-chameleon-gnupg/gpgconf.el
+++ b/pkgs/by-name/se/sequoia-chameleon-gnupg/gpgconf.el
@@ -1,0 +1,3 @@
+#!@execlineb@ -s0
+pipeline -w { @sed@ -e "s|^gpg:OpenPGP:.*/bin/gpg$|gpg:OpenPGP:@out@/bin/gpg|" }
+@gpgconf@ $@

--- a/pkgs/by-name/se/sequoia-chameleon-gnupg/package.nix
+++ b/pkgs/by-name/se/sequoia-chameleon-gnupg/package.nix
@@ -1,12 +1,15 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitLab,
   pkg-config,
+  makeWrapper,
   nettle,
   openssl,
   sqlite,
+  gnupg,
+  execline,
+  gnused,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -25,6 +28,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     rustPlatform.bindgenHook
     pkg-config
+    makeWrapper
   ];
 
   buildInputs = [
@@ -32,6 +36,26 @@ rustPlatform.buildRustPackage rec {
     openssl
     sqlite
   ];
+
+  postInstall = ''
+    # Wrap to find gpg-agent from GnuPG.
+    makeWrapper $out/bin/gpg-sq $out/bin/gpg \
+      --suffix PATH : ${lib.makeBinPath [ gnupg ]}
+    makeWrapper $out/bin/gpgv-sq $out/bin/gpgv \
+      --suffix PATH : ${lib.makeBinPath [ gnupg ]}
+
+    # Modify the output of gpgconf to resolve gpg to this package.
+    substitute ${./gpgconf.el} $out/bin/gpgconf \
+      --subst-var-by execlineb ${lib.getExe' execline "execlineb"} \
+      --subst-var-by gpgconf ${lib.getExe' gnupg "gpgconf"} \
+      --subst-var-by sed ${lib.getExe' gnused "sed"} \
+      --subst-var out
+
+    # Additional wrappers.
+    chmod +x $out/bin/gpgconf
+    ln -s gpg $out/bin/gpg2
+    ln -s ${lib.getExe' gnupg "gpg"} $out/bin/gpg-g10code
+  '';
 
   # gpgconf: error creating socket directory
   doCheck = false;

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -108,14 +108,12 @@ stdenv.mkDerivation rec {
     cp "contrib/dmenu/passmenu" "$out/bin/"
   '';
 
-  wrapperPath = lib.makeBinPath (
+  wrapperPathPrefix = lib.makeBinPath (
     [
       coreutils
       findutils
       getopt
-      git
       gnugrep
-      gnupg
       gnused
       tree
       which
@@ -136,6 +134,11 @@ stdenv.mkDerivation rec {
     ]
   );
 
+  wrapperPathSuffix = lib.makeBinPath [
+    git
+    gnupg
+  ];
+
   postFixup = ''
     # Fix program name in --help
     substituteInPlace $out/bin/pass \
@@ -143,13 +146,15 @@ stdenv.mkDerivation rec {
 
     # Ensure all dependencies are in PATH
     wrapProgram $out/bin/pass \
-      --prefix PATH : "${wrapperPath}"
+      --prefix PATH : "${wrapperPathPrefix}" \
+      --suffix PATH : "${wrapperPathSuffix}"
   ''
   + lib.optionalString dmenuSupport ''
     # We just wrap passmenu with the same PATH as pass. It doesn't
     # need all the tools in there but it doesn't hurt either.
     wrapProgram $out/bin/passmenu \
-      --prefix PATH : "$out/bin:${wrapperPath}"
+      --prefix PATH : "$out/bin:${wrapperPathPrefix}" \
+      --suffix PATH : "${wrapperPathSuffix}"
   '';
 
   # Turn "check" into "installcheck", since we want to test our pass,


### PR DESCRIPTION
Sequoia Chameleon can be used as a GnuPG replacement but must provide its own `gpg` and `gpgconf` programs that are able to start `gpg-agent` from GnuPG.

*(Sequoia-PGP is an OpenPGP implementation written in Rust)*

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
