### PR TITLE
xendmail: init at 0.5.0

### DIFF
--- a/pkgs/by-name/xe/xendmail/package.nix
+++ b/pkgs/by-name/xe/xendmail/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromSourcehut,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xendmail";
+  version = "0.5.0";
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = "xendmail";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-oX5+4LDjDXaDIBZCARG9s9pMA9KDlDATB+dkhObMWpM=";
+  };
+
+  cargoHash = "sha256-iiq9T0S62/jDgSmg0d5g+wbn2kpWkjKX8EpSsYb9Jic=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A sendmail drop-in replacement designed to be configured by individual system users";
+    homepage = "https://git.sr.ht/~whynothugo/xendmail";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      philocalyst
+    ];
+    mainProgram = "xendmail";
+  };
+})

--- a/pkgs/by-name/xe/xendmail/package.nix
+++ b/pkgs/by-name/xe/xendmail/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromSourcehut,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xendmail";
+  version = "0.5.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = "xendmail";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oX5+4LDjDXaDIBZCARG9s9pMA9KDlDATB+dkhObMWpM=";
+  };
+
+  cargoHash = "sha256-iiq9T0S62/jDgSmg0d5g+wbn2kpWkjKX8EpSsYb9Jic=";
+
+  meta = {
+    description = "Sendmail drop-in replacement designed to be configured by individual system users";
+    homepage = "https://git.sr.ht/~whynothugo/xendmail";
+    changelog = "https://git.sr.ht/~whynothugo/xendmail/tree/main/item/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      philocalyst
+    ];
+    mainProgram = "xendmail";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Xendmail !!!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
