### PR TITLE
yabridgectl: patch to fix 'yabridgectl set'

### DIFF
--- a/pkgs/by-name/ya/yabridgectl/package.nix
+++ b/pkgs/by-name/ya/yabridgectl/package.nix
@@ -1,4 +1,5 @@
 {
+  fetchpatch,
   lib,
   rustPlatform,
   yabridge,
@@ -21,6 +22,11 @@ rustPlatform.buildRustPackage {
 
     # Dependencies are hardcoded in yabridge, so the check is unnecessary and likely incorrect
     ./remove-dependency-verification.patch
+
+    (fetchpatch {
+      url = "https://github.com/robbert-vdh/yabridge/commit/5151f1c447ba5d0f96d4f27931a0a6582cbf511f.patch";
+      sha256 = "sha256-hn4biAxcWewSkx2PlQKWCJWJJ1cJ3KBcRAsL3WRd8hE=";
+    })
   ];
 
   patchFlags = [ "-p3" ];


### PR DESCRIPTION
The patch has been in yabridge's master since late 2024, but yabridge has not cut a release since then. The issue essentially prevents one from using `yabridgectl set`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
