### PR TITLE
nixos: allow core modules to be evaluated more independently: optionalAttrs

### DIFF
--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -81,8 +82,6 @@ in
 
     environment.sessionVariables.TZDIR = "/etc/zoneinfo";
 
-    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
-
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
@@ -106,6 +105,9 @@ in
         LOCAL
       '';
     };
+  }
+  // lib.optionalAttrs (options ? services.geoclue2) {
+    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
   };
 
 }

--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -81,8 +82,6 @@ in
 
     environment.sessionVariables.TZDIR = "/etc/zoneinfo";
 
-    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
-
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
@@ -102,6 +101,9 @@ in
         LOCAL
       '';
     };
+  }
+  // lib.optionalAttrs (options ? services.geoclue2) {
+    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
   };
 
 }

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -76,18 +77,19 @@
       export TERM=$TERM
     '';
 
-    security =
-      let
-        extraConfig = ''
+  }
+  // lib.optionalAttrs (options ? security.sudo.extraConfig) (
+    let
+      extraConfig = ''
 
-          # Keep terminfo database for root and %wheel.
-          Defaults:root,%wheel env_keep+=TERMINFO_DIRS
-          Defaults:root,%wheel env_keep+=TERMINFO
-        '';
-      in
-      lib.mkIf config.security.sudo.keepTerminfo {
-        sudo = { inherit extraConfig; };
-        sudo-rs = { inherit extraConfig; };
-      };
-  };
+        # Keep terminfo database for root and %wheel.
+        Defaults:root,%wheel env_keep+=TERMINFO_DIRS
+        Defaults:root,%wheel env_keep+=TERMINFO
+      '';
+    in
+    lib.mkIf config.security.sudo.keepTerminfo {
+      security.sudo = { inherit extraConfig; };
+      security.sudo-rs = { inherit extraConfig; };
+    }
+  );
 }

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -27,66 +28,68 @@
     };
   };
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    # This should not contain packages that are broken or can't build, since it
-    # will break this expression
-    #
-    # can be generated with:
-    # lib.attrNames (lib.filterAttrs
-    #  (_: drv: (builtins.tryEval (lib.isDerivation drv && drv ? terminfo)).value)
-    #  pkgs)
-    environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (
-      map (x: x.terminfo) (
-        with pkgs.pkgsBuildBuild;
-        [
-          alacritty
-          contour
-          foot
-          ghostty
-          kitty
-          mtm
-          rio
-          rxvt-unicode-unwrapped
-          rxvt-unicode-unwrapped-emoji
-          st
-          tmux
-          wezterm
-          yaft
-        ]
-      )
-    );
+      # This should not contain packages that are broken or can't build, since it
+      # will break this expression
+      #
+      # can be generated with:
+      # lib.attrNames (lib.filterAttrs
+      #  (_: drv: (builtins.tryEval (lib.isDerivation drv && drv ? terminfo)).value)
+      #  pkgs)
+      environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (
+        map (x: x.terminfo) (
+          with pkgs.pkgsBuildBuild;
+          [
+            alacritty
+            contour
+            foot
+            ghostty
+            kitty
+            mtm
+            rio
+            rxvt-unicode-unwrapped
+            rxvt-unicode-unwrapped-emoji
+            st
+            tmux
+            wezterm
+            yaft
+          ]
+        )
+      );
 
-    environment.pathsToLink = [
-      "/share/terminfo"
-    ];
+      environment.pathsToLink = [
+        "/share/terminfo"
+      ];
 
-    environment.etc.terminfo = {
-      source = "${config.system.path}/share/terminfo";
-    };
+      environment.etc.terminfo = {
+        source = "${config.system.path}/share/terminfo";
+      };
 
-    boot.initrd.systemd.contents = lib.listToAttrs (
-      lib.map
-        (ti: lib.nameValuePair "/etc/terminfo/${ti}" { source = "${pkgs.ncurses}/share/terminfo/${ti}"; })
-        [
-          "l/linux"
-          "v/vt100"
-          "v/vt102"
-          "v/vt220"
-        ]
-    );
+      boot.initrd.systemd.contents = lib.listToAttrs (
+        lib.map
+          (ti: lib.nameValuePair "/etc/terminfo/${ti}" { source = "${pkgs.ncurses}/share/terminfo/${ti}"; })
+          [
+            "l/linux"
+            "v/vt100"
+            "v/vt102"
+            "v/vt220"
+          ]
+      );
 
-    environment.profileRelativeSessionVariables = {
-      TERMINFO_DIRS = [ "/share/terminfo" ];
-    };
+      environment.profileRelativeSessionVariables = {
+        TERMINFO_DIRS = [ "/share/terminfo" ];
+      };
 
-    environment.extraInit = ''
+      environment.extraInit = ''
 
-      # reset TERM with new TERMINFO available (if any)
-      export TERM=$TERM
-    '';
+        # reset TERM with new TERMINFO available (if any)
+        export TERM=$TERM
+      '';
 
-    security =
+    }
+    (lib.optionalAttrs (options ? security.sudo.extraConfig) (
       let
         extraConfig = ''
 
@@ -96,8 +99,9 @@
         '';
       in
       lib.mkIf config.security.sudo.keepTerminfo {
-        sudo = { inherit extraConfig; };
-        sudo-rs = { inherit extraConfig; };
-      };
-  };
+        security.sudo = { inherit extraConfig; };
+        security.sudo-rs = { inherit extraConfig; };
+      }
+    ))
+  ];
 }

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -2,7 +2,12 @@
 
 # Most of the stuff here should probably be moved elsewhere sometime.
 
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
 
@@ -16,14 +21,8 @@ in
 
     environment.variables = {
       NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-      # note: many programs exec() this directly, so default options for less must not
-      # be specified here; do so in the default value of programs.less.envVariables instead
-      PAGER = lib.mkDefault "less";
       EDITOR = lib.mkDefault "nano";
     };
-
-    # since we set PAGER to this above, make sure it's installed
-    programs.less.enable = true;
 
     environment.profiles = lib.mkAfter [
       "/nix/var/nix/profiles/default"
@@ -63,6 +62,14 @@ in
       export NIX_PROFILES="${builtins.concatStringsSep " " (lib.reverseList cfg.profiles)}"
     '';
 
+  }
+  // lib.optionalAttrs (options ? programs.less) {
+    # note: many programs exec() this directly, so default options for
+    # less must not be specified here; do so in the default value of
+    # programs.less.envVariables instead.
+    environment.variables.PAGER = lib.mkDefault "less";
+    # Make sure less is installed since we default PAGER to it.
+    programs.less.enable = true;
   };
 
 }

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -2,7 +2,12 @@
 
 # Most of the stuff here should probably be moved elsewhere sometime.
 
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
 
@@ -12,57 +17,61 @@ in
 
 {
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    environment.variables = {
-      NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-      # note: many programs exec() this directly, so default options for less must not
-      # be specified here; do so in the default value of programs.less.envVariables instead
-      PAGER = lib.mkDefault "less";
-      EDITOR = lib.mkDefault "nano";
-    };
+      environment.variables = {
+        NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
+        EDITOR = lib.mkDefault "nano";
+      };
 
-    # since we set PAGER to this above, make sure it's installed
-    programs.less.enable = true;
-
-    environment.profiles = lib.mkAfter [
-      "/nix/var/nix/profiles/default"
-      "/run/current-system/sw"
-    ];
-
-    environment.sessionVariables = {
-      XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
-    };
-
-    # TODO: move most of these elsewhere
-    environment.profileRelativeSessionVariables = {
-      PATH = [ "/bin" ];
-      INFOPATH = [
-        "/info"
-        "/share/info"
+      environment.profiles = lib.mkAfter [
+        "/nix/var/nix/profiles/default"
+        "/run/current-system/sw"
       ];
-      QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
-      GTK_PATH = [
+
+      environment.sessionVariables = {
+        XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
+      };
+
+      # TODO: move most of these elsewhere
+      environment.profileRelativeSessionVariables = {
+        PATH = [ "/bin" ];
+        INFOPATH = [
+          "/info"
+          "/share/info"
+        ];
+        QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
+        GTK_PATH = [
+          "/lib/gtk-2.0"
+          "/lib/gtk-3.0"
+          "/lib/gtk-4.0"
+        ];
+        XDG_CONFIG_DIRS = [ "/etc/xdg" ];
+        XDG_DATA_DIRS = [ "/share" ];
+        LIBEXEC_PATH = [ "/libexec" ];
+      };
+
+      environment.pathsToLink = [
         "/lib/gtk-2.0"
         "/lib/gtk-3.0"
         "/lib/gtk-4.0"
       ];
-      XDG_CONFIG_DIRS = [ "/etc/xdg" ];
-      XDG_DATA_DIRS = [ "/share" ];
-      LIBEXEC_PATH = [ "/libexec" ];
-    };
 
-    environment.pathsToLink = [
-      "/lib/gtk-2.0"
-      "/lib/gtk-3.0"
-      "/lib/gtk-4.0"
-    ];
+      environment.extraInit = ''
+        export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
+        export NIX_PROFILES="${builtins.concatStringsSep " " (lib.reverseList cfg.profiles)}"
+      '';
 
-    environment.extraInit = ''
-      export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
-      export NIX_PROFILES="${builtins.concatStringsSep " " (lib.reverseList cfg.profiles)}"
-    '';
-
-  };
+    }
+    (lib.optionalAttrs (options ? programs.less) {
+      # note: many programs exec() this directly, so default options for
+      # less must not be specified here; do so in the default value of
+      # programs.less.envVariables instead.
+      environment.variables.PAGER = lib.mkDefault "less";
+      # Make sure less is installed since we default PAGER to it.
+      programs.less.enable = true;
+    })
+  ];
 
 }

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -245,134 +246,140 @@ in
   };
 
   ###### implementation
-  config = lib.mkIf config.security.enableWrappers {
-
-    assertions = lib.mapAttrsToList (name: opts: {
-      assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
-      message = ''
-        The security.wrappers.${name} wrapper is not valid:
-            setuid/setgid and capabilities are mutually exclusive.
-      '';
-    }) wrappers;
-
-    security.wrappers =
-      let
-        mkSetuidRoot = source: {
-          setuid = true;
-          owner = "root";
-          group = "root";
-          inherit source;
-        };
-      in
+  config = lib.mkIf config.security.enableWrappers (
+    lib.mkMerge [
       {
-        # These are mount related wrappers that require the +s permission.
-        mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
-        umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
-      };
 
-    # Make sure our wrapperDir exports to the PATH env variable when
-    # initializing the shell
-    environment.extraInit = ''
-      # Wrappers override other bin directories.
-      export PATH="${wrapperDir}:$PATH"
-    '';
+        assertions = lib.mapAttrsToList (name: opts: {
+          assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
+          message = ''
+            The security.wrappers.${name} wrapper is not valid:
+                setuid/setgid and capabilities are mutually exclusive.
+          '';
+        }) wrappers;
 
-    security.apparmor.includes = lib.mapAttrs' (
-      wrapName: wrap:
-      lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
-        include "${
-          pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
-            (securityWrapper wrap.source)
-          ]
-        }"
-        mrpx ${wrap.source},
-      ''
-    ) wrappers;
+        security.wrappers =
+          let
+            mkSetuidRoot = source: {
+              setuid = true;
+              owner = "root";
+              group = "root";
+              inherit source;
+            };
+          in
+          {
+            # These are mount related wrappers that require the +s permission.
+            mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
+            umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
+          };
 
