### PR TITLE
minimal-bootstrap: Prepare late-stage packages for cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/static.nix
@@ -4,8 +4,8 @@
   hostPlatform,
   fetchurl,
   bash,
+  gcc-buildbuild,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -25,6 +25,10 @@ let
     url = "mirror://gnu/bash/bash-${version}.tar.gz";
     sha256 = "sha256-DVzYaWX4aaJs9k9Lcb57lvkKO6iz104n6OnZ1VUPMbo=";
   };
+
+  binutilsTargetPrefix = lib.optionalString (
+    hostPlatform.config != buildPlatform.config
+  ) "${hostPlatform.config}-";
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -32,7 +36,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -56,6 +59,10 @@ bash.runCommand "${pname}-${version}"
     tar xf ${src}
     cd bash-${version}
 
+    export AR="${binutilsTargetPrefix}ar"
+    export STRIP="${binutilsTargetPrefix}strip"
+    export STRIPPROG="$STRIP"
+
     # Configure
     bash ./configure \
       --prefix=$out \
@@ -64,7 +71,7 @@ bash.runCommand "${pname}-${version}"
       --without-bash-malloc \
       --disable-dependency-tracking \
       --enable-static-link \
-      CC=musl-gcc
+      CC_FOR_BUILD=${gcc-buildbuild}/bin/gcc
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/bash/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bash/static.nix
@@ -4,8 +4,8 @@
   hostPlatform,
   fetchurl,
   bash,
+  gcc-buildbuild,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -25,6 +25,10 @@ let
     url = "mirror://gnu/bash/bash-${version}.tar.gz";
     sha256 = "sha256-DVzYaWX4aaJs9k9Lcb57lvkKO6iz104n6OnZ1VUPMbo=";
   };
+
+  binutilsTargetPrefix = lib.optionalString (
+    hostPlatform.config != buildPlatform.config
+  ) "${hostPlatform.config}-";
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -32,7 +36,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -56,6 +59,10 @@ bash.runCommand "${pname}-${version}"
     tar xf ${src}
     cd bash-${version}
 
+    export AR="${binutilsTargetPrefix}ar"
+    export STRIP="${binutilsTargetPrefix}strip"
+    export STRIPPROG="$STRIP"
+
     # Configure
     bash ./configure \
       --prefix=$out \
@@ -65,7 +72,7 @@ bash.runCommand "${pname}-${version}"
       --disable-dependency-tracking \
       --disable-nls \
       --enable-static-link \
-      CC=musl-gcc
+      CC_FOR_BUILD=${gcc-buildbuild}/bin/gcc
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -4,8 +4,8 @@
   hostPlatform,
   fetchurl,
   bash,
