### PR TITLE
lib/services: improve configure function documentation

### DIFF
--- a/lib/services/lib.nix
+++ b/lib/services/lib.nix
@@ -37,17 +37,63 @@ rec {
   );
 
   /**
-    This is the entrypoint for the portable part of modular services.
+    Entrypoint for integrating modular services into a containing module system.
 
-    It provides the various options that are consumed by service manager implementations.
+    Each containing system (NixOS, ...) calls `configure` to
+    obtain a `serviceSubmodule` type for its services option. The returned submodule
+    includes the portable service base and any service-manager-specific modules
+    passed via `extraRootModules`.
+
+    **Implementing for a new system** (e.g. home-manager, nix-darwin):
+
+    ```nix
+    # darwin/modules/services/system.nix
+    { lib, config, pkgs, ... }:
+    let
+      portable-lib = import <nixpkgs/lib/services/lib.nix> { inherit lib; };
+
+      modularServiceConfiguration = portable-lib.configure {
+        serviceManagerPkgs = pkgs;
+        extraRootModules = [
+          ./launchd-service.nix    # launchd-specific options (plist generation, etc.)
+        ];
+      };
+    in
+    {
+      options.services = lib.mkOption {
+        type = lib.types.attrsOf modularServiceConfiguration.serviceSubmodule;
+        default = { };
+      };
+
+      config = {
+        # Convert service tree -> launchd plists, assertions, etc.
+        # (analogous to how NixOS converts to systemd units)
+        launchd.agents = ...;
+        assertions = ...;
+        warnings = ...;
+      };
+    }
+    ```
+
+    lib.services.configure :: AttrSet -> { serviceSubmodule :: SubmoduleType }
 
     # Inputs
 
-    `serviceManagerPkgs`: A Nixpkgs instance which will be used for built-in logic such as converting `configData.<path>.text` to a store path.
+    `serviceManagerPkgs`
 
-    `extraRootModules`: Modules to be loaded into the "root" service submodule, but not into its sub-`services`. That's the modules' own responsibility.
+    : 1\. A Nixpkgs instance used for built-in logic such as converting
+    `configData.<path>.text` to a store path.
 
-    `extraRootSpecialArgs`: Fixed module arguments that are provided in a similar manner to `extraRootModules`.
+    `extraRootModules`
+
+    : 2\. Modules to be loaded into the "root" service submodule, but not
+    into its sub-`services`. That's the modules' own responsibility.
+    Typically contains service-manager-specific option modules
+    (e.g. systemd unit options, launchd plist options).
+
+    `extraRootSpecialArgs`
+
+    : 3\. Fixed module arguments provided alongside `extraRootModules`.
 
     # Output
 


### PR DESCRIPTION
Expand the doc comment with a structured description, type signature, properly formatted parameter docs, and an example showing how to implement modular services for a new containing system.

split out from #506343.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
