### PR TITLE
platformio-chrootenv: add cmake, ninja, wheel, virtualenv

### DIFF
--- a/pkgs/by-name/pl/platformio-chrootenv/package.nix
+++ b/pkgs/by-name/pl/platformio-chrootenv/package.nix
@@ -17,11 +17,18 @@ let
       xdg-user-dirs
       ncurses
       udev
+      # Required for esp-idf and other frameworks that manage their own
+      # Python virtual environments during the build process.
+      # See: https://github.com/NixOS/nixpkgs/issues/133185
+      cmake
+      ninja
     ])
     ++ (with python.pkgs; [
       python
       setuptools
       pip
+      wheel
+      virtualenv
       bottle
     ]);
 


### PR DESCRIPTION
esp-idf and Zephyr create their own Python venvs during builds. Without `pip`, `wheel`, and `virtualenv` in the FHS environment, this fails with `No module named pip`. They also need `cmake` and `ninja` for their build systems.

Fixes #133185

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
