### PR TITLE
batman-adv: 2026.0 -> 2026.1

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,14 +1,14 @@
 {
-  version = "2026.0";
+  version = "2026.1";
 
   # To get these, run:
   #
   # ```
-  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2026.0/$tool-2026.0.tar.gz --type sha256 | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri; done
+  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2026.1/$tool-2026.1.tar.gz --type sha256 | xargs nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri; done
   # ```
   sha256 = {
-    alfred = "sha256-35EVL+Mftjd6JM6TEwRFlzUQRpr5N35MycX10l4451E=";
-    batctl = "sha256-tLcNrmIBBuRe492x9RL2kHVpKxI0PQUhJnQDyyEqSiY=";
-    batman-adv = "sha256-lGHWE8T4OgojOp9wBq1tFed514nEm9NePMCNfiiG/Ko=";
+    alfred = "sha256-Rd+8uKfLuq7j4SYHpGYB3YbOUiUHJTXptJ2kC78CtIk=";
+    batctl = "sha256-hEQWhsHUTtV6Vg8qC+n4brksMQ8iqqSgCTPrbIk2CHo=";
+    batman-adv = "sha256-ZIfdO0rQ+FUQ3tu6M1/nexuHfQ53OTxR3coHp0Ubj0U=";
   };
 }


### PR DESCRIPTION
## Changes

### batman-adv

  - support latest kernels (5.10 - 7.1)
  - coding style cleanups and refactoring
  - bugs squashed:
    - reject oversized global TT response buffers
    - avoid OGM aggregation when skb tailroom is insufficient
    - prevent freed backbones when dumping BLA claims

### batctl

  - coding style cleanups and refactoring
  - bugs squashed:
    - tcpdump: Fix printing of usecs
    - fix tbl preprocessing of manpage

### alfred

 - coding style cleanups and refactoring
 - bugs squashed:
   - fix printing of timespec

Changelog: https://www.open-mesh.org/news/127


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
