### PR TITLE
vscode-with-extensions: respect macos package bundle's CFBundleExecutable value when generating the wrapper

### DIFF
--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -92,12 +92,14 @@ runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}"
         mkdir -p $out/bin/
         mkdir -p "$out/Applications/${longName}.app/Contents/MacOS"
 
+        binary_name="$(awk -F'[<>]' '/CFBundleExecutable/{getline; print $3}' '${vscode}/Applications/${longName}.app/Contents/Info.plist')"
+
         for path in PkgInfo Frameworks Resources _CodeSignature Info.plist; do
           ln -s "${vscode}/Applications/${longName}.app/Contents/$path" "$out/Applications/${longName}.app/Contents/"
         done
 
         makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" ${extensionsFlag}
-        makeWrapper "${vscode}/Applications/${longName}.app/Contents/MacOS/Electron" "$out/Applications/${longName}.app/Contents/MacOS/Electron" ${extensionsFlag}
+        makeWrapper "${vscode}/Applications/${longName}.app/Contents/MacOS/$binary_name" "$out/Applications/${longName}.app/Contents/MacOS/$binary_name" ${extensionsFlag}
       ''
     else
       ''


### PR DESCRIPTION
When generating the wrapper in vscode-with-extensions, we should respect the original application's CFBundleExecutable. Previously the the code just assumed the executable to be named "Electron" which is no longer the case for VS Code/VSCodium.

## Things done

Added `binary_name` variable that reads the value of CFBundleExecutable from the original package's Info.plist
Used the new variable in the call to makeWrapper

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
