### PR TITLE
nixos/netbird: fix login service false-positive status match

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -780,7 +780,7 @@ in
                 refresh_status
                 <"$status_file" sed 's/^/STATUS:PRE-CONNECT : /g'
 
-                until refresh_status && <"$status_file" grep --quiet 'Connected\|NeedsLogin' ; do
+                until refresh_status && <"$status_file" grep --quiet 'Management: Connected\|NeedsLogin' ; do
                   sleep 1
                 done
                 <"$status_file" sed 's/^/STATUS:POST-CONNECT: /g'


### PR DESCRIPTION
## Problem
The `netbird-default-login.service` oneshot greps for `'Connected|NeedsLogin'` in `netbird status` output to detect when the daemon is ready for setup-key login. However, `netbird status` always includes a line like:
Peers count: 0/0 Connected
This matches `Connected` before the management connection reports `NeedsLogin`, causing the loop to exit immediately. The subsequent `NeedsLogin` check fails, so the setup key is never sent to the daemon.
## Fix
Match `Management: Connected` instead of bare `Connected`. The `Management:` prefix ensures only the management status line matches, not the peers summary.
## Testing
Diagnosed from live service logs on a self-hosted NetBird deployment with `login.enable = true`. The unpatched login service exited without authenticating due to the false grep match. The fix has not been end-to-end tested yet.
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.