### PR TITLE
home-assistant-custom-lovelace-modules.navbar-card: use finalAttrs, add update script, support aarch64-linux

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/navbar-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/navbar-card/package.nix
@@ -4,24 +4,24 @@
   fetchFromGitHub,
   bun,
   nodejs-slim,
+  nix-update-script,
   writableTmpDirAsHomeHook,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "navbar-card";
   version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "joseluis9595";
     repo = "lovelace-navbar-card";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ngKsH83nrDglRQBdQhJzMC8/TRV+uL21vi2ovsLEPuY=";
   };
 
-  # Create node_modules as a separate derivation
   node_modules = stdenv.mkDerivation {
-    pname = "${pname}-node_modules";
-    inherit version src;
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) version src;
 
     nativeBuildInputs = [
       bun
@@ -40,6 +40,7 @@ let
         --frozen-lockfile \
         --ignore-scripts \
         --no-progress \
+        --omit=optional \
         --production
 
       runHook postBuild
@@ -57,14 +58,9 @@ let
     # Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-F8nNDBl/BYhtwggaZd61oibYE4j5u7WPVjLG8P4UEcc=";
-    outputHashAlgo = "sha256";
+    outputHash = "sha256-By1ZTJ+cZO+vhs0BL8HSu36k+dvG0WPRnuUwIoaclnw=";
     outputHashMode = "recursive";
   };
-
-in
-stdenv.mkDerivation {
-  inherit pname version src;
 
   nativeBuildInputs = [
     bun
@@ -75,7 +71,7 @@ stdenv.mkDerivation {
     runHook preConfigure
 
     # Copy node_modules from the separate derivation
-    cp -R ${node_modules}/node_modules .
+    cp -R ${finalAttrs.node_modules}/node_modules .
 
     runHook postConfigure
   '';
@@ -84,7 +80,7 @@ stdenv.mkDerivation {
     runHook preBuild
 
     # Build the project using bun
-    bun build src/navbar-card.ts --outfile=dist/navbar-card.js --target=browser
+    NODE_ENV=production bun build src/navbar-card.ts --outfile=dist/navbar-card.js --target=browser
 
     runHook postBuild
   '';
@@ -98,13 +94,25 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.entrypoint = "navbar-card.js";
+  passthru = {
+    entrypoint = "navbar-card.js";
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "node_modules"
+      ];
+    };
+  };
 
   meta = {
     description = "Navbar Card for Home Assistant's Lovelace UI - easily navigate through dashboards";
     homepage = "https://github.com/joseluis9595/lovelace-navbar-card";
-    changelog = "https://github.com/joseluis9595/lovelace-navbar-card/releases/tag/v${version}";
+    changelog = "https://github.com/joseluis9595/lovelace-navbar-card/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = [ lib.maintainers.jamiemagee ];
   };
-}
+})


### PR DESCRIPTION
Three small changes:

1. Refactor to `finalAttrs` so the `node_modules` FOD is a subpackage. The [nixpkgs-update bot was failing](https://nixpkgs-update-logs.nix-community.org/home-assistant-custom-lovelace-modules.navbar-card/2026-04-08.log) because it couldn't reach the inner FOD; with `finalAttrs` the new `nix-update-script` (`--subpackage node_modules`) handles its hash.

2. Add aarch64-linux. The awkward part: `bun install` pulls in different platform-specific optional binaries on each arch (`@biomejs/cli-linux-x64` vs `@biomejs/cli-linux-arm64`, plus some `esbuild`/`rollup` ones), so the FOD hash diverged per system. None of those get imported by `src/navbar-card.ts`, so `--omit=optional` drops them and the FOD ends up with one hash that works everywhere.

3. Set `NODE_ENV=production` for `bun build` to match upstream's build script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

