### PR TITLE
[Backport release-25.11] vim: 9.2.0106 -> 9.2.0272

### DIFF
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -1,6 +1,6 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "9.1.2148";
+  version = "9.2.0272";
 
   outputs = [
     "out"
@@ -11,7 +11,7 @@ rec {
     owner = "vim";
     repo = "vim";
     rev = "v${version}";
-    hash = "sha256-4ZEbfpffPp6kqSQRp7NFioWGRdG+JsVf7unU0Hqn/Xk=";
+    hash = "sha256-9y+dZYbwuIzgseXdg/k8fqZ5JiohgOiK00evMwF9HOM=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/505178 to 25.11