### PR TITLE
python3Packages.types-lxml: 2026.01.01 -> 2026.02.16, add dependency

### DIFF
--- a/pkgs/development/python-modules/pytest-revealtype-injector/default.nix
+++ b/pkgs/development/python-modules/pytest-revealtype-injector/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  pytest,
+  schema,
+  typeguard,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-revealtype-injector";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pytest_revealtype_injector";
+    inherit (finalAttrs) version;
+    hash = "sha256-+KuSByu92K7bkdaTmef6qrjhzUvCKcuqL7O1cfubKuQ=";
+  };
+
+  build-system = [ hatchling ];
+
+  buildInput = [ pytest ];
+
+  dependencies = [
+    pytest
+    schema
+    typeguard
+    typing-extensions
+  ];
+
+  # Upstream tests require external type checker binaries (mypy/pyright/pyrefly/ty)
+  # that are not propagated by this plugin.
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytest_revealtype_injector" ];
+
+  meta = {
+    description = "Pytest plugin for replacing reveal_type calls with static and runtime checks";
+    homepage = "https://github.com/abelcheung/pytest-revealtype-injector";
+    changelog = "https://github.com/abelcheung/pytest-revealtype-injector/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ attila ];
+  };
+})

--- a/pkgs/development/python-modules/pytest-revealtype-injector/default.nix
+++ b/pkgs/development/python-modules/pytest-revealtype-injector/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  basedpyright,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  hatchling,
+  mypy,
+  pyrefly,
+  pyright,
+  pytest,
+  pytestCheckHook,
+  schema,
+  ty,
+  typeguard,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-revealtype-injector";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "abelcheung";
+    repo = "pytest-revealtype-injector";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HXYH2CE6AQVBTm/Lse3qGMeNeuHVg5rqztVhSZKrry4=";
+  };
+
+  build-system = [ hatchling ];
+
+  patches = [
+    # Support mypy 1.20 additional schema fields
+    # https://github.com/abelcheung/pytest-revealtype-injector/pull/33
+    (fetchpatch {
+      url = "https://github.com/attilaolah/pytest-revealtype-injector/commit/f063c687a24b34daa0dd94f5fc2cf3a835211d0e.patch";
+      hash = "sha256-3HTDMqxAbKjuC9ulC/rXQgLnQEaBduqO6n2jQPU9r9E=";
+    })
+  ];
+
+  buildInputs = [ pytest ];
+
+  dependencies = [
+    schema
+    typeguard
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    basedpyright
+    mypy
+    pyrefly
+    pyright
+    pytestCheckHook
+    ty
+  ];
+
+  # Upstream's pytester tests load the plugin explicitly in nested pytest runs.
+  preCheck = ''
+    export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+  '';
+
+  pytestFlags = [ "--runpytest=subprocess" ];
+
+  disabledTests = [
+    # pyrefly does not infer reveal_type results for these AST transformations.
+    "test_nested_call"
+    "test_return_result"
+    # ty reports invalid-assignment before the runtime import tests execute.
+    "test_basic"
+    "test_import_as"
+    "test_import_module_as"
+  ];
+
+  pythonImportsCheck = [ "pytest_revealtype_injector" ];
+
+  meta = {
+    description = "Pytest plugin for replacing reveal_type calls with static and runtime checks";
+    homepage = "https://github.com/abelcheung/pytest-revealtype-injector";
+    changelog = "https://github.com/abelcheung/pytest-revealtype-injector/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ attila ];
+  };
+})

--- a/pkgs/development/python-modules/types-lxml/default.nix
+++ b/pkgs/development/python-modules/types-lxml/default.nix
@@ -12,6 +12,8 @@
   pook,
   pyright,
   pytestCheckHook,
+  pytest-revealtype-injector,
+  rnc2rng,
   typeguard,
   types-html5lib,
   typing-extensions,
@@ -20,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "types-lxml";
-  version = "2026.01.01";
+  version = "2026.02.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "abelcheung";
     repo = "types-lxml";
     tag = finalAttrs.version;
-    hash = "sha256-odkIwuh2VxDliRd6cPTCBSz19zxIBOBlVN0Sisngkn0=";
+    hash = "sha256-bjJnVBFLjkuM/czbsEAcwWGbiuTyr9nyx9TCVLn/U+Y=";
   };
 
   pythonRelaxDeps = [ "beautifulsoup4" ];
@@ -53,6 +55,8 @@ buildPythonPackage (finalAttrs: {
     lxml
     pook
     pytestCheckHook
+    pytest-revealtype-injector
+    rnc2rng
     typeguard
     urllib3
   ]
@@ -60,25 +64,24 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "lxml-stubs" ];
 
