### PR TITLE
draupnir: 2.9.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/dr/draupnir/package.nix
+++ b/pkgs/by-name/dr/draupnir/package.nix
@@ -2,67 +2,53 @@
   lib,
   fetchFromGitHub,
   makeBinaryWrapper,
-  nodejs_22,
+  nodejs_24,
   matrix-sdk-crypto-nodejs,
   python3,
   sqlite,
   srcOnly,
   removeReferencesTo,
-  fetchYarnDeps,
+  buildNpmPackage,
   stdenv,
   cctools,
   nixosTests,
-  yarnBuildHook,
-  yarnConfigHook,
   nix-update-script,
 }:
 let
-  nodeSources = srcOnly nodejs_22;
+  nodeSources = srcOnly nodejs_24;
 in
 
-stdenv.mkDerivation (finalAttrs: {
+buildNpmPackage (finalAttrs: {
   pname = "draupnir";
-  version = "2.9.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "the-draupnir-project";
     repo = "Draupnir";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j5UEW9JpIHhFWGMEwrPE1v0hdFAw5Z4CImRYEm56I4k=";
+    hash = "sha256-WrMYak6ztIy3KqjcVuN2OmIy1uxlIVNvHPGw7e3LRw0=";
   };
 
   nativeBuildInputs = [
     makeBinaryWrapper
     sqlite
     python3
-    yarnConfigHook
-    yarnBuildHook
-    nodejs_22
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin cctools.libtool;
 
-  offlineCache = fetchYarnDeps {
-    inherit (finalAttrs) src;
-    hash = "sha256-Ck6Ba/qDlEW5jqKUX8tyB0QbiVXU8+ND2tvhftmYktY=";
-  };
+  npmDepsHash = "sha256-CnSeg7sGFzPD+VQl8sWXtiBfuSdeieNhDrLFjWlHcUs=";
 
   preBuild = ''
-    # install proper version info
-    echo "${finalAttrs.version}-nix" > version.txt
+    # install proper version and branch info
+    echo "${finalAttrs.version}-nix" > apps/draupnir/version.txt
+    echo "main" > apps/draupnir/branch.txt
 
-    # makes network requests
-    sed -i 's/corepack //g' package.json
-  '';
-
-  postBuild = ''
-    yarn --offline run copy-assets
+    # we already set the version and branch above
+    substituteInPlace apps/draupnir/package.json \
+      --replace-fail " && npm run describe-version && npm run describe-branch" ""
   '';
 
   postInstall = ''
-    # Re-install only production dependencies
-    yarn install --frozen-lockfile --force --production --offline --non-interactive \
-      --ignore-engines --ignore-platform --ignore-scripts --no-progress
-
     # Replace matrix-sdk-crypto-nodejs with nixpkgs version
     nodeCryptoPath="node_modules/@matrix-org/matrix-sdk-crypto-nodejs"
     rm -rf "$nodeCryptoPath"
@@ -83,12 +69,14 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib/node_modules/draupnir
     mkdir $out/bin
     # Install outputs
-    mv ./lib ./version.txt ./node_modules ./package.json $out/lib/node_modules/draupnir
+    mv ./node_modules ./packages ./apps/draupnir/dist ./apps/draupnir/version.txt ./apps/draupnir/package.json $out/lib/node_modules/draupnir
+    # Fix dangling symlink pointing to relative path ../apps/draupnir
+    rm $out/lib/node_modules/draupnir/node_modules/draupnir
 
     # Create wrapper executable
-    makeWrapper ${lib.getExe nodejs_22} $out/bin/draupnir \
+    makeWrapper ${lib.getExe nodejs_24} $out/bin/draupnir \
       --add-flags "--enable-source-maps" \
-      --add-flags "$out/lib/node_modules/draupnir/lib/index.js"
+      --add-flags "$out/lib/node_modules/draupnir/dist/index.js"
 
   '';
 


### PR DESCRIPTION
https://github.com/the-draupnir-project/Draupnir/releases/tag/v3.0.0

Upstream moved multiple repos into a monorepo and switched from `yarn` to `npm`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
