### PR TITLE
haskellPackages.tasty: set -j value matching $NIX_BUILD_CORES

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -876,6 +876,26 @@ builtins.intersectAttrs super {
       ++ lib.optionals (!(pkgs.stdenv.hostPlatform.isAarch64 || pkgs.stdenv.hostPlatform.isx86_64)) [
         self.unbounded-delays
       ];
+
+    setupHooks = drv.setupHooks or [ ] ++ [
+      (pkgs.makeSetupHook
+        {
+          name = "tasty-set-parallelism-hook";
+          substitutions.shell = pkgs.bash + pkgs.bash.shellPath;
+        }
+        (
+          pkgs.writeScript "tasty-set-parallelism-hook.sh" ''
+            #!@shell@
+
+            _tastySetParallelismHook() {
+              prependToVar checkFlagsArray -j$NIX_BUILD_CORES
+            }
+
+            preCheckHooks+=(_tastySetParallelismHook)
+          ''
+        )
+      )
+    ];
   }) super.tasty;
 
   tasty-discover = overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -202,6 +202,7 @@ in
   preFixup ? null,
   postFixup ? null,
   shellHook ? "",
+  setupHooks ? [ ],
   coreSetup ? false, # Use only core packages to build Setup.hs.
   useCpphs ? false,
   hardeningDisable ? null,
@@ -1063,7 +1064,7 @@ lib.fix (
             ghcCommandCaps = lib.toUpper ghcCommand';
           in
           runCommandCC name {
-            inherit shellHook;
+            inherit shellHook setupHooks;
 
             depsBuildBuild = lib.optional isCross ghcEnvForBuild;
             nativeBuildInputs = [
@@ -1137,5 +1138,6 @@ lib.fix (
     // optionalAttrs (__darwinAllowLocalNetworking || args ? __darwinAllowLocalNetworking) {
       inherit __darwinAllowLocalNetworking;
     }
+    // optionalAttrs (args ? setupHooks) { inherit setupHooks; }
   )
 )

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -865,6 +865,7 @@ lib.fix (
           "--test-wrapper=${testWrapperScript}"
           ${lib.escapeShellArgs (map (opt: "--test-option=${opt}") testFlags)}
         )
+        echo "checkFlags: ${testTargetsString} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}"
         export NIX_GHC_PACKAGE_PATH_FOR_TEST="''${NIX_GHC_PACKAGE_PATH_FOR_TEST:-$packageConfDir:}"
         ${setupCommand} test ${testTargetsString} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}
         runHook postCheck


### PR DESCRIPTION
tasty-1.5.4 automatically enables test suite parallelism when the test suite is compiled with -threaded. This is a good opportunity to make sure (as we should with other test frameworks) that we don't use more threads than we should. (On Hydra builders we typically have $NIX_BUILD_CORES set to 2 while the machines have more than 32 cores.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
