### PR TITLE
nixos/gdm: add extraPackages to extend XDG_DATA_DIRS

### DIFF
--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -169,6 +169,16 @@ in
         '';
       };
 
+      extraPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [ ];
+        example = lib.literalExpression "[ pkgs.gnome-themes-extra ]";
+        description = ''
+          Additional packages to add to XDG_DATA_DIRS for GDM.
+          The `/share` directory of each package will be added to the data path.
+        '';
+      };
+
     };
 
   };
@@ -221,13 +231,16 @@ in
         enable = true;
         environment = {
           GDM_X_SERVER_EXTRA_ARGS = toString (lib.filter (arg: arg != "-terminate") xdmcfg.xserverArgs);
-          XDG_DATA_DIRS = lib.makeSearchPath "share" [
-            gdm # for gnome-login.session
-            config.services.displayManager.sessionData.desktops
-            pkgs.gnome-control-center # for accessibility icon
-            pkgs.adwaita-icon-theme
-            pkgs.hicolor-icon-theme # empty icon theme as a base
-          ];
+          XDG_DATA_DIRS = lib.makeSearchPath "share" (
+            [
+              gdm # for gnome-login.session
+              config.services.displayManager.sessionData.desktops
+              pkgs.gnome-control-center # for accessibility icon
+              pkgs.adwaita-icon-theme
+              pkgs.hicolor-icon-theme # empty icon theme as a base
+            ]
+            ++ cfg.extraPackages
+          );
         }
         // lib.optionalAttrs (xSessionWrapper != null) {
           # Make GDM use this wrapper before running the session, which runs the


### PR DESCRIPTION
This value is currently hard to extend/modify as it is an environment variable. This makes it easier to change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.