### PR TITLE
nix-functional-tests: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
+++ b/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
@@ -62,6 +62,11 @@ mkMesonDerivation (
       nix-expr
     ];
 
+    env = lib.optionalAttrs (test-daemon != null) {
+      NIX_DAEMON_PACKAGE = test-daemon;
+      _NIX_TEST_CLIENT_VERSION = nix-cli.version;
+    };
+
     preConfigure =
       # TEMP hack for Meson before make is gone, where
       # `src/nix-functional-tests` is during the transition a symlink and
@@ -92,9 +97,5 @@ mkMesonDerivation (
       platforms = lib.platforms.unix;
     };
 
-  }
-  // lib.optionalAttrs (test-daemon != null) {
-    NIX_DAEMON_PACKAGE = test-daemon;
-    _NIX_TEST_CLIENT_VERSION = nix-cli.version;
   }
 )

--- a/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
+++ b/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
@@ -28,74 +28,71 @@
   test-daemon ? null,
 }:
 
-mkMesonDerivation (
-  finalAttrs:
-  {
-    inherit pname version;
+mkMesonDerivation (finalAttrs: {
+  inherit pname version;
 
-    workDir = ./.;
+  workDir = ./.;
 
-    nativeBuildInputs = [
-      meson
-      ninja
-      pkg-config
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
 
-      jq
-      git
-      mercurial
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      # For various sandboxing tests that needs a statically-linked shell,
-      # etc.
-      busybox-sandbox-shell
-      # For Overlay FS tests need `mount`, `umount`, and `unshare`.
-      # For `script` command (ensuring a TTY)
-      # TODO use `unixtools` to be precise over which executables instead?
-      util-linux
-    ]
-    ++ [
-      nix-cli
-    ];
+    jq
+    git
+    mercurial
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # For various sandboxing tests that needs a statically-linked shell,
+    # etc.
+    busybox-sandbox-shell
+    # For Overlay FS tests need `mount`, `umount`, and `unshare`.
+    # For `script` command (ensuring a TTY)
+    # TODO use `unixtools` to be precise over which executables instead?
+    util-linux
+  ]
+  ++ [
+    nix-cli
+  ];
 
-    buildInputs = [
-      nix-store
-      nix-expr
-    ];
+  buildInputs = [
+    nix-store
+    nix-expr
+  ];
 
-    env = lib.optionalAttrs (test-daemon != null) {
-      NIX_DAEMON_PACKAGE = test-daemon;
-      _NIX_TEST_CLIENT_VERSION = nix-cli.version;
-    };
+  env = lib.optionalAttrs (test-daemon != null) {
+    NIX_DAEMON_PACKAGE = test-daemon;
+    _NIX_TEST_CLIENT_VERSION = nix-cli.version;
+  };
 
-    preConfigure =
-      # TEMP hack for Meson before make is gone, where
-      # `src/nix-functional-tests` is during the transition a symlink and
-      # not the actual directory directory.
-      ''
-        cd $(readlink -e $PWD)
-        echo $PWD | grep tests/functional
-      '';
-
-    # `toml11` upgrade causes these to fail in 2.32+: https://github.com/NixOS/nixpkgs/pull/442682
-    # Remove when that PR lands in master.
-    ${if lib.versionAtLeast (lib.versions.majorMinor version) "2.32" then "preCheck" else null} =
-      lib.optionalString (lib.versionOlder toml11.version "4.0") ''
-        rm -f ../lang/eval-fail-fromTOML-{over,under}flow*
-      '';
-
-    mesonCheckFlags = [
-      "--print-errorlogs"
-    ];
-
-    doCheck = true;
-
-    installPhase = ''
-      mkdir $out
+  preConfigure =
+    # TEMP hack for Meson before make is gone, where
+    # `src/nix-functional-tests` is during the transition a symlink and
+    # not the actual directory directory.
+    ''
+      cd $(readlink -e $PWD)
+      echo $PWD | grep tests/functional
     '';
 
-    meta = {
-      platforms = lib.platforms.unix;
-    };
+  # `toml11` upgrade causes these to fail in 2.32+: https://github.com/NixOS/nixpkgs/pull/442682
+  # Remove when that PR lands in master.
+  ${if lib.versionAtLeast (lib.versions.majorMinor version) "2.32" then "preCheck" else null} =
+    lib.optionalString (lib.versionOlder toml11.version "4.0") ''
+      rm -f ../lang/eval-fail-fromTOML-{over,under}flow*
+    '';
 
-  }
-)
+  mesonCheckFlags = [
+    "--print-errorlogs"
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    mkdir $out
+  '';
+
+  meta = {
+    platforms = lib.platforms.unix;
+  };
+
+})


### PR DESCRIPTION
I'm seeing a test failure on `nix-functional-tests:json` with `structuredAttrsByDefault` enabled on staging without this PR - this doesn't fix it and I'm still looking into whether it's broken on staging in general, but this looks like a necessary improvement anyway.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
