### PR TITLE
python3Packages.peft: cleanup, fix on aarch64-linux; python3Packages.tinygrad: skip failing tests on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -29,7 +29,7 @@
   scipy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "peft";
   version = "0.18.1";
   pyproject = true;
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "peft";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qlM8yEN/CJZbSAGNCltS4JQSzstVXRVqu47qZbLPVNc=";
   };
 
@@ -70,12 +70,20 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "tests" ];
 
-  # These tests fail when MPS devices are detected
-  disabledTests = lib.optional stdenv.hostPlatform.isDarwin [
-    "gpu"
-    "test_save_load"
-    "test_resume_training_model_with_topk_weights"
-  ];
+  disabledTests =
+    lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # RuntimeError: Failed to initialize cpuinfo!
+      "test_randlora_dtypes"
+      "test_shira_dtypes"
+      "test_vblora_dtypes"
+      "test_vera_dtypes"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # These tests fail when MPS devices are detected
+      "gpu"
+      "test_save_load"
+      "test_resume_training_model_with_topk_weights"
+    ];
 
   disabledTestPaths = [
     # ValueError: Can't find 'adapter_config.json'
@@ -113,8 +121,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/huggingface/peft";
     description = "State-of-the art parameter-efficient fine tuning";
-    changelog = "https://github.com/huggingface/peft/releases/tag/${src.tag}";
+    changelog = "https://github.com/huggingface/peft/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/tinygrad/default.nix
+++ b/pkgs/development/python-modules/tinygrad/default.nix
@@ -247,6 +247,12 @@ buildPythonPackage (finalAttrs: {
     "test_float_cast_to_unsigned_underflow"
     "test_int8"
     "test_int8_to_uint16_negative"
+
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_conv2d_fused_half"
+    "test_conv2d_half"
+    "test_gemm_fp16"
+    "test_softmax_dtype"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Flaky (pass when running a smaller set of tests: tests/unit/*, but not within the full test suite)


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