+  pytestFlags = [
+    "--revealtype-disable-adapter=basedpyright"
+    "--revealtype-disable-adapter=pyrefly"
+    "--revealtype-disable-adapter=ty"
+    "--revealtype-mypy-config=tests/mypy.ini"
+  ];
+
   # there may only be one conftest.py
   preCheck = ''
     rm -r tests/static
     mv tests/runtime/* tests/
     rmdir tests/runtime
     substituteInPlace tests/conftest.py \
-      --replace-fail '"pytest-revealtype-injector",' "" \
       --replace-fail 'runtime.register_strategy' 'tests.register_strategy'
   '';
 
   disabledTests = [
-    "test_single_ns_all_tag_2"
-    "test_default_ns"
-    # Tests require network access
-    "TestRelaxNGInput"
-    "TestXmldtdid"
-    "TestIddict"
-    "TestParseid"
-    # BaseExceptionGroup: Hypothesis found 5 distinct failures. (5 sub-exceptions)
+    # BaseExceptionGroup: Hypothesis found multiple distinct failures.
     "test_start_arg_bad_1"
     "test_stop_arg_bad_1"
     "test_index_arg_bad_1"

--- a/pkgs/development/python-modules/types-lxml/default.nix
+++ b/pkgs/development/python-modules/types-lxml/default.nix
@@ -1,17 +1,23 @@
 {
   lib,
+  basedpyright,
   beautifulsoup4,
   buildPythonPackage,
   cssselect,
   fetchFromGitHub,
+  fetchpatch,
   html5lib,
   hypothesis,
   lxml,
   mypy,
   pdm-backend,
   pook,
+  pyrefly,
   pyright,
   pytestCheckHook,
+  pytest-revealtype-injector,
+  rnc2rng,
+  ty,
   typeguard,
   types-html5lib,
   typing-extensions,
@@ -20,15 +26,31 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "types-lxml";
-  version = "2026.01.01";
+  version = "2026.02.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "abelcheung";
     repo = "types-lxml";
     tag = finalAttrs.version;
-    hash = "sha256-odkIwuh2VxDliRd6cPTCBSz19zxIBOBlVN0Sisngkn0=";
+    hash = "sha256-bjJnVBFLjkuM/czbsEAcwWGbiuTyr9nyx9TCVLn/U+Y=";
   };
+
+  patches = [
+    # Support mypy 1.20
+    # https://github.com/abelcheung/types-lxml/pull/127
+    (fetchpatch {
+      url = "https://github.com/attilaolah/types-lxml/commit/b86b6cd719eb3ddb1267d1e0a3d6b1f3e4a51ec0.patch";
+      hash = "sha256-Mi4vS9PcrHxCovpiMVR/A7pWDRwvqsUCTTp3BW0JCjU=";
+    })
+    # Support pyright 1.1.410 and basedpyright 1.39.8
+    # https://github.com/abelcheung/types-lxml/pull/128
+    (fetchpatch {
+      url = "https://github.com/attilaolah/types-lxml/commit/19b328abbb00820e4bb37d2cdc149ac4677c490b.patch";
+      hash = "sha256-nydwteX3yo4vW+zkhBoWqp/0BWQXlT/lnJgFicNEqwU=";
+      excludes = [ "pyproject.toml" ];
+    })
+  ];
 
   pythonRelaxDeps = [ "beautifulsoup4" ];
 
@@ -47,12 +69,17 @@ buildPythonPackage (finalAttrs: {
   };
 
   nativeCheckInputs = [
+    basedpyright
     beautifulsoup4
     html5lib
     hypothesis
     lxml
     pook
+    pyrefly
     pytestCheckHook
+    pytest-revealtype-injector
+    rnc2rng
+    ty
     typeguard
     urllib3
   ]
@@ -60,28 +87,28 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "lxml-stubs" ];
 
+  pytestFlags = [
+    "--revealtype-mypy-config=tests/mypy.ini"
+    "--revealtype-pyrefly-config=tests/pyrefly.toml"
+    # Upstream disables ty during runtime tests, see:
+    # https://github.com/abelcheung/types-lxml/issues/104
+    "--revealtype-disable-adapter=ty"
+  ];
+
   # there may only be one conftest.py
   preCheck = ''
     rm -r tests/static
     mv tests/runtime/* tests/
     rmdir tests/runtime
     substituteInPlace tests/conftest.py \
-      --replace-fail '"pytest-revealtype-injector",' "" \
       --replace-fail 'runtime.register_strategy' 'tests.register_strategy'
   '';
 
   disabledTests = [
-    "test_single_ns_all_tag_2"
-    "test_default_ns"
-    # Tests require network access
-    "TestRelaxNGInput"
-    "TestXmldtdid"
-    "TestIddict"
-    "TestParseid"
-    # BaseExceptionGroup: Hypothesis found 5 distinct failures. (5 sub-exceptions)
+    # BaseExceptionGroup: Hypothesis found multiple distinct failures.
+    "test_index_arg_bad_1"
     "test_start_arg_bad_1"
     "test_stop_arg_bad_1"
-    "test_index_arg_bad_1"
   ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15438,6 +15438,10 @@ self: super: with self; {
 
   pytest-retry = callPackage ../development/python-modules/pytest-retry { };
 
+  pytest-revealtype-injector =
+    callPackage ../development/python-modules/pytest-revealtype-injector
+      { };
+
   pytest-reverse = callPackage ../development/python-modules/pytest-reverse { };
 
   pytest-ruff = callPackage ../development/python-modules/pytest-ruff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20941,7 +20941,9 @@ self: super: with self; {
 
   types-jinja2 = callPackage ../development/python-modules/types-jinja2 { };
 
-  types-lxml = callPackage ../development/python-modules/types-lxml { };
+  types-lxml = callPackage ../development/python-modules/types-lxml {
+    inherit (pkgs) basedpyright pyrefly;
+  };
 
   types-markdown = callPackage ../development/python-modules/types-markdown { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15915,6 +15915,10 @@ self: super: with self; {
 
   pytest-retry = callPackage ../development/python-modules/pytest-retry { };
 
+  pytest-revealtype-injector = callPackage ../development/python-modules/pytest-revealtype-injector {
+    inherit (pkgs) basedpyright pyrefly;
+  };
+
   pytest-reverse = callPackage ../development/python-modules/pytest-reverse { };
 
   pytest-ruff = callPackage ../development/python-modules/pytest-ruff { };


### PR DESCRIPTION
- Bump `python3Packages.types-lxml` to 2026.02.16
- Package the test-dependency `pytest-revealtype-injector` at 0.9.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
