### PR TITLE
davinci-resolve(-studio): install/fix auxillary applications and udev rules

### DIFF
--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -34,6 +34,7 @@
   buildFHSEnv,
   bash,
   writeText,
+  writeShellScript,
   ocl-icd,
   xkeyboard_config,
   glib,
@@ -171,6 +172,23 @@ let
           appimage-exec.sh -x $out ${lib.escapeShellArg appimageName}
 
           mkdir -p $out/{"Apple Immersive/Calibration",configs,DolbyVision,easyDCP,Extras,Fairlight,GPUCache,logs,Media,"Resolve Disk Database",.crashreport,.license,.LUT}
+
+          # Install udev rules for Blackmagic hardware (color panels, Speed Editor, Editor Keyboard)
+          mkdir -p $out/lib/udev/rules.d
+          cp $out/share/etc/udev/rules.d/99-BlackmagicDevices.rules $out/lib/udev/rules.d/
+          cp $out/share/etc/udev/rules.d/99-ResolveKeyboardHID.rules $out/lib/udev/rules.d/
+          # Generate catch-all rules for Blackmagic Design vendor ID (096e)
+          # USB device access (color panels, general hardware)
+          echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="096e", MODE="0666"' \
+            > $out/lib/udev/rules.d/99-DavinciPanel.rules
+          # hidraw access (Speed Editor jog wheel, Editor Keyboard, future HID devices)
+          echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="096e", MODE="0666"' \
+            >> $out/lib/udev/rules.d/99-DavinciPanel.rules
+
+          # Verify all three rules files are present
+          test -f $out/lib/udev/rules.d/99-BlackmagicDevices.rules
+          test -f $out/lib/udev/rules.d/99-ResolveKeyboardHID.rules
+          test -f $out/lib/udev/rules.d/99-DavinciPanel.rules
           runHook postInstall
         '';
 
@@ -208,7 +226,59 @@ let
           ];
           startupWMClass = "resolve";
         })
-      ];
+        (makeDesktopItem {
+          name = "blackmagicraw-player";
+          desktopName = "Blackmagic RAW Player";
+          exec = "blackmagicraw-player %f";
+          icon = "blackmagicraw-player";
+          mimeTypes = [
+            "application/x-braw-clip"
+            "application/x-braw-sidecar"
+          ];
+          categories = [
+            "Video"
+            "AudioVideo"
+          ];
+        })
+        (makeDesktopItem {
+          name = "blackmagicraw-speedtest";
+          desktopName = "Blackmagic RAW Speed Test";
+          exec = "blackmagicraw-speedtest";
+          icon = "blackmagicraw-speedtest";
+          categories = [
+            "Video"
+            "AudioVideo"
+          ];
+        })
+        (makeDesktopItem {
+          name = "davinci-control-panels-setup";
+          desktopName = "DaVinci Control Panels Setup";
+          exec = "davinci-control-panels-setup";
+          icon = "davinci-control-panels-setup";
+          categories = [ "Settings" ];
+        })
+        (makeDesktopItem {
+          name = "davinci-fairlight-studio-utility";
+          desktopName = "Fairlight Studio Utility";
+          exec = "davinci-fairlight-studio-utility";
+          icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
+          categories = [
+            "AudioVideo"
+            "Audio"
+          ];
+        })
+      ]
+      ++ lib.optional studioVariant (makeDesktopItem {
+        name = "davinci-remote-monitor";
+        desktopName = "DaVinci Remote Monitor";
+        exec = "davinci-remote-monitor";
+        icon = "davinci-remote-monitor";
+        comment = "DaVinci Remote Monitor";
+        categories = [
+          "AudioVideo"
+          "Video"
+        ];
+      });
     }
   );
 in
