### PR TITLE
freac: add VZstless as maintainer

### DIFF
--- a/pkgs/by-name/fr/freac/package.nix
+++ b/pkgs/by-name/fr/freac/package.nix
@@ -7,6 +7,7 @@
   smooth,
   systemd,
   wrapGAppsHook3,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "enzo1982";
     repo = "freac";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-bHoRxxhSM7ipRkiBG7hEa1Iw8Z3tOHQ/atngC/3X1a4=";
   };
 
@@ -31,10 +32,16 @@ stdenv.mkDerivation (finalAttrs: {
     "prefix=$(out)"
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Audio converter and CD ripper with support for various popular formats and encoders";
     license = lib.licenses.gpl2Plus;
     homepage = "https://www.freac.org/";
+    downloadPage = "https://www.freac.org/downloads-mainmenu-33";
+    changelog = "https://github.com/enzo1982/freac/releases/tag/${finalAttrs.src.tag}";
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ VZstless ];
+    mainProgram = "freac";
   };
 })


### PR DESCRIPTION
Though there isn't a new release in more than 2 years, it seems that this package is under actively development according to github commit record.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
