### PR TITLE
qdng: init at 1.0.0

### DIFF
--- a/pkgs/by-name/qd/qdng/package.nix
+++ b/pkgs/by-name/qd/qdng/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  bison,
+  flex,
+  gfortran,
+  blas,
+  bzip2,
+  fftw,
+  lapack,
+  libxml2,
+  protobuf_21,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qdng";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "quantum-dynamics-ng";
+    repo = "QDng";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-T59Bb014KSUOOFTFjPOrWmbF6GqIqAIyrb3Xe5TwU88=";
+  };
+
+  configureFlags = [
+    "--enable-openmp"
+    "--disable-gccopt"
+  ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    gfortran
+  ];
+
+  buildInputs = [
+    blas
+    bzip2
+    fftw
+    lapack
+    libxml2
+    protobuf_21
+    zlib
+  ];
+
+  meta = {
+    description = "Molecular wavepacket dynamics package";
+    homepage = "https://github.com/quantum-dynamics-ng/QDng";
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.markuskowa ];
+    license = lib.licenses.gpl3Only;
+  };
+})


### PR DESCRIPTION
Nuclear wave packet dynamics written in C++.

https://github.com/quantum-dynamics-ng/QDng

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
