### PR TITLE
{linuxPackages.ena,amazon-ssm-agent}: fix cross

### DIFF
--- a/pkgs/by-name/am/amazon-ssm-agent/0001-makefile-don-t-use-tool-to-generate-version-file.patch
+++ b/pkgs/by-name/am/amazon-ssm-agent/0001-makefile-don-t-use-tool-to-generate-version-file.patch
@@ -1,0 +1,35 @@
+From be3aca2216ecb4aab6d1e3c5e11ed621fd75691a Mon Sep 17 00:00:00 2001
+From: Winter M <winter@antithesis.com>
+Date: Wed, 8 Apr 2026 17:34:43 -0400
+Subject: [PATCH] makefile: don't use tool to generate version file
+
+---
+ makefile | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/makefile b/makefile
+index fa3e0943..d3bc479e 100644
+--- a/makefile
++++ b/makefile
+@@ -118,10 +118,7 @@ pre-build:
+ 	$(COPY) $(GO_SPACE)/seelog_windows.xml.template $(GO_SPACE)/bin/
+ 	$(COPY) $(GO_SPACE)/agent/integration-cli/integration-cli.json $(GO_SPACE)/bin/
+ 
+-	@echo "Regenerate version file during pre-release"
+-# Remove overrides for GOARCH and GOOS when invoking 'go run', since we want the local host's settings
+-	GOARCH= GOOS= go run $(GO_SPACE)/agent/version/versiongenerator/version-gen.go
+-	$(COPY) $(GO_SPACE)/VERSION $(GO_SPACE)/bin/
++	echo -e 'package version\nconst Version = "@VERSION@"' > $(GO_SPACE)/agent/version/version.go
+ 
+ # General build recipe. Defaults to generating a linux/amd64 non-PIE build, but can be overriden
+ # by setting appropriate variables.
+@@ -493,4 +490,4 @@ argot-check:
+ 	$(GO_SPACE)/Tools/src/run_argot.sh
+ 
+ argot-update:
+-	$(GO_SPACE)/Tools/src/run_argot.sh "true"
+\ No newline at end of file
++	$(GO_SPACE)/Tools/src/run_argot.sh "true"
+-- 
+2.53.0
+

--- a/pkgs/by-name/am/amazon-ssm-agent/package.nix
+++ b/pkgs/by-name/am/amazon-ssm-agent/package.nix
@@ -5,6 +5,7 @@
   makeWrapper,
   darwin,
   fetchFromGitHub,
+  substitute,
   coreutils,
   unixtools,
   util-linux,
@@ -60,6 +61,18 @@ buildGoModule (finalAttrs: {
     # They used constants from another package that I couldn't figure
     # out how to resolve, so hardcoded the constants.
     ./0002-version-gen-don-t-use-unnecessary-constants.patch
+
+    # They run a tool on the build platform in a way that isn't quite
+    # compatible with cross (`go run`). Simplest thing is to just make
+    # the file with a hardcoded value, as we already have it from attrs.
+    (substitute {
+      src = ./0001-makefile-don-t-use-tool-to-generate-version-file.patch;
+      substitutions = [
+        "--subst-var-by"
+        "VERSION"
+        finalAttrs.version
+      ];
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.KERNEL_BUILD_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 
+  postPatch = ''
+    substituteInPlace kernel/linux/ena/configure.sh --replace-fail '^HOSTCC' '^CC'
+  '';
   configurePhase = ''
     runHook preConfigure
     cd kernel/linux/ena


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (via cross from x86_64-linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
