### PR TITLE
retroshare: fix build with gcc 14 and newer cmake

### DIFF
--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -88,6 +88,24 @@ stdenv.mkDerivation rec {
       --replace-fail \
         "LIBSAM3_MAKE_PARAMS =" \
         "LIBSAM3_MAKE_PARAMS = CC=$CC AR=$AR"
+
+    # openpgpsdk uses 'bool' as a variable name, which became a C23 keyword.
+    # Rename it to avoid compile errors with GCC 14+ which defaults to c23.
+    substituteInPlace openpgpsdk/src/openpgpsdk/packet-print.c \
+      --replace-fail \
+        "static void print_boolean(const char *name, unsigned char bool)" \
+        "static void print_boolean(const char *name, unsigned char bool_val)" \
+      --replace-fail "    if(bool)" "    if(bool_val)"
+    # The C source inconsistently uses 'limited_read (bool,' (with a space) on line 1600
+    substituteInPlace openpgpsdk/src/openpgpsdk/packet-parse.c \
+      --replace-fail "unsigned char bool[1]=" 'unsigned char bool_val[1]=' \
+      --replace-fail "limited_read(bool," "limited_read(bool_val," \
+      --replace-fail "limited_read (bool," "limited_read (bool_val," \
+      --replace-fail "!!bool[0]" "!!bool_val[0]"
+
+    # Update cmake version for supportlibs to fix build with newer cmake
+    substituteInPlace supportlibs/udp-discovery-cpp/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.5)"
   '';
 
   postInstall = ''

--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
 
     # Update cmake version for supportlibs to fix build with newer cmake
     substituteInPlace supportlibs/udp-discovery-cpp/CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.5)"
+      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
   postInstall = ''


### PR DESCRIPTION
Fixes #507584 
### Cause 
Starting with GCC 14, the C compiler implicitly defaults to `-std=c23`, making `bool` a reserved language keyword. The `openpgpsdk` submodule in `retroshare` historically used `bool` as a variable name, which triggered build failures during `packet-print.c` and `packet-parse.c` compilation. 

Furthermore, once past the GCC 14 issues, the build failed configuring the `udp-discovery-cpp` submodule because its `CMakeLists.txt` strictly requested CMake `2.8`. Modern CMake in Nixpkgs dropped compatibility for `< 3.5`, resulting in configuration failures.

### Changes
- Rename `bool` variables in openpgpsdk to `bool_val` to resolve 
  GCC 14 / C23 keyword compilation errors (Fixes #507584)
- Bump minimum required CMake version in udp-discovery-cpp from 
  2.8 to 3.5 to fix configuration errors with newer CMake versions

## Things done

- Built on platform:
  - [x] x86_64-linux

- Tested, as applicable:
ran ```nix-build -A retroshare``` which builds successfully on NixOS 26.05.
- [x] Tested basic functionality of  binary in `./result/bin/`

Maintainer ping for review/testing: @Stekke 