+  gcc-buildbuild,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnupatch,
@@ -33,15 +33,12 @@ let
   ];
 
   configureFlags = [
-    "CC=musl-gcc"
-    "LDFLAGS=--static"
     "--prefix=${placeholder "out"}"
     "--build=${buildPlatform.config}"
     "--host=${hostPlatform.config}"
 
     "--disable-dependency-tracking"
 
-    "--with-sysroot=/"
     "--enable-deterministic-archives"
     # depends on bison
     "--disable-gprofng"
@@ -63,7 +60,7 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
+      gcc-buildbuild
       binutils
       gnumake
       gnupatch

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -4,8 +4,8 @@
   hostPlatform,
   fetchurl,
   bash,
+  gcc-buildbuild,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnupatch,
@@ -33,8 +33,6 @@ let
   ];
 
   configureFlags = [
-    "CC=musl-gcc"
-    "LDFLAGS=--static"
     "--prefix=${placeholder "out"}"
     "--build=${buildPlatform.config}"
     "--host=${hostPlatform.config}"
@@ -42,7 +40,6 @@ let
     "--disable-dependency-tracking"
     "--disable-nls"
 
-    "--with-sysroot=/"
     "--enable-deterministic-archives"
     # depends on bison
     "--disable-gprofng"
@@ -70,7 +67,7 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
+      gcc-buildbuild
       binutils
       gnumake
       gnupatch

--- a/pkgs/os-specific/linux/minimal-bootstrap/bison/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bison/default.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -70,8 +68,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/bzip2/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bzip2/static.nix
@@ -1,9 +1,10 @@
 {
   lib,
   fetchurl,
+  buildPlatform,
+  hostPlatform,
   bash,
   gcc,
-  musl,
   binutils,
   findutils,
   gnumake,
@@ -18,6 +19,10 @@ let
     url = "https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz";
     sha256 = "0s92986cv0p692icqlw1j42y9nld8zd83qwhzbqd61p1dqbh6nmb";
   };
+
+  binutilsTargetPrefix = lib.optionalString (
+    hostPlatform.config != buildPlatform.config
+  ) "${hostPlatform.config}-";
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -25,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       findutils
       gnumake
@@ -56,14 +60,15 @@ bash.runCommand "${pname}-${version}"
     # Build
     make \
       -j $NIX_BUILD_CORES \
-      CC=musl-gcc \
-      CFLAGS=-static \
-      bzip2 bzip2recover
+      bzip2 bzip2recover \
+      CC=${hostPlatform.config}-gcc \
+      AR=${binutilsTargetPrefix}ar \
+      RANLIB=${binutilsTargetPrefix}ranlib
 
     # Install
     make install -j $NIX_BUILD_CORES PREFIX=$out
 
     # Strip
     # Ignore failures, because strip may fail on non-elf files.
-    find $out/{bin,lib} -type f -exec strip --strip-debug {} + || true
+    find $out/{bin,lib} -type f -exec ${binutilsTargetPrefix}strip --strip-debug {} + || true
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/bzip2/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/bzip2/static.nix
@@ -1,9 +1,10 @@
 {
   lib,
   fetchurl,
+  buildPlatform,
+  hostPlatform,
   bash,
   gcc,
-  musl,
   binutils,
   findutils,
   gnumake,
@@ -18,6 +19,10 @@ let
     url = "https://sourceware.org/pub/bzip2/bzip2-${version}.tar.gz";
     sha256 = "0s92986cv0p692icqlw1j42y9nld8zd83qwhzbqd61p1dqbh6nmb";
   };
+
+  binutilsTargetPrefix = lib.optionalString (
+    hostPlatform.config != buildPlatform.config
+  ) "${hostPlatform.config}-";
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -25,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       findutils
       gnumake
@@ -72,9 +76,10 @@ bash.runCommand "${pname}-${version}"
     # Build
     make \
       -j $NIX_BUILD_CORES \
-      CC=musl-gcc \
-      CFLAGS=-static \
-      bzip2
+      bzip2 \
+      CC=${hostPlatform.config}-gcc \
+      AR=${binutilsTargetPrefix}ar \
+      RANLIB=${binutilsTargetPrefix}ranlib
 
     # Install
     mkdir -p $out/bin
@@ -84,5 +89,5 @@ bash.runCommand "${pname}-${version}"
 
     # Strip
     # Ignore failures, because strip may fail on non-elf files.
-    strip --strip-debug $out/bin/bzip2 || true
+    ${binutilsTargetPrefix}strip --strip-debug $out/bin/bzip2 || true
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -35,8 +34,7 @@ let
     # libstdbuf.so fails in static builds
     "--enable-no-install-program=stdbuf"
     "--enable-single-binary=symlinks"
-    "CC=musl-gcc"
-    "CFLAGS=\"-static -I${linux-headers}/include\""
+    "CFLAGS=\"-I${linux-headers}/include\""
   ];
 in
 bash.runCommand "${pname}-${version}"
@@ -45,7 +43,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -36,8 +35,7 @@ let
     # libstdbuf.so fails in static builds
     "--enable-no-install-program=stdbuf"
     "--enable-single-binary=symlinks"
-    "CC=musl-gcc"
-    "CFLAGS=\"-static -I${linux-headers}/include\""
+    "CFLAGS=\"-I${linux-headers}/include\""
   ];
 in
 bash.runCommand "${pname}-${version}"
