### PR TITLE
nixos/profiles/minimal/bootable: init

### DIFF
--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -81,8 +82,6 @@ in
 
     environment.sessionVariables.TZDIR = "/etc/zoneinfo";
 
-    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
-
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
@@ -106,6 +105,9 @@ in
         LOCAL
       '';
     };
+  }
+  // lib.optionalAttrs (options ? services.geoclue2) {
+    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
   };
 
 }

--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -81,8 +82,6 @@ in
 
     environment.sessionVariables.TZDIR = "/etc/zoneinfo";
 
-    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
-
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
@@ -102,6 +101,9 @@ in
         LOCAL
       '';
     };
+  }
+  // lib.optionalAttrs (options ? services.geoclue2) {
+    services.geoclue2.enable = lib.mkIf (lcfg.provider == "geoclue2") true;
   };
 
 }

--- a/nixos/modules/config/networking.nix
+++ b/nixos/modules/config/networking.nix
@@ -174,9 +174,11 @@ in
     # hostname and FQDN correctly:
     networking.hosts =
       let
+        hostName = cfg.hostName or config.system.nixos.distroId;
+        domain = cfg.domain or null;
         hostnames = # Note: The FQDN (canonical hostname) has to come first:
-          lib.optional (cfg.hostName != "" && cfg.domain != null) "${cfg.hostName}.${cfg.domain}"
-          ++ lib.optional (cfg.hostName != "") cfg.hostName; # Then the hostname (without the domain)
+          lib.optional (hostName != "" && domain != null) "${hostName}.${domain}"
+          ++ lib.optional (hostName != "") hostName; # Then the hostname (without the domain)
       in
       {
         "127.0.0.2" = hostnames;
@@ -190,7 +192,7 @@ in
         # FQDN so that e.g. "hostname -f" works correctly.
         localhostHosts = pkgs.writeText "localhost-hosts" ''
           127.0.0.1 localhost
-          ${lib.optionalString cfg.enableIPv6 "::1 localhost"}
+          ${lib.optionalString (cfg.enableIPv6 or true) "::1 localhost"}
         '';
         stringHosts =
           let

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -131,7 +131,7 @@
   config = {
     assertions = [
       {
-        assertion = config.system.nssModules.path != "" -> config.services.nscd.enable;
+        assertion = config.system.nssModules.path != "" -> (config.services.nscd.enable or false);
         message = ''
           Loading NSS modules from system.nssModules (${config.system.nssModules.path}),
           requires services.nscd.enable being set to true.

--- a/nixos/modules/config/resolvconf.nix
+++ b/nixos/modules/config/resolvconf.nix
@@ -21,7 +21,7 @@ let
     # variable with the same name exported by dhcpcd.
     interface_order='lo lo[0-9]*'
   ''
-  + lib.optionalString config.services.nscd.enable ''
+  + lib.optionalString (config.services.nscd.enable or false) ''
     # Invalidate the nscd cache whenever resolv.conf is
     # regenerated.
     libc_restart='/run/current-system/systemd/bin/systemctl try-restart --no-block nscd.service 2> /dev/null'

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -76,18 +77,19 @@
       export TERM=$TERM
     '';
 
-    security =
-      let
-        extraConfig = ''
+  }
+  // lib.optionalAttrs (options ? security.sudo.extraConfig) (
+    let
+      extraConfig = ''
 
-          # Keep terminfo database for root and %wheel.
-          Defaults:root,%wheel env_keep+=TERMINFO_DIRS
-          Defaults:root,%wheel env_keep+=TERMINFO
-        '';
-      in
-      lib.mkIf config.security.sudo.keepTerminfo {
-        sudo = { inherit extraConfig; };
-        sudo-rs = { inherit extraConfig; };
-      };
-  };
+        # Keep terminfo database for root and %wheel.
+        Defaults:root,%wheel env_keep+=TERMINFO_DIRS
+        Defaults:root,%wheel env_keep+=TERMINFO
+      '';
+    in
+    lib.mkIf config.security.sudo.keepTerminfo {
+      security.sudo = { inherit extraConfig; };
+      security.sudo-rs = { inherit extraConfig; };
+    }
+  );
 }

--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -27,66 +28,68 @@
     };
   };
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    # This should not contain packages that are broken or can't build, since it
-    # will break this expression
-    #
-    # can be generated with:
-    # lib.attrNames (lib.filterAttrs
-    #  (_: drv: (builtins.tryEval (lib.isDerivation drv && drv ? terminfo)).value)
-    #  pkgs)
-    environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (
-      map (x: x.terminfo) (
-        with pkgs.pkgsBuildBuild;
-        [
-          alacritty
-          contour
-          foot
-          ghostty
-          kitty
-          mtm
-          rio
-          rxvt-unicode-unwrapped
-          rxvt-unicode-unwrapped-emoji
-          st
-          tmux
-          wezterm
-          yaft
-        ]
-      )
-    );
+      # This should not contain packages that are broken or can't build, since it
+      # will break this expression
+      #
+      # can be generated with:
+      # lib.attrNames (lib.filterAttrs
+      #  (_: drv: (builtins.tryEval (lib.isDerivation drv && drv ? terminfo)).value)
+      #  pkgs)
+      environment.systemPackages = lib.mkIf config.environment.enableAllTerminfo (
+        map (x: x.terminfo) (
+          with pkgs.pkgsBuildBuild;
+          [
+            alacritty
+            contour
+            foot
+            ghostty
+            kitty
+            mtm
+            rio
+            rxvt-unicode-unwrapped
+            rxvt-unicode-unwrapped-emoji
+            st
+            tmux
+            wezterm
+            yaft
+          ]
+        )
+      );
 
-    environment.pathsToLink = [
-      "/share/terminfo"
-    ];
+      environment.pathsToLink = [
+        "/share/terminfo"
+      ];
 
-    environment.etc.terminfo = {
-      source = "${config.system.path}/share/terminfo";
-    };
+      environment.etc.terminfo = {
+        source = "${config.system.path}/share/terminfo";
+      };
 
-    boot.initrd.systemd.contents = lib.listToAttrs (
-      lib.map
-        (ti: lib.nameValuePair "/etc/terminfo/${ti}" { source = "${pkgs.ncurses}/share/terminfo/${ti}"; })
-        [
-          "l/linux"
-          "v/vt100"
-          "v/vt102"
-          "v/vt220"
-        ]
-    );
+      boot.initrd.systemd.contents = lib.listToAttrs (
+        lib.map
+          (ti: lib.nameValuePair "/etc/terminfo/${ti}" { source = "${pkgs.ncurses}/share/terminfo/${ti}"; })
+          [
+            "l/linux"
+            "v/vt100"
+            "v/vt102"
+            "v/vt220"
+          ]
+      );
 
-    environment.profileRelativeSessionVariables = {
-      TERMINFO_DIRS = [ "/share/terminfo" ];
-    };
+      environment.profileRelativeSessionVariables = {
+        TERMINFO_DIRS = [ "/share/terminfo" ];
+      };
 
-    environment.extraInit = ''
+      environment.extraInit = ''
 
-      # reset TERM with new TERMINFO available (if any)
-      export TERM=$TERM
-    '';
+        # reset TERM with new TERMINFO available (if any)
+        export TERM=$TERM
+      '';
 
-    security =
+    }
+    (lib.optionalAttrs (options ? security.sudo.extraConfig) (
       let
         extraConfig = ''
 
@@ -96,8 +99,9 @@
         '';
       in
       lib.mkIf config.security.sudo.keepTerminfo {
-        sudo = { inherit extraConfig; };
-        sudo-rs = { inherit extraConfig; };
-      };
-  };
+        security.sudo = { inherit extraConfig; };
+        security.sudo-rs = { inherit extraConfig; };
+      }
+    ))
+  ];
 }

--- a/nixos/modules/profiles/minimal/bootable.nix
+++ b/nixos/modules/profiles/minimal/bootable.nix
@@ -1,0 +1,107 @@
+/*
+  A minimal set of NixOS modules that produces a bootable system.
+
+  This is meant to be used with `lib.nixos.evalModules` (the minimal
+  entrypoint that loads zero modules by default). It includes only what
+  is needed for: kernel, systemd initrd, systemd stage 2, a login
+  getty, and basic networking via systemd-networkd.
+
+  Notably absent: nix daemon, bootloader (use UKI or external), X11,
+  NetworkManager, firewall, containers, and ~1500 other modules from
+  the full `module-list.nix`.
+
+  Usage:
+
+    let
+      nixosLib = import (nixpkgs + "/nixos/lib") {
+        lib = import (nixpkgs + "/lib");
+        featureFlags.minimalModules = {};
+      };
+    in
+    nixosLib.evalModules {
+      modules = [
+        (nixpkgs + "/nixos/modules/profiles/minimal/bootable.nix")
+        {
+          nixpkgs.hostPlatform = "x86_64-linux";
+          fileSystems."/".device = "/dev/disk/by-label/nixos";
+          fileSystems."/".fsType = "ext4";
+        }
+      ];
+    }
+
+  See also: nixos/tests/minimal-bootable.nix
+*/
+{ lib, modulesPath, ... }:
+{
+
+  imports = [
+    # Module system plumbing
+    (modulesPath + "/misc/nixpkgs.nix")
+    (modulesPath + "/misc/assertions.nix")
+    (modulesPath + "/misc/lib.nix")
+    (modulesPath + "/misc/ids.nix")
+    (modulesPath + "/misc/extra-arguments.nix")
+    (modulesPath + "/misc/meta.nix")
+    (modulesPath + "/misc/version.nix")
+    (modulesPath + "/misc/passthru.nix")
+
+    # Activation & toplevel
+    (modulesPath + "/system/activation/nixos-init.nix")
+    (modulesPath + "/system/activation/pre-switch-check.nix")
+    (modulesPath + "/system/activation/top-level.nix")
+    (modulesPath + "/system/activation/activation-script.nix")
+    (modulesPath + "/system/activation/activatable-system.nix")
+    (modulesPath + "/system/activation/bootspec.nix")
+    (modulesPath + "/system/activation/specialisation.nix")
+
+    # Boot chain (kernel → systemd initrd → stage 2 → systemd)
+    (modulesPath + "/system/boot/kernel.nix")
+    (modulesPath + "/system/boot/modprobe.nix")
+    (modulesPath + "/system/boot/stage-1.nix")
+    (modulesPath + "/system/boot/stage-2.nix")
+    (modulesPath + "/system/boot/systemd.nix")
+    (modulesPath + "/system/boot/systemd/tmpfiles.nix")
+    (modulesPath + "/system/boot/systemd/journald.nix")
+    (modulesPath + "/system/boot/systemd/logind.nix")
+    (modulesPath + "/system/boot/systemd/user.nix")
+    (modulesPath + "/system/boot/systemd/initrd.nix")
+    (modulesPath + "/system/boot/systemd/sysusers.nix")
+
+    # UKI + EFI (no bootloader)
+    (modulesPath + "/system/boot/uki.nix")
+    (modulesPath + "/system/boot/loader/loader.nix")
+    (modulesPath + "/system/boot/loader/efi.nix")
+
+    # /etc, environment, programs
+    (modulesPath + "/system/etc/etc-activation.nix")
+    (modulesPath + "/config/shells-environment.nix")
+    (modulesPath + "/config/system-environment.nix")
+    (modulesPath + "/config/system-path.nix")
+    (modulesPath + "/config/locale.nix")
+    (modulesPath + "/config/i18n.nix")
+    (modulesPath + "/config/console.nix")
+    (modulesPath + "/config/terminfo.nix")
+    (modulesPath + "/config/sysctl.nix")
+    (modulesPath + "/config/nsswitch.nix")
+    (modulesPath + "/programs/environment.nix")
+    (modulesPath + "/programs/bash/bash.nix")
+    (modulesPath + "/programs/shadow.nix")
+
+    # Users & security
+    (modulesPath + "/config/users-groups.nix")
+    (modulesPath + "/security/pam.nix")
+    (modulesPath + "/security/wrappers/default.nix")
+
+    # Hardware & filesystems
+    (modulesPath + "/services/hardware/udev.nix")
+    (modulesPath + "/tasks/filesystems.nix")
+    (modulesPath + "/tasks/filesystems/ext.nix")
+    (modulesPath + "/tasks/filesystems/vfat.nix")
+
+    # Services
+    (modulesPath + "/services/ttys/getty.nix")
+    (modulesPath + "/services/system/userborn.nix")
+    (modulesPath + "/services/system/nscd.nix")
+    (modulesPath + "/services/system/dbus.nix")
+  ];
+}

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -223,7 +223,7 @@ in
 
     users.defaultUserShell = lib.mkDefault pkgs.bashInteractive;
 
-    environment.pathsToLink = lib.optionals cfg.completion.enable [
+    environment.pathsToLink = lib.optionals (cfg.completion.enable or false) [
       "/etc/bash_completion.d"
       "/share/bash-completion"
     ];

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -2,7 +2,12 @@
 
 # Most of the stuff here should probably be moved elsewhere sometime.
 
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
 
@@ -16,14 +21,8 @@ in
 
     environment.variables = {
       NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-      # note: many programs exec() this directly, so default options for less must not
-      # be specified here; do so in the default value of programs.less.envVariables instead
-      PAGER = lib.mkDefault "less";
       EDITOR = lib.mkDefault "nano";
     };
-
-    # since we set PAGER to this above, make sure it's installed
-    programs.less.enable = true;
 
     environment.profiles = lib.mkAfter [
       "/nix/var/nix/profiles/default"
@@ -63,6 +62,14 @@ in
       export NIX_PROFILES="${builtins.concatStringsSep " " (lib.reverseList cfg.profiles)}"
     '';
 
+  }
+  // lib.optionalAttrs (options ? programs.less) {
+    # note: many programs exec() this directly, so default options for
+    # less must not be specified here; do so in the default value of
+    # programs.less.envVariables instead.
+    environment.variables.PAGER = lib.mkDefault "less";
+    # Make sure less is installed since we default PAGER to it.
+    programs.less.enable = true;
   };
 
 }

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -2,7 +2,12 @@
 
 # Most of the stuff here should probably be moved elsewhere sometime.
 
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
 
@@ -12,57 +17,61 @@ in
 
 {
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    environment.variables = {
-      NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
-      # note: many programs exec() this directly, so default options for less must not
-      # be specified here; do so in the default value of programs.less.envVariables instead
-      PAGER = lib.mkDefault "less";
-      EDITOR = lib.mkDefault "nano";
-    };
+      environment.variables = {
+        NIXPKGS_CONFIG = "/etc/nix/nixpkgs-config.nix";
+        EDITOR = lib.mkDefault "nano";
+      };
 
-    # since we set PAGER to this above, make sure it's installed
-    programs.less.enable = true;
-
-    environment.profiles = lib.mkAfter [
-      "/nix/var/nix/profiles/default"
-      "/run/current-system/sw"
-    ];
-
-    environment.sessionVariables = {
-      XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
-    };
-
-    # TODO: move most of these elsewhere
-    environment.profileRelativeSessionVariables = {
-      PATH = [ "/bin" ];
-      INFOPATH = [
-        "/info"
-        "/share/info"
+      environment.profiles = lib.mkAfter [
+        "/nix/var/nix/profiles/default"
+        "/run/current-system/sw"
       ];
-      QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
-      GTK_PATH = [
+
+      environment.sessionVariables = {
+        XDG_CONFIG_DIRS = [ "/etc/xdg" ]; # needs to be before profile-relative paths to allow changes through environment.etc
+      };
+
+      # TODO: move most of these elsewhere
+      environment.profileRelativeSessionVariables = {
+        PATH = [ "/bin" ];
+        INFOPATH = [
+          "/info"
+          "/share/info"
+        ];
+        QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
+        GTK_PATH = [
+          "/lib/gtk-2.0"
+          "/lib/gtk-3.0"
+          "/lib/gtk-4.0"
+        ];
+        XDG_CONFIG_DIRS = [ "/etc/xdg" ];
+        XDG_DATA_DIRS = [ "/share" ];
+        LIBEXEC_PATH = [ "/libexec" ];
+      };
+
+      environment.pathsToLink = [
         "/lib/gtk-2.0"
         "/lib/gtk-3.0"
         "/lib/gtk-4.0"
       ];
-      XDG_CONFIG_DIRS = [ "/etc/xdg" ];
-      XDG_DATA_DIRS = [ "/share" ];
-      LIBEXEC_PATH = [ "/libexec" ];
-    };
 
-    environment.pathsToLink = [
-      "/lib/gtk-2.0"
-      "/lib/gtk-3.0"
-      "/lib/gtk-4.0"
-    ];
+      environment.extraInit = ''
+        export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
+        export NIX_PROFILES="${builtins.concatStringsSep " " (lib.reverseList cfg.profiles)}"
+      '';
 
-    environment.extraInit = ''
-      export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
-      export NIX_PROFILES="${builtins.concatStringsSep " " (lib.reverseList cfg.profiles)}"
-    '';
-
-  };
+    }
+    (lib.optionalAttrs (options ? programs.less) {
+      # note: many programs exec() this directly, so default options for
+      # less must not be specified here; do so in the default value of
+      # programs.less.envVariables instead.
+      environment.variables.PAGER = lib.mkDefault "less";
+      # Make sure less is installed since we default PAGER to it.
+      programs.less.enable = true;
+    })
+  ];
 
 }

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -45,7 +45,7 @@ in
 
       enableAskPassword = lib.mkOption {
         type = lib.types.bool;
-        default = config.services.xserver.enable;
+        default = config.services.xserver.enable or false;
         defaultText = lib.literalExpression "config.services.xserver.enable";
         description = "Whether to configure SSH_ASKPASS in the environment.";
       };
