### PR TITLE
nixos/shells-environment: escape environment.variables values

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -242,6 +242,8 @@
 
 - The default packages in `services.jenkins.packages` have been dropped, since not every Jenkins installation needs any package at all. It's more reasonable to leave it empty and let users configure what they need.
 
+- The `environment.variables` option is now escaped of backslashes, newlines and double quotes
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -26,7 +26,23 @@ let
       ];
 
       exportVariables = lib.mapAttrsToList (
-        n: v: ''export ${n}="${lib.concatStringsSep ":" v}"''
+        n: v:
+        ''export ${n}="${
+          lib.concatStringsSep ":" (
+            map (lib.replaceStrings
+              [
+                "\\"
+                "\n"
+                "\""
+              ]
+              [
+                "\\\\"
+                "\\n"
+                "\\\""
+              ]
+            ) v
+          )
+        }"''
       ) allVariables;
     in
     lib.concatStringsSep "\n" exportVariables;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1463,6 +1463,7 @@ in
   sharkey = runTest ./web-apps/sharkey.nix;
   shattered-pixel-dungeon = runTest ./shattered-pixel-dungeon.nix;
   shelfmark = runTest ./shelfmark.nix;
+  shells-environment = runTest ./shells-environment.nix;
   shiori = runTest ./shiori.nix;
   shoko = import ./shoko.nix { inherit runTest; };
   signal-desktop = runTest ./signal-desktop.nix;

--- a/nixos/tests/shells-environment.nix
+++ b/nixos/tests/shells-environment.nix
@@ -1,0 +1,16 @@
+let
+  myJson = ''{ "key": "my super \n\"quirky\"\n value" }'';
+in
+{
+  name = "shells-environment";
+
+  nodes.machine = {
+    environment.variables = {
+      MY_JSON = myJson;
+    };
+  };
+
+  testScript = ''
+    machine.succeed(r"""[ "$MY_JSON" = '${myJson}' ]""")
+  '';
+}


### PR DESCRIPTION
Added backslash, quote and newline escaping to shell variables along with a test to confirm it works.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
