### PR TITLE
vimPlugins.codediff-nvim: fix library build on Darwin

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/codediff-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/codediff-nvim/default.nix
@@ -7,6 +7,7 @@
   vimPlugins,
   autoPatchelfHook,
   stdenv,
+  llvmPackages,
 }:
 vimUtils.buildVimPlugin rec {
   pname = "codediff.nvim";
@@ -22,8 +23,16 @@ vimUtils.buildVimPlugin rec {
   dependencies = [ vimPlugins.nui-nvim ];
 
   nativeBuildInputs = [ cmake ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
   dontUseCmakeConfigure = true;
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace libvscode-diff/CMakeLists.txt \
+      --replace-fail 'COMMAND brew --prefix libomp' 'COMMAND echo ${llvmPackages.openmp}'
+  '';
+
   buildPhase = ''
     runHook preBuild
     make


### PR DESCRIPTION
Build on darwin currently falls back to sequential character-level diff, rather than parallel OpenMP implementation.

Upstream falls back to `brew --prefix libomp` on macOS when `find_package(OpenMP)` fails, which does not work in the Nix sandbox.

Patch the CMake brew fallback to use `llvmPackages.openmp` instead.

No extra `libomp.dylib` symlink is needed on Darwin, since the built library already references `libomp.dylib` from the Nix store. I verified this with otool.

## Things done

- Built on platform:
  - [x] aarch64-darwin
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.