### PR TITLE
resticprofile: 0.31.0 -> 0.33.1

### DIFF
--- a/pkgs/by-name/re/resticprofile/package.nix
+++ b/pkgs/by-name/re/resticprofile/package.nix
@@ -11,19 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "resticprofile";
-  version = "0.31.0";
+  version = "0.33.0";
 
   src = fetchFromGitHub {
     owner = "creativeprojects";
     repo = "resticprofile";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ezelvyroQG1EW3SU63OVHJ/T4qjN5DRllvPIXnei1Z4=";
+    hash = "sha256-VkE8xZiHRXTPikDA60vV6frTbokwcPtNryQdEKdngwI=";
   };
 
   postPatch = ''
-    substituteInPlace schedule_jobs.go \
-        --replace-fail "os.Executable()" "\"$out/bin/resticprofile\", nil"
-
     substituteInPlace shell/command.go \
         --replace-fail '"bash"' '"${lib.getExe bash}"'
 
@@ -32,7 +29,7 @@ buildGoModule (finalAttrs: {
 
   '';
 
-  vendorHash = "sha256-M9S6F/Csz7HnOq8PSWjpENKm1704kVx9zDts1ieraTE=";
+  vendorHash = "sha256-Dp/uRr4ARdiKSXZziQNnbJm+vsR2gYy0QmubwiIEMvM=";
 
   ldflags = [
     "-X main.version=${finalAttrs.version}"
@@ -56,6 +53,15 @@ buildGoModule (finalAttrs: {
     rm user/user_test.go # expects normal environment
     rm util/tempdir_test.go # expects normal environment
   '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # mount: fusermount: exec: "fusermount": executable file not found in $PATH
+        "TestMemFS"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   installPhase = ''
     runHook preInstall
@@ -85,7 +91,10 @@ buildGoModule (finalAttrs: {
       lgpl3 # bash shell completion
     ];
     mainProgram = "resticprofile";
-    maintainers = with lib.maintainers; [ tomasajt ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      bbigras
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/re/resticprofile/package.nix
+++ b/pkgs/by-name/re/resticprofile/package.nix
@@ -11,19 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "resticprofile";
-  version = "0.31.0";
+  version = "0.33.1";
 
   src = fetchFromGitHub {
     owner = "creativeprojects";
     repo = "resticprofile";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ezelvyroQG1EW3SU63OVHJ/T4qjN5DRllvPIXnei1Z4=";
+    hash = "sha256-L6L1JfBa/nsrwtvIw2U++jIDLJTxxweqcXQ3SomtS1A=";
   };
 
   postPatch = ''
-    substituteInPlace schedule_jobs.go \
-        --replace-fail "os.Executable()" "\"$out/bin/resticprofile\", nil"
-
     substituteInPlace shell/command.go \
         --replace-fail '"bash"' '"${lib.getExe bash}"'
 
@@ -32,7 +29,7 @@ buildGoModule (finalAttrs: {
 
   '';
 
-  vendorHash = "sha256-M9S6F/Csz7HnOq8PSWjpENKm1704kVx9zDts1ieraTE=";
+  vendorHash = "sha256-dYzx27HtIME/mrtQrRg7064Ii20715FVYj5uw4Aian0=";
 
   ldflags = [
     "-X main.version=${finalAttrs.version}"
@@ -56,6 +53,15 @@ buildGoModule (finalAttrs: {
     rm user/user_test.go # expects normal environment
     rm util/tempdir_test.go # expects normal environment
   '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # mount: fusermount: exec: "fusermount": executable file not found in $PATH
+        "TestMemFS"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   installPhase = ''
     runHook preInstall
@@ -85,7 +91,10 @@ buildGoModule (finalAttrs: {
       lgpl3 # bash shell completion
     ];
     mainProgram = "resticprofile";
-    maintainers = with lib.maintainers; [ tomasajt ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
+      tomasajt
+      bbigras
+    ];
+    platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION

supersede stalled PR #477588

fix #477440
close #477588

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
