### PR TITLE
surf: fix build and force use of X11

### DIFF
--- a/pkgs/by-name/su/surf/package.nix
+++ b/pkgs/by-name/su/surf/package.nix
@@ -8,9 +8,8 @@
   gcr,
   glib-networking,
   gsettings-desktop-schemas,
-  gtk2,
-  libsoup_2_4,
-  # webkitgtk_4_0,
+  gtk3,
+  libsoup_3,
   webkitgtk_4_1,
   xprop,
   dmenu,
@@ -20,16 +19,15 @@
   gst_all_1,
   patches ? null,
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "surf";
-  version = "2.1";
+  version = "2.1-unstable-2025-04-19";
 
   # tarball is missing file common.h
   src = fetchgit {
     url = "git://git.suckless.org/surf";
-    rev = version;
-    sha256 = "1v926hiayddylq79n8l7dy51bm0dsa9n18nx9bkhg666cx973x4z";
+    rev = "48517e586cdc98bc1af7115674b554cc70c8bc2e";
+    hash = "sha256-+qg1mF5X/hYxCy7N3CxIEM2yHi1jmUGiK/vaQBjKy1I=";
   };
 
   nativeBuildInputs = [
@@ -41,9 +39,9 @@ stdenv.mkDerivation rec {
     gcr
     glib-networking
     gsettings-desktop-schemas
-    gtk2
-    libsoup_2_4
-    # webkitgtk_4_0
+    libsoup_3
+    gtk3
+    webkitgtk_4_1
   ]
   ++ (with gst_all_1; [
     # Audio & video support for webkitgtk WebView
@@ -72,13 +70,11 @@ stdenv.mkDerivation rec {
     ''
       gappsWrapperArgs+=(
         --suffix PATH : ${depsPath}
+        --set GDK_BACKEND x11
       )
     '';
 
   meta = {
-    # webkitgtk_4_0 was removed. master is supposed to support 4.1
-    # but it crashes with BadWindow X Error
-    broken = true;
     description = "Simple web browser based on WebKitGTK";
     mainProgram = "surf";
     longDescription = ''


### PR DESCRIPTION
The latest version of surf from upstream git has support for webkitgtk-4.1, but it will crash on startup if allowed to run as a Wayland application (which any gtk3 app will happily do).  So, I forced GDK_BACKEND=x11 in the wrapper as an interim solution until surf fully supports Wayland.

This is more or less the [same approach that Debian is taking](https://packages.debian.org/trixie/surf), except they are patching the source to force the X11 backend.

This fixes #508340.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
