### PR TITLE
python3Packages.certbot: 5.4.0 -> 5.5.0

### DIFF
--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -22,7 +22,7 @@
   writeShellScriptBin,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "certbot";
   version = "5.5.0";
   pyproject = true;
@@ -30,11 +30,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hSRMxWQbGFFA5AA+M3wlvVckR+M9qaEIywLC5y6YH0A=";
   };
 
-  sourceRoot = "${src.name}/certbot";
+  sourceRoot = "${finalAttrs.src.name}/certbot";
 
   build-system = [ setuptools ];
 
@@ -87,9 +87,9 @@ buildPythonPackage rec {
     let
       pythonEnv = python.withPackages f;
     in
-    runCommand "certbot-with-plugins-${version}"
+    runCommand "certbot-with-plugins-${finalAttrs.version}"
       {
-        inherit pname version;
+        inherit (finalAttrs) pname version;
       }
       ''
         mkdir -p $out/bin
@@ -99,11 +99,11 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/certbot/certbot";
-    changelog = "https://github.com/certbot/certbot/blob/${src.tag}/certbot/CHANGELOG.md";
+    changelog = "https://github.com/certbot/certbot/blob/${finalAttrs.src.tag}/certbot/CHANGELOG.md";
     description = "ACME client that can obtain certs and extensibly update server configurations";
     platforms = lib.platforms.unix;
     mainProgram = "certbot";
     maintainers = with lib.maintainers; [ miniharinn ];
     license = with lib.licenses; [ asl20 ];
   };
-}
+})

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "5.4.0";
+  version = "5.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
     tag = "v${version}";
-    hash = "sha256-Tu46Wybod89TiwsVccNuQcweWoeQE1wbH+pDWNC9+kE=";
+    hash = "sha256-hSRMxWQbGFFA5AA+M3wlvVckR+M9qaEIywLC5y6YH0A=";
   };
 
   sourceRoot = "${src.name}/certbot";

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -103,7 +103,7 @@ buildPythonPackage rec {
     description = "ACME client that can obtain certs and extensibly update server configurations";
     platforms = lib.platforms.unix;
     mainProgram = "certbot";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
     license = with lib.licenses; [ asl20 ];
   };
 }


### PR DESCRIPTION
Release: https://github.com/certbot/certbot/releases/tag/v5.5.0
Diff: https://github.com/certbot/certbot/compare/v5.4.0...v5.5.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
