### PR TITLE
androidenv.ndk-bundle: use jdk_headless instead of jdk

### DIFF
--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -24,7 +24,7 @@ let
         gawk
         gnugrep
         gnused
-        jdk
+        jdk_headless
         python3
         which
       ]


### PR DESCRIPTION
## Description

Switch the Android NDK bundle's runtime JDK dependency from `jdk` (full OpenJDK, ~864 MB closure) to `jdk_headless` (~607 MB closure).

`ndk-build` only invokes `java`/`javac` — it never uses AWT, Swing, or any GUI capability. The full JDK pulls in GTK+3, icu4c, harfbuzz, cups, and systemd (~257 MB of desktop libraries) that are completely unused.

## Change

One-line change in `pkgs/development/mobile/androidenv/ndk-bundle/default.nix`: `jdk` → `jdk_headless` in the `runtime_paths` list.

## Impact

- Saves ~257 MB of closure size for any derivation depending on the NDK bundle
- No functional change — `java` and `javac` remain available in PATH
- Particularly beneficial for CI and cross-compilation environments (e.g., Android cross-GHC builds)

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux