### PR TITLE
govee2mqtt: 2025.11.25-60a39bcc -> 2026.03.25-ab9deb66

### DIFF
--- a/pkgs/by-name/go/govee2mqtt/package.nix
+++ b/pkgs/by-name/go/govee2mqtt/package.nix
@@ -42,7 +42,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/wez/govee2mqtt";
     changelog = "https://github.com/wez/govee2mqtt/blob/${finalAttrs.version}/addon/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    maintainers = with lib.maintainers; [
+      SuperSandro2000
+      niklaskorz
+    ];
     mainProgram = "govee";
   };
 })

--- a/pkgs/by-name/go/govee2mqtt/package.nix
+++ b/pkgs/by-name/go/govee2mqtt/package.nix
@@ -8,13 +8,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "govee2mqtt";
-  version = "2025.11.25-60a39bcc";
+  version = "2026.03.25-ab9deb66";
 
   src = fetchFromGitHub {
     owner = "wez";
     repo = "govee2mqtt";
     tag = finalAttrs.version;
-    hash = "sha256-8N/qQHJvVKWdlPQDbLskGw9le0L7yzTwxwz1w4cFu5g=";
+    hash = "sha256-APGvE5BIYgZtAWbM9DGJFuGyI3715g8Gyxou8uhspdM=";
   };
 
   cargoPatches = [
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace '"assets"' '"${placeholder "out"}/share/govee2mqtt/assets"'
   '';
 
-  cargoHash = "sha256-rs3wfvotR2p7jC6dn+JkTLJxVBtQR/IWgM9KmoYSelA=";
+  cargoHash = "sha256-XIdWxhyARhAHV0IZXOHOl4mHFS5/4Is74B4615jYeDs=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
The changelog entry was only added in the commit after the release tag:

https://github.com/wez/govee2mqtt/blob/91583538eb62cbcb572b7e79277e9886d8e85d9d/addon/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
