### PR TITLE
rocmPackages.rocprof-compute-viewer: init at 0.1.6

### DIFF
--- a/pkgs/development/rocm-modules/default.nix
+++ b/pkgs/development/rocm-modules/default.nix
@@ -88,6 +88,8 @@ let
         inherit (llvm) clang;
       };
 
+      rocprof-compute-viewer = self.callPackage ./rocprof-compute-viewer { };
+
       rocprof-trace-decoder = self.callPackage ./rocprof-trace-decoder { };
 
       roctracer = self.callPackage ./roctracer { };

--- a/pkgs/development/rocm-modules/rocprof-compute-viewer/default.nix
+++ b/pkgs/development/rocm-modules/rocprof-compute-viewer/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  nix-update-script,
+  qt6,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rocprof-compute-viewer";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "rocprof-compute-viewer";
+    rev = finalAttrs.version;
+    hash = "sha256-hjwqU5TxV4p2EjGy5haQfQqItVtYMI7i/VIfrKZvqhE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+  ];
+
+  # tries to use qt_deploy_runtime_dependencies, but wrapQtAppsHook
+  # handles that instead
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'install(SCRIPT ''${deploy_script})' ""
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "QT_VERSION_MAJOR" "6")
+    (lib.cmakeBool "RCV_DISABLE_OPENGL" true)
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Visualization tool for AMD GPU thread traces from rocprofv3 --att";
+    homepage = "https://github.com/ROCm/rocprof-compute-viewer";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "rocprof-compute-viewer";
+  };
+})


### PR DESCRIPTION
Companion package for rocprofv3's ATT mode. #506820

<img width="1236" height="317" alt="image" src="https://github.com/user-attachments/assets/a6653516-c565-4c73-9f01-07df425bc650" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
