### PR TITLE
avahi: Handle 5 security findings + 1 NixOS mitigation

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -202,6 +202,8 @@
 
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.
 
+- The `services.avahi.wideArea` option now defaults to `false` as a mitigation against [`CVE-2024-52615`/`GHSA-x6vp-f33h-h32g`](https://github.com/avahi/avahi/security/advisories/GHSA-x6vp-f33h-h32g).
+
 - `coreth` has been removed, as upstream has moved it into `avalanchego`.
 
 - `nodePackages.prebuild-install` was removed because it appeared to be unmaintained upstream.

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -283,6 +283,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = [
+      (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
+    ];
+
     users.users.avahi = {
       description = "avahi-daemon privilege separation user";
       home = "/var/empty";

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -155,8 +155,12 @@ in
 
     wideArea = lib.mkOption {
       type = lib.types.bool;
-      default = true;
-      description = "Whether to enable wide-area service discovery.";
+      default = false;
+      description = ''
+        Whether to enable wide-area service discovery.
+
+        This is currently disabled by default as a mitigation for `CVE-2024-52615`/`GHSA-x6vp-f33h-h32g`.
+      '';
     };
 
     reflector = lib.mkOption {

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -159,7 +159,7 @@ in
       description = ''
         Whether to enable wide-area service discovery.
 
-        This is currently disabled by default as a mitigation for `CVE-2024-52615`/`GHSA-x6vp-f33h-h32g`.
+        It is recommended to keep this options disabled as it exposes the system to `CVE-2024-52615`/`GHSA-x6vp-f33h-h32g`.
       '';
     };
 

--- a/pkgs/by-name/av/avahi/package.nix
+++ b/pkgs/by-name/av/avahi/package.nix
@@ -150,6 +150,34 @@ stdenv.mkDerivation rec {
         hash = "sha256-rW6jmKg9oH44rRZow0zE4z6lfTlD8wpFUC8DaI/gruA=";
       })
     */
+    # https://github.com/avahi/avahi/pull/806 merged 2025-12-17
+    (fetchpatch {
+      name = "CVE-2025-68276.patch"; # AKA GHSA-mhf3-865v-g5rc
+      url = "https://github.com/avahi/avahi/commit/0c013e2e819be3bda74cecf48b5f64956cf8a760.patch";
+      hash = "sha256-kNOwl2DC2FR7CFvPQBBEYaSUSbFnR/ETH9JNGMwzzLE=";
+    })
+    (fetchpatch {
+      name = "CVE-2025-68468.patch"; # AKA GHSA-cp79-r4x9-vf52
+      url = "https://github.com/avahi/avahi/commit/f66be13d7f31a3ef806d226bf8b67240179d309a.patch";
+      hash = "sha256-HkbKSN2LYqPfVnij1/n6ToN4vKugex3ZPxjHz6pN8eA=";
+    })
+    (fetchpatch {
+      name = "CVE-2025-68471.patch"; # AKA GHSA-56rf-42xr-qmmg
+      url = "https://github.com/avahi/avahi/commit/9c6eb53bf2e290aed84b1f207e3ce35c54cc0aa1.patch";
+      hash = "sha256-V0OiC0UkZXhUnOUcrPZ+Xvph7MJMQ9DEXgVafoshSi4=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-24401.patch"; # AKA GHSA-h4vp-5m8j-f6w3
+      url = "https://github.com/avahi/avahi/commit/78eab31128479f06e30beb8c1cbf99dd921e2524.patch";
+      hash = "sha256-Iq7ghHS8gTJ5OeD6Bemis+wPJzKXb2P44qbtTaAaWZI=";
+    })
+    # https://github.com/avahi/avahi/pull/891 merged 2026-04-01
+    (fetchpatch {
+      name = "CVE-2026-34933.patch"; # AKA GHSA-w65r-6gxh-vhvc
+      url = "https://github.com/avahi/avahi/compare/0ccadca425af151ebb67f276e5cc88e50266a8e6%5E%5E...0ccadca425af151ebb67f276e5cc88e50266a8e6.patch";
+      hash = "sha256-yi40iuQmTAW+nLsOIJhh7kg4vG/lqT/PCaSEBPfF2mw=";
+    })
+
   ];
 
   depsBuildBuild = [

--- a/pkgs/by-name/av/avahi/package.nix
+++ b/pkgs/by-name/av/avahi/package.nix
@@ -140,6 +140,16 @@ stdenv.mkDerivation rec {
       url = "https://github.com/avahi/avahi/commit/366e3798bdbd6b7bf24e59379f4a9a51af575ce9.patch";
       hash = "sha256-9AdhtzrimmcpMmeyiFcjmDfG5nqr/S8cxWTaM1mzCWA=";
     })
+    # https://github.com/avahi/avahi/pull/662 merged 2025-06-19
+    # NOTE: CVE-2024-52615 is mitigated by the default NixOS configuration.
+    # NOTE: CVE-2025-59529 is introduced by 4e2e1ea0908d7e6ad7f38ae04fdcdf2411f8b942.
+    /*
+      (fetchpatch {
+        name = "CVE-2024-52615.patch"; # AKA GHSA-x6vp-f33h-h32g
+        url = "https://github.com/avahi/avahi/commit/4e2e1ea0908d7e6ad7f38ae04fdcdf2411f8b942.patch";
+        hash = "sha256-rW6jmKg9oH44rRZow0zE4z6lfTlD8wpFUC8DaI/gruA=";
+      })
+    */
   ];
 
   depsBuildBuild = [

--- a/pkgs/by-name/av/avahi/package.nix
+++ b/pkgs/by-name/av/avahi/package.nix
@@ -251,5 +251,10 @@ stdenv.mkDerivation rec {
       DNS") and DNS-SD (for "DNS-Based Service Discovery")
       protocols.
     '';
+
+    knownVulnerabilities = [
+      # NOTE: CVE-2024-52615 mitigated by the default NixOS configuration.
+      # "CVE-2024-52615: Avahi Wide-Area DNS Uses Constant Source Port"
+    ];
   };
 }


