### PR TITLE
[staging-next] python3Packages.torch: include upstream patch for pybind11 3.0.3

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -317,6 +317,17 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
       url = "https://github.com/pytorch/pytorch/commit/39565a7dcf8f93ea22cedeaa20088b24ff6d2634.patch";
       hash = "sha256-Au5fVbs7i33d9c4Xj8koiBP7lGnsTGTaX4VlE2gAfy8=";
     })
+
+    # pybind11 3.0.3 changes led to ambiguous deduction in some return types
+    # that used `py::make_tuple`, so the type is explicitly specified where
+    # needed.
+    # Merged pull request: https://github.com/pytorch/pytorch/pull/179277
+    # TODO: remove at the next release
+    (fetchpatch {
+      name = "pybind11-3.0.3-ambiguous-return-type.patch";
+      url = "https://github.com/pytorch/pytorch/commit/b248ebc17075c0c3ad2b2532970d2ada32b2cf94.patch";
+      hash = "sha256-HY5JFGNoroFsfuUOO5j6WNP6gMHWUcIJFmWLqV8PV94=";
+    })
   ]
   ++ lib.optionals cudaSupport [
     ./fix-cmake-cuda-toolkit.patch


### PR DESCRIPTION
pybind11 3.0.3 (#506838) changes led to ambiguous deduction in some return types that used `py::make_tuple`, so we include an upstream patch to make sure the type is explicitly specified where needed.

Merged pull request: https://github.com/pytorch/pytorch/pull/179277

Build failure on Hydra: https://hydra.nixos.org/build/326053948

## Things done

- Built on platform:
  - [x] x86_64-linux
    - `python313Packages.torch`
    - `python313Packages.torchaudio`
    - `python313Packages.torchcodec`
    - `python313Packages.torcheval`
    - `python313Packages.torchtnt`
    - `python313Packages.torchvision`
    - `python314Packages.torch`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (`python313Packages.torch.tests`)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
