### PR TITLE
iwe: 0.0.64 -> 0.0.67

### DIFF
--- a/pkgs/by-name/iw/iwe/package.nix
+++ b/pkgs/by-name/iw/iwe/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "iwe";
-  version = "0.0.64";
+  version = "0.0.67";
 
   src = fetchFromGitHub {
     owner = "iwe-org";
     repo = "iwe";
     tag = "iwe-v${finalAttrs.version}";
-    hash = "sha256-aqoUTatYUUFKw3ZQYagQ0KchQM3JMgSzL/hG6CiyG9U=";
+    hash = "sha256-/irCQgMDuO2boitdTyl4OlkMvuyFPfsTx8Jo/VhLYuw=";
   };
 
-  cargoHash = "sha256-iTudRDC53wZvWwuPYGG3rQfsC/th+3FwpiqZsZnbekg=";
+  cargoHash = "sha256-oAIF+ekKzvfT7WzQ+PE4RWUUMMDkBOFBdgwUMXBZsFk=";
 
   cargoBuildFlags = [
     "--package=iwe"
@@ -28,14 +28,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     substituteInPlace crates/iwe/tests/common.rs --replace-fail \
       'binary_path.push("target");' \
       'binary_path.push("target/${stdenv.hostPlatform.rust.rustcTarget}");'
-
-    # Tests here are looking for /usr to exist, which is not present in a build environment
-    substituteInPlace crates/iwes/tests/transform_test.rs --replace-fail \
-      'cwd: Some("/usr".to_string()),' \
-      'cwd: Some("/tmp".to_string()),'
-    substituteInPlace crates/iwes/tests/transform_test.rs --replace-fail \
-      'vec![uri(1).to_edit("/usr\n")]' \
-      'vec![uri(1).to_edit("/tmp\n")]'
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
https://github.com/iwe-org/iwe/compare/iwe-v0.0.64...iwe-v0.0.67

Substitution in `transform_test.rs` is no longer needed, tests were updated in commit https://github.com/iwe-org/iwe/commit/31fd23254b61c30835d1435cdf11e1e16ed56ff4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
