### PR TITLE
nixos/tests/dawarich: fix points being flagged as anomalies

### DIFF
--- a/nixos/tests/web-apps/dawarich.nix
+++ b/nixos/tests/web-apps/dawarich.nix
@@ -3,17 +3,50 @@
   name = "dawarich-nixos";
 
   nodes.machine =
-    { pkgs, ... }:
+    { lib, pkgs, ... }:
     {
       services.dawarich = {
         enable = true;
         localDomain = "localhost";
       };
 
-      environment.etc.geojson.source = pkgs.fetchurl {
-        url = "https://github.com/Freika/dawarich/raw/8c24764aa56a084e980e21bc2ffd13a72fd611db/spec/fixtures/files/geojson/export.json";
-        hash = "sha256-qI00E5ixKTRJduAD+qB3JzvrpoJmC55llNtSiPVyxz4=";
-      };
+      environment.etc.geojson.text =
+        let
+          # based on https://github.com/Freika/dawarich/raw/8c24764aa56a084e980e21bc2ffd13a72fd611db/spec/fixtures/files/geojson/export.json
+          # but with different timestamps to avoid points being flagged as anomalies
+          points = map (i: {
+            lat = i / 10.0;
+            lon = i / 10.0;
+            timestamp = 1609459200 + i * 1000;
+          }) (lib.range 1 10);
+
+          mkGeoJsonPoint =
+            {
+              lat,
+              lon,
+              timestamp,
+            }:
+            {
+              type = "Feature";
+              geometry = {
+                type = "Point";
+                coordinates = [
+                  lon
+                  lat
+                ];
+              };
+              properties = {
+                altitude = 1;
+                vertical_accuracy = 1;
+                accuracy = 1;
+                inherit timestamp;
+              };
+            };
+        in
+        builtins.toJSON {
+          type = "FeatureCollection";
+          features = map mkGeoJsonPoint points;
+        };
     };
 
   testScript = ''


### PR DESCRIPTION
Due to a change upstream [1], points with velocity over 1000 km/h are flagged as anomalies and do not show up in the /points endpoint. This results in an assertion failure.

To fix this, the dummy data file that was in use has been replaced with custom data that has spaced out timestamps, which avoids the points being flagged as anomalies.

[1]: https://github.com/Freika/dawarich/commit/95ea3ed962c99b3790527655d512993b28270018


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
