### PR TITLE
bio-gappa: fix build with gcc15

### DIFF
--- a/pkgs/by-name/bi/bio-gappa/fix-cstdint.patch
+++ b/pkgs/by-name/bi/bio-gappa/fix-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/libs/CLI11/include/CLI/Validators.hpp b/libs/CLI11/include/CLI/Validators.hpp
+index 536f8a6..3371905 100644
+--- a/libs/CLI11/include/CLI/Validators.hpp
++++ b/libs/CLI11/include/CLI/Validators.hpp
+@@ -18,6 +18,7 @@
+ // Could be swapped for filesystem in C++17
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <cstdint>
+ 
+ namespace CLI {
+ 

--- a/pkgs/by-name/bi/bio-gappa/package.nix
+++ b/pkgs/by-name/bi/bio-gappa/package.nix
@@ -8,6 +8,7 @@
   libz,
   bzip2,
   xz,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,8 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
     xz
   ];
 
-  # CMake 2.8.7 is deprecated and is no longer supported by CMake > 4
-  # https://github.com/NixOS/nixpkgs/issues/445447
+  patches = [
+    ./fix-cstdint.patch
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace-fail \
       "cmake_minimum_required (VERSION 2.8.7 FATAL_ERROR)" \
@@ -51,6 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 ../bin/gappa $out/bin/gappa
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = !stdenv.hostPlatform.isDarwin; # skip on Darwin - missing /libz.1.dylib in sandbox
 
   meta = {
     homepage = "https://github.com/lczech/gappa";


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/322271157

Added versionCheckHook.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
