### PR TITLE
nginxModules.vod: 1.33 -> 1.7.0; switch to fork

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -640,6 +640,7 @@ in
           listen 127.0.0.1:5000;
 
           # vod settings
+          vod_hls_version 6;
           vod_base_url "";
           vod_segments_base_url "";
           vod_mode mapped;

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -998,34 +998,34 @@ let
       };
     };
 
-    vod = {
+    vod = rec {
       name = "vod";
+      version = "1.7.0";
+
       src = applyPatches {
         name = "vod";
         src = fetchFromGitHub {
-          owner = "kaltura";
+          owner = "dio-az";
           repo = "nginx-vod-module";
-          tag = "1.33";
-          hash = "sha256-hf4iprkdNP7lVlrm/7kMkrp/8440PuTZiL1hv/Icfm4=";
+          tag = "v${version}";
+          hash = "sha256-IcXbbmAs16F9qOEJWgH6XqP5sBMYszclGByVghj0eBM=";
         };
+
         postPatch = ''
           substituteInPlace vod/media_set.h \
             --replace-fail "MAX_CLIPS (128)" "MAX_CLIPS (1024)"
-          substituteInPlace vod/subtitle/dfxp_format.c \
-            --replace-fail '(!ctxt->wellFormed && !ctxt->recovery))' '!ctxt->wellFormed)'
-          # https://github.com/kaltura/nginx-vod-module/pull/1593
-          substituteInPlace ngx_http_vod_module.c \
-            --replace-fail 'ngx_http_vod_exit_process()' 'ngx_http_vod_exit_process(ngx_cycle_t *cycle)'
         '';
       };
 
       inputs = [
-        ffmpeg_6-headless
+        ffmpeg-headless
         fdk_aac
         openssl
         libxml2
         libiconv
       ];
+
+      passthru.tests = nixosTests.frigate;
 
       meta = {
         description = "VOD packager";


### PR DESCRIPTION
The kaltura upstream has not merged any PRs since 2024-05. In the
meantime a well-maintained upstream has picked up open PRs and made 12
releases since 2025-06.

For Frigate we now need to set  `vod_hls_version = 6`, since it uses `fMP4`.

> For maximum compatibility, set the version to the lowest value that allows the required features for playback. While this is not strictly spec-compliant, most clients are lenient and will ignore unknown or unsupported tags. However, advanced features (such as fMP4) may not be recognized or used by clients unless the version is set to the minimum required for those features.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
