### PR TITLE
python3Packages.rich-click: 1.9.5 -> 1.9.7

### DIFF
--- a/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
+++ b/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
@@ -1,12 +1,15 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
   django,
+  fetchFromGitHub,
   netaddr,
   netbox,
+  numpy,
+  requests,
   setuptools,
 }:
+
 buildPythonPackage rec {
   pname = "netbox-interface-synchronization";
   version = "4.1.7";
@@ -24,6 +27,8 @@ buildPythonPackage rec {
   dependencies = [
     django
     netaddr
+    requests
+    numpy
   ];
 
   # netbox is required for the pythonImportsCheck; plugin does not provide unit tests

--- a/pkgs/development/python-modules/netbox-plugin-prometheus-sd/default.nix
+++ b/pkgs/development/python-modules/netbox-plugin-prometheus-sd/default.nix
@@ -10,19 +10,17 @@
 
 buildPythonPackage rec {
   pname = "netbox-plugin-prometheus-sd";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "FlxPeters";
     repo = "netbox-plugin-prometheus-sd";
     tag = "v${version}";
-    hash = "sha256-L5kJnaY9gKpsWAgwkjVRQQauL2qViinqk7rHLXTVzT4=";
+    hash = "sha256-2SVfWkw6/AkDihWp9chU8rTqLiSn9ax4uLaK1xydfGM=";
   };
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'version = "0.0.0"' 'version = "${version}"'
     substituteInPlace netbox_prometheus_sd/__init__.py \
       --replace-fail "from extras.plugins import PluginConfig" "from netbox.plugins import PluginConfig"
   '';

--- a/pkgs/development/python-modules/netbox-plugin-prometheus-sd/default.nix
+++ b/pkgs/development/python-modules/netbox-plugin-prometheus-sd/default.nix
@@ -8,7 +8,7 @@
   poetry-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "netbox-plugin-prometheus-sd";
   version = "1.3.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "FlxPeters";
     repo = "netbox-plugin-prometheus-sd";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2SVfWkw6/AkDihWp9chU8rTqLiSn9ax4uLaK1xydfGM=";
   };
 
@@ -43,8 +43,8 @@ buildPythonPackage rec {
   meta = {
     description = "Netbox plugin to provide Netbox entires to Prometheus HTTP service discovery";
     homepage = "https://github.com/FlxPeters/netbox-plugin-prometheus-sd";
-    changelog = "https://github.com/FlxPeters/netbox-plugin-prometheus-sd/releases/tag/${src.tag}";
+    changelog = "https://github.com/FlxPeters/netbox-plugin-prometheus-sd/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ xanderio ];
   };
-}
+})

--- a/pkgs/development/python-modules/rich-click/default.nix
+++ b/pkgs/development/python-modules/rich-click/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "rich-click";
-  version = "1.9.5";
+  version = "1.9.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ewels";
     repo = "rich-click";
     tag = "v${version}";
-    hash = "sha256-VSaPSC49icIB4z3ZPHtedh2gXkYBIODrG362T++i0Eo=";
+    hash = "sha256-HT82Dk3dYNMVU4lKJodKtn2KfEH7HUAORpa2RKSmg68=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Diff: https://github.com/ewels/rich-click/compare/v1.9.5...v1.9.7

Changelog: https://github.com/ewels/rich-click/blob/v1.9.7/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
