### PR TITLE
nixos/cockpit: disable LoginTo by default

### DIFF
--- a/nixos/modules/services/monitoring/cockpit.nix
+++ b/nixos/modules/services/monitoring/cockpit.nix
@@ -111,6 +111,17 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings =
+      lib.optional (lib.versionOlder cfg.package.version "360" && cfg.settings.WebService.LoginTo or true)
+        ''
+          The current Cockpit version is older than 360, and logging into other
+          hosts is enabled. This makes the system vulnerable to CVE-2026-4631,
+          which allows unauthenticated users on the network that can reach Cockpit
+          to gain code execution on the machine. Please upgrade your Cockpit
+          package or disable logging into other hosts by setting the option:
+
+            services.cockpit.settings.WebService.LoginTo = false;
+        '';
 
     environment.etc = {
       # generate cockpit settings
@@ -151,7 +162,7 @@ in
     };
 
     # Enable connecting to remote hosts from the login page
-    systemd.services = mkIf (cfg.settings ? LoginTo -> cfg.settings.LoginTo) {
+    systemd.services = mkIf (cfg.settings.WebService.LoginTo or false) {
       "cockpit-wsinstance-http".path = [
         config.programs.ssh.package
         cfg.package
@@ -174,8 +185,10 @@ in
       "https://localhost:${toString config.services.cockpit.port}"
     ];
 
-    services.cockpit.settings.WebService.Origins =
-      builtins.concatStringsSep " " config.services.cockpit.allowed-origins;
+    services.cockpit.settings.WebService = {
+      Origins = builtins.concatStringsSep " " config.services.cockpit.allowed-origins;
+      LoginTo = lib.mkDefault false;
+    };
   };
 
   meta.maintainers = pkgs.cockpit.meta.maintainers;


### PR DESCRIPTION
Mitigation for CVE-2026-4631, see also #507922.

1. `LoginTo` (the option that allows connecting to remote hosts) disabled by default
2. If `LoginTo` is enabled and the package is a version that is not patched, a warning is shown


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
