### PR TITLE
python3Packages.reactivex: support python 3.14

### DIFF
--- a/pkgs/development/python-modules/reactivex/default.nix
+++ b/pkgs/development/python-modules/reactivex/default.nix
@@ -2,10 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   poetry-core,
   pytest-asyncio,
   pytestCheckHook,
-  pythonAtLeast,
   typing-extensions,
 }:
 
@@ -14,15 +14,21 @@ buildPythonPackage rec {
   version = "4.1.0";
   pyproject = true;
 
-  # https://github.com/ReactiveX/RxPY/issues/737
-  disabled = pythonAtLeast "3.14";
-
   src = fetchFromGitHub {
     owner = "ReactiveX";
     repo = "RxPY";
     tag = "v${version}";
     hash = "sha256-napPfp72gqy43UmkPu1/erhjmJbZypHZQikmjIFVBqA=";
   };
+
+  patches = [
+    # Upstream PR: https://github.com/ReactiveX/RxPY/pull/728
+    (fetchpatch {
+      name = "python-3.14.patch";
+      url = "https://github.com/ReactiveX/RxPY/commit/78f4a594ca2b0e27ad93ec0e1b1c0d56d5d6540d.patch";
+      hash = "sha256-1GQm/4BTd5ZnIqfEUSb0Ja3w0y1R9EoFpzwua7gpIzo=";
+    })
+  ];
 
   build-system = [ poetry-core ];
 

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -172,6 +172,13 @@ let
       # outdated snapshot
       "tests/components/hypontech/test_sensor.py::test_sensors"
     ];
+    influxdb = [
+      # These tests fail because they check for the number of warnings in the
+      # logs and there is an extra warning in the logs:
+      # `WARNING:aiohttp_fast_zlib:zlib_ng and isal are not available, falling back to zlib, performance will be degraded.`
+      "tests/components/influxdb/test_sensor.py::test_state_for_no_results"
+      "tests/components/influxdb/test_sensor.py::test_state_matches_first_query_result_for_multiple_return"
+    ];
     jellyfin = [
       # AssertionError: assert 'audio/x-flac' == 'audio/flac'
       "tests/components/jellyfin/test_media_source.py::test_resolve"


### PR DESCRIPTION
Upstream PR: https://github.com/ReactiveX/RxPY/pull/728
Upstream issue: https://github.com/ReactiveX/RxPY/issues/737

Hydra: https://hydra.nixos.org/build/320081869 (back when the package was still enabled for 3.14)

Closes https://github.com/NixOS/nixpkgs/issues/507983

cc @n8henrie

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.reactivex`, `python314Packages.{influxdb3-python,influxdb-client}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
