### PR TITLE
littlesnitch: init at 1.0.0.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1172,6 +1172,13 @@ lib.mapAttrs mkLicense (
       redistributable = true;
     };
 
+    obdevProprietaryFreeware = {
+      fullName = "Little Snitch for Linux daemon and command line tool — Proprietary Freeware License";
+      url = "https://obdev.at/products/littlesnitch-linux/license.html";
+      free = false;
+      redistributable = true;
+    };
+
     obsidian = {
       fullName = "Obsidian End User Agreement";
       url = "https://obsidian.md/eula";

--- a/pkgs/by-name/li/littlesnitch/package.nix
+++ b/pkgs/by-name/li/littlesnitch/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  zstd,
+  autoPatchelfHook,
+  pam,
+  sqlite,
+}:
+
+let
+  hash =
+    {
+      x86_64-linux = "sha256-Emx87E14sNDXfDD46Fy5jscKBeoVGG6+aGlBvJiTx24=";
+      aarch64-linux = "sha256-wPwsROSrNyaFcANDEpLrlg+EUFTwMsHNo7XygL/oxAo=";
+    }
+    .${stdenv.hostPlatform.system} or (throw "unsupported system");
+in
+stdenv.mkDerivation {
+  pname = "littlesnitch";
+  version = "1.0.0.1";
+
+  src = fetchzip {
+    url = "https://obdev.at/downloads/littlesnitch-linux/littlesnitch-1.0.0-1-${
+      if stdenv.hostPlatform.isx86_64 then "x86_64" else "aarch64"
+    }.pkg.tar.zst";
+    nativeBuildInputs = [ zstd ];
+    stripRoot = false;
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    stdenv.cc.cc
+    pam
+    sqlite
+  ];
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir "$out"
+    mv usr/* "$out"
+    substituteInPlace "$out/lib/systemd/system/littlesnitch.service" --replace-fail "/usr/bin" "$out/bin"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Application firewall";
+    homepage = "https://obdev.at/products/littlesnitch-linux/index.html";
+    changelog = "https://obdev.at/products/littlesnitch-linux/download.html";
+    license = lib.licenses.obdevProprietaryFreeware;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}


### PR DESCRIPTION
Will likely add a module/test in a bit, but wanted to get this up now as opposed to ~days from now when I can do that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
