### PR TITLE
haskellPackages.iserv-proxy: use in subprocess mode when doing cross 

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -46,14 +46,8 @@ let
           in
           buildPackages.writeShellScriptBin ("iserv-wrapper" + lib.optionalString enableProfiling "-prof") ''
             set -euo pipefail
-            PORT=$((5000 + $RANDOM % 5000))
             ${lib.optionalString stdenv.hostPlatform.isWindows "export WINEDEBUG=-all WINEPREFIX=$TMP"}
-            (>&2 echo "---> Starting interpreter on port $PORT")
-            ${emulator} ${hostProxy} tmp $PORT &
-            RISERV_PID="$!"
-            trap "kill $RISERV_PID" EXIT # Needs cleanup when building without sandbox
-            ${buildProxy} $@ 127.0.0.1 "$PORT"
-            (>&2 echo "---> killing interpreter...")
+            ${buildProxy} $@ --pipe ${emulator} ${hostProxy} tmp --stdio
           '';
 
         # GHC will add `-prof` to the external interpreter when doing a profiled build.
@@ -262,8 +256,7 @@ in
   __onlyPropagateKnownPkgConfigModules ? false,
   enableExternalInterpreter ?
     isCross && crossSupport.canProxyTH && crossSupport.needsExternalInterpreterSetup,
-  # iserv-proxy needs local network access
-  __darwinAllowLocalNetworking ? stdenv.hostPlatform.isDarwin && enableExternalInterpreter,
+  __darwinAllowLocalNetworking ? false,
 }@args:
 
 assert editedCabalFile != null -> revision != null;

--- a/pkgs/development/tools/haskell/iserv-proxy/default.nix
+++ b/pkgs/development/tools/haskell/iserv-proxy/default.nix
@@ -15,14 +15,14 @@
 }:
 mkDerivation {
   pname = "iserv-proxy";
-  version = "9.3-unstable-2026-02-04";
+  version = "9.3-unstable-2026-04-08";
 
   # https://github.com/stable-haskell/iserv-proxy/pull/1
   src = fetchFromGitHub {
     owner = "stable-haskell";
     repo = "iserv-proxy";
-    rev = "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6";
-    hash = "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg";
+    rev = "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4";
+    hash = "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=";
   };
 
   isLibrary = true;


### PR DESCRIPTION
Adapted from https://github.com/input-output-hk/haskell.nix/commit/bf27e699a8170d255b9b2bbb69c327b9f65b7e4d
Made possible by https://github.com/stable-haskell/iserv-proxy/commit/3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
