### PR TITLE
nixos/beszel.agent: fix GPU monitoring and expose SKIP_GPU

### DIFF
--- a/nixos/modules/services/monitoring/beszel-agent.nix
+++ b/nixos/modules/services/monitoring/beszel-agent.nix
@@ -55,6 +55,14 @@ in
               Enabling this option will skip systemd tracking and its setup in NixOS.
             '';
           };
+          SKIP_GPU = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Whether to disable GPU monitoring.
+              Enabling this option will skip GPU tracking.
+            '';
+          };
         };
       };
       default = { };
@@ -131,15 +139,17 @@ in
       path =
         cfg.extraPath
         ++ lib.optionals cfg.smartmon.enable [ cfg.smartmon.package ]
-        ++ lib.optionals (builtins.elem "nvidia" config.services.xserver.videoDrivers) [
-          (lib.getBin config.hardware.nvidia.package)
-        ]
-        ++ lib.optionals (builtins.elem "amdgpu" config.services.xserver.videoDrivers) [
-          (lib.getBin pkgs.rocmPackages.rocm-smi)
-        ]
-        ++ lib.optionals (builtins.elem "intel" config.services.xserver.videoDrivers) [
-          (lib.getBin pkgs.intel-gpu-tools)
-        ];
+        ++ lib.optionals (!cfg.environment.SKIP_GPU) (
+          lib.optionals (builtins.elem "nvidia" config.services.xserver.videoDrivers) [
+            (lib.getBin config.hardware.nvidia.package)
+          ]
+          ++ lib.optionals (builtins.elem "amdgpu" config.services.xserver.videoDrivers) [
+            (lib.getBin pkgs.rocmPackages.rocm-smi)
+          ]
+          ++ lib.optionals (builtins.elem "intel" config.services.xserver.videoDrivers) [
+            (lib.getBin pkgs.intel-gpu-tools)
+          ]
+        );
 
       serviceConfig = {
         ExecStart = ''
@@ -176,7 +186,7 @@ in
 
         LockPersonality = true;
         NoNewPrivileges = !cfg.smartmon.enable;
-        PrivateDevices = !cfg.smartmon.enable;
+        PrivateDevices = !cfg.smartmon.enable && cfg.environment.SKIP_GPU;
         PrivateTmp = true;
         PrivateUsers = !cfg.smartmon.enable && !cfg.environment.SKIP_SYSTEMD;
         ProtectClock = true;

--- a/nixos/modules/services/monitoring/beszel-agent.nix
+++ b/nixos/modules/services/monitoring/beszel-agent.nix
@@ -63,6 +63,36 @@ in
               Enabling this option will skip GPU tracking.
             '';
           };
+          GPU_COLLECTOR = lib.mkOption {
+            type =
+              with lib.types;
+              listOf (enum [
+                "nvml"
+                "nvidia-smi"
+                "amd_sysfs"
+                "rocm-smi"
+                "intel_gpu_top"
+                "nvtop"
+              ]);
+            default =
+              let
+                hasDriver = driver: builtins.elem driver config.services.xserver.videoDrivers;
+              in
+              lib.optionals (hasDriver "nvidia") [ "nvidia-smi" ]
+              ++ lib.optionals (hasDriver "amdgpu") [ "rocm-smi" ]
+              ++ lib.optionals (hasDriver "intel") [ "intel_gpu_top" ];
+            defaultText = lib.literalExpression ''
+              Automatically populated based on `config.services.xserver.videoDrivers`.
+            '';
+            example = [
+              "nvidia-smi"
+              "intel_gpu_top"
+            ];
+            description = ''
+              List of collectors or a comma-separated string to use for GPU monitoring.
+              If left unconfigured, it will attempt to detect the correct collector based on the system's video drivers.
+            '';
+          };
         };
       };
       default = { };
@@ -133,80 +163,95 @@ in
       after = [ "network-online.target" ];
 
       environment = lib.mapAttrs (
-        _: value: if lib.isBool value then (lib.boolToString value) else value
+        _: value:
+        if lib.isBool value then
+          (lib.boolToString value)
+        else if lib.isList value then
+          lib.concatStringsSep "," value
+        else
+          value
       ) cfg.environment;
 
       path =
         cfg.extraPath
         ++ lib.optionals cfg.smartmon.enable [ cfg.smartmon.package ]
         ++ lib.optionals (!cfg.environment.SKIP_GPU) (
-          lib.optionals (builtins.elem "nvidia" config.services.xserver.videoDrivers) [
-            (lib.getBin config.hardware.nvidia.package)
-          ]
-          ++ lib.optionals (builtins.elem "amdgpu" config.services.xserver.videoDrivers) [
-            (lib.getBin pkgs.rocmPackages.rocm-smi)
-          ]
-          ++ lib.optionals (builtins.elem "intel" config.services.xserver.videoDrivers) [
-            (lib.getBin pkgs.intel-gpu-tools)
-          ]
+          let
+            hasCollector = collector: builtins.elem collector cfg.environment.GPU_COLLECTOR;
+          in
+          lib.optionals (hasCollector "nvidia-smi") [ (lib.getBin config.hardware.nvidia.package) ]
+          ++ lib.optionals (hasCollector "rocm-smi") [ (lib.getBin pkgs.rocmPackages.rocm-smi) ]
+          ++ lib.optionals (hasCollector "intel_gpu_top") [ (lib.getBin pkgs.intel-gpu-tools) ]
+          ++ lib.optionals (hasCollector "nvtop") [ (lib.getBin pkgs.nvtopPackages.full) ]
         );
 
