### PR TITLE
nixos/repart: make user namespaces optional during build

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -41,6 +41,7 @@
   sectorSize,
   mkfsEnv ? { },
   createEmpty ? true,
+  useUnshare ? true,
 }:
 
 let
@@ -130,6 +131,8 @@ let
         "zeekstd --no-progress --frame-size 2M --compression-level ${toString compression.level}";
     }
     ."${compression.algorithm}";
+
+  fakerootCommand = if useUnshare then "unshare --map-root-user fakeroot" else "fakeroot";
 in
 stdenvNoCC.mkDerivation (
   finalAttrs:
@@ -151,8 +154,10 @@ stdenvNoCC.mkDerivation (
 
     nativeBuildInputs = [
       systemd
-      util-linux
       fakeroot
+    ]
+    ++ lib.optionals useUnshare [
+      util-linux
     ]
     ++ lib.optionals (compression.enable) [
       compressionPkg
@@ -204,7 +209,7 @@ stdenvNoCC.mkDerivation (
       runHook preBuild
 
       echo "Building image with systemd-repart..."
-      unshare --map-root-user fakeroot systemd-repart \
+      ${fakerootCommand} systemd-repart \
         ''${systemdRepartFlags[@]} \
         ${baseName}.raw \
         | tee repart-output.json

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -209,6 +209,16 @@ in
         or 'auto' to determine the minimal size automatically";
     };
 
+    useUnshare = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enables user namespace creation to simulate root-owned nodes during the
+        image building process, required by some filesystems like btrfs.
+        Disable if building in a restricted sandbox.
+      '';
+    };
+
     package = lib.mkPackageOption pkgs "systemd-repart" {
       # We use buildPackages so that repart images are built with the build
       # platform's systemd, allowing for cross-compiled systems to work.
@@ -426,6 +436,7 @@ in
             imageSize
             sectorSize
             finalPartitions
+            useUnshare
             ;
           inherit fileSystems definitionsDirectory mkfsEnv;
         };


### PR DESCRIPTION
Container runtimes like Docker and Podman disable the unshare system call as a security precaution. A hard-coded use of unshare prevents repart-image from working in such sandboxed environments.

This change lets consumers opt out from remapping the root user on the kernel side. It should be safe to disable if the image only uses userspace tools, but may break images using kernel-space filesystem drivers like btrfs.

**Note:** I'm not quite sure how to test this option without introducing too much duplication. `nixos/tests/appliance-repart-image-verity-store.nix` builds successfully with `useUnshare = false`, but we probably want to test building an image with it enabled as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
