### PR TITLE
python3Packages.just-playback: init at 0.1.8

### DIFF
--- a/pkgs/development/python-modules/just-playback/default.nix
+++ b/pkgs/development/python-modules/just-playback/default.nix
@@ -1,0 +1,35 @@
+{
+  buildPythonPackage,
+  fetchurl,
+  cffi,
+  lib,
+  pydub,
+  setuptools,
+  tinytag,
+}:
+
+buildPythonPackage rec {
+  pname = "just-playback";
+  version = "0.1.8";
+  pyproject = true;
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/a4/2d/19ffa29233196f146dd98ffcfd3751b81e43efdd6274f5fac0bdd245038d/just_playback-0.1.8.tar.gz";
+    sha256 = "sha256-5ZdHSfEPque7drPx43eaE2knWrF52HWdrifp8ptBA1A=";
+  };
+
+  nativeBuildInputs = [ setuptools cffi ];
+
+  propagatedBuildInputs = [
+    cffi
+    tinytag
+    pydub
+  ];
+
+  meta = {
+    description = "A small library for playing audio files in python, with essential playback functionality.";
+    homepage = "https://github.com/cheofusi/just_playback";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
[just playback](https://github.com/cheofusi/just_playback) is A small library for playing audio files in python, with essential playback functionality.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
