### PR TITLE
casacpp, libsakura, python3Packages.{casaconfig,casatools,casatasks}: init; casacore: update build inputs

### DIFF
--- a/pkgs/by-name/ca/casacore/casacore-pkgconfig.patch
+++ b/pkgs/by-name/ca/casacore/casacore-pkgconfig.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 574150c05..109e96889 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -566,6 +566,14 @@ foreach (module ${_modules})
+ endforeach (module)
+ 
+ # Install pkg-config support file
++set(pc_req_public "")
++if (_usewcs AND WCSLIB_FOUND)
++    list(APPEND pc_req_public "wcslib")
++endif()
++if (_usefits AND CFITSIO_FOUND)
++    list(APPEND pc_req_public "cfitsio")
++endif()
++list(JOIN pc_req_public " " pc_req_public)
+ CONFIGURE_FILE("casacore.pc.in" "casacore.pc" @ONLY)
+ set(CASA_PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+ INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/casacore.pc" DESTINATION "${CASA_PKGCONFIG_INSTALL_PREFIX}")
+diff --git a/casacore.pc.in b/casacore.pc.in
+index 6881300df..d0a01b240 100644
+--- a/casacore.pc.in
++++ b/casacore.pc.in
+@@ -9,4 +9,4 @@ Version: @PROJECT_VERSION@
+ Requires: @pc_req_public@
+ Requires.private: @pc_req_private@
+ Libs: -L${libdir} @PRIVATE_LIBS@
+-Cflags: -I${includedir} -I@WCSLIB_INCLUDE_DIR@
++Cflags: -I${includedir}

--- a/pkgs/by-name/ca/casacore/package.nix
+++ b/pkgs/by-name/ca/casacore/package.nix
@@ -14,8 +14,33 @@
   fftwFloat,
   readline,
   gsl,
+  mpi,
+  adios2,
+  hdf5,
+  llvmPackages,
+  mpiSupport ? false,
+  adios2Support ? false,
+  hdf5Support ? false,
 }:
-
+let
+  casacorePackages = {
+    adios2 = adios2.override {
+      inherit mpi mpiSupport;
+    };
+    fftw = fftw.override {
+      inherit mpi;
+      enableMpi = mpiSupport;
+    };
+    fftwFloat = fftwFloat.override {
+      inherit mpi;
+      enableMpi = mpiSupport;
+    };
+    hdf5 = hdf5.override {
+      inherit mpi mpiSupport;
+      cppSupport = !mpiSupport;
+    };
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "casacore";
   version = "3.8.0";
@@ -27,31 +52,55 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-NOxuHMCuHGk9XuWXMwQTN6kOFDI0QuHMgfNRDdlPw44=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     gfortran
     flex
     bison
-  ];
+  ]
+  ++ lib.optional mpiSupport mpi;
+
+  propagatedBuildInputs = [
+    wcslib
+    cfitsio
+  ]
+  ++ lib.optional hdf5Support casacorePackages.hdf5
+  ++ lib.optional mpiSupport mpi
+  ++ lib.optional adios2Support casacorePackages.adios2;
 
   buildInputs = [
     blas
     lapack
-    cfitsio
-    wcslib
-    fftw
-    fftwFloat
+    casacorePackages.fftw
+    casacorePackages.fftwFloat
     readline
     gsl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    llvmPackages.openmp
+  ];
+
+  patches = [
+    # Fix the generated .pc file: set Requires from a variable instead of
+    # leaving it empty, and remove hardcoded absolute cmake build paths from
+    # Cflags (which would embed /nix/store paths from the build environment).
+    ./casacore-pkgconfig.patch
   ];
 
   enableParallelBuilding = true;
 
