### PR TITLE
winboat: unpin buildGo125Module

### DIFF
--- a/pkgs/by-name/wi/winboat/guest-server.nix
+++ b/pkgs/by-name/wi/winboat/guest-server.nix
@@ -11,6 +11,7 @@ buildGo125Module {
   vendorHash = "sha256-vpBvSaqbbJ8sHNMm299z/3Qb7FKMWbr62amtKT3acYk=";
 
   env = {
+    CGO_ENABLED = 0;
     GOOS = "windows";
     GOARCH = "amd64";
     PACKAGE = "winboat-server";

--- a/pkgs/by-name/wi/winboat/guest-server.nix
+++ b/pkgs/by-name/wi/winboat/guest-server.nix
@@ -1,10 +1,18 @@
 {
   lib,
-  buildGo125Module,
+  buildGoModule,
+  buildPackages,
   winboat,
 }:
 
-buildGo125Module {
+let
+  go = buildPackages.go.overrideAttrs (previousAttrs: {
+    env = previousAttrs.env // {
+      CGO_ENABLED = 0;
+    };
+  });
+in
+buildGoModule.override { inherit go; } {
   inherit (winboat) version src;
   modRoot = "guest_server";
   pname = "winboat-guest-server";


### PR DESCRIPTION
  ## Description of changes

  `winboat` failes to build (tested on `x86_64-linux`) because its
  `winboat-guest-server` subpackage cross-compiles a Windows binary and
  inherited `CGO_ENABLED=1` from the Go toolchain defaults.

  That caused the build to enter the MinGW cgo bootstrap path and fail with:

  - `loadinternal: cannot find runtime/cgo`
  - `cannot export _cgo_stub_export: symbol not defined`

  This change sets `CGO_ENABLED = 0;` in
  `pkgs/by-name/wi/winboat/guest-server.nix`, avoiding the broken cross-cgo
  path. After this change, `winboat` builds successfully and `winboat` launches
  as expected.

  ## Things done

  - Built on platform:
    - [x] x86_64-linux

  - Tested, as applicable:
    - [x] `nix-build -A winboat`
    - [x] Tested execution of the main binary (`./result/bin/winboat`)

  ## Pinging maintainers for review

  cc @Rexcrazy804 @ppom0