### PR TITLE
[staging-next] python3Packages.numpy: fix loongarch64-linux build

### DIFF
--- a/pkgs/development/python-modules/numpy/2.nix
+++ b/pkgs/development/python-modules/numpy/2.nix
@@ -63,7 +63,7 @@ buildPythonPackage (finalAttrs: {
       --replace-fail '/bin/true' '${lib.getExe' coreutils "true"}'
   '';
 
-  mesonFlags = [
+  mesonFlags = lib.optionals (!stdenv.hostPlatform.isLoongArch64) [
     # This is required to support CPUs with feature-sets earlier than x86-64-v2
     # (before 2009). This will still build optimizations for newer features, but
     # allow for importing with older machines. See:


### PR DESCRIPTION
On loongarch64-linux we have LSX as the baseline, so #504426 doesn't apply there. 

```shell
> =========================== short test summary info ============================
> FAILED lib/python3.13/site-packages/numpy/_core/tests/test_cpu_dispatcher.py::test_dispatcher - AssertionError:
> Items are not equal:
>  ACTUAL: 'func'
>  DESIRED: 'func_LSX'
> = 1 failed, 46492 passed, 1083 skipped, 32 xfailed, 2 xpassed, 534 warnings in 423.62s (0:07:03) =
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
