### PR TITLE
 rocmPackages.miopen: fix bnorm and dropout kernels

### DIFF
--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -295,6 +295,11 @@ stdenv.mkDerivation (finalAttrs: {
       name = "conv";
       testScript = "MIOpenDriver conv -n 1 -c 1 -H 4 -W 4 -k 1 -y 3 -x 3 -p 0 -q 0 -V 0";
     };
+    dropout = callPackage ./test-runtime-compilation.nix {
+      miopen = finalAttrs.finalPackage;
+      name = "dropout";
+      testScript = "MIOpenDriver dropout -d 64,32,14,14";
+    };
     pool = callPackage ./test-runtime-compilation.nix {
       miopen = finalAttrs.finalPackage;
       name = "pool";

--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -23,6 +23,7 @@
   half,
   boost,
   sqlite,
+  symlinkJoin,
   bzip2,
   lbzip2,
   nlohmann_json,
@@ -81,6 +82,15 @@ let
       ]
     )
   );
+
+  # for hiprtcCompileProgram (dropout kernels require rocrand in -I at runtime)
+  hiprtcCompileRocmPath = symlinkJoin {
+    name = "miopen-hiprtc-compile-rocm-path";
+    paths = [
+      clr
+      rocrand
+    ];
+  };
 
   # Kernel databases moved from Git LFS to DVC (anonymous s3 bucket s3://therock-dvc/rocm-libraries)
   fetchKdb =
@@ -243,7 +253,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs test src/composable_kernel fin utils install_deps.cmake
 
     substituteInPlace src/comgr.cpp \
-      --replace-fail '"/opt/rocm"' '"${clr}"'
+      --replace-fail '"/opt/rocm"' '"${hiprtcCompileRocmPath}"'
   ''
   + linkKDBsTo "src/kernels"
   + ''

--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -285,7 +285,12 @@ stdenv.mkDerivation (finalAttrs: {
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru.impureTests = {
-    # bash $(nix-build -A rocmPackages.miopen.passthru.impureTests.conv)
+    # bash $(nix-build -A rocmPackages.miopen.passthru.impureTests.conv) etc
+    bnorm = callPackage ./test-runtime-compilation.nix {
+      miopen = finalAttrs.finalPackage;
+      name = "bnorm";
+      testScript = "MIOpenDriver bnorm -n 16 -c 16 -H 512 -W 512 -m 1 -F 1 -s 1 -r 1";
+    };
     conv = callPackage ./test-runtime-compilation.nix {
       miopen = finalAttrs.finalPackage;
       name = "conv";

--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -203,7 +203,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DAMDGPU_TARGETS=${lib.concatStringsSep ";" supportedTargets}"
     "-DGPU_TARGETS=${lib.concatStringsSep ";" supportedTargets}"
     "-DGPU_ARCHS=${lib.concatStringsSep ";" supportedTargets}"
-    "-DMIOPEN_USE_SQLITE_PERFDB=ON"
     "-DCMAKE_VERBOSE_MAKEFILE=ON"
     "-DCMAKE_MODULE_PATH=${clr}/hip/cmake"
     "-DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
Fixes #498893

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
