### PR TITLE
pkgsMusl.util-linuxMinimal: fix build

### DIFF
--- a/pkgs/by-name/ut/util-linux/fix-musl-nsenter.patch
+++ b/pkgs/by-name/ut/util-linux/fix-musl-nsenter.patch
@@ -1,0 +1,25 @@
+From 126c850f74cbafd3af55a6f829308d7f63de4c7b Mon Sep 17 00:00:00 2001
+From: Aleksi Hannula <ahannula4+nixgit@gmail.com>
+Date: Tue, 7 Apr 2026 14:52:16 +0300
+Subject: [PATCH] nsenter: Fix AT_HANDLE_FID on musl
+
+---
+ sys-utils/nsenter.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys-utils/nsenter.c b/sys-utils/nsenter.c
+index e10ba9c..340e6b1 100644
+--- a/sys-utils/nsenter.c
++++ b/sys-utils/nsenter.c
+@@ -220,7 +220,7 @@ static int fill_nsfs_file_handle(struct file_handle *fh, uint64_t ns_id)
+ 
+ 	fh->handle_bytes = sizeof(struct nsfs_file_handle);
+ 	if (name_to_handle_at(nsfs_fd, "", fh, &mount_id,
+-			      AT_EMPTY_PATH | AT_HANDLE_FID) == -1)
++			      AT_EMPTY_PATH | 0x200 /* AT_HANDLE_FID */) == -1)
+ 		return -errno;
+ 	assert(fh->handle_type);
+ 	nsfs_fh_tmpl = *fh;
+-- 
+2.51.2
+

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -59,7 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix compile of 2.42+ on Darwin.
     # https://lore.kernel.org/util-linux/CAEUYr6ZjVX1bd-xcBGtFN_ZYwQnXDYsw7d1-7sTpF2BbgfrR+g@mail.gmail.com/T/#u
     ./include-correct-struct-statfs-header.patch
-
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isMusl [
     # Musl does not define AT_HANDLE_FID, hard-code it.
     # https://github.com/util-linux/util-linux/pull/4203
     ./fix-musl-nsenter.patch

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -59,6 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix compile of 2.42+ on Darwin.
     # https://lore.kernel.org/util-linux/CAEUYr6ZjVX1bd-xcBGtFN_ZYwQnXDYsw7d1-7sTpF2BbgfrR+g@mail.gmail.com/T/#u
     ./include-correct-struct-statfs-header.patch
+
+    # Musl does not define AT_HANDLE_FID, hard-code it.
+    # https://github.com/util-linux/util-linux/pull/4203
+    ./fix-musl-nsenter.patch
   ];
 
   # We separate some of the utilities into their own outputs. This


### PR DESCRIPTION
Musl does not define AT_HANDLE_FID, but we can hard-code the value instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
