### PR TITLE
nixos/lib/make-disk-image: add some semblance of support for cross

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -389,22 +389,24 @@ let
     echo -n ${config.system.nixos.versionSuffix} > $out/nixos/.version-suffix
   '';
 
-  binPath = lib.makeBinPath (
-    with pkgs;
-    [
-      rsync
-      util-linux
-      parted
-      e2fsprogs
-      lkl
-      config.system.build.nixos-install
-      nixos-enter
-      nix
-      systemdMinimal
-    ]
-    ++ lib.optional deterministic gptfdisk
-    ++ stdenv.initialPath
-  );
+  mkBinPath =
+    p:
+    lib.makeBinPath (
+      with p;
+      [
+        rsync
+        util-linux
+        parted
+        e2fsprogs
+        lkl
+        config.system.build.nixos-install
+        nixos-enter
+        nix
+        systemdMinimal
+      ]
+      ++ lib.optional deterministic gptfdisk
+      ++ stdenv.initialPath
+    );
 
   # I'm preserving the line below because I'm going to search for it across nixpkgs to consolidate
   # image building logic. The comment right below this now appears in 4 different places in nixpkgs :)
@@ -426,7 +428,7 @@ let
   blockSize = toString (4 * 1024); # ext4fs block size (not block device sector size)
 
   prepareImage = ''
-    export PATH=${binPath}
+    export PATH=${mkBinPath pkgs.buildPackages}
 
     # Yes, mkfs.ext4 takes different units in different contexts. Fun.
     sectorsToKilobytes() {
@@ -640,7 +642,7 @@ let
         ''
       else
         ''
-          ${pkgs.qemu-utils}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
+          ${pkgs.buildPackages.qemu-utils}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
         ''
     }
     diskImage=$out/${filename}
@@ -657,8 +659,12 @@ let
     echo "file ${format}-image $out/${filename}" >> $out/nix-support/hydra-build-products
   '';
 
