### PR TITLE
prometheus: 3.10.0 -> 3.11.1

### DIFF
--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -216,6 +216,7 @@ buildGoModule (finalAttrs: {
       fpletz
       Frostman
       jpds
+      miniharinn
     ];
     mainProgram = "prometheus";
   };

--- a/pkgs/by-name/pr/prometheus/source.nix
+++ b/pkgs/by-name/pr/prometheus/source.nix
@@ -1,6 +1,6 @@
 {
-  version = "3.10.0";
-  hash = "sha256-tTxHLngOsJ0STwfnBfuXN7CUaVgtpRGzEiFtXTWVDD4=";
-  npmDepsHash = "sha256-+nu7qfxlVa8OWARFgQnXj5riTQ0P1sjxbIgYUvJpcHw=";
-  vendorHash = "sha256-AsVy9RPemaKDuX8is2IXjlzRBsJFJiRfFj18SQl8Oc8=";
+  version = "3.11.1";
+  hash = "sha256-U3vvYRDzJprIQ03G7deRGc3NV0FPxTSH/RGKP1j5jxU=";
+  npmDepsHash = "sha256-4n4T2KN+QVhLso5rGk83UTdJ7zMseFpOq1anJc2dN1g=";
+  vendorHash = "sha256-wR1b5jV/2B50OeKokv8Ss+tpSXNjJBsLIZrK7gOb168=";
 }


### PR DESCRIPTION
Release: https://github.com/prometheus/prometheus/releases/tag/v3.11.1
Diff: https://github.com/prometheus/prometheus/compare/v3.10.0...v3.11.1

I also added myself as a maintainer of this package, hopefully the other maintainers don't mind :D
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
