### PR TITLE
cpython: 3.13.12 -> 3.13.13; 3.14.3 -> 3.14.4; 3.15.0a7 -> 3.15.0a8

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -79,10 +79,10 @@
       sourceVersion = {
         major = "3";
         minor = "14";
-        patch = "3";
+        patch = "4";
         suffix = "";
       };
-      hash = "sha256-qX1VSemtgf4XFZ7QLGh3StXSZscvjZoLWpw3H+hdkCs=";
+      hash = "sha256-2SPFEwPjjiSRNvwb3zVo1W7LAyFO/e9IUWF209f6rvg=";
       inherit passthruFun;
     };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -92,9 +92,9 @@
         major = "3";
         minor = "15";
         patch = "0";
-        suffix = "a7";
+        suffix = "a8";
       };
-      hash = "sha256-j1kMQot/DUBt+Si4Vzfno6+ijt3U0UGUEOqAloftHqc=";
+      hash = "sha256-KPG2NYYJBC68yBSI7CRWlRn1CAS7B9wjzHB7KBsDHGk=";
       inherit passthruFun;
     };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -20,10 +20,10 @@
         sourceVersion = {
           major = "3";
           minor = "13";
-          patch = "12";
+          patch = "13";
           suffix = "";
         };
-        hash = "sha256-KoTNMd2Njqiq/3XeZvwbSwEn3VeZqlCmSumjE4hbRZM=";
+        hash = "sha256-Krkf9AF4PMymT3XRDIgulXvf1g4r9acvhCF5Nym3inE=";
       };
     };
 

--- a/pkgs/development/python-modules/charset-normalizer/default.nix
+++ b/pkgs/development/python-modules/charset-normalizer/default.nix
@@ -12,20 +12,15 @@
 
 buildPythonPackage rec {
   pname = "charset-normalizer";
-  version = "3.4.4";
+  version = "3.4.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "charset_normalizer";
     tag = version;
-    hash = "sha256-MtSBKG8bXUsgEPyXxMRBPPFI8mfuIETy6UVshe7yqGg=";
+    hash = "sha256-dOdJ4f98smCYdskp3BwtQG6aOyK+2a73+x580FKRWDk=";
   };
-
-  postPatch = ''
-    substituteInPlace _mypyc_hook/backend.py \
-      --replace-fail "mypy>=1.4.1,<=1.18.2" "mypy"
-  '';
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "46.0.6";
+  version = "46.0.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyca";
     repo = "cryptography";
     tag = version;
-    hash = "sha256-b6wQnPEf18ViqQVch+Jg1w0Cn372QKxLknD9rL4JjxY=";
+    hash = "sha256-xMe+gQl4/CfoT+H21ltbo+aPILoRYCAlylsqnB7Ms8s=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   cryptography,
-  fetchpatch2,
   uv-build,
 }:
 

--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -2,11 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   flit-scm,
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
-  isPy313,
   typing-extensions,
 }:
 
@@ -22,14 +22,19 @@ buildPythonPackage rec {
     hash = "sha256-3WInufN+Pp6vB/Gik6e8V1a34Dr/oiH3wDMB+2lHRMM=";
   };
 
-  # CPython fixed https://github.com/python/cpython/issues/141732 in
-  # https://github.com/python/cpython/pull/141736, but exceptiongroup 1.3.1,
-  # including its test suite, still matches the old repr behavior.
-  # The CPython fix has only been backported to 3.13 so far, where it was
-  # first included in version 3.13.12, so we only need to patch for 3.13
-  # and 3.15+.
-  # Upstream issue: https://github.com/agronholm/exceptiongroup/issues/154
-  patches = lib.optional (isPy313 || pythonAtLeast "3.15") ./match-repr-fix.patch;
+  patches = [
+    # CPython fixed https://github.com/python/cpython/issues/141732 in
+    # https://github.com/python/cpython/pull/141736 (backported to Python 3.13+),
+    # but exceptiongroup 1.3.1, including its test suite, still matches the old
+    # repr behavior.
+    # Upstream issue: https://github.com/agronholm/exceptiongroup/issues/154
+    # Upstream PR: https://github.com/agronholm/exceptiongroup/pull/155
+    (fetchpatch {
+      name = "match-repr-fix.patch";
+      url = "https://github.com/agronholm/exceptiongroup/commit/0c6cfbf677f6b50df17311cfdad01e9ff17310aa.patch";
+      hash = "sha256-EeYu1/JKYRDwdq8+n38RrdogipNzX0ate1trDs1Z3c0=";
+    })
+  ];
 
   build-system = [ flit-scm ];
 

