### PR TITLE
Add score generators

### DIFF
--- a/pkgs/by-name/sc/score-compose/package.nix
+++ b/pkgs/by-name/sc/score-compose/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGo126Module,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGo126Module (finalAttrs: {
+  pname = "score-compose";
+  version = "0.36.6";
+
+  src = fetchFromGitHub {
+    owner = "score-spec";
+    repo = "score-compose";
+    tag = finalAttrs.version;
+    hash = "sha256-SCmFA1SgebDSzx/bWuxwwdq1zCE8VdSXk+TigPpjAkU=";
+  };
+
+  vendorHash = "sha256-OT5jqaVlEMDUyhFliXXdlN36LUll3K3fc1r47977aT8=";
+
+  subPackages = [ "cmd/score-compose" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/score-spec/score-compose/internal/version.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "CLI to generate Docker Compose manifests from Score specs";
+    homepage = "https://github.com/score-spec/score-compose";
+    changelog = "https://github.com/score-spec/score-compose/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "score-compose";
+    maintainers = with lib.maintainers; [ jocelynthode ];
+  };
+
+  passthru.updateScript = nix-update-script { };
+})

--- a/pkgs/by-name/sc/score-k8s/package.nix
+++ b/pkgs/by-name/sc/score-k8s/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGo126Module,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGo126Module (finalAttrs: {
+  pname = "score-k8s";
+  version = "0.10.4";
+
+  src = fetchFromGitHub {
+    owner = "score-spec";
+    repo = "score-k8s";
+    tag = finalAttrs.version;
+    hash = "sha256-6kMJMRrnzChApigwM7OkxRZR1I2tZ6Fo7ePwH+JHUzE=";
+  };
+
+  vendorHash = "sha256-boqD3OhqdGe1QSGg0oKdgcQPZyI5Ec4Iq2xEbpw8SqI=";
+
+  subPackages = [ "cmd/score-k8s" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/score-spec/score-k8s/internal/version.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "CLI to generate Kubernetes manifests from Score specs";
+    homepage = "https://github.com/score-spec/score-k8s";
+    changelog = "https://github.com/score-spec/score-k8s/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "score-k8s";
+    maintainers = with lib.maintainers; [ jocelynthode ];
+  };
+
+  passthru.updateScript = nix-update-script { };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add score reference cli generator implementation for https://www.cncf.io/projects/score/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
