### PR TITLE
flightgear: 2024.1.4 -> 2024.1.5; simgear: 2024.1.4 -> 2024.1.5; 

### DIFF
--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -34,7 +34,7 @@
 }:
 
 let
-  version = "2024.1.4";
+  version = "2024.1.5";
   data = stdenv.mkDerivation rec {
     pname = "flightgear-data";
     inherit version;
@@ -43,7 +43,7 @@ let
       owner = "flightgear";
       repo = "fgdata";
       tag = version;
-      hash = "sha256-0cIOyQhw/+jqwO1OddBC09ZnvrmtyjSoMhcu1tuwx4k=";
+      hash = "sha256-8B5wSYjkWuPEySpqBiprZ+jrHy01HA9+iX70wNAn81s=";
     };
 
     dontUnpack = true;
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
     owner = "flightgear";
     repo = "flightgear";
     tag = version;
-    hash = "sha256-s897bsHsVP0OAcrwDVRTPz3YNJkynyErJpH18oLPl3Y=";
+    hash = "sha256-sORiO0SDChIVWIhGKelm7IE/cZ40gMqlZ1OoZZna7kI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/simgear/package.nix
+++ b/pkgs/by-name/si/simgear/package.nix
@@ -28,7 +28,7 @@
   c-ares,
 }:
 let
-  version = "2024.1.4";
+  version = "2024.1.5";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "simgear";
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flightgear";
     repo = "simgear";
     tag = finalAttrs.version;
-    hash = "sha256-WJI15egN1H+EAIaFuI3svYCvM0xzsIGcIPsZgLsvBc0=";
+    hash = "sha256-WONlVdfDWIcoj/UfcFA4Vw5edlgr0vlT/fjIPDti7fk=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION

<img width="1919" height="1051" alt="image" src="https://github.com/user-attachments/assets/970fe1dd-a102-4fa9-80fc-3829dbaa0980" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
