### PR TITLE
commitlint: 20.5.0 -> 20.5.1; adopt

### DIFF
--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -12,18 +12,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "commitlint";
-  version = "20.5.0";
+  version = "20.5.1";
 
   src = fetchFromGitHub {
     owner = "conventional-changelog";
     repo = "commitlint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AVc3uToQ3hvpesWkhIdYfvawoIJmDW+T5pHonujaL/s=";
+    hash = "sha256-kOZym07WOcUszUxYWy10+08+wjsPQ8FdiJdyJOUXOgk=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     inherit (finalAttrs) src;
-    hash = "sha256-SOUweX/dvA67E6Vjpq3WLITbh6bevErV0wGZgWQ3U7o=";
+    hash = "sha256-oo0KWaDCQhZ7xWvKcfqi5QySb7Hq1C0CH037/8V60yU=";
   };
 
   nativeBuildInputs = [
@@ -31,6 +31,13 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     makeBinaryWrapper
   ];
+
+  postPatch = ''
+    # Patch the CLI manifest to 20.5.1 so commitlint --version reports the correct version.
+    # Keep this intentionally specific so the next update fails and can drop this patch.
+    substituteInPlace @commitlint/cli/package.json \
+      --replace-fail '"version": "20.5.0"' '"version": "20.5.1"'
+  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -105,6 +105,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://commitlint.js.org/";
     license = lib.licenses.mit;
     mainProgram = "commitlint";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })


### PR DESCRIPTION
Release: https://github.com/conventional-changelog/commitlint/releases/tag/v20.5.1
Diff: https://github.com/conventional-changelog/commitlint/compare/v20.5.0...v20.5.1

Install checks are failing due to a version mismatch between the expected value and the command output; upstream may have forgotten to bump the embedded version const.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