-    systemd.mounts = [
-      {
-        where = parentWrapperDir;
-        what = "tmpfs";
-        type = "tmpfs";
-        options = lib.concatStringsSep "," [
-          "nodev"
-          "mode=755"
-          "size=${config.security.wrapperDirSize}"
+        # Make sure our wrapperDir exports to the PATH env variable when
+        # initializing the shell
+        environment.extraInit = ''
+          # Wrappers override other bin directories.
+          export PATH="${wrapperDir}:$PATH"
+        '';
+
+        systemd.mounts = [
+          {
+            where = parentWrapperDir;
+            what = "tmpfs";
+            type = "tmpfs";
+            options = lib.concatStringsSep "," [
+              "nodev"
+              "mode=755"
+              "size=${config.security.wrapperDirSize}"
+            ];
+          }
         ];
-      }
-    ];
 
-    systemd.services.suid-sgid-wrappers = {
-      description = "Create SUID/SGID Wrappers";
-      wantedBy = [ "sysinit.target" ];
-      before = [
-        "sysinit.target"
-        "shutdown.target"
-      ];
-      conflicts = [ "shutdown.target" ];
-      after = [ "systemd-sysusers.service" ];
-      unitConfig.DefaultDependencies = false;
-      unitConfig.RequiresMountsFor = [
-        "/nix/store"
-        "/run/wrappers"
-      ];
-      serviceConfig.RestrictSUIDSGID = false;
-      serviceConfig.Type = "oneshot";
-      script = ''
-        chmod 755 "${parentWrapperDir}"
+        systemd.services.suid-sgid-wrappers = {
+          description = "Create SUID/SGID Wrappers";
+          wantedBy = [ "sysinit.target" ];
+          before = [
+            "sysinit.target"
+            "shutdown.target"
+          ];
+          conflicts = [ "shutdown.target" ];
+          after = [ "systemd-sysusers.service" ];
+          unitConfig.DefaultDependencies = false;
+          unitConfig.RequiresMountsFor = [
+            "/nix/store"
+            "/run/wrappers"
+          ];
+          serviceConfig.RestrictSUIDSGID = false;
+          serviceConfig.Type = "oneshot";
+          script = ''
+            chmod 755 "${parentWrapperDir}"
 
-        # We want to place the tmpdirs for the wrappers to the parent dir.
-        wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
-        chmod a+rx "$wrapperDir"
+            # We want to place the tmpdirs for the wrappers to the parent dir.
+            wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
+            chmod a+rx "$wrapperDir"
 
-        ${lib.concatStringsSep "\n" mkWrappedPrograms}
+            ${lib.concatStringsSep "\n" mkWrappedPrograms}
 
-        if [ -L ${wrapperDir} ]; then
-          # Atomically replace the symlink
-          # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
-          old=$(readlink -f ${wrapperDir})
-          if [ -e "${wrapperDir}-tmp" ]; then
-            rm --force --recursive "${wrapperDir}-tmp"
-          fi
-          ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
-          mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
-          rm --force --recursive "$old"
-        else
-          # For initial setup
-          ln --symbolic "$wrapperDir" "${wrapperDir}"
-        fi
-      '';
-    };
-
-    ###### wrappers consistency checks
-    system.checks = lib.singleton (
-      pkgs.runCommand "ensure-all-wrappers-paths-exist"
-        {
-          preferLocalBuild = true;
-        }
-        ''
-          # make sure we produce output
-          mkdir -p $out
-
-          echo -n "Checking that Nix store paths of all wrapped programs exist... "
-
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
-
-          for name in "''${!wrappers[@]}"; do
-            path="''${wrappers[$name]}"
-            if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-              test -t 1 && echo -ne '\033[1;31m'
-              echo "FAIL"
-              echo "The path $path does not exist!"
-              echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-              test -t 1 && echo -ne '\033[0m'
-              exit 1
+            if [ -L ${wrapperDir} ]; then
+              # Atomically replace the symlink
+              # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
+              old=$(readlink -f ${wrapperDir})
+              if [ -e "${wrapperDir}-tmp" ]; then
+                rm --force --recursive "${wrapperDir}-tmp"
+              fi
+              ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
+              mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
+              rm --force --recursive "$old"
+            else
+              # For initial setup
+              ln --symbolic "$wrapperDir" "${wrapperDir}"
             fi
-          done
+          '';
+        };
 
-          echo "OK"
-        ''
-    );
-  };
+        ###### wrappers consistency checks
+        system.checks = lib.singleton (
+          pkgs.runCommand "ensure-all-wrappers-paths-exist"
+            {
+              preferLocalBuild = true;
+            }
+            ''
+              # make sure we produce output
+              mkdir -p $out
+
+              echo -n "Checking that Nix store paths of all wrapped programs exist... "
+
+              declare -A wrappers
+              ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+
+              for name in "''${!wrappers[@]}"; do
+                path="''${wrappers[$name]}"
+                if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
+                  test -t 1 && echo -ne '\033[1;31m'
+                  echo "FAIL"
+                  echo "The path $path does not exist!"
+                  echo 'Please, check the value of `security.wrappers."'$name'".source`.'
+                  test -t 1 && echo -ne '\033[0m'
+                  exit 1
+                fi
+              done
+
+              echo "OK"
+            ''
+        );
+      }
+
+      (lib.optionalAttrs (options ? security.apparmor.includes) {
+        security.apparmor.includes = lib.mapAttrs' (
+          wrapName: wrap:
+          lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
+            include "${
+              pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
+                (securityWrapper wrap.source)
+              ]
+            }"
+            mrpx ${wrap.source},
+          ''
+        ) wrappers;
+      })
+    ]
+  );
 }

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -260,134 +261,140 @@ in
   };
 
   ###### implementation
-  config = lib.mkIf config.security.enableWrappers {
-
-    assertions = lib.mapAttrsToList (name: opts: {
-      assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
-      message = ''
-        The security.wrappers.${name} wrapper is not valid:
-            setuid/setgid and capabilities are mutually exclusive.
-      '';
-    }) wrappers;
-
-    security.wrappers =
-      let
-        mkSetuidRoot = source: {
-          setuid = true;
-          owner = "root";
-          group = "root";
-          inherit source;
-        };
-      in
+  config = lib.mkIf config.security.enableWrappers (
+    lib.mkMerge [
       {
-        # These are mount related wrappers that require the +s permission.
-        mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
-        umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
-      };
 
-    # Make sure our wrapperDir exports to the PATH env variable when
-    # initializing the shell
-    environment.extraInit = ''
-      # Wrappers override other bin directories.
-      export PATH="${wrapperDir}:$PATH"
-    '';
+        assertions = lib.mapAttrsToList (name: opts: {
+          assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
+          message = ''
+            The security.wrappers.${name} wrapper is not valid:
+                setuid/setgid and capabilities are mutually exclusive.
+          '';
+        }) wrappers;
 
-    security.apparmor.includes = lib.mapAttrs' (
-      wrapName: wrap:
-      lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
-        include "${
-          pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
-            (securityWrapper wrap.source)
-          ]
-        }"
-        mrpx ${wrap.source},
-      ''
-    ) wrappers;
+        security.wrappers =
+          let
+            mkSetuidRoot = source: {
+              setuid = true;
+              owner = "root";
+              group = "root";
+              inherit source;
+            };
+          in
+          {
+            # These are mount related wrappers that require the +s permission.
+            mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
+            umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
+          };
 
-    systemd.mounts = [
-      {
-        where = parentWrapperDir;
-        what = "tmpfs";
-        type = "tmpfs";
-        options = lib.concatStringsSep "," [
-          "nodev"
-          "mode=755"
-          "size=${config.security.wrapperDirSize}"
+        # Make sure our wrapperDir exports to the PATH env variable when
+        # initializing the shell
+        environment.extraInit = ''
+          # Wrappers override other bin directories.
+          export PATH="${wrapperDir}:$PATH"
+        '';
+
+        systemd.mounts = [
+          {
+            where = parentWrapperDir;
+            what = "tmpfs";
+            type = "tmpfs";
+            options = lib.concatStringsSep "," [
+              "nodev"
+              "mode=755"
+              "size=${config.security.wrapperDirSize}"
+            ];
+          }
         ];
-      }
-    ];
 
-    systemd.services.suid-sgid-wrappers = {
-      description = "Create SUID/SGID Wrappers";
-      wantedBy = [ "sysinit.target" ];
-      before = [
-        "sysinit.target"
-        "shutdown.target"
-      ];
-      conflicts = [ "shutdown.target" ];
-      after = [ "systemd-sysusers.service" ];
-      unitConfig.DefaultDependencies = false;
-      unitConfig.RequiresMountsFor = [
-        "/nix/store"
-        "/run/wrappers"
-      ];
-      serviceConfig.RestrictSUIDSGID = false;
-      serviceConfig.Type = "oneshot";
-      script = ''
-        chmod 755 "${parentWrapperDir}"
+        systemd.services.suid-sgid-wrappers = {
+          description = "Create SUID/SGID Wrappers";
+          wantedBy = [ "sysinit.target" ];
+          before = [
+            "sysinit.target"
+            "shutdown.target"
+          ];
+          conflicts = [ "shutdown.target" ];
+          after = [ "systemd-sysusers.service" ];
+          unitConfig.DefaultDependencies = false;
+          unitConfig.RequiresMountsFor = [
+            "/nix/store"
+            "/run/wrappers"
+          ];
+          serviceConfig.RestrictSUIDSGID = false;
+          serviceConfig.Type = "oneshot";
+          script = ''
+            chmod 755 "${parentWrapperDir}"
 
-        # We want to place the tmpdirs for the wrappers to the parent dir.
-        wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
-        chmod a+rx "$wrapperDir"
+            # We want to place the tmpdirs for the wrappers to the parent dir.
+            wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
+            chmod a+rx "$wrapperDir"
 
-        ${lib.concatStringsSep "\n" mkWrappedPrograms}
+            ${lib.concatStringsSep "\n" mkWrappedPrograms}
 
-        if [ -L ${wrapperDir} ]; then
-          # Atomically replace the symlink
-          # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
-          old=$(readlink -f ${wrapperDir})
-          if [ -e "${wrapperDir}-tmp" ]; then
-            rm --force --recursive "${wrapperDir}-tmp"
-          fi
-          ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
-          mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
-          rm --force --recursive "$old"
-        else
-          # For initial setup
-          ln --symbolic "$wrapperDir" "${wrapperDir}"
-        fi
-      '';
-    };
-
-    ###### wrappers consistency checks
-    system.checks = lib.singleton (
-      pkgs.runCommand "ensure-all-wrappers-paths-exist"
-        {
-          preferLocalBuild = true;
-        }
-        ''
-          # make sure we produce output
-          mkdir -p $out
-
-          echo -n "Checking that Nix store paths of all wrapped programs exist... "
-
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
-
-          for name in "''${!wrappers[@]}"; do
-            path="''${wrappers[$name]}"
-            if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-              test -t 1 && echo -ne '\033[1;31m'
-              echo "FAIL"
-              echo "The path $path does not exist!"
-              echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-              test -t 1 && echo -ne '\033[0m'
-              exit 1
+            if [ -L ${wrapperDir} ]; then
+              # Atomically replace the symlink
+              # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
+              old=$(readlink -f ${wrapperDir})
+              if [ -e "${wrapperDir}-tmp" ]; then
+                rm --force --recursive "${wrapperDir}-tmp"
+              fi
+              ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
+              mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
+              rm --force --recursive "$old"
+            else
+              # For initial setup
+              ln --symbolic "$wrapperDir" "${wrapperDir}"
             fi
-          done
+          '';
+        };
 
-          echo "OK"
-        ''
-    );
-  };
+        ###### wrappers consistency checks
+        system.checks = lib.singleton (
+          pkgs.runCommand "ensure-all-wrappers-paths-exist"
+            {
+              preferLocalBuild = true;
+            }
+            ''
+              # make sure we produce output
+              mkdir -p $out
+
+              echo -n "Checking that Nix store paths of all wrapped programs exist... "
+
+              declare -A wrappers
+              ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+
+              for name in "''${!wrappers[@]}"; do
+                path="''${wrappers[$name]}"
+                if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
+                  test -t 1 && echo -ne '\033[1;31m'
+                  echo "FAIL"
+                  echo "The path $path does not exist!"
+                  echo 'Please, check the value of `security.wrappers."'$name'".source`.'
+                  test -t 1 && echo -ne '\033[0m'
+                  exit 1
+                fi
+              done
+
+              echo "OK"
+            ''
+        );
+      }
+
+      (lib.optionalAttrs (options ? security.apparmor.includes) {
+        security.apparmor.includes = lib.mapAttrs' (
+          wrapName: wrap:
+          lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
+            include "${
+              pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
+                (securityWrapper wrap.source)
+              ]
+            }"
+            mrpx ${wrap.source},
+          ''
+        ) wrappers;
+      })
+    ]
+  );
 }

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -104,8 +105,6 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
-      system.switch.inhibitors.dbus-implementation = cfg.implementation;
-
       environment.etc."dbus-1".source = configDir;
 
       environment.pathsToLink = [
@@ -142,6 +141,10 @@ in
         "sockets.target"
       ];
     }
+
+    (lib.optionalAttrs (options ? system.switch.inhibitors) {
+      system.switch.inhibitors.dbus-implementation = cfg.implementation;
+    })
 
     (mkIf config.boot.initrd.systemd.dbus.enable {
       boot.initrd.systemd = {

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -116,8 +117,6 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
-      system.switch.inhibitors.dbus-implementation = cfg.implementation;
-
       environment.etc."dbus-1".source = configDir;
 
       environment.pathsToLink = [
@@ -154,6 +153,10 @@ in
         "sockets.target"
       ];
     }
+
+    (lib.optionalAttrs (options ? system.switch.inhibitors) {
+      system.switch.inhibitors.dbus-implementation = cfg.implementation;
+    })
 
     (mkIf config.boot.initrd.systemd.dbus.enable {
       boot.initrd.systemd = {

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   utils,
   ...
@@ -271,6 +272,8 @@ in
         }
       ) cfg.emulatedSystems
     );
+  }
+  // lib.optionalAttrs (options ? nix.settings) {
     nix.settings = lib.mkIf (cfg.addEmulatedSystemsToNixSandbox && cfg.emulatedSystems != [ ]) {
       extra-platforms =
         cfg.emulatedSystems ++ lib.optional pkgs.stdenv.hostPlatform.isx86_64 "i686-linux";
@@ -286,7 +289,8 @@ in
           map (system: (ruleFor system).interpreterSandboxPath) cfg.emulatedSystems
         );
     };
-
+  }
+  // {
     environment.etc."binfmt.d/nixos.conf".source = builtins.toFile "binfmt_nixos.conf" (
       lib.concatStringsSep "\n" (lib.mapAttrsToList makeBinfmtLine config.boot.binfmt.registrations)
     );

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -216,15 +217,19 @@ in
         }
       ) cfg.dnsDelegates;
 
-      # If networkmanager is enabled, ask it to interface with resolved.
-      networking.networkmanager.dns = "systemd-resolved";
-
       networking.resolvconf.package = config.systemd.package;
 
+    })
+
+    # If networkmanager is enabled, ask it to interface with resolved.
+    (lib.optionalAttrs (options ? networking.networkmanager) {
+      networking.networkmanager.dns = "systemd-resolved";
+    })
+
+    (lib.optionalAttrs (options ? nix.firewall) {
       nix.firewall.extraNftablesRules = [
         "ip daddr { 127.0.0.53, 127.0.0.54 } udp dport 53 accept comment \"systemd-resolved listening IPs\""
       ];
-
     })
 
     (mkIf config.boot.initrd.services.resolved.enable {

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -220,19 +221,23 @@ in
         }
       ) cfg.dnsDelegates;
 
-      # If networkmanager is enabled, ask it to interface with resolved.
-      networking.networkmanager.dns = "systemd-resolved";
-
       # Since we explicitly provide a resolv.conf, disable resolvconf
       networking.resolvconf.enable = false;
 
       # ... but we still set the package for correct compatibility.
       networking.resolvconf.package = config.systemd.package;
 
