### PR TITLE
tango-cpp: 10.1.2 -> 10.3.0, add meta.changelog

### DIFF
--- a/pkgs/by-name/ta/tango-cpp/package.nix
+++ b/pkgs/by-name/ta/tango-cpp/package.nix
@@ -16,23 +16,15 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "tango-cpp";
-  version = "10.1.2";
+  version = "10.3.0";
 
   src = fetchFromGitLab {
     owner = "tango-controls";
     repo = "cppTango";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-8AFQMw3mUKbHFJBm3Xmme2ehqgZowLQsU0cn1gMLbTc=";
+    hash = "sha256-X4r2nMdW61TAqDLcVZ0tibJnn/ffXHt8RWSBDRqA0/8=";
   };
-
-  patches = [
-    # corresponds to PR https://gitlab.com/tango-controls/cppTango/-/merge_requests/1525
-    (fetchpatch {
-      url = "https://gitlab.com/tango-controls/cppTango/-/commit/66bd2d9deb79fb557eb2314376f9559e7476d3a1.patch";
-      hash = "sha256-ZUcBS4apVfXmXKnpGOQJ9DF8t79qJ2yqKXwaseiOC6U=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ta/tango-cpp/package.nix
+++ b/pkgs/by-name/ta/tango-cpp/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Tango Distributed Control System - C++ library";
     homepage = "https://gitlab.com/tango-controls/cppTango";
+    changelog = "https://gitlab.com/tango-controls/cppTango/-/blob/${finalAttrs.version}/RELEASE_NOTES.md";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.gilice ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