-      serviceConfig = {
-        ExecStart = ''
-          ${cfg.package}/bin/beszel-agent
-        '';
+      serviceConfig =
+        let
+          needsIntelPmu =
+            !cfg.environment.SKIP_GPU && builtins.elem "intel_gpu_top" cfg.environment.GPU_COLLECTOR;
+        in
+        {
+          ExecStart = ''
+            ${cfg.package}/bin/beszel-agent
+          '';
 
-        EnvironmentFile = cfg.environmentFile;
+          EnvironmentFile = cfg.environmentFile;
 
-        # adds ability to monitor docker/podman containers
-        SupplementaryGroups =
-          lib.optionals config.virtualisation.docker.enable [ "docker" ]
-          ++ lib.optionals (
-            config.virtualisation.podman.enable && config.virtualisation.podman.dockerSocket.enable
-          ) [ "podman" ]
-          ++ lib.optionals cfg.smartmon.enable [ "disk" ];
+          # adds ability to monitor docker/podman containers
+          SupplementaryGroups =
+            lib.optionals config.virtualisation.docker.enable [ "docker" ]
+            ++ lib.optionals (
+              config.virtualisation.podman.enable && config.virtualisation.podman.dockerSocket.enable
+            ) [ "podman" ]
+            ++ lib.optionals cfg.smartmon.enable [ "disk" ];
 
-        DynamicUser = true;
-        User = "beszel-agent";
+          DynamicUser = true;
+          User = "beszel-agent";
 
-        # Capabilities needed for SMART monitoring
-        AmbientCapabilities = lib.mkIf cfg.smartmon.enable [
-          "CAP_SYS_RAWIO"
-          "CAP_SYS_ADMIN"
-        ];
-        CapabilityBoundingSet = lib.mkIf cfg.smartmon.enable [
-          "CAP_SYS_RAWIO"
-          "CAP_SYS_ADMIN"
-        ];
+          # Capabilities needed for
+          #   SMART monitoring
+          #   Intel (i)GPUs
+          AmbientCapabilities =
+            lib.optionals cfg.smartmon.enable [
+              "CAP_SYS_RAWIO"
+              "CAP_SYS_ADMIN"
+            ]
+            ++ lib.optionals needsIntelPmu [ "CAP_PERFMON" ];
+          CapabilityBoundingSet =
+            lib.optionals cfg.smartmon.enable [
+              "CAP_SYS_RAWIO"
+              "CAP_SYS_ADMIN"
+            ]
+            ++ lib.optionals needsIntelPmu [ "CAP_PERFMON" ];
 
-        # Device access for SMART monitoring
-        DeviceAllow = lib.mkIf (cfg.smartmon.enable && cfg.smartmon.deviceAllow != [ ]) (
-          map (device: "${device} r") cfg.smartmon.deviceAllow
-        );
+          # Device access for SMART monitoring
+          DeviceAllow = lib.mkIf (cfg.smartmon.enable && cfg.smartmon.deviceAllow != [ ]) (
+            map (device: "${device} r") cfg.smartmon.deviceAllow
+          );
 
-        LockPersonality = true;
-        NoNewPrivileges = !cfg.smartmon.enable;
-        PrivateDevices = !cfg.smartmon.enable && cfg.environment.SKIP_GPU;
-        PrivateTmp = true;
-        PrivateUsers = !cfg.smartmon.enable && !cfg.environment.SKIP_SYSTEMD;
-        ProtectClock = true;
-        ProtectControlGroups = "strict";
-        ProtectHome = "read-only";
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectSystem = "strict";
-        Restart = "on-failure";
-        RestartSec = "30s";
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallErrorNumber = "EPERM";
-        SystemCallFilter = [ "@system-service" ];
-        Type = "simple";
-        UMask = 27;
-      };
+          LockPersonality = true;
+          NoNewPrivileges = !cfg.smartmon.enable;
+          PrivateDevices = !cfg.smartmon.enable && cfg.environment.SKIP_GPU;
+          PrivateUsers = !cfg.smartmon.enable && !cfg.environment.SKIP_SYSTEMD && cfg.environment.SKIP_GPU;
+          PrivateTmp = true;
+          ProtectClock = true;
+          ProtectControlGroups = "strict";
+          ProtectHome = "read-only";
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          Restart = "on-failure";
+          RestartSec = "30s";
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallErrorNumber = "EPERM";
+          SystemCallFilter = [ "@system-service" ] ++ lib.optionals needsIntelPmu [ "perf_event_open" ];
+          Type = "simple";
+          UMask = 27;
+        };
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [


### PR DESCRIPTION
When `PrivateDevices=true`, systemd mounts an isolated `/dev` namespace, blocking access to physical hardware nodes (like `/dev/nvidia0` or `/dev/dri/`). This broke the agent's ability to collect GPU metrics out of the box unless `smartmon` happened to be enabled.

This commit exposes the upstream `SKIP_GPU` environment variable in the module's environment submodule (defaulting to `false` to match upstream behavior) and uses it to conditionally toggle systemd sandboxing.

`PrivateDevices` are now disabled by default to allow hardware observability, but will tightly sandbox the service if both `smartmon.enable = false` and `environment.SKIP_GPU = true`.

Additionally, when `SKIP_GPU = true`, hardware diagnostic tools (e.g., `nvidia-smi`, `intel-gpu-tools`) are excluded from the service's `path`. This trims unused packages from the system closure, saving disk space when GPU monitoring is explicitly disabled.

Resolves #507976

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
