### PR TITLE
python3Packages.mmengine: add missing test dependency

### DIFF
--- a/pkgs/development/python-modules/mmengine/default.nix
+++ b/pkgs/development/python-modules/mmengine/default.nix
@@ -27,11 +27,12 @@
   mlflow,
   parameterized,
   pytestCheckHook,
+  torchvision,
   transformers,
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mmengine";
   version = "0.10.7";
   pyproject = true;
@@ -39,7 +40,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "open-mmlab";
     repo = "mmengine";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hQnwenuxHQwl+DwQXbIfsKlJkmcRvcHV1roK7q2X1KA=";
   };
 
@@ -63,7 +64,7 @@ buildPythonPackage rec {
       substituteInPlace setup.py \
         --replace-fail \
           "return locals()['__version__']" \
-          "return '${version}'"
+          "return '${finalAttrs.version}'"
     ''
     + ''
       substituteInPlace tests/test_config/test_lazy.py \
@@ -94,6 +95,7 @@ buildPythonPackage rec {
     mlflow
     parameterized
     pytestCheckHook
+    torchvision
     transformers
     writableTmpDirAsHomeHook
   ];
@@ -172,6 +174,23 @@ buildPythonPackage rec {
     # AssertionError: os is not <module 'os' (frozen)>
     "test_lazy_module"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_to_device_and_dtype_00_cpu"
+    "test_to_device_and_dtype_01_cpu"
+    "test_to_device_and_dtype_02_cpu"
+    "test_to_device_and_dtype_09_cpu"
+    "test_to_device_and_dtype_10_cpu"
+    "test_to_device_and_dtype_11_cpu"
+    "test_to_device_and_dtype_12"
+    "test_to_device_and_dtype_13"
+    "test_to_device_and_dtype_14"
+    "test_to_device_and_dtype_21"
+    "test_to_device_and_dtype_22"
+    "test_to_device_and_dtype_23"
+    "test_to_dtype_0"
+    "test_to_dtype_3"
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Fails when max-jobs is set to use fewer processes than cores
     # for example `AssertionError: assert 14 == 4`
@@ -184,8 +203,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library for training deep learning models based on PyTorch";
     homepage = "https://github.com/open-mmlab/mmengine";
-    changelog = "https://github.com/open-mmlab/mmengine/releases/tag/v${version}";
+    changelog = "https://github.com/open-mmlab/mmengine/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ rxiao ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done



- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
