### PR TITLE
jamin: 0.95.0 -> 0.98.9-unstable-2015-01-14

### DIFF
--- a/pkgs/by-name/ja/jamin/fix-crash.patch
+++ b/pkgs/by-name/ja/jamin/fix-crash.patch
@@ -1,0 +1,21 @@
+From a6498278654792d46ebef4f918b8a1c7b663a2d9 Mon Sep 17 00:00:00 2001
+From: Herwig Hochleitner <herwig@bendlas.net>
+Date: Mon, 14 Apr 2025 15:11:37 +0200
+Subject: [PATCH] fix use-after-free during init
+
+---
+ src/state.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/state.c b/src/state.c
+index 6ee4099..48e0b30 100644
+--- a/src/state.c
++++ b/src/state.c
+@@ -234,6 +234,7 @@ void s_clear_history()
+     }
+     g_list_free(history);
+     history = NULL;
++    undo_pos = NULL;
+     s_history_add("Initial state");
+     undo_pos = history->next;
+     //s_restore_state((s_state *)history->data);

--- a/pkgs/by-name/ja/jamin/package.nix
+++ b/pkgs/by-name/ja/jamin/package.nix
@@ -1,44 +1,72 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchgit,
+  fetchpatch,
   fftwFloat,
-  gtk2,
+  gtk3,
   ladspaPlugins,
   libjack2,
   liblo,
   libxml2,
+  autoconf,
+  automake,
+  intltool,
+  libtool,
   makeWrapper,
   pkg-config,
   perlPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.95.0";
   pname = "jamin";
+  version = "0.98.9-unstable-2015-01-14";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/jamin/jamin-${finalAttrs.version}.tar.gz";
-    hash = "sha256-di/uiGgvJ4iORt+wE6mrXnmFM7m2dkP/HXdgUBk5uzw=";
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/jamin/code";
+    rev = "199091a6e3709e2890eaf2c8b4e57c6749776cdc";
+    hash = "sha256-wiIBymvpPxY+z/nZi+dH0hXEuhO5FYQjon6VfJaTwC0=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-    makeWrapper
+  patches = [
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/j/jamin/0.98.9~git20170111~199091~repack1-3/debian/patches/gcc15.patch";
+      hash = "sha256-dH0NI12Xfw9Rl7Iwm4QzDvXIHT7XzBC8Ly0lQOpDD84=";
+    })
+    # https://github.com/bendlas/jamin/commit/a6498278654792d46ebef4f918b8a1c7b663a2d9.patch
+    ./fix-crash.patch
   ];
 
-  buildInputs = [
-    fftwFloat
-    gtk2
-    ladspaPlugins
-    libjack2
-    liblo
-    libxml2
+  postPatch = ''
+    patchShebangs --build controller/xml2c.pl
+    # for whatever reason the default config file is gzipped
+    mv examples/default.jam{,.gz}
+    gunzip examples/default.jam.gz
+  '';
+
+  preConfigure = "./autogen.sh";
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    intltool
+    libtool
+    pkg-config
+    makeWrapper
   ]
   ++ (with perlPackages; [
     perl
     XMLParser
   ]);
+
+  buildInputs = [
+    fftwFloat
+    gtk3
+    ladspaPlugins
+    libjack2
+    liblo
+    libxml2
+  ];
 
   # Workaround build failure on -fno-common toolchains like upstream
   # gcc-10. Otherwise build fails as:


### PR DESCRIPTION
- #475479 
- #410814 
- #516381
- https://hydra.nixos.org/build/322333076

Borrowed two patches and fixed to a point that it loads up its GUI.
However I can't get jack working on my system so the actual testing is not done.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
