### PR TITLE
podman-desktop: 1.23.1 -> 1.26.2

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   copyDesktopItems,
-  electron_39,
+  electron_41,
   nodejs,
   pnpm_10_29_2,
   fetchPnpmDeps,
@@ -21,12 +21,12 @@
 }:
 
 let
-  electron = electron_39;
+  electron = electron_41;
   appName = "Podman Desktop";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.23.1";
+  version = "1.26.2";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -59,14 +59,14 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-08boCPsuT09OileZUWhB8awXWHrlJzoER2Bx0WXeOHU=";
+    hash = "sha256-VVyKC1z7YECZlbTaFaq2OwGg0k22qBbn/HEOYiJ8fcw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10_29_2;
     fetcherVersion = 2;
-    hash = "sha256-nBjAmXzjR0qGCM91UAonQKP0NG7+DXImueSbhbnMK/k=";
+    hash = "sha256-tCp5qLZVo93H8VIToU3mkmwNsVXOAd1IEsL6RlazPXo=";
   };
 
   patches = [
@@ -75,7 +75,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./system-defaults-dir.patch
   ];
 
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    ELECTRON_OVERRIDE_DIST_PATH = electron.dist;
+  };
 
   nativeBuildInputs = [
     makeBinaryWrapper

--- a/pkgs/by-name/po/podman-desktop/system-defaults-dir.patch
+++ b/pkgs/by-name/po/podman-desktop/system-defaults-dir.patch
@@ -1,10 +1,13 @@
-diff --git a/packages/main/src/plugin/managed-by-constants.ts b/packages/main/src/plugin/managed-by-constants.ts
-index 5a20d2de29e..9fea8a17165 100644
---- a/packages/main/src/plugin/managed-by-constants.ts
-+++ b/packages/main/src/plugin/managed-by-constants.ts
-@@ -29,4 +29,4 @@ export const SYSTEM_LOCKED_FILENAME = 'locked.json';
- // Folders for managed defaults on different platforms
- export const SYSTEM_DEFAULTS_FOLDER_MACOS = '/Library/Application Support/io.podman_desktop.PodmanDesktop';
- export const SYSTEM_DEFAULTS_FOLDER_WINDOWS = 'Podman Desktop';
--export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/usr/share/podman-desktop';
-+export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/etc/podman-desktop';
+diff --git a/product.json b/product.json
+index 74b7299ee93..a80fe7373bc 100644
+--- a/product.json
++++ b/product.json
+@@ -8,7 +8,7 @@
+     "managed": {
+       "macOS": "/Library/Application Support/io.podman_desktop.PodmanDesktop",
+       "windows": "%PROGRAMDATA%\\Podman Desktop",
+-      "linux": "/usr/share/podman-desktop",
++      "linux": "/etc/podman-desktop",
+       "flatpak": "/run/host/usr/share/podman-desktop"
+     }
+   },


### PR DESCRIPTION
This includes fix for:
https://nvd.nist.gov/vuln/detail/CVE-2026-34045

Fixes #507930


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
