### PR TITLE
flatpak: Add autoUpdate options

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -264,6 +264,8 @@
 
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
+- `services.flatpak` now supports automatically updating applications using `autoUpdate` options
+
 - `buildNpmPackage` now supports `npmDepsFetcherVersion` (and `fetchNpmDeps` now supports `fetcherVersion`). Set to `2` to enable packument caching, which fixes builds for projects using npm workspaces.
 
 - Added `dell-bios-fan-control` package and service.

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -22,6 +22,72 @@ in
       enable = lib.mkEnableOption "flatpak";
 
       package = lib.mkPackageOption pkgs "flatpak" { };
+
+      autoUpdate = {
+        enable = lib.mkEnableOption "autoUpdate" // {
+          description = ''
+            Whether to periodically update Flatpak apps to the latest
+            version. If enabled, a systemd timer will run
+            `flatpak update --asumeyes --noninteractive` once a day.
+
+            This is usually handled by desktop environments, but it can
+            be useful to enable on a minimal desktop environment.
+          '';
+        };
+
+        dates = lib.mkOption {
+          type = lib.types.str;
+          default = "03:40";
+          example = "daily";
+          description = ''
+            How often or when update occurs. For most desktop and server systems
+            a sufficient update frequency is once a day.
+
+            The format is described in
+            {manpage}`systemd.time(7)`.
+          '';
+        };
+
+        randomizedDelaySec = lib.mkOption {
+          default = "0";
+          type = lib.types.str;
+          example = "45min";
+          description = ''
+            Add a randomized delay before each automatic update.
+            The delay will be chosen between zero and this value.
+            This value must be a time span in the format specified by
+            {manpage}`systemd.time(7)`
+          '';
+        };
+
+        fixedRandomDelay = lib.mkOption {
+          default = false;
+          type = lib.types.bool;
+          example = true;
+          description = ''
+            Make the randomized delay consistent between runs.
+            This reduces the jitter between automatic updates.
+            See {option}`randomizedDelaySec` for configuring the randomized delay.
+          '';
+        };
+
+        persistent = lib.mkOption {
+          default = true;
+          type = lib.types.bool;
+          example = false;
+          description = ''
+            Takes a boolean argument. If true, the time when the service
+            unit was last triggered is stored on disk. When the timer is
+            activated, the service unit is triggered immediately if it
+            would have been triggered at least once during the time when
+            the timer was inactive. Such triggering is nonetheless
+            subject to the delay imposed by RandomizedDelaySec=. This is
+            useful to catch up on missed runs of the service when the
+            system was powered down.
+          '';
+        };
+      };
+
     };
   };
 
@@ -48,6 +114,26 @@ in
 
     systemd.packages = [ cfg.package ];
     systemd.tmpfiles.packages = [ cfg.package ];
+
+    systemd.services.flatpak-update = {
+      startAt = lib.optional cfg.autoUpdate.enable cfg.autoUpdate.dates;
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      description = "Flatpak apps auto update";
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${lib.getExe' cfg.package "flatpak"} update --assumeyes --noninteractive";
+      };
+    };
+
+    systemd.timers.flatpak-update = lib.mkIf cfg.autoUpdate.enable {
+      description = "Timer for Flatpak auto update";
+      timerConfig = {
+        OnCalendar = cfg.autoUpdate.dates;
+        RandomizedDelaySec = cfg.autoUpdate.randomizedDelaySec;
+        Persistent = cfg.autoUpdate.persistent;
+      };
+    };
 
     environment.profiles = [
       "$HOME/.local/share/flatpak/exports"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Allow setting up flatpak service/timer to automatically update flatpak
apps once a day (or other chosen frequency). Useful in minimal desktop
environments which would not notify user about missing updates out of
the box.

This is modeled on system.autoUpgrade options/descriptions etc

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->