### PR TITLE
[25.11] goshs: 1.1.2 -> 2.0.0-beta.3

### DIFF
--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-0KeIRmqX+YkjZrUXtMPELT+3f06bVaGoBOGuBbqmY8A=";
+    tag = finalAttrs.version;
+    hash = "sha256-oGcGaLPtagyvDNdSkNx4U0wEj57yrYCGnKUGGR4U0aw=";
   };
 
-  vendorHash = "sha256-eu4ytWargmwSfCVfXPykCX0VD7XO7m/T8Her10XpM3s=";
+  vendorHash = "sha256-43Bu4BAmMmd6WrDNztQNCi2OdlzIfbrQC100DkcD4uE=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "1.1.3";
+  version = "1.1.4";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
-    tag = finalAttrs.version;
-    hash = "sha256-oGcGaLPtagyvDNdSkNx4U0wEj57yrYCGnKUGGR4U0aw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7z/7dUTDHteAwK78hbrvsHk3Gnv7ZSvaW25sC3vkwW4=";
   };
 
   vendorHash = "sha256-43Bu4BAmMmd6WrDNztQNCi2OdlzIfbrQC100DkcD4uE=";
@@ -44,7 +44,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Simple, yet feature-rich web server written in Go";
     homepage = "https://goshs.de";
-    changelog = "https://github.com/patrickhener/goshs/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/patrickhener/goshs/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab

--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -2,29 +2,30 @@
   buildGoModule,
   fetchFromGitHub,
   stdenv,
-  versionCheckHook,
   lib,
+  testers,
+
+  # passthru
+  goshs,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "1.1.4";
+  version = "2.0.0-beta.3";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7z/7dUTDHteAwK78hbrvsHk3Gnv7ZSvaW25sC3vkwW4=";
+    hash = "sha256-ELYeabx0hb4oy2RH0yUIt6xTb2rm1eqxZIH+VhEZlvU=";
   };
 
-  vendorHash = "sha256-43Bu4BAmMmd6WrDNztQNCi2OdlzIfbrQC100DkcD4uE=";
+  vendorHash = "sha256-EXu1VQWxbKa0EkfqgOL8MDnOCGd8yynP1Bko5wqRCBg=";
 
   ldflags = [
     "-s"
     "-w"
   ];
-
-  nativeInstallCheckInputs = [ versionCheckHook ];
 
   doInstallCheck = true;
 
@@ -40,6 +41,13 @@ buildGoModule (finalAttrs: {
     # does not work in sandbox even with __darwinAllowLocalNetworking
     "-skip=^TestGetIPv4Addr$"
   ];
+
+  # Disabled until https://github.com/patrickhener/goshs/issues/137 is resolved
+  # passthru.tests.version = testers.testVersion {
+  #   package = goshs;
+  #   command = "goshs -v";
+  #   version = "goshs ${finalAttrs.version}";
+  # };
 
   meta = {
     description = "Simple, yet feature-rich web server written in Go";


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/507892

(the nixos-25.11 part)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
