### PR TITLE
python3Packages.crewai: 1.13.0 -> 1.14.1

### DIFF
--- a/pkgs/development/python-modules/crewai/default.nix
+++ b/pkgs/development/python-modules/crewai/default.nix
@@ -7,6 +7,7 @@
   hatchling,
 
   # dependencies
+  aiofiles,
   aiosqlite,
   appdirs,
   chromadb,
@@ -54,14 +55,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "crewai";
-  version = "1.13.0";
+  version = "1.14.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "crewAIInc";
     repo = "crewAI";
     tag = finalAttrs.version;
-    hash = "sha256-IKtfwM9xOMNs993ggT1EejjWKixWEjDMFUuq+RXXvfQ=";
+    hash = "sha256-MwBcum9HX0emKPB0UpTCBTvZRnNP0YqU02YCEHZ4CeA=";
   };
 
   postPatch = ''
@@ -82,6 +83,7 @@ buildPythonPackage (finalAttrs: {
   build-system = [ hatchling ];
 
   pythonRelaxDeps = [
+    "aiofiles"
     "chromadb"
     "click"
     "json-repair"
@@ -107,6 +109,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
+    aiofiles
     aiosqlite
     appdirs
     chromadb


### PR DESCRIPTION
Diff : https://github.com/crewAIInc/crewAI/compare/1.13.0...1.14.1
Changelog : https://github.com/crewAIInc/crewAI/releases/tag/1.14.1


Fix : 
https://github.com/NixOS/nixpkgs/issues/505307
https://github.com/NixOS/nixpkgs/issues/505308

CVE :
CVE-2026-35030
CVE-2026-1839

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
