### PR TITLE
ausweisapp: 2.4.1 -> 2.5.1

### DIFF
--- a/pkgs/by-name/au/ausweisapp/package.nix
+++ b/pkgs/by-name/au/ausweisapp/package.nix
@@ -8,16 +8,17 @@
   qt6,
   pcsclite,
   gitUpdater,
+  llhttp,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ausweisapp";
-  version = "2.4.1";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "Governikus";
     repo = "AusweisApp2";
     rev = finalAttrs.version;
-    hash = "sha256-cLKF5QYDPngvN6+3p7B8YO/MYvDfD1fbnyEMZPmjj8w=";
+    hash = "sha256-R+2swDzIHlgE0kVonoYQih8r8p38RN7bqkbb+WB1hCc=";
   };
 
   postPatch = ''
@@ -39,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   buildInputs = [
+    llhttp
     pcsclite
     qt6.qtscxml
     qt6.qtsvg


### PR DESCRIPTION
- https://github.com/Governikus/AusweisApp/releases/tag/2.5.0
- https://github.com/Governikus/AusweisApp/releases/tag/2.5.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
