### PR TITLE
python3Packages.webrtc-noise-gain: fix build

### DIFF
--- a/pkgs/development/python-modules/webrtc-noise-gain/0001-fix-missing-cstdint-include.patch
+++ b/pkgs/development/python-modules/webrtc-noise-gain/0001-fix-missing-cstdint-include.patch
@@ -1,0 +1,24 @@
+From 54b34a4a58d305ad9f40aceaf333486bc4e59706 Mon Sep 17 00:00:00 2001
+From: Alex Martens <alex@thinglab.org>
+Date: Tue, 7 Apr 2026 19:56:25 -0700
+Subject: [PATCH] Fix missing cstdint include in task_queue_base.h
+
+---
+ .../webrtc-audio-processing-1/api/task_queue/task_queue_base.h   | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/webrtc-audio-processing/webrtc-audio-processing-1/api/task_queue/task_queue_base.h b/webrtc-audio-processing/webrtc-audio-processing-1/api/task_queue/task_queue_base.h
+index 90b1efd..7403ee9 100644
+--- a/webrtc-audio-processing/webrtc-audio-processing-1/api/task_queue/task_queue_base.h
++++ b/webrtc-audio-processing/webrtc-audio-processing-1/api/task_queue/task_queue_base.h
+@@ -11,6 +11,7 @@
+ #define API_TASK_QUEUE_TASK_QUEUE_BASE_H_
+ 
+ #include <memory>
++#include <cstdint>
+ 
+ #include "api/task_queue/queued_task.h"
+ #include "rtc_base/system/rtc_export.h"
+-- 
+2.53.0
+

--- a/pkgs/development/python-modules/webrtc-noise-gain/default.nix
+++ b/pkgs/development/python-modules/webrtc-noise-gain/default.nix
@@ -27,6 +27,10 @@ buildPythonPackage rec {
     hash = "sha256-GbdG2XM11zgPk2VZ0mu7qMv256jaMyJDHdBCBUnynMY=";
   };
 
+  patches = [
+    ./0001-fix-missing-cstdint-include.patch
+  ];
+
   postPatch = with stdenv.hostPlatform.uname; ''
     # Configure the correct host platform for cross builds
     substituteInPlace setup.py --replace-fail \


### PR DESCRIPTION
`task_queue_base.h` was missing a `cstdint.h` include.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