+    })
+
+    # If networkmanager is enabled, ask it to interface with resolved.
+    (lib.optionalAttrs (options ? networking.networkmanager) {
+      networking.networkmanager.dns = "systemd-resolved";
+    })
+
+    (lib.optionalAttrs (options ? nix.firewall) {
       nix.firewall.extraNftablesRules = [
         "ip daddr { 127.0.0.53, 127.0.0.54 } udp dport 53 accept comment \"systemd-resolved listening IPs\""
       ];
-
     })
 
     (mkIf config.boot.initrd.services.resolved.enable {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   utils,
@@ -839,21 +840,6 @@ in
     # https://github.com/systemd/systemd/pull/12226
     boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
 
-    services.logrotate.settings = {
-      "/var/log/btmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0660 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
-      };
-      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0664 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
-      };
-    };
-
     # Remove with systemd 259.4
     security.polkit.extraConfig = mkIf config.security.polkit.enable ''
       polkit.addRule(function(action, subject) {
@@ -874,6 +860,22 @@ in
         # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
         setLoginUid = true;
         pamMount = false;
+      };
+    };
+  }
+  // lib.optionalAttrs (options ? services.logrotate) {
+    services.logrotate.settings = {
+      "/var/log/btmp" = mapAttrs (_: mkDefault) {
+        frequency = "monthly";
+        rotate = 1;
+        create = "0660 root ${config.users.groups.utmp.name}";
+        minsize = "1M";
+      };
+      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
+        frequency = "monthly";
+        rotate = 1;
+        create = "0664 root ${config.users.groups.utmp.name}";
+        minsize = "1M";
       };
     };
   };

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -840,16 +840,6 @@ in
     # https://github.com/systemd/systemd/pull/12226
     boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
 
-    # Remove with systemd 259.4
-    security.polkit.extraConfig = mkIf config.security.polkit.enable ''
-      polkit.addRule(function(action, subject) {
-          if (action.id == "org.freedesktop.machine1.register-machine" &&
-              subject.user != "root") {
-              return polkit.Result.AUTH_ADMIN_KEEP;
-          }
-      });
-    '';
-
     # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
     # part, run0 would fail to run the command even if authentication is successful and the user has
     # permission to run the command. This next part is only enabled if polkit is enabled because the
@@ -862,6 +852,17 @@ in
         pamMount = false;
       };
     };
+  }
+  // lib.optionalAttrs (options ? security.polkit.extraConfig) {
+    # Remove with systemd 259.4
+    security.polkit.extraConfig = mkIf config.security.polkit.enable ''
+      polkit.addRule(function(action, subject) {
+          if (action.id == "org.freedesktop.machine1.register-machine" &&
+              subject.user != "root") {
+              return polkit.Result.AUTH_ADMIN_KEEP;
+          }
+      });
+    '';
   }
   // lib.optionalAttrs (options ? services.logrotate) {
     services.logrotate.settings = {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -672,8 +672,6 @@ in
         "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
       };
 
-    services.dbus.enable = true;
-
     users.users.systemd-network = {
       uid = config.ids.uids.systemd-network;
       group = "systemd-network";
@@ -852,6 +850,9 @@ in
         pamMount = false;
       };
     };
