### PR TITLE
pulumi: 3.192.0 -> 3.228.0

### DIFF
--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "pulumi";
-  version = "3.192.0";
+  version = "3.228.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rcDXC+xlUa67afuXvmEv8UNsYWBvQQ0P4httdtdcrh4=";
+    hash = "sha256-I2Lbc/dv+WdFW0KJsXBp6CX3zewBCGX6fpwnXZ/I1RQ=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-BaFw8EnPd2GPA/p9wm8XpVy/iE8gqbteRnMQC8Z4NHQ=";
+  vendorHash = "sha256-YoeTU8M0qH2POUkiWiwWvseTJ55U2Fy15bT//lQKVQo=";
 
   sourceRoot = "${finalAttrs.src.name}/pkg";
 

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-jwsdMSLDn2PNJFIIVhqwBLH7acFTOFLPgVNMKbI5DZE=";
+  vendorHash = "sha256-+DWnHrLMNbsNZVzl6AfPd3R0U7iK46ZlKe1n292VnpM=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-Q5Pk2f3EAiM4oit1vhc+PMEuMxdbrKAue3e0pnrZw2c=";
+  vendorHash = "sha256-KRZdY5ucz2qXOUCrfKqOKPOsBpbiHeakqexrxYCNafQ=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-BfkjDesPdPDV2uILYaMJFIvaEBKT15ukwaReAL3yziw=";
+  vendorHash = "sha256-kWUUW93w1tluYNjElB5OYSTRbSzbIo5PW2M/w2NcwVw=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION

## Things done

- updated `pulumi` package version, source, and vendor hashes
- updated `pulumi-go` package vendor hash
- updated `pulumi-nodejs` package vendor hash
- updated `pulumi-python` package vendor hash

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
