### PR TITLE
github-copilot-cli: 1.0.19 -> 1.0.21

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/sources.json
+++ b/pkgs/by-name/gi/github-copilot-cli/sources.json
@@ -1,19 +1,19 @@
 {
-  "version": "1.0.19",
+  "version": "1.0.21",
   "x86_64-linux": {
     "name": "copilot-linux-x64",
-    "hash": "sha256-8ZlmXw8lIuTDFf59nl65g+Yg7CvJeyJJ1pGMaARz+bg="
+    "hash": "sha256-pvxJSj3Vp2JG+zNCS68Iq7W0y2iJ//KM8pUVXCixz3c="
   },
   "aarch64-linux": {
     "name": "copilot-linux-arm64",
-    "hash": "sha256-/hGO951vg8oWE3ONQ03Pa4yeMRqJaml5Q2J3YaMOzRI="
+    "hash": "sha256-QUuuOtIo5LtJ734f5pf7wUSdNF+VdmBxp8Haa7IasWg="
   },
   "x86_64-darwin": {
     "name": "copilot-darwin-x64",
-    "hash": "sha256-zsPRSgIe5h+EkKeqCPZZpQvmWgJpIXMg86YgvIIEHy4="
+    "hash": "sha256-dS3MmOrDhgatzqZOXumIiinINduWm17dq95rqPmeqXc="
   },
   "aarch64-darwin": {
     "name": "copilot-darwin-arm64",
-    "hash": "sha256-0hvupLiJbzc89Pw5u8DS9MS+1N4LEjkR3nx6U+AN78w="
+    "hash": "sha256-mQy7nZTNLa0CRej3xO0riP+qhlMb+Eboby2QWPTUWIo="
   }
 }


### PR DESCRIPTION
https://github.com/github/copilot-cli/releases/tag/v1.0.21

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
