### PR TITLE
gh-cherry-pick: init at 1.2.0

### DIFF
--- a/pkgs/by-name/gh/gh-cherry-pick/package.nix
+++ b/pkgs/by-name/gh/gh-cherry-pick/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "gh-cherry-pick";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PerchunPak";
+    repo = "gh-cherry-pick";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EiXWgiCV99k3810nCWA+AnlLjG8VKRCPnns9KtfGxqY=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  pythonRelaxDeps = [
+    "attrs"
+    "trio"
+  ];
+
+  dependencies = with python3Packages; [
+    attrs
+    cyclopts
+    httpx
+    loguru
+    trio
+    typing-extensions
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest
+    pytest-cov-stub
+    pytest-mock
+    pytest-trio
+  ];
+
+  pythonImportsCheck = [ "gh_cherry_pick" ];
+
+  meta = {
+    description = "Cherry-pick commits across GitHub repositories using only the GitHub API";
+    homepage = "https://github.com/PerchunPak/gh-cherry-pick";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.PerchunPak ];
+    mainProgram = "gh-cherry-pick";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Cherry-pick commits across GitHub repositories using only the GitHub API
https://github.com/PerchunPak/gh-cherry-pick

Usage example:

```bash
GITHUB_TOKEN=ghp_... gh-cherry-pick \
  --target MyOrg/nixpkgs@patched \
  `: # cherry-pick these commits` \
  NixOS/nixpkgs/3f5ba52cc4701bf341457dfe5f6cb58e0cbb7f83 \
  NixOS/nixpkgs/49ba75edefc8dc4fee45482f77a280ddd7121797 \
  `: # or merge the entire branch!` \
  Someone/nixpkgs@pr-branch
```

[See also the discourse post](https://discourse.nixos.org/t/patch-nixpkgs-using-cherry-picks-without-local-clone/76925)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