+  }
+  // lib.optionalAttrs (options ? services.dbus) {
+    services.dbus.enable = true;
   }
   // lib.optionalAttrs (options ? security.polkit.extraConfig) {
     # Remove with systemd 259.4

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   utils,
@@ -529,396 +530,398 @@ in
 
   ###### implementation
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    warnings =
-      let
-        mkOneNetOnlineWarn =
-          typeStr: name: def:
-          lib.optional (
-            lib.elem "network-online.target" def.after
-            && !(lib.elem "network-online.target" (def.wants ++ def.requires ++ def.bindsTo))
-          ) "${name}.${typeStr} is ordered after 'network-online.target' but doesn't depend on it";
-        mkNetOnlineWarns =
-          typeStr: defs: lib.concatLists (lib.mapAttrsToList (mkOneNetOnlineWarn typeStr) defs);
-        mkMountNetOnlineWarns =
-          typeStr: defs: lib.concatLists (map (m: mkOneNetOnlineWarn typeStr m.what m) defs);
-      in
-      concatLists (
+      warnings =
+        let
+          mkOneNetOnlineWarn =
+            typeStr: name: def:
+            lib.optional (
+              lib.elem "network-online.target" def.after
+              && !(lib.elem "network-online.target" (def.wants ++ def.requires ++ def.bindsTo))
+            ) "${name}.${typeStr} is ordered after 'network-online.target' but doesn't depend on it";
+          mkNetOnlineWarns =
+            typeStr: defs: lib.concatLists (lib.mapAttrsToList (mkOneNetOnlineWarn typeStr) defs);
+          mkMountNetOnlineWarns =
+            typeStr: defs: lib.concatLists (map (m: mkOneNetOnlineWarn typeStr m.what m) defs);
+        in
+        concatLists (
+          mapAttrsToList (
+            name: service:
+            let
+              type = service.serviceConfig.Type or "";
+              restart = service.serviceConfig.Restart or "no";
+              hasDeprecated = builtins.hasAttr "StartLimitInterval" service.serviceConfig;
+            in
+            concatLists [
+              (optional (type == "oneshot" && (restart == "always" || restart == "on-success"))
+                "Service '${name}.service' with 'Type=oneshot' cannot have 'Restart=always' or 'Restart=on-success'"
+              )
+              (optional hasDeprecated "Service '${name}.service' uses the attribute 'StartLimitInterval' in the Service section, which is deprecated. See https://github.com/NixOS/nixpkgs/issues/45786.")
+              (optional (service.reloadIfChanged && service.reloadTriggers != [ ])
+                "Service '${name}.service' has both 'reloadIfChanged' and 'reloadTriggers' set. This is probably not what you want, because 'reloadTriggers' behave the same whay as 'restartTriggers' if 'reloadIfChanged' is set."
+              )
+            ]
+          ) cfg.services
+        )
+        ++ (mkNetOnlineWarns "target" cfg.targets)
+        ++ (mkNetOnlineWarns "service" cfg.services)
+        ++ (mkNetOnlineWarns "socket" cfg.sockets)
+        ++ (mkNetOnlineWarns "timer" cfg.timers)
+        ++ (mkNetOnlineWarns "path" cfg.paths)
+        ++ (mkMountNetOnlineWarns "mount" cfg.mounts)
+        ++ (mkMountNetOnlineWarns "automount" cfg.automounts)
+        ++ (mkNetOnlineWarns "slice" cfg.slices);
+
+      assertions = concatLists (
         mapAttrsToList (
           name: service:
-          let
-            type = service.serviceConfig.Type or "";
-            restart = service.serviceConfig.Restart or "no";
-            hasDeprecated = builtins.hasAttr "StartLimitInterval" service.serviceConfig;
-          in
-          concatLists [
-            (optional (type == "oneshot" && (restart == "always" || restart == "on-success"))
-              "Service '${name}.service' with 'Type=oneshot' cannot have 'Restart=always' or 'Restart=on-success'"
-            )
-            (optional hasDeprecated "Service '${name}.service' uses the attribute 'StartLimitInterval' in the Service section, which is deprecated. See https://github.com/NixOS/nixpkgs/issues/45786.")
-            (optional (service.reloadIfChanged && service.reloadTriggers != [ ])
-              "Service '${name}.service' has both 'reloadIfChanged' and 'reloadTriggers' set. This is probably not what you want, because 'reloadTriggers' behave the same whay as 'restartTriggers' if 'reloadIfChanged' is set."
-            )
-          ]
-        ) cfg.services
-      )
-      ++ (mkNetOnlineWarns "target" cfg.targets)
-      ++ (mkNetOnlineWarns "service" cfg.services)
-      ++ (mkNetOnlineWarns "socket" cfg.sockets)
-      ++ (mkNetOnlineWarns "timer" cfg.timers)
-      ++ (mkNetOnlineWarns "path" cfg.paths)
-      ++ (mkMountNetOnlineWarns "mount" cfg.mounts)
-      ++ (mkMountNetOnlineWarns "automount" cfg.automounts)
-      ++ (mkNetOnlineWarns "slice" cfg.slices);
-
-    assertions = concatLists (
-      mapAttrsToList (
-        name: service:
-        map
-          (message: {
-            assertion = false;
-            inherit message;
-          })
-          (concatLists [
-            (optional
-              (
-                (builtins.elem "network-interfaces.target" service.after)
-                || (builtins.elem "network-interfaces.target" service.wants)
+          map
+            (message: {
+              assertion = false;
+              inherit message;
+            })
+            (concatLists [
+              (optional
+                (
+                  (builtins.elem "network-interfaces.target" service.after)
+                  || (builtins.elem "network-interfaces.target" service.wants)
+                )
+                "Service '${name}.service' is using the deprecated target network-interfaces.target, which no longer exists. Using network.target is recommended instead."
               )
-              "Service '${name}.service' is using the deprecated target network-interfaces.target, which no longer exists. Using network.target is recommended instead."
-            )
-          ])
-      ) cfg.services
-    );
-
-    system.build.units = cfg.units;
-
-    system.nssModules = [ cfg.package.out ];
-    system.nssDatabases = {
-      hosts = (
-        mkMerge [
-          (mkOrder 400 [ "mymachines" ]) # 400 to ensure it comes before resolve (which is 501)
-          (mkOrder 999 [ "myhostname" ]) # after files (which is 998), but before regular nss modules
-        ]
+            ])
+        ) cfg.services
       );
-      passwd = (
-        mkMerge [
-          (mkAfter [ "systemd" ])
-        ]
-      );
-      group = (
-        mkMerge [
-          (mkAfter [ "[success=merge] systemd" ]) # need merge so that NSS won't stop at file-based groups
-        ]
-      );
-      shadow = (
-        mkMerge [
-          (mkAfter [ "systemd" ])
-        ]
-      );
-    };
 
-    environment.systemPackages = [ cfg.package ];
+      system.build.units = cfg.units;
 
-    environment.variables = {
-      SYSTEMD_XKB_DIRECTORY = "/etc/X11/xkb";
-    };
+      system.nssModules = [ cfg.package.out ];
+      system.nssDatabases = {
+        hosts = (
+          mkMerge [
+            (mkOrder 400 [ "mymachines" ]) # 400 to ensure it comes before resolve (which is 501)
+            (mkOrder 999 [ "myhostname" ]) # after files (which is 998), but before regular nss modules
+          ]
+        );
+        passwd = (
+          mkMerge [
+            (mkAfter [ "systemd" ])
+          ]
+        );
+        group = (
+          mkMerge [
+            (mkAfter [ "[success=merge] systemd" ]) # need merge so that NSS won't stop at file-based groups
+          ]
+        );
+        shadow = (
+          mkMerge [
+            (mkAfter [ "systemd" ])
+          ]
+        );
+      };
 
-    environment.etc =
-      let
-        # generate contents for /etc/systemd/${dir} from attrset of links and packages
-        hooks =
-          dir: links:
-          pkgs.runCommand "${dir}"
-            {
-              preferLocalBuild = true;
-              packages = cfg.packages;
-            }
-            ''
-              set -e
-              mkdir -p $out
-              for package in $packages
-              do
-                for hook in $package/lib/systemd/${dir}/*
+      environment.systemPackages = [ cfg.package ];
+
+      environment.variables = {
+        SYSTEMD_XKB_DIRECTORY = "/etc/X11/xkb";
+      };
+
+      environment.etc =
+        let
+          # generate contents for /etc/systemd/${dir} from attrset of links and packages
+          hooks =
+            dir: links:
+            pkgs.runCommand "${dir}"
+              {
+                preferLocalBuild = true;
+                packages = cfg.packages;
+              }
+              ''
+                set -e
+                mkdir -p $out
+                for package in $packages
                 do
-                  ln -s $hook $out/
+                  for hook in $package/lib/systemd/${dir}/*
+                  do
+                    ln -s $hook $out/
+                  done
                 done
-              done
-              ${concatStrings (mapAttrsToList (exec: target: "ln -s ${target} $out/${exec};\n") links)}
-            '';
+                ${concatStrings (mapAttrsToList (exec: target: "ln -s ${target} $out/${exec};\n") links)}
+              '';
 
-        enabledUpstreamSystemUnits = filter (n: !elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
-        enabledUnits = removeAttrs cfg.units cfg.suppressedSystemUnits;
+          enabledUpstreamSystemUnits = filter (n: !elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
+          enabledUnits = removeAttrs cfg.units cfg.suppressedSystemUnits;
 
-      in
-      {
-        "systemd/system".source = generateUnits {
-          type = "system";
-          units = enabledUnits;
-          upstreamUnits = enabledUpstreamSystemUnits;
-          upstreamWants = upstreamSystemWants;
-        };
-
-        "systemd/system.conf".text = settingsToSections cfg.settings;
-
-        "systemd/sleep.conf".text = settingsToSections cfg.sleep.settings;
-
-        "systemd/user-generators" = {
-          source = hooks "user-generators" cfg.user.generators;
-        };
-        "systemd/system-generators" = {
-          source = hooks "system-generators" cfg.generators;
-        };
-        "systemd/system-shutdown" = {
-          source = hooks "system-shutdown" cfg.shutdown;
-        };
-
-        # Ignore all other preset files so systemd doesn't try to enable/disable
-        # units during runtime.
-        "systemd/system-preset/00-nixos.preset".text = ''
-          ignore *
-        '';
-        "systemd/user-preset/00-nixos.preset".text = ''
-          ignore *
-        '';
-
-        "systemd/generator-environment.json".source =
-          json.generate "systemd-generator-environment.json" cfg.generatorEnvironment;
-
-        "systemd/system-environment-generators/env-generator".source =
-          "${config.system.nixos-init.package}/bin/env-generator";
-
-        "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
-      };
-
-    services.dbus.enable = true;
-
-    users.users.systemd-network = {
-      uid = config.ids.uids.systemd-network;
-      group = "systemd-network";
-    };
-    users.groups.systemd-network.gid = config.ids.gids.systemd-network;
-    users.users.systemd-resolve = {
-      uid = config.ids.uids.systemd-resolve;
-      group = "systemd-resolve";
-    };
-    users.groups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
-
-    # Target for ‘charon send-keys’ to hook into.
-    users.groups.keys.gid = config.ids.gids.keys;
-
-    systemd.targets.keys = {
-      description = "Security Keys";
-      unitConfig.X-StopOnReconfiguration = true;
-    };
-
-    # This target only exists so that services ordered before sysinit.target
-    # are restarted in the correct order, notably BEFORE the other services,
-    # when switching configurations.
-    systemd.targets.sysinit-reactivation = {
-      description = "Reactivate sysinit units";
-    };
-
-    systemd.units =
-      let
-        withName = cfgToUnit: cfg: lib.nameValuePair cfg.name (cfgToUnit cfg);
-      in
-      mapAttrs' (_: withName pathToUnit) cfg.paths
-      // mapAttrs' (_: withName serviceToUnit) cfg.services
-      // mapAttrs' (_: withName sliceToUnit) cfg.slices
-      // mapAttrs' (_: withName socketToUnit) cfg.sockets
-      // mapAttrs' (_: withName targetToUnit) cfg.targets
-      // mapAttrs' (_: withName timerToUnit) cfg.timers
-      // listToAttrs (map (withName mountToUnit) cfg.mounts)
-      // listToAttrs (map (withName automountToUnit) cfg.automounts);
-
-    # Environment of PID 1
-    systemd.managerEnvironment = {
-      # Doesn't contain systemd itself - everything works so it seems to use the compiled-in value for its tools
-      # util-linux is needed for the main fsck utility wrapping the fs-specific ones
-      PATH = lib.makeBinPath (
-        config.system.fsPackages
-        ++ [ cfg.package.util-linux ]
-        # systemd-ssh-generator needs sshd in PATH
-        ++ lib.optional config.services.openssh.enable config.services.openssh.package
-      );
-      LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
-      TZDIR = "/etc/zoneinfo";
-      # If SYSTEMD_UNIT_PATH ends with an empty component (":"), the usual unit load path will be appended to the contents of the variable
-      SYSTEMD_UNIT_PATH = lib.mkIf (
-        config.boot.extraSystemdUnitPaths != [ ]
-      ) "${builtins.concatStringsSep ":" config.boot.extraSystemdUnitPaths}:";
-    };
-    systemd.settings.Manager = {
-      ManagerEnvironment = lib.concatStringsSep " " (
-        lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
-      );
-      DefaultIOAccounting = lib.mkDefault true;
-      DefaultIPAccounting = lib.mkDefault true;
-    };
-
-    # These are needed for systemd-fstab-generator to schedule systemd-fsck@
-    # units.
-    systemd.generatorPath = config.system.fsPackages ++ [
-      cfg.package.util-linux
-    ];
-
-    systemd.generatorEnvironment = {
-      PATH = lib.makeBinPath cfg.generatorPath;
-    };
-
-    system.requiredKernelConfig = map config.lib.kernelConfig.isEnabled [
-      "DEVTMPFS"
-      "CGROUPS"
-      "INOTIFY_USER"
-      "SIGNALFD"
-      "TIMERFD"
-      "EPOLL"
-      "NET"
-      "SYSFS"
-      "PROC_FS"
-      "FHANDLE"
-      "CRYPTO_USER_API_HASH"
-      "CRYPTO_HMAC"
-      "CRYPTO_SHA256"
-      "DMIID"
-      "AUTOFS_FS"
-      "TMPFS_POSIX_ACL"
-      "TMPFS_XATTR"
-      "SECCOMP"
-    ];
-
-    # Generate timer units for all services that have a ‘startAt’ value.
-    systemd.timers = mapAttrs (name: service: {
-      wantedBy = [ "timers.target" ];
-      timerConfig.OnCalendar = service.startAt;
-    }) (filterAttrs (name: service: service.enable && service.startAt != [ ]) cfg.services);
-
-    # Some overrides to upstream units.
-    systemd.services."systemd-backlight@".restartIfChanged = false;
-    systemd.services."systemd-fsck@".restartIfChanged = false;
-    systemd.services."systemd-fsck@".path = [ pkgs.util-linux ] ++ config.system.fsPackages;
-    systemd.services."systemd-makefs@" = {
-      restartIfChanged = false;
-      path = [ pkgs.util-linux ] ++ config.system.fsPackages;
-      # Since there is no /etc/systemd/system/systemd-makefs@.service
-      # file, the units generated in /run/systemd/generator would
-      # override anything we put here. But by forcing the use of a
-      # drop-in in /etc, it does apply.
-      overrideStrategy = "asDropin";
-    };
-    systemd.services."systemd-mkswap@" = {
-      restartIfChanged = false;
-      path = [ pkgs.util-linux ];
-      overrideStrategy = "asDropin";
-    };
-    systemd.services."modprobe@" = {
-      restartIfChanged = false;
-      serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.kmod ];
-    };
-    systemd.services.systemd-random-seed.restartIfChanged = false;
-    systemd.services.systemd-remount-fs.restartIfChanged = false;
-    systemd.services.systemd-update-utmp.restartIfChanged = false;
-    systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.services.systemd-importd = lib.mkIf cfg.package.withImportd {
-      environment = proxy_env;
-      path = [ pkgs.gnupgMinimal ];
-    };
-    systemd.services.systemd-pstore.wantedBy = [ "sysinit.target" ]; # see #81138
-
-    # NixOS has kernel modules in a different location, so override that here.
-    systemd.services.kmod-static-nodes.unitConfig.ConditionFileNotEmpty = [
-      "" # required to unset the previous value!
-      "/run/booted-system/kernel-modules/lib/modules/%v/modules.devname"
-    ];
-
-    # Don't bother with certain units in containers.
-    systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";
-
-    # When using the classic /etc mechanism, we set certain paths in /etc to
-    # /etc/static so that systemd cannot change them (as they are symlinks to
-    # the read-only Nix Store). This is only done so that these services cannot
-    # change the values. All other parts of systemd should read them from their
-    # canonical locations.
-    #
-    # If you use the overlay mechanism to manage /etc, this is unnecessary
-    # because either the overlay is mutable (and users can legitimately change
-    # values without them being overridden) or it is immutable and systemd will
-    # suggest to only make runtime changes.
-    systemd.services."systemd-localed".environment =
-      lib.mkIf (!config.system.etc.overlay.enable && !config.i18n.imperativeLocale)
+        in
         {
-          SYSTEMD_ETC_LOCALE_CONF = "/etc/static/locale.conf";
-          SYSTEMD_ETC_VCONSOLE_CONF = "/etc/static/vconsole.conf";
+          "systemd/system".source = generateUnits {
+            type = "system";
+            units = enabledUnits;
+            upstreamUnits = enabledUpstreamSystemUnits;
+            upstreamWants = upstreamSystemWants;
+          };
+
+          "systemd/system.conf".text = settingsToSections cfg.settings;
+
+          "systemd/sleep.conf".text = settingsToSections cfg.sleep.settings;
+
+          "systemd/user-generators" = {
+            source = hooks "user-generators" cfg.user.generators;
+          };
+          "systemd/system-generators" = {
+            source = hooks "system-generators" cfg.generators;
+          };
+          "systemd/system-shutdown" = {
+            source = hooks "system-shutdown" cfg.shutdown;
+          };
+
+          # Ignore all other preset files so systemd doesn't try to enable/disable
+          # units during runtime.
+          "systemd/system-preset/00-nixos.preset".text = ''
+            ignore *
+          '';
+          "systemd/user-preset/00-nixos.preset".text = ''
+            ignore *
+          '';
+
+          "systemd/generator-environment.json".source =
+            json.generate "systemd-generator-environment.json" cfg.generatorEnvironment;
+
+          "systemd/system-environment-generators/env-generator".source =
+            "${config.system.nixos-init.package}/bin/env-generator";
+
+          "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
         };
-    systemd.services."systemd-timedated".environment =
-      lib.mkIf (!config.system.etc.overlay.enable && config.time.timeZone != null)
-        {
-          SYSTEMD_ETC_LOCALTIME = "/etc/static/localtime";
-          SYSTEMD_ETC_ADJTIME = "/etc/static/adjtime";
+
+      services.dbus.enable = true;
+
+      users.users.systemd-network = {
+        uid = config.ids.uids.systemd-network;
+        group = "systemd-network";
+      };
+      users.groups.systemd-network.gid = config.ids.gids.systemd-network;
+      users.users.systemd-resolve = {
+        uid = config.ids.uids.systemd-resolve;
+        group = "systemd-resolve";
+      };
+      users.groups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
+
+      # Target for ‘charon send-keys’ to hook into.
+      users.groups.keys.gid = config.ids.gids.keys;
+
+      systemd.targets.keys = {
+        description = "Security Keys";
+        unitConfig.X-StopOnReconfiguration = true;
+      };
+
+      # This target only exists so that services ordered before sysinit.target
+      # are restarted in the correct order, notably BEFORE the other services,
+      # when switching configurations.
+      systemd.targets.sysinit-reactivation = {
+        description = "Reactivate sysinit units";
+      };
+
+      systemd.units =
+        let
+          withName = cfgToUnit: cfg: lib.nameValuePair cfg.name (cfgToUnit cfg);
+        in
+        mapAttrs' (_: withName pathToUnit) cfg.paths
+        // mapAttrs' (_: withName serviceToUnit) cfg.services
+        // mapAttrs' (_: withName sliceToUnit) cfg.slices
+        // mapAttrs' (_: withName socketToUnit) cfg.sockets
+        // mapAttrs' (_: withName targetToUnit) cfg.targets
+        // mapAttrs' (_: withName timerToUnit) cfg.timers
+        // listToAttrs (map (withName mountToUnit) cfg.mounts)
+        // listToAttrs (map (withName automountToUnit) cfg.automounts);
+
+      # Environment of PID 1
+      systemd.managerEnvironment = {
+        # Doesn't contain systemd itself - everything works so it seems to use the compiled-in value for its tools
+        # util-linux is needed for the main fsck utility wrapping the fs-specific ones
+        PATH = lib.makeBinPath (
+          config.system.fsPackages
+          ++ [ cfg.package.util-linux ]
+          # systemd-ssh-generator needs sshd in PATH
+          ++ lib.optional config.services.openssh.enable config.services.openssh.package
+        );
+        LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
+        TZDIR = "/etc/zoneinfo";
+        # If SYSTEMD_UNIT_PATH ends with an empty component (":"), the usual unit load path will be appended to the contents of the variable
+        SYSTEMD_UNIT_PATH = lib.mkIf (
+          config.boot.extraSystemdUnitPaths != [ ]
+        ) "${builtins.concatStringsSep ":" config.boot.extraSystemdUnitPaths}:";
+      };
+      systemd.settings.Manager = {
+        ManagerEnvironment = lib.concatStringsSep " " (
+          lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
+        );
+        DefaultIOAccounting = lib.mkDefault true;
+        DefaultIPAccounting = lib.mkDefault true;
+      };
+
+      # These are needed for systemd-fstab-generator to schedule systemd-fsck@
+      # units.
+      systemd.generatorPath = config.system.fsPackages ++ [
+        cfg.package.util-linux
+      ];
+
+      systemd.generatorEnvironment = {
+        PATH = lib.makeBinPath cfg.generatorPath;
+      };
+
+      system.requiredKernelConfig = map config.lib.kernelConfig.isEnabled [
+        "DEVTMPFS"
+        "CGROUPS"
+        "INOTIFY_USER"
+        "SIGNALFD"
+        "TIMERFD"
+        "EPOLL"
+        "NET"
+        "SYSFS"
+        "PROC_FS"
+        "FHANDLE"
+        "CRYPTO_USER_API_HASH"
+        "CRYPTO_HMAC"
+        "CRYPTO_SHA256"
+        "DMIID"
+        "AUTOFS_FS"
+        "TMPFS_POSIX_ACL"
+        "TMPFS_XATTR"
+        "SECCOMP"
+      ];
+
+      # Generate timer units for all services that have a ‘startAt’ value.
+      systemd.timers = mapAttrs (name: service: {
+        wantedBy = [ "timers.target" ];
+        timerConfig.OnCalendar = service.startAt;
+      }) (filterAttrs (name: service: service.enable && service.startAt != [ ]) cfg.services);
+
+      # Some overrides to upstream units.
+      systemd.services."systemd-backlight@".restartIfChanged = false;
+      systemd.services."systemd-fsck@".restartIfChanged = false;
+      systemd.services."systemd-fsck@".path = [ pkgs.util-linux ] ++ config.system.fsPackages;
+      systemd.services."systemd-makefs@" = {
+        restartIfChanged = false;
+        path = [ pkgs.util-linux ] ++ config.system.fsPackages;
+        # Since there is no /etc/systemd/system/systemd-makefs@.service
+        # file, the units generated in /run/systemd/generator would
+        # override anything we put here. But by forcing the use of a
+        # drop-in in /etc, it does apply.
+        overrideStrategy = "asDropin";
+      };
+      systemd.services."systemd-mkswap@" = {
+        restartIfChanged = false;
+        path = [ pkgs.util-linux ];
+        overrideStrategy = "asDropin";
+      };
+      systemd.services."modprobe@" = {
+        restartIfChanged = false;
+        serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.kmod ];
+      };
+      systemd.services.systemd-random-seed.restartIfChanged = false;
+      systemd.services.systemd-remount-fs.restartIfChanged = false;
+      systemd.services.systemd-update-utmp.restartIfChanged = false;
+      systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
+      systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
+      systemd.services.systemd-importd = lib.mkIf cfg.package.withImportd {
+        environment = proxy_env;
+        path = [ pkgs.gnupgMinimal ];
+      };
+      systemd.services.systemd-pstore.wantedBy = [ "sysinit.target" ]; # see #81138
+
+      # NixOS has kernel modules in a different location, so override that here.
+      systemd.services.kmod-static-nodes.unitConfig.ConditionFileNotEmpty = [
+        "" # required to unset the previous value!
+        "/run/booted-system/kernel-modules/lib/modules/%v/modules.devname"
+      ];
+
+      # Don't bother with certain units in containers.
+      systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";
+
+      # When using the classic /etc mechanism, we set certain paths in /etc to
+      # /etc/static so that systemd cannot change them (as they are symlinks to
+      # the read-only Nix Store). This is only done so that these services cannot
+      # change the values. All other parts of systemd should read them from their
+      # canonical locations.
+      #
+      # If you use the overlay mechanism to manage /etc, this is unnecessary
+      # because either the overlay is mutable (and users can legitimately change
+      # values without them being overridden) or it is immutable and systemd will
+      # suggest to only make runtime changes.
+      systemd.services."systemd-localed".environment =
+        lib.mkIf (!config.system.etc.overlay.enable && !config.i18n.imperativeLocale)
+          {
+            SYSTEMD_ETC_LOCALE_CONF = "/etc/static/locale.conf";
+            SYSTEMD_ETC_VCONSOLE_CONF = "/etc/static/vconsole.conf";
+          };
+      systemd.services."systemd-timedated".environment =
+        lib.mkIf (!config.system.etc.overlay.enable && config.time.timeZone != null)
+          {
+            SYSTEMD_ETC_LOCALTIME = "/etc/static/localtime";
+            SYSTEMD_ETC_ADJTIME = "/etc/static/adjtime";
+          };
+      systemd.services."systemd-hostnamed".environment = lib.mkIf (!config.system.etc.overlay.enable) {
+        SYSTEMD_ETC_HOSTNAME = "/etc/static/hostname";
+        SYSTEMD_ETC_MACHINE_INFO = "/etc/static/machine-info";
+      };
+
+      # Increase numeric PID range (set directly instead of copying a one-line file from systemd)
+      # https://github.com/systemd/systemd/pull/12226
+      boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
+
+      # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
+      # part, run0 would fail to run the command even if authentication is successful and the user has
+      # permission to run the command. This next part is only enabled if polkit is enabled because the
+      # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
+      # enabled, run0 will fail before it even tries to run the command.
+      security.pam.services = mkIf config.security.polkit.enable {
+        systemd-run0 = {
+          # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
+          setLoginUid = true;
+          pamMount = false;
         };
-    systemd.services."systemd-hostnamed".environment = lib.mkIf (!config.system.etc.overlay.enable) {
-      SYSTEMD_ETC_HOSTNAME = "/etc/static/hostname";
-      SYSTEMD_ETC_MACHINE_INFO = "/etc/static/machine-info";
-    };
-
-    # Increase numeric PID range (set directly instead of copying a one-line file from systemd)
-    # https://github.com/systemd/systemd/pull/12226
-    boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
-
-    services.logrotate.settings = {
-      "/var/log/btmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0660 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
       };
-      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0664 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
+      # the systemd vmspawn credential dropin executes sshd and expects ExecSearchPath to be set, see:
+      # https://github.com/systemd/systemd/blob/v259.3/src/vmspawn/vmspawn.c#L2662
+      # this service is used, for example, when NixOS is started via systemd-vmspawn
+      systemd.services."sshd-vsock@" = mkIf config.services.openssh.enable {
+        serviceConfig.ExecSearchPath = "${config.services.openssh.package}/bin";
+        overrideStrategy = "asDropin";
       };
-    };
 
-    # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
-    # part, run0 would fail to run the command even if authentication is successful and the user has
-    # permission to run the command. This next part is only enabled if polkit is enabled because the
-    # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
-    # enabled, run0 will fail before it even tries to run the command.
-    security.pam.services = mkIf config.security.polkit.enable {
-      systemd-run0 = {
-        # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
-        setLoginUid = true;
-        pamMount = false;
+      # Fix paths in sshd-vsock.socket
+      # https://github.com/systemd/systemd/blob/v259.3/src/ssh-generator/ssh-generator.c#L239
+      # this socket is used, for example, when NixOS is started via systemd-vmspawn
+      systemd.sockets.sshd-vsock = mkIf config.services.openssh.enable {
+        overrideStrategy = "asDropin";
+        socketConfig.ExecStartPost = [
+          ""
+          "${config.systemd.package}/lib/systemd/systemd-ssh-issue --make-vsock"
+        ];
+        socketConfig.ExecStopPre = [
+          ""
+          "${config.systemd.package}/lib/systemd/systemd-ssh-issue --rm-vsock"
+        ];
       };
-    };
-
-    # the systemd vmspawn credential dropin executes sshd and expects ExecSearchPath to be set, see:
-    # https://github.com/systemd/systemd/blob/v259.3/src/vmspawn/vmspawn.c#L2662
-    # this service is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.services."sshd-vsock@" = mkIf config.services.openssh.enable {
-      serviceConfig.ExecSearchPath = "${config.services.openssh.package}/bin";
-      overrideStrategy = "asDropin";
-    };
-
-    # Fix paths in sshd-vsock.socket
-    # https://github.com/systemd/systemd/blob/v259.3/src/ssh-generator/ssh-generator.c#L239
-    # this socket is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.sockets.sshd-vsock = mkIf config.services.openssh.enable {
-      overrideStrategy = "asDropin";
-      socketConfig.ExecStartPost = [
-        ""
-        "${config.systemd.package}/lib/systemd/systemd-ssh-issue --make-vsock"
-      ];
-      socketConfig.ExecStopPre = [
-        ""
-        "${config.systemd.package}/lib/systemd/systemd-ssh-issue --rm-vsock"
-      ];
-    };
-  };
+    }
+    (lib.optionalAttrs (options ? services.logrotate) {
+      services.logrotate.settings = {
+        "/var/log/btmp" = mapAttrs (_: mkDefault) {
+          frequency = "monthly";
+          rotate = 1;
+          create = "0660 root ${config.users.groups.utmp.name}";
+          minsize = "1M";
+        };
+        "/var/log/wtmp" = mapAttrs (_: mkDefault) {
+          frequency = "monthly";
+          rotate = 1;
+          create = "0664 root ${config.users.groups.utmp.name}";
+          minsize = "1M";
+        };
+      };
+    })
+  ];
 
   # FIXME: Remove these eventually.
   imports = [

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -905,6 +905,17 @@ in
         ];
       };
     }
+    (lib.optionalAttrs (options ? security.polkit.extraConfig) {
+      # Remove with systemd 259.4
+      security.polkit.extraConfig = mkIf config.security.polkit.enable ''
+        polkit.addRule(function(action, subject) {
+            if (action.id == "org.freedesktop.machine1.register-machine" &&
+                subject.user != "root") {
+                return polkit.Result.AUTH_ADMIN_KEEP;
+            }
+        });
+      '';
+    })
     (lib.optionalAttrs (options ? services.logrotate) {
       services.logrotate.settings = {
         "/var/log/btmp" = mapAttrs (_: mkDefault) {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -694,8 +694,6 @@ in
           "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
         };
 
-      services.dbus.enable = true;
-
       users.users.systemd-network = {
         uid = config.ids.uids.systemd-network;
         group = "systemd-network";
@@ -905,6 +903,9 @@ in
         ];
       };
     }
+    (lib.optionalAttrs (options ? services.dbus) {
+      services.dbus.enable = true;
+    })
     (lib.optionalAttrs (options ? security.polkit.extraConfig) {
       # Remove with systemd 259.4
       security.polkit.extraConfig = mkIf config.security.polkit.enable ''

--- a/nixos/modules/system/boot/systemd/dm-verity.nix
+++ b/nixos/modules/system/boot/systemd/dm-verity.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
   cfg = config.boot.initrd.systemd.dmVerity;
@@ -17,41 +22,47 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
       {
-        assertion = config.boot.initrd.systemd.enable;
-        message = ''
-          'boot.initrd.systemd.dmVerity.enable' requires 'boot.initrd.systemd.enable' to be enabled.
-        '';
-      }
-    ];
+        assertions = [
+          {
+            assertion = config.boot.initrd.systemd.enable;
+            message = ''
+              'boot.initrd.systemd.dmVerity.enable' requires 'boot.initrd.systemd.enable' to be enabled.
+            '';
+          }
+        ];
 
-    boot.initrd = {
-      availableKernelModules = [
-        "dm_mod"
-        "dm_verity"
-      ];
+        boot.initrd = {
+          availableKernelModules = [
+            "dm_mod"
+            "dm_verity"
+          ];
+
+          # The additional targets and store paths allow users to integrate verity-protected devices
+          # through the systemd tooling.
+          systemd = {
+            additionalUpstreamUnits = [
+              "veritysetup-pre.target"
+              "veritysetup.target"
+              "remote-veritysetup.target"
+            ];
+
+            storePaths = [
+              "${config.boot.initrd.systemd.package}/lib/systemd/systemd-veritysetup"
+              "${config.boot.initrd.systemd.package}/lib/systemd/system-generators/systemd-veritysetup-generator"
+            ];
+          };
+        };
+      }
 
       # dm-verity needs additional udev rules from LVM to work.
-      services.lvm.enable = true;
-
-      # The additional targets and store paths allow users to integrate verity-protected devices
-      # through the systemd tooling.
-      systemd = {
-        additionalUpstreamUnits = [
-          "veritysetup-pre.target"
-          "veritysetup.target"
-          "remote-veritysetup.target"
-        ];
-
-        storePaths = [
-          "${config.boot.initrd.systemd.package}/lib/systemd/systemd-veritysetup"
-          "${config.boot.initrd.systemd.package}/lib/systemd/system-generators/systemd-veritysetup-generator"
-        ];
-      };
-    };
-  };
+      (lib.optionalAttrs (options ? boot.initrd.services.lvm) {
+        boot.initrd.services.lvm.enable = true;
+      })
+    ]
+  );
 
   meta.maintainers = with lib.maintainers; [
     msanft

--- a/nixos/modules/system/boot/systemd/userdbd.nix
+++ b/nixos/modules/system/boot/systemd/userdbd.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
   cfg = config.services.userdbd;
@@ -30,55 +35,62 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = lib.singleton {
-      assertion = cfg.enableSSHSupport -> config.security.enableWrappers;
-      message = "OpenSSH userdb integration requires security wrappers.";
-    };
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = lib.singleton {
+          assertion = cfg.enableSSHSupport -> config.security.enableWrappers;
+          message = "OpenSSH userdb integration requires security wrappers.";
+        };
 
-    warnings = lib.optional (lib.length highSystemUsers > 0 && !cfg.silenceHighSystemUsers) ''
-      The following system users have UIDs higher than 1000:
+        warnings = lib.optional (lib.length highSystemUsers > 0 && !cfg.silenceHighSystemUsers) ''
+          The following system users have UIDs higher than 1000:
 
-      ${lib.concatLines (lib.map (user: user.name) highSystemUsers)}
+          ${lib.concatLines (lib.map (user: user.name) highSystemUsers)}
 
-      These users will be recognized by systemd-userdb as "regular" users, not
-      "system" users. This will affect programs that query regular users, such
-      as systemd-homed, which will not run the first boot user creation flow,
-      as regular users already exist.
+          These users will be recognized by systemd-userdb as "regular" users, not
+          "system" users. This will affect programs that query regular users, such
+          as systemd-homed, which will not run the first boot user creation flow,
+          as regular users already exist.
 
-      To fix this issue, please remove or redefine these system users to have
-      UIDs below 1000. For Nix build users, it's possible to adjust the base
-      build user ID using the `ids.uids.nixbld` option, however care must be
-      taken to avoid collisions with UIDs of other services. Alternatively, you
-      may enable the `auto-allocate-uids` experimental feature and option in
-      the Nix configuration to avoid creating these users, however please note
-      that this option is experimental and subject to change.
+          To fix this issue, please remove or redefine these system users to have
+          UIDs below 1000. For Nix build users, it's possible to adjust the base
+          build user ID using the `ids.uids.nixbld` option, however care must be
+          taken to avoid collisions with UIDs of other services. Alternatively, you
+          may enable the `auto-allocate-uids` experimental feature and option in
+          the Nix configuration to avoid creating these users, however please note
+          that this option is experimental and subject to change.
 
-      Alternatively, to acknowledge and silence this warning, set
-      `services.userdbd.silenceHighSystemUsers` to true.
-    '';
+          Alternatively, to acknowledge and silence this warning, set
+          `services.userdbd.silenceHighSystemUsers` to true.
+        '';
 
-    systemd.additionalUpstreamSystemUnits = [
-      "systemd-userdbd.socket"
-      "systemd-userdbd.service"
-    ];
+        systemd.additionalUpstreamSystemUnits = [
+          "systemd-userdbd.socket"
+          "systemd-userdbd.service"
+        ];
 
-    systemd.sockets.systemd-userdbd.wantedBy = [ "sockets.target" ];
+        systemd.sockets.systemd-userdbd.wantedBy = [ "sockets.target" ];
 
-    # OpenSSH requires AuthorizedKeysCommand to be owned only by root.
-    # Referencing `userdbctl` directly from the Nix store won't work, as
-    # `/nix/store` is owned by the `nixbld` group.
-    security.wrappers = lib.mkIf cfg.enableSSHSupport {
-      userdbctl = {
-        owner = "root";
-        group = "root";
-        source = lib.getExe' config.systemd.package "userdbctl";
-      };
-    };
+        # OpenSSH requires AuthorizedKeysCommand to be owned only by root.
+        # Referencing `userdbctl` directly from the Nix store won't work, as
+        # `/nix/store` is owned by the `nixbld` group.
+        security.wrappers = lib.mkIf cfg.enableSSHSupport {
+          userdbctl = {
+            owner = "root";
+            group = "root";
+            source = lib.getExe' config.systemd.package "userdbctl";
+          };
+        };
 
-    services.openssh = lib.mkIf cfg.enableSSHSupport {
-      authorizedKeysCommand = "/run/wrappers/bin/userdbctl ssh-authorized-keys %u";
-      authorizedKeysCommandUser = "root";
-    };
-  };
+      }
+
+      (lib.optionalAttrs (options ? services.openssh) {
+        services.openssh = lib.mkIf cfg.enableSSHSupport {
+          authorizedKeysCommand = "/run/wrappers/bin/userdbctl ssh-authorized-keys %u";
+          authorizedKeysCommandUser = "root";
+        };
+      })
+    ]
+  );
 }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -19,150 +20,156 @@
       ] config.system.build.etcActivationCommands;
     }
 
-    (lib.mkIf config.system.etc.overlay.enable {
+    # The overlay block sets boot.initrd.* and system.requiredKernelConfig,
+    # which are defined in system/boot/stage-1.nix and system/boot/kernel.nix.
+    # Wrap with optionalAttrs so etc-activation works without stage-1 loaded
+    # (e.g. for container profiles).
+    (lib.optionalAttrs (options ? boot.initrd.availableKernelModules) (
+      lib.mkIf config.system.etc.overlay.enable {
 
-      assertions = [
-        {
-          assertion = config.boot.initrd.systemd.enable;
-          message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
-        }
-        {
-          assertion =
-            (!config.system.etc.overlay.mutable)
-            -> (config.systemd.sysusers.enable || config.services.userborn.enable);
-          message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
-        }
-        {
-          assertion =
-            (config.system.switch.enable)
-            -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
-          message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
-        }
-      ];
-
-      boot.initrd.availableKernelModules = [
-        "loop"
-        "erofs"
-        "overlay"
-      ];
-
-      system.requiredKernelConfig = with config.lib.kernelConfig; [
-        (isEnabled "EROFS_FS")
-      ];
-
-      boot.initrd.systemd = {
-        mounts = [
+        assertions = [
           {
-            where = "/run/nixos-etc-metadata";
-            what = "/etc-metadata-image";
-            type = "erofs";
-            options = "loop,ro,nodev,nosuid";
-            unitConfig = {
-              # Since this unit depends on the nix store being mounted, it cannot
-              # be a dependency of local-fs.target, because if it did, we'd have
-              # local-fs.target ordered after the nix store mount which would cause
-              # things like network.target to only become active after the nix store
-              # has been mounted.
-              # This breaks for instance setups where sshd needs to be up before
-              # any encrypted disks can be mounted.
-              DefaultDependencies = false;
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-              ];
-            };
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
+            assertion = config.boot.initrd.systemd.enable;
+            message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
           }
           {
-            where = "/sysroot/etc";
-            what = "overlay";
-            type = "overlay";
-            options = lib.concatStringsSep "," (
-              [
-                "nodev"
-                "nosuid"
-                "relatime"
-                "redirect_dir=on"
-                "metacopy=on"
-                "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
-              ]
-              ++ lib.optionals config.system.etc.overlay.mutable [
-                "rw"
-                "upperdir=/sysroot/.rw-etc/upper"
-                "workdir=/sysroot/.rw-etc/work"
-              ]
-              ++ lib.optionals (!config.system.etc.overlay.mutable) [
-                "ro"
-              ]
-            );
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            unitConfig = {
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-                "/run/nixos-etc-metadata"
-              ];
-              DefaultDependencies = false;
-            };
+            assertion =
+              (!config.system.etc.overlay.mutable)
+              -> (config.systemd.sysusers.enable || config.services.userborn.enable);
+            message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
+          }
+          {
+            assertion =
+              (config.system.switch.enable)
+              -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
+            message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
           }
         ];
-        services = lib.mkMerge [
-          (lib.mkIf config.system.etc.overlay.mutable {
-            rw-etc = {
+
+        boot.initrd.availableKernelModules = [
+          "loop"
+          "erofs"
+          "overlay"
+        ];
+
+        system.requiredKernelConfig = with config.lib.kernelConfig; [
+          (isEnabled "EROFS_FS")
+        ];
+
+        boot.initrd.systemd = {
+          mounts = [
+            {
+              where = "/run/nixos-etc-metadata";
+              what = "/etc-metadata-image";
+              type = "erofs";
+              options = "loop,ro,nodev,nosuid";
+              unitConfig = {
+                # Since this unit depends on the nix store being mounted, it cannot
+                # be a dependency of local-fs.target, because if it did, we'd have
+                # local-fs.target ordered after the nix store mount which would cause
+                # things like network.target to only become active after the nix store
+                # has been mounted.
+                # This breaks for instance setups where sshd needs to be up before
+                # any encrypted disks can be mounted.
+                DefaultDependencies = false;
+                RequiresMountsFor = [
+                  "/sysroot/nix/store"
+                ];
+              };
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
               requiredBy = [ "initrd-fs.target" ];
               before = [ "initrd-fs.target" ];
+            }
+            {
+              where = "/sysroot/etc";
+              what = "overlay";
+              type = "overlay";
+              options = lib.concatStringsSep "," (
+                [
+                  "nodev"
+                  "nosuid"
+                  "relatime"
+                  "redirect_dir=on"
+                  "metacopy=on"
+                  "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
+                ]
+                ++ lib.optionals config.system.etc.overlay.mutable [
+                  "rw"
+                  "upperdir=/sysroot/.rw-etc/upper"
+                  "workdir=/sysroot/.rw-etc/work"
+                ]
+                ++ lib.optionals (!config.system.etc.overlay.mutable) [
+                  "ro"
+                ]
+              );
+              requiredBy = [ "initrd-fs.target" ];
+              before = [ "initrd-fs.target" ];
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
               unitConfig = {
+                RequiresMountsFor = [
+                  "/sysroot/nix/store"
+                  "/run/nixos-etc-metadata"
+                ];
                 DefaultDependencies = false;
-                RequiresMountsFor = "/sysroot";
               };
-              serviceConfig = {
-                Type = "oneshot";
-                ExecStart = ''
-                  /bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work
-                '';
+            }
+          ];
+          services = lib.mkMerge [
+            (lib.mkIf config.system.etc.overlay.mutable {
+              rw-etc = {
+                requiredBy = [ "initrd-fs.target" ];
+                before = [ "initrd-fs.target" ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = "/sysroot";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  ExecStart = ''
+                    /bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work
+                  '';
+                };
               };
-            };
-          })
-          {
-            initrd-find-etc = {
-              description = "Find the path to the etc metadata image and based dir";
-              before = [ "shutdown.target" ];
-              conflicts = [ "shutdown.target" ];
-              requiredBy = [ "initrd.target" ];
-              path = [ config.system.nixos-init.package ];
-              unitConfig = {
-                DefaultDependencies = false;
-                RequiresMountsFor = "/sysroot/nix/store";
+            })
+            {
+              initrd-find-etc = {
+                description = "Find the path to the etc metadata image and based dir";
+                before = [ "shutdown.target" ];
+                conflicts = [ "shutdown.target" ];
+                requiredBy = [ "initrd.target" ];
+                path = [ config.system.nixos-init.package ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = "/sysroot/nix/store";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
+                };
               };
-              serviceConfig = {
-                Type = "oneshot";
-                RemainAfterExit = true;
-                ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
-              };
-            };
-          }
-        ];
-      };
+            }
+          ];
+        };
 
-    })
+      }
+    ))
 
   ];
 }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }:
 
@@ -18,168 +19,174 @@
       ] config.system.build.etcActivationCommands;
     }
 
-    (lib.mkIf config.system.etc.overlay.enable {
+    # The overlay block sets boot.initrd.* and system.requiredKernelConfig,
+    # which are defined in system/boot/stage-1.nix and system/boot/kernel.nix.
+    # Wrap with optionalAttrs so etc-activation works without stage-1 loaded
+    # (e.g. for container profiles).
+    (lib.optionalAttrs (options ? boot.initrd.availableKernelModules) (
+      lib.mkIf config.system.etc.overlay.enable {
 
-      assertions = [
-        {
-          assertion = config.boot.initrd.systemd.enable;
-          message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
-        }
-        {
-          assertion =
-            (!config.system.etc.overlay.mutable)
-            -> (config.systemd.sysusers.enable || config.services.userborn.enable);
-          message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
-        }
-        {
-          assertion =
-            (config.system.switch.enable)
-            -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
-          message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
-        }
-      ];
-
-      boot.initrd.availableKernelModules = [
-        "loop"
-        "erofs"
-        "overlay"
-      ];
-
-      system.requiredKernelConfig = with config.lib.kernelConfig; [
-        (isEnabled "EROFS_FS")
-      ];
-
-      boot.initrd.systemd = {
-        storePaths = lib.mkIf config.system.etc.overlay.mutable [
-          "${config.system.nixos-init.package}/bin/clear-etc-opaque"
-        ];
-        mounts = [
+        assertions = [
           {
-            where = "/run/nixos-etc-metadata";
-            what = "/etc-metadata-image";
-            type = "erofs";
-            options = "loop,ro,nodev,nosuid";
-            unitConfig = {
-              # Since this unit depends on the nix store being mounted, it cannot
-              # be a dependency of local-fs.target, because if it did, we'd have
-              # local-fs.target ordered after the nix store mount which would cause
-              # things like network.target to only become active after the nix store
-              # has been mounted.
-              # This breaks for instance setups where sshd needs to be up before
-              # any encrypted disks can be mounted.
-              DefaultDependencies = false;
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-              ];
-              # find-etc only creates this symlink for a NixOS init. For a
-              # non-NixOS init= (e.g. init=/bin/sh) it is absent, so skip the
-              # mount instead of failing the whole initrd.
-              ConditionPathExists = "/etc-metadata-image";
-            };
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
+            assertion = config.boot.initrd.systemd.enable;
+            message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
           }
           {
-            where = "/sysroot/etc";
-            what = "overlay";
-            type = "overlay";
-            options = lib.concatStringsSep "," (
-              [
-                "nodev"
-                "nosuid"
-                "relatime"
-                "redirect_dir=on"
-                "metacopy=on"
-                "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
-              ]
-              ++ lib.optionals config.system.etc.overlay.mutable [
-                "rw"
-                "upperdir=/sysroot/.rw-etc/upper"
-                "workdir=/sysroot/.rw-etc/work"
-              ]
-              ++ lib.optionals (!config.system.etc.overlay.mutable) [
-                "ro"
-              ]
-            );
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            unitConfig = {
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-                "/run/nixos-etc-metadata"
-              ];
-              DefaultDependencies = false;
-              # Skip for a non-NixOS init=, see the metadata mount above.
-              ConditionPathExists = "/etc-basedir";
-            };
+            assertion =
+              (!config.system.etc.overlay.mutable)
+              -> (config.systemd.sysusers.enable || config.services.userborn.enable);
+            message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
+          }
+          {
+            assertion =
+              (config.system.switch.enable)
+              -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
+            message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
           }
         ];
-        services = lib.mkMerge [
-          (lib.mkIf config.system.etc.overlay.mutable {
-            rw-etc = {
-              requiredBy = [ "initrd-fs.target" ];
-              before = [ "initrd-fs.target" ];
+
+        boot.initrd.availableKernelModules = [
+          "loop"
+          "erofs"
+          "overlay"
+        ];
+
+        system.requiredKernelConfig = with config.lib.kernelConfig; [
+          (isEnabled "EROFS_FS")
+        ];
+
+        boot.initrd.systemd = {
+          storePaths = lib.mkIf config.system.etc.overlay.mutable [
+            "${config.system.nixos-init.package}/bin/clear-etc-opaque"
+          ];
+          mounts = [
+            {
+              where = "/run/nixos-etc-metadata";
+              what = "/etc-metadata-image";
+              type = "erofs";
+              options = "loop,ro,nodev,nosuid";
               unitConfig = {
+                # Since this unit depends on the nix store being mounted, it cannot
+                # be a dependency of local-fs.target, because if it did, we'd have
+                # local-fs.target ordered after the nix store mount which would cause
+                # things like network.target to only become active after the nix store
+                # has been mounted.
+                # This breaks for instance setups where sshd needs to be up before
+                # any encrypted disks can be mounted.
                 DefaultDependencies = false;
                 RequiresMountsFor = [
-                  "/sysroot"
-                  # Needed so we can clear stale opaque markers from the
-                  # upperdir based on the contents of the new metadata layer
-                  # before the overlay is mounted.
-                  "/run/nixos-etc-metadata"
+                  "/sysroot/nix/store"
                 ];
-                # Skip for a non-NixOS init=, see the metadata mount above.
+                # find-etc only creates this symlink for a NixOS init. For a
+                # non-NixOS init= (e.g. init=/bin/sh) it is absent, so skip the
+                # mount instead of failing the whole initrd.
                 ConditionPathExists = "/etc-metadata-image";
               };
-              serviceConfig = {
-                Type = "oneshot";
-                ExecStart = [
-                  "/bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work"
-                  "${config.system.nixos-init.package}/bin/clear-etc-opaque /run/nixos-etc-metadata /sysroot/.rw-etc/upper"
-                ];
-              };
-            };
-          })
-          {
-            initrd-find-etc = {
-              description = "Find the path to the etc metadata image and based dir";
-              before = [ "shutdown.target" ];
-              conflicts = [ "shutdown.target" ];
-              requiredBy = [ "initrd.target" ];
-              path = [ config.system.nixos-init.package ];
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
+              requiredBy = [ "initrd-fs.target" ];
+              before = [ "initrd-fs.target" ];
+            }
+            {
+              where = "/sysroot/etc";
+              what = "overlay";
+              type = "overlay";
+              options = lib.concatStringsSep "," (
+                [
+                  "nodev"
+                  "nosuid"
+                  "relatime"
+                  "redirect_dir=on"
+                  "metacopy=on"
+                  "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
+                ]
+                ++ lib.optionals config.system.etc.overlay.mutable [
+                  "rw"
+                  "upperdir=/sysroot/.rw-etc/upper"
+                  "workdir=/sysroot/.rw-etc/work"
+                ]
+                ++ lib.optionals (!config.system.etc.overlay.mutable) [
+                  "ro"
+                ]
+              );
+              requiredBy = [ "initrd-fs.target" ];
+              before = [ "initrd-fs.target" ];
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
               unitConfig = {
+                RequiresMountsFor = [
+                  "/sysroot/nix/store"
+                  "/run/nixos-etc-metadata"
+                ];
                 DefaultDependencies = false;
-                RequiresMountsFor = "/sysroot/nix/store";
+                # Skip for a non-NixOS init=, see the metadata mount above.
+                ConditionPathExists = "/etc-basedir";
               };
-              serviceConfig = {
-                Type = "oneshot";
-                RemainAfterExit = true;
-                ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
+            }
+          ];
+          services = lib.mkMerge [
+            (lib.mkIf config.system.etc.overlay.mutable {
+              rw-etc = {
+                requiredBy = [ "initrd-fs.target" ];
+                before = [ "initrd-fs.target" ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = [
+                    "/sysroot"
+                    # Needed so we can clear stale opaque markers from the
+                    # upperdir based on the contents of the new metadata layer
+                    # before the overlay is mounted.
+                    "/run/nixos-etc-metadata"
+                  ];
+                  # Skip for a non-NixOS init=, see the metadata mount above.
+                  ConditionPathExists = "/etc-metadata-image";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  ExecStart = [
+                    "/bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work"
+                    "${config.system.nixos-init.package}/bin/clear-etc-opaque /run/nixos-etc-metadata /sysroot/.rw-etc/upper"
+                  ];
+                };
               };
-            };
-          }
-        ];
-      };
+            })
+            {
+              initrd-find-etc = {
+                description = "Find the path to the etc metadata image and based dir";
+                before = [ "shutdown.target" ];
+                conflicts = [ "shutdown.target" ];
+                requiredBy = [ "initrd.target" ];
+                path = [ config.system.nixos-init.package ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = "/sysroot/nix/store";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
+                };
+              };
+            }
+          ];
+        };
 
-    })
+      }
+    ))
 
     (lib.mkIf (config.system.etc.overlay.enable && !config.system.etc.overlay.mutable) {
       # An empty regular file means systemd will bind mount /run/machine-id

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1864,10 +1864,6 @@ in
       EOF
     '';
 
-    services.mstpd = mkIf needsMstpd { enable = true; };
-
-    virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
-
     services.udev.packages =
       lib.optionals (!config.systemd.network.enable) [
         (pkgs.writeTextFile rec {
@@ -2009,6 +2005,12 @@ in
             );
         }
       );
+  }
+  // lib.optionalAttrs (options ? services.mstpd) {
+    services.mstpd = mkIf needsMstpd { enable = true; };
+  }
+  // lib.optionalAttrs (options ? virtualisation.vswitch) {
+    virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
   };
 
 }

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1721,295 +1721,299 @@ in
 
   meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    warnings =
-      (concatMap (i: i.warnings) interfaces)
-      ++ (lib.optional (config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd) ''
-        The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false` can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking. It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting (by disabling `systemd.network.enable`)
-      '');
+      warnings =
+        (concatMap (i: i.warnings) interfaces)
+        ++ (lib.optional (config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd) ''
+          The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false` can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking. It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting (by disabling `systemd.network.enable`)
+        '');
 
-    assertions =
-      (forEach interfaces (i: {
-        # With the linux kernel, interface name length is limited by IFNAMSIZ
-        # to 16 bytes, including the trailing null byte.
-        # See include/linux/if.h in the kernel sources
-        assertion = stringLength i.name < 16;
-        message = ''
-          The name of networking.interfaces."${i.name}" is too long, it needs to be less than 16 characters.
-        '';
-      }))
-      ++ (forEach slaveIfs (i: {
-        assertion = i.ipv4.addresses == [ ] && i.ipv6.addresses == [ ];
-        message = ''
-          The networking.interfaces."${i.name}" must not have any defined ips when it is a slave.
-        '';
-      }))
-      ++ (forEach interfaces (i: {
-        assertion = i.tempAddress != "disabled" -> cfg.enableIPv6;
-        message = ''
-          Temporary addresses are only needed when IPv6 is enabled.
-        '';
-      }))
-      ++ (forEach interfaces (i: {
-        assertion = (i.virtual && i.virtualType == "tun") -> i.macAddress == null;
-        message = ''
-          Setting a MAC Address for tun device ${i.name} isn't supported.
-        '';
-      }))
-      ++ [
-        {
-          assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
-          message = "Invalid value given to the networking.hostId option.";
-        }
+      assertions =
+        (forEach interfaces (i: {
+          # With the linux kernel, interface name length is limited by IFNAMSIZ
+          # to 16 bytes, including the trailing null byte.
+          # See include/linux/if.h in the kernel sources
+          assertion = stringLength i.name < 16;
+          message = ''
+            The name of networking.interfaces."${i.name}" is too long, it needs to be less than 16 characters.
+          '';
+        }))
+        ++ (forEach slaveIfs (i: {
+          assertion = i.ipv4.addresses == [ ] && i.ipv6.addresses == [ ];
+          message = ''
+            The networking.interfaces."${i.name}" must not have any defined ips when it is a slave.
+          '';
+        }))
+        ++ (forEach interfaces (i: {
+          assertion = i.tempAddress != "disabled" -> cfg.enableIPv6;
+          message = ''
+            Temporary addresses are only needed when IPv6 is enabled.
+          '';
+        }))
+        ++ (forEach interfaces (i: {
+          assertion = (i.virtual && i.virtualType == "tun") -> i.macAddress == null;
+          message = ''
+            Setting a MAC Address for tun device ${i.name} isn't supported.
+          '';
+        }))
+        ++ [
+          {
+            assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
+            message = "Invalid value given to the networking.hostId option.";
+          }
+        ];
+
+      boot.kernelModules =
+        [ ]
+        ++ optional hasVirtuals "tun"
+        ++ optional hasSits "sit"
+        ++ optional hasGres "gre"
+        ++ optional hasBonds "bonding"
+        ++ optional hasFous "fou";
+
+      boot.extraModprobeConfig =
+        # This setting is intentional as it prevents default bond devices
+        # from being created.
+        optionalString hasBonds "options bonding max_bonds=0";
+
+      boot.kernel.sysctl = {
+        # Only set when proxyARP needs it; never write =0 (the kernel default),
+        # which would race with systemd-networkd's IPv4Forwarding= on switch.
+        "net.ipv4.conf.all.forwarding" = mkIf (any (i: i.proxyARP) interfaces) (mkDefault true);
+        "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
+        "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
+        # allow all users to do ICMP echo requests (ping)
+        "net.ipv4.ping_group_range" = mkDefault "0 2147483647";
+        # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
+        "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
+      }
+      // listToAttrs (
+        forEach interfaces (
+          i: nameValuePair "net.ipv4.conf.${replaceStrings [ "." ] [ "/" ] i.name}.proxy_arp" i.proxyARP
+        )
+      )
+      // listToAttrs (
+        forEach interfaces (
+          i:
+          let
+            opt = i.tempAddress;
+            val = tempaddrValues.${opt}.sysctl;
+          in
+          nameValuePair "net.ipv6.conf.${replaceStrings [ "." ] [ "/" ] i.name}.use_tempaddr" val
+        )
+      );
+
+      environment.etc.hostid = mkIf (cfg.hostId != null) { source = hostidFile; };
+      boot.initrd.systemd.contents."/etc/hostid" = mkIf (cfg.hostId != null) { source = hostidFile; };
+
+      # static hostname configuration needed for hostnamectl and the
+      # org.freedesktop.hostname1 dbus service (both provided by systemd)
+      environment.etc.hostname = mkIf (cfg.hostName != "") {
+        text = cfg.hostName + "\n";
+      };
+
+      environment.corePackages = [
+        pkgs.host
+        pkgs.hostname
+        pkgs.iproute2
+        pkgs.iputils # ping
+      ]
+      ++ bridgeStp;
+
+      # Wake-on-LAN configuration is shared by the scripted and networkd backends.
+      systemd.network.links = pipe interfaces [
+        (filter (i: i.wakeOnLan.enable))
+        (map (
+          i:
+          nameValuePair "40-${i.name}" {
+            matchConfig.OriginalName = i.name;
+            linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
+          }
+        ))
+        listToAttrs
       ];
 
-    boot.kernelModules =
-      [ ]
-      ++ optional hasVirtuals "tun"
-      ++ optional hasSits "sit"
-      ++ optional hasGres "gre"
-      ++ optional hasBonds "bonding"
-      ++ optional hasFous "fou";
-
-    boot.extraModprobeConfig =
-      # This setting is intentional as it prevents default bond devices
-      # from being created.
-      optionalString hasBonds "options bonding max_bonds=0";
-
-    boot.kernel.sysctl = {
-      # Only set when proxyARP needs it; never write =0 (the kernel default),
-      # which would race with systemd-networkd's IPv4Forwarding= on switch.
-      "net.ipv4.conf.all.forwarding" = mkIf (any (i: i.proxyARP) interfaces) (mkDefault true);
-      "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
-      "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
-      # allow all users to do ICMP echo requests (ping)
-      "net.ipv4.ping_group_range" = mkDefault "0 2147483647";
-      # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
-      "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
-    }
-    // listToAttrs (
-      forEach interfaces (
-        i: nameValuePair "net.ipv4.conf.${replaceStrings [ "." ] [ "/" ] i.name}.proxy_arp" i.proxyARP
-      )
-    )
-    // listToAttrs (
-      forEach interfaces (
-        i:
-        let
-          opt = i.tempAddress;
-          val = tempaddrValues.${opt}.sysctl;
-        in
-        nameValuePair "net.ipv6.conf.${replaceStrings [ "." ] [ "/" ] i.name}.use_tempaddr" val
-      )
-    );
-
-    environment.etc.hostid = mkIf (cfg.hostId != null) { source = hostidFile; };
-    boot.initrd.systemd.contents."/etc/hostid" = mkIf (cfg.hostId != null) { source = hostidFile; };
-
-    # static hostname configuration needed for hostnamectl and the
-    # org.freedesktop.hostname1 dbus service (both provided by systemd)
-    environment.etc.hostname = mkIf (cfg.hostName != "") {
-      text = cfg.hostName + "\n";
-    };
-
-    environment.corePackages = [
-      pkgs.host
-      pkgs.hostname
-      pkgs.iproute2
-      pkgs.iputils # ping
-    ]
-    ++ bridgeStp;
-
-    # Wake-on-LAN configuration is shared by the scripted and networkd backends.
-    systemd.network.links = pipe interfaces [
-      (filter (i: i.wakeOnLan.enable))
-      (map (
-        i:
-        nameValuePair "40-${i.name}" {
-          matchConfig.OriginalName = i.name;
-          linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
-        }
-      ))
-      listToAttrs
-    ];
-
-    systemd.services = {
-      network-local-commands = {
-        enable = (cfg.localCommands != "");
-        description = "Extra networking commands.";
-        before = [ "network.target" ];
-        wantedBy = [ "network.target" ];
-        after = [ "network-pre.target" ];
-        unitConfig.ConditionCapability = "CAP_NET_ADMIN";
-        path = [ pkgs.iproute2 ];
-        serviceConfig.Type = "oneshot";
-        serviceConfig.RemainAfterExit = true;
-        script = ''
-          # Run any user-specified commands.
-          ${cfg.localCommands}
-        '';
+      systemd.services = {
+        network-local-commands = {
+          enable = (cfg.localCommands != "");
+          description = "Extra networking commands.";
+          before = [ "network.target" ];
+          wantedBy = [ "network.target" ];
+          after = [ "network-pre.target" ];
+          unitConfig.ConditionCapability = "CAP_NET_ADMIN";
+          path = [ pkgs.iproute2 ];
+          serviceConfig.Type = "oneshot";
+          serviceConfig.RemainAfterExit = true;
+          script = ''
+            # Run any user-specified commands.
+            ${cfg.localCommands}
+          '';
+        };
       };
-    };
 
-    networking.localCommands = lib.mkIf config.networking.resolvconf.enable ''
-      # Set the static DNS configuration, if given.
-      ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
-      ${optionalString (cfg.nameservers != [ ] && cfg.domain != null) ''
-        domain ${cfg.domain}
-      ''}
-      ${optionalString (cfg.search != [ ]) ("search " + concatStringsSep " " cfg.search)}
-      ${flip concatMapStrings cfg.nameservers (ns: ''
-        nameserver ${ns}
-      '')}
-      EOF
-    '';
+      networking.localCommands = lib.mkIf config.networking.resolvconf.enable ''
+        # Set the static DNS configuration, if given.
+        ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
+        ${optionalString (cfg.nameservers != [ ] && cfg.domain != null) ''
+          domain ${cfg.domain}
+        ''}
+        ${optionalString (cfg.search != [ ]) ("search " + concatStringsSep " " cfg.search)}
+        ${flip concatMapStrings cfg.nameservers (ns: ''
+          nameserver ${ns}
+        '')}
+        EOF
+      '';
 
-    services.mstpd = mkIf needsMstpd { enable = true; };
-
-    virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
-
-    services.udev.packages =
-      lib.optionals (!config.systemd.network.enable) [
-        (pkgs.writeTextFile rec {
-          name = "ipv6-privacy-extensions.rules";
-          destination = "/etc/udev/rules.d/98-${name}";
-          text =
-            let
-              sysctl-value = tempaddrValues.${cfg.tempAddresses}.sysctl;
-            in
-            ''
-              # enable and prefer IPv6 privacy addresses by default
-              ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.bash}/bin/sh -c 'echo ${sysctl-value} > /proc/sys/net/ipv6/conf/$name/use_tempaddr'"
-            '';
-        })
-        (pkgs.writeTextFile rec {
-          name = "ipv6-privacy-extensions.rules";
-          destination = "/etc/udev/rules.d/99-${name}";
-          text = concatMapStrings (
-            i:
-            let
-              opt = i.tempAddress;
-              val = tempaddrValues.${opt}.sysctl;
-              msg = tempaddrValues.${opt}.description;
-            in
-            ''
-              # override to ${msg} for ${i.name}
-              ACTION=="add", SUBSYSTEM=="net", NAME=="${i.name}", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${
-                replaceStrings [ "." ] [ "/" ] i.name
-              }.use_tempaddr=${val}"
-            ''
-          ) (filter (i: i.tempAddress != cfg.tempAddresses) interfaces);
-        })
-      ]
-      ++ lib.optional (cfg.wlanInterfaces != { }) (
-        pkgs.writeTextFile {
-          name = "99-zzz-40-wlanInterfaces.rules";
-          destination = "/etc/udev/rules.d/99-zzz-40-wlanInterfaces.rules";
-          text =
-            let
-              # Collect all interfaces that are defined for a device
-              # as device:interface key:value pairs.
-              wlanDeviceInterfaces =
-                let
-                  allDevices = unique (mapAttrsToList (_: v: v.device) cfg.wlanInterfaces);
-                  interfacesOfDevice = d: filterAttrs (_: v: v.device == d) cfg.wlanInterfaces;
-                in
-                genAttrs allDevices (d: interfacesOfDevice d);
-
-              # Convert device:interface key:value pairs into a list, and if it exists,
-              # place the interface which is named after the device at the beginning.
-              wlanListDeviceFirst =
-                device: interfaces:
-                if hasAttr device interfaces then
-                  mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n == device) interfaces)
-                  ++ mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n != device) interfaces)
-                else
-                  mapAttrsToList (n: v: v // { _iName = n; }) interfaces;
-
-              # Udev script to execute for the default WLAN interface with the persistend udev name.
-              # The script creates the required, new WLAN interfaces interfaces and configures the
-              # existing, default interface.
-              curInterfaceScript =
-                device: current: new:
-                pkgs.writeScript "udev-run-script-wlan-interfaces-${device}.sh" ''
-                  #!${pkgs.runtimeShell}
-                  # Change the wireless phy device to a predictable name.
-                  ${pkgs.iw}/bin/iw phy `${pkgs.coreutils}/bin/cat /sys/class/net/$INTERFACE/phy80211/name` set name ${device}
-
-                  # Add new WLAN interfaces
-                  ${flip concatMapStrings new (i: ''
-                    ${pkgs.iw}/bin/iw phy ${device} interface add ${i._iName} type managed
-                  '')}
-
-                  # Configure the current interface
-                  ${pkgs.iw}/bin/iw dev ${device} set type ${current.type}
-                  ${optionalString (
-                    current.type == "mesh" && current.meshID != null
-                  ) "${pkgs.iw}/bin/iw dev ${device} set meshid ${current.meshID}"}
-                  ${optionalString (
-                    current.type == "monitor" && current.flags != null
-                  ) "${pkgs.iw}/bin/iw dev ${device} set monitor ${current.flags}"}
-                  ${optionalString (
-                    current.type == "managed" && current.fourAddr != null
-                  ) "${pkgs.iw}/bin/iw dev ${device} set 4addr ${if current.fourAddr then "on" else "off"}"}
-                  ${optionalString (
-                    current.mac != null
-                  ) "${pkgs.iproute2}/bin/ip link set dev ${device} address ${current.mac}"}
-                '';
-
-              # Udev script to execute for a new WLAN interface. The script configures the new WLAN interface.
-              newInterfaceScript =
-                new:
-                pkgs.writeScript "udev-run-script-wlan-interfaces-${new._iName}.sh" ''
-                  #!${pkgs.runtimeShell}
-                  # Configure the new interface
-                  ${pkgs.iw}/bin/iw dev ${new._iName} set type ${new.type}
-                  ${optionalString (
-                    new.type == "mesh" && new.meshID != null
-                  ) "${pkgs.iw}/bin/iw dev ${new._iName} set meshid ${new.meshID}"}
-                  ${optionalString (
-                    new.type == "monitor" && new.flags != null
-                  ) "${pkgs.iw}/bin/iw dev ${new._iName} set monitor ${new.flags}"}
-                  ${optionalString (
-                    new.type == "managed" && new.fourAddr != null
-                  ) "${pkgs.iw}/bin/iw dev ${new._iName} set 4addr ${if new.fourAddr then "on" else "off"}"}
-                  ${optionalString (
-                    new.mac != null
-                  ) "${pkgs.iproute2}/bin/ip link set dev ${new._iName} address ${new.mac}"}
-                '';
-
-              # Udev attributes for systemd to name the device and to create a .device target.
-              systemdAttrs =
-                n:
-                ''NAME:="${n}", ENV{ID_NET_NAME}="${n}", ENV{SYSTEMD_ALIAS}="/sys/subsystem/net/devices/${n}", TAG+="systemd"'';
-            in
-            flip (concatMapStringsSep "\n") (attrNames wlanDeviceInterfaces) (
-              device:
+      services.udev.packages =
+        lib.optionals (!config.systemd.network.enable) [
+          (pkgs.writeTextFile rec {
+            name = "ipv6-privacy-extensions.rules";
+            destination = "/etc/udev/rules.d/98-${name}";
+            text =
               let
-                interfaces = wlanListDeviceFirst device wlanDeviceInterfaces.${device};
-                curInterface = elemAt interfaces 0;
-                newInterfaces = drop 1 interfaces;
+                sysctl-value = tempaddrValues.${cfg.tempAddresses}.sysctl;
               in
               ''
-                # It is important to have that rule first as overwriting the NAME attribute also prevents the
-                # next rules from matching.
-                ${flip (concatMapStringsSep "\n") (wlanListDeviceFirst device wlanDeviceInterfaces.${device}) (
-                  interface:
-                  ''ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", ENV{INTERFACE}=="${interface._iName}", ${systemdAttrs interface._iName}, RUN+="${newInterfaceScript interface}"''
-                )}
-
-                # Add the required, new WLAN interfaces to the default WLAN interface with the
-                # persistent, default name as assigned by udev.
-                ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}, RUN+="${
-                  curInterfaceScript device curInterface newInterfaces
-                }"
-                # Generate the same systemd events for both 'add' and 'move' udev events.
-                ACTION=="move", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}
+                # enable and prefer IPv6 privacy addresses by default
+                ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.bash}/bin/sh -c 'echo ${sysctl-value} > /proc/sys/net/ipv6/conf/$name/use_tempaddr'"
+              '';
+          })
+          (pkgs.writeTextFile rec {
+            name = "ipv6-privacy-extensions.rules";
+            destination = "/etc/udev/rules.d/99-${name}";
+            text = concatMapStrings (
+              i:
+              let
+                opt = i.tempAddress;
+                val = tempaddrValues.${opt}.sysctl;
+                msg = tempaddrValues.${opt}.description;
+              in
               ''
-            );
-        }
-      );
-  };
+                # override to ${msg} for ${i.name}
+                ACTION=="add", SUBSYSTEM=="net", NAME=="${i.name}", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${
+                  replaceStrings [ "." ] [ "/" ] i.name
+                }.use_tempaddr=${val}"
+              ''
+            ) (filter (i: i.tempAddress != cfg.tempAddresses) interfaces);
+          })
+        ]
+        ++ lib.optional (cfg.wlanInterfaces != { }) (
+          pkgs.writeTextFile {
+            name = "99-zzz-40-wlanInterfaces.rules";
+            destination = "/etc/udev/rules.d/99-zzz-40-wlanInterfaces.rules";
+            text =
+              let
+                # Collect all interfaces that are defined for a device
+                # as device:interface key:value pairs.
+                wlanDeviceInterfaces =
+                  let
+                    allDevices = unique (mapAttrsToList (_: v: v.device) cfg.wlanInterfaces);
+                    interfacesOfDevice = d: filterAttrs (_: v: v.device == d) cfg.wlanInterfaces;
+                  in
+                  genAttrs allDevices (d: interfacesOfDevice d);
+
+                # Convert device:interface key:value pairs into a list, and if it exists,
+                # place the interface which is named after the device at the beginning.
+                wlanListDeviceFirst =
+                  device: interfaces:
+                  if hasAttr device interfaces then
+                    mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n == device) interfaces)
+                    ++ mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n != device) interfaces)
+                  else
+                    mapAttrsToList (n: v: v // { _iName = n; }) interfaces;
+
+                # Udev script to execute for the default WLAN interface with the persistend udev name.
+                # The script creates the required, new WLAN interfaces interfaces and configures the
+                # existing, default interface.
+                curInterfaceScript =
+                  device: current: new:
+                  pkgs.writeScript "udev-run-script-wlan-interfaces-${device}.sh" ''
+                    #!${pkgs.runtimeShell}
+                    # Change the wireless phy device to a predictable name.
+                    ${pkgs.iw}/bin/iw phy `${pkgs.coreutils}/bin/cat /sys/class/net/$INTERFACE/phy80211/name` set name ${device}
+
+                    # Add new WLAN interfaces
+                    ${flip concatMapStrings new (i: ''
+                      ${pkgs.iw}/bin/iw phy ${device} interface add ${i._iName} type managed
+                    '')}
+
+                    # Configure the current interface
+                    ${pkgs.iw}/bin/iw dev ${device} set type ${current.type}
+                    ${optionalString (
+                      current.type == "mesh" && current.meshID != null
+                    ) "${pkgs.iw}/bin/iw dev ${device} set meshid ${current.meshID}"}
+                    ${optionalString (
+                      current.type == "monitor" && current.flags != null
+                    ) "${pkgs.iw}/bin/iw dev ${device} set monitor ${current.flags}"}
+                    ${optionalString (
+                      current.type == "managed" && current.fourAddr != null
+                    ) "${pkgs.iw}/bin/iw dev ${device} set 4addr ${if current.fourAddr then "on" else "off"}"}
+                    ${optionalString (
+                      current.mac != null
+                    ) "${pkgs.iproute2}/bin/ip link set dev ${device} address ${current.mac}"}
+                  '';
+
+                # Udev script to execute for a new WLAN interface. The script configures the new WLAN interface.
+                newInterfaceScript =
+                  new:
+                  pkgs.writeScript "udev-run-script-wlan-interfaces-${new._iName}.sh" ''
+                    #!${pkgs.runtimeShell}
+                    # Configure the new interface
+                    ${pkgs.iw}/bin/iw dev ${new._iName} set type ${new.type}
+                    ${optionalString (
+                      new.type == "mesh" && new.meshID != null
+                    ) "${pkgs.iw}/bin/iw dev ${new._iName} set meshid ${new.meshID}"}
+                    ${optionalString (
+                      new.type == "monitor" && new.flags != null
+                    ) "${pkgs.iw}/bin/iw dev ${new._iName} set monitor ${new.flags}"}
+                    ${optionalString (
+                      new.type == "managed" && new.fourAddr != null
+                    ) "${pkgs.iw}/bin/iw dev ${new._iName} set 4addr ${if new.fourAddr then "on" else "off"}"}
+                    ${optionalString (
+                      new.mac != null
+                    ) "${pkgs.iproute2}/bin/ip link set dev ${new._iName} address ${new.mac}"}
+                  '';
+
+                # Udev attributes for systemd to name the device and to create a .device target.
+                systemdAttrs =
+                  n:
+                  ''NAME:="${n}", ENV{ID_NET_NAME}="${n}", ENV{SYSTEMD_ALIAS}="/sys/subsystem/net/devices/${n}", TAG+="systemd"'';
+              in
+              flip (concatMapStringsSep "\n") (attrNames wlanDeviceInterfaces) (
+                device:
+                let
+                  interfaces = wlanListDeviceFirst device wlanDeviceInterfaces.${device};
+                  curInterface = elemAt interfaces 0;
+                  newInterfaces = drop 1 interfaces;
+                in
+                ''
+                  # It is important to have that rule first as overwriting the NAME attribute also prevents the
+                  # next rules from matching.
+                  ${flip (concatMapStringsSep "\n") (wlanListDeviceFirst device wlanDeviceInterfaces.${device}) (
+                    interface:
+                    ''ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", ENV{INTERFACE}=="${interface._iName}", ${systemdAttrs interface._iName}, RUN+="${newInterfaceScript interface}"''
+                  )}
+
+                  # Add the required, new WLAN interfaces to the default WLAN interface with the
+                  # persistent, default name as assigned by udev.
+                  ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}, RUN+="${
+                    curInterfaceScript device curInterface newInterfaces
+                  }"
+                  # Generate the same systemd events for both 'add' and 'move' udev events.
+                  ACTION=="move", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}
+                ''
+              );
+          }
+        );
+    }
+    (lib.optionalAttrs (options ? services.mstpd) {
+      services.mstpd = mkIf needsMstpd { enable = true; };
+    })
+    (lib.optionalAttrs (options ? virtualisation.vswitch) {
+      virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
+    })
+  ];
 
 }


### PR DESCRIPTION
Second part of https://github.com/NixOS/nixpkgs/pull/507676.

uses `optionalAttrs` in order to keep references for options defined outside the given module optional in core moduels.

This is deliberately kept simple and boring in the hopes of making reviews easier and minimizing risk.

It's another small step towards evaluating NixOS from a potentially much smaller set of modules. (see https://github.com/NixOS/nixpkgs/pull/507740)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
