### PR TITLE
dnsdist: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/by-name/dn/dnsdist/package.nix
+++ b/pkgs/by-name/dn/dnsdist/package.nix
@@ -1,10 +1,8 @@
 {
   boost,
   cargo,
-  fetchpatch,
   fetchurl,
   fstrm,
-  h2o,
   lib,
   libbpf,
   libcap,
@@ -28,21 +26,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dnsdist";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/dnsdist-${finalAttrs.version}.tar.xz";
-    hash = "sha256-M3Trplpco8+5/Fl5HEflA1FJ/lIcy7ztX4NKF/RWQb8=";
+    hash = "sha256-oiklC4GcQNVRc6+nIC7x7yprco+Fx1Bol6Hxymq1cUk=";
   };
-
-  patches = [
-    # Fix build error when only protobuf is enabled
-    (fetchpatch {
-      url = "https://github.com/PowerDNS/pdns/commit/daece82818d7f83b26dcf724ec1864644bc3f854.patch";
-      hash = "sha256-Ag65Gjmm2m4yvRfqMjSo1EEJg/2EHWDBg15vSL5DKCU=";
-      stripLen = 2;
-    })
-  ];
 
   nativeBuildInputs = [
     cargo
@@ -52,10 +41,10 @@ stdenv.mkDerivation (finalAttrs: {
     python3.pkgs.pyyaml
     rustPlatform.cargoSetupHook
   ];
+
   buildInputs = [
     boost
     fstrm # Required for DNSTAP
-    h2o
     libbpf
     libcap
     libedit
@@ -91,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) cargoRoot src;
-    hash = "sha256-nDAvgM3xb+95dcGIHiSKlFo4/0Rs5Evf1vvR5vF4MXs=";
+    hash = "sha256-OU24ahqFc4DivCpO451rsHV8rofyHv+LnLgkVsFPMG4=";
   };
 
   cargoRoot = "dnsdist-rust-lib/rust";


### PR DESCRIPTION
Changelog : https://www.dnsdist.org/changelog.html#change-2.0.3-Bug-Fixes

CVE : 
CVE-2026-0396
CVE-2026-0397
CVE-2026-24028
CVE-2026-24029
CVE-2026-24030
CVE-2026-27853
CVE-2026-27854

nixosTests.dnsdist : OK

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
