### PR TITLE
avogadro2: 1.103.0 -> 2.0.0

### DIFF
--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -12,29 +12,29 @@
   mesa,
 }:
 
-let
-  avogadroI18N = fetchFromGitHub {
-    owner = "OpenChemistry";
-    repo = "avogadro-i18n";
-    tag = "1.103.0";
-    hash = "sha256-gdr0Ed0UWjQB0LQq+6RvlAb8ZNFQAjV9mrgFLePG+CM=";
-  };
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "avogadro2";
-  version = "1.103.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadroapp";
     rev = finalAttrs.version;
-    hash = "sha256-nmvK3R966Xv2Xs5wXDh/8itIZLIRqbXHFe8dffFiI+s=";
+    hash = "sha256-+/NZwLRrbrfrQqxLqgiqZk6324BGoN+qRfOq7G+UIBE=";
   };
 
-  postUnpack = ''
-    cp -r ${avogadroI18N} avogadro-i18n
-  '';
+  postUnpack =
+    let
+      avogadroI18N = fetchFromGitHub {
+        owner = "OpenChemistry";
+        repo = "avogadro-i18n";
+        tag = finalAttrs.version;
+        hash = "sha256-5eiOFJ5tbS+HFbnLbc6sjk62BvXDMQYpPsB4xFpVWXM=";
+      };
+    in
+    ''
+      cp -r ${avogadroI18N} avogadro-i18n
+    '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -23,44 +23,45 @@ let
       numpy
     ]
   );
-
-  # Pure data repositories
-  moleculesRepo = fetchFromGitHub {
-    owner = "OpenChemistry";
-    repo = "molecules";
-    tag = "1.103.0";
-    hash = "sha256-hMLf0gYYnQpjSGKcPy4tihNbmpRR7UxnXF/hyhforgI=";
-  };
-  crystalsRepo = fetchFromGitHub {
-    owner = "OpenChemistry";
-    repo = "crystals";
-    tag = "1.103.0";
-    hash = "sha256-WhzFldaOt/wJy1kk+ypOkw1OYFT3hqD7j5qGdq9g+IY=";
-  };
-  fragmentsRepo = fetchFromGitHub {
-    owner = "OpenChemistry";
-    repo = "fragments";
-    tag = "1.103.0";
-    hash = "sha256-jH8k+qPlyU3Tset63uxrDlMFLdcWh8JhJoe5sl1pJ2E=";
-  };
-
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "avogadrolibs";
-  version = "1.103.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadrolibs";
     tag = finalAttrs.version;
-    hash = "sha256-2SuSNaZnY3LXcUuGboc8ZRCCeoClENoYtWmNNahdor4=";
+    hash = "sha256-Un1TSXFucCFmHq8DoWQS7RaNgtXiD2JcXGueavugU64=";
   };
 
-  postUnpack = ''
-    cp -r ${moleculesRepo} molecules
-    cp -r ${crystalsRepo} crystals
-    cp -r ${fragmentsRepo} fragments
-  '';
+  postUnpack =
+    let
+      # Pure data repositories
+      moleculesRepo = fetchFromGitHub {
+        owner = "OpenChemistry";
+        repo = "molecules";
+        tag = finalAttrs.version;
+        hash = "sha256-hMLf0gYYnQpjSGKcPy4tihNbmpRR7UxnXF/hyhforgI=";
+      };
+      crystalsRepo = fetchFromGitHub {
+        owner = "OpenChemistry";
+        repo = "crystals";
+        tag = finalAttrs.version;
+        hash = "sha256-WhzFldaOt/wJy1kk+ypOkw1OYFT3hqD7j5qGdq9g+IY=";
+      };
+      fragmentsRepo = fetchFromGitHub {
+        owner = "OpenChemistry";
+        repo = "fragments";
+        tag = finalAttrs.version;
+        hash = "sha256-OLLcQX3a9j9rEJtBziEU4fCZB2DiDDzql2mr2KfSp70=";
+      };
+    in
+    ''
+      cp -r ${moleculesRepo} molecules
+      cp -r ${crystalsRepo} crystals
+      cp -r ${fragmentsRepo} fragments
+    '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Updates Avogadro2 and its library to the latest releases.

Changelogs:

* https://github.com/OpenChemistry/avogadrolibs/releases/tag/2.0.0
* https://github.com/OpenChemistry/avogadroapp/releases/tag/2.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
