### PR TITLE
various: remove gravndal from maintainers

### DIFF
--- a/pkgs/by-name/gi/git-annex-remote-googledrive/package.nix
+++ b/pkgs/by-name/gi/git-annex-remote-googledrive/package.nix
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Git-annex special remote for Google Drive";
     homepage = "https://github.com/Lykos153/git-annex-remote-googledrive";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ gravndal ];
+    maintainers = [ ];
     mainProgram = "git-annex-remote-googledrive";
   };
 })

--- a/pkgs/development/python-modules/drivelib/default.nix
+++ b/pkgs/development/python-modules/drivelib/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Easy access to the most common Google Drive API calls";
     homepage = "https://github.com/Lykos153/python-drivelib";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ gravndal ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/expiringdict/default.nix
+++ b/pkgs/development/python-modules/expiringdict/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     description = "Dictionary with auto-expiring values for caching purposes";
     homepage = "https://github.com/mailgun/expiringdict";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ gravndal ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I no longer use this as I luckily no longer need to use gsuite.

Git annex remote googledrive should probably be removed from nixpkgs at some point, as rclone now has a native git annex special remote built-in, but they use different directory structures and so migration is non-trivial.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
