### PR TITLE
urxvt-tabbedex: update to latest 26.15 version

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-tabbedex/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-tabbedex/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "urxvt-tabbedex";
-  version = "22.32";
+  version = "26.15";
 
   src = fetchFromGitHub {
     owner = "mina86";
     repo = "urxvt-tabbedex";
     rev = "v${version}";
-    sha256 = "sha256-4+4iPFoy1j5xjXRM5kBauhff44Y7/ik/+ZLZ1prc+Xo=";
+    sha256 = "sha256-Jo6pldGffeT4WHXzult0IfYBkXiZXcPTYh4dxV5boZU=";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
Update the urxvt-tabbedex package to the latest release.  The `sha256` value obtained with `nix-prefetch-github` (see below).  No other changes to the package so things should work as they did in the past:

    $ docker run --rm nixos/nix nix-shell -p nix-prefetch-github --run "
          nix-prefetch-github mina86 urxvt-tabbedex --rev v26.15"
    …
    {
        "owner": "mina86",
        "repo": "urxvt-tabbedex",
        "rev": "17a3e0ff07729f24a00e4f5d624caa6e934b39c2",
        "hash": "sha256-Jo6pldGffeT4WHXzult0IfYBkXiZXcPTYh4dxV5boZU="
    }


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested with `docker run --rm -v $(pwd):/work -w /work nixos/nix   nix^Cuild -E 'with import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") {}; callPackage ./default.nix {}'` which terminated successfully and whose output looks correct.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
