### PR TITLE
prism-cli: init at 5.15.6

### DIFF
--- a/pkgs/by-name/pr/prism-cli/package.nix
+++ b/pkgs/by-name/pr/prism-cli/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prism-cli";
+  version = "5.15.6";
+
+  src = fetchFromGitHub {
+    owner = "stoplightio";
+    repo = "prism";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TVY1hub6bC/4kl+DxUL7FPOQP44mQqcAUWfZP7dt3f8=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-/i0Z4IGZW/AfnaG49J0SnQPntVuEk0LvEC2S+VFN/mg=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/lib/prism" "$out/bin"
+    # -L resolves workspace symlinks (e.g. @stoplight/prism-cli -> ../../packages/cli)
+    # into real directories so the store path is self-contained.
+    cp -rL node_modules "$out/lib/prism/node_modules"
+    makeWrapper "${nodejs}/bin/node" "$out/bin/prism" \
+      --add-flags "$out/lib/prism/node_modules/@stoplight/prism-cli/dist/index.js"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Turn any OpenAPI2/3 and Postman Collection file into an API server with mocking, transformations and validations";
+    homepage = "https://github.com/stoplightio/prism";
+    changelog = "https://github.com/stoplightio/prism/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ davsanchez ];
+    mainProgram = "prism";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds `prism` CLI as a package. [`prism`](https://github.com/stoplightio/prism) is a tool for mocking OpenAPI specs.

First time actually packaging a node and yarn one so please let me know if there's a better pattern for this!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
