### PR TITLE
neovim: support per-plugin lua config

### DIFF
--- a/pkgs/applications/editors/neovim/plugin-submodule.nix
+++ b/pkgs/applications/editors/neovim/plugin-submodule.nix
@@ -11,6 +11,7 @@ let
         plugin = null;
         config = null;
         optional = false;
+        type = "viml";
       };
     in
     map (x: defaultPlugin // (if x ? plugin then x else { plugin = x; })) plugins;
@@ -24,6 +25,15 @@ let
           description = "viml configuration associated with this plugin.";
           default = null;
           example = "set title";
+        };
+
+        type = lib.mkOption {
+          type = lib.types.either (lib.types.enum [
+            "lua"
+            "viml"
+          ]) lib.types.str;
+          description = "Language used in config. Configurations are aggregated per-language.";
+          default = "viml";
         };
 
         optional = mkEnableOption "optional" // {
@@ -78,9 +88,17 @@ in
 
     userPluginViml = lib.mkOption {
       readOnly = true;
-      type = lib.types.listOf lib.types.lines;
+      type = lib.types.nullOr lib.types.lines;
       description = ''
         The viml config set by the user.
+      '';
+    };
+
+    userPluginConfigs = lib.mkOption {
+      readOnly = true;
+      type = lib.types.attrsOf lib.types.lines;
+      description = ''
+        The user configurations (viml, lua, ...) set by the user.
       '';
     };
 
@@ -106,6 +124,13 @@ in
   config =
     let
       pluginsNormalized = config.plugins;
+
+      userPluginConfigs =
+        let
+          grouped = lib.groupBy (x: x.type) pluginsNormalized;
+          configsOnly = lib.foldl (acc: p: if p.config != null then acc ++ [ p.config ] else acc) [ ];
+        in
+        lib.mapAttrs (_name: vals: lib.concatStringsSep "\n" (configsOnly vals)) grouped;
     in
     {
       pluginAdvisedLua =
@@ -125,9 +150,9 @@ in
         in
         lib.foldl' op [ ] pluginsNormalized;
 
-      userPluginViml = lib.foldl (
-        acc: p: if p.config != null then acc ++ [ p.config ] else acc
-      ) [ ] pluginsNormalized;
+      userPluginViml = userPluginConfigs.viml or null;
+
+      inherit userPluginConfigs;
 
       pluginPython3Packages = map (plugin: plugin.python3Dependencies or (_: [ ])) pluginsNormalized;
 

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -12,7 +12,6 @@
   writeText,
   neovim,
   vimPlugins,
-  neovimUtils,
   wrapNeovimUnstable,
   neovim-unwrapped,
   fetchFromGitLab,
@@ -21,8 +20,6 @@
   pkgs,
 }:
 let
-  inherit (neovimUtils) makeNeovimConfig;
-
   plugins = with vimPlugins; [
     {
       plugin = vim-obsession;
@@ -42,20 +39,6 @@ let
       config = ''" placeholder config'';
     }
   ];
