### PR TITLE
redact: update version to 0.21.18 & fix passthru.updateScript

### DIFF
--- a/pkgs/by-name/re/redact/package.nix
+++ b/pkgs/by-name/re/redact/package.nix
@@ -7,10 +7,10 @@
 }:
 let
   pname = "redact";
-  version = "0.18.0";
+  version = "0.21.18";
   src = fetchurl {
     url = "https://update-desktop.redact.dev/build/Redact-${version}.AppImage";
-    hash = "sha256-qqqf8BAwXEKgZwl6vsPw/0S+qItz5ZqB59DJkW9q1xc=";
+    hash = "sha256-NnOQIVv/Y4C+qR5TsXh7rQq/WOYd7Vdtfru4x78djZA=";
   };
   appimageContents = appimageTools.extractType2 { inherit pname src version; };
 in

--- a/pkgs/by-name/re/redact/package.nix
+++ b/pkgs/by-name/re/redact/package.nix
@@ -41,11 +41,8 @@ appimageTools.wrapType2 {
         set -eu -o pipefail
         url="$(curl -ILs -w %{url_effective} -o /dev/null https://download.redact.dev/windows)"
         version="$(echo $url | sed -n 's/.*Redact-Setup-\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')"
-        currentVersion=$(nix-instantiate --eval -E "with import ./. {}; redact.version or (lib.getVersion redact)" | tr -d '"')
-        if [[ "$version" != "$currentVersion" ]]; then
-          hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$url")")
-          update-source-version redact "$version" "$hash" --print-changes
-        fi
+        hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "https://update-desktop.redact.dev/build/Redact-$version.AppImage")")
+        update-source-version redact "$version" "$hash" --print-changes --ignore-same-version
       '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Updates redact from version 0.18.0 -> 0.21.18
Fix passthru.updateScript hash calculation.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