-  strictDeps = true;
-
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_SHARED" (!stdenv.hostPlatform.isStatic))
-    (lib.cmakeBool "BUILD_PYTHON3" false) # TODO: If/when we package python-casacore, this will change
+    (lib.cmakeBool "BUILD_PYTHON3" false)
+    (lib.cmakeBool "USE_OPENMP" true)
+    (lib.cmakeBool "USE_ADIOS2" adios2Support)
+    (lib.cmakeBool "USE_HDF5" hdf5Support)
+    (lib.cmakeBool "USE_MPI" mpiSupport)
+    (lib.cmakeBool "PORTABLE" true)
+    (lib.cmakeBool "USE_PCH" false)
+    (lib.cmakeBool "BUILD_FFTPACK_DEPRECATED" true) # Needed for casacpp
   ];
 
   meta = {

--- a/pkgs/by-name/ca/casacpp/casacpp-pkgconfig.patch
+++ b/pkgs/by-name/ca/casacpp/casacpp-pkgconfig.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d3cae2326..7954107f8f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -195,6 +195,7 @@ foreach(_component IN LISTS casacpp_all_components)
+ endforeach()
+ 
+ # Install pkg-config support file
++set(pc_req_public "casacore cfitsio libxml-2.0 gsl protobuf grpc++ fftw3 libsakura")
+ CONFIGURE_FILE("casacpp.pc.in" "casacpp.pc" @ONLY)
+ set(CASACPP_PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+ INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/casacpp.pc" DESTINATION "${CASACPP_PKGCONFIG_INSTALL_PREFIX}")
+diff --git a/casacpp.pc.in b/casacpp.pc.in
+index 08a996b2c3..699cfb7319 100644
+--- a/casacpp.pc.in
++++ b/casacpp.pc.in
+@@ -9,4 +9,4 @@ Version: @PROJECT_VERSION@
+ Requires: @pc_req_public@
+ Requires.private: @pc_req_private@
+ Libs: -L${libdir} @PRIVATE_LIBS@
+-Cflags: -DWITHOUT_ACS -DWITHOUT_BOOST -I${includedir}/casacpp -I${includedir}/casacpp/protobuf_generated -I@CASACORE_INCLUDE_DIRS@ -I@CFITSIO_INCLUDE_DIRS@ -I@LibXML_INCLUDE_DIRS@ -I@GSL_INCLUDE_DIRS@
++Cflags: -DWITHOUT_ACS -DWITHOUT_BOOST -I${includedir}/casacpp -I${includedir}/casacpp/protobuf_generated

--- a/pkgs/by-name/ca/casacpp/package.nix
+++ b/pkgs/by-name/ca/casacpp/package.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  common-updater-scripts,
+  curl,
+  gnugrep,
+  writeShellScript,
+  pkg-config,
+  flex,
+  bison,
+  gfortran,
+  casacore,
+  libsakura,
+  grpc,
+  protobuf,
+  gsl,
+  libxml2,
+  libxslt,
+  fftw,
+  fftwFloat,
+  sqlite,
+  openssl,
+  mpi,
+  mpiSupport ? false,
+}:
+let
+  casacppPackages = {
+    fftw = fftw.override {
+      inherit mpi;
+      enableMpi = mpiSupport;
+    };
+    fftwFloat = fftwFloat.override {
+      inherit mpi;
+      enableMpi = mpiSupport;
+    };
+    casacore = casacore.override {
+      inherit mpi mpiSupport;
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "casacpp";
+  version = "6.7.5.18";
+
+  src = fetchgit {
+    url = "https://open-bitbucket.nrao.edu/scm/casa/casa6.git";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-75oIlaNAyu70KWSjz38LoYAvV7RJgzH/X9uBnGpriF4=";
+    fetchSubmodules = false;
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/casatools/src/code";
+
+  patches = [
+    # Fix the generated .pc file: set Requires from a variable instead of
+    # leaving it empty, and remove hardcoded absolute cmake build paths from
+    # Cflags (which would embed /nix/store paths from the build environment).
+    ./casacpp-pkgconfig.patch
+  ];
+
+  postPatch = ''
+    sed -i '/execute_process(COMMAND/,/OUTPUT_VARIABLE CASACPP_VERSION)/c\set(CASACPP_VERSION "${finalAttrs.version}")' CMakeLists.txt
+    sed -i 's/string(REGEX MATCH.*CASACPP_VERSION)//' CMakeLists.txt
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'find_package(gRPC QUIET)' \
+        'set(gRPC_FOUND 0)'
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    flex
+    bison
+    gfortran
+    grpc # for grpc_cpp_plugin
+  ]
+  ++ lib.optional mpiSupport mpi;
+
+  buildInputs = [
+    libxslt
+    sqlite
+    openssl
+  ];
+
+  propagatedBuildInputs = [
+    casacppPackages.casacore
+    protobuf
+    grpc
+    casacppPackages.fftw
+    casacppPackages.fftwFloat
+    libsakura
+    gsl
+    libxml2
+  ];
+
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-ffp-contract=off")
+  ];
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = writeShellScript "update-casacpp" ''
+    version=$(${lib.getExe curl} -s https://pypi.org/pypi/casatasks/json | ${lib.getExe gnugrep} -oP '"version"\s*:\s*"\K[^"]+' | head -1)
+    ${lib.getExe' common-updater-scripts "update-source-version"} casacpp "$version"
+  '';
+
+  meta = {
+    description = "C++ core libraries for radio interferometry data reduction";
+    homepage = "https://casa.nrao.edu/";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ kiranshila ];
+  };
+})

--- a/pkgs/by-name/li/libsakura/package.nix
+++ b/pkgs/by-name/li/libsakura/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  eigen,
+  fftw,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libsakura";
+  version = "5.3.2";
+
+  src = fetchFromGitHub {
+    owner = "tnakazato";
+    repo = "sakura";
+    tag = "${finalAttrs.pname}-${finalAttrs.version}";
+    hash = "sha256-QkVZXb9m4iMTeFYUOK1u+9HM0oMu48bwe7AovafanVU=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pname}";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    eigen
+    fftw
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "SIMD_ARCH" "GENERIC")
+    (lib.cmakeBool "PYTHON_BINDING" false)
+    (lib.cmakeBool "BUILD_DOC" false)
+    (lib.cmakeBool "ENABLE_TEST" false)
+  ];
+
+  meta = {
+    homepage = "https://tnakazato.github.io/sakura/";
+    changelog = "https://github.com/tnakazato/sakura/releases/tag/${finalAttrs.pname}-${finalAttrs.version}";
+    description = "Thread-safe library for signal processing in radio astronomy";
+    maintainers = with lib.maintainers; [ kiranshila ];
+    license = lib.licenses.lgpl3Plus;
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/python-modules/casaconfig/default.nix
+++ b/pkgs/development/python-modules/casaconfig/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  certifi,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "casaconfig";
+  version = "1.5.0";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-/O0rzef1Yqn+ezjTWfe1oRIh6FyU1W3Ev9tuXldukys=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ certifi ];
+
+  meta = {
+    description = "Reference data and converters for CASA operation";
+    homepage = "https://casa.nrao.edu/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kiranshila ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/casatasks/default.nix
+++ b/pkgs/development/python-modules/casatasks/default.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchgit,
+  fetchurl,
+  common-updater-scripts,
+  curl,
+  gnugrep,
+  gnused,
+  writeShellScript,
+  jdk,
+  wheel,
+  casatools,
+  casaconfig,
+  matplotlib,
+  scipy,
+  certifi,
+  pyerfa,
+  setuptools,
+  pipInstallHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "casatasks";
+  version = "6.7.5.18";
+
+  src = fetchgit {
+    url = "https://open-bitbucket.nrao.edu/scm/casa/casa6.git";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-75oIlaNAyu70KWSjz38LoYAvV7RJgzH/X9uBnGpriF4=";
+    fetchSubmodules = false;
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/casatasks";
+
+  format = "other";
+
+  nativeBuildInputs = [
+    jdk
+    wheel
+    setuptools
+    pipInstallHook
+  ];
+
+  propagatedBuildInputs = [
+    casatools
+    casaconfig
+    matplotlib
+    scipy
+    certifi
+    pyerfa
+  ];
+
+  jarName = "xml-casa-assembly-1.88.jar";
+
+  xml_jar = fetchurl {
+    url = "http://casa.nrao.edu/download/devel/xml-casa/java/${finalAttrs.jarName}";
+    hash = "sha256-UJCiXLXAe7Prm1qGXJ9jbuZcgKhPTSrU8qnf4C5Goxs="; # xml-jar
+  };
+
+  postPatch = ''
+    mkdir -p java
+    cp ${finalAttrs.xml_jar} java/${finalAttrs.jarName}
+  '';
+
+  buildPhase = ''
+      runHook preBuild
+      export HOME=$(mktemp -d)
+      mkdir -p $HOME/.casa/data
+      cat > $HOME/.casa/config.py <<EOF
+    measures_auto_update=False
+    data_auto_update=False
+    EOF
+      python setup.py bdist_wheel --version ${finalAttrs.version}
+      runHook postBuild
+  '';
+
+  # Tests require a full CASA data directory and network access
+  doCheck = false;
+
+  passthru.updateScript = writeShellScript "update-casatasks" ''
+    set -euo pipefail
+    version=$(${lib.getExe curl} -s https://pypi.org/pypi/casatasks/json | ${lib.getExe gnugrep} -oP '"version"\s*:\s*"\K[^"]+' | head -1)
+    ${lib.getExe' common-updater-scripts "update-source-version"} python3Packages.casatasks "$version"
+
+    # Extract the jar filename from the xml-casa script at the new tag
+    jar_name=$(${lib.getExe curl} -s \
+      "https://open-bitbucket.nrao.edu/rest/api/1.0/projects/CASA/repos/casa6/raw/casatools/scripts/xml-casa?at=refs/tags/$version" | \
+      ${lib.getExe gnugrep} -oP '(?<=jarfile_name = ").*(?=")')
+    jar_url="http://casa.nrao.edu/download/devel/xml-casa/java/$jar_name"
+    jar_sri=$(nix-prefetch-url --type sha256 "$jar_url" | xargs nix hash convert --hash-algo sha256 --to sri)
+
+    nix_file=pkgs/development/python-modules/casatasks/default.nix
+    ${lib.getExe gnused} -i \
+      -e "s|xml-casa-assembly-[^ \"]*\.jar|$jar_name|" \
+      -e "s|hash = \"sha256-.*\"; # xml-jar|hash = \"$jar_sri\"; # xml-jar|" \
+      "$nix_file"
+  '';
+
+  meta = {
+    description = "High-level Python tasks for radio astronomy data reduction";
+    homepage = "https://casa.nrao.edu/";
+    license = lib.licenses.lgpl2Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ kiranshila ];
+  };
+})

--- a/pkgs/development/python-modules/casatools/default.nix
+++ b/pkgs/development/python-modules/casatools/default.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchgit,
+  fetchurl,
+  common-updater-scripts,
+  curl,
+  gnugrep,
+  gnused,
+  writeShellScript,
+  cmake,
+  pkg-config,
+  swig,
+  flex,
+  bison,
+  gfortran,
+  jdk,
+  setuptools,
+  wheel,
+  build,
+  numpy,
+  casaconfig,
+  casacpp,
+  xercesc,
+  grpc,
+  readline,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "casatools";
+  version = "6.7.5.18";
+
+  src = fetchgit {
+    url = "https://open-bitbucket.nrao.edu/scm/casa/casa6.git";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-75oIlaNAyu70KWSjz38LoYAvV7RJgzH/X9uBnGpriF4=";
+    fetchSubmodules = false;
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/casatools";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    swig
+    flex
+    bison
+    gfortran
+    jdk
+    grpc
+    setuptools
+    wheel
+    build
+  ];
+
+  dontConfigure = true;
+
+  buildInputs = [
+    casacpp
+    xercesc
+    readline
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    casaconfig
+  ];
+
+  jarName = "xml-casa-assembly-1.88.jar";
+
+  xml_jar = fetchurl {
+    url = "http://casa.nrao.edu/download/devel/xml-casa/java/${finalAttrs.jarName}";
+    hash = "sha256-UJCiXLXAe7Prm1qGXJ9jbuZcgKhPTSrU8qnf4C5Goxs="; # xml-jar
+  };
+
+  postPatch = ''
+    mkdir -p scripts/java
+    cp ${finalAttrs.xml_jar} scripts/java/${finalAttrs.jarName}
+    echo "${finalAttrs.version} ${finalAttrs.version}" > version.txt
+    sed -i 's/def compute_version():/def compute_version():\n    return "${finalAttrs.version}"\ndef _compute_version_orig():/' setup.py
+  '';
+
+  # Tests require a full CASA data directory and network access
+  doCheck = false;
+
+  passthru.updateScript = writeShellScript "update-casatools" ''
+    set -euo pipefail
+    version=$(${lib.getExe curl} -s https://pypi.org/pypi/casatools/json | ${lib.getExe gnugrep} -oP '"version"\s*:\s*"\K[^"]+' | head -1)
+    ${lib.getExe' common-updater-scripts "update-source-version"} python3Packages.casatools "$version"
+
+    # Extract the jar filename from the xml-casa script at the new tag
+    jar_name=$(${lib.getExe curl} -s \
+      "https://open-bitbucket.nrao.edu/rest/api/1.0/projects/CASA/repos/casa6/raw/casatools/scripts/xml-casa?at=refs/tags/$version" | \
+      ${lib.getExe gnugrep} -oP '(?<=jarfile_name = ").*(?=")')
+    jar_url="http://casa.nrao.edu/download/devel/xml-casa/java/$jar_name"
+    jar_sri=$(nix-prefetch-url --type sha256 "$jar_url" | xargs nix hash convert --hash-algo sha256 --to sri)
+
+    nix_file=pkgs/development/python-modules/casatools/default.nix
+    ${lib.getExe gnused} -i \
+      -e "s|xml-casa-assembly-[^ \"]*\.jar|$jar_name|" \
+      -e "s|hash = \"sha256-.*\"; # xml-jar|hash = \"$jar_sri\"; # xml-jar|" \
+      "$nix_file"
+  '';
+
+  meta = {
+    description = "Python interface to core radio astronomy data processing routines";
+    homepage = "https://casa.nrao.edu/";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ kiranshila ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2509,6 +2509,8 @@ self: super: with self; {
     }
   );
 
+  casatools = callPackage ../development/python-modules/casatools { };
+
   case-converter = callPackage ../development/python-modules/case-converter { };
 
   cashaddress = callPackage ../development/python-modules/cashaddress { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2509,6 +2509,8 @@ self: super: with self; {
     }
   );
 
+  casatasks = callPackage ../development/python-modules/casatasks { };
+
   casatools = callPackage ../development/python-modules/casatools { };
 
   case-converter = callPackage ../development/python-modules/case-converter { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2500,6 +2500,8 @@ self: super: with self; {
 
   casa-formats-io = callPackage ../development/python-modules/casa-formats-io { };
 
+  casaconfig = callPackage ../development/python-modules/casaconfig { };
+
   casadi = toPythonModule (
     pkgs.casadi.override {
       pythonSupport = true;


### PR DESCRIPTION
Adds the CASA (Common Astronomy Software Applications) Python stack for radio astronomy data processing (https://casa.nrao.edu). Commits are in order to build up dependencies for casatasks
                                                                                                                        
  New packages:                                                                                                                                                 
  - **libsakura** (5.3.2): High-performance, thread-safe C++ library for astronomy data analysis
  - **casacpp** (6.7.5.18): CASA C++ libraries, extracted from the CASA 6 monorepo                                                
  - **python3Packages.casaconfig** (1.5.0): Reference data and configuration for CASA                                               
  - **python3Packages.casatools** (6.7.5.18): Python bindings to casacpp, the core CASA tool interface
  - **python3Packages.casatasks** (6.7.5.18): High-level Python tasks built on casatools

  **casacore** is also updated to propagate `wcslib`/`cfitsio` as build inputs (needed by casacpp downstream), add a pkgconfig patch, and enable OpenMP, fftpack, and dysco builds.   

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
