### PR TITLE
arf: init at 0.2.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3874,6 +3874,12 @@
     githubId = 86652;
     name = "Bram Duvigneau";
   };
+  brancengregory = {
+    name = "Brancen Gregory";
+    email = "brancengregory@gmail.com";
+    github = "brancengregory";
+    githubId = 13408602;
+  };
   brancz = {
     email = "frederic.branczyk@polarsignals.com";
     name = "Frederic Branczyk";

--- a/pkgs/by-name/ar/arf/package.nix
+++ b/pkgs/by-name/ar/arf/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  R,
+  glibcLocales,
+  air-formatter,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "arf";
+  version = "0.2.7";
+
+  src = fetchFromGitHub {
+    owner = "eitsupi";
+    repo = "arf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-b2O87n90JqMzOQMxsaf78GIKteG7IXynJSTpn32V/cM=";
+  };
+
+  cargoHash = "sha256-v71Zy+1uI3jVQ3nek5+f5TKoN+wXK89VpFx0vcbZjIE=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [
+    air-formatter
+    glibcLocales
+    R
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+    export TERM=xterm-256color
+    export LANG=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/arf \
+      --prefix PATH : ${lib.makeBinPath [ R ]} \
+      --set R_HOME ${R}/lib/R
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Alternative R Frontend — a modern R console written in Rust";
+    homepage = "https://github.com/eitsupi/arf";
+    changelog = "https://github.com/eitsupi/arf/releases/tag/${finalAttrs.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "arf";
+    maintainers = [ lib.maintainers.brancengregory ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**arf: init at 0.2.7**

Alternative R Frontend — a modern, cross-platform R console written in Rust. Provides syntax highlighting, fuzzy history search, bracketed paste support, and integration with the `air` R code formatter.

https://github.com/eitsupi/arf

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test