### PR TITLE
 tidal: init at 2.41.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9306,6 +9306,12 @@
     githubId = 134872;
     name = "Sergei Lukianov";
   };
+  frostplexx = {
+    email = "daniel.inama02@gmail.com";
+    github = "frostplexx";
+    githubId = 62436912;
+    name = "Daniel Inama";
+  };
   fryuni = {
     name = "Luiz Ferraz";
     email = "luiz@lferraz.com";

--- a/pkgs/by-name/ti/tidal/package.nix
+++ b/pkgs/by-name/ti/tidal/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  undmg,
+}:
+let
+  updateScript = ./update.sh;
+in
+stdenv.mkDerivation {
+  pname = "tidal";
+  version = "2.41.3";
+
+  src =
+    if stdenv.hostPlatform.isAarch64 then
+      (fetchurl {
+        url = "https://web.archive.org/web/20260314112555/https://download.tidal.com/desktop/TIDAL.arm64.dmg";
+        hash = "sha256-18RjsLHhpUSAyITfwu3efokUbezE1b3GpFiafWHW/qo=";
+      })
+    else
+      (fetchurl {
+        url = "https://web.archive.org/web/20260314112436/https://download.tidal.com/desktop/TIDAL.x64.dmg";
+        hash = "sha256-5nUU8TOSph1v1C0+/KR/F5Y7m5TitbYH/ujsiZ/n6LU=";
+      });
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru = { inherit updateScript; };
+
+  meta = {
+    description = "Play music from the Tidal streaming service";
+    homepage = "https://tidal.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "tidal";
+    maintainers = with lib.maintainers; [
+      frostplexx
+    ];
+  };
+}

--- a/pkgs/by-name/ti/tidal/update.sh
+++ b/pkgs/by-name/ti/tidal/update.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq git gnused gnugrep nix libplist undmg
+set -euo pipefail
+
+# executing this script without arguments will
+# - find the newest stable spotify version avaiable on snapcraft (https://snapcraft.io/spotify)
+# - read the current spotify version from the current nix expression
+# - update the nix expression if the versions differ
+# - try to build the updated version, exit if that fails
+# - give instructions for upstreaming
+
+# Please test the update manually before pushing. There have been errors before
+# and because the service is proprietary and a paid account is necessary to do
+# anything with spotify automatic testing is not possible.
+
+# As an optional argument you can specify the snapcraft channel to update to.
+# Default is `stable` and only stable updates should be pushed to nixpkgs. For
+# testing you may specify `candidate` or `edge`.
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+
+update_macos() {
+  nix_file="$nixpkgs/pkgs/by-name/ti/tidal/package.nix"
+
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  pushd $tmp_dir
+
+  x86_64_url="https://download.tidal.com/desktop/TIDAL.x64.dmg"
+  aarch64_url="https://download.tidal.com/desktop/TIDAL.arm64.dmg"
+
+  curl -OL "$aarch64_url"
+  undmg TIDAL.arm64.dmg
+  upstream_version=$(plistutil -i TIDAL.app/Contents/Info.plist -f json -o - | jq -r '.CFBundleShortVersionString')
+
+  popd
+
+  current_nix_version=$(
+    grep 'version\s*=' "$nix_file" |
+      sed -Ene 's/.*"(.*)".*/\1/p'
+  )
+
+  if [[ "$current_nix_version" != "$upstream_version" ]]; then
+    archive_url="https://web.archive.org/save"
+    archived_x86_64_url=$(curl -s -I -L -o /dev/null "$archive_url/$x86_64_url" -w '%{url_effective}')
+    archived_aarch64_url=$(curl -s -I -L -o /dev/null "$archive_url/$aarch64_url" -w '%{url_effective}')
+
+    aarch64_hash=$(nix-prefetch-url "$archived_aarch64_url" --type sha256 | xargs nix hash convert --hash-algo sha256 --to sri)
+    x86_64_hash=$(nix-prefetch-url "$archived_x86_64_url" --type sha256 | xargs nix hash convert --hash-algo sha256 --to sri)
+
+    sed --regexp-extended \
+      -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
+      -i "$nix_file"
+
+    # Update aarch64 (first fetchurl block) url and hash
+    sed -e '/isAarch64/,/})/{
+      s|url = ".*"|url = "'"${archived_aarch64_url}"'"|
+      s|hash = ".*"|hash = "'"${aarch64_hash}"'"|
+    }' -i "$nix_file"
+
+    # Update x86_64 (second fetchurl block) url and hash
+    sed -e '/else/,/})/{
+      s|url = ".*"|url = "'"${archived_x86_64_url}"'"|
+      s|hash = ".*"|hash = "'"${x86_64_hash}"'"|
+    }' -i "$nix_file"
+  fi
+}
+
+update_macos


### PR DESCRIPTION
This PR adds the official macOS client for the streaming platform TIDAL (https://tidal.com/) to nixpkgs. While a similar package called `tidal-hifi` already exists, that one is a community maintained web wrapper that only works on Linux while the package in my PR only works on macOS (aarch64-darwin & x86_64-darwin). I modeled the package definition and update approach after the already existing spotify package found in `pkgs/by-name/sp/spotify`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