@@ -315,9 +315,9 @@ in
   config = {
 
     programs.ssh.setXAuthLocation = lib.mkDefault (
-      config.services.xserver.enable
+      (config.services.xserver.enable or false)
       || config.programs.ssh.forwardX11 == true
-      || config.services.openssh.settings.X11Forwarding
+      || (config.services.openssh.settings.X11Forwarding or false)
     );
 
     assertions = [

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2,6 +2,7 @@
 # Authentication Modules) system.
 {
   config,
+  options,
   lib,
   pkgs,
   ...
@@ -303,8 +304,8 @@ let
         };
 
         mysqlAuth = lib.mkOption {
-          default = config.users.mysql.enable;
-          defaultText = lib.literalExpression "config.users.mysql.enable";
+          default = config.users.mysql.enable or false;
+          defaultText = lib.literalExpression "config.users.mysql.enable or false";
           type = lib.types.bool;
           description = ''
             If set, the `pam_mysql` module will be used to
@@ -313,8 +314,8 @@ let
         };
 
         fprintAuth = lib.mkOption {
-          default = config.services.fprintd.enable;
-          defaultText = lib.literalExpression "config.services.fprintd.enable";
+          default = config.services.fprintd.enable or false;
+          defaultText = lib.literalExpression "config.services.fprintd.enable or false";
           type = lib.types.bool;
           description = ''
             If set, fingerprint reader will be used (if exists and
@@ -345,8 +346,8 @@ let
         };
 
         oathAuth = lib.mkOption {
-          default = config.security.pam.oath.enable;
-          defaultText = lib.literalExpression "config.security.pam.oath.enable";
+          default = config.security.pam.oath.enable or false;
+          defaultText = lib.literalExpression "config.security.pam.oath.enable or false";
           type = lib.types.bool;
           description = ''
             If set, the OATH Toolkit will be used.
@@ -472,8 +473,8 @@ let
         };
 
         pamMount = lib.mkOption {
-          default = config.security.pam.mount.enable;
-          defaultText = lib.literalExpression "config.security.pam.mount.enable";
+          default = config.security.pam.mount.enable or false;
+          defaultText = lib.literalExpression "config.security.pam.mount.enable or false";
           type = lib.types.bool;
           description = ''
             Enable PAM mount (pam_mount) system to mount filesystems on user login.
@@ -903,7 +904,7 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.unix.enable;
+                enable = config.services.kanidm.unix.enable or false;
                 control = "sufficient";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
                 settings = {
@@ -912,7 +913,7 @@ let
               }
               {
                 name = "sss";
-                enable = config.services.sssd.enable;
+                enable = config.services.sssd.enable or false;
                 control =
                   if cfg.sssdStrictAccess then "[default=bad success=ok user_unknown=ignore]" else "sufficient";
                 modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
@@ -937,7 +938,7 @@ let
               }
               {
                 name = "systemd_home";
-                enable = config.services.homed.enable;
+                enable = config.services.homed.enable or false;
                 control = "sufficient";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
@@ -1070,7 +1071,12 @@ let
                 )
                 (
                   let
-                    oath = config.security.pam.oath;
+                    oath =
+                      config.security.pam.oath or {
+                        window = 5;
+                        digits = 6;
+                        usersFile = "/etc/users.oath";
+                      };
                   in
                   {
                     name = "oath";
@@ -1137,13 +1143,13 @@ let
                 # The same principle applies to systemd-homed
                 (lib.optionals
                   (
-                    (cfg.unixAuth || config.services.homed.enable)
+                    (cfg.unixAuth || (config.services.homed.enable or false))
                     && (
                       config.security.pam.enableFscrypt
                       || cfg.pamMount
                       || cfg.kwallet.enable
                       || cfg.enableGnomeKeyring
-                      || config.services.intune.enable
+                      || config.services.intune.enable or false
                       || cfg.googleAuthenticator.enable
                       || cfg.gnupg.enable
                       || cfg.failDelay.enable
@@ -1154,7 +1160,7 @@ let
                   [
                     {
                       name = "systemd_home-early";
-                      enable = config.services.homed.enable;
+                      enable = config.services.homed.enable or false;
                       control = "optional";
                       modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
                     }
@@ -1208,7 +1214,7 @@ let
                     }
                     {
                       name = "intune";
-                      enable = config.services.intune.enable;
+                      enable = config.services.intune.enable or false;
                       control = "optional";
                       modulePath = "${pkgs.intune-portal}/lib/security/pam_intune.so";
                     }
@@ -1252,7 +1258,7 @@ let
               ++ [
                 {
                   name = "systemd_home";
-                  enable = config.services.homed.enable;
+                  enable = config.services.homed.enable or false;
                   control = "sufficient";
                   modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
                 }
@@ -1285,7 +1291,7 @@ let
                 }
                 {
                   name = "kanidm";
-                  enable = config.services.kanidm.unix.enable;
+                  enable = config.services.kanidm.unix.enable or false;
                   control = "sufficient";
                   modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
                   settings = {
@@ -1295,7 +1301,7 @@ let
                 }
                 {
                   name = "sss";
-                  enable = config.services.sssd.enable;
+                  enable = config.services.sssd.enable or false;
                   control = "sufficient";
                   modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
                   settings = {
@@ -1342,7 +1348,7 @@ let
             password = autoOrderRules [
               {
                 name = "systemd_home";
-                enable = config.services.homed.enable;
+                enable = config.services.homed.enable or false;
                 control = "sufficient";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
@@ -1394,13 +1400,13 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.unix.enable;
+                enable = config.services.kanidm.unix.enable or false;
                 control = "sufficient";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
               }
               {
                 name = "sss";
-                enable = config.services.sssd.enable;
+                enable = config.services.sssd.enable or false;
                 control = "sufficient";
                 modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
               }
@@ -1443,7 +1449,7 @@ let
               {
                 name = "loginuid";
                 enable = cfg.setLoginUid;
-                control = if config.boot.isContainer then "optional" else "required";
+                control = if (config.boot.isContainer or false) then "optional" else "required";
                 modulePath = "${package}/lib/security/pam_loginuid.so";
               }
               {
@@ -1465,7 +1471,7 @@ let
               }
               {
                 name = "systemd_home";
-                enable = config.services.homed.enable;
+                enable = config.services.homed.enable or false;
                 control = "required";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
@@ -1558,13 +1564,13 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.unix.enable;
+                enable = config.services.kanidm.unix.enable or false;
                 control = "optional";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
               }
               {
                 name = "sss";
-                enable = config.services.sssd.enable;
+                enable = config.services.sssd.enable or false;
                 control = "optional";
                 modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
               }
@@ -1616,7 +1622,7 @@ let
               }
               {
                 name = "apparmor";
-                enable = cfg.enableAppArmor && config.security.apparmor.enable;
+                enable = cfg.enableAppArmor && (config.security.apparmor.enable or false);
                 control = "optional";
                 modulePath = "${pkgs.apparmor-pam}/lib/security/pam_apparmor.so";
                 settings = {
@@ -1651,7 +1657,7 @@ let
               }
               {
                 name = "intune";
-                enable = config.services.intune.enable;
+                enable = config.services.intune.enable or false;
                 control = "optional";
                 modulePath = "${pkgs.intune-portal}/lib/security/pam_intune.so";
               }
@@ -1663,8 +1669,8 @@ let
 
   inherit (pkgs) pam_krb5 pam_ccreds;
 
-  use_ldap = (config.users.ldap.enable && config.users.ldap.loginPam);
-  pam_ldap = if config.users.ldap.daemon.enable then pkgs.nss_pam_ldapd else pkgs.pam_ldap;
+  use_ldap = ((config.users.ldap.enable or false) && (config.users.ldap.loginPam or false));
+  pam_ldap = if (config.users.ldap.daemon.enable or false) then pkgs.nss_pam_ldapd else pkgs.pam_ldap;
 
   # Create a limits.conf(5) file.
   makeLimitsConf =
@@ -1973,8 +1979,8 @@ in
 
     security.pam.howdy = {
       enable = lib.mkOption {
-        default = config.services.howdy.enable;
-        defaultText = lib.literalExpression "config.services.howdy.enable";
+        default = config.services.howdy.enable or false;
+        defaultText = lib.literalExpression "config.services.howdy.enable or false";
         type = lib.types.bool;
         description = ''
           Whether to enable the Howdy PAM module.
@@ -1984,8 +1990,8 @@ in
         '';
       };
       control = lib.mkOption {
-        default = config.services.howdy.control;
-        defaultText = lib.literalExpression "config.services.howdy.control";
+        default = config.services.howdy.control or "sufficient";
+        defaultText = lib.literalExpression ''config.services.howdy.control or "sufficient"'';
         type = lib.types.str;
         description = ''
           This option sets the PAM "control" used for this module.
@@ -1995,8 +2001,8 @@ in
 
     security.pam.krb5 = {
       enable = lib.mkOption {
-        default = config.security.krb5.enable;
-        defaultText = lib.literalExpression "config.security.krb5.enable";
+        default = config.security.krb5.enable or false;
+        defaultText = lib.literalExpression "config.security.krb5.enable or false";
         type = lib.types.bool;
         description = ''
           Enables Kerberos PAM modules (`pam-krb5`,
@@ -2484,15 +2490,15 @@ in
     environment.systemPackages =
       # Include the PAM modules in the system path mostly for the manpages.
       [ package ]
-      ++ lib.optional config.users.ldap.enable pam_ldap
-      ++ lib.optional config.services.kanidm.unix.enable config.services.kanidm.package
-      ++ lib.optional config.services.sssd.enable pkgs.sssd
+      ++ lib.optional (config.users.ldap.enable or false) pam_ldap
+      ++ lib.optional (config.services.kanidm.unix.enable or false) config.services.kanidm.package
+      ++ lib.optional (config.services.sssd.enable or false) pkgs.sssd
       ++ lib.optionals config.security.pam.krb5.enable [
         pam_krb5
         pam_ccreds
       ]
       ++ lib.optionals config.security.pam.enableOTPW [ pkgs.otpw ]
-      ++ lib.optionals config.security.pam.oath.enable [ pkgs.oath-toolkit ]
+      ++ lib.optionals (config.security.pam.oath.enable or false) [ pkgs.oath-toolkit ]
       ++ lib.optionals config.security.pam.p11.enable [ pkgs.pam_p11 ]
       ++ lib.optionals config.security.pam.enableFscrypt [ pkgs.fscrypt-experimental ]
       ++ lib.optionals config.security.pam.u2f.enable [ pkgs.pam_u2f ];
@@ -2543,11 +2549,11 @@ in
       '';
 
       # Most of these should be moved to specific modules.
-      i3lock.enable = lib.mkDefault config.programs.i3lock.enable;
-      i3lock-color.enable = lib.mkDefault config.programs.i3lock.enable;
-      vlock.enable = lib.mkDefault config.console.enable;
-      xlock.enable = lib.mkDefault config.services.xserver.enable;
-      xscreensaver.enable = lib.mkDefault config.services.xscreensaver.enable;
+      i3lock.enable = lib.mkDefault (config.programs.i3lock.enable or false);
+      i3lock-color.enable = lib.mkDefault (config.programs.i3lock.enable or false);
+      vlock.enable = lib.mkDefault (config.console.enable or false);
+      xlock.enable = lib.mkDefault (config.services.xserver.enable or false);
+      xscreensaver.enable = lib.mkDefault (config.services.xscreensaver.enable or false);
 
       runuser = {
         rootOK = true;
@@ -2570,6 +2576,8 @@ in
       fscrypt = { };
     };
 
+  }
+  // lib.optionalAttrs (options ? security.apparmor.includes) {
     security.apparmor.includes."abstractions/pam" =
       lib.concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
         lib.attrNames enabledServices
@@ -2594,8 +2602,11 @@ in
           concatLines
         ]
       );
-
+  }
+  // lib.optionalAttrs (options ? security.sudo.extraConfig) {
     security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;
+  }
+  // lib.optionalAttrs (options ? security.sudo-rs.extraConfig) {
     security.sudo-rs.extraConfig = optionalSudoConfigForSSHAgentAuth;
   };
 }

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2,6 +2,7 @@
 # Authentication Modules) system.
 {
   config,
+  options,
   lib,
   utils,
   pkgs,
@@ -365,8 +366,8 @@ let
         };
 
         mysqlAuth = lib.mkOption {
-          default = config.users.mysql.enable;
-          defaultText = lib.literalExpression "config.users.mysql.enable";
+          default = config.users.mysql.enable or false;
+          defaultText = lib.literalExpression "config.users.mysql.enable or false";
           type = lib.types.bool;
           description = ''
             If set, the `pam_mysql` module will be used to
@@ -375,8 +376,8 @@ let
         };
 
         fprintAuth = lib.mkOption {
-          default = config.services.fprintd.enable;
-          defaultText = lib.literalExpression "config.services.fprintd.enable";
+          default = config.services.fprintd.enable or false;
+          defaultText = lib.literalExpression "config.services.fprintd.enable or false";
           type = lib.types.bool;
           description = ''
             If set, fingerprint reader will be used (if exists and
@@ -407,8 +408,8 @@ let
         };
 
         oathAuth = lib.mkOption {
-          default = config.security.pam.oath.enable;
-          defaultText = lib.literalExpression "config.security.pam.oath.enable";
+          default = config.security.pam.oath.enable or false;
+          defaultText = lib.literalExpression "config.security.pam.oath.enable or false";
           type = lib.types.bool;
           description = ''
             If set, the OATH Toolkit will be used.
@@ -534,8 +535,8 @@ let
         };
 
         pamMount = lib.mkOption {
-          default = config.security.pam.mount.enable;
-          defaultText = lib.literalExpression "config.security.pam.mount.enable";
+          default = config.security.pam.mount.enable or false;
+          defaultText = lib.literalExpression "config.security.pam.mount.enable or false";
           type = lib.types.bool;
           description = ''
             Enable PAM mount (pam_mount) system to mount filesystems on user login.
@@ -966,7 +967,7 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.unix.enable;
+                enable = config.services.kanidm.unix.enable or false;
                 control = "sufficient";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
                 settings = {
@@ -975,7 +976,7 @@ let
               }
               {
                 name = "sss";
-                enable = config.services.sssd.enable;
+                enable = config.services.sssd.enable or false;
                 control =
                   if cfg.sssdStrictAccess then "[default=bad success=ok user_unknown=ignore]" else "sufficient";
                 modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
@@ -1000,7 +1001,7 @@ let
               }
               {
                 name = "systemd_home";
-                enable = config.services.homed.enable;
+                enable = config.services.homed.enable or false;
                 control = "sufficient";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
@@ -1133,7 +1134,12 @@ let
                 )
                 (
                   let
-                    oath = config.security.pam.oath;
+                    oath =
+                      config.security.pam.oath or {
+                        window = 5;
+                        digits = 6;
+                        usersFile = "/etc/users.oath";
+                      };
                   in
                   {
                     name = "oath";
@@ -1200,14 +1206,14 @@ let
                 # The same principle applies to systemd-homed
                 (lib.optionals
                   (
-                    (cfg.unixAuth || config.services.homed.enable)
+                    (cfg.unixAuth || (config.services.homed.enable or false))
                     && (
                       config.security.pam.enableFscrypt
                       || cfg.pamMount
                       || cfg.kwallet.enable
                       || cfg.enableGnomeKeyring
                       || cfg.oo7.enable
-                      || config.services.intune.enable
+                      || config.services.intune.enable or false
                       || cfg.googleAuthenticator.enable
                       || cfg.gnupg.enable
                       || cfg.failDelay.enable
@@ -1218,7 +1224,7 @@ let
                   [
                     {
                       name = "systemd_home-early";
-                      enable = config.services.homed.enable;
+                      enable = config.services.homed.enable or false;
                       control = "optional";
                       modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
                     }
@@ -1278,7 +1284,7 @@ let
                     }
                     {
                       name = "intune";
-                      enable = config.services.intune.enable;
+                      enable = config.services.intune.enable or false;
                       control = "optional";
                       modulePath = "${pkgs.intune-portal}/lib/security/pam_intune.so";
                     }
@@ -1322,7 +1328,7 @@ let
               ++ [
                 {
                   name = "systemd_home";
-                  enable = config.services.homed.enable;
+                  enable = config.services.homed.enable or false;
                   control = "sufficient";
                   modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
                 }
@@ -1355,7 +1361,7 @@ let
                 }
                 {
                   name = "kanidm";
-                  enable = config.services.kanidm.unix.enable;
+                  enable = config.services.kanidm.unix.enable or false;
                   control = "sufficient";
                   modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
                   settings = {
@@ -1365,7 +1371,7 @@ let
                 }
                 {
                   name = "sss";
-                  enable = config.services.sssd.enable;
+                  enable = config.services.sssd.enable or false;
                   control = "sufficient";
                   modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
                   settings = {
@@ -1412,7 +1418,7 @@ let
             password = utils.pam.autoOrderRules [
               {
                 name = "systemd_home";
-                enable = config.services.homed.enable;
+                enable = config.services.homed.enable or false;
                 control = "sufficient";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
@@ -1464,13 +1470,13 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.unix.enable;
+                enable = config.services.kanidm.unix.enable or false;
                 control = "sufficient";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
               }
               {
                 name = "sss";
-                enable = config.services.sssd.enable;
+                enable = config.services.sssd.enable or false;
                 control = "sufficient";
                 modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
               }
@@ -1519,7 +1525,7 @@ let
               {
                 name = "loginuid";
                 enable = cfg.setLoginUid;
-                control = if config.boot.isContainer then "optional" else "required";
+                control = if (config.boot.isContainer or false) then "optional" else "required";
                 modulePath = "${package}/lib/security/pam_loginuid.so";
               }
               {
@@ -1541,7 +1547,7 @@ let
               }
               {
                 name = "systemd_home";
-                enable = config.services.homed.enable;
+                enable = config.services.homed.enable or false;
                 control = "required";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
@@ -1634,13 +1640,13 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.unix.enable;
+                enable = config.services.kanidm.unix.enable or false;
                 control = "optional";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
               }
               {
                 name = "sss";
-                enable = config.services.sssd.enable;
+                enable = config.services.sssd.enable or false;
                 control = "optional";
                 modulePath = "${pkgs.sssd}/lib/security/pam_sss.so";
               }
@@ -1692,7 +1698,7 @@ let
               }
               {
                 name = "apparmor";
-                enable = cfg.enableAppArmor && config.security.apparmor.enable;
+                enable = cfg.enableAppArmor && (config.security.apparmor.enable or false);
                 control = "optional";
                 modulePath = "${pkgs.apparmor-pam}/lib/security/pam_apparmor.so";
                 settings = {
@@ -1736,7 +1742,7 @@ let
               }
               {
                 name = "intune";
-                enable = config.services.intune.enable;
+                enable = config.services.intune.enable or false;
                 control = "optional";
                 modulePath = "${pkgs.intune-portal}/lib/security/pam_intune.so";
               }
@@ -1749,8 +1755,8 @@ let
 
   inherit (pkgs) pam_krb5 pam_ccreds;
 
-  use_ldap = (config.users.ldap.enable && config.users.ldap.loginPam);
-  pam_ldap = if config.users.ldap.daemon.enable then pkgs.nss_pam_ldapd else pkgs.pam_ldap;
+  use_ldap = ((config.users.ldap.enable or false) && (config.users.ldap.loginPam or false));
+  pam_ldap = if (config.users.ldap.daemon.enable or false) then pkgs.nss_pam_ldapd else pkgs.pam_ldap;
 
   # Create a limits.conf(5) file.
   makeLimitsConf =
@@ -2091,8 +2097,8 @@ in
 
     security.pam.howdy = {
       enable = lib.mkOption {
-        default = config.services.howdy.enable;
-        defaultText = lib.literalExpression "config.services.howdy.enable";
+        default = config.services.howdy.enable or false;
+        defaultText = lib.literalExpression "config.services.howdy.enable or false";
         type = lib.types.bool;
         description = ''
           Whether to enable the Howdy PAM module.
@@ -2102,8 +2108,8 @@ in
         '';
       };
       control = lib.mkOption {
-        default = config.services.howdy.control;
-        defaultText = lib.literalExpression "config.services.howdy.control";
+        default = config.services.howdy.control or "sufficient";
+        defaultText = lib.literalExpression ''config.services.howdy.control or "sufficient"'';
         type = lib.types.str;
         description = ''
           This option sets the PAM "control" used for this module.
@@ -2113,8 +2119,8 @@ in
 
     security.pam.krb5 = {
       enable = lib.mkOption {
-        default = config.security.krb5.enable;
-        defaultText = lib.literalExpression "config.security.krb5.enable";
+        default = config.security.krb5.enable or false;
+        defaultText = lib.literalExpression "config.security.krb5.enable or false";
         type = lib.types.bool;
         description = ''
           Enables Kerberos PAM modules (`pam-krb5`,
@@ -2565,194 +2571,203 @@ in
 
   ###### implementation
 
-  config = lib.mkIf config.security.pam.enable {
-    assertions = [
+  config = lib.mkIf config.security.pam.enable (
+    lib.mkMerge [
       {
-        assertion = config.users.motd == "" || config.users.motdFile == null;
-        message = ''
-          Only one of users.motd and users.motdFile can be set.
-        '';
-      }
-      {
-        assertion = config.security.pam.zfs.enable -> config.boot.zfs.enabled;
-        message = ''
-          `security.pam.zfs.enable` requires enabling ZFS (`boot.zfs.enabled`).
-        '';
-      }
-      {
-        assertion = with config.security.pam.sshAgentAuth; enable -> authorizedKeysFiles != [ ];
-        message = ''
-          `security.pam.enableSSHAgentAuth` requires `services.openssh.authorizedKeysFiles` to be a non-empty list.
-          Did you forget to set `services.openssh.enable` ?
-        '';
-      }
-      {
-        assertion =
-          with config.security.pam.rssh;
-          enable
-          -> (settings.auth_key_file or null != null || settings.authorized_keys_command or null != null);
-        message = ''
-          security.pam.rssh.enable requires either security.pam.rssh.settings.auth_key_file or
-          security.pam.rssh.settings.authorized_keys_command to be set.
-        '';
-      }
-    ];
+        assertions = [
+          {
+            assertion = config.users.motd == "" || config.users.motdFile == null;
+            message = ''
+              Only one of users.motd and users.motdFile can be set.
+            '';
+          }
+          {
+            assertion = config.security.pam.zfs.enable -> config.boot.zfs.enabled;
+            message = ''
+              `security.pam.zfs.enable` requires enabling ZFS (`boot.zfs.enabled`).
+            '';
+          }
+          {
+            assertion = with config.security.pam.sshAgentAuth; enable -> authorizedKeysFiles != [ ];
+            message = ''
+              `security.pam.enableSSHAgentAuth` requires `services.openssh.authorizedKeysFiles` to be a non-empty list.
+              Did you forget to set `services.openssh.enable` ?
+            '';
+          }
+          {
+            assertion =
+              with config.security.pam.rssh;
+              enable
+              -> (settings.auth_key_file or null != null || settings.authorized_keys_command or null != null);
+            message = ''
+              security.pam.rssh.enable requires either security.pam.rssh.settings.auth_key_file or
+              security.pam.rssh.settings.authorized_keys_command to be set.
+            '';
+          }
+        ];
 
-    warnings =
-      lib.optional
-        (
-          with config.security.pam.sshAgentAuth;
-          enable && lib.any (s: lib.hasPrefix "%h" s || lib.hasPrefix "~" s) authorizedKeysFiles
-        )
-        ''
-          security.pam.sshAgentAuth.authorizedKeysFiles contains files in the user's home directory.
+        warnings =
+          lib.optional
+            (
+              with config.security.pam.sshAgentAuth;
+              enable && lib.any (s: lib.hasPrefix "%h" s || lib.hasPrefix "~" s) authorizedKeysFiles
+            )
+            ''
+              security.pam.sshAgentAuth.authorizedKeysFiles contains files in the user's home directory.
 
-          Specifying user-writeable files there result in an insecure configuration:
-          a malicious process can then edit such an authorized_keys file and bypass the ssh-agent-based authentication.
-          See https://github.com/NixOS/nixpkgs/issues/31611
-        ''
-      ++
-        lib.optional
-          (
-            with config.security.pam.rssh;
-            enable && settings.auth_key_file or null != null && settings.authorized_keys_command or null != null
-          )
-          ''
-            security.pam.rssh.settings.auth_key_file will be ignored as
-            security.pam.rssh.settings.authorized_keys_command has been specified.
-            Explictly set the former to null to silence this warning.
-          '';
+              Specifying user-writeable files there result in an insecure configuration:
+              a malicious process can then edit such an authorized_keys file and bypass the ssh-agent-based authentication.
+              See https://github.com/NixOS/nixpkgs/issues/31611
+            ''
+          ++
+            lib.optional
+              (
+                with config.security.pam.rssh;
+                enable && settings.auth_key_file or null != null && settings.authorized_keys_command or null != null
+              )
+              ''
+                security.pam.rssh.settings.auth_key_file will be ignored as
+                security.pam.rssh.settings.authorized_keys_command has been specified.
+                Explictly set the former to null to silence this warning.
+              '';
 
-    environment.systemPackages =
-      # Include the PAM modules in the system path mostly for the manpages.
-      [ package ]
-      ++ lib.optional config.users.ldap.enable pam_ldap
-      ++ lib.optional config.services.kanidm.unix.enable config.services.kanidm.package
-      ++ lib.optional config.services.sssd.enable pkgs.sssd
-      ++ lib.optionals config.security.pam.krb5.enable [
-        pam_krb5
-        pam_ccreds
-      ]
-      ++ lib.optionals config.security.pam.enableOTPW [ pkgs.otpw ]
-      ++ lib.optionals config.security.pam.oath.enable [ pkgs.oath-toolkit ]
-      ++ lib.optionals config.security.pam.p11.enable [ pkgs.pam_p11 ]
-      ++ lib.optionals config.security.pam.enableFscrypt [ pkgs.fscrypt-experimental ]
-      ++ lib.optionals config.security.pam.u2f.enable [ pkgs.pam_u2f ];
+        environment.systemPackages =
+          # Include the PAM modules in the system path mostly for the manpages.
+          [ package ]
+          ++ lib.optional (config.users.ldap.enable or false) pam_ldap
+          ++ lib.optional (config.services.kanidm.unix.enable or false) config.services.kanidm.package
+          ++ lib.optional (config.services.sssd.enable or false) pkgs.sssd
+          ++ lib.optionals config.security.pam.krb5.enable [
+            pam_krb5
+            pam_ccreds
+          ]
+          ++ lib.optionals config.security.pam.enableOTPW [ pkgs.otpw ]
+          ++ lib.optionals (config.security.pam.oath.enable or false) [ pkgs.oath-toolkit ]
+          ++ lib.optionals config.security.pam.p11.enable [ pkgs.pam_p11 ]
+          ++ lib.optionals config.security.pam.enableFscrypt [ pkgs.fscrypt-experimental ]
+          ++ lib.optionals config.security.pam.u2f.enable [ pkgs.pam_u2f ];
 
-    security.wrappers = {
-      unix_chkpwd = {
-        setuid = true;
-        owner = "root";
-        group = "root";
-        source = "${package}/bin/unix_chkpwd";
-      };
-    };
-
-    environment.etc = lib.mapAttrs' makePAMService enabledServices;
-
-    systemd =
-      lib.mkIf (lib.any (service: service.lastlog.enable) (lib.attrValues config.security.pam.services))
-        {
-          tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
-          services.lastlog2-import = {
-            enable = true;
-            wantedBy = [ "default.target" ];
-            after = [
-              "local-fs.target"
-              "systemd-tmpfiles-setup.service"
-            ];
-            # TODO: ${pkgs.util-linux.lastlog}/lib/systemd/system/lastlog2-import.service
-            # uses unpatched /usr/bin/mv, needs to be fixed on staging
-            # in the meantime, use a service drop-in here
-            serviceConfig.ExecStartPost = [
-              ""
-              "${lib.getExe' pkgs.coreutils "mv"} /var/log/lastlog /var/log/lastlog.migrated"
-            ];
+        security.wrappers = {
+          unix_chkpwd = {
+            setuid = true;
+            owner = "root";
+            group = "root";
+            source = "${package}/bin/unix_chkpwd";
           };
-          packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
         };
 
-    security.pam.services = {
-      other = {
-        useDefaultRules = false;
-        rules =
-          let
-            rules = utils.pam.autoOrderRules [
+        environment.etc = lib.mapAttrs' makePAMService enabledServices;
+
+        systemd =
+          lib.mkIf (lib.any (service: service.lastlog.enable) (lib.attrValues config.security.pam.services))
+            {
+              tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
+              services.lastlog2-import = {
+                enable = true;
+                wantedBy = [ "default.target" ];
+                after = [
+                  "local-fs.target"
+                  "systemd-tmpfiles-setup.service"
+                ];
+                # TODO: ${pkgs.util-linux.lastlog}/lib/systemd/system/lastlog2-import.service
+                # uses unpatched /usr/bin/mv, needs to be fixed on staging
+                # in the meantime, use a service drop-in here
+                serviceConfig.ExecStartPost = [
+                  ""
+                  "${lib.getExe' pkgs.coreutils "mv"} /var/log/lastlog /var/log/lastlog.migrated"
+                ];
+              };
+              packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
+            };
+
+        security.pam.services = {
+          other = {
+            useDefaultRules = false;
+            rules =
+              let
+                rules = utils.pam.autoOrderRules [
+                  {
+                    name = "warn";
+                    control = "required";
+                    modulePath = "${package}/lib/security/pam_warn.so";
+                  }
+                  {
+                    name = "deny";
+                    control = "required";
+                    modulePath = "${package}/lib/security/pam_deny.so";
+                  }
+                ];
+              in
               {
-                name = "warn";
-                control = "required";
-                modulePath = "${package}/lib/security/pam_warn.so";
-              }
-              {
-                name = "deny";
-                control = "required";
-                modulePath = "${package}/lib/security/pam_deny.so";
-              }
-            ];
-          in
-          {
-            auth = rules;
-            account = rules;
-            password = rules;
-            session = rules;
+                auth = rules;
+                account = rules;
+                password = rules;
+                session = rules;
+              };
           };
-      };
 
-      # Most of these should be moved to specific modules.
-      i3lock.enable = lib.mkDefault config.programs.i3lock.enable;
-      i3lock-color.enable = lib.mkDefault config.programs.i3lock.enable;
-      vlock.enable = lib.mkDefault config.console.enable;
-      xlock.enable = lib.mkDefault config.services.xserver.enable;
-      xscreensaver.enable = lib.mkDefault config.services.xscreensaver.enable;
+          # Most of these should be moved to specific modules.
+          i3lock.enable = lib.mkDefault (config.programs.i3lock.enable or false);
+          i3lock-color.enable = lib.mkDefault (config.programs.i3lock.enable or false);
+          vlock.enable = lib.mkDefault (config.console.enable or false);
+          xlock.enable = lib.mkDefault (config.services.xserver.enable or false);
+          xscreensaver.enable = lib.mkDefault (config.services.xscreensaver.enable or false);
 
-      runuser = {
-        rootOK = true;
-        unixAuth = false;
-        setEnvironment = false;
-      };
+          runuser = {
+            rootOK = true;
+            unixAuth = false;
+            setEnvironment = false;
+          };
 
-      /*
-        FIXME: should runuser -l start a systemd session? Currently
-        it complains "Cannot create session: Already running in a
-        session".
-      */
-      runuser-l = {
-        rootOK = true;
-        unixAuth = false;
-      };
-    }
-    // lib.optionalAttrs (config.security.pam.enableFscrypt) {
-      # Allow fscrypt to verify login passphrase
-      fscrypt = { };
-    };
+          /*
+            FIXME: should runuser -l start a systemd session? Currently
+            it complains "Cannot create session: Already running in a
+            session".
+          */
+          runuser-l = {
+            rootOK = true;
+            unixAuth = false;
+          };
+        }
+        // lib.optionalAttrs (config.security.pam.enableFscrypt) {
+          # Allow fscrypt to verify login passphrase
+          fscrypt = { };
+        };
 
-    security.apparmor.includes."abstractions/pam" =
-      concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
-        attrNames enabledServices
-      )
-      + (
-        let
-          types = concatMap attrValues (catAttrs "rules" (attrValues enabledServices));
-          rules = concatMap attrValues types;
+      }
+      (lib.optionalAttrs (options ? security.apparmor.includes) {
+        security.apparmor.includes."abstractions/pam" =
+          concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
+            attrNames enabledServices
+          )
+          + (
+            let
+              types = concatMap attrValues (catAttrs "rules" (attrValues enabledServices));
+              rules = concatMap attrValues types;
 
-          isDirect = flip elem [
-            "include"
-            "substack"
-          ];
-          activeRules = filter (rule: rule.enable && !isDirect rule.control) rules;
+              isDirect = flip elem [
+                "include"
+                "substack"
+              ];
+              activeRules = filter (rule: rule.enable && !isDirect rule.control) rules;
 
-          modulePaths = concatMap (
-            rule:
-            if (!hasPrefix "/" rule.modulePath) then
-              throw ''non-absolute PAM modulePath "${rule.modulePath}" is unsupported by apparmor''
-            else
-              [ rule.modulePath ]
-          ) activeRules;
-        in
-        concatLines (map (module: "mr ${module},") (unique modulePaths))
-      );
-
-    security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;
-    security.sudo-rs.extraConfig = optionalSudoConfigForSSHAgentAuth;
-  };
+              modulePaths = concatMap (
+                rule:
+                if (!hasPrefix "/" rule.modulePath) then
+                  throw ''non-absolute PAM modulePath "${rule.modulePath}" is unsupported by apparmor''
+                else
+                  [ rule.modulePath ]
+              ) activeRules;
+            in
+            concatLines (map (module: "mr ${module},") (unique modulePaths))
+          );
+      })
+      (lib.optionalAttrs (options ? security.sudo.extraConfig) {
+        security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;
+      })
+      (lib.optionalAttrs (options ? security.sudo-rs.extraConfig) {
+        security.sudo-rs.extraConfig = optionalSudoConfigForSSHAgentAuth;
+      })
+    ]
+  );
 }

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -245,134 +246,140 @@ in
   };
 
   ###### implementation
-  config = lib.mkIf config.security.enableWrappers {
-
-    assertions = lib.mapAttrsToList (name: opts: {
-      assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
-      message = ''
-        The security.wrappers.${name} wrapper is not valid:
-            setuid/setgid and capabilities are mutually exclusive.
-      '';
-    }) wrappers;
-
-    security.wrappers =
-      let
-        mkSetuidRoot = source: {
-          setuid = true;
-          owner = "root";
-          group = "root";
-          inherit source;
-        };
-      in
+  config = lib.mkIf config.security.enableWrappers (
+    lib.mkMerge [
       {
-        # These are mount related wrappers that require the +s permission.
-        mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
-        umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
-      };
 
-    # Make sure our wrapperDir exports to the PATH env variable when
-    # initializing the shell
-    environment.extraInit = ''
-      # Wrappers override other bin directories.
-      export PATH="${wrapperDir}:$PATH"
-    '';
+        assertions = lib.mapAttrsToList (name: opts: {
+          assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
+          message = ''
+            The security.wrappers.${name} wrapper is not valid:
+                setuid/setgid and capabilities are mutually exclusive.
+          '';
+        }) wrappers;
 
-    security.apparmor.includes = lib.mapAttrs' (
-      wrapName: wrap:
-      lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
-        include "${
-          pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
-            (securityWrapper wrap.source)
-          ]
-        }"
-        mrpx ${wrap.source},
-      ''
-    ) wrappers;
+        security.wrappers =
+          let
+            mkSetuidRoot = source: {
+              setuid = true;
+              owner = "root";
+              group = "root";
+              inherit source;
+            };
+          in
+          {
+            # These are mount related wrappers that require the +s permission.
+            mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
+            umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
+          };
 
-    systemd.mounts = [
-      {
-        where = parentWrapperDir;
-        what = "tmpfs";
-        type = "tmpfs";
-        options = lib.concatStringsSep "," [
-          "nodev"
-          "mode=755"
-          "size=${config.security.wrapperDirSize}"
+        # Make sure our wrapperDir exports to the PATH env variable when
+        # initializing the shell
+        environment.extraInit = ''
+          # Wrappers override other bin directories.
+          export PATH="${wrapperDir}:$PATH"
+        '';
+
+        systemd.mounts = [
+          {
+            where = parentWrapperDir;
+            what = "tmpfs";
+            type = "tmpfs";
+            options = lib.concatStringsSep "," [
+              "nodev"
+              "mode=755"
+              "size=${config.security.wrapperDirSize}"
+            ];
+          }
         ];
-      }
-    ];
 
-    systemd.services.suid-sgid-wrappers = {
-      description = "Create SUID/SGID Wrappers";
-      wantedBy = [ "sysinit.target" ];
-      before = [
-        "sysinit.target"
-        "shutdown.target"
-      ];
-      conflicts = [ "shutdown.target" ];
-      after = [ "systemd-sysusers.service" ];
-      unitConfig.DefaultDependencies = false;
-      unitConfig.RequiresMountsFor = [
-        "/nix/store"
-        "/run/wrappers"
-      ];
-      serviceConfig.RestrictSUIDSGID = false;
-      serviceConfig.Type = "oneshot";
-      script = ''
-        chmod 755 "${parentWrapperDir}"
+        systemd.services.suid-sgid-wrappers = {
+          description = "Create SUID/SGID Wrappers";
+          wantedBy = [ "sysinit.target" ];
+          before = [
+            "sysinit.target"
+            "shutdown.target"
+          ];
+          conflicts = [ "shutdown.target" ];
+          after = [ "systemd-sysusers.service" ];
+          unitConfig.DefaultDependencies = false;
+          unitConfig.RequiresMountsFor = [
+            "/nix/store"
+            "/run/wrappers"
+          ];
+          serviceConfig.RestrictSUIDSGID = false;
+          serviceConfig.Type = "oneshot";
+          script = ''
+            chmod 755 "${parentWrapperDir}"
 
-        # We want to place the tmpdirs for the wrappers to the parent dir.
-        wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
-        chmod a+rx "$wrapperDir"
+            # We want to place the tmpdirs for the wrappers to the parent dir.
+            wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
+            chmod a+rx "$wrapperDir"
 
-        ${lib.concatStringsSep "\n" mkWrappedPrograms}
+            ${lib.concatStringsSep "\n" mkWrappedPrograms}
 
-        if [ -L ${wrapperDir} ]; then
-          # Atomically replace the symlink
-          # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
-          old=$(readlink -f ${wrapperDir})
-          if [ -e "${wrapperDir}-tmp" ]; then
-            rm --force --recursive "${wrapperDir}-tmp"
-          fi
-          ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
-          mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
-          rm --force --recursive "$old"
-        else
-          # For initial setup
-          ln --symbolic "$wrapperDir" "${wrapperDir}"
-        fi
-      '';
-    };
-
-    ###### wrappers consistency checks
-    system.checks = lib.singleton (
-      pkgs.runCommand "ensure-all-wrappers-paths-exist"
-        {
-          preferLocalBuild = true;
-        }
-        ''
-          # make sure we produce output
-          mkdir -p $out
-
-          echo -n "Checking that Nix store paths of all wrapped programs exist... "
-
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
-
-          for name in "''${!wrappers[@]}"; do
-            path="''${wrappers[$name]}"
-            if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-              test -t 1 && echo -ne '\033[1;31m'
-              echo "FAIL"
-              echo "The path $path does not exist!"
-              echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-              test -t 1 && echo -ne '\033[0m'
-              exit 1
+            if [ -L ${wrapperDir} ]; then
+              # Atomically replace the symlink
+              # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
+              old=$(readlink -f ${wrapperDir})
+              if [ -e "${wrapperDir}-tmp" ]; then
+                rm --force --recursive "${wrapperDir}-tmp"
+              fi
+              ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
+              mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
+              rm --force --recursive "$old"
+            else
+              # For initial setup
+              ln --symbolic "$wrapperDir" "${wrapperDir}"
             fi
-          done
+          '';
+        };
 
-          echo "OK"
-        ''
-    );
-  };
+        ###### wrappers consistency checks
+        system.checks = lib.singleton (
+          pkgs.runCommand "ensure-all-wrappers-paths-exist"
+            {
+              preferLocalBuild = true;
+            }
+            ''
+              # make sure we produce output
+              mkdir -p $out
+
+              echo -n "Checking that Nix store paths of all wrapped programs exist... "
+
+              declare -A wrappers
+              ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+
+              for name in "''${!wrappers[@]}"; do
+                path="''${wrappers[$name]}"
+                if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
+                  test -t 1 && echo -ne '\033[1;31m'
+                  echo "FAIL"
+                  echo "The path $path does not exist!"
+                  echo 'Please, check the value of `security.wrappers."'$name'".source`.'
+                  test -t 1 && echo -ne '\033[0m'
+                  exit 1
+                fi
+              done
+
+              echo "OK"
+            ''
+        );
+      }
+
+      (lib.optionalAttrs (options ? security.apparmor.includes) {
+        security.apparmor.includes = lib.mapAttrs' (
+          wrapName: wrap:
+          lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
+            include "${
+              pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
+                (securityWrapper wrap.source)
+              ]
+            }"
+            mrpx ${wrap.source},
+          ''
+        ) wrappers;
+      })
+    ]
+  );
 }

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -260,134 +261,140 @@ in
   };
 
   ###### implementation
-  config = lib.mkIf config.security.enableWrappers {
-
-    assertions = lib.mapAttrsToList (name: opts: {
-      assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
-      message = ''
-        The security.wrappers.${name} wrapper is not valid:
-            setuid/setgid and capabilities are mutually exclusive.
-      '';
-    }) wrappers;
-
-    security.wrappers =
-      let
-        mkSetuidRoot = source: {
-          setuid = true;
-          owner = "root";
-          group = "root";
-          inherit source;
-        };
-      in
+  config = lib.mkIf config.security.enableWrappers (
+    lib.mkMerge [
       {
-        # These are mount related wrappers that require the +s permission.
-        mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
-        umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
-      };
 
-    # Make sure our wrapperDir exports to the PATH env variable when
-    # initializing the shell
-    environment.extraInit = ''
-      # Wrappers override other bin directories.
-      export PATH="${wrapperDir}:$PATH"
-    '';
+        assertions = lib.mapAttrsToList (name: opts: {
+          assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
+          message = ''
+            The security.wrappers.${name} wrapper is not valid:
+                setuid/setgid and capabilities are mutually exclusive.
+          '';
+        }) wrappers;
 
-    security.apparmor.includes = lib.mapAttrs' (
-      wrapName: wrap:
-      lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
-        include "${
-          pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
-            (securityWrapper wrap.source)
-          ]
-        }"
-        mrpx ${wrap.source},
-      ''
-    ) wrappers;
+        security.wrappers =
+          let
+            mkSetuidRoot = source: {
+              setuid = true;
+              owner = "root";
+              group = "root";
+              inherit source;
+            };
+          in
+          {
+            # These are mount related wrappers that require the +s permission.
+            mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
+            umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
+          };
 
-    systemd.mounts = [
-      {
-        where = parentWrapperDir;
-        what = "tmpfs";
-        type = "tmpfs";
-        options = lib.concatStringsSep "," [
-          "nodev"
-          "mode=755"
-          "size=${config.security.wrapperDirSize}"
+        # Make sure our wrapperDir exports to the PATH env variable when
+        # initializing the shell
+        environment.extraInit = ''
+          # Wrappers override other bin directories.
+          export PATH="${wrapperDir}:$PATH"
+        '';
+
+        systemd.mounts = [
+          {
+            where = parentWrapperDir;
+            what = "tmpfs";
+            type = "tmpfs";
+            options = lib.concatStringsSep "," [
+              "nodev"
+              "mode=755"
+              "size=${config.security.wrapperDirSize}"
+            ];
+          }
         ];
-      }
-    ];
 
-    systemd.services.suid-sgid-wrappers = {
-      description = "Create SUID/SGID Wrappers";
-      wantedBy = [ "sysinit.target" ];
-      before = [
-        "sysinit.target"
-        "shutdown.target"
-      ];
-      conflicts = [ "shutdown.target" ];
-      after = [ "systemd-sysusers.service" ];
-      unitConfig.DefaultDependencies = false;
-      unitConfig.RequiresMountsFor = [
-        "/nix/store"
-        "/run/wrappers"
-      ];
-      serviceConfig.RestrictSUIDSGID = false;
-      serviceConfig.Type = "oneshot";
-      script = ''
-        chmod 755 "${parentWrapperDir}"
+        systemd.services.suid-sgid-wrappers = {
+          description = "Create SUID/SGID Wrappers";
+          wantedBy = [ "sysinit.target" ];
+          before = [
+            "sysinit.target"
+            "shutdown.target"
+          ];
+          conflicts = [ "shutdown.target" ];
+          after = [ "systemd-sysusers.service" ];
+          unitConfig.DefaultDependencies = false;
+          unitConfig.RequiresMountsFor = [
+            "/nix/store"
+            "/run/wrappers"
+          ];
+          serviceConfig.RestrictSUIDSGID = false;
+          serviceConfig.Type = "oneshot";
+          script = ''
+            chmod 755 "${parentWrapperDir}"
 
-        # We want to place the tmpdirs for the wrappers to the parent dir.
-        wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
-        chmod a+rx "$wrapperDir"
+            # We want to place the tmpdirs for the wrappers to the parent dir.
+            wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
+            chmod a+rx "$wrapperDir"
 
-        ${lib.concatStringsSep "\n" mkWrappedPrograms}
+            ${lib.concatStringsSep "\n" mkWrappedPrograms}
 
-        if [ -L ${wrapperDir} ]; then
-          # Atomically replace the symlink
-          # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
-          old=$(readlink -f ${wrapperDir})
-          if [ -e "${wrapperDir}-tmp" ]; then
-            rm --force --recursive "${wrapperDir}-tmp"
-          fi
-          ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
-          mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
-          rm --force --recursive "$old"
-        else
-          # For initial setup
-          ln --symbolic "$wrapperDir" "${wrapperDir}"
-        fi
-      '';
-    };
-
-    ###### wrappers consistency checks
-    system.checks = lib.singleton (
-      pkgs.runCommand "ensure-all-wrappers-paths-exist"
-        {
-          preferLocalBuild = true;
-        }
-        ''
-          # make sure we produce output
-          mkdir -p $out
-
-          echo -n "Checking that Nix store paths of all wrapped programs exist... "
-
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
-
-          for name in "''${!wrappers[@]}"; do
-            path="''${wrappers[$name]}"
-            if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-              test -t 1 && echo -ne '\033[1;31m'
-              echo "FAIL"
-              echo "The path $path does not exist!"
-              echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-              test -t 1 && echo -ne '\033[0m'
-              exit 1
+            if [ -L ${wrapperDir} ]; then
+              # Atomically replace the symlink
+              # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
+              old=$(readlink -f ${wrapperDir})
+              if [ -e "${wrapperDir}-tmp" ]; then
+                rm --force --recursive "${wrapperDir}-tmp"
+              fi
+              ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
+              mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
+              rm --force --recursive "$old"
+            else
+              # For initial setup
+              ln --symbolic "$wrapperDir" "${wrapperDir}"
             fi
-          done
+          '';
+        };
 
-          echo "OK"
-        ''
-    );
-  };
+        ###### wrappers consistency checks
+        system.checks = lib.singleton (
+          pkgs.runCommand "ensure-all-wrappers-paths-exist"
+            {
+              preferLocalBuild = true;
+            }
+            ''
+              # make sure we produce output
+              mkdir -p $out
+
+              echo -n "Checking that Nix store paths of all wrapped programs exist... "
+
+              declare -A wrappers
+              ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+
+              for name in "''${!wrappers[@]}"; do
+                path="''${wrappers[$name]}"
+                if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
+                  test -t 1 && echo -ne '\033[1;31m'
+                  echo "FAIL"
+                  echo "The path $path does not exist!"
+                  echo 'Please, check the value of `security.wrappers."'$name'".source`.'
+                  test -t 1 && echo -ne '\033[0m'
+                  exit 1
+                fi
+              done
+
+              echo "OK"
+            ''
+        );
+      }
+
+      (lib.optionalAttrs (options ? security.apparmor.includes) {
+        security.apparmor.includes = lib.mapAttrs' (
+          wrapName: wrap:
+          lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
+            include "${
+              pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
+                (securityWrapper wrap.source)
+              ]
+            }"
+            mrpx ${wrap.source},
+          ''
+        ) wrappers;
+      })
+    ]
+  );
 }

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -104,8 +105,6 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
-      system.switch.inhibitors.dbus-implementation = cfg.implementation;
-
       environment.etc."dbus-1".source = configDir;
 
       environment.pathsToLink = [
@@ -142,6 +141,10 @@ in
         "sockets.target"
       ];
     }
+
+    (lib.optionalAttrs (options ? system.switch.inhibitors) {
+      system.switch.inhibitors.dbus-implementation = cfg.implementation;
+    })
 
     (mkIf config.boot.initrd.systemd.dbus.enable {
       boot.initrd.systemd = {

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -3,6 +3,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -116,8 +117,6 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     {
-      system.switch.inhibitors.dbus-implementation = cfg.implementation;
-
       environment.etc."dbus-1".source = configDir;
 
       environment.pathsToLink = [
@@ -154,6 +153,10 @@ in
         "sockets.target"
       ];
     }
+
+    (lib.optionalAttrs (options ? system.switch.inhibitors) {
+      system.switch.inhibitors.dbus-implementation = cfg.implementation;
+    })
 
     (mkIf config.boot.initrd.systemd.dbus.enable {
       boot.initrd.systemd = {

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -136,7 +136,7 @@ in
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';
     services.getty.helpLine = mkIf (
-      config.documentation.nixos.enable && config.documentation.doc.enable
+      (config.documentation.nixos.enable or false) && (config.documentation.doc.enable or false)
     ) "\nRun 'nixos-help' for the NixOS manual.";
 
     systemd.additionalUpstreamSystemUnits = [

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -196,7 +196,7 @@ in
       ];
       serviceConfig.Restart = "always";
       restartIfChanged = false;
-      enable = mkDefault config.boot.isContainer;
+      enable = mkDefault (config.boot.isContainer or false);
     };
 
     environment.etc.issue = mkDefault {

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -151,7 +151,7 @@ in
     # We can't just rely on 'Conflicts=autovt@tty1.service' because
     # 'switch-to-configuration switch' will start 'autovt@tty1.service'
     # and kill the display manager.
-    systemd.targets.getty.wants = lib.mkIf (!config.services.displayManager.enable) [
+    systemd.targets.getty.wants = lib.mkIf (!(config.services.displayManager.enable or false)) [
       "autovt@tty1.service"
     ];
 

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -171,7 +171,7 @@ in
     # We can't just rely on 'Conflicts=autovt@tty1.service' because
     # 'switch-to-configuration switch' will start 'autovt@tty1.service'
     # and kill the display manager.
-    systemd.targets.getty.wants = lib.mkIf (!config.services.displayManager.enable) [
+    systemd.targets.getty.wants = lib.mkIf (!(config.services.displayManager.enable or false)) [
       "autovt@tty1.service"
     ];
 

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -211,7 +211,7 @@ in
       ];
       serviceConfig.Restart = "always";
       restartIfChanged = false;
-      enable = mkDefault config.boot.isContainer;
+      enable = mkDefault (config.boot.isContainer or false);
     };
 
     environment.etc.issue = mkDefault {

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -156,7 +156,7 @@ in
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';
     services.getty.helpLine = mkIf (
-      config.documentation.nixos.enable && config.documentation.doc.enable
+      (config.documentation.nixos.enable or false) && (config.documentation.doc.enable or false)
     ) "\nRun 'nixos-help' for the NixOS manual.";
 
     systemd.additionalUpstreamSystemUnits = [

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -278,7 +278,7 @@ in
       "D /var/empty 0555 root root -"
       "h /var/empty - - - - +i"
     ]
-    ++ lib.optionals config.nix.enable [
+    ++ lib.optionals (config.nix.enable or false) [
       # Prevent the current configuration from being garbage-collected.
       "d /nix/var/nix/gcroots -"
       "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"

--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -51,7 +51,7 @@ in
           message = "nixos-init can only be used with system.etc.overlay.enable";
         }
         {
-          assertion = config.services.userborn.enable || config.systemd.sysusers.enable;
+          assertion = (config.services.userborn.enable or false) || (config.systemd.sysusers.enable or false);
           message = "nixos-init can only be used with services.userborn.enable or systemd.sysusers.enable";
         }
         {

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -44,7 +44,7 @@ let
 
     cp "$extraDependenciesPath" "$out/extra-dependencies"
 
-    ${optionalString (!config.boot.isContainer && config.boot.bootspec.enable) ''
+    ${optionalString (!(config.boot.isContainer or false) && config.boot.bootspec.enable) ''
       ${config.boot.bootspec.writer}
       ${optionalString config.boot.bootspec.enableValidation ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
     ''}

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -283,11 +283,15 @@ in
 
     system.name = mkOption {
       type = types.str;
-      default = if config.networking.hostName == "" then "unnamed" else config.networking.hostName;
+      default =
+        if (config.networking.hostName or config.system.nixos.distroId) == "" then
+          "unnamed"
+        else
+          config.networking.hostName or config.system.nixos.distroId;
       defaultText = literalExpression ''
-        if config.networking.hostName == ""
+        if (config.networking.hostName or config.system.nixos.distroId) == ""
         then "unnamed"
-        else config.networking.hostName;
+        else config.networking.hostName or config.system.nixos.distroId;
       '';
       description = ''
         The name of the system used in the {option}`system.build.toplevel` derivation.

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -44,7 +44,7 @@ let
 
     printf "%s " "''${extraDependencies[@]}" > "$out/extra-dependencies"
 
-    ${optionalString (!config.boot.isContainer) ''
+    ${optionalString (!(config.boot.isContainer or false)) ''
       ${config.boot.bootspec.writer}
       ${optionalString config.boot.bootspec.enableValidation ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
     ''}

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -285,11 +285,15 @@ in
 
     system.name = mkOption {
       type = types.str;
-      default = if config.networking.hostName == "" then "unnamed" else config.networking.hostName;
+      default =
+        if (config.networking.hostName or config.system.nixos.distroId) == "" then
+          "unnamed"
+        else
+          config.networking.hostName or config.system.nixos.distroId;
       defaultText = literalExpression ''
-        if config.networking.hostName == ""
+        if (config.networking.hostName or config.system.nixos.distroId) == ""
         then "unnamed"
-        else config.networking.hostName;
+        else config.networking.hostName or config.system.nixos.distroId;
       '';
       description = ''
         The name of the system used in the {option}`system.build.toplevel` derivation.

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   utils,
   ...
@@ -271,6 +272,8 @@ in
         }
       ) cfg.emulatedSystems
     );
+  }
+  // lib.optionalAttrs (options ? nix.settings) {
     nix.settings = lib.mkIf (cfg.addEmulatedSystemsToNixSandbox && cfg.emulatedSystems != [ ]) {
       extra-platforms =
         cfg.emulatedSystems ++ lib.optional pkgs.stdenv.hostPlatform.isx86_64 "i686-linux";
@@ -286,7 +289,8 @@ in
           map (system: (ruleFor system).interpreterSandboxPath) cfg.emulatedSystems
         );
     };
-
+  }
+  // {
     environment.etc."binfmt.d/nixos.conf".source = builtins.toFile "binfmt_nixos.conf" (
       lib.concatStringsSep "\n" (lib.mapAttrsToList makeBinfmtLine config.boot.binfmt.registrations)
     );

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -406,7 +407,7 @@ in
 
           ln -s ${kernelPath} $out/kernel
           ln -s ${config.system.modulesTree} $out/kernel-modules
-          ${optionalString (config.hardware.deviceTree.package != null) ''
+          ${optionalString (options ? hardware.deviceTree && config.hardware.deviceTree.package != null) ''
             ln -s ${config.hardware.deviceTree.package} $out/dtbs
           ''}
 

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -402,7 +403,7 @@ in
 
           ln -s ${kernelPath} $out/kernel
           ln -s ${config.system.modulesTree} $out/kernel-modules
-          ${optionalString (config.hardware.deviceTree.package != null) ''
+          ${optionalString (options ? hardware.deviceTree && config.hardware.deviceTree.package != null) ''
             ln -s ${config.hardware.deviceTree.package} $out/dtbs
           ''}
 

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -4219,7 +4220,7 @@ let
         with types;
         attrsOf (submodule {
           # Default in initrd is dhcp-on-stop, which is correct if flushBeforeStage2 = false
-          config = mkIf config.boot.initrd.network.flushBeforeStage2 {
+          config = mkIf (options ? boot.initrd.network && config.boot.initrd.network.flushBeforeStage2) {
             networkConfig.KeepConfiguration = mkDefault false;
           };
         });
@@ -4234,7 +4235,9 @@ let
       (commonConfig config.boot.initrd)
 
       {
-        systemd.network.enable = mkDefault config.boot.initrd.network.enable;
+        systemd.network.enable = mkDefault (
+          options ? boot.initrd.network && config.boot.initrd.network.enable
+        );
         systemd.contents = mkUnitFiles "/etc/" cfg;
 
         # Networkd link files are used early by udev to set up interfaces early.
@@ -4301,16 +4304,16 @@ in
   config = mkMerge [
     stage2Config
     (mkIf config.boot.initrd.systemd.enable {
-      assertions = [
-        {
-          assertion =
-            !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
-          message = ''
-            systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
-            DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
-          '';
-        }
-      ];
+      # Only assert against the legacy udhcpc options if initrd-network.nix is loaded;
+      # they don't exist otherwise.
+      assertions = lib.optional (options ? boot.initrd.network) {
+        assertion =
+          !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
+        message = ''
+          systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
+          DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
+        '';
+      };
 
       boot.initrd = stage1Config;
     })

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,7 +1,7 @@
 {
   config,
-  lib,
   options,
+  lib,
   utils,
   ...
 }:
@@ -4166,52 +4166,57 @@ let
 
       { environment.etc = unitFiles; }
 
-      (mkIf config.systemd.network.enable {
+      (
+        mkIf config.systemd.network.enable {
 
-        users.users.systemd-network.group = "systemd-network";
+          users.users.systemd-network.group = "systemd-network";
 
-        systemd.additionalUpstreamSystemUnits = [
-          "systemd-networkd-wait-online.service"
-          "systemd-networkd-wait-online@.service"
-          "systemd-networkd.service"
-          "systemd-networkd.socket"
-          "systemd-networkd-persistent-storage.service"
-        ];
+          systemd.additionalUpstreamSystemUnits = [
+            "systemd-networkd-wait-online.service"
+            "systemd-networkd-wait-online@.service"
+            "systemd-networkd.service"
+            "systemd-networkd.socket"
+            "systemd-networkd-persistent-storage.service"
+          ];
 
-        environment.etc."systemd/networkd.conf" = renderConfig cfg.config;
+          environment.etc."systemd/networkd.conf" = renderConfig cfg.config;
 
-        systemd.services.systemd-networkd =
-          let
-            isReloadableUnitFileName = unitFileName: strings.hasSuffix ".network" unitFileName;
-            reloadableUnitFiles = attrsets.filterAttrs (k: v: isReloadableUnitFileName k) unitFiles;
-            nonReloadableUnitFiles = attrsets.filterAttrs (k: v: !isReloadableUnitFileName k) unitFiles;
-            unitFileSources = unitFiles: map (x: x.source) (attrValues unitFiles);
-          in
-          {
-            wantedBy = [ "multi-user.target" ];
-            reloadTriggers = unitFileSources reloadableUnitFiles;
-            restartTriggers = unitFileSources nonReloadableUnitFiles ++ [
-              config.environment.etc."systemd/networkd.conf".source
-            ];
-            aliases = [ "dbus-org.freedesktop.network1.service" ];
-            notSocketActivated = true;
-            stopIfChanged = false;
+          systemd.services.systemd-networkd =
+            let
+              isReloadableUnitFileName = unitFileName: strings.hasSuffix ".network" unitFileName;
+              reloadableUnitFiles = attrsets.filterAttrs (k: v: isReloadableUnitFileName k) unitFiles;
+              nonReloadableUnitFiles = attrsets.filterAttrs (k: v: !isReloadableUnitFileName k) unitFiles;
+              unitFileSources = unitFiles: map (x: x.source) (attrValues unitFiles);
+            in
+            {
+              wantedBy = [ "multi-user.target" ];
+              reloadTriggers = unitFileSources reloadableUnitFiles;
+              restartTriggers = unitFileSources nonReloadableUnitFiles ++ [
+                config.environment.etc."systemd/networkd.conf".source
+              ];
+              aliases = [ "dbus-org.freedesktop.network1.service" ];
+              notSocketActivated = true;
+              stopIfChanged = false;
+            };
+
+        }
+        // lib.optionalAttrs (options ? networking.iproute2) {
+          networking.iproute2 = mkIf (cfg.config.addRouteTablesToIPRoute2 && cfg.config.routeTables != { }) {
+            enable = mkDefault true;
+            rttablesExtraConfig = ''
+
+              # Extra tables defined in NixOS systemd.networkd.config.routeTables.
+              ${concatStringsSep "\n" (
+                mapAttrsToList (name: number: "${toString number} ${name}") cfg.config.routeTables
+              )}
+            '';
           };
+        }
+        // {
+          services.resolved.enable = mkDefault true;
 
-        networking.iproute2 = mkIf (cfg.config.addRouteTablesToIPRoute2 && cfg.config.routeTables != { }) {
-          enable = mkDefault true;
-          rttablesExtraConfig = ''
-
-            # Extra tables defined in NixOS systemd.networkd.config.routeTables.
-            ${concatStringsSep "\n" (
-              mapAttrsToList (name: number: "${toString number} ${name}") cfg.config.routeTables
-            )}
-          '';
-        };
-
-        services.resolved.enable = mkDefault true;
-
-      })
+        }
+      )
     ];
 
   stage1Options = {

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -4281,7 +4282,7 @@ let
         with types;
         attrsOf (submodule {
           # Default in initrd is dhcp-on-stop, which is correct if flushBeforeStage2 = false
-          config = mkIf config.boot.initrd.network.flushBeforeStage2 {
+          config = mkIf (options ? boot.initrd.network && config.boot.initrd.network.flushBeforeStage2) {
             networkConfig.KeepConfiguration = mkDefault false;
           };
         });
@@ -4296,7 +4297,9 @@ let
       (commonConfig config.boot.initrd)
 
       {
-        systemd.network.enable = mkDefault config.boot.initrd.network.enable;
+        systemd.network.enable = mkDefault (
+          options ? boot.initrd.network && config.boot.initrd.network.enable
+        );
         systemd.contents = mkUnitFiles "/etc/" cfg;
 
         # Networkd link files are used early by udev to set up interfaces early.
@@ -4366,16 +4369,16 @@ in
   config = mkMerge [
     stage2Config
     (mkIf config.boot.initrd.systemd.enable {
-      assertions = [
-        {
-          assertion =
-            !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
-          message = ''
-            systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
-            DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
-          '';
-        }
-      ];
+      # Only assert against the legacy udhcpc options if initrd-network.nix is loaded;
+      # they don't exist otherwise.
+      assertions = lib.optional (options ? boot.initrd.network) {
+        assertion =
+          !config.boot.initrd.network.udhcpc.enable && config.boot.initrd.network.udhcpc.extraArgs == [ ];
+        message = ''
+          systemd stage 1 networking does not support 'boot.initrd.network.udhcpc'. Configure
+          DHCP with 'networking.*' options or with 'boot.initrd.systemd.network' options.
+        '';
+      };
 
       boot.initrd = stage1Config;
     })

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,7 +1,7 @@
 {
   config,
-  lib,
   options,
+  lib,
   utils,
   ...
 }:
@@ -4223,57 +4223,62 @@ let
 
       { environment.etc = unitFiles; }
 
-      (mkIf config.systemd.network.enable {
+      (
+        mkIf config.systemd.network.enable {
 
-        users.users.systemd-network.group = "systemd-network";
+          users.users.systemd-network.group = "systemd-network";
 
-        systemd.additionalUpstreamSystemUnits = [
-          "systemd-networkd-wait-online.service"
-          "systemd-networkd-wait-online@.service"
-          "systemd-networkd.service"
-          "systemd-networkd.socket"
-          "systemd-networkd-resolve-hook.socket"
-          "systemd-networkd-varlink-metrics.socket"
-          "systemd-networkd-varlink.socket"
-          "systemd-networkd-persistent-storage.service"
-        ];
+          systemd.additionalUpstreamSystemUnits = [
+            "systemd-networkd-wait-online.service"
+            "systemd-networkd-wait-online@.service"
+            "systemd-networkd.service"
+            "systemd-networkd.socket"
+            "systemd-networkd-resolve-hook.socket"
+            "systemd-networkd-varlink-metrics.socket"
+            "systemd-networkd-varlink.socket"
+            "systemd-networkd-persistent-storage.service"
+          ];
 
         systemd.sockets.systemd-networkd-varlink-metrics.wantedBy = [ "sockets.target" ];
 
-        environment.etc."systemd/networkd.conf" = renderConfig cfg.config;
+          environment.etc."systemd/networkd.conf" = renderConfig cfg.config;
 
-        systemd.services.systemd-networkd =
-          let
-            isReloadableUnitFileName = unitFileName: strings.hasSuffix ".network" unitFileName;
-            reloadableUnitFiles = attrsets.filterAttrs (k: v: isReloadableUnitFileName k) unitFiles;
-            nonReloadableUnitFiles = attrsets.filterAttrs (k: v: !isReloadableUnitFileName k) unitFiles;
-            unitFileSources = unitFiles: map (x: x.source) (attrValues unitFiles);
-          in
-          {
-            wantedBy = [ "multi-user.target" ];
-            reloadTriggers = unitFileSources reloadableUnitFiles;
-            restartTriggers = unitFileSources nonReloadableUnitFiles ++ [
-              config.environment.etc."systemd/networkd.conf".source
-            ];
-            aliases = [ "dbus-org.freedesktop.network1.service" ];
-            notSocketActivated = true;
-            stopIfChanged = false;
+          systemd.services.systemd-networkd =
+            let
+              isReloadableUnitFileName = unitFileName: strings.hasSuffix ".network" unitFileName;
+              reloadableUnitFiles = attrsets.filterAttrs (k: v: isReloadableUnitFileName k) unitFiles;
+              nonReloadableUnitFiles = attrsets.filterAttrs (k: v: !isReloadableUnitFileName k) unitFiles;
+              unitFileSources = unitFiles: map (x: x.source) (attrValues unitFiles);
+            in
+            {
+              wantedBy = [ "multi-user.target" ];
+              reloadTriggers = unitFileSources reloadableUnitFiles;
+              restartTriggers = unitFileSources nonReloadableUnitFiles ++ [
+                config.environment.etc."systemd/networkd.conf".source
+              ];
+              aliases = [ "dbus-org.freedesktop.network1.service" ];
+              notSocketActivated = true;
+              stopIfChanged = false;
+            };
+
+        }
+        // lib.optionalAttrs (options ? networking.iproute2) {
+          networking.iproute2 = mkIf (cfg.config.addRouteTablesToIPRoute2 && cfg.config.routeTables != { }) {
+            enable = mkDefault true;
+            rttablesExtraConfig = ''
+
+              # Extra tables defined in NixOS systemd.networkd.config.routeTables.
+              ${concatStringsSep "\n" (
+                mapAttrsToList (name: number: "${toString number} ${name}") cfg.config.routeTables
+              )}
+            '';
           };
+        }
+        // {
+          services.resolved.enable = mkDefault true;
 
-        networking.iproute2 = mkIf (cfg.config.addRouteTablesToIPRoute2 && cfg.config.routeTables != { }) {
-          enable = mkDefault true;
-          rttablesExtraConfig = ''
-
-            # Extra tables defined in NixOS systemd.networkd.config.routeTables.
-            ${concatStringsSep "\n" (
-              mapAttrsToList (name: number: "${toString number} ${name}") cfg.config.routeTables
-            )}
-          '';
-        };
-
-        services.resolved.enable = mkDefault true;
-
-      })
+        }
+      )
     ];
 
   stage1Options = {

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -28,7 +28,8 @@ let
 
   cfg = config.services.resolved;
 
-  dnsmasqResolve = config.services.dnsmasq.enable && config.services.dnsmasq.resolveLocalQueries;
+  dnsmasqResolve =
+    (config.services.dnsmasq.enable or false) && (config.services.dnsmasq.resolveLocalQueries or false);
 
   transformSettings =
     settings:

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -217,15 +218,19 @@ in
         }
       ) cfg.dnsDelegates;
 
-      # If networkmanager is enabled, ask it to interface with resolved.
-      networking.networkmanager.dns = "systemd-resolved";
-
       networking.resolvconf.package = config.systemd.package;
 
+    })
+
+    # If networkmanager is enabled, ask it to interface with resolved.
+    (lib.optionalAttrs (options ? networking.networkmanager) {
+      networking.networkmanager.dns = "systemd-resolved";
+    })
+
+    (lib.optionalAttrs (options ? nix.firewall) {
       nix.firewall.extraNftablesRules = [
         "ip daddr { 127.0.0.53, 127.0.0.54 } udp dport 53 accept comment \"systemd-resolved listening IPs\""
       ];
-
     })
 
     (mkIf config.boot.initrd.services.resolved.enable {

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   utils,
   ...
 }:
@@ -221,19 +222,23 @@ in
         }
       ) cfg.dnsDelegates;
 
-      # If networkmanager is enabled, ask it to interface with resolved.
-      networking.networkmanager.dns = "systemd-resolved";
-
       # Since we explicitly provide a resolv.conf, disable resolvconf
       networking.resolvconf.enable = false;
 
       # ... but we still set the package for correct compatibility.
       networking.resolvconf.package = config.systemd.package;
 
+    })
+
+    # If networkmanager is enabled, ask it to interface with resolved.
+    (lib.optionalAttrs (options ? networking.networkmanager) {
+      networking.networkmanager.dns = "systemd-resolved";
+    })
+
+    (lib.optionalAttrs (options ? nix.firewall) {
       nix.firewall.extraNftablesRules = [
         "ip daddr { 127.0.0.53, 127.0.0.54 } udp dport 53 accept comment \"systemd-resolved listening IPs\""
       ];
-
     })
 
     (mkIf config.boot.initrd.services.resolved.enable {

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -786,6 +786,5 @@ in
   };
 
   imports = [
-    (mkRenamedOptionModule [ "boot" "initrd" "mdadmConf" ] [ "boot" "swraid" "mdadmConf" ])
   ];
 }

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -333,7 +333,7 @@ let
           && !sd.randomEncryption.enable
           # Don't include zram devices
           && !(hasPrefix "/dev/zram" sd.device)
-        ) config.swapDevices
+        ) (config.swapDevices or [ ])
       );
 
       fsInfo =

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -487,8 +487,8 @@ in
 
     boot.initrd.enable = mkOption {
       type = types.bool;
-      default = !config.boot.isContainer;
-      defaultText = literalExpression "!config.boot.isContainer";
+      default = !(config.boot.isContainer or false);
+      defaultText = literalExpression "!(config.boot.isContainer or false)";
       description = ''
         Whether to enable the NixOS initial RAM disk (initrd). This may be
         needed to perform some initialisation tasks (like mounting

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -9,7 +10,11 @@ with lib;
 
 let
 
-  useHostResolvConf = config.networking.resolvconf.enable && config.networking.useHostResolvConf;
+  useHostResolvConf =
+    options ? networking.resolvconf
+    && options ? networking.useHostResolvConf
+    && config.networking.resolvconf.enable
+    && config.networking.useHostResolvConf;
 
   bootStage2 = pkgs.replaceVarsWith {
     src = ./stage-2-init.sh;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   utils,
@@ -839,21 +840,6 @@ in
     # https://github.com/systemd/systemd/pull/12226
     boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
 
-    services.logrotate.settings = {
-      "/var/log/btmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0660 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
-      };
-      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0664 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
-      };
-    };
-
     # Remove with systemd 259.4
     security.polkit.extraConfig = mkIf config.security.polkit.enable ''
       polkit.addRule(function(action, subject) {
@@ -874,6 +860,22 @@ in
         # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
         setLoginUid = true;
         pamMount = false;
+      };
+    };
+  }
+  // lib.optionalAttrs (options ? services.logrotate) {
+    services.logrotate.settings = {
+      "/var/log/btmp" = mapAttrs (_: mkDefault) {
+        frequency = "monthly";
+        rotate = 1;
+        create = "0660 root ${config.users.groups.utmp.name}";
+        minsize = "1M";
+      };
+      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
+        frequency = "monthly";
+        rotate = 1;
+        create = "0664 root ${config.users.groups.utmp.name}";
+        minsize = "1M";
       };
     };
   };

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -869,7 +869,7 @@ in
     # permission to run the command. This next part is only enabled if polkit is enabled because the
     # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
     # enabled, run0 will fail before it even tries to run the command.
-    security.pam.services = mkIf config.security.polkit.enable {
+    security.pam.services = mkIf (config.security.polkit.enable or false) {
       systemd-run0 = {
         # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
         setLoginUid = true;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -840,16 +840,6 @@ in
     # https://github.com/systemd/systemd/pull/12226
     boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
 
-    # Remove with systemd 259.4
-    security.polkit.extraConfig = mkIf config.security.polkit.enable ''
-      polkit.addRule(function(action, subject) {
-          if (action.id == "org.freedesktop.machine1.register-machine" &&
-              subject.user != "root") {
-              return polkit.Result.AUTH_ADMIN_KEEP;
-          }
-      });
-    '';
-
     # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
     # part, run0 would fail to run the command even if authentication is successful and the user has
     # permission to run the command. This next part is only enabled if polkit is enabled because the
@@ -862,6 +852,17 @@ in
         pamMount = false;
       };
     };
+  }
+  // lib.optionalAttrs (options ? security.polkit.extraConfig) {
+    # Remove with systemd 259.4
+    security.polkit.extraConfig = mkIf config.security.polkit.enable ''
+      polkit.addRule(function(action, subject) {
+          if (action.id == "org.freedesktop.machine1.register-machine" &&
+              subject.user != "root") {
+              return polkit.Result.AUTH_ADMIN_KEEP;
+          }
+      });
+    '';
   }
   // lib.optionalAttrs (options ? services.logrotate) {
     services.logrotate.settings = {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -672,8 +672,6 @@ in
         "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
       };
 
-    services.dbus.enable = true;
-
     users.users.systemd-network = {
       uid = config.ids.uids.systemd-network;
       group = "systemd-network";
@@ -852,6 +850,9 @@ in
         pamMount = false;
       };
     };
+  }
+  // lib.optionalAttrs (options ? services.dbus) {
+    services.dbus.enable = true;
   }
   // lib.optionalAttrs (options ? security.polkit.extraConfig) {
     # Remove with systemd 259.4

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -231,7 +231,7 @@ let
     "factory-reset.target.wants"
   ];
 
-  proxy_env = config.networking.proxy.envVars;
+  proxy_env = config.networking.proxy.envVars or { };
 
   json = pkgs.formats.json { };
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -720,7 +720,7 @@ in
         config.system.fsPackages
         ++ [ cfg.package.util-linux ]
         # systemd-ssh-generator needs sshd in PATH
-        ++ lib.optional config.services.openssh.enable config.services.openssh.package
+        ++ lib.optional (config.services.openssh.enable or false) config.services.openssh.package
       );
       LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       TZDIR = "/etc/zoneinfo";

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -67,7 +67,7 @@ let
     "systemd-udevd.service"
     "systemd-udev-settle.service"
   ]
-  ++ (optional (!config.boot.isContainer) "systemd-udev-trigger.service")
+  ++ (optional (!(config.boot.isContainer or false)) "systemd-udev-trigger.service")
   ++ [
     # hwdb.bin is managed by NixOS
     # "systemd-hwdb-update.service"
@@ -99,7 +99,7 @@ let
     "dev-mqueue.mount"
     "sys-fs-fuse-connections.mount"
   ]
-  ++ (optional (!config.boot.isContainer) "sys-kernel-config.mount")
+  ++ (optional (!(config.boot.isContainer or false)) "sys-kernel-config.mount")
   ++ [
     "sys-kernel-debug.mount"
     "sys-kernel-tracing.mount"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -248,7 +248,7 @@ let
     "factory-reset.target.wants"
   ];
 
-  proxy_env = config.networking.proxy.envVars;
+  proxy_env = config.networking.proxy.envVars or { };
 
   json = pkgs.formats.json { };
 

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   utils,
@@ -529,396 +530,398 @@ in
 
   ###### implementation
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    warnings =
-      let
-        mkOneNetOnlineWarn =
-          typeStr: name: def:
-          lib.optional (
-            lib.elem "network-online.target" def.after
-            && !(lib.elem "network-online.target" (def.wants ++ def.requires ++ def.bindsTo))
-          ) "${name}.${typeStr} is ordered after 'network-online.target' but doesn't depend on it";
-        mkNetOnlineWarns =
-          typeStr: defs: lib.concatLists (lib.mapAttrsToList (mkOneNetOnlineWarn typeStr) defs);
-        mkMountNetOnlineWarns =
-          typeStr: defs: lib.concatLists (map (m: mkOneNetOnlineWarn typeStr m.what m) defs);
-      in
-      concatLists (
+      warnings =
+        let
+          mkOneNetOnlineWarn =
+            typeStr: name: def:
+            lib.optional (
+              lib.elem "network-online.target" def.after
+              && !(lib.elem "network-online.target" (def.wants ++ def.requires ++ def.bindsTo))
+            ) "${name}.${typeStr} is ordered after 'network-online.target' but doesn't depend on it";
+          mkNetOnlineWarns =
+            typeStr: defs: lib.concatLists (lib.mapAttrsToList (mkOneNetOnlineWarn typeStr) defs);
+          mkMountNetOnlineWarns =
+            typeStr: defs: lib.concatLists (map (m: mkOneNetOnlineWarn typeStr m.what m) defs);
+        in
+        concatLists (
+          mapAttrsToList (
+            name: service:
+            let
+              type = service.serviceConfig.Type or "";
+              restart = service.serviceConfig.Restart or "no";
+              hasDeprecated = builtins.hasAttr "StartLimitInterval" service.serviceConfig;
+            in
+            concatLists [
+              (optional (type == "oneshot" && (restart == "always" || restart == "on-success"))
+                "Service '${name}.service' with 'Type=oneshot' cannot have 'Restart=always' or 'Restart=on-success'"
+              )
+              (optional hasDeprecated "Service '${name}.service' uses the attribute 'StartLimitInterval' in the Service section, which is deprecated. See https://github.com/NixOS/nixpkgs/issues/45786.")
+              (optional (service.reloadIfChanged && service.reloadTriggers != [ ])
+                "Service '${name}.service' has both 'reloadIfChanged' and 'reloadTriggers' set. This is probably not what you want, because 'reloadTriggers' behave the same whay as 'restartTriggers' if 'reloadIfChanged' is set."
+              )
+            ]
+          ) cfg.services
+        )
+        ++ (mkNetOnlineWarns "target" cfg.targets)
+        ++ (mkNetOnlineWarns "service" cfg.services)
+        ++ (mkNetOnlineWarns "socket" cfg.sockets)
+        ++ (mkNetOnlineWarns "timer" cfg.timers)
+        ++ (mkNetOnlineWarns "path" cfg.paths)
+        ++ (mkMountNetOnlineWarns "mount" cfg.mounts)
+        ++ (mkMountNetOnlineWarns "automount" cfg.automounts)
+        ++ (mkNetOnlineWarns "slice" cfg.slices);
+
+      assertions = concatLists (
         mapAttrsToList (
           name: service:
-          let
-            type = service.serviceConfig.Type or "";
-            restart = service.serviceConfig.Restart or "no";
-            hasDeprecated = builtins.hasAttr "StartLimitInterval" service.serviceConfig;
-          in
-          concatLists [
-            (optional (type == "oneshot" && (restart == "always" || restart == "on-success"))
-              "Service '${name}.service' with 'Type=oneshot' cannot have 'Restart=always' or 'Restart=on-success'"
-            )
-            (optional hasDeprecated "Service '${name}.service' uses the attribute 'StartLimitInterval' in the Service section, which is deprecated. See https://github.com/NixOS/nixpkgs/issues/45786.")
-            (optional (service.reloadIfChanged && service.reloadTriggers != [ ])
-              "Service '${name}.service' has both 'reloadIfChanged' and 'reloadTriggers' set. This is probably not what you want, because 'reloadTriggers' behave the same whay as 'restartTriggers' if 'reloadIfChanged' is set."
-            )
-          ]
-        ) cfg.services
-      )
-      ++ (mkNetOnlineWarns "target" cfg.targets)
-      ++ (mkNetOnlineWarns "service" cfg.services)
-      ++ (mkNetOnlineWarns "socket" cfg.sockets)
-      ++ (mkNetOnlineWarns "timer" cfg.timers)
-      ++ (mkNetOnlineWarns "path" cfg.paths)
-      ++ (mkMountNetOnlineWarns "mount" cfg.mounts)
-      ++ (mkMountNetOnlineWarns "automount" cfg.automounts)
-      ++ (mkNetOnlineWarns "slice" cfg.slices);
-
-    assertions = concatLists (
-      mapAttrsToList (
-        name: service:
-        map
-          (message: {
-            assertion = false;
-            inherit message;
-          })
-          (concatLists [
-            (optional
-              (
-                (builtins.elem "network-interfaces.target" service.after)
-                || (builtins.elem "network-interfaces.target" service.wants)
+          map
+            (message: {
+              assertion = false;
+              inherit message;
+            })
+            (concatLists [
+              (optional
+                (
+                  (builtins.elem "network-interfaces.target" service.after)
+                  || (builtins.elem "network-interfaces.target" service.wants)
+                )
+                "Service '${name}.service' is using the deprecated target network-interfaces.target, which no longer exists. Using network.target is recommended instead."
               )
-              "Service '${name}.service' is using the deprecated target network-interfaces.target, which no longer exists. Using network.target is recommended instead."
-            )
-          ])
-      ) cfg.services
-    );
-
-    system.build.units = cfg.units;
-
-    system.nssModules = [ cfg.package.out ];
-    system.nssDatabases = {
-      hosts = (
-        mkMerge [
-          (mkOrder 400 [ "mymachines" ]) # 400 to ensure it comes before resolve (which is 501)
-          (mkOrder 999 [ "myhostname" ]) # after files (which is 998), but before regular nss modules
-        ]
+            ])
+        ) cfg.services
       );
-      passwd = (
-        mkMerge [
-          (mkAfter [ "systemd" ])
-        ]
-      );
-      group = (
-        mkMerge [
-          (mkAfter [ "[success=merge] systemd" ]) # need merge so that NSS won't stop at file-based groups
-        ]
-      );
-      shadow = (
-        mkMerge [
-          (mkAfter [ "systemd" ])
-        ]
-      );
-    };
 
-    environment.systemPackages = [ cfg.package ];
+      system.build.units = cfg.units;
 
-    environment.variables = {
-      SYSTEMD_XKB_DIRECTORY = "/etc/X11/xkb";
-    };
+      system.nssModules = [ cfg.package.out ];
+      system.nssDatabases = {
+        hosts = (
+          mkMerge [
+            (mkOrder 400 [ "mymachines" ]) # 400 to ensure it comes before resolve (which is 501)
+            (mkOrder 999 [ "myhostname" ]) # after files (which is 998), but before regular nss modules
+          ]
+        );
+        passwd = (
+          mkMerge [
+            (mkAfter [ "systemd" ])
+          ]
+        );
+        group = (
+          mkMerge [
+            (mkAfter [ "[success=merge] systemd" ]) # need merge so that NSS won't stop at file-based groups
+          ]
+        );
+        shadow = (
+          mkMerge [
+            (mkAfter [ "systemd" ])
+          ]
+        );
+      };
 
-    environment.etc =
-      let
-        # generate contents for /etc/systemd/${dir} from attrset of links and packages
-        hooks =
-          dir: links:
-          pkgs.runCommand "${dir}"
-            {
-              preferLocalBuild = true;
-              packages = cfg.packages;
-            }
-            ''
-              set -e
-              mkdir -p $out
-              for package in $packages
-              do
-                for hook in $package/lib/systemd/${dir}/*
+      environment.systemPackages = [ cfg.package ];
+
+      environment.variables = {
+        SYSTEMD_XKB_DIRECTORY = "/etc/X11/xkb";
+      };
+
+      environment.etc =
+        let
+          # generate contents for /etc/systemd/${dir} from attrset of links and packages
+          hooks =
+            dir: links:
+            pkgs.runCommand "${dir}"
+              {
+                preferLocalBuild = true;
+                packages = cfg.packages;
+              }
+              ''
+                set -e
+                mkdir -p $out
+                for package in $packages
                 do
-                  ln -s $hook $out/
+                  for hook in $package/lib/systemd/${dir}/*
+                  do
+                    ln -s $hook $out/
+                  done
                 done
-              done
-              ${concatStrings (mapAttrsToList (exec: target: "ln -s ${target} $out/${exec};\n") links)}
-            '';
+                ${concatStrings (mapAttrsToList (exec: target: "ln -s ${target} $out/${exec};\n") links)}
+              '';
 
-        enabledUpstreamSystemUnits = filter (n: !elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
-        enabledUnits = removeAttrs cfg.units cfg.suppressedSystemUnits;
+          enabledUpstreamSystemUnits = filter (n: !elem n cfg.suppressedSystemUnits) upstreamSystemUnits;
+          enabledUnits = removeAttrs cfg.units cfg.suppressedSystemUnits;
 
-      in
-      {
-        "systemd/system".source = generateUnits {
-          type = "system";
-          units = enabledUnits;
-          upstreamUnits = enabledUpstreamSystemUnits;
-          upstreamWants = upstreamSystemWants;
-        };
-
-        "systemd/system.conf".text = settingsToSections cfg.settings;
-
-        "systemd/sleep.conf".text = settingsToSections cfg.sleep.settings;
-
-        "systemd/user-generators" = {
-          source = hooks "user-generators" cfg.user.generators;
-        };
-        "systemd/system-generators" = {
-          source = hooks "system-generators" cfg.generators;
-        };
-        "systemd/system-shutdown" = {
-          source = hooks "system-shutdown" cfg.shutdown;
-        };
-
-        # Ignore all other preset files so systemd doesn't try to enable/disable
-        # units during runtime.
-        "systemd/system-preset/00-nixos.preset".text = ''
-          ignore *
-        '';
-        "systemd/user-preset/00-nixos.preset".text = ''
-          ignore *
-        '';
-
-        "systemd/generator-environment.json".source =
-          json.generate "systemd-generator-environment.json" cfg.generatorEnvironment;
-
-        "systemd/system-environment-generators/env-generator".source =
-          "${config.system.nixos-init.package}/bin/env-generator";
-
-        "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
-      };
-
-    services.dbus.enable = true;
-
-    users.users.systemd-network = {
-      uid = config.ids.uids.systemd-network;
-      group = "systemd-network";
-    };
-    users.groups.systemd-network.gid = config.ids.gids.systemd-network;
-    users.users.systemd-resolve = {
-      uid = config.ids.uids.systemd-resolve;
-      group = "systemd-resolve";
-    };
-    users.groups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
-
-    # Target for ‘charon send-keys’ to hook into.
-    users.groups.keys.gid = config.ids.gids.keys;
-
-    systemd.targets.keys = {
-      description = "Security Keys";
-      unitConfig.X-StopOnReconfiguration = true;
-    };
-
-    # This target only exists so that services ordered before sysinit.target
-    # are restarted in the correct order, notably BEFORE the other services,
-    # when switching configurations.
-    systemd.targets.sysinit-reactivation = {
-      description = "Reactivate sysinit units";
-    };
-
-    systemd.units =
-      let
-        withName = cfgToUnit: cfg: lib.nameValuePair cfg.name (cfgToUnit cfg);
-      in
-      mapAttrs' (_: withName pathToUnit) cfg.paths
-      // mapAttrs' (_: withName serviceToUnit) cfg.services
-      // mapAttrs' (_: withName sliceToUnit) cfg.slices
-      // mapAttrs' (_: withName socketToUnit) cfg.sockets
-      // mapAttrs' (_: withName targetToUnit) cfg.targets
-      // mapAttrs' (_: withName timerToUnit) cfg.timers
-      // listToAttrs (map (withName mountToUnit) cfg.mounts)
-      // listToAttrs (map (withName automountToUnit) cfg.automounts);
-
-    # Environment of PID 1
-    systemd.managerEnvironment = {
-      # Doesn't contain systemd itself - everything works so it seems to use the compiled-in value for its tools
-      # util-linux is needed for the main fsck utility wrapping the fs-specific ones
-      PATH = lib.makeBinPath (
-        config.system.fsPackages
-        ++ [ cfg.package.util-linux ]
-        # systemd-ssh-generator needs sshd in PATH
-        ++ lib.optional (config.services.openssh.enable or false) config.services.openssh.package
-      );
-      LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
-      TZDIR = "/etc/zoneinfo";
-      # If SYSTEMD_UNIT_PATH ends with an empty component (":"), the usual unit load path will be appended to the contents of the variable
-      SYSTEMD_UNIT_PATH = lib.mkIf (
-        config.boot.extraSystemdUnitPaths != [ ]
-      ) "${builtins.concatStringsSep ":" config.boot.extraSystemdUnitPaths}:";
-    };
-    systemd.settings.Manager = {
-      ManagerEnvironment = lib.concatStringsSep " " (
-        lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
-      );
-      DefaultIOAccounting = lib.mkDefault true;
-      DefaultIPAccounting = lib.mkDefault true;
-    };
-
-    # These are needed for systemd-fstab-generator to schedule systemd-fsck@
-    # units.
-    systemd.generatorPath = config.system.fsPackages ++ [
-      cfg.package.util-linux
-    ];
-
-    systemd.generatorEnvironment = {
-      PATH = lib.makeBinPath cfg.generatorPath;
-    };
-
-    system.requiredKernelConfig = map config.lib.kernelConfig.isEnabled [
-      "DEVTMPFS"
-      "CGROUPS"
-      "INOTIFY_USER"
-      "SIGNALFD"
-      "TIMERFD"
-      "EPOLL"
-      "NET"
-      "SYSFS"
-      "PROC_FS"
-      "FHANDLE"
-      "CRYPTO_USER_API_HASH"
-      "CRYPTO_HMAC"
-      "CRYPTO_SHA256"
-      "DMIID"
-      "AUTOFS_FS"
-      "TMPFS_POSIX_ACL"
-      "TMPFS_XATTR"
-      "SECCOMP"
-    ];
-
-    # Generate timer units for all services that have a ‘startAt’ value.
-    systemd.timers = mapAttrs (name: service: {
-      wantedBy = [ "timers.target" ];
-      timerConfig.OnCalendar = service.startAt;
-    }) (filterAttrs (name: service: service.enable && service.startAt != [ ]) cfg.services);
-
-    # Some overrides to upstream units.
-    systemd.services."systemd-backlight@".restartIfChanged = false;
-    systemd.services."systemd-fsck@".restartIfChanged = false;
-    systemd.services."systemd-fsck@".path = [ pkgs.util-linux ] ++ config.system.fsPackages;
-    systemd.services."systemd-makefs@" = {
-      restartIfChanged = false;
-      path = [ pkgs.util-linux ] ++ config.system.fsPackages;
-      # Since there is no /etc/systemd/system/systemd-makefs@.service
-      # file, the units generated in /run/systemd/generator would
-      # override anything we put here. But by forcing the use of a
-      # drop-in in /etc, it does apply.
-      overrideStrategy = "asDropin";
-    };
-    systemd.services."systemd-mkswap@" = {
-      restartIfChanged = false;
-      path = [ pkgs.util-linux ];
-      overrideStrategy = "asDropin";
-    };
-    systemd.services."modprobe@" = {
-      restartIfChanged = false;
-      serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.kmod ];
-    };
-    systemd.services.systemd-random-seed.restartIfChanged = false;
-    systemd.services.systemd-remount-fs.restartIfChanged = false;
-    systemd.services.systemd-update-utmp.restartIfChanged = false;
-    systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
-    systemd.services.systemd-importd = lib.mkIf cfg.package.withImportd {
-      environment = proxy_env;
-      path = [ pkgs.gnupgMinimal ];
-    };
-    systemd.services.systemd-pstore.wantedBy = [ "sysinit.target" ]; # see #81138
-
-    # NixOS has kernel modules in a different location, so override that here.
-    systemd.services.kmod-static-nodes.unitConfig.ConditionFileNotEmpty = [
-      "" # required to unset the previous value!
-      "/run/booted-system/kernel-modules/lib/modules/%v/modules.devname"
-    ];
-
-    # Don't bother with certain units in containers.
-    systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";
-
-    # When using the classic /etc mechanism, we set certain paths in /etc to
-    # /etc/static so that systemd cannot change them (as they are symlinks to
-    # the read-only Nix Store). This is only done so that these services cannot
-    # change the values. All other parts of systemd should read them from their
-    # canonical locations.
-    #
-    # If you use the overlay mechanism to manage /etc, this is unnecessary
-    # because either the overlay is mutable (and users can legitimately change
-    # values without them being overridden) or it is immutable and systemd will
-    # suggest to only make runtime changes.
-    systemd.services."systemd-localed".environment =
-      lib.mkIf (!config.system.etc.overlay.enable && !config.i18n.imperativeLocale)
+        in
         {
-          SYSTEMD_ETC_LOCALE_CONF = "/etc/static/locale.conf";
-          SYSTEMD_ETC_VCONSOLE_CONF = "/etc/static/vconsole.conf";
+          "systemd/system".source = generateUnits {
+            type = "system";
+            units = enabledUnits;
+            upstreamUnits = enabledUpstreamSystemUnits;
+            upstreamWants = upstreamSystemWants;
+          };
+
+          "systemd/system.conf".text = settingsToSections cfg.settings;
+
+          "systemd/sleep.conf".text = settingsToSections cfg.sleep.settings;
+
+          "systemd/user-generators" = {
+            source = hooks "user-generators" cfg.user.generators;
+          };
+          "systemd/system-generators" = {
+            source = hooks "system-generators" cfg.generators;
+          };
+          "systemd/system-shutdown" = {
+            source = hooks "system-shutdown" cfg.shutdown;
+          };
+
+          # Ignore all other preset files so systemd doesn't try to enable/disable
+          # units during runtime.
+          "systemd/system-preset/00-nixos.preset".text = ''
+            ignore *
+          '';
+          "systemd/user-preset/00-nixos.preset".text = ''
+            ignore *
+          '';
+
+          "systemd/generator-environment.json".source =
+            json.generate "systemd-generator-environment.json" cfg.generatorEnvironment;
+
+          "systemd/system-environment-generators/env-generator".source =
+            "${config.system.nixos-init.package}/bin/env-generator";
+
+          "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
         };
-    systemd.services."systemd-timedated".environment =
-      lib.mkIf (!config.system.etc.overlay.enable && config.time.timeZone != null)
-        {
-          SYSTEMD_ETC_LOCALTIME = "/etc/static/localtime";
-          SYSTEMD_ETC_ADJTIME = "/etc/static/adjtime";
+
+      services.dbus.enable = true;
+
+      users.users.systemd-network = {
+        uid = config.ids.uids.systemd-network;
+        group = "systemd-network";
+      };
+      users.groups.systemd-network.gid = config.ids.gids.systemd-network;
+      users.users.systemd-resolve = {
+        uid = config.ids.uids.systemd-resolve;
+        group = "systemd-resolve";
+      };
+      users.groups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
+
+      # Target for ‘charon send-keys’ to hook into.
+      users.groups.keys.gid = config.ids.gids.keys;
+
+      systemd.targets.keys = {
+        description = "Security Keys";
+        unitConfig.X-StopOnReconfiguration = true;
+      };
+
+      # This target only exists so that services ordered before sysinit.target
+      # are restarted in the correct order, notably BEFORE the other services,
+      # when switching configurations.
+      systemd.targets.sysinit-reactivation = {
+        description = "Reactivate sysinit units";
+      };
+
+      systemd.units =
+        let
+          withName = cfgToUnit: cfg: lib.nameValuePair cfg.name (cfgToUnit cfg);
+        in
+        mapAttrs' (_: withName pathToUnit) cfg.paths
+        // mapAttrs' (_: withName serviceToUnit) cfg.services
+        // mapAttrs' (_: withName sliceToUnit) cfg.slices
+        // mapAttrs' (_: withName socketToUnit) cfg.sockets
+        // mapAttrs' (_: withName targetToUnit) cfg.targets
+        // mapAttrs' (_: withName timerToUnit) cfg.timers
+        // listToAttrs (map (withName mountToUnit) cfg.mounts)
+        // listToAttrs (map (withName automountToUnit) cfg.automounts);
+
+      # Environment of PID 1
+      systemd.managerEnvironment = {
+        # Doesn't contain systemd itself - everything works so it seems to use the compiled-in value for its tools
+        # util-linux is needed for the main fsck utility wrapping the fs-specific ones
+        PATH = lib.makeBinPath (
+          config.system.fsPackages
+          ++ [ cfg.package.util-linux ]
+          # systemd-ssh-generator needs sshd in PATH
+          ++ lib.optional (config.services.openssh.enable or false) config.services.openssh.package
+        );
+        LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
+        TZDIR = "/etc/zoneinfo";
+        # If SYSTEMD_UNIT_PATH ends with an empty component (":"), the usual unit load path will be appended to the contents of the variable
+        SYSTEMD_UNIT_PATH = lib.mkIf (
+          config.boot.extraSystemdUnitPaths != [ ]
+        ) "${builtins.concatStringsSep ":" config.boot.extraSystemdUnitPaths}:";
+      };
+      systemd.settings.Manager = {
+        ManagerEnvironment = lib.concatStringsSep " " (
+          lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
+        );
+        DefaultIOAccounting = lib.mkDefault true;
+        DefaultIPAccounting = lib.mkDefault true;
+      };
+
+      # These are needed for systemd-fstab-generator to schedule systemd-fsck@
+      # units.
+      systemd.generatorPath = config.system.fsPackages ++ [
+        cfg.package.util-linux
+      ];
+
+      systemd.generatorEnvironment = {
+        PATH = lib.makeBinPath cfg.generatorPath;
+      };
+
+      system.requiredKernelConfig = map config.lib.kernelConfig.isEnabled [
+        "DEVTMPFS"
+        "CGROUPS"
+        "INOTIFY_USER"
+        "SIGNALFD"
+        "TIMERFD"
+        "EPOLL"
+        "NET"
+        "SYSFS"
+        "PROC_FS"
+        "FHANDLE"
+        "CRYPTO_USER_API_HASH"
+        "CRYPTO_HMAC"
+        "CRYPTO_SHA256"
+        "DMIID"
+        "AUTOFS_FS"
+        "TMPFS_POSIX_ACL"
+        "TMPFS_XATTR"
+        "SECCOMP"
+      ];
+
+      # Generate timer units for all services that have a ‘startAt’ value.
+      systemd.timers = mapAttrs (name: service: {
+        wantedBy = [ "timers.target" ];
+        timerConfig.OnCalendar = service.startAt;
+      }) (filterAttrs (name: service: service.enable && service.startAt != [ ]) cfg.services);
+
+      # Some overrides to upstream units.
+      systemd.services."systemd-backlight@".restartIfChanged = false;
+      systemd.services."systemd-fsck@".restartIfChanged = false;
+      systemd.services."systemd-fsck@".path = [ pkgs.util-linux ] ++ config.system.fsPackages;
+      systemd.services."systemd-makefs@" = {
+        restartIfChanged = false;
+        path = [ pkgs.util-linux ] ++ config.system.fsPackages;
+        # Since there is no /etc/systemd/system/systemd-makefs@.service
+        # file, the units generated in /run/systemd/generator would
+        # override anything we put here. But by forcing the use of a
+        # drop-in in /etc, it does apply.
+        overrideStrategy = "asDropin";
+      };
+      systemd.services."systemd-mkswap@" = {
+        restartIfChanged = false;
+        path = [ pkgs.util-linux ];
+        overrideStrategy = "asDropin";
+      };
+      systemd.services."modprobe@" = {
+        restartIfChanged = false;
+        serviceConfig.ExecSearchPath = lib.makeBinPath [ pkgs.kmod ];
+      };
+      systemd.services.systemd-random-seed.restartIfChanged = false;
+      systemd.services.systemd-remount-fs.restartIfChanged = false;
+      systemd.services.systemd-update-utmp.restartIfChanged = false;
+      systemd.targets.local-fs.unitConfig.X-StopOnReconfiguration = true;
+      systemd.targets.remote-fs.unitConfig.X-StopOnReconfiguration = true;
+      systemd.services.systemd-importd = lib.mkIf cfg.package.withImportd {
+        environment = proxy_env;
+        path = [ pkgs.gnupgMinimal ];
+      };
+      systemd.services.systemd-pstore.wantedBy = [ "sysinit.target" ]; # see #81138
+
+      # NixOS has kernel modules in a different location, so override that here.
+      systemd.services.kmod-static-nodes.unitConfig.ConditionFileNotEmpty = [
+        "" # required to unset the previous value!
+        "/run/booted-system/kernel-modules/lib/modules/%v/modules.devname"
+      ];
+
+      # Don't bother with certain units in containers.
+      systemd.services.systemd-remount-fs.unitConfig.ConditionVirtualization = "!container";
+
+      # When using the classic /etc mechanism, we set certain paths in /etc to
+      # /etc/static so that systemd cannot change them (as they are symlinks to
+      # the read-only Nix Store). This is only done so that these services cannot
+      # change the values. All other parts of systemd should read them from their
+      # canonical locations.
+      #
+      # If you use the overlay mechanism to manage /etc, this is unnecessary
+      # because either the overlay is mutable (and users can legitimately change
+      # values without them being overridden) or it is immutable and systemd will
+      # suggest to only make runtime changes.
+      systemd.services."systemd-localed".environment =
+        lib.mkIf (!config.system.etc.overlay.enable && !config.i18n.imperativeLocale)
+          {
+            SYSTEMD_ETC_LOCALE_CONF = "/etc/static/locale.conf";
+            SYSTEMD_ETC_VCONSOLE_CONF = "/etc/static/vconsole.conf";
+          };
+      systemd.services."systemd-timedated".environment =
+        lib.mkIf (!config.system.etc.overlay.enable && config.time.timeZone != null)
+          {
+            SYSTEMD_ETC_LOCALTIME = "/etc/static/localtime";
+            SYSTEMD_ETC_ADJTIME = "/etc/static/adjtime";
+          };
+      systemd.services."systemd-hostnamed".environment = lib.mkIf (!config.system.etc.overlay.enable) {
+        SYSTEMD_ETC_HOSTNAME = "/etc/static/hostname";
+        SYSTEMD_ETC_MACHINE_INFO = "/etc/static/machine-info";
+      };
+
+      # Increase numeric PID range (set directly instead of copying a one-line file from systemd)
+      # https://github.com/systemd/systemd/pull/12226
+      boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
+
+      # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
+      # part, run0 would fail to run the command even if authentication is successful and the user has
+      # permission to run the command. This next part is only enabled if polkit is enabled because the
+      # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
+      # enabled, run0 will fail before it even tries to run the command.
+      security.pam.services = mkIf (config.security.polkit.enable or false) {
+        systemd-run0 = {
+          # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
+          setLoginUid = true;
+          pamMount = false;
         };
-    systemd.services."systemd-hostnamed".environment = lib.mkIf (!config.system.etc.overlay.enable) {
-      SYSTEMD_ETC_HOSTNAME = "/etc/static/hostname";
-      SYSTEMD_ETC_MACHINE_INFO = "/etc/static/machine-info";
-    };
-
-    # Increase numeric PID range (set directly instead of copying a one-line file from systemd)
-    # https://github.com/systemd/systemd/pull/12226
-    boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.hostPlatform.is64bit (lib.mkDefault 4194304);
-
-    services.logrotate.settings = {
-      "/var/log/btmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0660 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
       };
-      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
-        frequency = "monthly";
-        rotate = 1;
-        create = "0664 root ${config.users.groups.utmp.name}";
-        minsize = "1M";
+      # the systemd vmspawn credential dropin executes sshd and expects ExecSearchPath to be set, see:
+      # https://github.com/systemd/systemd/blob/v259.3/src/vmspawn/vmspawn.c#L2662
+      # this service is used, for example, when NixOS is started via systemd-vmspawn
+      systemd.services."sshd-vsock@" = mkIf (config.services.openssh.enable or false) {
+        serviceConfig.ExecSearchPath = "${config.services.openssh.package}/bin";
+        overrideStrategy = "asDropin";
       };
-    };
 
-    # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
-    # part, run0 would fail to run the command even if authentication is successful and the user has
-    # permission to run the command. This next part is only enabled if polkit is enabled because the
-    # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
-    # enabled, run0 will fail before it even tries to run the command.
-    security.pam.services = mkIf (config.security.polkit.enable or false) {
-      systemd-run0 = {
-        # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
-        setLoginUid = true;
-        pamMount = false;
+      # Fix paths in sshd-vsock.socket
+      # https://github.com/systemd/systemd/blob/v259.3/src/ssh-generator/ssh-generator.c#L239
+      # this socket is used, for example, when NixOS is started via systemd-vmspawn
+      systemd.sockets.sshd-vsock = mkIf (config.services.openssh.enable or false) {
+        overrideStrategy = "asDropin";
+        socketConfig.ExecStartPost = [
+          ""
+          "${config.systemd.package}/lib/systemd/systemd-ssh-issue --make-vsock"
+        ];
+        socketConfig.ExecStopPre = [
+          ""
+          "${config.systemd.package}/lib/systemd/systemd-ssh-issue --rm-vsock"
+        ];
       };
-    };
-
-    # the systemd vmspawn credential dropin executes sshd and expects ExecSearchPath to be set, see:
-    # https://github.com/systemd/systemd/blob/v259.3/src/vmspawn/vmspawn.c#L2662
-    # this service is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.services."sshd-vsock@" = mkIf (config.services.openssh.enable or false) {
-      serviceConfig.ExecSearchPath = "${config.services.openssh.package}/bin";
-      overrideStrategy = "asDropin";
-    };
-
-    # Fix paths in sshd-vsock.socket
-    # https://github.com/systemd/systemd/blob/v259.3/src/ssh-generator/ssh-generator.c#L239
-    # this socket is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.sockets.sshd-vsock = mkIf (config.services.openssh.enable or false) {
-      overrideStrategy = "asDropin";
-      socketConfig.ExecStartPost = [
-        ""
-        "${config.systemd.package}/lib/systemd/systemd-ssh-issue --make-vsock"
-      ];
-      socketConfig.ExecStopPre = [
-        ""
-        "${config.systemd.package}/lib/systemd/systemd-ssh-issue --rm-vsock"
-      ];
-    };
-  };
+    }
+    (lib.optionalAttrs (options ? services.logrotate) {
+      services.logrotate.settings = {
+        "/var/log/btmp" = mapAttrs (_: mkDefault) {
+          frequency = "monthly";
+          rotate = 1;
+          create = "0660 root ${config.users.groups.utmp.name}";
+          minsize = "1M";
+        };
+        "/var/log/wtmp" = mapAttrs (_: mkDefault) {
+          frequency = "monthly";
+          rotate = 1;
+          create = "0664 root ${config.users.groups.utmp.name}";
+          minsize = "1M";
+        };
+      };
+    })
+  ];
 
   # FIXME: Remove these eventually.
   imports = [

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -741,7 +741,7 @@ in
         config.system.fsPackages
         ++ [ cfg.package.util-linux ]
         # systemd-ssh-generator needs sshd in PATH
-        ++ lib.optional config.services.openssh.enable config.services.openssh.package
+        ++ lib.optional (config.services.openssh.enable or false) config.services.openssh.package
       );
       LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       TZDIR = "/etc/zoneinfo";
@@ -899,7 +899,7 @@ in
     # the systemd vmspawn credential dropin executes sshd and expects ExecSearchPath to be set, see:
     # https://github.com/systemd/systemd/blob/v259.3/src/vmspawn/vmspawn.c#L2662
     # this service is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.services."sshd-vsock@" = mkIf config.services.openssh.enable {
+    systemd.services."sshd-vsock@" = mkIf (config.services.openssh.enable or false) {
       serviceConfig.ExecSearchPath = "${config.services.openssh.package}/bin";
       overrideStrategy = "asDropin";
     };
@@ -907,7 +907,7 @@ in
     # Fix paths in sshd-vsock.socket
     # https://github.com/systemd/systemd/blob/v259.3/src/ssh-generator/ssh-generator.c#L239
     # this socket is used, for example, when NixOS is started via systemd-vmspawn
-    systemd.sockets.sshd-vsock = mkIf config.services.openssh.enable {
+    systemd.sockets.sshd-vsock = mkIf (config.services.openssh.enable or false) {
       overrideStrategy = "asDropin";
       socketConfig.ExecStartPost = [
         ""

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -68,7 +68,7 @@ let
     "systemd-udevd-varlink.socket"
     "systemd-udevd.service"
   ]
-  ++ (optional (!config.boot.isContainer) "systemd-udev-trigger.service")
+  ++ (optional (!(config.boot.isContainer or false)) "systemd-udev-trigger.service")
   ++ [
     # hwdb.bin is managed by NixOS
     # "systemd-hwdb-update.service"
@@ -100,7 +100,7 @@ let
     "dev-mqueue.mount"
     "sys-fs-fuse-connections.mount"
   ]
-  ++ (optional (!config.boot.isContainer) "sys-kernel-config.mount")
+  ++ (optional (!(config.boot.isContainer or false)) "sys-kernel-config.mount")
   ++ [
     "sys-kernel-debug.mount"
     "sys-kernel-tracing.mount"

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -888,7 +888,7 @@ in
     # permission to run the command. This next part is only enabled if polkit is enabled because the
     # error that we’re trying to avoid can’t possibly happen if polkit isn’t enabled. When polkit isn’t
     # enabled, run0 will fail before it even tries to run the command.
-    security.pam.services = mkIf config.security.polkit.enable {
+    security.pam.services = mkIf (config.security.polkit.enable or false) {
       systemd-run0 = {
         # Upstream config: https://github.com/systemd/systemd/blob/main/src/run/systemd-run0.in
         setLoginUid = true;

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -905,6 +905,17 @@ in
         ];
       };
     }
+    (lib.optionalAttrs (options ? security.polkit.extraConfig) {
+      # Remove with systemd 259.4
+      security.polkit.extraConfig = mkIf config.security.polkit.enable ''
+        polkit.addRule(function(action, subject) {
+            if (action.id == "org.freedesktop.machine1.register-machine" &&
+                subject.user != "root") {
+                return polkit.Result.AUTH_ADMIN_KEEP;
+            }
+        });
+      '';
+    })
     (lib.optionalAttrs (options ? services.logrotate) {
       services.logrotate.settings = {
         "/var/log/btmp" = mapAttrs (_: mkDefault) {

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -694,8 +694,6 @@ in
           "sysctl.d/50-default.conf".source = "${cfg.package}/example/sysctl.d/50-default.conf";
         };
 
-      services.dbus.enable = true;
-
       users.users.systemd-network = {
         uid = config.ids.uids.systemd-network;
         group = "systemd-network";
@@ -905,6 +903,9 @@ in
         ];
       };
     }
+    (lib.optionalAttrs (options ? services.dbus) {
+      services.dbus.enable = true;
+    })
     (lib.optionalAttrs (options ? security.polkit.extraConfig) {
       # Remove with systemd 259.4
       security.polkit.extraConfig = mkIf config.security.polkit.enable ''

--- a/nixos/modules/system/boot/systemd/dm-verity.nix
+++ b/nixos/modules/system/boot/systemd/dm-verity.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
   cfg = config.boot.initrd.systemd.dmVerity;
@@ -17,41 +22,47 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
       {
-        assertion = config.boot.initrd.systemd.enable;
-        message = ''
-          'boot.initrd.systemd.dmVerity.enable' requires 'boot.initrd.systemd.enable' to be enabled.
-        '';
-      }
-    ];
+        assertions = [
+          {
+            assertion = config.boot.initrd.systemd.enable;
+            message = ''
+              'boot.initrd.systemd.dmVerity.enable' requires 'boot.initrd.systemd.enable' to be enabled.
+            '';
+          }
+        ];
 
-    boot.initrd = {
-      availableKernelModules = [
-        "dm_mod"
-        "dm_verity"
-      ];
+        boot.initrd = {
+          availableKernelModules = [
+            "dm_mod"
+            "dm_verity"
+          ];
+
+          # The additional targets and store paths allow users to integrate verity-protected devices
+          # through the systemd tooling.
+          systemd = {
+            additionalUpstreamUnits = [
+              "veritysetup-pre.target"
+              "veritysetup.target"
+              "remote-veritysetup.target"
+            ];
+
+            storePaths = [
+              "${config.boot.initrd.systemd.package}/lib/systemd/systemd-veritysetup"
+              "${config.boot.initrd.systemd.package}/lib/systemd/system-generators/systemd-veritysetup-generator"
+            ];
+          };
+        };
+      }
 
       # dm-verity needs additional udev rules from LVM to work.
-      services.lvm.enable = true;
-
-      # The additional targets and store paths allow users to integrate verity-protected devices
-      # through the systemd tooling.
-      systemd = {
-        additionalUpstreamUnits = [
-          "veritysetup-pre.target"
-          "veritysetup.target"
-          "remote-veritysetup.target"
-        ];
-
-        storePaths = [
-          "${config.boot.initrd.systemd.package}/lib/systemd/systemd-veritysetup"
-          "${config.boot.initrd.systemd.package}/lib/systemd/system-generators/systemd-veritysetup-generator"
-        ];
-      };
-    };
-  };
+      (lib.optionalAttrs (options ? boot.initrd.services.lvm) {
+        boot.initrd.services.lvm.enable = true;
+      })
+    ]
+  );
 
   meta.maintainers = with lib.maintainers; [
     msanft

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -431,19 +431,23 @@ in
       }
     ]
     ++
-      map
-        (name: {
-          assertion = lib.attrByPath name (throw "impossible") config.boot.initrd == "";
-          message = ''
-            systemd stage 1 does not support 'boot.initrd.${lib.concatStringsSep "." name}'. Please
-              convert it to analogous systemd units in 'boot.initrd.systemd'.
+      lib.concatMap
+        (
+          name:
+          # Only assert if the option actually exists (it may not with minimal modules)
+          lib.optional (lib.hasAttrByPath name config.boot.initrd) {
+            assertion = lib.attrByPath name "" config.boot.initrd == "";
+            message = ''
+              systemd stage 1 does not support 'boot.initrd.${lib.concatStringsSep "." name}'. Please
+                convert it to analogous systemd units in 'boot.initrd.systemd'.
 
-                Definitions:
-            ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
-              (lib.attrByPath name (throw "impossible") options.boot.initrd).definitionsWithLocations
-            }
-          '';
-        })
+                  Definitions:
+              ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
+                (lib.attrByPath name (throw "impossible") options.boot.initrd).definitionsWithLocations
+              }
+            '';
+          }
+        )
         [
           [ "preFailCommands" ]
           [ "preDeviceCommands" ]

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -530,7 +530,7 @@ in
         "/etc/initrd-release".source = config.boot.initrd.osRelease;
 
         # For systemd-journald's _HOSTNAME field; needs to be set early, cannot be backfilled.
-        "/etc/hostname".text = config.networking.hostName;
+        "/etc/hostname".text = config.networking.hostName or config.system.nixos.distroId;
 
       }
       // optionalAttrs (config.environment.etc ? "modprobe.d/nixos.conf") {

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -589,7 +589,7 @@ in
         "/etc/initrd-release".source = config.boot.initrd.osRelease;
 
         # For systemd-journald's _HOSTNAME field; needs to be set early, cannot be backfilled.
-        "/etc/hostname".text = config.networking.hostName;
+        "/etc/hostname".text = config.networking.hostName or config.system.nixos.distroId;
 
       }
       // optionalAttrs (config.environment.etc ? "modprobe.d/nixos.conf") {

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -471,16 +471,20 @@ in
       let
         obsoleteOpt =
           opts: msgFn:
-          lib.flip map opts (opt: {
-            assertion = lib.attrByPath opt (throw "impossible") config.boot.initrd == "";
-            message = ''
-              ${msgFn (lib.concatStringsSep "." opt)}
-                  Definitions:
-              ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
-                (lib.attrByPath opt (throw "impossible") options.boot.initrd).definitionsWithLocations
-              }
-            '';
-          });
+          lib.flip lib.concatMap opts (
+            opt:
+            # Only assert if the option actually exists (it may not with minimal modules)
+            lib.optional (lib.hasAttrByPath opt config.boot.initrd) {
+              assertion = lib.attrByPath opt "" config.boot.initrd == "";
+              message = ''
+                ${msgFn (lib.concatStringsSep "." opt)}
+                    Definitions:
+                ${lib.concatMapStringsSep "\n" ({ file, ... }: "    - ${file}")
+                  (lib.attrByPath opt (throw "impossible") options.boot.initrd).definitionsWithLocations
+                }
+              '';
+            }
+          );
       in
       [
         {

--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -21,6 +21,13 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "enableHttpGateway" ]
+      [ "services" "journald" "gateway" "enable" ]
+    )
+  ];
+
   meta.maintainers = [ lib.maintainers.raitobezarius ];
   options.services.journald.gateway = {
     enable = lib.mkEnableOption "the HTTP gateway to the journal";

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -10,10 +10,6 @@ let
 in
 {
   imports = [
-    (lib.mkRenamedOptionModule
-      [ "services" "journald" "enableHttpGateway" ]
-      [ "services" "journald" "gateway" "enable" ]
-    )
   ];
 
   options = {

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -105,7 +105,7 @@ in
     };
 
     services.journald.forwardToSyslog = lib.mkOption {
-      default = config.services.rsyslogd.enable || config.services.syslog-ng.enable;
+      default = (config.services.rsyslogd.enable or false) || (config.services.syslog-ng.enable or false);
       defaultText = lib.literalExpression "services.rsyslogd.enable || services.syslog-ng.enable";
       type = lib.types.bool;
       description = ''

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -350,7 +350,7 @@ in
       "d  /var/db                            0755 root root - -"
       "L  /var/lock                          -    -    -    - ../run/lock"
     ]
-    ++ lib.optionals config.nix.enable [
+    ++ lib.optionals (config.nix.enable or false) [
       "d  /nix/var                           0755 root root - -"
       "L+ /nix/var/nix/gcroots/booted-system 0755 root root - /run/booted-system"
     ]
@@ -360,7 +360,7 @@ in
       "R! /etc/passwd.lock                   -    -    -    - -"
       "R! /etc/shadow.lock                   -    -    -    - -"
     ]
-    ++ lib.optionals config.nix.enable [
+    ++ lib.optionals (config.nix.enable or false) [
       "R! /nix/var/nix/gcroots/tmp           -    -    -    - -"
       "R! /nix/var/nix/temproots             -    -    -    - -"
     ];

--- a/nixos/modules/system/boot/systemd/userdbd.nix
+++ b/nixos/modules/system/boot/systemd/userdbd.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 
 let
   cfg = config.services.userdbd;
@@ -30,55 +35,62 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = lib.singleton {
-      assertion = cfg.enableSSHSupport -> config.security.enableWrappers;
-      message = "OpenSSH userdb integration requires security wrappers.";
-    };
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = lib.singleton {
+          assertion = cfg.enableSSHSupport -> config.security.enableWrappers;
+          message = "OpenSSH userdb integration requires security wrappers.";
+        };
 
-    warnings = lib.optional (lib.length highSystemUsers > 0 && !cfg.silenceHighSystemUsers) ''
-      The following system users have UIDs higher than 1000:
+        warnings = lib.optional (lib.length highSystemUsers > 0 && !cfg.silenceHighSystemUsers) ''
+          The following system users have UIDs higher than 1000:
 
-      ${lib.concatLines (lib.map (user: user.name) highSystemUsers)}
+          ${lib.concatLines (lib.map (user: user.name) highSystemUsers)}
 
-      These users will be recognized by systemd-userdb as "regular" users, not
-      "system" users. This will affect programs that query regular users, such
-      as systemd-homed, which will not run the first boot user creation flow,
-      as regular users already exist.
+          These users will be recognized by systemd-userdb as "regular" users, not
+          "system" users. This will affect programs that query regular users, such
+          as systemd-homed, which will not run the first boot user creation flow,
+          as regular users already exist.
 
-      To fix this issue, please remove or redefine these system users to have
-      UIDs below 1000. For Nix build users, it's possible to adjust the base
-      build user ID using the `ids.uids.nixbld` option, however care must be
-      taken to avoid collisions with UIDs of other services. Alternatively, you
-      may enable the `auto-allocate-uids` experimental feature and option in
-      the Nix configuration to avoid creating these users, however please note
-      that this option is experimental and subject to change.
+          To fix this issue, please remove or redefine these system users to have
+          UIDs below 1000. For Nix build users, it's possible to adjust the base
+          build user ID using the `ids.uids.nixbld` option, however care must be
+          taken to avoid collisions with UIDs of other services. Alternatively, you
+          may enable the `auto-allocate-uids` experimental feature and option in
+          the Nix configuration to avoid creating these users, however please note
+          that this option is experimental and subject to change.
 
-      Alternatively, to acknowledge and silence this warning, set
-      `services.userdbd.silenceHighSystemUsers` to true.
-    '';
+          Alternatively, to acknowledge and silence this warning, set
+          `services.userdbd.silenceHighSystemUsers` to true.
+        '';
 
-    systemd.additionalUpstreamSystemUnits = [
-      "systemd-userdbd.socket"
-      "systemd-userdbd.service"
-    ];
+        systemd.additionalUpstreamSystemUnits = [
+          "systemd-userdbd.socket"
+          "systemd-userdbd.service"
+        ];
 
-    systemd.sockets.systemd-userdbd.wantedBy = [ "sockets.target" ];
+        systemd.sockets.systemd-userdbd.wantedBy = [ "sockets.target" ];
 
-    # OpenSSH requires AuthorizedKeysCommand to be owned only by root.
-    # Referencing `userdbctl` directly from the Nix store won't work, as
-    # `/nix/store` is owned by the `nixbld` group.
-    security.wrappers = lib.mkIf cfg.enableSSHSupport {
-      userdbctl = {
-        owner = "root";
-        group = "root";
-        source = lib.getExe' config.systemd.package "userdbctl";
-      };
-    };
+        # OpenSSH requires AuthorizedKeysCommand to be owned only by root.
+        # Referencing `userdbctl` directly from the Nix store won't work, as
+        # `/nix/store` is owned by the `nixbld` group.
+        security.wrappers = lib.mkIf cfg.enableSSHSupport {
+          userdbctl = {
+            owner = "root";
+            group = "root";
+            source = lib.getExe' config.systemd.package "userdbctl";
+          };
+        };
 
-    services.openssh = lib.mkIf cfg.enableSSHSupport {
-      authorizedKeysCommand = "/run/wrappers/bin/userdbctl ssh-authorized-keys %u";
-      authorizedKeysCommandUser = "root";
-    };
-  };
+      }
+
+      (lib.optionalAttrs (options ? services.openssh) {
+        services.openssh = lib.mkIf cfg.enableSSHSupport {
+          authorizedKeysCommand = "/run/wrappers/bin/userdbctl ssh-authorized-keys %u";
+          authorizedKeysCommandUser = "root";
+        };
+      })
+    ]
+  );
 }

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -11,8 +11,8 @@ in
 
     services.timesyncd = with types; {
       enable = mkOption {
-        default = !config.boot.isContainer;
-        defaultText = literalExpression "!config.boot.isContainer";
+        default = !(config.boot.isContainer or false);
+        defaultText = literalExpression "!(config.boot.isContainer or false)";
         type = bool;
         description = ''
           Enables the systemd NTP client daemon.

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -22,8 +22,8 @@ in
 
     services.timesyncd = {
       enable = lib.mkOption {
-        default = !config.boot.isContainer;
-        defaultText = lib.literalExpression "!config.boot.isContainer";
+        default = !(config.boot.isContainer or false);
+        defaultText = lib.literalExpression "!(config.boot.isContainer or false)";
         type = lib.types.bool;
         description = ''
           Enables the systemd NTP client daemon.

--- a/nixos/modules/system/boot/uki.nix
+++ b/nixos/modules/system/boot/uki.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -88,7 +89,12 @@ in
         EFIArch = lib.mkOptionDefault efiArch;
       }
       //
-        lib.optionalAttrs (config.hardware.deviceTree.enable && config.hardware.deviceTree.name != null)
+        lib.optionalAttrs
+          (
+            options ? hardware.deviceTree
+            && config.hardware.deviceTree.enable
+            && config.hardware.deviceTree.name != null
+          )
           {
             DeviceTree = lib.mkOptionDefault "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
           };

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -19,150 +20,156 @@
       ] config.system.build.etcActivationCommands;
     }
 
-    (lib.mkIf config.system.etc.overlay.enable {
+    # The overlay block sets boot.initrd.* and system.requiredKernelConfig,
+    # which are defined in system/boot/stage-1.nix and system/boot/kernel.nix.
+    # Wrap with optionalAttrs so etc-activation works without stage-1 loaded
+    # (e.g. for container profiles).
+    (lib.optionalAttrs (options ? boot.initrd.availableKernelModules) (
+      lib.mkIf config.system.etc.overlay.enable {
 
-      assertions = [
-        {
-          assertion = config.boot.initrd.systemd.enable;
-          message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
-        }
-        {
-          assertion =
-            (!config.system.etc.overlay.mutable)
-            -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
-          message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
-        }
-        {
-          assertion =
-            (config.system.switch.enable or false)
-            -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
-          message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
-        }
-      ];
-
-      boot.initrd.availableKernelModules = [
-        "loop"
-        "erofs"
-        "overlay"
-      ];
-
-      system.requiredKernelConfig = with config.lib.kernelConfig; [
-        (isEnabled "EROFS_FS")
-      ];
-
-      boot.initrd.systemd = {
-        mounts = [
+        assertions = [
           {
-            where = "/run/nixos-etc-metadata";
-            what = "/etc-metadata-image";
-            type = "erofs";
-            options = "loop,ro,nodev,nosuid";
-            unitConfig = {
-              # Since this unit depends on the nix store being mounted, it cannot
-              # be a dependency of local-fs.target, because if it did, we'd have
-              # local-fs.target ordered after the nix store mount which would cause
-              # things like network.target to only become active after the nix store
-              # has been mounted.
-              # This breaks for instance setups where sshd needs to be up before
-              # any encrypted disks can be mounted.
-              DefaultDependencies = false;
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-              ];
-            };
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
+            assertion = config.boot.initrd.systemd.enable;
+            message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
           }
           {
-            where = "/sysroot/etc";
-            what = "overlay";
-            type = "overlay";
-            options = lib.concatStringsSep "," (
-              [
-                "nodev"
-                "nosuid"
-                "relatime"
-                "redirect_dir=on"
-                "metacopy=on"
-                "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
-              ]
-              ++ lib.optionals config.system.etc.overlay.mutable [
-                "rw"
-                "upperdir=/sysroot/.rw-etc/upper"
-                "workdir=/sysroot/.rw-etc/work"
-              ]
-              ++ lib.optionals (!config.system.etc.overlay.mutable) [
-                "ro"
-              ]
-            );
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            unitConfig = {
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-                "/run/nixos-etc-metadata"
-              ];
-              DefaultDependencies = false;
-            };
+            assertion =
+              (!config.system.etc.overlay.mutable)
+              -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
+            message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
+          }
+          {
+            assertion =
+              (config.system.switch.enable or false)
+              -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
+            message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
           }
         ];
-        services = lib.mkMerge [
-          (lib.mkIf config.system.etc.overlay.mutable {
-            rw-etc = {
+
+        boot.initrd.availableKernelModules = [
+          "loop"
+          "erofs"
+          "overlay"
+        ];
+
+        system.requiredKernelConfig = with config.lib.kernelConfig; [
+          (isEnabled "EROFS_FS")
+        ];
+
+        boot.initrd.systemd = {
+          mounts = [
+            {
+              where = "/run/nixos-etc-metadata";
+              what = "/etc-metadata-image";
+              type = "erofs";
+              options = "loop,ro,nodev,nosuid";
+              unitConfig = {
+                # Since this unit depends on the nix store being mounted, it cannot
+                # be a dependency of local-fs.target, because if it did, we'd have
+                # local-fs.target ordered after the nix store mount which would cause
+                # things like network.target to only become active after the nix store
+                # has been mounted.
+                # This breaks for instance setups where sshd needs to be up before
+                # any encrypted disks can be mounted.
+                DefaultDependencies = false;
+                RequiresMountsFor = [
+                  "/sysroot/nix/store"
+                ];
+              };
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
               requiredBy = [ "initrd-fs.target" ];
               before = [ "initrd-fs.target" ];
+            }
+            {
+              where = "/sysroot/etc";
+              what = "overlay";
+              type = "overlay";
+              options = lib.concatStringsSep "," (
+                [
+                  "nodev"
+                  "nosuid"
+                  "relatime"
+                  "redirect_dir=on"
+                  "metacopy=on"
+                  "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
+                ]
+                ++ lib.optionals config.system.etc.overlay.mutable [
+                  "rw"
+                  "upperdir=/sysroot/.rw-etc/upper"
+                  "workdir=/sysroot/.rw-etc/work"
+                ]
+                ++ lib.optionals (!config.system.etc.overlay.mutable) [
+                  "ro"
+                ]
+              );
+              requiredBy = [ "initrd-fs.target" ];
+              before = [ "initrd-fs.target" ];
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
               unitConfig = {
+                RequiresMountsFor = [
+                  "/sysroot/nix/store"
+                  "/run/nixos-etc-metadata"
+                ];
                 DefaultDependencies = false;
-                RequiresMountsFor = "/sysroot";
               };
-              serviceConfig = {
-                Type = "oneshot";
-                ExecStart = ''
-                  /bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work
-                '';
+            }
+          ];
+          services = lib.mkMerge [
+            (lib.mkIf config.system.etc.overlay.mutable {
+              rw-etc = {
+                requiredBy = [ "initrd-fs.target" ];
+                before = [ "initrd-fs.target" ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = "/sysroot";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  ExecStart = ''
+                    /bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work
+                  '';
+                };
               };
-            };
-          })
-          {
-            initrd-find-etc = {
-              description = "Find the path to the etc metadata image and based dir";
-              before = [ "shutdown.target" ];
-              conflicts = [ "shutdown.target" ];
-              requiredBy = [ "initrd.target" ];
-              path = [ config.system.nixos-init.package ];
-              unitConfig = {
-                DefaultDependencies = false;
-                RequiresMountsFor = "/sysroot/nix/store";
+            })
+            {
+              initrd-find-etc = {
+                description = "Find the path to the etc metadata image and based dir";
+                before = [ "shutdown.target" ];
+                conflicts = [ "shutdown.target" ];
+                requiredBy = [ "initrd.target" ];
+                path = [ config.system.nixos-init.package ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = "/sysroot/nix/store";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
+                };
               };
-              serviceConfig = {
-                Type = "oneshot";
-                RemainAfterExit = true;
-                ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
-              };
-            };
-          }
-        ];
-      };
+            }
+          ];
+        };
 
-    })
+      }
+    ))
 
   ];
 }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -29,7 +29,7 @@
         {
           assertion =
             (!config.system.etc.overlay.mutable)
-            -> (config.systemd.sysusers.enable || config.services.userborn.enable);
+            -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
           message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
         }
         {

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -34,7 +34,7 @@
         }
         {
           assertion =
-            (config.system.switch.enable)
+            (config.system.switch.enable or false)
             -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
           message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
         }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   ...
 }:
 
@@ -18,168 +19,174 @@
       ] config.system.build.etcActivationCommands;
     }
 
-    (lib.mkIf config.system.etc.overlay.enable {
+    # The overlay block sets boot.initrd.* and system.requiredKernelConfig,
+    # which are defined in system/boot/stage-1.nix and system/boot/kernel.nix.
+    # Wrap with optionalAttrs so etc-activation works without stage-1 loaded
+    # (e.g. for container profiles).
+    (lib.optionalAttrs (options ? boot.initrd.availableKernelModules) (
+      lib.mkIf config.system.etc.overlay.enable {
 
-      assertions = [
-        {
-          assertion = config.boot.initrd.systemd.enable;
-          message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
-        }
-        {
-          assertion =
-            (!config.system.etc.overlay.mutable)
-            -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
-          message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
-        }
-        {
-          assertion =
-            (config.system.switch.enable or false)
-            -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
-          message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
-        }
-      ];
-
-      boot.initrd.availableKernelModules = [
-        "loop"
-        "erofs"
-        "overlay"
-      ];
-
-      system.requiredKernelConfig = with config.lib.kernelConfig; [
-        (isEnabled "EROFS_FS")
-      ];
-
-      boot.initrd.systemd = {
-        storePaths = lib.mkIf config.system.etc.overlay.mutable [
-          "${config.system.nixos-init.package}/bin/clear-etc-opaque"
-        ];
-        mounts = [
+        assertions = [
           {
-            where = "/run/nixos-etc-metadata";
-            what = "/etc-metadata-image";
-            type = "erofs";
-            options = "loop,ro,nodev,nosuid";
-            unitConfig = {
-              # Since this unit depends on the nix store being mounted, it cannot
-              # be a dependency of local-fs.target, because if it did, we'd have
-              # local-fs.target ordered after the nix store mount which would cause
-              # things like network.target to only become active after the nix store
-              # has been mounted.
-              # This breaks for instance setups where sshd needs to be up before
-              # any encrypted disks can be mounted.
-              DefaultDependencies = false;
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-              ];
-              # find-etc only creates this symlink for a NixOS init. For a
-              # non-NixOS init= (e.g. init=/bin/sh) it is absent, so skip the
-              # mount instead of failing the whole initrd.
-              ConditionPathExists = "/etc-metadata-image";
-            };
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ];
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
+            assertion = config.boot.initrd.systemd.enable;
+            message = "`system.etc.overlay.enable` requires `boot.initrd.systemd.enable`";
           }
           {
-            where = "/sysroot/etc";
-            what = "overlay";
-            type = "overlay";
-            options = lib.concatStringsSep "," (
-              [
-                "nodev"
-                "nosuid"
-                "relatime"
-                "redirect_dir=on"
-                "metacopy=on"
-                "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
-              ]
-              ++ lib.optionals config.system.etc.overlay.mutable [
-                "rw"
-                "upperdir=/sysroot/.rw-etc/upper"
-                "workdir=/sysroot/.rw-etc/work"
-              ]
-              ++ lib.optionals (!config.system.etc.overlay.mutable) [
-                "ro"
-              ]
-            );
-            requiredBy = [ "initrd-fs.target" ];
-            before = [ "initrd-fs.target" ];
-            requires = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            after = [
-              config.boot.initrd.systemd.services.initrd-find-etc.name
-            ]
-            ++ lib.optionals config.system.etc.overlay.mutable [
-              config.boot.initrd.systemd.services."rw-etc".name
-            ];
-            unitConfig = {
-              RequiresMountsFor = [
-                "/sysroot/nix/store"
-                "/run/nixos-etc-metadata"
-              ];
-              DefaultDependencies = false;
-              # Skip for a non-NixOS init=, see the metadata mount above.
-              ConditionPathExists = "/etc-basedir";
-            };
+            assertion =
+              (!config.system.etc.overlay.mutable)
+              -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
+            message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
+          }
+          {
+            assertion =
+              (config.system.switch.enable or false)
+              -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
+            message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
           }
         ];
-        services = lib.mkMerge [
-          (lib.mkIf config.system.etc.overlay.mutable {
-            rw-etc = {
-              requiredBy = [ "initrd-fs.target" ];
-              before = [ "initrd-fs.target" ];
+
+        boot.initrd.availableKernelModules = [
+          "loop"
+          "erofs"
+          "overlay"
+        ];
+
+        system.requiredKernelConfig = with config.lib.kernelConfig; [
+          (isEnabled "EROFS_FS")
+        ];
+
+        boot.initrd.systemd = {
+          storePaths = lib.mkIf config.system.etc.overlay.mutable [
+            "${config.system.nixos-init.package}/bin/clear-etc-opaque"
+          ];
+          mounts = [
+            {
+              where = "/run/nixos-etc-metadata";
+              what = "/etc-metadata-image";
+              type = "erofs";
+              options = "loop,ro,nodev,nosuid";
               unitConfig = {
+                # Since this unit depends on the nix store being mounted, it cannot
+                # be a dependency of local-fs.target, because if it did, we'd have
+                # local-fs.target ordered after the nix store mount which would cause
+                # things like network.target to only become active after the nix store
+                # has been mounted.
+                # This breaks for instance setups where sshd needs to be up before
+                # any encrypted disks can be mounted.
                 DefaultDependencies = false;
                 RequiresMountsFor = [
-                  "/sysroot"
-                  # Needed so we can clear stale opaque markers from the
-                  # upperdir based on the contents of the new metadata layer
-                  # before the overlay is mounted.
-                  "/run/nixos-etc-metadata"
+                  "/sysroot/nix/store"
                 ];
-                # Skip for a non-NixOS init=, see the metadata mount above.
+                # find-etc only creates this symlink for a NixOS init. For a
+                # non-NixOS init= (e.g. init=/bin/sh) it is absent, so skip the
+                # mount instead of failing the whole initrd.
                 ConditionPathExists = "/etc-metadata-image";
               };
-              serviceConfig = {
-                Type = "oneshot";
-                ExecStart = [
-                  "/bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work"
-                  "${config.system.nixos-init.package}/bin/clear-etc-opaque /run/nixos-etc-metadata /sysroot/.rw-etc/upper"
-                ];
-              };
-            };
-          })
-          {
-            initrd-find-etc = {
-              description = "Find the path to the etc metadata image and based dir";
-              before = [ "shutdown.target" ];
-              conflicts = [ "shutdown.target" ];
-              requiredBy = [ "initrd.target" ];
-              path = [ config.system.nixos-init.package ];
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ];
+              requiredBy = [ "initrd-fs.target" ];
+              before = [ "initrd-fs.target" ];
+            }
+            {
+              where = "/sysroot/etc";
+              what = "overlay";
+              type = "overlay";
+              options = lib.concatStringsSep "," (
+                [
+                  "nodev"
+                  "nosuid"
+                  "relatime"
+                  "redirect_dir=on"
+                  "metacopy=on"
+                  "lowerdir=/run/nixos-etc-metadata::/etc-basedir"
+                ]
+                ++ lib.optionals config.system.etc.overlay.mutable [
+                  "rw"
+                  "upperdir=/sysroot/.rw-etc/upper"
+                  "workdir=/sysroot/.rw-etc/work"
+                ]
+                ++ lib.optionals (!config.system.etc.overlay.mutable) [
+                  "ro"
+                ]
+              );
+              requiredBy = [ "initrd-fs.target" ];
+              before = [ "initrd-fs.target" ];
+              requires = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
+              after = [
+                config.boot.initrd.systemd.services.initrd-find-etc.name
+              ]
+              ++ lib.optionals config.system.etc.overlay.mutable [
+                config.boot.initrd.systemd.services."rw-etc".name
+              ];
               unitConfig = {
+                RequiresMountsFor = [
+                  "/sysroot/nix/store"
+                  "/run/nixos-etc-metadata"
+                ];
                 DefaultDependencies = false;
-                RequiresMountsFor = "/sysroot/nix/store";
+                # Skip for a non-NixOS init=, see the metadata mount above.
+                ConditionPathExists = "/etc-basedir";
               };
-              serviceConfig = {
-                Type = "oneshot";
-                RemainAfterExit = true;
-                ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
+            }
+          ];
+          services = lib.mkMerge [
+            (lib.mkIf config.system.etc.overlay.mutable {
+              rw-etc = {
+                requiredBy = [ "initrd-fs.target" ];
+                before = [ "initrd-fs.target" ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = [
+                    "/sysroot"
+                    # Needed so we can clear stale opaque markers from the
+                    # upperdir based on the contents of the new metadata layer
+                    # before the overlay is mounted.
+                    "/run/nixos-etc-metadata"
+                  ];
+                  # Skip for a non-NixOS init=, see the metadata mount above.
+                  ConditionPathExists = "/etc-metadata-image";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  ExecStart = [
+                    "/bin/mkdir -p -m 0755 /sysroot/.rw-etc/upper /sysroot/.rw-etc/work"
+                    "${config.system.nixos-init.package}/bin/clear-etc-opaque /run/nixos-etc-metadata /sysroot/.rw-etc/upper"
+                  ];
+                };
               };
-            };
-          }
-        ];
-      };
+            })
+            {
+              initrd-find-etc = {
+                description = "Find the path to the etc metadata image and based dir";
+                before = [ "shutdown.target" ];
+                conflicts = [ "shutdown.target" ];
+                requiredBy = [ "initrd.target" ];
+                path = [ config.system.nixos-init.package ];
+                unitConfig = {
+                  DefaultDependencies = false;
+                  RequiresMountsFor = "/sysroot/nix/store";
+                };
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  ExecStart = "${config.system.nixos-init.package}/bin/find-etc";
+                };
+              };
+            }
+          ];
+        };
 
-    })
+      }
+    ))
 
     (lib.mkIf (config.system.etc.overlay.enable && !config.system.etc.overlay.mutable) {
       # An empty regular file means systemd will bind mount /run/machine-id

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -33,7 +33,7 @@
         }
         {
           assertion =
-            (config.system.switch.enable)
+            (config.system.switch.enable or false)
             -> (lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.6");
           message = "switchable systems with `system.etc.overlay.enable` require a newer kernel, at least version 6.6";
         }

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -28,7 +28,7 @@
         {
           assertion =
             (!config.system.etc.overlay.mutable)
-            -> (config.systemd.sysusers.enable || config.services.userborn.enable);
+            -> ((config.systemd.sysusers.enable or false) || (config.services.userborn.enable or false));
           message = "`!system.etc.overlay.mutable` requires `systemd.sysusers.enable` or `services.userborn.enable`";
         }
         {

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -519,8 +519,10 @@ in
         # Filesystems.
         ${makeFstabEntries fileSystems { }}
 
-        ${optionalString (config.swapDevices != [ ]) "# Swap devices."}
-        ${flip concatMapStrings config.swapDevices (sw: "${sw.realDevice} none swap ${swapOptions sw}\n")}
+        ${optionalString ((config.swapDevices or [ ]) != [ ]) "# Swap devices."}
+        ${flip concatMapStrings (config.swapDevices or [ ]) (
+          sw: "${sw.realDevice} none swap ${swapOptions sw}\n"
+        )}
       '';
 
     boot.initrd.systemd.storePaths = [ initrdFstab ];

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -553,7 +553,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isContainer) {
+    // optionalAttrs (!(config.boot.isContainer or false)) {
       # systemd-nspawn populates /sys by itself, and remounting it causes all
       # kinds of weird issues (most noticeably, waiting for host disk device
       # nodes).
@@ -566,7 +566,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isNspawnContainer) {
+    // optionalAttrs (!(config.boot.isNspawnContainer or false)) {
       "/proc" = {
         fsType = "proc";
         options = [

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -552,7 +552,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isContainer) {
+    // optionalAttrs (!(config.boot.isContainer or false)) {
       # systemd-nspawn populates /sys by itself, and remounting it causes all
       # kinds of weird issues (most noticeably, waiting for host disk device
       # nodes).
@@ -565,7 +565,7 @@ in
         ];
       };
     }
-    // optionalAttrs (!config.boot.isNspawnContainer) {
+    // optionalAttrs (!(config.boot.isNspawnContainer or false)) {
       "/proc" = {
         fsType = "proc";
         options = [

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -518,8 +518,10 @@ in
         # Filesystems.
         ${makeFstabEntries fileSystems { }}
 
-        ${optionalString (config.swapDevices != [ ]) "# Swap devices."}
-        ${flip concatMapStrings config.swapDevices (sw: "${sw.realDevice} none swap ${swapOptions sw}\n")}
+        ${optionalString ((config.swapDevices or [ ]) != [ ]) "# Swap devices."}
+        ${flip concatMapStrings (config.swapDevices or [ ]) (
+          sw: "${sw.realDevice} none swap ${swapOptions sw}\n"
+        )}
       '';
 
     boot.initrd.systemd.storePaths = [ initrdFstab ];

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1864,10 +1864,6 @@ in
       EOF
     '';
 
-    services.mstpd = mkIf needsMstpd { enable = true; };
-
-    virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
-
     services.udev.packages =
       lib.optionals (!config.systemd.network.enable) [
         (pkgs.writeTextFile rec {
@@ -2009,6 +2005,12 @@ in
             );
         }
       );
+  }
+  // lib.optionalAttrs (options ? services.mstpd) {
+    services.mstpd = mkIf needsMstpd { enable = true; };
+  }
+  // lib.optionalAttrs (options ? virtualisation.vswitch) {
+    virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
   };
 
 }

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1721,295 +1721,299 @@ in
 
   meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
-  config = {
+  config = lib.mkMerge [
+    {
 
-    warnings =
-      (concatMap (i: i.warnings) interfaces)
-      ++ (lib.optional (config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd) ''
-        The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false` can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking. It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting (by disabling `systemd.network.enable`)
-      '');
+      warnings =
+        (concatMap (i: i.warnings) interfaces)
+        ++ (lib.optional (config.systemd.network.enable && cfg.useDHCP && !cfg.useNetworkd) ''
+          The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false` can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking. It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting (by disabling `systemd.network.enable`)
+        '');
 
-    assertions =
-      (forEach interfaces (i: {
-        # With the linux kernel, interface name length is limited by IFNAMSIZ
-        # to 16 bytes, including the trailing null byte.
-        # See include/linux/if.h in the kernel sources
-        assertion = stringLength i.name < 16;
-        message = ''
-          The name of networking.interfaces."${i.name}" is too long, it needs to be less than 16 characters.
-        '';
-      }))
-      ++ (forEach slaveIfs (i: {
-        assertion = i.ipv4.addresses == [ ] && i.ipv6.addresses == [ ];
-        message = ''
-          The networking.interfaces."${i.name}" must not have any defined ips when it is a slave.
-        '';
-      }))
-      ++ (forEach interfaces (i: {
-        assertion = i.tempAddress != "disabled" -> cfg.enableIPv6;
-        message = ''
-          Temporary addresses are only needed when IPv6 is enabled.
-        '';
-      }))
-      ++ (forEach interfaces (i: {
-        assertion = (i.virtual && i.virtualType == "tun") -> i.macAddress == null;
-        message = ''
-          Setting a MAC Address for tun device ${i.name} isn't supported.
-        '';
-      }))
-      ++ [
-        {
-          assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
-          message = "Invalid value given to the networking.hostId option.";
-        }
+      assertions =
+        (forEach interfaces (i: {
+          # With the linux kernel, interface name length is limited by IFNAMSIZ
+          # to 16 bytes, including the trailing null byte.
+          # See include/linux/if.h in the kernel sources
+          assertion = stringLength i.name < 16;
+          message = ''
+            The name of networking.interfaces."${i.name}" is too long, it needs to be less than 16 characters.
+          '';
+        }))
+        ++ (forEach slaveIfs (i: {
+          assertion = i.ipv4.addresses == [ ] && i.ipv6.addresses == [ ];
+          message = ''
+            The networking.interfaces."${i.name}" must not have any defined ips when it is a slave.
+          '';
+        }))
+        ++ (forEach interfaces (i: {
+          assertion = i.tempAddress != "disabled" -> cfg.enableIPv6;
+          message = ''
+            Temporary addresses are only needed when IPv6 is enabled.
+          '';
+        }))
+        ++ (forEach interfaces (i: {
+          assertion = (i.virtual && i.virtualType == "tun") -> i.macAddress == null;
+          message = ''
+            Setting a MAC Address for tun device ${i.name} isn't supported.
+          '';
+        }))
+        ++ [
+          {
+            assertion = cfg.hostId == null || (stringLength cfg.hostId == 8 && isHexString cfg.hostId);
+            message = "Invalid value given to the networking.hostId option.";
+          }
+        ];
+
+      boot.kernelModules =
+        [ ]
+        ++ optional hasVirtuals "tun"
+        ++ optional hasSits "sit"
+        ++ optional hasGres "gre"
+        ++ optional hasBonds "bonding"
+        ++ optional hasFous "fou";
+
+      boot.extraModprobeConfig =
+        # This setting is intentional as it prevents default bond devices
+        # from being created.
+        optionalString hasBonds "options bonding max_bonds=0";
+
+      boot.kernel.sysctl = {
+        # Only set when proxyARP needs it; never write =0 (the kernel default),
+        # which would race with systemd-networkd's IPv4Forwarding= on switch.
+        "net.ipv4.conf.all.forwarding" = mkIf (any (i: i.proxyARP) interfaces) (mkDefault true);
+        "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
+        "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
+        # allow all users to do ICMP echo requests (ping)
+        "net.ipv4.ping_group_range" = mkDefault "0 2147483647";
+        # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
+        "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
+      }
+      // listToAttrs (
+        forEach interfaces (
+          i: nameValuePair "net.ipv4.conf.${replaceStrings [ "." ] [ "/" ] i.name}.proxy_arp" i.proxyARP
+        )
+      )
+      // listToAttrs (
+        forEach interfaces (
+          i:
+          let
+            opt = i.tempAddress;
+            val = tempaddrValues.${opt}.sysctl;
+          in
+          nameValuePair "net.ipv6.conf.${replaceStrings [ "." ] [ "/" ] i.name}.use_tempaddr" val
+        )
+      );
+
+      environment.etc.hostid = mkIf (cfg.hostId != null) { source = hostidFile; };
+      boot.initrd.systemd.contents."/etc/hostid" = mkIf (cfg.hostId != null) { source = hostidFile; };
+
+      # static hostname configuration needed for hostnamectl and the
+      # org.freedesktop.hostname1 dbus service (both provided by systemd)
+      environment.etc.hostname = mkIf (cfg.hostName != "") {
+        text = cfg.hostName + "\n";
+      };
+
+      environment.corePackages = [
+        pkgs.host
+        pkgs.hostname
+        pkgs.iproute2
+        pkgs.iputils # ping
+      ]
+      ++ bridgeStp;
+
+      # Wake-on-LAN configuration is shared by the scripted and networkd backends.
+      systemd.network.links = pipe interfaces [
+        (filter (i: i.wakeOnLan.enable))
+        (map (
+          i:
+          nameValuePair "40-${i.name}" {
+            matchConfig.OriginalName = i.name;
+            linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
+          }
+        ))
+        listToAttrs
       ];
 
-    boot.kernelModules =
-      [ ]
-      ++ optional hasVirtuals "tun"
-      ++ optional hasSits "sit"
-      ++ optional hasGres "gre"
-      ++ optional hasBonds "bonding"
-      ++ optional hasFous "fou";
-
-    boot.extraModprobeConfig =
-      # This setting is intentional as it prevents default bond devices
-      # from being created.
-      optionalString hasBonds "options bonding max_bonds=0";
-
-    boot.kernel.sysctl = {
-      # Only set when proxyARP needs it; never write =0 (the kernel default),
-      # which would race with systemd-networkd's IPv4Forwarding= on switch.
-      "net.ipv4.conf.all.forwarding" = mkIf (any (i: i.proxyARP) interfaces) (mkDefault true);
-      "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
-      "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
-      # allow all users to do ICMP echo requests (ping)
-      "net.ipv4.ping_group_range" = mkDefault "0 2147483647";
-      # networkmanager falls back to "/proc/sys/net/ipv6/conf/default/use_tempaddr"
-      "net.ipv6.conf.default.use_tempaddr" = tempaddrValues.${cfg.tempAddresses}.sysctl;
-    }
-    // listToAttrs (
-      forEach interfaces (
-        i: nameValuePair "net.ipv4.conf.${replaceStrings [ "." ] [ "/" ] i.name}.proxy_arp" i.proxyARP
-      )
-    )
-    // listToAttrs (
-      forEach interfaces (
-        i:
-        let
-          opt = i.tempAddress;
-          val = tempaddrValues.${opt}.sysctl;
-        in
-        nameValuePair "net.ipv6.conf.${replaceStrings [ "." ] [ "/" ] i.name}.use_tempaddr" val
-      )
-    );
-
-    environment.etc.hostid = mkIf (cfg.hostId != null) { source = hostidFile; };
-    boot.initrd.systemd.contents."/etc/hostid" = mkIf (cfg.hostId != null) { source = hostidFile; };
-
-    # static hostname configuration needed for hostnamectl and the
-    # org.freedesktop.hostname1 dbus service (both provided by systemd)
-    environment.etc.hostname = mkIf (cfg.hostName != "") {
-      text = cfg.hostName + "\n";
-    };
-
-    environment.corePackages = [
-      pkgs.host
-      pkgs.hostname
-      pkgs.iproute2
-      pkgs.iputils # ping
-    ]
-    ++ bridgeStp;
-
-    # Wake-on-LAN configuration is shared by the scripted and networkd backends.
-    systemd.network.links = pipe interfaces [
-      (filter (i: i.wakeOnLan.enable))
-      (map (
-        i:
-        nameValuePair "40-${i.name}" {
-          matchConfig.OriginalName = i.name;
-          linkConfig.WakeOnLan = concatStringsSep " " i.wakeOnLan.policy;
-        }
-      ))
-      listToAttrs
-    ];
-
-    systemd.services = {
-      network-local-commands = {
-        enable = (cfg.localCommands != "");
-        description = "Extra networking commands.";
-        before = [ "network.target" ];
-        wantedBy = [ "network.target" ];
-        after = [ "network-pre.target" ];
-        unitConfig.ConditionCapability = "CAP_NET_ADMIN";
-        path = [ pkgs.iproute2 ];
-        serviceConfig.Type = "oneshot";
-        serviceConfig.RemainAfterExit = true;
-        script = ''
-          # Run any user-specified commands.
-          ${cfg.localCommands}
-        '';
+      systemd.services = {
+        network-local-commands = {
+          enable = (cfg.localCommands != "");
+          description = "Extra networking commands.";
+          before = [ "network.target" ];
+          wantedBy = [ "network.target" ];
+          after = [ "network-pre.target" ];
+          unitConfig.ConditionCapability = "CAP_NET_ADMIN";
+          path = [ pkgs.iproute2 ];
+          serviceConfig.Type = "oneshot";
+          serviceConfig.RemainAfterExit = true;
+          script = ''
+            # Run any user-specified commands.
+            ${cfg.localCommands}
+          '';
+        };
       };
-    };
 
-    networking.localCommands = lib.mkIf config.networking.resolvconf.enable ''
-      # Set the static DNS configuration, if given.
-      ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
-      ${optionalString (cfg.nameservers != [ ] && cfg.domain != null) ''
-        domain ${cfg.domain}
-      ''}
-      ${optionalString (cfg.search != [ ]) ("search " + concatStringsSep " " cfg.search)}
-      ${flip concatMapStrings cfg.nameservers (ns: ''
-        nameserver ${ns}
-      '')}
-      EOF
-    '';
+      networking.localCommands = lib.mkIf config.networking.resolvconf.enable ''
+        # Set the static DNS configuration, if given.
+        ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
+        ${optionalString (cfg.nameservers != [ ] && cfg.domain != null) ''
+          domain ${cfg.domain}
+        ''}
+        ${optionalString (cfg.search != [ ]) ("search " + concatStringsSep " " cfg.search)}
+        ${flip concatMapStrings cfg.nameservers (ns: ''
+          nameserver ${ns}
+        '')}
+        EOF
+      '';
 
-    services.mstpd = mkIf needsMstpd { enable = true; };
-
-    virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
-
-    services.udev.packages =
-      lib.optionals (!config.systemd.network.enable) [
-        (pkgs.writeTextFile rec {
-          name = "ipv6-privacy-extensions.rules";
-          destination = "/etc/udev/rules.d/98-${name}";
-          text =
-            let
-              sysctl-value = tempaddrValues.${cfg.tempAddresses}.sysctl;
-            in
-            ''
-              # enable and prefer IPv6 privacy addresses by default
-              ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.bash}/bin/sh -c 'echo ${sysctl-value} > /proc/sys/net/ipv6/conf/$name/use_tempaddr'"
-            '';
-        })
-        (pkgs.writeTextFile rec {
-          name = "ipv6-privacy-extensions.rules";
-          destination = "/etc/udev/rules.d/99-${name}";
-          text = concatMapStrings (
-            i:
-            let
-              opt = i.tempAddress;
-              val = tempaddrValues.${opt}.sysctl;
-              msg = tempaddrValues.${opt}.description;
-            in
-            ''
-              # override to ${msg} for ${i.name}
-              ACTION=="add", SUBSYSTEM=="net", NAME=="${i.name}", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${
-                replaceStrings [ "." ] [ "/" ] i.name
-              }.use_tempaddr=${val}"
-            ''
-          ) (filter (i: i.tempAddress != cfg.tempAddresses) interfaces);
-        })
-      ]
-      ++ lib.optional (cfg.wlanInterfaces != { }) (
-        pkgs.writeTextFile {
-          name = "99-zzz-40-wlanInterfaces.rules";
-          destination = "/etc/udev/rules.d/99-zzz-40-wlanInterfaces.rules";
-          text =
-            let
-              # Collect all interfaces that are defined for a device
-              # as device:interface key:value pairs.
-              wlanDeviceInterfaces =
-                let
-                  allDevices = unique (mapAttrsToList (_: v: v.device) cfg.wlanInterfaces);
-                  interfacesOfDevice = d: filterAttrs (_: v: v.device == d) cfg.wlanInterfaces;
-                in
-                genAttrs allDevices (d: interfacesOfDevice d);
-
-              # Convert device:interface key:value pairs into a list, and if it exists,
-              # place the interface which is named after the device at the beginning.
-              wlanListDeviceFirst =
-                device: interfaces:
-                if hasAttr device interfaces then
-                  mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n == device) interfaces)
-                  ++ mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n != device) interfaces)
-                else
-                  mapAttrsToList (n: v: v // { _iName = n; }) interfaces;
-
-              # Udev script to execute for the default WLAN interface with the persistend udev name.
-              # The script creates the required, new WLAN interfaces interfaces and configures the
-              # existing, default interface.
-              curInterfaceScript =
-                device: current: new:
-                pkgs.writeScript "udev-run-script-wlan-interfaces-${device}.sh" ''
-                  #!${pkgs.runtimeShell}
-                  # Change the wireless phy device to a predictable name.
-                  ${pkgs.iw}/bin/iw phy `${pkgs.coreutils}/bin/cat /sys/class/net/$INTERFACE/phy80211/name` set name ${device}
-
-                  # Add new WLAN interfaces
-                  ${flip concatMapStrings new (i: ''
-                    ${pkgs.iw}/bin/iw phy ${device} interface add ${i._iName} type managed
-                  '')}
-
-                  # Configure the current interface
-                  ${pkgs.iw}/bin/iw dev ${device} set type ${current.type}
-                  ${optionalString (
-                    current.type == "mesh" && current.meshID != null
-                  ) "${pkgs.iw}/bin/iw dev ${device} set meshid ${current.meshID}"}
-                  ${optionalString (
-                    current.type == "monitor" && current.flags != null
-                  ) "${pkgs.iw}/bin/iw dev ${device} set monitor ${current.flags}"}
-                  ${optionalString (
-                    current.type == "managed" && current.fourAddr != null
-                  ) "${pkgs.iw}/bin/iw dev ${device} set 4addr ${if current.fourAddr then "on" else "off"}"}
-                  ${optionalString (
-                    current.mac != null
-                  ) "${pkgs.iproute2}/bin/ip link set dev ${device} address ${current.mac}"}
-                '';
-
-              # Udev script to execute for a new WLAN interface. The script configures the new WLAN interface.
-              newInterfaceScript =
-                new:
-                pkgs.writeScript "udev-run-script-wlan-interfaces-${new._iName}.sh" ''
-                  #!${pkgs.runtimeShell}
-                  # Configure the new interface
-                  ${pkgs.iw}/bin/iw dev ${new._iName} set type ${new.type}
-                  ${optionalString (
-                    new.type == "mesh" && new.meshID != null
-                  ) "${pkgs.iw}/bin/iw dev ${new._iName} set meshid ${new.meshID}"}
-                  ${optionalString (
-                    new.type == "monitor" && new.flags != null
-                  ) "${pkgs.iw}/bin/iw dev ${new._iName} set monitor ${new.flags}"}
-                  ${optionalString (
-                    new.type == "managed" && new.fourAddr != null
-                  ) "${pkgs.iw}/bin/iw dev ${new._iName} set 4addr ${if new.fourAddr then "on" else "off"}"}
-                  ${optionalString (
-                    new.mac != null
-                  ) "${pkgs.iproute2}/bin/ip link set dev ${new._iName} address ${new.mac}"}
-                '';
-
-              # Udev attributes for systemd to name the device and to create a .device target.
-              systemdAttrs =
-                n:
-                ''NAME:="${n}", ENV{ID_NET_NAME}="${n}", ENV{SYSTEMD_ALIAS}="/sys/subsystem/net/devices/${n}", TAG+="systemd"'';
-            in
-            flip (concatMapStringsSep "\n") (attrNames wlanDeviceInterfaces) (
-              device:
+      services.udev.packages =
+        lib.optionals (!config.systemd.network.enable) [
+          (pkgs.writeTextFile rec {
+            name = "ipv6-privacy-extensions.rules";
+            destination = "/etc/udev/rules.d/98-${name}";
+            text =
               let
-                interfaces = wlanListDeviceFirst device wlanDeviceInterfaces.${device};
-                curInterface = elemAt interfaces 0;
-                newInterfaces = drop 1 interfaces;
+                sysctl-value = tempaddrValues.${cfg.tempAddresses}.sysctl;
               in
               ''
-                # It is important to have that rule first as overwriting the NAME attribute also prevents the
-                # next rules from matching.
-                ${flip (concatMapStringsSep "\n") (wlanListDeviceFirst device wlanDeviceInterfaces.${device}) (
-                  interface:
-                  ''ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", ENV{INTERFACE}=="${interface._iName}", ${systemdAttrs interface._iName}, RUN+="${newInterfaceScript interface}"''
-                )}
-
-                # Add the required, new WLAN interfaces to the default WLAN interface with the
-                # persistent, default name as assigned by udev.
-                ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}, RUN+="${
-                  curInterfaceScript device curInterface newInterfaces
-                }"
-                # Generate the same systemd events for both 'add' and 'move' udev events.
-                ACTION=="move", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}
+                # enable and prefer IPv6 privacy addresses by default
+                ACTION=="add", SUBSYSTEM=="net", RUN+="${pkgs.bash}/bin/sh -c 'echo ${sysctl-value} > /proc/sys/net/ipv6/conf/$name/use_tempaddr'"
+              '';
+          })
+          (pkgs.writeTextFile rec {
+            name = "ipv6-privacy-extensions.rules";
+            destination = "/etc/udev/rules.d/99-${name}";
+            text = concatMapStrings (
+              i:
+              let
+                opt = i.tempAddress;
+                val = tempaddrValues.${opt}.sysctl;
+                msg = tempaddrValues.${opt}.description;
+              in
               ''
-            );
-        }
-      );
-  };
+                # override to ${msg} for ${i.name}
+                ACTION=="add", SUBSYSTEM=="net", NAME=="${i.name}", RUN+="${pkgs.procps}/bin/sysctl net.ipv6.conf.${
+                  replaceStrings [ "." ] [ "/" ] i.name
+                }.use_tempaddr=${val}"
+              ''
+            ) (filter (i: i.tempAddress != cfg.tempAddresses) interfaces);
+          })
+        ]
+        ++ lib.optional (cfg.wlanInterfaces != { }) (
+          pkgs.writeTextFile {
+            name = "99-zzz-40-wlanInterfaces.rules";
+            destination = "/etc/udev/rules.d/99-zzz-40-wlanInterfaces.rules";
+            text =
+              let
+                # Collect all interfaces that are defined for a device
+                # as device:interface key:value pairs.
+                wlanDeviceInterfaces =
+                  let
+                    allDevices = unique (mapAttrsToList (_: v: v.device) cfg.wlanInterfaces);
+                    interfacesOfDevice = d: filterAttrs (_: v: v.device == d) cfg.wlanInterfaces;
+                  in
+                  genAttrs allDevices (d: interfacesOfDevice d);
+
+                # Convert device:interface key:value pairs into a list, and if it exists,
+                # place the interface which is named after the device at the beginning.
+                wlanListDeviceFirst =
+                  device: interfaces:
+                  if hasAttr device interfaces then
+                    mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n == device) interfaces)
+                    ++ mapAttrsToList (n: v: v // { _iName = n; }) (filterAttrs (n: _: n != device) interfaces)
+                  else
+                    mapAttrsToList (n: v: v // { _iName = n; }) interfaces;
+
+                # Udev script to execute for the default WLAN interface with the persistend udev name.
+                # The script creates the required, new WLAN interfaces interfaces and configures the
+                # existing, default interface.
+                curInterfaceScript =
+                  device: current: new:
+                  pkgs.writeScript "udev-run-script-wlan-interfaces-${device}.sh" ''
+                    #!${pkgs.runtimeShell}
+                    # Change the wireless phy device to a predictable name.
+                    ${pkgs.iw}/bin/iw phy `${pkgs.coreutils}/bin/cat /sys/class/net/$INTERFACE/phy80211/name` set name ${device}
+
+                    # Add new WLAN interfaces
+                    ${flip concatMapStrings new (i: ''
+                      ${pkgs.iw}/bin/iw phy ${device} interface add ${i._iName} type managed
+                    '')}
+
+                    # Configure the current interface
+                    ${pkgs.iw}/bin/iw dev ${device} set type ${current.type}
+                    ${optionalString (
+                      current.type == "mesh" && current.meshID != null
+                    ) "${pkgs.iw}/bin/iw dev ${device} set meshid ${current.meshID}"}
+                    ${optionalString (
+                      current.type == "monitor" && current.flags != null
+                    ) "${pkgs.iw}/bin/iw dev ${device} set monitor ${current.flags}"}
+                    ${optionalString (
+                      current.type == "managed" && current.fourAddr != null
+                    ) "${pkgs.iw}/bin/iw dev ${device} set 4addr ${if current.fourAddr then "on" else "off"}"}
+                    ${optionalString (
+                      current.mac != null
+                    ) "${pkgs.iproute2}/bin/ip link set dev ${device} address ${current.mac}"}
+                  '';
+
+                # Udev script to execute for a new WLAN interface. The script configures the new WLAN interface.
+                newInterfaceScript =
+                  new:
+                  pkgs.writeScript "udev-run-script-wlan-interfaces-${new._iName}.sh" ''
+                    #!${pkgs.runtimeShell}
+                    # Configure the new interface
+                    ${pkgs.iw}/bin/iw dev ${new._iName} set type ${new.type}
+                    ${optionalString (
+                      new.type == "mesh" && new.meshID != null
+                    ) "${pkgs.iw}/bin/iw dev ${new._iName} set meshid ${new.meshID}"}
+                    ${optionalString (
+                      new.type == "monitor" && new.flags != null
+                    ) "${pkgs.iw}/bin/iw dev ${new._iName} set monitor ${new.flags}"}
+                    ${optionalString (
+                      new.type == "managed" && new.fourAddr != null
+                    ) "${pkgs.iw}/bin/iw dev ${new._iName} set 4addr ${if new.fourAddr then "on" else "off"}"}
+                    ${optionalString (
+                      new.mac != null
+                    ) "${pkgs.iproute2}/bin/ip link set dev ${new._iName} address ${new.mac}"}
+                  '';
+
+                # Udev attributes for systemd to name the device and to create a .device target.
+                systemdAttrs =
+                  n:
+                  ''NAME:="${n}", ENV{ID_NET_NAME}="${n}", ENV{SYSTEMD_ALIAS}="/sys/subsystem/net/devices/${n}", TAG+="systemd"'';
+              in
+              flip (concatMapStringsSep "\n") (attrNames wlanDeviceInterfaces) (
+                device:
+                let
+                  interfaces = wlanListDeviceFirst device wlanDeviceInterfaces.${device};
+                  curInterface = elemAt interfaces 0;
+                  newInterfaces = drop 1 interfaces;
+                in
+                ''
+                  # It is important to have that rule first as overwriting the NAME attribute also prevents the
+                  # next rules from matching.
+                  ${flip (concatMapStringsSep "\n") (wlanListDeviceFirst device wlanDeviceInterfaces.${device}) (
+                    interface:
+                    ''ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", ENV{INTERFACE}=="${interface._iName}", ${systemdAttrs interface._iName}, RUN+="${newInterfaceScript interface}"''
+                  )}
+
+                  # Add the required, new WLAN interfaces to the default WLAN interface with the
+                  # persistent, default name as assigned by udev.
+                  ACTION=="add", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}, RUN+="${
+                    curInterfaceScript device curInterface newInterfaces
+                  }"
+                  # Generate the same systemd events for both 'add' and 'move' udev events.
+                  ACTION=="move", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", NAME=="${device}", ${systemdAttrs curInterface._iName}
+                ''
+              );
+          }
+        );
+    }
+    (lib.optionalAttrs (options ? services.mstpd) {
+      services.mstpd = mkIf needsMstpd { enable = true; };
+    })
+    (lib.optionalAttrs (options ? virtualisation.vswitch) {
+      virtualisation.vswitch = mkIf (cfg.vswitches != { }) { enable = true; };
+    })
+  ];
 
 }

--- a/nixos/modules/tasks/swraid.nix
+++ b/nixos/modules/tasks/swraid.nix
@@ -26,6 +26,7 @@ in
       [ "boot" "initrd" "services" "swraid" "mdadmConf" ]
       [ "boot" "swraid" "mdadmConf" ]
     )
+    (lib.mkRenamedOptionModule [ "boot" "initrd" "mdadmConf" ] [ "boot" "swraid" "mdadmConf" ])
   ];
 
   options.boot.swraid = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -962,6 +962,7 @@ in
   minecraft-server = runTest ./minecraft-server.nix;
   minidlna = runTest ./minidlna.nix;
   miniflux = runTest ./miniflux.nix;
+  minimal-bootable = runTest ./minimal-bootable.nix;
   minio = runTest ./minio.nix;
   miracle-wm = runTest ./miracle-wm.nix;
   miriway = runTest ./miriway.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1030,6 +1030,7 @@ in
   minecraft-server = runTest ./minecraft-server.nix;
   minidlna = runTest ./minidlna.nix;
   miniflux = runTest ./miniflux.nix;
+  minimal-bootable = runTest ./minimal-bootable.nix;
   minio = runTest ./minio.nix;
   miracle-wm = runTest ./miracle-wm.nix;
   miriway = runTest ./miriway.nix;

--- a/nixos/tests/minimal-bootable.nix
+++ b/nixos/tests/minimal-bootable.nix
@@ -1,0 +1,166 @@
+# Boot test for the minimal/bootable.nix profile.
+#
+# Builds a UKI + disk image (ESP + ext4 root via systemd-repart) from
+# the minimal profile, then boots the image in QEMU with OVMF and
+# verifies the system reaches a login prompt.
+#
+# The profile's toplevel has no test-driver backdoor agent, so the
+# test uses OCR on the VGA console (wait_for_text / send_chars)
+# instead of machine.succeed().
+{
+  pkgs,
+  lib,
+  ...
+}:
+let
+  nixosLib = import (pkgs.path + "/nixos/lib/default.nix") {
+    featureFlags.minimalModules = { };
+  };
+
+  nixos = nixosLib.evalModules {
+    modules = [
+      ../modules/profiles/minimal/bootable.nix
+      ../modules/image/repart.nix
+      # repart.nix imports repart-verity-store.nix which sets
+      # boot.initrd.systemd.dmVerity.enable, so we need dm-verity.nix
+      # for the option declaration (not actually used).
+      ../modules/system/boot/systemd/dm-verity.nix
+      {
+        nixpkgs.pkgs = pkgs;
+
+        boot.initrd.systemd.enable = true;
+        boot.loader.efi.canTouchEfiVariables = false;
+
+        # Kernel modules needed to mount the root FS
+        boot.initrd.availableKernelModules = [
+          "ext4"
+          "sd_mod"
+          "ahci"
+          "virtio_blk"
+          "virtio_pci"
+        ];
+
+        # Emit to serial and VGA so OCR works and logs are captured
+        boot.kernelParams = [
+          "console=ttyS0,115200"
+          "console=tty0"
+        ];
+
+        # Passwordless root for the OCR login step
+        users.users.root.initialHashedPassword = "";
+
+        # Image metadata (used by UKI filename and os-release)
+        system.image.id = "minimal-nixos";
+        system.image.version = "1";
+
+        fileSystems."/" = {
+          device = "/dev/disk/by-label/nixos";
+          fsType = "ext4";
+        };
+        fileSystems."/boot" = {
+          device = "/dev/disk/by-label/ESP";
+          fsType = "vfat";
+        };
+
+        # GPT disk image: ESP partition containing the UKI, plus ext4 root.
+        image.repart = {
+          sectorSize = 512; # OVMF doesn't support 4096-byte sectors
+          partitions = {
+            "10-esp" = {
+              contents = {
+                "/EFI/BOOT/BOOTX64.EFI".source =
+                  "${nixos.config.system.build.uki}/${nixos.config.system.boot.loader.ukiFile}";
+              };
+              repartConfig = {
+                Type = "esp";
+                Format = "vfat";
+                SizeMinBytes = "64M";
+              };
+            };
+            "20-root" = {
+              storePaths = [ nixos.config.system.build.toplevel ];
+              repartConfig = {
+                Type = "root";
+                Format = "ext4";
+                Label = "nixos";
+                Minimize = "guess";
+              };
+            };
+          };
+        };
+
+        system.stateVersion = "26.05";
+      }
+    ];
+  };
+
+  image = nixos.config.system.build.image;
+  diskImage = "${image}/${nixos.config.image.fileName}";
+in
+{
+  name = "minimal-bootable";
+
+  enableOCR = true;
+
+  nodes.machine = {
+    # The test runner itself is a full NixOS system — we override
+    # its disk image with our pre-built minimal one via
+    # NIX_DISK_IMAGE in the test script.
+    virtualisation.directBoot.enable = false;
+    virtualisation.mountHostNixStore = false;
+    virtualisation.useEFIBoot = true;
+    virtualisation.fileSystems = lib.mkForce {
+      "/" = {
+        device = "/dev/disk/by-label/nixos";
+        fsType = "ext4";
+      };
+    };
+    boot.loader.grub.enable = false;
+  };
+
+  testScript = ''
+    import os
+    import subprocess
+    import tempfile
+
+    # Copy the read-only image to a writable qcow2 overlay.
+    tmp_disk_image = tempfile.NamedTemporaryFile()
+    subprocess.run(
+        [
+            "${pkgs.qemu_kvm}/bin/qemu-img",
+            "create",
+            "-f",
+            "qcow2",
+            "-b",
+            "${diskImage}",
+            "-F",
+            "raw",
+            tmp_disk_image.name,
+        ],
+        check=True,
+    )
+    os.environ["NIX_DISK_IMAGE"] = tmp_disk_image.name
+
+    machine.start()
+
+    # Wait for the login prompt on the VGA console.
+    machine.wait_for_text("login:", timeout=120)
+
+    # Log in as root with the empty password and verify the shell
+    # is reachable via OCR.
+    machine.send_chars("root\n")
+    machine.wait_for_text("root@nixos", timeout=30)
+
+    # systemctl is-system-running --wait blocks until boot is
+    # complete and reports running/degraded/…; the OCR needs a
+    # single word to match.
+    machine.send_chars("systemctl is-system-running --wait\n")
+    machine.wait_for_text("running", timeout=60)
+
+    machine.send_chars("hostname\n")
+    machine.wait_for_text("nixos", timeout=10)
+
+    machine.send_chars("poweroff\n")
+    machine.wait_for_console_text("Power down", timeout=30)
+  '';
+}


### PR DESCRIPTION
Add a minimal module profile for lib.nixos.evalModules that produces a bootable NixOS system with 53 modules (and adds a test for that).

A bit more invasive, but also more thorough take on https://github.com/NixOS/nixpkgs/pull/401751 et al in a way. We can reduce the resulting module set even further, but I'd prefer to do so iteratively in follow-up PRs. I also have a [minimal container profile ](https://github.com/phaer/nixpkgs/commit/8b4e20632da2da49bc33fbc992e5cb84417ea72e) planned.

---

`lib.nixos.evalModules` (with `featureFlags.minimalModules`) is the experimental entrypoint for evaluating NixOS with an explicit module set - empty even by default - instead of all >1500 modules from `module-list.nix`. This significantly speeds up evaluation for minimal nixos closures (~25% for the booteable profile) and eases future developments around leaner NixOS closures.

Currently, many modules have hard cross-module dependencies: they read `config.services.foo.enable` or set `services.bar.baz` for modules that may not be loaded. With a custom module set this causes evaluation errors.

We make many of those cross-module dependencies optional and add a new minimal/bootable.nix profile, as well as a test for it, to ensure we'll notice future breakage.

---

## Status & dependencies

This PR is ready, it just currently includes its pre-requisites for convenience during review. Only the last commit is intended to be merged here. I'll rebase once each of the following PRs is merged:

- [x] https://github.com/NixOS/nixpkgs/pull/507667
- [ ] https://github.com/NixOS/nixpkgs/pull/507676
- [ ] https://github.com/NixOS/nixpkgs/pull/507695
- [ ] https://github.com/NixOS/nixpkgs/pull/507727

---

## Stats (master + module-list.nix vs this branch + minimal/bootable.nix)

 | Metric              | upstream master full | patched minimal | Ratio          |
   | ------------------- | -------------------: | --------------: | -------------: |
   | CPU time            |               2.99 s |          1.76 s |           1.7× |
   | Values              |           11,946,710 |       7,866,649 |           1.5× |
   | Attr sets           |            1,743,825 |       1,046,435 |           1.7× |
   | Thunks              |            8,182,353 |       4,996,561 |           1.6× |
   | Expressions         |            1,493,514 |         302,636 |           4.9× |
   | Primop calls        |            2,759,295 |       1,622,118 |           1.7× |
   | GC total            |               610 MB |          419 MB |           1.5× |
   | Wall-clock (5 runs) |      3.006 s ± 0.018 | 1.976 s ± 0.018 | **1.52× ± 0.02** |

---

## Prior Work & Discussion

* https://github.com/NixOS/nixpkgs/pull/401751
* https://github.com/NixOS/nixpkgs/pull/148456
* https://github.com/NixOS/rfcs/pull/22