### PR TITLE
cmakefmt: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22028,6 +22028,12 @@
     github = "pulsation";
     githubId = 1838397;
   };
+  puneetmatharu = {
+    email = "puneet.matharu@hotmail.co.uk";
+    github = "puneetmatharu";
+    githubId = 25821489;
+    name = "Puneet Matharu";
+  };
   purcell = {
     email = "steve@sanityinc.com";
     github = "purcell";

--- a/pkgs/by-name/cm/cmakefmt/package.nix
+++ b/pkgs/by-name/cm/cmakefmt/package.nix
@@ -8,28 +8,28 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cmakefmt";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src =
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-x86_64-unknown-linux-musl.tar.gz";
-        hash = "sha256-Ps/6tIObs97gTbwJIkAbNsL/fVAW5Of2DP+PrmWhlIE=";
+        hash = "sha256-uEIHVzgyvxlDxN742rojQ4dqFibTQTYNnrCbwwJUY8Y=";
       }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
       fetchurl {
         url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-aarch64-unknown-linux-gnu.tar.gz";
-        hash = "sha256-VWLw4MHegWfLnjKIBDlKpYO3e3rvApAEE2vD9yRGPew=";
+        hash = "sha256-ezWjOov9G67UIFCkF/2RkSuGKidw2A7gAKTJbBszCNA=";
       }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then
       fetchurl {
         url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-x86_64-apple-darwin.tar.gz";
-        hash = "sha256-4L1cAECf9MMiAUCnwfSc71py5ldUCfeCiXtAQ0/oOns=";
+        hash = "sha256-Nc7ZOfJNW/qRlfPseg1ZPYSRSKg4ynnkJ8u/Jd40RCA=";
       }
     else if stdenv.hostPlatform.system == "aarch64-darwin" then
       fetchurl {
         url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-aarch64-apple-darwin.tar.gz";
-        hash = "sha256-RoNHwgt2TJi1rkMzrfMT+AlUSjHY+bLQyXJIKGm2n68=";
+        hash = "sha256-4qpTmVX8JzsJwWJVkWiUGRS3aoWVZuvzHiIPltJhTJg=";
       }
     else
       throw "cmakefmt: unsupported system ${stdenv.hostPlatform.system}";

--- a/pkgs/by-name/cm/cmakefmt/package.nix
+++ b/pkgs/by-name/cm/cmakefmt/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  autoPatchelfHook,
+  gcc-unwrapped,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cmakefmt";
+  version = "0.2.0";
+
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-x86_64-unknown-linux-musl.tar.gz";
+        hash = "sha256-Ps/6tIObs97gTbwJIkAbNsL/fVAW5Of2DP+PrmWhlIE=";
+      }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl {
+        url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-aarch64-unknown-linux-gnu.tar.gz";
+        hash = "sha256-VWLw4MHegWfLnjKIBDlKpYO3e3rvApAEE2vD9yRGPew=";
+      }
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      fetchurl {
+        url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-x86_64-apple-darwin.tar.gz";
+        hash = "sha256-4L1cAECf9MMiAUCnwfSc71py5ldUCfeCiXtAQ0/oOns=";
+      }
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+      fetchurl {
+        url = "https://github.com/cmakefmt/cmakefmt/releases/download/v${finalAttrs.version}/cmakefmt-${finalAttrs.version}-aarch64-apple-darwin.tar.gz";
+        hash = "sha256-RoNHwgt2TJi1rkMzrfMT+AlUSjHY+bLQyXJIKGm2n68=";
+      }
+    else
+      throw "cmakefmt: unsupported system ${stdenv.hostPlatform.system}";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals (stdenv.isLinux && stdenv.hostPlatform.system == "aarch64-linux") [
+    gcc-unwrapped.lib
+  ];
+
+  unpackPhase = ''
+    tar -xzf $src
+    cd cmakefmt-${finalAttrs.version}-*
+  '';
+
+  installPhase = ''
+    install -Dm755 cmakefmt $out/bin/cmakefmt
+  '';
+
+  meta = {
+    description = "A fast, correct CMake formatter";
+    longDescription = ''
+      cmakefmt is a fast, correct, configurable CMake formatter written in
+      Rust. It is a native-binary drop-in replacement for cmake-format with
+      full legacy config conversion support.
+    '';
+    homepage = "https://cmakefmt.dev";
+    changelog = "https://github.com/cmakefmt/cmakefmt/blob/main/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ puneetmatharu ];
+    mainProgram = "cmakefmt";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
## Description

Add [cmakefmt](https://cmakefmt.dev), a fast, correct, configurable CMake formatter written in Rust. It is a native-binary drop-in replacement for cmake-format with full legacy config conversion support.

- Homepage: https://cmakefmt.dev
- Source: https://github.com/cmakefmt/cmakefmt
- License: MIT OR Apache-2.0

The package uses pre-built binaries for four platforms:
- `x86_64-linux` (musl, static)
- `aarch64-linux` (glibc)
- `x86_64-darwin`
- `aarch64-darwin`

## Things done

- [x] Built on platform(s)
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Correct `meta.maintainers` set (added in separate commit)
- [x] `meta.sourceProvenance` set to `binaryNativeCode`
- [x] `meta.license` matches upstream (`MIT OR Apache-2.0`)
- [x] Package placed in `pkgs/by-name/cm/cmakefmt/package.nix`