### PR TITLE
python3Packages.black: 25.1.0 -> 26.3.1

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch,
   pytestCheckHook,
   aiohttp,
   click,
@@ -17,37 +16,22 @@
   pathspec,
   parameterized,
   platformdirs,
+  pythonOlder,
+  pytokens,
   tokenize-rt,
+  tomli,
+  typing-extensions,
   uvloop,
 }:
-
 buildPythonPackage rec {
   pname = "black";
-  version = "25.1.0";
+  version = "26.3.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-M0ltXNEiKtczkTUrSujaFSU8Xeibk6gLPiyNmhnsJmY=";
+    hash = "sha256-LFD1BjqWQcfu13lQFLo3sPX6In89QIuWiTbiS8BWawc=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "click-8.2-compat-1.patch";
-      url = "https://github.com/psf/black/commit/14e1de805a5d66744a08742cad32d1660bf7617a.patch";
-      hash = "sha256-fHRlMetE6+09MKkuFNQQr39nIKeNrqwQuBNqfIlP4hc=";
-    })
-    (fetchpatch {
-      name = "click-8.2-compat-2.patch";
-      url = "https://github.com/psf/black/commit/ed64d89faa7c738c4ba0006710f7e387174478af.patch";
-      hash = "sha256-df/J6wiRqtnHk3mAY3ETiRR2G4hWY1rmZMfm2rjP2ZQ=";
-    })
-    (fetchpatch {
-      name = "click-8.2-compat-3.patch";
-      url = "https://github.com/psf/black/commit/b0f36f5b4233ef4cf613daca0adc3896d5424159.patch";
-      hash = "sha256-SGLCxbgrWnAi79IjQOb2H8mD/JDbr2SGfnKyzQsJrOA=";
-    })
-  ];
 
   nativeBuildInputs = [
     hatch-fancy-pypi-readme
@@ -61,6 +45,11 @@ buildPythonPackage rec {
     packaging
     pathspec
     platformdirs
+    pytokens
+  ]
+  ++ lib.optionals (pythonOlder "3.11") [
+    tomli
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -102,9 +91,6 @@ buildPythonPackage rec {
   disabledTests = [
     # requires network access
     "test_gen_check_output"
-    # broken on Python 3.13.4
-    # FIXME: remove this when fixed upstream
-    "test_simple_format[pep_701]"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fails on darwin

--- a/pkgs/development/python-modules/librt/default.nix
+++ b/pkgs/development/python-modules/librt/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-RZGaOq8hmkwekCs1fKshDrx3vmHdJl/wI3IO9ZLH5rc=";
   };
 
-  # https://github.com/mypyc/librt/blob/v0.7.8/.github/workflows/buildwheels.yml#L90-L93
+  # https://github.com/mypyc/librt/blob/v0.9.0/.github/workflows/buildwheels.yml#L90-L93
   postPatch = ''
     cp -rv lib-rt/* .
   '';

--- a/pkgs/development/python-modules/librt/default.nix
+++ b/pkgs/development/python-modules/librt/default.nix
@@ -8,7 +8,7 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "librt";
   version = "0.9.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mypyc";
     repo = "librt";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-RZGaOq8hmkwekCs1fKshDrx3vmHdJl/wI3IO9ZLH5rc=";
   };
 
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     description = "Mypyc runtime library";
     homepage = "https://github.com/mypyc/librt";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ attila ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytokens/default.nix
+++ b/pkgs/development/python-modules/pytokens/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  mypy,
+  setuptools,
+  wheel,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "pytokens";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tusharsadhwani";
+    repo = "pytokens";
+    tag = finalAttrs.version;
+    hash = "sha256-DOCOoZ3T7qh8me1vn7qYlEMiyc31d77sf1/5RsW5sUg=";
+  };
+
+  build-system = [
+    mypy
+    setuptools
+    wheel
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytokens" ];
+
+  meta = {
+    description = "Fast, spec-compliant tokenizer for modern Python syntax";
+    homepage = "https://github.com/tusharsadhwani/pytokens";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ attila ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16105,6 +16105,8 @@ self: super: with self; {
 
   pytmx = callPackage ../development/python-modules/pytmx { };
 
+  pytokens = callPackage ../development/python-modules/pytokens { };
+
   pytomlpp = callPackage ../development/python-modules/pytomlpp { };
 
   pytomorrowio = callPackage ../development/python-modules/pytomorrowio { };


### PR DESCRIPTION
- Update `black` to 26.3.1
- Package new dependency `pytokens` at 0.4.1
- Update dependency pathspec 0.12.1 -> 1.0.4
- Update mypy 1.19.1 -> 1.20.0 since the new version should support pathspec >= 1.0.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
