### PR TITLE
jpmml-evaluator: init at 1.7.7

### DIFF
--- a/pkgs/by-name/jp/jpmml-evaluator/package.nix
+++ b/pkgs/by-name/jp/jpmml-evaluator/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  maven,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  jre_headless,
+  nix-update-script,
+}:
+
+let
+  pname = "jpmml-evaluator";
+  version = "1.7.7";
+in
+maven.buildMavenPackage {
+  inherit pname version;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jpmml";
+    repo = "jpmml-evaluator";
+    tag = version;
+    hash = "sha256-DtI/cHmiKVH0IAp3mWJr2sDDjAzM5d9/cBx4KJm74WM=";
+  };
+
+  mvnHash = "sha256-PBkRDMPF/btYROGs4bl71wl2em05N6T2Klf1qFZLHDI=";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/java $out/bin
+    cp pmml-evaluator-example/target/pmml-evaluator-example-executable-*.jar $out/share/java/jpmml-evaluator.jar
+
+    makeBinaryWrapper ${jre_headless}/bin/java $out/bin/jpmml-evaluator \
+      --add-flags "-jar $out/share/java/jpmml-evaluator.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Java Evaluator API for PMML";
+    homepage = "https://github.com/jpmml/jpmml-evaluator";
+    changelog = "https://github.com/jpmml/jpmml-evaluator/releases/tag/${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.b-rodrigues ];
+    mainProgram = "jpmml-evaluator";
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
Adds the Java Evaluator API for Predictive Model Markup Language (PMML).

Release: https://github.com/jpmml/jpmml-evaluator/releases/tag/1.7.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
