### PR TITLE
tcl.tclRequiresCheckHook: make compatible with structuredAttrs

### DIFF
--- a/pkgs/development/interpreters/tcl/tcl-requires-check-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-requires-check-hook.sh
@@ -5,9 +5,28 @@ tclRequiresCheckPhase () {
     echo "Executing tclRequiresCheckPhase"
 
     if [ -n "$tclRequiresCheck" ]; then
-        echo "Check whether the following packages can be required: ${tclRequiresCheck[*]}"
         export TCLLIBPATH="$out/lib $TCLLIBPATH" # Redundant if tcl-package-hook is also used
-        tclRequiresCheck="${tclRequiresCheck[@]}" tclsh <<<'exit [catch {foreach req $env(tclRequiresCheck) {package require $req}}]'
+        tclsh <<'EOF'
+          if {[info exists env(NIX_ATTRS_JSON_FILE)]} {
+            set nix_attrs_json_file [open $env(NIX_ATTRS_JSON_FILE)]
+            set nix_attrs_json [read $nix_attrs_json_file]
+            close $nix_attrs_json_file
+            # Normally we'd use one of tcllib/tdom/rl_json/yajl-tcl to parse JSON,
+            # however we don't want to introduce a circular dependency,
+            # so we rely on the JSON capabilities of the builtin sqlite package
+            # https://wiki.tcl-lang.org/page/SQLite+extension+JSON1
+            package require sqlite3
+            sqlite3 db :memory: -readonly 1
+            set packages_to_check [db eval {
+              select value from json_each(jsonb_extract($nix_attrs_json, '$.tclRequiresCheck'))
+            }]
+            db close
+          } else {
+            set packages_to_check $env(tclRequiresCheck)
+          }
+          puts "Check whether the following packages can be required: $packages_to_check"
+          exit [catch {foreach pkg $packages_to_check {package require $pkg}}]
+EOF
     fi
 }
 

--- a/pkgs/development/interpreters/tcl/tcl-requires-check-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-requires-check-hook.sh
@@ -5,9 +5,9 @@ tclRequiresCheckPhase () {
     echo "Executing tclRequiresCheckPhase"
 
     if [ -n "$tclRequiresCheck" ]; then
-        echo "Check whether the following packages can be required: $tclRequiresCheck"
+        echo "Check whether the following packages can be required: ${tclRequiresCheck[*]}"
         export TCLLIBPATH="$out/lib $TCLLIBPATH" # Redundant if tcl-package-hook is also used
-        tclsh <<<'exit [catch {foreach req $env(tclRequiresCheck) {package require $req}}]'
+        tclRequiresCheck="${tclRequiresCheck[@]}" tclsh <<<'exit [catch {foreach req $env(tclRequiresCheck) {package require $req}}]'
     fi
 }
 


### PR DESCRIPTION
With `__structuredAttrs` enabled, arguments to `mkDerivation` are not exported as environment variables inside the bash builder by default, so in this case `tclRequiresCheck` doesn't exist when the tcl oneliner tries to read it. `tclRequiresCheck` is also an array in this case.

So, expand the array and set the environment variable explicitly for the tcl call only.

I'm not very familiar with tcl, but if it's easy to read a json file without pulling in extra dependencies it might be better to read from `$NIX_ATTRS_JSON_FILE` if it exists so we can actually use the structured attributes, but I think the contents of `tclRequiresCheck` will generally be single string module names that don't need very careful treatment in terms of argument splitting etc?

Followup to https://github.com/NixOS/nixpkgs/pull/500462 .
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