@@ -240,6 +310,11 @@ buildFHSEnv {
       opencl-headers
       python3
       python3.pkgs.numpy
+      libdrm # libdrm.so.2 needed by bundled Qt6 WebEngine (Control Panels Setup)
+      libxkbfile # libxkbfile.so.1 needed by bundled Qt6 WebEngine (Control Panels Setup)
+      krb5 # libgssapi_krb5.so.2 needed by bundled Qt6 (Control Panels Setup, Fairlight Studio Utility)
+      nss # libsmime3.so needed by bundled Qt6 (Control Panels Setup)
+      libxcb-cursor # libxcb-cursor.so needed by Qt6 xcb platform plugin (Fairlight Studio Utility)
       udev
       xdg-utils # xdg-open needed to open URLs
       libice
@@ -281,14 +356,67 @@ buildFHSEnv {
     export QT_XKB_CONFIG_ROOT="${xkeyboard_config}/share/X11/xkb"
     export QT_PLUGIN_PATH="${davinci}/libs/plugins:$QT_PLUGIN_PATH"
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib:/usr/lib32:${davinci}/libs
-    ${davinci}/bin/resolve
+    if [ $# -gt 0 ]; then
+      exec "$@"
+    else
+      exec ${davinci}/bin/resolve
+    fi
   ''}";
 
-  extraInstallCommands = ''
-    mkdir -p $out/share/applications $out/share/icons/hicolor/128x128/apps
-    ln -s ${davinci}/share/applications/*.desktop $out/share/applications/
-    ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
-  '';
+  extraInstallCommands =
+    let
+      execName = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
+      # Each wrapper re-enters the FHS environment and execs a different binary
+      mkWrapper =
+        name: bin:
+        writeShellScript name ''
+          exec "$(dirname "$0")/${execName}" ${bin} "$@"
+        '';
+      wrappers = {
+        "blackmagicraw-player" = "${davinci}/BlackmagicRAWPlayer/BlackmagicRAWPlayer";
+        "blackmagicraw-speedtest" = "${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest";
+        "davinci-control-panels-setup" =
+          ''"${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"'';
+        "davinci-fairlight-studio-utility" =
+          ''"${davinci}/Fairlight Studio Utility/Fairlight Studio Utility"'';
+      }
+      // lib.optionalAttrs studioVariant {
+        "davinci-remote-monitor" = ''"${davinci}/bin/DaVinci Remote Monitor"'';
+      };
+    in
+    ''
+      # Desktop files
+      mkdir -p $out/share/applications
+      ln -s ${davinci}/share/applications/*.desktop $out/share/applications/
+
+      # Icons
+      mkdir -p $out/share/icons/hicolor/{128x128,256x256}/apps
+      ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
+      ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/davinci-control-panels-setup.png
+      ${lib.optionalString studioVariant ''
+        ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/davinci-remote-monitor.png
+      ''}
+      ln -s ${davinci}/graphics/blackmagicraw-player_256x256_apps.png $out/share/icons/hicolor/256x256/apps/blackmagicraw-player.png
+      ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/blackmagicraw-speedtest.png
+
+      # Wrapper scripts for additional programs
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: bin: ''
+          ln -s ${mkWrapper name bin} $out/bin/${name}
+        '') wrappers
+      )}
+
+      # MIME type definitions for .drp, .braw, etc.
+      mkdir -p $out/share/mime/packages
+      ln -s ${davinci}/share/resolve.xml $out/share/mime/packages/
+      ln -s ${davinci}/share/blackmagicraw.xml $out/share/mime/packages/
+
+      # Expose udev rules so NixOS can aggregate them from environment.systemPackages
+      mkdir -p $out/lib/udev/rules.d
+      ln -s ${davinci}/lib/udev/rules.d/99-BlackmagicDevices.rules $out/lib/udev/rules.d/
+      ln -s ${davinci}/lib/udev/rules.d/99-ResolveKeyboardHID.rules $out/lib/udev/rules.d/
+      ln -s ${davinci}/lib/udev/rules.d/99-DavinciPanel.rules $out/lib/udev/rules.d/
+    '';
 
   passthru = {
     inherit davinci;

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -455,6 +455,7 @@ buildFHSEnv {
       amarshall
       XBagon
       toXel
+      cafkafk
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];


### PR DESCRIPTION
This adds the additional applictaions and UDEV rules shipped with davinci-resolve(-studio). 

This should also fix most hardware devices, but the upstream udev rules can be out of date or inaccurate.

To add these udev rules to your nixos config, you'll need to add the package to `services.udev.packages`.

Closes: https://github.com/NixOS/nixpkgs/issues/167389
Closes: https://github.com/NixOS/nixpkgs/issues/420744
Closes: https://github.com/NixOS/nixpkgs/issues/366384
Closes: https://github.com/NixOS/nixpkgs/issues/364646

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
