### PR TITLE
wordreaper: init at 2.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24008,6 +24008,12 @@
     githubId = 226872;
     name = "Samuel Ainsworth";
   };
+  SamuelBozeman = {
+    email = "sbozeman@proton.me";
+    github = "SamuelBozeman";
+    githubId = 110150973;
+    name = "Samuel Bozeman";
+  };
   samuelefacenda = {
     name = "Samuele Facenda";
     email = "samuele.facenda@gmail.com";

--- a/pkgs/by-name/wo/wordreaper/package.nix
+++ b/pkgs/by-name/wo/wordreaper/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "wordreaper";
+  version = "2.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Nemorous";
+    repo = "wordreaper";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-pZpKL2FHnbuYCMkaVYqo3SuIUvbepgE39byYHcbPo3M=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    colorama
+    beautifulsoup4
+    requests
+    tqdm
+    psutil
+    wordninja
+  ];
+
+  doCheck = false; # upstream has no tests
+
+  postInstall = ''
+    chmod +x $out/${python3Packages.python.sitePackages}/word_reaper/bin/*.bin
+  '';
+
+  meta = {
+    description = "Scrape targeted wordlists for password cracking using CSS selectors";
+    homepage = "https://github.com/Nemorous/wordreaper";
+    changelog = "https://github.com/Nemorous/wordreaper/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.SamuelBozeman ];
+    mainProgram = "wordreaper";
+  };
+})


### PR DESCRIPTION
wordreaper: a Python CLI tool that scrapes targeted wordlists for password cracking using CSS selectors. Homepage:                               https://github.com/Nemorous/wordreaper

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.