### PR TITLE
check-sieve: 0.11 -> 1.0.0

### DIFF
--- a/pkgs/by-name/ch/check-sieve/package.nix
+++ b/pkgs/by-name/ch/check-sieve/package.nix
@@ -10,13 +10,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "check-sieve";
-  version = "0.11";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "dburkart";
     repo = "check-sieve";
-    tag = "check-sieve-${finalAttrs.version}";
-    hash = "sha256-vmfHXjcZ5J/+kO3/a0p8krLOuC67+q8SxcPJgW+UaTw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dElVfLSVtlELleuxCScR6BGuLsJ+KRqcNA8y0lgrBfI=";
   };
 
   nativeBuildInputs = [
@@ -28,8 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     (python3.withPackages (p: [ p.setuptools ]))
   ];
 
-  # https://github.com/dburkart/check-sieve/issues/67
-  # Remove after the next (>0.10) release
   env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-result";
 
   installPhase = ''
@@ -39,17 +37,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preCheck = ''
-    substituteInPlace test/AST/util.py \
+    substituteInPlace test/{AST,simulate}/util.py \
       --replace-fail "/usr/bin/diff" "${diffutils}/bin/diff"
-    # Disable flaky tests: https://github.com/dburkart/check-sieve/issues/68
-    # Remove after the next (>0.10) release
-    rm -rf test/{6785,7352}
   '';
 
   doCheck = true;
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version-regex=check-sieve-(.*)" ];
+    extraArgs = [ "--version-regex=v(.*)" ];
   };
 
   meta = {


### PR DESCRIPTION
https://github.com/dburkart/check-sieve/releases/tag/v1.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
