### PR TITLE
kuma{,-experimental,ctl,-cp,-dp}: migrate to by-name, preserve override behavior

### DIFF
--- a/pkgs/by-name/ku/kuma-cp/package.nix
+++ b/pkgs/by-name/ku/kuma-cp/package.nix
@@ -1,0 +1,13 @@
+{
+  kuma,
+  ...
+}@args:
+
+kuma.override (
+  {
+    pname = "kumactl";
+    isFull = false;
+    components = [ "kumactl" ];
+  }
+  // removeAttrs args [ "kuma" ]
+)

--- a/pkgs/by-name/ku/kuma-dp/package.nix
+++ b/pkgs/by-name/ku/kuma-dp/package.nix
@@ -1,0 +1,13 @@
+{
+  kuma,
+  ...
+}@args:
+
+kuma.override (
+  {
+    pname = "kuma-dp";
+    isFull = false;
+    components = [ "kuma-dp" ];
+  }
+  // removeAttrs args [ "kuma" ]
+)

--- a/pkgs/by-name/ku/kuma-experimental/package.nix
+++ b/pkgs/by-name/ku/kuma-experimental/package.nix
@@ -1,0 +1,14 @@
+{
+  kuma,
+  ...
+}@args:
+
+kuma.override (
+  {
+    pname = "kuma-experimental";
+    isFull = true;
+    enableGateway = true;
+
+  }
+  // removeAttrs args [ "kuma" ]
+)

--- a/pkgs/by-name/ku/kuma/package.nix
+++ b/pkgs/by-name/ku/kuma/package.nix
@@ -5,7 +5,7 @@
   buildGoModule,
   coredns,
   installShellFiles,
-  isFull ? false,
+  isFull ? true,
   enableGateway ? false,
   pname ? "kuma",
   components ? lib.optionals isFull [

--- a/pkgs/by-name/ku/kumactl/package.nix
+++ b/pkgs/by-name/ku/kumactl/package.nix
@@ -1,0 +1,13 @@
+{
+  kuma,
+  ...
+}@args:
+
+kuma.override (
+  {
+    pname = "kumactl";
+    isFull = false;
+    components = [ "kumactl" ];
+  }
+  // removeAttrs args [ "kuma" ]
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9605,10 +9605,6 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
-  kuma-cp = callPackage ../applications/networking/cluster/kuma {
-    components = [ "kuma-cp" ];
-    pname = "kuma-cp";
-  };
   kuma-dp = callPackage ../applications/networking/cluster/kuma {
     components = [ "kuma-dp" ];
     pname = "kuma-dp";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9605,10 +9605,6 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
-  kumactl = callPackage ../applications/networking/cluster/kuma {
-    components = [ "kumactl" ];
-    pname = "kumactl";
-  };
   kuma-cp = callPackage ../applications/networking/cluster/kuma {
     components = [ "kuma-cp" ];
     pname = "kuma-cp";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9605,11 +9605,6 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
-  kuma-experimental = callPackage ../applications/networking/cluster/kuma {
-    isFull = true;
-    enableGateway = true;
-    pname = "kuma-experimental";
-  };
   kumactl = callPackage ../applications/networking/cluster/kuma {
     components = [ "kumactl" ];
     pname = "kumactl";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9605,7 +9605,6 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
-  kuma = callPackage ../applications/networking/cluster/kuma { isFull = true; };
   kuma-experimental = callPackage ../applications/networking/cluster/kuma {
     isFull = true;
     enableGateway = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9605,11 +9605,6 @@ with pkgs;
   linkerd_edge = callPackage ../applications/networking/cluster/linkerd/edge.nix { };
   linkerd_stable = linkerd;
 
-  kuma-dp = callPackage ../applications/networking/cluster/kuma {
-    components = [ "kuma-dp" ];
-    pname = "kuma-dp";
-  };
-
   kubernetes-helm = callPackage ../applications/networking/cluster/helm { };
 
   wrapHelm = callPackage ../applications/networking/cluster/helm/wrapper.nix { };


### PR DESCRIPTION
This pull request restructures the packaging of Kuma and its components, moving their definitions to a new location and updating how they are referenced in the package set. It also updates the version and hash for the `unstructured-api` package.

**Kuma packaging refactor:**

* Moved Kuma and its component package definitions (`kuma`, `kuma-cp`, `kuma-dp`, `kumactl`, `kuma-experimental`) from `pkgs/applications/networking/cluster/kuma` to `pkgs/by-name/ku/kuma` and split each component into its own `package.nix` file for improved modularity and clarity.

* Updated `all-packages.nix` to reference the new package locations and removed the old inlined definitions. (`[pkgs/top-level/all-packages.nix

**Kuma build configuration:**

* Changed the default value of `isFull` from `false` to `true` in the main `kuma` package definition, making the full build the default. (`[pkgs/by-name/ku/kuma/package.nix

**Unstructured API update:**

* Updated `unstructured-api` to version 0.1.2 and changed its source hash to match the new version
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
