### PR TITLE
python3Packages.signalrcore: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/signalrcore/default.nix
+++ b/pkgs/development/python-modules/signalrcore/default.nix
@@ -66,12 +66,10 @@ buildPythonPackage rec {
 
   meta = {
     mainProgram = "signalrcore";
-
-    description = "A complete Python client for ASP.NET Core SignalR — supporting all transports, encodings, authentication, and reconnection strategies.";
+    description = "Complete Python client for ASP.NET Core SignalR — supporting all transports, encodings, authentication, and reconnection strategies";
     homepage = "https://mandrewcito.github.io/signalrcore";
     changelog = "https://github.com/mandrewcito/signalrcore/releases/tag/${version}";
     license = lib.licenses.mit;
-
     maintainers = with lib.maintainers; [ vaisriv ];
   };
 }

--- a/pkgs/development/python-modules/signalrcore/default.nix
+++ b/pkgs/development/python-modules/signalrcore/default.nix
@@ -1,0 +1,77 @@
+{
+  # lib & utils
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pytestCheckHook,
+
+  # build
+  setuptools,
+
+  # deps
+  msgpack,
+
+  # test deps
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "signalrcore";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mandrewcito";
+    repo = "signalrcore";
+    tag = version;
+    hash = "sha256-BLbD6IYo4YN1bvB33MIfHUVPEIm1DND5oh/k07e4odI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ msgpack ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  disabledTests = [
+    # requires network access
+    "test_check_azure_url"
+    "test_send"
+    "test_build"
+    "test_skip_negotiation"
+    "test_unsubscribe"
+    "test_enable_trace"
+    "test_enable_trace_messagepack"
+  ];
+
+  disabledTestPaths = [
+    # requires network access
+    "test/integration/builder/certificates_test.py"
+    "test/integration/connection_state_test.py"
+    "test/integration/open_close_test.py"
+    "test/integration/reconnection/*"
+    "test/integration/send/*"
+    "test/integration/streamming/*"
+    "test/integration/trace_test.py"
+    "test/integration/transport_test.py"
+  ];
+
+  pythonImportsCheck = [ "signalrcore" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "signalrcore";
+
+    description = "A complete Python client for ASP.NET Core SignalR — supporting all transports, encodings, authentication, and reconnection strategies.";
+    homepage = "https://mandrewcito.github.io/signalrcore";
+    changelog = "https://github.com/mandrewcito/signalrcore/releases/tag/${version}";
+    license = lib.licenses.mit;
+
+    maintainers = with lib.maintainers; [ vaisriv ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17636,6 +17636,8 @@ self: super: with self; {
 
   sievelib = callPackage ../development/python-modules/sievelib { };
 
+  signalrcore = callPackage ../development/python-modules/signalrcore { };
+
   signalslot = callPackage ../development/python-modules/signalslot { };
 
   signedjson = callPackage ../development/python-modules/signedjson { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the Python library [SignalRCore](https://github.com/mandrewcito/signalrcore). From the library's [homepage](https://mandrewcito.github.io/signalrcoret): "A complete Python client for ASP.NET Core SignalR — supporting all transports, encodings, authentication, and reconnection strategies".

SignalRCore is:
  1. required for the [FastF1](https://github.com/theOehrly/Fast-F1) python library, which I have packaged in PR #418309
  2. was suggested to be packaged here: https://github.com/NixOS/nixpkgs/pull/418309#discussion_r2995189314

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test