### PR TITLE
uim: remove null from inputs

### DIFF
--- a/pkgs/by-name/ui/uim/package.nix
+++ b/pkgs/by-name/ui/uim/package.nix
@@ -16,45 +16,31 @@
   m17n_db,
   expat,
   withAnthy ? true,
-  anthy ? null,
+  anthy,
   withGtk ? true,
   withGtk2 ? withGtk,
-  gtk2 ? null,
+  gtk2,
   withGtk3 ? withGtk,
-  gtk3 ? null,
+  gtk3,
   # Was never enabled in the history of this package and is not needed by any
   # dependent package, hence disabled to save up closure size.
   withQt ? false,
   withQt5 ? withQt,
-  qt5 ? null,
+  qt5,
   withLibnotify ? true,
-  libnotify ? null,
+  libnotify,
   withSqlite ? true,
-  sqlite ? null,
+  sqlite,
   withNetworking ? true,
-  curl ? null,
-  openssl ? null,
+  curl,
+  openssl,
   withFFI ? true,
-  libffi ? null,
+  libffi,
 
   # Things that are clearly an overkill to be enabled by default
   withMisc ? false,
-  libeb ? null,
+  libeb,
 }:
-
-let
-  automake = automake116x;
-in
-
-assert withGtk2 -> gtk2 != null;
-assert withGtk3 -> gtk3 != null;
-
-assert withAnthy -> anthy != null;
-assert withLibnotify -> libnotify != null;
-assert withSqlite -> sqlite != null;
-assert withNetworking -> curl != null && openssl != null;
-assert withFFI -> libffi != null;
-assert withMisc -> libeb != null;
 
 stdenv.mkDerivation (finalAttrs: {
   version = "1.9.6";
@@ -70,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoconf
-    automake
+    automake116x
     intltool
     libtool
     pkg-config


### PR DESCRIPTION
Those packages are never undefined and if they would, that would be a bug, hence we can remove that outdated pattern.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
