### PR TITLE
librewolf-unwrapped: 149.0-1 -> 149.0.2-2

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
@@ -30,6 +30,8 @@ rec {
     cp ${source}/assets/search-config.json services/settings/dumps/main/search-config.json
     sed -i '/MOZ_SERVICES_HEALTHREPORT/ s/True/False/' browser/moz.configure
 
+    sed -i '/# This must remain last./i gkrust_features += ["glean_disable_upload"]\'$'\n' toolkit/library/rust/gkrust-features.mozbuild
+
     cp ${source}/patches/pref-pane/category-librewolf.svg browser/themes/shared/preferences
     cp ${source}/patches/pref-pane/librewolf.css browser/themes/shared/preferences
     cp ${source}/patches/pref-pane/librewolf.inc.xhtml browser/components/preferences

--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -48,5 +48,9 @@ in
 }).override
   {
     crashreporterSupport = false;
-    enableOfficialBranding = false;
+    # This will set `MOZILLA_OFFICIAL=1`, which is set by the mozconfig upstream, but has to
+    # be set manually in our case.
+    # This will not override the branding as `branding` is already set to the official
+    # Librewolf branding.
+    enableOfficialBranding = true;
   }

--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "149.0-1",
+  "packageVersion": "149.0.2-2",
   "source": {
-    "rev": "149.0-1",
-    "hash": "sha256-lf9psaFT9PMk8CozjvUqBb6hxHct2kdzcVbQDbID+0U="
+    "rev": "149.0.2-2",
+    "hash": "sha256-rnDL98f3vwpcRmWfNuTcp2SDk6CKiOPEZFYnNsVDUa0="
   },
   "firefox": {
-    "version": "149.0",
-    "hash": "sha512-zdhxp3OPtw2FpwPonEh00b9EGEtMmyiQGQKty/olwZlnXnRjBrtZ1mgh5uzRfgfJm2akjYJ/OazKbDsBK5U3Gg=="
+    "version": "149.0.2",
+    "hash": "sha512-hEpG7gaOzcZrcifQiaBXrT9JRRFP6iyygNXio4PQoCL8ZiitV8Bo6jTPFZRy9jxQ6n7RKLwRoLJ/Frt7Z9fzzw=="
   }
 }


### PR DESCRIPTION
diff: https://codeberg.org/librewolf/source/compare/149.0-1...149.0.2-2
mfsa: https://www.mozilla.org/en-US/security/advisories/mfsa2026-25/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