--- a/pkgs/development/python-modules/librt/default.nix
+++ b/pkgs/development/python-modules/librt/default.nix
@@ -5,18 +5,19 @@
   setuptools,
   mypy-extensions,
   python,
+  pytest,
 }:
 
 buildPythonPackage rec {
   pname = "librt";
-  version = "0.7.8";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mypyc";
     repo = "librt";
     tag = "v${version}";
-    hash = "sha256-FlLilZQMsXAYfreBAfYoutCEww8IVoU7jjxvvJr8pTk=";
+    hash = "sha256-RZGaOq8hmkwekCs1fKshDrx3vmHdJl/wI3IO9ZLH5rc=";
   };
 
   # https://github.com/mypyc/librt/blob/v0.7.8/.github/workflows/buildwheels.yml#L90-L93
@@ -30,6 +31,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mypy-extensions
+    pytest
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   gitUpdater,
   pythonAtLeast,
   isPyPy,
@@ -34,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "mypy";
-  version = "1.19.1";
+  version = "1.20.0";
   pyproject = true;
 
   # relies on several CPython internals
@@ -44,7 +43,7 @@ buildPythonPackage rec {
     owner = "python";
     repo = "mypy";
     tag = "v${version}";
-    hash = "sha256-REUJgYd00qr36hoHevkJEWK/+2hE/caymjD/asqa6eI=";
+    hash = "sha256-QkUk7Y8mJSJtttfSiA7m4JL2Q4XFXEYs5irI8/FygaQ=";
   };
 
   passthru.updateScript = gitUpdater {
@@ -104,9 +103,15 @@ buildPythonPackage rec {
   ++ lib.concatAttrValues optional-dependencies;
 
   disabledTests = [
-    # fails with typing-extensions>=4.10
-    # https://github.com/python/mypy/issues/17005
-    "test_runtime_typing_objects"
+    # A change to the base64 decoder in CPython 3.13.13 and 3.14.4 causes this
+    # test to fail. At the time of writing, upstream skips the test.
+    # Upstream issue: https://github.com/python/mypy/issues/21120
+    # CPython issue: https://github.com/python/cpython/issues/145264
+    "testAllBase64Features_librt_experimental"
+    # https://github.com/python/mypy/issues/21120
+    "testAllBase64Features_librt"
+    # fails to import librt
+    "test_diff_cache_produces_valid_json"
   ]
   ++ lib.optionals (pythonAtLeast "3.12") [
     # requires distutils
@@ -114,6 +119,8 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
+    # circular dependency on distutils
+    "mypyc/test/test_external.py"
     # fails to find tyoing_extensions
     "mypy/test/testcmdline.py"
     "mypy/test/testdaemon.py"

--- a/pkgs/development/python-modules/pathspec/default.nix
+++ b/pkgs/development/python-modules/pathspec/default.nix
@@ -14,12 +14,12 @@
 
 buildPythonPackage rec {
   pname = "pathspec";
-  version = "0.12.1";
+  version = "1.0.4";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-pILVFQOhqzOxxnpsOBOiaVPb3HHDHayu+ag4xOKfVxI=";
+    hash = "sha256-AhDiroohqRN8DUcFeMsOWVr4ftqm6/Ev8XbxSgLg5kU=";
   };
 
   nativeBuildInputs = [ flit-core ];

--- a/pkgs/development/python-modules/pytest/default.nix
+++ b/pkgs/development/python-modules/pytest/default.nix
@@ -26,12 +26,12 @@
 
 buildPythonPackage rec {
   pname = "pytest";
-  version = "9.0.2";
+  version = "9.0.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-dRhmUakr2JYR0dn8IPC0NF/YJ8QczVwpmoaKBdcO3xE=";
+    hash = "sha256-uGraUIr4HRnt6yE8aBsdSCRsGpHTBMbIGkJ2dMF+uRw=";
   };
 
   outputs = [


### PR DESCRIPTION
https://docs.python.org/release/3.13.13/whatsnew/changelog.html
https://docs.python.org/release/3.14.4/whatsnew/changelog.html
https://docs.python.org/3.15/whatsnew/changelog.html#python-3-15-0-alpha-8

Fixes: CVE-2026-4224, CVE-2026-3644, CVE-2026-2297

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test