### PR TITLE
python3Packages.davey package init 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27989,6 +27989,12 @@
     githubId = 787843;
     keys = [ { fingerprint = "E631 8869 586F 99B4 F6E6  D785 5942 58F0 389D 2802"; } ];
   };
+  twig = {
+    name = "Twig";
+    github = "justtemmie";
+    githubId = 47639983;
+    email = "git@beaver.mom";
+  };
   twitchy0 = {
     email = "code@nitinpassa.com";
     github = "twitchy0";

--- a/pkgs/development/python-modules/davey/default.nix
+++ b/pkgs/development/python-modules/davey/default.nix
@@ -6,20 +6,19 @@
   maturin,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "davey";
   version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "Snazzah";
     repo = "davey";
-    tag = "py-${version}";
+    tag = "py-${finalAttrs.version}";
     hash = "sha256-WR8OBYZXNxFfToVn0ZNkacZPN04w/y3tCK6/xCP50gI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit (finalAttrs) pname version src;
     hash = "sha256-kLLOuwGCfkByXt6LW8vGxS1JYQW+r/tW7dOiKx6M4k4=";
   };
 
@@ -39,9 +38,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "davey" ];
 
   meta = {
-    description = "A Discord Audio & Video End-to-End Encryption (DAVE) Protocol Rust implementation";
+    description = "Discord Audio & Video End-to-End Encryption (DAVE) Protocol Rust implementation";
     homepage = "https://github.com/Snazzah/davey";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ twig ];
   };
-}
+})

--- a/pkgs/development/python-modules/davey/default.nix
+++ b/pkgs/development/python-modules/davey/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  maturin,
+}:
+
+buildPythonPackage rec {
+  pname = "davey";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "Snazzah";
+    repo = "davey";
+    tag = "py-${version}";
+    hash = "sha256-WR8OBYZXNxFfToVn0ZNkacZPN04w/y3tCK6/xCP50gI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-kLLOuwGCfkByXt6LW8vGxS1JYQW+r/tW7dOiKx6M4k4=";
+  };
+
+  nativeBuildInputs = [
+    maturin
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  format = "pyproject";
+
+  maturinBuildFlags = [
+    "--manifest-path"
+    "davey-python/Cargo.toml"
+  ];
+
+  pythonImportsCheck = [ "davey" ];
+
+  meta = {
+    description = "A Discord Audio & Video End-to-End Encryption (DAVE) Protocol Rust implementation";
+    homepage = "https://github.com/Snazzah/davey";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ twig ];
+  };
+}

--- a/pkgs/development/python-modules/davey/default.nix
+++ b/pkgs/development/python-modules/davey/default.nix
@@ -9,6 +9,8 @@
 buildPythonPackage (finalAttrs: {
   pname = "davey";
   version = "0.1.5";
+  pyproject = true;
+
 
   src = fetchFromGitHub {
     owner = "Snazzah";
@@ -27,8 +29,6 @@ buildPythonPackage (finalAttrs: {
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];
-
-  format = "pyproject";
 
   maturinBuildFlags = [
     "--manifest-path"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3654,6 +3654,8 @@ self: super: with self; {
 
   datrie = callPackage ../development/python-modules/datrie { };
 
+  davey = callPackage ../development/python-modules/davey { };
+
   dawg-python = callPackage ../development/python-modules/dawg-python { };
 
   dawg2-python = callPackage ../development/python-modules/dawg2-python { };


### PR DESCRIPTION
Davey is required for python3Packages.discordpy to support voice for any version >= 2.7.0; [source](https://github.com/Rapptz/discord.py/blob/5d74ed3e0ce5178cf454825bd5a71f0248738f54/discord/voice_client.py#L222). And the lack of this package seems to be blocking #496171

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
