### PR TITLE
open-webui: fix pyodide update, update pyodide to 0.29.3

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -24,11 +24,9 @@ let
 
     # the backend for run-on-client-browser python execution
     # must match lock file in open-webui
-    # TODO: should we automate this?
-    # TODO: with JQ? "jq -r '.packages["node_modules/pyodide"].version' package-lock.json"
-    pyodideVersion = "0.28.2";
+    pyodideVersion = "0.28.3";
     pyodide = fetchurl {
-      hash = "sha256-MQIRdOj9yVVsF+nUNeINnAfyA6xULZFhyjuNnV0E5+c=";
+      hash = "sha256-fcqubT8VmGoJ8PnmxHE6DA8kv/DJDHToWoFyPxvGCUA=";
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 

--- a/pkgs/by-name/op/open-webui/update.sh
+++ b/pkgs/by-name/op/open-webui/update.sh
@@ -22,11 +22,8 @@ npm_hash=$(prefetch-npm-deps package-lock.json)
 sed -i 's#npmDepsHash = "[^"]*"#npmDepsHash = "'"$npm_hash"'"#' "$path"
 
 # Extract pyodide version
-pyodide_version=$(sed -rn 's/^.*pyodide.*\^([0-9.]*)\".*$/\1/p' package.json)
+pyodide_version=$(jq -r '.packages["node_modules/pyodide"].version' package-lock.json)
 popd
 
-# Update the pyodide version if necessary
-current_pyodide_version=$(nix eval --raw -f . open-webui.frontend.pyodideVersion)
-if [ "$current_pyodide_version" < "$pyodide_version" ]; then
-  update-source-version open-webui.frontend "${pyodide_version}" --file="$path" --version-key=pyodideVersion --source-key=pyodide
-fi
+# Update the pyodide version
+update-source-version open-webui.frontend "${pyodide_version}" --file="$path" --version-key=pyodideVersion --source-key=pyodide


### PR DESCRIPTION
The update script read the pyodide version from package.json, but the
actual version locked in package-lock.json can be different. This is
currently the case, since the derivation used an older version (0.28.2)
than the locked one (0.28.3), breaking in-browser python evaluation.

## Things done

Instead, extract the pyodide version from package-lock.json, using the
jq command previously suggested in the TODO comment.

Also remove the version comparison against the existing value:
- bash string comparison is lexographic, which is incorrect for semver
- update-sourcce-version is already idempotent
- we want to always match the locked pyodide version, even if it gets
  downgraded

Run the update script twice, to update pyodide to the correct version
and to verify idempotency.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
