### PR TITLE
[25.11] navidrome: 0.60.3 -> 0.61.1

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -443,6 +443,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `haskell.lib.addOptparseApplicativeCompletionScripts` has been removed, use `haskellPackages.generateOptparseApplicativeCompletions` instead.
 
+- `navidrome` has removed the built-in Spotify integration https://github.com/navidrome/navidrome/releases/tag/v0.61.0 has details on optional replacements
+
 - `lib.attrsets.cartesianProductOfSets` has been removed, following its deprecation in NixOS 24.11. Use `lib.attrsets.cartesianProduct` instead.
 
 - `lib.attrsets.zipWithNames` has been removed, following its deprecation in 2009. Use `lib.attrsets.zipAttrsWithNames` instead.

--- a/pkgs/by-name/na/navidrome/package.nix
+++ b/pkgs/by-name/na/navidrome/package.nix
@@ -3,6 +3,7 @@
   buildPackages,
   fetchFromGitHub,
   fetchNpmDeps,
+  fetchpatch,
   lib,
   nodejs_24,
   npmHooks,
@@ -19,23 +20,37 @@
 
 buildGoModule (finalAttrs: {
   pname = "navidrome";
-  version = "0.60.3";
+  version = "0.61.1";
 
   src = fetchFromGitHub {
     owner = "navidrome";
     repo = "navidrome";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-DwVmNJKjwEhTKIVPYFqaUR9SD4HpACkK4XJoFfQVRus=";
+    hash = "sha256-BRMJCBQl38AqsCI2UYQ9X36U57pg9uuiHsx8sHpVBKE=";
   };
 
-  vendorHash = "sha256-StI4CfWN/OnbYFktRriTJWMHTuJkCinpYk9qgsxMGG8=";
+  patches = [
+    # https://github.com/navidrome/navidrome/pull/5276 (waiting on release)
+    (fetchpatch {
+      name = "regenerate-package-lock-json";
+      url = "https://github.com/navidrome/navidrome/compare/v0.61.1...33a05ef662760fd9feb0a3ae43c7fe149eda610b.patch";
+      hash = "sha256-IQ0wJ7vsSaLjBZS/fKIApNM8UV8oj6L2taCQIPhHvwg=";
+    })
+  ];
+
+  vendorHash = "sha256-iVXJPP41rIpC6Tu1P/jWcePYCQ2Z9lEoTOrDLN26kTU=";
 
   npmRoot = "ui";
 
   npmDeps = fetchNpmDeps {
-    inherit (finalAttrs) src;
+    inherit (finalAttrs) src patches;
+    # Remove after https://github.com/navidrome/navidrome/pull/5276 is released
+    # patches are applied after we run npmDeps without inheriting patches here
+    # so we have to get out of the sourceRoot to apply it then get back in to it
+    prePatch = "cd ..";
+    postPatch = "cd ui";
     sourceRoot = "${finalAttrs.src.name}/ui";
-    hash = "sha256-EA2WM7xaqP7rS0pjx+yXwpjdauaduvDefmFH73eByxI=";
+    hash = "sha256-iXey2XmDwsTR1/bIrBLzm6uvVGzPgQFcDLUtNy8robI=";
   };
 
   nativeBuildInputs = [
@@ -66,9 +81,6 @@ buildGoModule (finalAttrs: {
 
   env = lib.optionalAttrs stdenv.cc.isGNU {
     CGO_CFLAGS = toString [ "-Wno-return-local-addr" ];
-    # Workaround for https://github.com/golang/go/issues/77387
-    # Remove when go1.25.8 has been merged
-    CGO_CFLAGS_ALLOW = "--define-prefix";
   };
 
   postPatch = ''
@@ -81,6 +93,7 @@ buildGoModule (finalAttrs: {
 
   tags = [
     "netgo"
+    "sqlite_fts5"
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Backport of #505529

changelog: https://github.com/navidrome/navidrome/releases/tag/v0.61.0
changelog: https://github.com/navidrome/navidrome/releases/tag/v0.61.1

Includes breaking change and 3 security fixes, including CVE-2026-33809.

package-lock.json is broken, PR https://github.com/navidrome/navidrome/pull/5276 proposed, using .patch from commit diff to apply changes.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
