### PR TITLE
xdg-desktop-portal: 1.20.3 -> 1.20.4

### DIFF
--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchFromGitLab,
   flatpak,
   fuse3,
   bubblewrap,
@@ -32,9 +33,19 @@
   enableSystemd ? true,
 }:
 
+let
+  # Update this revision when updating this package, found in https://github.com/flatpak/xdg-desktop-portal/blob/master/subprojects/libglnx.wrap
+  libglnxSrc = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "libglnx";
+    rev = "ccea836b799256420788c463a638ded0636b1632";
+    hash = "sha256-H8Bg9QCSkt/aBOaHLyHYC2ei6OU7UpcLq8zLurkYOuA=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal";
-  version = "1.20.3";
+  version = "1.20.4";
 
   outputs = [
     "out"
@@ -46,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flatpak";
     repo = "xdg-desktop-portal";
     tag = finalAttrs.version;
-    hash = "sha256-ntTGEsk8GlXkp3i9RtF+T7jqnNdL2GVbu05d68WVTYc=";
+    hash = "sha256-wLQgJsVicOb8G7M5Qwd+t90UgNYTD04bZ5Ki85Alr1w=";
   };
 
   patches = [
@@ -145,6 +156,9 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   postPatch = ''
+    mkdir -p subprojects/libglnx
+    cp -r ${libglnxSrc}/* subprojects/libglnx/
+
     # until/unless bubblewrap ships a pkg-config file, meson has no way to find it when cross-compiling.
     substituteInPlace meson.build \
       --replace-fail "find_program('bwrap'"  "find_program('${lib.getExe bubblewrap}'"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Security fix, should be backported: https://www.phoronix.com/news/XDG-Desktop-Portal-1.20.4
Fixes: GHSA-rqr9-jwwf-wxgj
Changelog: https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.20.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
