### PR TITLE
zsh: use `finalAttrs` pattern

### DIFF
--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -16,13 +16,9 @@
   nixosTests,
 }:
 
-let
-  version = "5.9";
-in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zsh";
-  inherit version;
+  version = "5.9";
   outputs = [
     "out"
     "doc"
@@ -31,7 +27,7 @@ stdenv.mkDerivation {
   ];
 
   src = fetchurl {
-    url = "mirror://sourceforge/zsh/zsh-${version}.tar.xz";
+    url = "mirror://sourceforge/zsh/zsh-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-m40ezt1bXoH78ZGOh2dSp92UjgXBoNuhCrhjhC1FrNU=";
   };
 
@@ -162,9 +158,9 @@ stdenv.mkDerivation {
         }
         mv $out/etc/zshenv $out/etc/zshenv_zwc_is_used
 
-        rm $out/bin/zsh-${version}
+        rm $out/bin/zsh-${finalAttrs.version}
         mkdir -p $out/share/doc/
-        mv $out/share/zsh/htmldoc $out/share/doc/zsh-$version
+        mv $out/share/zsh/htmldoc $out/share/doc/zsh-${finalAttrs.version}
   '';
   # XXX: patch zsh to take zwc if newer _or equal_
 
@@ -198,4 +194,4 @@ stdenv.mkDerivation {
       inherit (nixosTests) oh-my-zsh;
     };
   };
-}
+})


### PR DESCRIPTION
This makes it easier to override the version in an overlay. For example:

```nix
final: prev: {
  zsh = prev.zsh.overrideAttrs (finalAttrs: prevAttrs: {
    version = "5.9.0.2-test";

    src = prev.fetchurl {
      url = "mirror://sourceforge/zsh/zsh-test/zsh-${finalAttrs.version}.tar.xz";
      hash = "sha256-2gRRBqZAIjceZw90WaBc9MYOYjelSK8Ur1ANFlL6h34=";
    };

    patches = [ ];
  });
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
