### PR TITLE
python3Packages.tensordict: fix hash

### DIFF
--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pytorch";
     repo = "tensordict";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5m5nNVsaBabUuKPHErBr+LQWfCvjG9b2CjwdK9mASF0=";
+    hash = "sha256-rnMp0u3sl9zqIKNp3OoM9PmE/468YCwqTY4rdDHxamw=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -89,6 +89,12 @@ buildPythonPackage (finalAttrs: {
     # AssertionError: assert 'a string!' == 'a metadata!'
     "test_save_load_memmap"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_cast_to"
+    "test_casts"
+    "test_td_params_cast"
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Hangs due to the use of a pool
     "test_chunksize_num_chunks"


### PR DESCRIPTION

## Things done

Upstream force-pushed the `v0.12.0` tag.

```patch
diff --git a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/scripts/linux-pre-script.sh b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/scripts/linux-pre-script.sh
index 14d1e3acd3a3..96e8ffda168d 100644
--- a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/scripts/linux-pre-script.sh
+++ b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/scripts/linux-pre-script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash

 ${CONDA_RUN} conda install -c conda-forge pybind11 -y
-# Install setuptools_scm which is required for building with --no-isolation
-${CONDA_RUN} pip install setuptools_scm
+# setuptools>=82 removed pkg_resources and no longer vendors `packaging`;
+# PyTorch imports `from packaging.version import Version` at init time,
+# so the standalone package must be present.
+${CONDA_RUN} pip install setuptools_scm packaging
diff --git a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/scripts/win-pre-script.bat b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/scripts/win-pre-script.bat
index 668f48b30149..e79a8249b06d 100644
--- a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/scripts/win-pre-script.bat
+++ b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/scripts/win-pre-script.bat
@@ -16,13 +16,16 @@ if errorlevel 1 (
     echo Successfully installed pybind11.
 )

-:: Install setuptools_scm which is required for building with --no-isolation
-%CONDA_RUN% pip install setuptools_scm
+:: Install setuptools_scm which is required for building with --no-isolation.
+:: setuptools>=82 removed pkg_resources and no longer vendors `packaging`;
+:: PyTorch imports `from packaging.version import Version` at init time,
+:: so the standalone package must be present.
+%CONDA_RUN% pip install setuptools_scm packaging

 :: Check if the installation was successful
 if errorlevel 1 (
-    echo Failed to install setuptools_scm.
+    echo Failed to install setuptools_scm or packaging.
     exit /b 1
 ) else (
-    echo Successfully installed setuptools_scm.
+    echo Successfully installed setuptools_scm and packaging.
 )
diff --git a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/workflows/build-wheels-linux.yml b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/workflows/build-wheels-linux.yml
index 198f0c6f04a1..ce3790326c78 100644
--- a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/workflows/build-wheels-linux.yml
+++ b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/workflows/build-wheels-linux.yml
@@ -31,6 +31,8 @@ jobs:
     with:
       package-type: wheel
       os: linux
+      with-cuda: disable
+      with-rocm: disable
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
   build:
diff --git a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/workflows/build-wheels-windows.yml b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/workflows/build-wheels-windows.yml
index 48eebf1c2231..857cf916c456 100644
--- a/nix/store/3vr3jyivsvpcrpfxdz1ns36789fsy2ii-source/.github/workflows/build-wheels-windows.yml
+++ b/nix/store/ns2slqncbd2nfnq40rzsb524ig3x14kb-source/.github/workflows/build-wheels-windows.yml
@@ -31,6 +31,7 @@ jobs:
     with:
       package-type: wheel
       os: windows
+      with-cuda: disable
       test-infra-repository: pytorch/test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
   build:
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
