### PR TITLE
onlyoffice-desktopeditors: add aarch64-linux

### DIFF
--- a/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
@@ -76,13 +76,27 @@ let
     pulseaudio
   ];
 
+  sources = {
+    x86_64-linux = {
+      arch = "amd64";
+      hash = "sha256-L92iTS7+ZVKNCqutBjPYaPIvZ88VZ/jfOecsuiT2ryQ=";
+    };
+    aarch64-linux = {
+      arch = "arm64";
+      hash = "sha256-um0LxqnucrEo+Qg4OxAhMGK+QVJv58qwj4d7+9E6fhI=";
+    };
+  };
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "unsupported system: ${stdenv.hostPlatform.system}");
+
   derivation = stdenv.mkDerivation rec {
     pname = "onlyoffice-desktopeditors";
-    version = "9.1.0";
+    version = "9.3.1";
     minor = null;
     src = fetchurl {
-      url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
-      hash = "sha256-D36E7hYCTJ9Lw9XnB8nxMGMJDJRhM+K+bviuM9uuzhk=";
+      url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_${source.arch}.deb";
+      inherit (source) hash;
     };
 
     nativeBuildInputs = [
@@ -199,7 +213,10 @@ buildFHSEnv {
     homepage = "https://www.onlyoffice.com/";
     downloadPage = "https://github.com/ONLYOFFICE/DesktopEditors/releases";
     changelog = "https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md";
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/on/onlyoffice-desktopeditors/update.sh
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/update.sh
@@ -2,4 +2,5 @@
 #!nix-shell -i bash -p curl jq common-updater-scripts
 
 version="$(curl -sL "https://api.github.com/repos/ONLYOFFICE/DesktopEditors/releases?per_page=1" | jq -r ".[0].tag_name" | sed 's/^v//')"
-update-source-version onlyoffice-bin "$version"
+update-source-version onlyoffice-desktopeditors "$version" --source-key=sources.x86_64-linux.hash --system=x86_64-linux
+update-source-version onlyoffice-desktopeditors "$version" --source-key=sources.aarch64-linux.hash --system=aarch64-linux --ignore-same-version


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