+  hostPkgs = import pkgs.path {
+    localSystem = pkgs.stdenv.hostPlatform;
+  };
+
   buildImage = pkgs.vmTools.runInLinuxVM (
-    pkgs.runCommand name
+    hostPkgs.runCommand name
       {
         preVM = prepareImage + lib.optionalString touchEFIVars createEFIVars;
         buildInputs = with pkgs; [
@@ -682,7 +688,15 @@ let
         inherit memSize;
       }
       ''
-        export PATH=${binPath}:$PATH
+        # This is a sily, stupid hack, and I'd love to get rid of it: basically,
+        # we use as much as possible from our (potentially cross) package set,
+        # while only picking up the stdenv so that e.g. `stdenv.initialPath`
+        # is right. I'm sure there's a better way to do this (e.g. just manually
+        # expanding `stdenv.initialPath` with our cross set?).
+        #
+        # I'm not sure this really gets away from the "you need a native stdenv
+        # to cross-compile a disk image" requirement, though.
+        export PATH=${mkBinPath (pkgs // { stdenv = hostPkgs.stdenv; })}:$PATH
 
         rootDisk=${if partitionTableType != "none" then "/dev/vda${rootPartition}" else "/dev/vda"}
 

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -48,7 +48,7 @@
 let
   qemu-common = import ../../../nixos/lib/qemu-common.nix { inherit lib stdenv; };
 
-  qemu = buildPackages.qemu_kvm;
+  qemu = buildPackages.qemu;
 
   modulesClosure = makeModulesClosure {
     kernel = lib.getOutput "modules" kernel;
@@ -270,11 +270,11 @@ let
   vmRunCommand =
     qemuCommand:
     writeText "vm-run" ''
-      ${coreutils}/bin/mkdir xchg
+      ${buildPackages.coreutils}/bin/mkdir xchg
       export > xchg/saved-env
 
       if [ -f "''${NIX_ATTRS_SH_FILE-}" ]; then
-        ${coreutils}/bin/cp $NIX_ATTRS_JSON_FILE $NIX_ATTRS_SH_FILE xchg
+        ${buildPackages.coreutils}/bin/cp $NIX_ATTRS_JSON_FILE $NIX_ATTRS_SH_FILE xchg
         source "$NIX_ATTRS_SH_FILE"
       fi
       source $stdenv/setup
@@ -298,22 +298,22 @@ let
       # Write the command to start the VM to a file so that the user can
       # debug inside the VM if the build fails (when Nix is called with
       # the -K option to preserve the temporary build directory).
-      ${coreutils}/bin/cat > ./run-vm <<EOF
-      #! ${bash}/bin/sh
+      ${buildPackages.coreutils}/bin/cat > ./run-vm <<EOF
+      #! ${buildPackages.bash}/bin/sh
       ''${diskImage:+diskImage=$diskImage}
       # GitHub Actions runners seems to not allow installing seccomp filter: https://github.com/rcambrj/nix-pi-loader/issues/1#issuecomment-2605497516
       # Since we are running in a sandbox already, the difference between seccomp and none is minimal
-      ${virtiofsd}/bin/virtiofsd --xattr --socket-path virtio-store.sock --sandbox none --seccomp none --shared-dir "${storeDir}" &
-      ${virtiofsd}/bin/virtiofsd --xattr --socket-path virtio-xchg.sock --sandbox none --seccomp none --shared-dir xchg &
+      ${buildPackages.virtiofsd}/bin/virtiofsd --xattr --socket-path virtio-store.sock --sandbox none --seccomp none --shared-dir "${storeDir}" &
+      ${buildPackages.virtiofsd}/bin/virtiofsd --xattr --socket-path virtio-xchg.sock --sandbox none --seccomp none --shared-dir xchg &
 
       # Wait until virtiofsd has created these sockets to avoid race condition.
-      until [[ -e virtio-store.sock ]]; do ${coreutils}/bin/sleep 0.1; done
-      until [[ -e virtio-xchg.sock ]]; do ${coreutils}/bin/sleep 0.1; done
+      until [[ -e virtio-store.sock ]]; do ${buildPackages.coreutils}/bin/sleep 0.1; done
+      until [[ -e virtio-xchg.sock ]]; do ${buildPackages.coreutils}/bin/sleep 0.1; done
 
       ${qemuCommand}
       EOF
 
-      ${coreutils}/bin/chmod +x ./run-vm
+      ${buildPackages.coreutils}/bin/chmod +x ./run-vm
       source ./run-vm
 
       if ! test -e xchg/in-vm-exit; then
@@ -321,7 +321,7 @@ let
         exit 1
       fi
 
-      exitCode="$(${coreutils}/bin/cat xchg/in-vm-exit)"
+      exitCode="$(${buildPackages.coreutils}/bin/cat xchg/in-vm-exit)"
       if [ "$exitCode" != "0" ]; then
         exit "$exitCode"
       fi
@@ -396,13 +396,14 @@ let
       }:
       {
         requiredSystemFeatures = [ "kvm" ];
-        builder = "${bash}/bin/sh";
+        builder = "${buildPackages.bash}/bin/sh";
         args = [
           "-e"
           (vmRunCommand qemuCommandLinux)
         ];
         origArgs = args;
         origBuilder = builder;
+        inherit (stdenv.buildPlatform) system;
         env.QEMU_OPTS = "${QEMU_OPTS} -m ${toString memSize} -object memory-backend-memfd,id=mem,size=${toString memSize}M,share=on -machine memory-backend=mem";
         __structuredAttrs = true;
       }


### PR DESCRIPTION
This is... probably awful and hacky and bad, *but* nonetheless I'd like to salvage/get reviews on as much as possible so that maybe one day this can be real? Though maybe the answer is just to use repart...

cc @ElvishJerricco as a potentially semi-interested party maybe

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (via cross from x86_64-linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
