### PR TITLE
papra: 26.2.2 -> 26.4.0; misc.

### DIFF
--- a/pkgs/by-name/pa/papra/package.nix
+++ b/pkgs/by-name/pa/papra/package.nix
@@ -26,6 +26,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-wQdDBS+QRarZhEIRmLQ4VRtq73I5YFIN2P3ZtAZWvxw=";
   };
 
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-8k8hzpyOQuHAPF+zzIhW+5vo6lHSyZeKAY+tYIf6jKU=";
+    pnpmWorkspaces = [
+      "@papra/app-client..."
+      "@papra/app-server..."
+    ];
+  };
+
   nativeBuildInputs = [
     makeBinaryWrapper
     nodejs
@@ -80,17 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
-
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    pnpm = pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-8k8hzpyOQuHAPF+zzIhW+5vo6lHSyZeKAY+tYIf6jKU=";
-    pnpmWorkspaces = [
-      "@papra/app-client..."
-      "@papra/app-server..."
-    ];
-  };
 
   meta = {
     description = "Open-source document management platform designed to help you organize, secure, and archive your files effortlessly.";

--- a/pkgs/by-name/pa/papra/package.nix
+++ b/pkgs/by-name/pa/papra/package.nix
@@ -17,12 +17,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "papra";
-  version = "26.2.2";
+  version = "26.4.0";
+
   src = fetchFromGitHub {
     owner = "papra-hq";
     repo = "papra";
     tag = "@papra/app@${finalAttrs.version}";
-    hash = "sha256-0MIar+fBwXRE8LlVLZDx/C0GOYVpobDTqFwkMs2k06Y=";
+    hash = "sha256-wQdDBS+QRarZhEIRmLQ4VRtq73I5YFIN2P3ZtAZWvxw=";
   };
 
   nativeBuildInputs = [
@@ -84,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm;
     fetcherVersion = 3;
-    hash = "sha256-NQakyRlL6deG13yt+FlmVcVvEkNWHW0Lhf/3NecfwaE=";
+    hash = "sha256-8k8hzpyOQuHAPF+zzIhW+5vo6lHSyZeKAY+tYIf6jKU=";
     pnpmWorkspaces = [
       "@papra/app-client..."
       "@papra/app-server..."

--- a/pkgs/by-name/pa/papra/package.nix
+++ b/pkgs/by-name/pa/papra/package.nix
@@ -11,6 +11,7 @@
   vips,
   pkg-config,
   python3,
+  nix-update-script,
 }:
 let
   pnpm = pnpm_10;
@@ -91,6 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open-source document management platform designed to help you organize, secure, and archive your files effortlessly.";

--- a/pkgs/by-name/pa/papra/package.nix
+++ b/pkgs/by-name/pa/papra/package.nix
@@ -97,6 +97,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://papra.app/";
     changelog = "https://github.com/papra-hq/papra/releases";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ wariuccio ];
+    maintainers = with lib.maintainers; [
+      wariuccio
+      miniharinn
+    ];
   };
 })


### PR DESCRIPTION
Release: https://github.com/papra-hq/papra/releases/tag/%40papra%2Fapp%4026.4.0

I've also move things around, added myself as a maintainer, add `passthru.updateScript`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
