### PR TITLE
python3Packages.mlx-lm: 0.31.1 -> 0.31.2; python3Packages.mlx-vlm: 0.4.2 -> 0.4.4

### DIFF
--- a/pkgs/development/python-modules/mlx-lm/default.nix
+++ b/pkgs/development/python-modules/mlx-lm/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mlx-lm";
-  version = "0.31.1";
+  version = "0.31.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ml-explore";
     repo = "mlx-lm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5KGXLpzGEmyay6HvEM8qOe5zUmFRo1VbZKzOQvfr7Sk=";
+    hash = "sha256-Ujt0KMs4dzIlbg7cg72TudAvlwJ4uWEG5Lx7+5j8cOU=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mlx-vlm/default.nix
+++ b/pkgs/development/python-modules/mlx-vlm/default.nix
@@ -24,18 +24,19 @@
   psutil,
   pytestCheckHook,
   rich,
+  sentencepiece,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "mlx-vlm";
-  version = "0.4.2";
+  version = "0.4.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Blaizzy";
     repo = "mlx-vlm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GmeMcANmztICfYR9Ca5wQfLOugOlK1mt5j3q616n6TQ=";
+    hash = "sha256-08cSwN8IkERxUaXyT9qAg9vmLw7FvU5qDygAkDsOxpU=";
   };
 
   build-system = [
@@ -63,6 +64,7 @@ buildPythonPackage (finalAttrs: {
     psutil
     pytestCheckHook
     rich
+    sentencepiece
   ];
 
   disabledTests = [


### PR DESCRIPTION
## Things done

- `python3Packages.mlx-lm: 0.31.1 -> 0.31.2`
  - Diff: https://github.com/ml-explore/mlx-lm/compare/v0.31.1...v0.31.2
  - Changelog: https://github.com/ml-explore/mlx-lm/releases/tag/v0.31.2
- `python3Packages.mlx-vlm: 0.4.2 -> 0.4.4`
  - Diff: https://github.com/Blaizzy/mlx-vlm/compare/v0.4.2...v0.4.4
  - https://github.com/Blaizzy/mlx-vlm/releases/tag/v0.4.4

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test