### PR TITLE
cups-printers: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/cu/cups-printers/package.nix
+++ b/pkgs/by-name/cu/cups-printers/package.nix
@@ -38,8 +38,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Tool for interacting with a CUPS server";
-    homepage = "https://github.com/audiusGmbH/cups-printers";
-    changelog = "https://github.com/audiusGmbH/cups-printers/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/audius/cups-printers";
+    changelog = "https://github.com/audius/cups-printers/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cups-printers";

--- a/pkgs/by-name/cu/cups-printers/package.nix
+++ b/pkgs/by-name/cu/cups-printers/package.nix
@@ -6,17 +6,18 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "cups-printers";
-  version = "1.0.0";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "audiusGmbH";
     repo = "cups-printers";
     tag = finalAttrs.version;
-    hash = "sha256-HTR9t9ElQmCzJfdWyu+JQ8xBfDNpXl8XtNsJxGSfBXk=";
+    hash = "sha256-Fne7V9dEZwdV6OsQPg2gzrz/wloAOOuwlx3CqXOyWBc=";
   };
 
   pythonRelaxDeps = [
+    "rich"
     "typer"
     "validators"
   ];
@@ -25,6 +26,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   dependencies = with python3.pkgs; [
     pycups
+    rich
     typer
     validators
   ];
@@ -37,7 +39,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Tool for interacting with a CUPS server";
     homepage = "https://github.com/audiusGmbH/cups-printers";
-    changelog = "https://github.com/audiusGmbH/cups-printers/blob/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/audiusGmbH/cups-printers/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cups-printers";


### PR DESCRIPTION
Changelog: https://github.com/audiusGmbH/cups-printers/blob/1.1.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
