### PR TITLE
husi: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6739,6 +6739,12 @@
     githubId = 15774340;
     name = "Thomas Depierre";
   };
+  Dichgrem = {
+    email = "brcefy@gmail.com";
+    github = "Dichgrem";
+    githubId = 128880743;
+    name = "Dichgrem";
+  };
   DictXiong = {
     email = "me@beardic.cn";
     github = "DictXiong";

--- a/pkgs/by-name/hu/husi/package.nix
+++ b/pkgs/by-name/hu/husi/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  openjdk21,
+  libGL,
+  libX11,
+  fontconfig,
+  freetype,
+  libxext,
+  libxrender,
+  libxtst,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "husi";
+  version = "1.1.1";
+
+  src = fetchurl {
+    url = "https://codeberg.org/xchacha20-poly1305/husi/releases/download/v${finalAttrs.version}/fr.husi_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-xdg1120vl2L2IuYs7zHHBZ8T2rrW9twcyOxw/bMv3Gc=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libGL
+    libX11
+    fontconfig
+    freetype
+    libxext
+    libxrender
+    libxtst
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec/husi
+    mkdir -p $out/bin
+
+    cp -r usr/lib/fr.husi/. $out/libexec/husi/
+    cp -r usr/share $out/
+
+    makeWrapper ${openjdk21}/bin/java $out/bin/husi \
+      --add-flags "-jar $out/libexec/husi/app/fr.husi.jar" \
+      --set JAVA_HOME ${openjdk21} \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libGL
+          libX11
+          fontconfig
+          freetype
+          libxext
+          libxrender
+          libxtst
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Non-professional and recreational proxy tool integration";
+    homepage = "https://codeberg.org/xchacha20-poly1305/husi";
+    license = lib.licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ Dichgrem ];
+    mainProgram = "husi";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/hu/husi/package.nix
+++ b/pkgs/by-name/hu/husi/package.nix
@@ -6,7 +6,7 @@
   makeWrapper,
   openjdk21,
   libGL,
-  libX11,
+  libx11,
   fontconfig,
   freetype,
   libxext,
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libGL
-    libX11
+    libx11
     fontconfig
     freetype
     libxext
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
           libGL
-          libX11
+          libx11
           fontconfig
           freetype
           libxext


### PR DESCRIPTION
husi is a non-professional and recreational proxy tool integration based on sing-box.
Homepage: https://codeberg.org/xchacha20-poly1305/husi

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran nixpkgs-review on this PR.
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.