### PR TITLE
make-initrd-ng: suppress spurious glibc dependency warnings

### DIFF
--- a/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
+++ b/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
@@ -5,9 +5,7 @@ use std::fs;
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::os::unix;
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
 
 use libc::umask;
 
@@ -159,13 +157,22 @@ fn add_dependencies<P: AsRef<Path> + AsRef<OsStr> + std::fmt::Debug>(
             }
         }
         if !found {
-            // glibc makes it tricky to make this an error because
-            // none of the files have a useful rpath.
-            println!(
-                "Warning: Couldn't satisfy dependency {} for {:?}",
-                line,
-                OsStr::new(&source)
-            );
+            // In Nix, glibc's own libraries lack rpath entries pointing to
+            // themselves, so the dynamic linker (ld-linux-*.so.*) and libc.so.*
+            // can never be resolved through rpath alone. They are always present
+            // in the initrd: the linker via elf.interpreter above, and libc via
+            // at least one binary's rpath. Suppress these known-benign cases.
+            // See also: the ld*.so.? skip in stage-1.nix findLibs.
+            let is_glibc_runtime = (line.starts_with("ld-") && line.contains(".so"))
+                || line.starts_with("libc.so");
+
+            if !is_glibc_runtime {
+                eprintln!(
+                    "Warning: Couldn't satisfy dependency {} for {:?}",
+                    line,
+                    OsStr::new(&source)
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Suppress false "Couldn't satisfy dependency" warnings for `libc.so.*` and `ld-linux-*.so.*` during initrd builds with `boot.initrd.systemd.enable`
- Remove two unused imports (`PermissionsExt`, `Command`)
- Move remaining warning output from stdout to stderr

## Problem

Every `nixos-rebuild` with systemd initrd prints warnings like:

```
initrd-linux> Warning: Couldn't satisfy dependency libc.so.6 for "/nix/store/...-glibc-2.42-51/lib/libnss_files.so.2"
initrd-linux> Warning: Couldn't satisfy dependency ld-linux-x86-64.so.2 for "/nix/store/...-glibc-2.42-51/lib/libc.so.6"
```

In Nix, glibc libraries lack rpath entries pointing to themselves, so `libc.so.6` and the dynamic linker can never be resolved through rpath alone. They are always present in the initrd through other paths (the ELF interpreter and other binaries' rpath entries).

The scripted initrd builder (`stage-1.nix` `findLibs`) already skips `ld*.so.?` for the same reason. This brings `make-initrd-ng` in line with that precedent.

## Test plan

- [x] `nixos-rebuild test` with `boot.initrd.systemd.enable = true` produces no spurious glibc warnings
- [x] `cargo check` passes with zero warnings
- [x] Verified on NixOS unstable, kernel 6.19.11, glibc 2.42

Closes #463894
Closes #282145
Closes #399281