### PR TITLE
lib/fileset/internal.nix: introduce `lib.lists.commonPrefixLength`

### DIFF
--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -835,8 +835,7 @@ rec {
       # The common base components prefix, e.g.
       # (/foo/bar, /foo/bar/baz) -> /foo/bar
       # (/foo/bar, /foo/baz) -> /foo
-      commonBaseComponentsLength =
-        commonPrefixLength fileset1._internalBaseComponents fileset2._internalBaseComponents;
+      commonBaseComponentsLength = commonPrefixLength fileset1._internalBaseComponents fileset2._internalBaseComponents;
 
       # To be able to intersect filesetTree's together, they need to have the same base path.
       # Base paths can be intersected by taking the longest one (if any)
@@ -916,8 +915,7 @@ rec {
       # The common base components prefix, e.g.
       # (/foo/bar, /foo/bar/baz) -> /foo/bar
       # (/foo/bar, /foo/baz) -> /foo
-      commonBaseComponentsLength =
-        commonPrefixLength positive._internalBaseComponents negative._internalBaseComponents;
+      commonBaseComponentsLength = commonPrefixLength positive._internalBaseComponents negative._internalBaseComponents;
 
       # We need filesetTree's with the same base to be able to compute the difference between them
       # This here is the filesetTree from the negative file set, but for a base path that matches the positive file set.

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -30,6 +30,7 @@ let
   inherit (lib.lists)
     all
     commonPrefix
+    commonPrefixLength
     concatLists
     elemAt
     filter
@@ -835,8 +836,7 @@ rec {
       # (/foo/bar, /foo/bar/baz) -> /foo/bar
       # (/foo/bar, /foo/baz) -> /foo
       commonBaseComponentsLength =
-        # TODO: Have a `lib.lists.commonPrefixLength` function such that we don't need the list allocation from commonPrefix here
-        length (commonPrefix fileset1._internalBaseComponents fileset2._internalBaseComponents);
+        commonPrefixLength fileset1._internalBaseComponents fileset2._internalBaseComponents;
 
       # To be able to intersect filesetTree's together, they need to have the same base path.
       # Base paths can be intersected by taking the longest one (if any)
@@ -917,8 +917,7 @@ rec {
       # (/foo/bar, /foo/bar/baz) -> /foo/bar
       # (/foo/bar, /foo/baz) -> /foo
       commonBaseComponentsLength =
-        # TODO: Have a `lib.lists.commonPrefixLength` function such that we don't need the list allocation from commonPrefix here
-        length (commonPrefix positive._internalBaseComponents negative._internalBaseComponents);
+        commonPrefixLength positive._internalBaseComponents negative._internalBaseComponents;
 
       # We need filesetTree's with the same base to be able to compute the difference between them
       # This here is the filesetTree from the negative file set, but for a base path that matches the positive file set.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1769,6 +1769,38 @@ rec {
   */
   commonPrefix =
     list1: list2:
+    take (commonPrefixLength list1 list2) list1;
+
+  /**
+    Returns the length of the common prefix of two lists,
+    i.e. the number of leading elements that are pairwise equal.
+
+    This is more efficient than `length (commonPrefix a b)` because
+    it avoids allocating an intermediate list.
+
+    # Type
+
+    ```
+    commonPrefixLength :: [a] -> [a] -> Int
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.lists.commonPrefixLength` usage example
+
+    ```nix
+    commonPrefixLength [ 1 2 3 4 5 6 ] [ 1 2 4 8 ]
+    => 2
+    commonPrefixLength [ 1 2 3 ] [ 1 2 3 4 5 ]
+    => 3
+    commonPrefixLength [ 1 2 3 ] [ 4 5 6 ]
+    => 0
+    ```
+
+    :::
+  */
+  commonPrefixLength =
+    list1: list2:
     let
       # Zip the lists together into a list of booleans whether each element matches
       matchings = zipListsWith (fst: snd: fst != snd) list1 list2;
@@ -1776,9 +1808,8 @@ rec {
       # which will then also be the length of the common prefix.
       # If all elements match, we fall back to the length of the zipped list,
       # which is the same as the length of the smaller list.
-      commonPrefixLength = findFirstIndex id (length matchings) matchings;
     in
-    take commonPrefixLength list1;
+    findFirstIndex id (length matchings) matchings;
 
   /**
     Returns the last element of a list.

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1767,9 +1767,7 @@ rec {
 
     :::
   */
-  commonPrefix =
-    list1: list2:
-    take (commonPrefixLength list1 list2) list1;
+  commonPrefix = list1: list2: take (commonPrefixLength list1 list2) list1;
 
   /**
     Returns the length of the common prefix of two lists,

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1809,7 +1809,10 @@ runTests {
     expected = 3;
   };
   testListCommonPrefixLengthLazy = {
-    expr = lists.commonPrefixLength [ 1 ] [ 1 (abort "lib.lists.commonPrefixLength shouldn't evaluate this") ];
+    expr =
+      lists.commonPrefixLength
+        [ 1 ]
+        [ 1 (abort "lib.lists.commonPrefixLength shouldn't evaluate this") ];
     expected = 1;
   };
   testListCommonPrefixLengthLong =

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1788,6 +1788,39 @@ runTests {
       expected = longList;
     };
 
+  testListCommonPrefixLengthExample1 = {
+    expr = lists.commonPrefixLength [ 1 2 3 4 5 6 ] [ 1 2 4 8 ];
+    expected = 2;
+  };
+  testListCommonPrefixLengthExample2 = {
+    expr = lists.commonPrefixLength [ 1 2 3 ] [ 1 2 3 4 5 ];
+    expected = 3;
+  };
+  testListCommonPrefixLengthExample3 = {
+    expr = lists.commonPrefixLength [ 1 2 3 ] [ 4 5 6 ];
+    expected = 0;
+  };
+  testListCommonPrefixLengthEmpty = {
+    expr = lists.commonPrefixLength [ ] [ 1 2 3 ];
+    expected = 0;
+  };
+  testListCommonPrefixLengthSame = {
+    expr = lists.commonPrefixLength [ 1 2 3 ] [ 1 2 3 ];
+    expected = 3;
+  };
+  testListCommonPrefixLengthLazy = {
+    expr = lists.commonPrefixLength [ 1 ] [ 1 (abort "lib.lists.commonPrefixLength shouldn't evaluate this") ];
+    expected = 1;
+  };
+  testListCommonPrefixLengthLong =
+    let
+      longList = genList (n: n) 100000;
+    in
+    {
+      expr = lists.commonPrefixLength longList longList;
+      expected = 100000;
+    };
+
   testSort = {
     expr = sort builtins.lessThan [
       40


### PR DESCRIPTION
## Summary

- Adds `lib.lists.commonPrefixLength`, which returns the length of the common prefix of two lists without allocating an intermediate list. The length-computation logic was already inside `commonPrefix`; this PR just exposes it as its own function.
- Reimplements `commonPrefix` in terms of `commonPrefixLength` so behavior is unchanged.
- Updates the two `length (commonPrefix ...)` callers in `lib/fileset/internal.nix` (`_intersection` and `_difference`) to use the new function, resolving the existing TODOs that were waiting on this.
- Adds tests in `lib/tests/misc.nix` mirroring the existing `commonPrefix` cases (basic examples, empty/equal lists, laziness, and a long-list non-stack-overflow check).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is `sandbox = relaxed` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested via `nix-instantiate --eval lib/tests/misc.nix` (lib unit tests pass)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` in a clone of [nixpkgs](https://github.com/nixos/nixpkgs) — N/A, lib-only change
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) release notes)
- [ ] (Package updates) Added a release notes entry if the change is major or breaking — N/A
- [ ] (Module updates) Added a release notes entry if the change is significant
- [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Added documentation — function has a doc comment with type signature and examples, matching `commonPrefix`

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc