### PR TITLE
jabcode-{reader,writer}: fix build

### DIFF
--- a/pkgs/development/libraries/jabcode/default.nix
+++ b/pkgs/development/libraries/jabcode/default.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals (subproject != "library") [ jabcode ];
 
+  postPatch = ''
+    substituteInPlace src/jabcode/Makefile src/jabcodeReader/Makefile src/jabcodeWriter/Makefile \
+      --replace-fail "CC 	= \$(PREFIX)gcc" ""
+    # remove bundled library binaries to force using system libraries
+    rm -rf src/jabcode/lib
+  '';
+
   preConfigure = "cd src/${subdir}";
 
   installPhase =
@@ -53,6 +60,5 @@ stdenv.mkDerivation {
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.xaverdh ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/jabcode.x86_64-darwin
   };
 }


### PR DESCRIPTION
- https://hydra.nixos.org/build/322332983
- https://hydra.nixos.org/build/322332984
- #471369

Avoid hardcoding gcc. Hope this works on darwin.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
