### PR TITLE
l8w8jwt: fix build with gcc15

### DIFF
--- a/pkgs/by-name/l8/l8w8jwt/fix-gcc15.patch
+++ b/pkgs/by-name/l8/l8w8jwt/fix-gcc15.patch
@@ -1,0 +1,29 @@
+diff --git a/lib/mbedtls/library/ssl_tls13_keys.c b/lib/mbedtls/library/ssl_tls13_keys.c
+index dbc703a6c124961cfe38973ed4a0cae4867ba870..51afb044ccf3892bd0d69ec06b1f0ab0d15c287d 100644
+--- a/lib/mbedtls/library/ssl_tls13_keys.c
++++ b/lib/mbedtls/library/ssl_tls13_keys.c
+@@ -80,7 +80,8 @@ struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
+  *            the HkdfLabel structure on success.
+  */
+ 
+-static const char tls13_label_prefix[6] = "tls13 ";
++/* We need to tell the compiler that we meant to leave out the null character. */
++static const char tls13_label_prefix[6] __attribute__ ((nonstring)) = "tls13 ";
+ 
+ #define SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(label_len, context_len) \
+     (2                     /* expansion length           */ \
+diff --git a/lib/mbedtls/library/ssl_tls13_keys.h b/lib/mbedtls/library/ssl_tls13_keys.h
+index 14f6e4876c64b7562eef7de589f92c1fd84b190a..f6d02b522a5e3f4a6f6802ae7655dee07218f8d1 100644
+--- a/lib/mbedtls/library/ssl_tls13_keys.h
++++ b/lib/mbedtls/library/ssl_tls13_keys.h
+@@ -40,8 +40,9 @@
+ 
+ #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+ 
++/* We need to tell the compiler that we meant to leave out the null character. */
+ #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
+-    const unsigned char name    [sizeof(string) - 1];
++    const unsigned char name    [sizeof(string) - 1] __attribute__ ((nonstring));
+ 
+ union mbedtls_ssl_tls13_labels_union {
+     MBEDTLS_SSL_TLS1_3_LABEL_LIST

--- a/pkgs/by-name/l8/l8w8jwt/package.nix
+++ b/pkgs/by-name/l8/l8w8jwt/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-aR3r84AYvCNx3jm9lB1qtbbEh9rU3LTkI+TK9LPQaPk=";
   };
 
+  patches = [
+    # adapted from https://github.com/Mbed-TLS/mbedtls/commit/79b513894a28718604f7cb531380bfea0354844f
+    ./fix-gcc15.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322337783

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
