### PR TITLE
jwhois: fix build with gcc15

### DIFF
--- a/pkgs/by-name/jw/jwhois/package.nix
+++ b/pkgs/by-name/jw/jwhois/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   lynx,
 }:
 
@@ -17,6 +18,10 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./connect.patch
     ./service-name.patch
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/jwhois/raw/422e2326397c7a48df61acb8ef649864a874272b/f/jwhois-4.0-gcc15-fix.patch";
+      hash = "sha256-bBZk2GUu8Y66u4u+zJxY/fxzzc2y17ECEJO6uNz9ngw=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322334297

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
