### PR TITLE
nixos: allow core modules to be evaluated more independently.

### DIFF
--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -174,9 +174,11 @@ in
     # hostname and FQDN correctly:
     networking.hosts =
       let
+        hostName = cfg.hostName or config.system.nixos.distroId;
+        domain = cfg.domain or null;
         hostnames = # Note: The FQDN (canonical hostname) has to come first:
-          lib.optional (cfg.hostName != "" && cfg.domain != null) "${cfg.hostName}.${cfg.domain}"
-          ++ lib.optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
+          lib.optional (hostName != "" && domain != null) "${hostName}.${domain}"
+          ++ lib.optional (hostName != "") hostName; # Then the hostname (without the domain)
       in
       {
         "127.0.0.2" = hostnames;
@@ -190,7 +192,7 @@ in
         # FQDN so that e.g. "hostname -f" works correctly.
         localhostHosts = pkgs.writeText "localhost-hosts" ''
           127.0.0.1 localhost
-          ${lib.optionalString cfg.enableIPv6 "::1 localhost"}
+          ${lib.optionalString (cfg.enableIPv6 or true) "::1 localhost"}
         '';
         stringHosts =
           let

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -131,7 +131,7 @@
   config = {
     assertions = [
       {
-        assertion = config.system.nssModules.path != "" -> config.services.nscd.enable;
+        assertion = config.system.nssModules.path != "" -> (config.services.nscd.enable or false);
         message = ''
           Loading NSS modules from system.nssModules (${config.system.nssModules.path}),
           requires services.nscd.enable being set to true.

--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -21,7 +21,7 @@ let
     # variable with the same name exported by dhcpcd.
     interface_order='lo lo[0-9]*'
   ''
-  + lib.optionalString config.services.nscd.enable ''
+  + lib.optionalString (config.services.nscd.enable or false) ''
     # Invalidate the nscd cache whenever resolv.conf is
     # regenerated.
     libc_restart='/run/current-system/systemd/bin/systemctl try-restart --no-block nscd.service 2> /dev/null'

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -223,7 +223,7 @@ in
 
     users.defaultUserShell = lib.mkDefault pkgs.bashInteractive;
 
-    environment.pathsToLink = lib.optionals cfg.completion.enable [
+    environment.pathsToLink = lib.optionals (cfg.completion.enable or false) [
       "/etc/bash_completion.d"
       "/share/bash-completion"
     ];

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -45,7 +45,7 @@ in
 
       enableAskPassword = lib.mkOption {
         type = lib.types.bool;
-        default = config.services.xserver.enable;
+        default = config.services.xserver.enable or false;
         defaultText = lib.literalExpression "config.services.xserver.enable";
         description = "Whether to configure SSH_ASKPASS in the environment.";
       };
@@ -315,9 +315,9 @@ in
   config = {
 
     programs.ssh.setXAuthLocation = lib.mkDefault (
-      config.services.xserver.enable
+      (config.services.xserver.enable or false)
       || config.programs.ssh.forwardX11 == true
-      || config.services.openssh.settings.X11Forwarding
+      || (config.services.openssh.settings.X11Forwarding or false)
     );
 
     assertions = [

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -136,7 +136,7 @@ in
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';
     services.getty.helpLine = mkIf (
-      config.documentation.nixos.enable && config.documentation.doc.enable
+      (config.documentation.nixos.enable or false) && (config.documentation.doc.enable or false)
     ) "\nRun 'nixos-help' for the NixOS manual.";
 
     systemd.additionalUpstreamSystemUnits = [

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -196,7 +196,7 @@ in
       ];
       serviceConfig.Restart = "always";
       restartIfChanged = false;
-      enable = mkDefault config.boot.isContainer;
+      enable = mkDefault (config.boot.isContainer or false);
     };
 
     environment.etc.issue = mkDefault {

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -151,7 +151,7 @@ in
     # We can't just rely on 'Conflicts=autovt@tty1.service' because
     # 'switch-to-configuration switch' will start 'autovt@tty1.service'
     # and kill the display manager.
-    systemd.targets.getty.wants = lib.mkIf (!config.services.displayManager.enable) [
+    systemd.targets.getty.wants = lib.mkIf (!(config.services.displayManager.enable or false)) [
       "autovt@tty1.service"
     ];
 

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -171,7 +171,7 @@ in
     # We can't just rely on 'Conflicts=autovt@tty1.service' because
     # 'switch-to-configuration switch' will start 'autovt@tty1.service'
     # and kill the display manager.
-    systemd.targets.getty.wants = lib.mkIf (!config.services.displayManager.enable) [
+    systemd.targets.getty.wants = lib.mkIf (!(config.services.displayManager.enable or false)) [
       "autovt@tty1.service"
     ];
 

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -211,7 +211,7 @@ in
       ];
       serviceConfig.Restart = "always";
       restartIfChanged = false;
-      enable = mkDefault config.boot.isContainer;
+      enable = mkDefault (config.boot.isContainer or false);
     };
 
     environment.etc.issue = mkDefault {

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -156,7 +156,7 @@ in
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';
     services.getty.helpLine = mkIf (
-      config.documentation.nixos.enable && config.documentation.doc.enable
+      (config.documentation.nixos.enable or false) && (config.documentation.doc.enable or false)
     ) "\nRun 'nixos-help' for the NixOS manual.";
 
     systemd.additionalUpstreamSystemUnits = [

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -278,7 +278,7 @@ in
       "D /var/empty 0555 root root -"
       "h /var/empty - - - - +i"
     ]
-    ++ lib.optionals config.nix.enable [
+    ++ lib.optionals (config.nix.enable or false) [
       # Prevent the current configuration from being garbage-collected.
       "d /nix/var/nix/gcroots -"
       "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"

--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -51,7 +51,7 @@ in
           message = "nixos-init can only be used with system.etc.overlay.enable";
         }
         {
-          assertion = config.services.userborn.enable || config.systemd.sysusers.enable;
+          assertion = (config.services.userborn.enable or false) || (config.systemd.sysusers.enable or false);
           message = "nixos-init can only be used with services.userborn.enable or systemd.sysusers.enable";
         }
         {

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -44,7 +44,7 @@ let
 
     cp "$extraDependenciesPath" "$out/extra-dependencies"
 
-    ${optionalString (!config.boot.isContainer && config.boot.bootspec.enable) ''
+    ${optionalString (!(config.boot.isContainer or false) && config.boot.bootspec.enable) ''
       ${config.boot.bootspec.writer}
       ${optionalString config.boot.bootspec.enableValidation ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
     ''}

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -283,11 +283,15 @@ in
 
     system.name = mkOption {
       type = types.str;
-      default = if config.networking.hostName == "" then "unnamed" else config.networking.hostName;
+      default =
+        if (config.networking.hostName or config.system.nixos.distroId) == "" then
+          "unnamed"
+        else
+          config.networking.hostName or config.system.nixos.distroId;
       defaultText = literalExpression ''
-        if config.networking.hostName == ""
+        if (config.networking.hostName or config.system.nixos.distroId) == ""
         then "unnamed"
-        else config.networking.hostName;
+        else config.networking.hostName or config.system.nixos.distroId;
       '';
       description = ''
         The name of the system used in the {option}`system.build.toplevel` derivation.

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -44,7 +44,7 @@ let
 
     printf "%s " "''${extraDependencies[@]}" > "$out/extra-dependencies"
 
-    ${optionalString (!config.boot.isContainer) ''
+    ${optionalString (!(config.boot.isContainer or false)) ''
       ${config.boot.bootspec.writer}
       ${optionalString config.boot.bootspec.enableValidation ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
     ''}

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -285,11 +285,15 @@ in
 
     system.name = mkOption {
       type = types.str;
-      default = if config.networking.hostName == "" then "unnamed" else config.networking.hostName;
+      default =
+        if (config.networking.hostName or config.system.nixos.distroId) == "" then
+          "unnamed"
+        else
+          config.networking.hostName or config.system.nixos.distroId;
       defaultText = literalExpression ''
-        if config.networking.hostName == ""
+        if (config.networking.hostName or config.system.nixos.distroId) == ""
         then "unnamed"
-        else config.networking.hostName;
+        else config.networking.hostName or config.system.nixos.distroId;
       '';
       description = ''
         The name of the system used in the {option}`system.build.toplevel` derivation.

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -406,7 +407,7 @@ in
 
           ln -s ${kernelPath} $out/kernel
           ln -s ${config.system.modulesTree} $out/kernel-modules
-          ${optionalString (config.hardware.deviceTree.package != null) ''
+          ${optionalString (options ? hardware.deviceTree && config.hardware.deviceTree.package != null) ''
             ln -s ${config.hardware.deviceTree.package} $out/dtbs
           ''}
 

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -402,7 +403,7 @@ in
 
           ln -s ${kernelPath} $out/kernel
           ln -s ${config.system.modulesTree} $out/kernel-modules
-          ${optionalString (config.hardware.deviceTree.package != null) ''
+          ${optionalString (options ? hardware.deviceTree && config.hardware.deviceTree.package != null) ''
             ln -s ${config.hardware.deviceTree.package} $out/dtbs
           ''}
 

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -4219,7 +4220,7 @@ let
         with types;
         attrsOf (submodule {
           # Default in initrd is dhcp-on-stop, which is correct if flushBeforeStage2 = false
-          config = mkIf config.boot.initrd.network.flushBeforeStage2 {
+          config = mkIf (options ? boot.initrd.network && config.boot.initrd.network.flushBeforeStage2) {
             networkConfig.KeepConfiguration = mkDefault false;
           };
         });
@@ -4234,7 +4235,9 @@ let
       (commonConfig config.boot.initrd)
 
       {
-        systemd.network.enable = mkDefault config.boot.initrd.network.enable;
+        systemd.network.enable = mkDefault (
+          options ? boot.initrd.network && config.boot.initrd.network.enable
+        );
         systemd.contents = mkUnitFiles "/etc/" cfg;
 
         # Networkd link files are used early by udev to set up interfaces early.
@@ -4301,16 +4304,16 @@ in
   config = mkMerge [
     stage2Config
     (mkIf config.boot.initrd.systemd.enable {
-      assertions = [
-        {
-          assertion =
-            !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
-          message = ''
-            systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
-            DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
-          '';
-        }
-      ];
+      # Only assert against the legacy udhcpc options if initrd-network.nix is loaded;
+      # they don't exist otherwise.
+      assertions = lib.optional (options ? boot.initrd.network) {
+        assertion =
+          !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
+        message = ''
+          systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
+          DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
+        '';
+      };
 
       boot.initrd = stage1Config;
     })

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -4281,7 +4282,7 @@ let
         with types;
         attrsOf (submodule {
           # Default in initrd is dhcp-on-stop, which is correct if flushBeforeStage2 = false
-          config = mkIf config.boot.initrd.network.flushBeforeStage2 {
+          config = mkIf (options ? boot.initrd.network && config.boot.initrd.network.flushBeforeStage2) {
             networkConfig.KeepConfiguration = mkDefault false;
           };
         });
@@ -4296,7 +4297,9 @@ let
       (commonConfig config.boot.initrd)
 
       {
-        systemd.network.enable = mkDefault config.boot.initrd.network.enable;
+        systemd.network.enable = mkDefault (
+          options ? boot.initrd.network && config.boot.initrd.network.enable
+        );
         systemd.contents = mkUnitFiles "/etc/" cfg;
 
         # Networkd link files are used early by udev to set up interfaces early.
@@ -4366,16 +4369,16 @@ in
   config = mkMerge [
     stage2Config
     (mkIf config.boot.initrd.systemd.enable {
-      assertions = [
-        {
-          assertion =
-            !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
-          message = ''
-            systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
-            DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
-          '';
-        }
-      ];
+      # Only assert against the legacy udhcpc options if initrd-network.nix is loaded;
+      # they don't exist otherwise.
+      assertions = lib.optional (options ? boot.initrd.network) {
+        assertion =
+          !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
+        message = ''
+          systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
+          DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
+        '';
+      };
 
       boot.initrd = stage1Config;
     })

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -28,7 +28,8 @@ let
 
   cfg = config.services.resolved;
 
-  dnsmasqResolve = config.services.dnsmasq.enable && config.services.dnsmasq.resolveLocalQueries;
+  dnsmasqResolve =
+    (config.services.dnsmasq.enable or false) && (config.services.dnsmasq.resolveLocalQueries or false);
 
   transformSettings =
     settings:

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -333,7 +333,7 @@ let
           && !sd.randomEncryption.enable
           # Don't include zram devices
           && !(hasPrefix "/dev/zram" sd.device)
-        ) config.swapDevices
+        ) (config.swapDevices or [ ])
       );
 
       fsInfo =

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -487,8 +487,8 @@ in
 
     boot.initrd.enable = mkOption {
       type = types.bool;
-      default = !config.boot.isContainer;
-      defaultText = literalExpression "!config.boot.isContainer";
+      default = !(config.boot.isContainer or false);
+      defaultText = literalExpression "!(config.boot.isContainer or false)";
       description = ''
         Whether to enable the NixOS initial RAM disk (initrd). This may be
         needed to perform some initialisation tasks (like mounting

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -9,7 +10,11 @@ with lib;
 
 let
 
-  useHostResolvConf = config.networking.resolvconf.enable && config.networking.useHostResolvConf;
+  useHostResolvConf =
+    options ? networking.resolvconf
+    && options ? networking.useHostResolvConf
+    && config.networking.resolvconf.enable
+    && config.networking.useHostResolvConf;
 
   bootStage2 = pkgs.replaceVarsWith {
     src = ./stage-2-init.sh;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -869,7 +869,7 @@ in
     # permission to run the command. This next part is only enabled if polkit is enabled because the
     # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
     # enabled, run0 will fail before it even tries to run the command.
-    security.pam.services = mkIf config.security.polkit.enable {
+    security.pam.services = mkIf (config.security.polkit.enable or false) {
       systemd-run0 = {
         # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
         setLoginUid = true;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -231,7 +231,7 @@ let
     "factory-reset.target.wants"
   ];
 
-  proxy_env = config.networking.proxy.envVars;
+  proxy_env = config.networking.proxy.envVars or { };
 
   json = pkgs.formats.json { };
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -720,7 +720,7 @@ in
         config.system.fsPackages
         ++ [ cfg.package.util-linux ]
         # systemd-ssh-generator needs sshd in PATH
-        ++ lib.optional config.services.openssh.enable config.services.openssh.package
+        ++ lib.optional (config.services.openssh.enable or false) config.services.openssh.package
       );
       LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       TZDIR = "/etc/zoneinfo";

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -67,7 +67,7 @@ let
     "systemd-udevd.service"
     "systemd-udev-settle.service"
   ]
-  ++ (optional (!config.boot.isContainer) "systemd-udev-trigger.service")
+  ++ (optional (!(config.boot.isContainer or false)) "systemd-udev-trigger.service")
   ++ [
     # hwdb.bin is managed by NixOS
     # "systemd-hwdb-update.service"
@@ -99,7 +99,7 @@ let
     "dev-mqueue.mount"
     "sys-fs-fuse-connections.mount"
   ]
-  ++ (optional (!config.boot.isContainer) "sys-kernel-config.mount")
+  ++ (optional (!(config.boot.isContainer or false)) "sys-kernel-config.mount")
   ++ [
     "sys-kernel-debug.mount"
     "sys-kernel-tracing.mount"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -248,7 +248,7 @@ let
     "factory-reset.target.wants"
   ];
 
-  proxy_env = config.networking.proxy.envVars;
+  proxy_env = config.networking.proxy.envVars or { };
 
   json = pkgs.formats.json { };
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -741,7 +741,7 @@ in
         config.system.fsPackages
         ++ [ cfg.package.util-linux ]
         # systemd-ssh-generator needs sshd in PATH
-        ++ lib.optional config.services.openssh.enable config.services.openssh.package
+        ++ lib.optional (config.services.openssh.enable or false) config.services.openssh.package
       );
       LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       TZDIR = "/etc/zoneinfo";
@@ -899,7 +899,7 @@ in
     # the systemd vmspawn credential dropin executes sshd and expects ExecSearchPath to be set, see:
     # https://github.com/systemd/systemd/blob/v259.3/src/vmspawn/vmspawn.c#L2662
     # this service is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.services."sshd-vsock@" = mkIf config.services.openssh.enable {
+    systemd.services."sshd-vsock@" = mkIf (config.services.openssh.enable or false) {
       serviceConfig.ExecSearchPath = "${config.services.openssh.package}/bin";
       overrideStrategy = "asDropin";
     };
@@ -907,7 +907,7 @@ in
     # Fix paths in sshd-vsock.socket
     # https://github.com/systemd/systemd/blob/v259.3/src/ssh-generator/ssh-generator.c#L239
     # this socket is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.sockets.sshd-vsock = mkIf config.services.openssh.enable {
+    systemd.sockets.sshd-vsock = mkIf (config.services.openssh.enable or false) {
       overrideStrategy = "asDropin";
       socketConfig.ExecStartPost = [
         ""

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -68,7 +68,7 @@ let
     "systemd-udevd-varlink.socket"
     "systemd-udevd.service"
   ]
-  ++ (optional (!config.boot.isContainer) "systemd-udev-trigger.service")
+  ++ (optional (!(config.boot.isContainer or false)) "systemd-udev-trigger.service")
   ++ [
     # hwdb.bin is managed by NixOS
     # "systemd-hwdb-update.service"
@@ -100,7 +100,7 @@ let
     "dev-mqueue.mount"
     "sys-fs-fuse-connections.mount"
   ]
-  ++ (optional (!config.boot.isContainer) "sys-kernel-config.mount")
+  ++ (optional (!(config.boot.isContainer or false)) "sys-kernel-config.mount")
   ++ [
     "sys-kernel-debug.mount"
     "sys-kernel-tracing.mount"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -888,7 +888,7 @@ in
     # permission to run the command. This next part is only enabled if polkit is enabled because the
     # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
     # enabled, run0 will fail before it even tries to run the command.
-    security.pam.services = mkIf config.security.polkit.enable {
+    security.pam.services = mkIf (config.security.polkit.enable or false) {
       systemd-run0 = {
         # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
         setLoginUid = true;

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -431,19 +431,23 @@ in
       }
     ]
     ++
-      map
-        (name: {
-          assertion = lib.attrByPath name (throw "impossible") config.boot.initrd == "";
-          message = ''
-            systemd stage 1 does not support 'boot.initrd.${lib.concatStringsSep "." name}'. Please
-              convert it to analogous systemd units in 'boot.initrd.systemd'.
+      lib.concatMap
+        (
+          name:
+          # Only assert if the option actually exists (it may not with minimal modules)
+          lib.optional (lib.hasAttrByPath name config.boot.initrd) {
+            assertion = lib.attrByPath name "" config.boot.initrd == "";
+            message = ''
+              systemd stage 1 does not support 'boot.initrd.${lib.concatStringsSep "." name}'. Please
+                convert it to analogous systemd units in 'boot.initrd.systemd'.
 
-                Definitions:
-            ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
-              (lib.attrByPath name (throw "impossible") options.boot.initrd).definitionsWithLocations
-            }
-          '';
-        })
+                  Definitions:
+              ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
+                (lib.attrByPath name (throw "impossible") options.boot.initrd).definitionsWithLocations
+              }
+            '';
+          }
+        )
         [
           [ "preFailCommands" ]
           [ "preDeviceCommands" ]

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -530,7 +530,7 @@ in
         "/etc/initrd-release".source = config.boot.initrd.osRelease;
 
         # For systemd-journald's _HOSTNAME field; needs to be set early, cannot be backfilled.
-        "/etc/hostname".text = config.networking.hostName;
+        "/etc/hostname".text = config.networking.hostName or config.system.nixos.distroId;
 
       }
       // optionalAttrs (config.environment.etc ? "modprobe.d/nixos.conf") {

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -589,7 +589,7 @@ in
         "/etc/initrd-release".source = config.boot.initrd.osRelease;
 
         # For systemd-journald's _HOSTNAME field; needs to be set early, cannot be backfilled.
-        "/etc/hostname".text = config.networking.hostName;
+        "/etc/hostname".text = config.networking.hostName or config.system.nixos.distroId;
 
       }
       // optionalAttrs (config.environment.etc ? "modprobe.d/nixos.conf") {

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -471,16 +471,20 @@ in
       let
         obsoleteOpt =
           opts: msgFn:
-          lib.flip map opts (opt: {
-            assertion = lib.attrByPath opt (throw "impossible") config.boot.initrd == "";
-            message = ''
-              ${msgFn (lib.concatStringsSep "." opt)}
-                  Definitions:
-              ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
-                (lib.attrByPath opt (throw "impossible") options.boot.initrd).definitionsWithLocations
-              }
-            '';
-          });
+          lib.flip lib.concatMap opts (
+            opt:
+            # Only assert if the option actually exists (it may not with minimal modules)
+            lib.optional (lib.hasAttrByPath opt config.boot.initrd) {
+              assertion = lib.attrByPath opt "" config.boot.initrd == "";
+              message = ''
+                ${msgFn (lib.concatStringsSep "." opt)}
+                    Definitions:
+                ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
+                  (lib.attrByPath opt (throw "impossible") options.boot.initrd).definitionsWithLocations
+                }
+              '';
+            }
+          );
       in
       [
         {

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -109,7 +109,7 @@ in
     };
 
     services.journald.forwardToSyslog = lib.mkOption {
-      default = config.services.rsyslogd.enable || config.services.syslog-ng.enable;
+      default = (config.services.rsyslogd.enable or false) || (config.services.syslog-ng.enable or false);
       defaultText = lib.literalExpression "services.rsyslogd.enable || services.syslog-ng.enable";
       type = lib.types.bool;
       description = ''

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -105,7 +105,7 @@ in
     };
 
     services.journald.forwardToSyslog = lib.mkOption {
-      default = config.services.rsyslogd.enable || config.services.syslog-ng.enable;
+      default = (config.services.rsyslogd.enable or false) || (config.services.syslog-ng.enable or false);
       defaultText = lib.literalExpression "services.rsyslogd.enable || services.syslog-ng.enable";
       type = lib.types.bool;
       description = ''

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -350,7 +350,7 @@ in
       "d  /var/db                            0755 root root - -"
       "L  /var/lock                          -    -    -    - ../run/lock"
     ]
-    ++ lib.optionals config.nix.enable [
+    ++ lib.optionals (config.nix.enable or false) [
       "d  /nix/var                           0755 root root - -"
       "L+ /nix/var/nix/gcroots/booted-system 0755 root root - /run/booted-system"
     ]
@@ -360,7 +360,7 @@ in
       "R! /etc/passwd.lock                   -    -    -    - -"
       "R! /etc/shadow.lock                   -    -    -    - -"
     ]
-    ++ lib.optionals config.nix.enable [
+    ++ lib.optionals (config.nix.enable or false) [
       "R! /nix/var/nix/gcroots/tmp           -    -    -    - -"
       "R! /nix/var/nix/temproots             -    -    -    - -"
     ];

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -11,8 +11,8 @@ in
 
     services.timesyncd = with types; {
       enable = mkOption {
-        default = !config.boot.isContainer;
-        defaultText = literalExpression "!config.boot.isContainer";
+        default = !(config.boot.isContainer or false);
+        defaultText = literalExpression "!(config.boot.isContainer or false)";
         type = bool;
         description = ''
           Enables the systemd NTP client daemon.

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -22,8 +22,8 @@ in
 
     services.timesyncd = {
       enable = lib.mkOption {
-        default = !config.boot.isContainer;
-        defaultText = lib.literalExpression "!config.boot.isContainer";
+        default = !(config.boot.isContainer or false);
+        defaultText = lib.literalExpression "!(config.boot.isContainer or false)";
         type = lib.types.bool;
         description = ''
           Enables the systemd NTP client daemon.

--- a/nixos/modules/system/boot/uki.nix
+++ b/nixos/modules/system/boot/uki.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -88,7 +89,12 @@ in
         EFIArch = lib.mkOptionDefault efiArch;
       }
       //
-        lib.optionalAttrs (config.hardware.deviceTree.enable && config.hardware.deviceTree.name != null)
+        lib.optionalAttrs
+          (
+            options ? hardware.deviceTree
+            && config.hardware.deviceTree.enable
+            && config.hardware.deviceTree.name != null
+          )
           {
             DeviceTree = lib.mkOptionDefault "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
           };

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -29,7 +29,7 @@
         {
           assertion =
             (!config.system.etc.overlay.mutable)
-            -> (config.systemd.sysusers.enable || config.services.userborn.enable);
+            -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
           message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
         }
         {

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -34,7 +34,7 @@
         }
         {
           assertion =
-            (config.system.switch.enable)
+            (config.system.switch.enable or false)
             -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
           message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
         }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -33,7 +33,7 @@
         }
         {
           assertion =
-            (config.system.switch.enable)
+            (config.system.switch.enable or false)
             -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
           message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
         }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -28,7 +28,7 @@
         {
           assertion =
             (!config.system.etc.overlay.mutable)
-            -> (config.systemd.sysusers.enable || config.services.userborn.enable);
+            -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
           message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
         }
         {

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -519,8 +519,10 @@ in
         # Filesystems.
         ${makeFstabEntries fileSystems { }}
 
-        ${optionalString (config.swapDevices != [ ]) "# Swap devices."}
-        ${flip concatMapStrings config.swapDevices (sw: "${sw.realDevice} none swap ${swapOptions sw}\n")}
+        ${optionalString ((config.swapDevices or [ ]) != [ ]) "# Swap devices."}
+        ${flip concatMapStrings (config.swapDevices or [ ]) (
+          sw: "${sw.realDevice} none swap ${swapOptions sw}\n"
+        )}
       '';
 
     boot.initrd.systemd.storePaths = [ initrdFstab ];

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -553,7 +553,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isContainer) {
+    // optionalAttrs (!(config.boot.isContainer or false)) {
       # systemd-nspawn populates /sys by itself, and remounting it causes all
       # kinds of weird issues (most noticeably, waiting for host disk device
       # nodes).
@@ -566,7 +566,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isNspawnContainer) {
+    // optionalAttrs (!(config.boot.isNspawnContainer or false)) {
       "/proc" = {
         fsType = "proc";
         options = [

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -552,7 +552,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isContainer) {
+    // optionalAttrs (!(config.boot.isContainer or false)) {
       # systemd-nspawn populates /sys by itself, and remounting it causes all
       # kinds of weird issues (most noticeably, waiting for host disk device
       # nodes).
@@ -565,7 +565,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isNspawnContainer) {
+    // optionalAttrs (!(config.boot.isNspawnContainer or false)) {
       "/proc" = {
         fsType = "proc";
         options = [

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -518,8 +518,10 @@ in
         # Filesystems.
         ${makeFstabEntries fileSystems { }}
 
-        ${optionalString (config.swapDevices != [ ]) "# Swap devices."}
-        ${flip concatMapStrings config.swapDevices (sw: "${sw.realDevice} none swap ${swapOptions sw}\n")}
+        ${optionalString ((config.swapDevices or [ ]) != [ ]) "# Swap devices."}
+        ${flip concatMapStrings (config.swapDevices or [ ]) (
+          sw: "${sw.realDevice} none swap ${swapOptions sw}\n"
+        )}
       '';
 
     boot.initrd.systemd.storePaths = [ initrdFstab ];


### PR DESCRIPTION
 * the very first commit makes the systemd-initrd module (more specifically: an assertion in it) evaluate, even if the module for the scripted, legacy, initrd isn't being evaluated.

* the bulk of the remaining commits mechanically guard cross-module reads with `or <default>` clauses, where the fallback matches the declared default of each option. That's mostly `or false`, but not always, see commits.

* the last four commits cover four reads whose declared default depends on other config (e.g. `!config.boot.initrd.systemd.enable` for `boot.initrd.network.flushBeforeStage2`), so a literal fallback can't capture it. We use `options ? X && config.X` here, so that it evaluates to the real, declared default when the module is loaded, and false otherwise.
test
All of this is deliberately kept simple and boring in the hopes of making reviews easier and minimizing risk.

 It's another small step towards evaluating NixOS from a potentially much smaller set of modules. (see https://github.com/NixOS/nixpkgs/pull/507740)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
