### PR TITLE
enpass: Updater fix.

### DIFF
--- a/pkgs/by-name/en/enpass/package.nix
+++ b/pkgs/by-name/en/enpass/package.nix
@@ -139,12 +139,13 @@ let
       buildInputs = with python3Packages; [
         python
         requests
+        packaging
         pathlib2
         six
         attrs
       ];
       shellHook = ''
-        exec python $SCRIPT --target pkgs/tools/security/enpass/data.json --repo ${baseUrl}
+        exec python $SCRIPT --target pkgs/by-name/en/enpass/data.json --repo ${baseUrl}
       '';
 
     };

--- a/pkgs/by-name/en/enpass/package.nix
+++ b/pkgs/by-name/en/enpass/package.nix
@@ -134,7 +134,7 @@ let
   updater = {
     update = stdenv.mkDerivation {
       name = "enpass-update-script";
-      SCRIPT = ./update_script.py;
+      SCRIPT = toString ./update_script.py;
 
       buildInputs = with python3Packages; [
         python

--- a/pkgs/by-name/en/enpass/update_script.py
+++ b/pkgs/by-name/en/enpass/update_script.py
@@ -33,7 +33,8 @@ def find_latest_version(arch):
     for package in packages.split("\n\n"):
         matches = version_selector.search(package)
         matched_version = matches.group('version') if matches and matches.group('version') else "0"
-        parsed_version = version.parse(matched_version)
+        try: parsed_version = version.parse(matched_version)
+        except version.InvalidVersion: continue
         if parsed_version > last_version:
             path = path_selector.search(package).group('path')
             sha256 = hash_selector.search(package).group('sha256')


### PR DESCRIPTION
- Fixed outdated paths in updater.
- Added 'packaging' dependency in updater buildInputs.
- Ran updater for latest version (already exists in `master`).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
