### PR TITLE
jerryscript: fix build with gcc15

### DIFF
--- a/pkgs/by-name/je/jerryscript/fix-gcc15.patch
+++ b/pkgs/by-name/je/jerryscript/fix-gcc15.patch
@@ -1,0 +1,19 @@
+diff --git a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+index 280a94c..b147679 100644
+--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
++++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+@@ -36,12 +36,12 @@
+ /**
+  * Day names
+  */
+-const char day_names_p[7][3] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
++const char day_names_p[7][3] __attribute__((nonstring)) = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+ 
+ /**
+  * Month names
+  */
+-const char month_names_p[12][3] = {
++const char month_names_p[12][3] __attribute__((nonstring)) = {
+   "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+ };
+ 

--- a/pkgs/by-name/je/jerryscript/package.nix
+++ b/pkgs/by-name/je/jerryscript/package.nix
@@ -30,6 +30,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Evu4qLlwg3Sf9w/ojtZMNxGJEtopHgKnwqlpf115zD4=";
   };
 
+  patches = [
+    # https://github.com/jerryscript-project/jerryscript/issues/5263
+    ./fix-gcc15.patch
+  ];
+
+  postPatch = ''
+    # get rid of bundled CMake toolchain files
+    rm cmake/toolchain_*
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -40,6 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "JERRY_MATH" enableMath)
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
   ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-enum-enum-conversion -Wno-enum-float-conversion -Wno-literal-range";
 
   nativeCheckInputs = [
     python3
@@ -57,8 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Uses a custom lib variable that ignores what nixpkgs's cmake setupHook specifies.
   postInstall = ''
-    mkdir -p "$lib/lib"
-    mv "$out/lib/"*.so "$lib/lib"
+    mkdir $lib
+    mv "$out/lib" "$lib/"
   '';
 
   nativeInstallCheckInputs = [
@@ -92,6 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
       "libjerry-ext"
       "libjerry-port"
     ];
-    maintainers = with lib.maintainers; [ RossSmyth ];
+    maintainers = with lib.maintainers; [
+      RossSmyth
+      wishstudio
+    ];
   };
 })


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322333470

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
