### PR TITLE
tests/snid: test that it proxies

### DIFF
--- a/nixos/tests/snid.nix
+++ b/nixos/tests/snid.nix
@@ -1,30 +1,83 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
+let
+  domain = "backend.example.com";
+  port = 443;
+  certs =
+    pkgs.runCommand "snid-test-certs"
+      {
+        nativeBuildInputs = [ pkgs.openssl ];
+      }
+      ''
+        mkdir -p $out
+        openssl req -x509 \
+          -subj '/CN=${domain}/' \
+          -addext 'subjectAltName = DNS:${domain}' \
+          -keyout "$out/key.pem" \
+          -out "$out/cert.pem" -noenc
+      '';
+in
 {
   _class = "nixosTest";
   name = "snid";
 
   nodes = {
-    machine =
-      { pkgs, ... }:
+    # Serves a simple HTTPS page that we expect to receive via snid
+    backend =
+      { ... }:
+      {
+        services.nginx = {
+          enable = true;
+          virtualHosts.${domain} = {
+            onlySSL = true;
+            sslCertificate = "${certs}/cert.pem";
+            sslCertificateKey = "${certs}/key.pem";
+            root = pkgs.writeTextDir "index.html" "snid test OK";
+          };
+        };
+        networking.firewall.allowedTCPPorts = [ port ];
+      };
+
+    # Runs snid, proxying to the backend.
+    snid =
+      { nodes, pkgs, ... }:
+      let
+        backendIp = nodes.backend.networking.primaryIPv6Address;
+      in
       {
         system.services.snid = {
           imports = [ pkgs.snid.services.default ];
           snid = {
-            listen = [ "tcp:8443" ];
+            listen = [ "tcp:${toString port}" ];
             mode = "tcp";
-            backendCidrs = [ "127.0.0.0/8" ];
+            backendCidrs = [ "${backendIp}/128" ];
           };
         };
 
-        networking.firewall.allowedTCPPorts = [ 8443 ];
+        networking.hosts.${backendIp} = [ domain ];
+        networking.firewall.allowedTCPPorts = [ port ];
+      };
+
+    # Makes HTTPS requests to snid.
+    client =
+      { nodes, pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.curl ];
+        networking.hosts.${nodes.snid.networking.primaryIPAddress} = [ domain ];
       };
   };
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("multi-user.target")
-    machine.wait_for_unit("snid.service")
-    machine.wait_for_open_port(8443)
+
+    backend.wait_for_unit("nginx.service")
+    backend.wait_for_open_port(${toString port})
+
+    snid.wait_for_unit("snid.service")
+    snid.wait_for_open_port(${toString port})
+
+    with subtest("snid proxies HTTPS connection based on SNI"):
+        result = client.succeed("curl -k -sf https://${domain}")
+        assert "snid test OK" in result, f"Unexpected response: {result!r}"
   '';
 
   meta.maintainers = with lib.maintainers; [ tomfitzhenry ];


### PR DESCRIPTION
This improves snid's test to test its primary function, rather than just checking the port opens.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