@@ -46,7 +44,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -48,6 +48,7 @@ lib.makeScope
         };
 
         bash-static = callPackage ./bash/static.nix {
+          gcc-buildbuild = gcc-latest;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
@@ -60,6 +61,7 @@ lib.makeScope
         };
 
         binutils-static = callPackage ./binutils/static.nix {
+          gcc-buildbuild = gcc-latest;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
@@ -251,6 +253,7 @@ lib.makeScope
         };
 
         gzip-static = callPackage ./gzip/static.nix {
+          libc = musl;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
@@ -299,6 +302,7 @@ lib.makeScope
         };
 
         musl-static = callPackage ./musl/static.nix {
+          libgcc = gcc-latest;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
         };

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -154,10 +154,18 @@ lib.makeScope
           gnutar = gnutar-latest;
         };
 
-        gcc-latest = callPackage ./gcc/latest.nix {
+        gcc-latest-unwrapped = callPackage ./gcc/latest.nix {
           gcc = gcc10;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
+        };
+        gcc-latest = callPackage ./gcc/wrapper.nix {
+          bash-build = bash;
+          gcc-unwrapped = gcc-latest-unwrapped;
+          targetPlatform = hostPlatform;
+          libc = musl;
+          libgcc = gcc-latest-unwrapped;
+          libstdcxx = gcc-latest-unwrapped;
         };
 
         gnugrep = callPackage ./gnugrep {
@@ -384,7 +392,7 @@ lib.makeScope
             echo ${gcc46.tests.get-version}
             echo ${gcc46-cxx.tests.hello-world}
             echo ${gcc10.tests.hello-world}
-            echo ${gcc-latest.tests.hello-world}
+            echo ${gcc-latest-unwrapped.tests.hello-world}
             echo ${gnugrep.tests.get-version}
             echo ${gnugrep-static.tests.get-version}
             echo ${gnum4.tests.get-version}
@@ -426,7 +434,7 @@ lib.makeScope
         };
 
         glibc = callPackage ./glibc {
-          gcc = gcc-latest;
+          gcc = gcc-latest-unwrapped;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
           gnugrep = gnugrep-static;

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -48,6 +48,7 @@ lib.makeScope
         };
 
         bash-static = callPackage ./bash/static.nix {
+          gcc-buildbuild = gcc-latest;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
@@ -60,6 +61,7 @@ lib.makeScope
         };
 
         binutils-static = callPackage ./binutils/static.nix {
+          gcc-buildbuild = gcc-latest;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
@@ -435,7 +437,7 @@ lib.makeScope
               echo ${gcc46.tests.get-version}
               echo ${gcc46-cxx.tests.hello-world}
               echo ${gcc10.tests.hello-world}
-              echo ${gcc-latest.tests.hello-world}
+              echo ${gcc-latest-unwrapped.tests.hello-world}
             ''
             + (lib.strings.optionalString (hostPlatform.libc == "glibc") ''
               echo ${gcc-glibc.tests.hello-world}

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -154,10 +154,18 @@ lib.makeScope
           gnutar = gnutar-latest;
         };
 
-        gcc-latest = callPackage ./gcc/latest.nix {
+        gcc-latest-unwrapped = callPackage ./gcc/latest.nix {
           gcc = gcc10;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
+        };
+        gcc-latest = callPackage ./gcc/wrapper.nix {
+          bash-build = bash;
+          gcc-unwrapped = gcc-latest-unwrapped;
+          targetPlatform = hostPlatform;
+          libc = musl;
+          libgcc = gcc-latest-unwrapped;
+          libstdcxx = gcc-latest-unwrapped;
         };
 
         gnugrep = callPackage ./gnugrep {
@@ -294,6 +302,7 @@ lib.makeScope
         };
 
         musl-static = callPackage ./musl/static.nix {
+          libgcc = gcc-latest-unwrapped;
           gcc = gcc-latest;
           gnumake = gnumake-musl;
         };
@@ -455,7 +464,7 @@ lib.makeScope
         };
 
         glibc = callPackage ./glibc {
-          gcc = gcc-latest;
+          gcc = gcc-latest-unwrapped;
           gnumake = gnumake-musl;
           gnutar = gnutar-latest;
           gnugrep = gnugrep-static;

--- a/pkgs/os-specific/linux/minimal-bootstrap/diffutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/diffutils/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -64,14 +62,14 @@ bash.runCommand "${pname}-${version}"
     cd diffutils-${version}
 
     # Configure
+    # Manually set strcasecmp_works, because we might be cross-compiling
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static \
-      ac_cv_path_PR_PROGRAM=pr
+      ac_cv_path_PR_PROGRAM=pr \
+      gl_cv_func_strcasecmp_works=y
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/diffutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/diffutils/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -64,15 +62,15 @@ bash.runCommand "${pname}-${version}"
     cd diffutils-${version}
 
     # Configure
+    # Manually set strcasecmp_works, because we might be cross-compiling
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
       --disable-nls \
-      CC=musl-gcc \
-      CFLAGS=-static \
-      ac_cv_path_PR_PROGRAM=pr
+      ac_cv_path_PR_PROGRAM=pr \
+      gl_cv_func_strcasecmp_works=y
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -68,9 +66,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/findutils/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -70,9 +68,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      --disable-nls \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-nls
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -61,9 +59,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -66,9 +64,7 @@ bash.runCommand "${pname}-${version}"
       --disable-extensions \
       --disable-mpfr \
       --disable-nls \
-      --disable-pma \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-pma
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
@@ -124,9 +124,6 @@ bash.runCommand "${pname}-${version}"
     ln -s ../isl-${islVersion} isl
 
     # Configure
-    export CC="gcc -Wl,-dynamic-linker -Wl,${musl}/lib/libc.so"
-    export CXX="g++ -Wl,-dynamic-linker -Wl,${musl}/lib/libc.so"
-
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
@@ -131,9 +131,11 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --with-native-system-header-dir=/include \
-      --with-sysroot=${musl} \
+      --with-native-system-header-dir=${musl}/include \
+      --with-sysroot=/ \
       --enable-languages=c,c++ \
+      --enable-static \
+      --disable-shared \
       --disable-bootstrap \
       --disable-dependency-tracking \
       --disable-libsanitizer \
@@ -146,4 +148,14 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+
+    if [ -d "$out/lib64" ]; then
+      shopt -s dotglob
+      for lib in $out/lib64/*; do
+        mv --no-clobber "$lib" "$out/lib/"
+      done
+      shopt -u dotglob
+      rm -rf "$out/lib64"
+      ln -s lib "$out/lib64"
+    fi
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
@@ -126,10 +126,12 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --with-native-system-header-dir=/include \
-      --with-sysroot=${musl} \
+      --with-native-system-header-dir=${musl}/include \
+      --with-sysroot=/ \
       --enable-languages=c,c++ \
       --enable-checking=release \
+      --enable-static \
+      --disable-shared \
       --disable-bootstrap \
       --disable-dependency-tracking \
       --disable-libsanitizer \
@@ -144,8 +146,7 @@ bash.runCommand "${pname}-${version}"
       --disable-multilib \
       --disable-nls \
       --disable-plugin \
-      --without-isl \
-      --disable-shared
+      --without-isl
 
     # Build
     make -j $NIX_BUILD_CORES
@@ -155,4 +156,14 @@ bash.runCommand "${pname}-${version}"
 
     # libstdc++ gdb pretty-printers + man pages are unused downstream.
     rm -rf $out/share/gcc-*/python $out/share/man $out/share/info
+
+    if [ -d "$out/lib64" ]; then
+      shopt -s dotglob
+      for lib in $out/lib64/*; do
+        mv --no-clobber "$lib" "$out/lib/"
+      done
+      shopt -u dotglob
+      rm -rf "$out/lib64"
+      ln -s lib "$out/lib64"
+    fi
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrapper.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrapper.nix
@@ -1,0 +1,81 @@
+{
+  fetchurl,
+  lib,
+  gnutar,
+  xz,
+  bash-build,
+  gnused,
+  targetPlatform,
+  libc,
+  libgcc,
+  libstdcxx,
+  gcc-unwrapped,
+  binutils,
+  bash,
+}:
+let
+  pname = "gcc-wrapper";
+  extraFlags = "-static-libgcc ";
+  # only supports musl for now
+  dynamicLinkerGlob = "${libc}/lib/libc.so";
+in
+bash-build.runCommand "${pname}-${gcc-unwrapped.version}"
+  {
+    inherit pname;
+    version = gcc-unwrapped.version;
+    meta = gcc-unwrapped.meta;
+    nativeBuildInputs = [ gnused ];
+    passthru.unwrapped = gcc-unwrapped;
+  }
+  ''
+    if [[ -z '${dynamicLinkerGlob}' ]]; then
+      echo "Don't know the name of the dynamic linker for platform '${targetPlatform.config}', so guessing instead."
+      dynamicLinker="${libc}/lib/ld*.so.?"
+    else
+      dynamicLinker='${dynamicLinkerGlob}'
+    fi
+    dynamicLinker=($dynamicLinker)
+    case ''${#dynamicLinker[@]} in
+      0) echo "No dynamic linker found for platform '${targetPlatform.config}'.";;
+      1) echo "Using dynamic linker: '$dynamicLinker'";;
+      *) echo "Multiple dynamic linkers found for platform '${targetPlatform.config}'.";;
+    esac
+
+    mkdir -p "$out/bin"
+    for orig in ${gcc-unwrapped}/bin/*gcc ${gcc-unwrapped}/bin/*gcc-${gcc-unwrapped.version}; do
+      sed \
+        -e 's,@bash@,${lib.getExe bash},' \
+        -e "s,@gcc@,$orig," \
+        -e "s,@origname@,$(basename "$orig")," \
+        -e "s,@origdir@,${gcc-unwrapped}/libexec/gcc," \
+        -e "s,@dynlinker@,$dynamicLinker," \
+        -e 's,@libgcc@,${libgcc}/lib/gcc/${targetPlatform.config}/${libgcc.version},' \
+        -e 's,@libc@,${libc}/lib,' \
+        -e 's,@gccinc@,${gcc-unwrapped}/lib/gcc/${targetPlatform.config}/${libgcc.version}/include,' \
+        -e 's,@binutils@,${binutils}/bin,' \
+        -e 's,@extraflags@,${extraFlags},' \
+        '${./wrapper.sh}' > "$out/bin/$(basename "$orig")"
+        chmod +x "$out/bin/$(basename "$orig")"
+    done
+    for orig in ${gcc-unwrapped}/bin/*++; do
+      sed \
+        -e 's,@bash@,${lib.getExe bash},' \
+        -e "s,@gcc@,$orig," \
+        -e "s,@origname@,$(basename "$orig")," \
+        -e "s,@origdir@,${gcc-unwrapped}/libexec/gcc," \
+        -e "s,@dynlinker@,$dynamicLinker," \
+        -e 's,@libgcc@,${libgcc}/lib/gcc/${targetPlatform.config}/${libgcc.version},' \
+        -e 's,@libc@,${libc}/lib,' \
+        -e 's,@libstdcxx@,${libstdcxx}/lib,' \
+        -e 's,@libstdcxxinc@,${libstdcxx}/include/c++/${libstdcxx.version},' \
+        -e 's,@libstdcxxarchinc@,${libstdcxx}/include/c++/${libstdcxx.version}/${targetPlatform.config},' \
+        -e 's,@gccinc@,${gcc-unwrapped}/lib/gcc/${targetPlatform.config}/${libgcc.version}/include,' \
+        -e 's,@binutils@,${binutils}/bin,' \
+        -e 's,@extraflags@,${extraFlags},' \
+        '${./wrappercxx.sh}' > "$out/bin/$(basename "$orig")"
+        chmod +x "$out/bin/$(basename "$orig")"
+    done
+    for orig in ${gcc-unwrapped}/bin/*cpp ${gcc-unwrapped}/bin/*-ar ${gcc-unwrapped}/bin/*-nm ${gcc-unwrapped}/bin/*-ranlib; do
+      ln -s "$orig" "$out/bin/$(basename "$orig")"
+    done
+  ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrapper.sh
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrapper.sh
@@ -1,0 +1,51 @@
+#!@bash@
+
+if [ 1 = "$#" ] && [ "x-v" = "x$1" ]; then
+  # HACK! should not pass -Wl if there are no input files, otherwise libtool breaks
+  exec -a "@origname@" @gcc@ -v
+fi
+
+# logic based on pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+# very hacky
+extraRpath=""
+prev=""
+for param in "$@"; do
+  case "$prev" in
+    -L | -B)
+      case "$param" in
+        "$NIX_STORE"/*)
+          extraRpath="$extraRpath -Wl,-rpath,${param}"
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+    *)
+      case "$param" in
+        -L"$NIX_STORE"/* | -B"$NIX_STORE"/*)
+          extraRpath="$extraRpath -Wl,-rpath,${param:2}"
+          ;;
+        "$NIX_STORE"/*.so | "$NIX_STORE"/*.so.*)
+          extraRpath="$extraRpath -Wl,-rpath,${param%/*}"
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+  esac
+  prev="$param"
+done
+
+# Order of -B is very particular. musl detection in gnulib requires that
+# libc/.. comes before libgcc, otherwise libc is assumed to be glibc.
+exec -a "@origname@" @gcc@ -Wl,-dynamic-linker=@dynlinker@ \
+  @extraflags@ \
+  $extraRpath \
+  -Wl,-rpath,@libc@,-rpath,@libgcc@ \
+  -B@libc@/.. \
+  -B@libgcc@ \
+  -B@libc@ \
+  -B@origdir@ \
+  -B@binutils@ \
+  -isystem @gccinc@ \
+  "$@"

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrappercxx.sh
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/wrappercxx.sh
@@ -1,0 +1,57 @@
+#!@bash@
+
+if [ 1 = "$#" ] && [ "x-v" = "x$1" ]; then
+  # HACK! should not pass -Wl if there are no input files, otherwise libtool breaks
+  exec -a "@origname@" @gcc@ -v
+fi
+
+# logic based on pkgs/build-support/bintools-wrapper/ld-wrapper.sh
+# very hacky
+extraRpath=""
+prev=""
+for param in "$@"; do
+  case "$prev" in
+    -L | -B)
+      case "$param" in
+        "$NIX_STORE"*)
+          extraRpath="$extraRpath -Wl,-rpath,${param}"
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+    *)
+      case "$param" in
+        -L"$NIX_STORE"/* | -B"$NIX_STORE"/*)
+          extraRpath="$extraRpath -Wl,-rpath,${param:2}"
+          ;;
+        "$NIX_STORE"/*.so | "$NIX_STORE"/*.so.*)
+          extraRpath="$extraRpath -Wl,-rpath,${param%/*}"
+          ;;
+        *)
+          ;;
+      esac
+      ;;
+  esac
+  prev="$param"
+done
+
+# Order of -B is very particular. musl detection in gnulib requires that
+# libc/.. comes before libgcc, otherwise libc is assumed to be glibc.
+# Also, libstdcxxinc uses #include_next directives that depend on
+# libc headers, so libstdcxx must come before libc.
+exec -a "@origname@" @gcc@ -Wl,-dynamic-linker=@dynlinker@ \
+  @extraflags@ \
+  $extraRpath \
+  -Wl,-rpath,@libc@,-rpath,@libgcc@,-rpath,@libstdcxx@ \
+  -I @libstdcxxarchinc@ \
+  -I @libstdcxxinc@ \
+  -B@libc@/.. \
+  -B@libc@ \
+  -B@libgcc@ \
+  -B@origdir@ \
+  -B@binutils@ \
+  -B@libstdcxx@ \
+  -isystem @gccinc@ \
+  "$@"
+

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -69,9 +67,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -70,9 +68,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      --disable-nls \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-nls
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnum4/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnum4/default.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -71,7 +69,6 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      CC=musl-gcc \
       CFLAGS=-I${linux-headers}/include
 
     # Build

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnupatch,
@@ -42,7 +41,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnupatch
@@ -79,8 +77,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS="-static -std=gnu17"
+      CFLAGS="-std=gnu17"
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnupatch,
@@ -42,7 +41,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnupatch
@@ -80,8 +78,7 @@ bash.runCommand "${pname}-${version}"
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
       --disable-nls \
-      CC=musl-gcc \
-      CFLAGS="-static -std=gnu17"
+      CFLAGS="-std=gnu17"
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnupatch/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -69,9 +67,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -61,9 +59,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnused/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -62,9 +60,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      --disable-nls \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-nls
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -61,9 +59,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -32,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -62,9 +60,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      --disable-nls \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-nls
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/gzip/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gzip/static.nix
@@ -5,7 +5,7 @@
   fetchurl,
   bash,
   gcc,
-  musl,
+  libc,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +31,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -68,9 +67,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CFLAGS=-static
+      --disable-dependency-tracking ${lib.optionalString hostPlatform.isMusl "CFLAGS=-static"}
 
     # Build
     make -j $NIX_BUILD_CORES bin_SCRIPTS=

--- a/pkgs/os-specific/linux/minimal-bootstrap/gzip/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gzip/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -69,7 +67,6 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      CC=musl-gcc \
       CFLAGS=-static
 
     # Build

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/static.nix
@@ -13,6 +13,7 @@
   gnutar,
   gzip,
   linux-headers,
+  libgcc,
 }:
 let
   inherit (import ./common.nix { inherit lib; }) pname meta;
@@ -22,6 +23,10 @@ let
     url = "https://musl.libc.org/releases/musl-${version}.tar.gz";
     hash = "sha256-1YX9O2E8ZhUfwySejtRPdwIMtebB5jWmFtP5+CRgUSo=";
   };
+
+  binutilsTargetPrefix = lib.optionalString (
+    hostPlatform.config != buildPlatform.config
+  ) "${hostPlatform.config}-";
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -77,23 +82,23 @@ bash.runCommand "${pname}-${version}"
       src/misc/wordexp.c
 
     # Configure
+    export CC="${binutilsTargetPrefix}gcc -B${libgcc}/lib/gcc/${hostPlatform.config}/${libgcc.version} -Wl,-rpath,${libgcc}/lib/gcc/${hostPlatform.config}/${libgcc.version}"
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --syslibdir=$out/lib \
-      --enable-wrapper
+      --syslibdir=$out/lib
 
     # Build
     make -j $NIX_BUILD_CORES
 
     # Install
     make -j $NIX_BUILD_CORES install
-    sed -i 's|/bin/sh|${lib.getExe bash}|' $out/bin/*
+    mkdir -p $out/bin
     ln -s ../lib/libc.so $out/bin/ldd
     ln -s $(ls -d ${linux-headers}/include/* | grep -v scsi\$) $out/include/
 
     # Strip
     # Ignore failures, because strip may fail on non-elf files.
-    find $out/{bin,lib} -type f -exec strip --strip-debug {} + || true
+    find $out/{bin,lib} -type f -exec ${binutilsTargetPrefix}strip --strip-debug {} + || true
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -68,9 +66,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out \
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
-      --disable-dependency-tracking \
-      CC=musl-gcc \
-      CXXFLAGS=-static
+      --disable-dependency-tracking
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/patchelf/static.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -31,7 +30,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -71,8 +69,7 @@ bash.runCommand "${pname}-${version}"
       --build=${buildPlatform.config} \
       --host=${hostPlatform.config} \
       --disable-dependency-tracking \
-      CC=musl-gcc \
-      CXXFLAGS="-static -g0 -O2 -DNDEBUG -ffile-prefix-map=${gcc}=. -fmacro-prefix-map=${gcc}=."
+      CXXFLAGS="-g0 -O2 -DNDEBUG -ffile-prefix-map=${gcc}=. -fmacro-prefix-map=${gcc}=."
 
     # Build
     make -j $NIX_BUILD_CORES

--- a/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
@@ -5,7 +5,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnupatch,
@@ -42,7 +41,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnupatch
@@ -80,11 +78,9 @@ bash.runCommand "${pname}-${version}"
     ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}
 
     # Configure
-    export CC=musl-gcc
     export C_INCLUDE_PATH="${zlib}/include"
     export LIBRARY_PATH="${zlib}/lib"
-    export LDFLAGS="-Wl,-rpath,${zlib}/lib -L${zlib}/lib"
-    export LD_LIBRARY_PATH="$LIBRARY_PATH"
+    export LDFLAGS="-L${zlib}/lib"
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \

--- a/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
@@ -12,7 +12,6 @@
   gawk,
   gnutar,
   gzip,
-  musl,
 }:
 let
   pname = "xz";
@@ -30,7 +29,6 @@ bash.runCommand "${pname}-${version}"
     nativeBuildInputs = [
       binutils
       gcc
-      musl
       gnumake
       gnused
       gnugrep
@@ -64,10 +62,6 @@ bash.runCommand "${pname}-${version}"
     cd xz-${version}
 
     # Configure
-    export CC=musl-gcc
-    export CFLAGS=-static
-    export CXXFLAGS=-static
-    export LDFLAGS=-static
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \

--- a/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
@@ -39,7 +39,7 @@ bash.runCommand "${pname}-${version}"
       gzip
     ];
 
-    disallowedReferences = [ musl ];
+    disallowedReferences = [ gcc ];
 
     passthru.tests.get-version =
       result:

--- a/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/xz/static.nix
@@ -12,7 +12,6 @@
   gawk,
   gnutar,
   gzip,
-  musl,
 }:
 let
   pname = "xz";
@@ -30,7 +29,6 @@ bash.runCommand "${pname}-${version}"
     nativeBuildInputs = [
       binutils
       gcc
-      musl
       gnumake
       gnused
       gnugrep
@@ -66,10 +64,8 @@ bash.runCommand "${pname}-${version}"
     cd xz-${version}
 
     # Configure
-    export CC=musl-gcc
     export CFLAGS="-g0 -O2 -DNDEBUG"
     export CXXFLAGS="$CFLAGS"
-    export LDFLAGS=-static
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \
@@ -87,7 +83,7 @@ bash.runCommand "${pname}-${version}"
       --disable-assembler
 
     # Build
-    make -j $NIX_BUILD_CORES LDFLAGS=-all-static
+    make -j $NIX_BUILD_CORES
 
     # Install
     make -j $NIX_BUILD_CORES install-strip

--- a/pkgs/os-specific/linux/minimal-bootstrap/zlib/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/zlib/default.nix
@@ -3,7 +3,6 @@
   fetchurl,
   bash,
   gcc,
-  musl,
   binutils,
   gnumake,
   gnused,
@@ -26,7 +25,6 @@ bash.runCommand "${pname}-${version}"
 
     nativeBuildInputs = [
       gcc
-      musl
       binutils
       gnumake
       gnused
@@ -49,7 +47,6 @@ bash.runCommand "${pname}-${version}"
     cd zlib-${version}
 
     # Configure
-    export CC=musl-gcc
     bash ./configure --prefix=$out
 
     # Build


### PR DESCRIPTION
Various packages under minimal-bootstrap explicitly use the musl gcc wrapper (especially the *-static packages).

In https://github.com/NixOS/nixpkgs/pull/494106, the desire is to allow these packages to run on a host platform which may differ from the bootstrap seed platform. That host platform may be a non-musl platform, and furthermore musl may not even be available on the desired host architecture.

This change aims to make the packages more generic wrt libc. It is extracted out of https://github.com/NixOS/nixpkgs/pull/494106.

To this end, a new gcc wrapper is added to replace the musl-gcc wrapper. Currently it does pretty much the same thing as musl-gcc. However, the dependent PR #494106 trivially extends it to work with glibc as well. It is also constructed in a way that allows gcc to be decomposed into smaller derivations (gccNgPackages-style). The dependent PR uses this kind of decomposition to avoid redundant compilations of libiberty/libgcc/libstdcxx etc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
