### PR TITLE
knope: init at 0.22.4

### DIFF
--- a/pkgs/by-name/kn/knope/package.nix
+++ b/pkgs/by-name/kn/knope/package.nix
@@ -1,0 +1,53 @@
+{
+  fetchFromGitHub,
+  git,
+  lib,
+  libgit2,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "knope";
+  version = "0.22.4";
+
+  src = fetchFromGitHub {
+    owner = "knope-dev";
+    repo = "knope";
+    tag = "knope/v${finalAttrs.version}";
+    hash = "sha256-2lZhetmctKSfLXd7jvepm1+Vc0db1teryx6tehEHCJM=";
+  };
+
+  cargoHash = "sha256-L7IT7nWinyWiuIwlBmGmHDyKB+o3LJBanHVFRQpWB+c=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libgit2 ];
+
+  env.LIBGIT2_NO_VENDOR = 1;
+
+  nativeCheckInputs = [ git ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __structuredAttrs = true;
+  doInstallCheck = true;
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "knope/v(.*)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/knope-dev/knope/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Automation for changelogs and releases using conventional commits and/or changesets";
+    homepage = "https://knope.tech/";
+    mainProgram = "knope";
+    maintainers = with lib.maintainers; [ mdaniels5757 ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
[Knope](https://knope.tech/) [(GitHub)](https://github.com/knope-dev/knope) automates changelogs and releases using conventional commits, changesets, or both.

Would like to have this packaged in order to use it easily in https://github.com/NixOS/nixpkgs-vet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
