### PR TITLE
nixos/{stage-1,journald}: move option renames to defining modules

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -786,6 +786,5 @@ in
   };
 
   imports = [
-    (mkRenamedOptionModule [ "boot" "initrd" "mdadmConf" ] [ "boot" "swraid" "mdadmConf" ])
   ];
 }

--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -21,6 +21,13 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "enableHttpGateway" ]
+      [ "services" "journald" "gateway" "enable" ]
+    )
+  ];
+
   meta.maintainers = [ lib.maintainers.raitobezarius ];
   options.services.journald.gateway = {
     enable = lib.mkEnableOption "the HTTP gateway to the journal";

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -10,10 +10,6 @@ let
 in
 {
   imports = [
-    (lib.mkRenamedOptionModule
-      [ "services" "journald" "enableHttpGateway" ]
-      [ "services" "journald" "gateway" "enable" ]
-    )
   ];
 
   options = {

--- a/nixos/modules/tasks/swraid.nix
+++ b/nixos/modules/tasks/swraid.nix
@@ -26,6 +26,7 @@ in
       [ "boot" "initrd" "services" "swraid" "mdadmConf" ]
       [ "boot" "swraid" "mdadmConf" ]
     )
+    (lib.mkRenamedOptionModule [ "boot" "initrd" "mdadmConf" ] [ "boot" "swraid" "mdadmConf" ])
   ];
 
   options.boot.swraid = {


### PR DESCRIPTION
Move module option renames to the modules where the target options are defined.
This is expected to be a no-op in the normal case where all NixOS modules are loaded during evaluation.
But it's one small step towards evaluating NixOS from a potentially much smaller set of modules (see https://github.com/NixOS/nixpkgs/pull/507740).



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
