### PR TITLE
fossil: migrate to by-name, remove unused tclPackages argument

### DIFF
--- a/pkgs/by-name/fo/fossil/package.nix
+++ b/pkgs/by-name/fo/fossil/package.nix
@@ -13,7 +13,6 @@
   sqlite,
   ed,
   which,
-  tclPackages,
   withJson ? true,
 }:
 
@@ -42,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     ed
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin libiconv
-  ++ lib.optional (!withInternalSqlite) sqlite;
+  ++ lib.optional (!withInternalSqlite) (sqlite.override { enableDeserialize = true; });
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/fo/fossil/package.nix
+++ b/pkgs/by-name/fo/fossil/package.nix
@@ -13,7 +13,6 @@
   sqlite,
   ed,
   which,
-  tclPackages,
   withJson ? true,
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9454,10 +9454,6 @@ with pkgs;
     hamlib = hamlib_4;
   };
 
-  fossil = callPackage ../applications/version-management/fossil {
-    sqlite = sqlite.override { enableDeserialize = true; };
-  };
-
   fvwm = fvwm2;
 
   gaucheBootstrap = callPackage ../development/interpreters/gauche/boot.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8567,10 +8567,6 @@ with pkgs;
 
   firewalld-gui = firewalld.override { withGui = true; };
 
-  fossil = callPackage ../applications/version-management/fossil {
-    sqlite = sqlite.override { enableDeserialize = true; };
-  };
-
   fvwm = fvwm2;
 
   gaucheBootstrap = callPackage ../development/interpreters/gauche/boot.nix { };


### PR DESCRIPTION
This PR modernizes the fossil package by migrating it to the by‑name layout and simplifying its dependencies.

Move to by‑name:  
  -  Relocates fossil from `pkgs/applications/version-management/fossil/default.nix to pkgs/by-name/fo/fossil/package.nix`.

Dependency cleanup:  
-    Drops unused tclPackages and ensures sqlite.override { enableDeserialize = true; } is consistently applied when not using the bundled SQLite.

Top‑level cleanup:  
-    Removes the manual fossil entry from all-packages.nix, since the by‑name directory now exposes it automatically.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
