### PR TITLE
[Backport release-25.11] flatpak: 1.16.2 -> 1.16.4

### DIFF
--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -80,7 +80,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak";
-  version = "1.16.2";
+  version = "1.16.3";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${finalAttrs.version}/flatpak-${finalAttrs.version}.tar.xz";
-    hash = "sha256-aRctGw2Fxo+B5t3wEV+OGwXXOxsBD+qNnssDvIrYQ+s=";
+    hash = "sha256-PWvT9fiUDoDAhyhso+QhgvxjDXgIlFNlEfzSz/wSz1s=";
   };
 
   patches = [

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -80,7 +80,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak";
-  version = "1.16.3";
+  version = "1.16.4";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${finalAttrs.version}/flatpak-${finalAttrs.version}.tar.xz";
-    hash = "sha256-PWvT9fiUDoDAhyhso+QhgvxjDXgIlFNlEfzSz/wSz1s=";
+    hash = "sha256-dh/zugDJmib5FMaZnpCxKlTKsZzqWIhBPxfkbuYY2P4=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backports #507753 to stable. cc @getchoo

This contains high-severity security fixes ([CVE-2026-34078](https://nvd.nist.gov/vuln/detail/CVE-2026-34078), [CVE-2026-34079](https://nvd.nist.gov/vuln/detail/CVE-2026-34079), [GHSA-2fxp-43j9-pwvc](https://github.com/flatpak/flatpak/security/advisories/GHSA-2fxp-43j9-pwvc) and [GHSA-89xm-3m96-w3jg](https://github.com/flatpak/flatpak/security/advisories/GHSA-89xm-3m96-w3jg)) and should be backported.
Changelog: https://github.com/flatpak/flatpak/releases/tag/1.16.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