### PR DESCRIPTION
These changes:

Handle 5 security findings:

 - CVE-2025-68276 / GHSA-mhf3-865v-g5rc
 - CVE-2025-68468 / GHSA-cp79-r4x9-vf52
 - CVE-2025-68471 / GHSA-56rf-42xr-qmmg
 - CVE-2026-24401 / GHSA-h4vp-5m8j-f6w3
 - CVE-2026-34933 / GHSA-w65r-6gxh-vhvc

Add mitigations for:

 - CVE-2024-52615 / GHSA-x6vp-f33h-h32g
     - CVE-2025-59529 / GHSA-73wf-3xmj-x82q  is mitigated by only mitigating CVE-2024-52615

The situation for CVE-2024-52615/CVE-2025-59529 is a bit confusing, but the TLDR is the latter (CVE-2025-59529) is introduced by the “fix” for CVE-2024-52615. There is a pull request for handling CVE-2025-59529, but it is not yet merged upstream, and might be incomplete.

## TBD

 - [x] ~~Does this warrant a release note for a potentially breaking change?~~
 - [ ] Which of the many `CVE-2024-52615` notes should be dropped/kept?
    - ~~`config.warnings`?~~ (To be kept.)
    - commented-out `knownVulnerabilities` entry?
    - commented-out patch?

The `avahi` package can't be outright marked `insecure`, which is what `knownVulnerabilities` would do. There is no way to properly convey "this is a known vulnerability *that we have mitigated*" in the meta attributes.

## Things done

> [!NOTE]
> - Picked `staging` due to the likelihood of 18K+ affected derivations on `x86_64-linux` alone.
> - I'm not sure this qualifies as “critical” considering the time spans involved.
> - Changes were tested against `nixos-unstable` @ 68d8aa3d661f0e6bd5862291b5bb263b2a6595c9.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (Found on `avahi.tests`)
  - [x] [Package tests] at `passthru.tests`. (NixOS tests on `avahi.tests`)
  - [ ] ~~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~~
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
