### PR TITLE
ocamlPackages.lwt_eio: 0.5.1 → 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/lwt_eio/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_eio/default.nix
@@ -2,25 +2,25 @@
   lib,
   buildDunePackage,
   fetchurl,
-  fetchpatch,
   eio,
   lwt,
 }:
-buildDunePackage rec {
+
+buildDunePackage (finalAttrs: {
   pname = "lwt_eio";
-  version = "0.5.1";
+  version = if lib.versionAtLeast lwt.version "6.0.0" then "0.6" else "0.5.1";
 
   minimalOCamlVersion = "5.1";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-multicore/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    hash = "sha256-dlJnhHh4VNO60NZJZqc1HS8wPR95WhdeBJTK37pPbCE=";
+    url = "https://github.com/ocaml-multicore/lwt_eio/releases/download/v${finalAttrs.version}/lwt_eio-${finalAttrs.version}.tbz";
+    hash =
+      {
+        "0.5.1" = "sha256-dlJnhHh4VNO60NZJZqc1HS8wPR95WhdeBJTK37pPbCE=";
+        "0.6" = "sha256-6xyIQyMRUE5Q+FQCzAkvaXZqqo8LSFzG6U1A7GZwSLw=";
+      }
+      ."${finalAttrs.version}";
   };
-
-  patches = lib.optional (lib.versionAtLeast lwt.version "6.0.0") (fetchpatch {
-    url = "https://github.com/ocaml-multicore/lwt_eio/commit/5f8bf1e7af33590683ee45151894d7b9a20607f0.patch";
-    hash = "sha256-5A3Bh+xOXo79Rw145hYqYv42li30M0TKLW+qu/dC0KQ=";
-  });
 
   propagatedBuildInputs = [
     eio
@@ -28,9 +28,9 @@ buildDunePackage rec {
   ];
 
   meta = {
-    homepage = "https://github.com/ocaml-multicore/${pname}";
-    changelog = "https://github.com/ocaml-multicore/${pname}/raw/v${version}/CHANGES.md";
+    homepage = "https://github.com/ocaml-multicore/lwt_eio";
+    changelog = "https://github.com/ocaml-multicore/lwt_eio/raw/v${finalAttrs.version}/CHANGES.md";
     description = "Use Lwt libraries from within Eio";
     license = with lib.licenses; [ isc ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
