### PR TITLE
seaweedfs: 4.18 -> 4.19

### DIFF
--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -11,7 +11,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.18";
+  version = "4.19";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-X0/BCdLpM7Cs2Q7goW9JHw8tA+ztlm+qxusn+OIQ/qg=";
+    hash = "sha256-xMfV3WE10iP8MqxYd5w8JRUL5O7vO6ATN1ZEHB8MRxg=";
   };
 
   postPatch = ''
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
     rm -rf unmaintained
   '';
 
-  vendorHash = "sha256-W5fRmE89IBP5h11+Op3mkCQw9WkUgAtXduEHBdHiQVI=";
+  vendorHash = "sha256-mGiA91y6ebbbdAu0+ZDylUDuZb8vcNaqeGv70/IFx9k=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Release: https://github.com/seaweedfs/seaweedfs/releases/tag/4.19
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
