### PR TITLE
nixos/nfc-nci: Adjust pcscd system call hardening

### DIFF
--- a/nixos/modules/hardware/nfc-nci.nix
+++ b/nixos/modules/hardware/nfc-nci.nix
@@ -185,6 +185,11 @@ in
       "nxp-pn5xx"
     ];
 
+    # libnfc-nci calls sched_setscheduler via pthread_setschedparam, which would be blocked by upstream SystemCallFilter=~@resources
+    systemd.services.pcscd.serviceConfig.SystemCallFilter = lib.mkIf cfg.enableIFD [
+      "sched_setscheduler"
+    ];
+
     services.pcscd.readerConfigs = lib.mkIf cfg.enableIFD [
       ''
         FRIENDLYNAME "NFC NCI"


### PR DESCRIPTION
This PR adds a missing system call `sched_setscheduler` to the `SystemCallFilter` hardening of the pcscd service file, if the user enables the IFD integration of the nfc-nci module. This is needed because the NFC library used by this IFD driver uses `pthread_setschedparam` . Without this fix, pcscd fails to start.

For more information, see https://github.com/StarGate01/linux_libnfc-nci/issues/3 . Essentially, upstream pcscd has added these systemd hardenings just recently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