-
-  nvimConfSingleLines = {
-    plugins = packagesWithSingleLineConfigs;
-    neovimRcContent = ''
-      " just a comment
-    '';
-  };
-
-  nvimConfNix = {
-    inherit plugins;
-    neovimRcContent = ''
-      " just a comment
-    '';
-  };
 
   nvim-with-luasnip = wrapNeovim2 "-with-luasnip" {
     plugins = [
@@ -105,6 +88,7 @@ let
       }
       (
         ''
+          export PATH="${neovim-drv}/bin:$PATH"
           source ${nmt}/bash-lib/assertions.sh
           vimrc="${writeText "test-${neovim-drv.name}-init.vim" neovim-drv.initRc}"
           luarc="${writeText "test-${neovim-drv.name}-init.lua" neovim-drv.luaRcContent}"
@@ -139,8 +123,19 @@ pkgs.lib.recurseIntoAttrs rec {
 
   ### neovim tests
   ##################
-  nvim_with_plugins = wrapNeovim2 "-with-plugins" nvimConfNix;
-  nvim_singlelines = wrapNeovim2 "-single-lines" nvimConfSingleLines;
+  nvim_with_plugins = wrapNeovim2 "-with-plugins" {
+    inherit plugins;
+    neovimRcContent = ''
+      " just a comment
+    '';
+  };
+
+  nvim_singlelines = wrapNeovim2 "-single-lines" {
+    plugins = packagesWithSingleLineConfigs;
+    neovimRcContent = ''
+      " just a comment
+    '';
+  };
 
   # test that passthru.initRc hasn't changed
   passthruInitRc = runTest nvim_singlelines ''
@@ -413,12 +408,13 @@ pkgs.lib.recurseIntoAttrs rec {
   # check that bringing in one plugin with lua deps makes those deps visible from wrapper
   # for instance luasnip has a dependency on jsregexp
   can_require_transitive_deps = runTest nvim-with-luasnip ''
-    ${nvim-with-luasnip}/bin/nvim -i NONE -c "lua require'jsregexp'" -e +quitall!
+    nvim --headless -i NONE -c "lua require'jsregexp'" -e +quitall!
   '';
 
   inherit nvim_with_rocks_nvim;
   rocks_install_plenary = runTest nvim_with_rocks_nvim ''
-    ${nvim_with_rocks_nvim}/bin/nvim -V3log.txt -i NONE +'Rocks install plenary.nvim' +quit! -e
+    nvim -V3rocks-log.txt -i NONE +'Rocks install plenary.nvim' +quit! -e
+  '';
   '';
 
   inherit (vimPlugins) corePlugins;

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -27,6 +27,14 @@ let
         map <Leader>$ <Cmd>Obsession<CR>
       '';
     }
+    {
+      plugin = vim-obsession;
+      type = "lua";
+      config = ''
+        -- this is a comment
+        vim.g.nixpkgs_test_value = 42
+      '';
+    }
   ];
 
   packagesWithSingleLineConfigs = with vimPlugins; [
@@ -415,6 +423,12 @@ pkgs.lib.recurseIntoAttrs rec {
   rocks_install_plenary = runTest nvim_with_rocks_nvim ''
     nvim -V3rocks-log.txt -i NONE +'Rocks install plenary.nvim' +quit! -e
   '';
+
+  can_load_lua_config = runTest nvim_with_plugins ''
+    if ! nvim --headless -V3lua-config-log.txt -i NONE -c 'lua if vim.g.nixpkgs_test_value ~= 42 then os.exit(42) end' +quit! -e; then
+      echo "Failed to find plugin config"
+      exit 1
+    fi
   '';
 
   inherit (vimPlugins) corePlugins;

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -6,12 +6,8 @@
   config,
   vimUtils,
   vimPlugins,
-  nodejs,
   neovim-unwrapped,
-  bundlerEnv,
-  ruby,
   lua,
-  python3Packages,
   wrapNeovimUnstable,
 }:
 let
@@ -109,11 +105,12 @@ let
 
       # viml config set by the user along with the plugin
       inherit (checked_cfg)
-        userPluginViml
+        userPluginViml # redefine via userPluginConfigs
         runtimeDeps
         pluginAdvisedLua
         pluginPython3Packages
         luaDependencies
+        userPluginConfigs
         ;
 
       # A Vim "package", see ':h packages'

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -100,7 +100,10 @@ let
 
         # we call vimrcContent without 'packages' to avoid the init.vim generation
         neovimRcContent' = lib.concatStringsSep "\n" (
-          vimPackageInfo.userPluginViml ++ lib.optional (neovimRcContent != null) neovimRcContent
+          lib.optional (vimPackageInfo.userPluginConfigs.viml or "" != "") (
+            vimPackageInfo.userPluginConfigs.viml
+          )
+          ++ (lib.optional (neovimRcContent != null) neovimRcContent)
         );
 
         packpathDirs.myNeovimPackages = vimPackageInfo.vimPackage;
@@ -126,6 +129,9 @@ let
           lib.optional (luaDeps != [ ]) luaPathLuaRc
           ++ [ providerLuaRc ]
           ++ lib.optional (luaRcContent != "") luaRcContent
+          ++ lib.optional (
+            vimPackageInfo.userPluginConfigs.lua or "" != ""
+          ) vimPackageInfo.userPluginConfigs.lua
           ++ lib.optional (neovimRcContent' != "") ''
             vim.cmd.source "${writeText "init.vim" neovimRcContent'}"
           ''

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -14,7 +14,6 @@
   neovimUtils,
   perl,
   lndir,
-  vimUtils,
   runCommand,
 }:
 


### PR DESCRIPTION
neoviom fixes

Adds a 'type' option to the plugin submodule so the user can precise
what language it is. For now we limit the enum to lua/viml but we can
extend it afterwards (to fennel/teal/free)

This changes the type of userPluginViml, we could even remove it (or add
lua one).

Draft 
- shall I change `type` to `lang` or `language` ?
- remove userPluginViml ? or a contrario add userPluginLua so one does not have to know about the `userPluginConfigs` ?
- publish the HM PR

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
