### PR TITLE
rfc-reader: init at 0.11.2

### DIFF
--- a/pkgs/by-name/rf/rfc-reader/package.nix
+++ b/pkgs/by-name/rf/rfc-reader/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  nix-update-script,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rfc-reader";
+  version = "0.11.2";
+
+  src = fetchFromGitHub {
+    owner = "ozan2003";
+    repo = "rfc_reader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hm8BVIMxRlyiVptvuS8vk2eO3hHboj5CRefWcMEhzvs=";
+  };
+
+  cargoHash = "sha256-ro0BVMbShxo/EsPBOCBOgYDsOkDnxpyTZlk2eAJ2IWA=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    # The version command triggers logging unconditionally, have to create a temp directory
+    command = "HOME=$(mktemp -d) rfc_reader --version";
+  };
+
+  meta = {
+    description = "RFC viewer with TUI";
+    homepage = "https://github.com/ozan2003/rfc_reader";
+    changelog = "https://github.com/ozan2003/rfc_reader/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ frantathefranta ];
+    mainProgram = "rfc_reader";
+  };
+})


### PR DESCRIPTION
Added `rfc-reader`

Release: https://github.com/ozan2003/rfc_reader/releases/tag/v0.11.2
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
