### PR TITLE
python3Packages.rfc3161-client: 1.0.5 -> 1.0.6

### DIFF
--- a/pkgs/development/python-modules/rfc3161-client/default.nix
+++ b/pkgs/development/python-modules/rfc3161-client/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "rfc3161-client";
-  version = "1.0.5";
+  version = "1.0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "rfc3161-client";
     tag = "v${version}";
-    hash = "sha256-EF4d9MnBhWt99vy2MOK+u0aUQ3ZEH/8mYezlWQtGvhU=";
+    hash = "sha256-8OjohrHqUgsKXRZ28Au6Un6Wlzh81XVSQosoQC2f+Fs=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/development/python-modules/rfc3161-client/default.nix
+++ b/pkgs/development/python-modules/rfc3161-client/default.nix
@@ -9,7 +9,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "rfc3161-client";
   version = "1.0.6";
   pyproject = true;
@@ -17,12 +17,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "rfc3161-client";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8OjohrHqUgsKXRZ28Au6Un6Wlzh81XVSQosoQC2f+Fs=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src pname;
+    inherit (finalAttrs) src pname;
     hash = "sha256-jQsogV+qR0jAkHz/Slg9oBO/f96osU8YcjuaX4ZJQTk=";
   };
 
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
-    changelog = "https://github.com/trailofbits/rfc3161-client/releases/tag/v${version}";
+    changelog = "https://github.com/trailofbits/rfc3161-client/releases/tag/${finalAttrs.src.tag}";
     description = "Opinionated Python RFC3161 Client";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/trailofbits/rfc3161-client/compare/v1.0.5...v1.0.6

Changelog: https://github.com/trailofbits/rfc3161-client/releases/tag/v1.0.6

https://github.com/trailofbits/rfc3161-client/security/advisories/GHSA-3xxc-pwj6-jgrj


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
