### PR TITLE
various: migrate from rev to tag

### DIFF
--- a/pkgs/by-name/_3/_3proxy/package.nix
+++ b/pkgs/by-name/_3/_3proxy/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "3proxy";
     repo = "3proxy";
     tag = finalAttrs.version;
-    sha256 = "sha256-0rCXz/vKFF5rvBXyvtt9DH0Jz+1i7rIylh07FqKBrZM=";
+    hash = "sha256-0rCXz/vKFF5rvBXyvtt9DH0Jz+1i7rIylh07FqKBrZM=";
   };
 
   # They use 'install -s', that calls the native strip instead of the cross.

--- a/pkgs/by-name/_6/_6tunnel/package.nix
+++ b/pkgs/by-name/_6/_6tunnel/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "wojtekka";
     repo = "6tunnel";
     tag = finalAttrs.version;
-    sha256 = "sha256-ftTAFjHlXRrXH6co8bX0RY092lAmv15svZn4BKGVuq0=";
+    hash = "sha256-ftTAFjHlXRrXH6co8bX0RY092lAmv15svZn4BKGVuq0=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/by-name/_9/_9pfs/package.nix
+++ b/pkgs/by-name/_9/_9pfs/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ftrvxmtrx";
     repo = "9pfs";
     tag = finalAttrs.version;
-    sha256 = "sha256-NT8oIQK8Os3HRZLOH2OvauiCvh5bXZFbeEtTFbzNvrs=";
+    hash = "sha256-NT8oIQK8Os3HRZLOH2OvauiCvh5bXZFbeEtTFbzNvrs=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ab/abi-compliance-checker/package.nix
+++ b/pkgs/by-name/ab/abi-compliance-checker/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "lvc";
     repo = "abi-compliance-checker";
     tag = finalAttrs.version;
-    sha256 = "1f1f9j2nf9j83sfl2ljadch99v6ha8rq8xm7ax5akc05hjpyckij";
+    hash = "sha256-Mk7mr4QFsKlKV6d2hDNS0OyUIGtKUkGdHkgmZ4VMLrg=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ab/abi-dumper/package.nix
+++ b/pkgs/by-name/ab/abi-dumper/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "lvc";
     repo = "abi-dumper";
     tag = finalAttrs.version;
-    sha256 = "sha256-BefDMeKHx4MNU6SyX5UpQnwdI+zqap7zunsgdWG/2xc=";
+    hash = "sha256-BefDMeKHx4MNU6SyX5UpQnwdI+zqap7zunsgdWG/2xc=";
   };
 
   patchPhase = ''

--- a/pkgs/by-name/ad/adapta-backgrounds/package.nix
+++ b/pkgs/by-name/ad/adapta-backgrounds/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "adapta-project";
     repo = "adapta-backgrounds";
     tag = finalAttrs.version;
-    sha256 = "04hmbmzf97rsii8gpwy3wkljy5xhxmlsl34d63s6hfy05knclydj";
+    hash = "sha256-snnK7CzAO2j0MI0MqmntsBcv6eTD8/tQjDqf5H5dFRI=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/ad/adapta-gtk-theme/package.nix
+++ b/pkgs/by-name/ad/adapta-gtk-theme/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "adapta-project";
     repo = "adapta-gtk-theme";
     tag = finalAttrs.version;
-    sha256 = "19skrhp10xx07hbd0lr3d619vj2im35d8p9rmb4v4zacci804q04";
+    hash = "sha256-BGACUGRMfbLJqjld1MqoUcidgmkjU9AWPKB3EC7MU6c=";
   };
 
   preferLocalBuild = true;

--- a/pkgs/by-name/ai/aircrack-ng/package.nix
+++ b/pkgs/by-name/ai/aircrack-ng/package.nix
@@ -140,6 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
         freebsd
         illumos
       ];
-    changelog = "https://github.com/aircrack-ng/aircrack-ng/blob/${finalAttrs.src.rev}/ChangeLog";
+    changelog = "https://github.com/aircrack-ng/aircrack-ng/blob/${finalAttrs.src.tag}/ChangeLog";
   };
 })

--- a/pkgs/by-name/an/anki/package.nix
+++ b/pkgs/by-name/an/anki/package.nix
@@ -103,7 +103,7 @@ let
   src = fetchFromGitHub {
     owner = "ankitects";
     repo = "anki";
-    rev = version;
+    tag = version;
     hash = srcHash;
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ar/archisteamfarm/package.nix
+++ b/pkgs/by-name/ar/archisteamfarm/package.nix
@@ -26,7 +26,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "JustArchiNET";
     repo = "ArchiSteamFarm";
-    rev = version;
+    tag = version;
     hash = "sha256-h9wvMT7BIzIMSnHoinBiZLYbWYPELT3dO+ao+gwTfbw=";
   };
 

--- a/pkgs/by-name/bl/blis/package.nix
+++ b/pkgs/by-name/bl/blis/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "flame";
     repo = "blis";
     tag = finalAttrs.version;
-    sha256 = "sha256-+n8SbiiEJDN4j1IPmZfI5g1i2J+jWrUXh7S48JEDTAE=";
+    hash = "sha256-+n8SbiiEJDN4j1IPmZfI5g1i2J+jWrUXh7S48JEDTAE=";
   };
 
   inherit blas64;

--- a/pkgs/by-name/cf/cfs-zen-tweaks/package.nix
+++ b/pkgs/by-name/cf/cfs-zen-tweaks/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "igo95862";
     repo = "cfs-zen-tweaks";
-    rev = version;
+    tag = version;
     hash = "sha256-E3sNWWXm0NEqLCzFccd/nfYby+/b/MVjIHeGlDxV1W4=";
   };
 

--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -18,7 +18,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "CleverCloud";
     repo = "clever-tools";
-    rev = version;
+    tag = version;
     hash = "sha256-EgGjlZ6Awg7SEC3ljPqii3wpq2SlXN/gARUJBSFcX0k=";
   };
 

--- a/pkgs/by-name/cl/clipster/package.nix
+++ b/pkgs/by-name/cl/clipster/package.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mrichar1";
     repo = "clipster";
-    rev = version;
-    sha256 = "sha256-MLLkFsBBQtb7RFQN+uoEmuCn5bnbkYsqoyWGZtTCI2U=";
+    tag = version;
+    hash = "sha256-MLLkFsBBQtb7RFQN+uoEmuCn5bnbkYsqoyWGZtTCI2U=";
   };
 
   pythonEnv = python3.withPackages (ps: with ps; [ pygobject3 ]);

--- a/pkgs/by-name/cl/cloudlog/package.nix
+++ b/pkgs/by-name/cl/cloudlog/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "magicbug";
     repo = "Cloudlog";
-    rev = version;
+    tag = version;
     hash = "sha256-9NC9hon+okj4jmOY0TMoDUPELDObJiermqSfgmf0gyY=";
   };
 

--- a/pkgs/by-name/cr/crawl/package.nix
+++ b/pkgs/by-name/cr/crawl/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "crawl";
     repo = "crawl";
-    rev = version;
+    tag = version;
     hash = "sha256-exntfZbGEDBwFA8AHhOoBPIXw/MDrHx5oxrxPDixpCc=";
   };
 

--- a/pkgs/by-name/cr/cryfs/package.nix
+++ b/pkgs/by-name/cr/cryfs/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cryfs";
     repo = "cryfs";
-    rev = version;
+    tag = version;
     hash = "sha256-bBe//AjA9QmdSDlb0xiOboE5F4g6LJ03cHQZpfOk+Y4=";
   };
 

--- a/pkgs/by-name/cu/cups-filters/package.nix
+++ b/pkgs/by-name/cu/cups-filters/package.nix
@@ -59,7 +59,7 @@
       src = fetchFromGitHub {
         owner = "OpenPrinting";
         repo = "cups-filters";
-        rev = version;
+        tag = version;
         hash = "sha256-bLOl64bdeZ10JLcQ7GbU+VffJu3Lzo0ves7O7GQIOWY=";
       };
 

--- a/pkgs/by-name/db/db-rest/package.nix
+++ b/pkgs/by-name/db/db-rest/package.nix
@@ -15,7 +15,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "derhuerst";
     repo = "db-rest";
-    rev = version;
+    tag = version;
     hash = "sha256-1iJ26l6C6GevNkoDVMztPHiH3YsutJa3xWAsfYvgR9U=";
   };
 

--- a/pkgs/by-name/de/denaro/package.nix
+++ b/pkgs/by-name/de/denaro/package.nix
@@ -20,7 +20,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "NickvisionApps";
     repo = "Denaro";
-    rev = version;
+    tag = version;
     hash = "sha256-fEhwup8SiYvKH2FtzruEFsj8axG5g3YJ917aqc8dn/8=";
   };
 

--- a/pkgs/by-name/de/dependency-track/package.nix
+++ b/pkgs/by-name/de/dependency-track/package.nix
@@ -25,7 +25,7 @@ let
     src = fetchFromGitHub {
       owner = "DependencyTrack";
       repo = "frontend";
-      rev = version;
+      tag = version;
       hash = "sha256-xjIRkffmXYMAfZ8wJehnPRfTThJjTgNL8ONl9N9ZJ+M=";
     };
 
@@ -50,7 +50,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "DependencyTrack";
     repo = "dependency-track";
-    rev = version;
+    tag = version;
     hash = "sha256-pIZM8FQ0IFqRbTQT5VIlCmS+fCCXULJJ6bdEv6xfjbc=";
   };
 

--- a/pkgs/by-name/di/diopser/package.nix
+++ b/pkgs/by-name/di/diopser/package.nix
@@ -23,7 +23,7 @@ let
     src = fetchFromGitHub {
       owner = "Naios";
       repo = "function2";
-      rev = version;
+      tag = version;
       hash = "sha256-JceZU8ZvtYhFheh8BjMvjjZty4hcYxHEK+IIo5X4eSk=";
     };
   };

--- a/pkgs/by-name/di/discordchatexporter-cli/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-cli/package.nix
@@ -14,7 +14,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
-    rev = version;
+    tag = version;
     hash = "sha256-r9bvTgqKQY605BoUlysSz4WJMxn2ibNh3EhoMYCfV3c=";
   };
 

--- a/pkgs/by-name/di/discordchatexporter-desktop/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-desktop/package.nix
@@ -14,7 +14,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
-    rev = version;
+    tag = version;
     hash = "sha256-Dc6OSWUTFftP2tyRFoxHm+TsnSMDfx627DhmYnPie9w=";
   };
 

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -22,7 +22,7 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "darrenldl";
     repo = "docfd";
-    rev = version;
+    tag = version;
     hash = "sha256-d7c72jXadwBtUqarfdGnEDo9yFwCAeEX0GGVqCe70Ak=";
   };
 

--- a/pkgs/by-name/ea/easyrpg-player/package.nix
+++ b/pkgs/by-name/ea/easyrpg-player/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "EasyRPG";
     repo = "Player";
-    rev = version;
+    tag = version;
     hash = "sha256-fYSpFhqETkQhRK1/Uws0fWWdCr35+1J4vCPX9ZiQ3ZA=";
   };
 

--- a/pkgs/by-name/em/emmet-ls/package.nix
+++ b/pkgs/by-name/em/emmet-ls/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "aca";
     repo = "emmet-ls";
-    rev = version;
+    tag = version;
     hash = "sha256-TmsJpVLF9FZf/6uOM9LZBKC6S3bMPjA3QMiRMPaY9Dg=";
   };
 

--- a/pkgs/by-name/fi/finamp/package.nix
+++ b/pkgs/by-name/fi/finamp/package.nix
@@ -23,7 +23,7 @@ flutter341.buildFlutterApplication {
   src = fetchFromGitHub {
     owner = "UnicornsOnLSD";
     repo = "finamp";
-    rev = version;
+    tag = version;
     hash = "sha256-N1+6rB16geFMYMbfiF7eppnXfXC/pqv90I9aY/57lKI=";
   };
 

--- a/pkgs/by-name/fi/firmware-manager/package.nix
+++ b/pkgs/by-name/fi/firmware-manager/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "firmware-manager";
-    rev = version;
+    tag = version;
     hash = "sha256-Q+LJJ4xK583fAcwuOFykt6GKT0rVJgmTt+zUX4o4Tm4=";
   };
 

--- a/pkgs/by-name/fl/flat-remix-gnome/package.nix
+++ b/pkgs/by-name/fl/flat-remix-gnome/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "daniruiz";
     repo = "flat-remix-gnome";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-6K/BQqVOeDeJuUi0+NgCFeerX5sSy+nKapYxIQfbKFQ=";
   };
 

--- a/pkgs/by-name/fl/flat-remix-gtk/package.nix
+++ b/pkgs/by-name/fl/flat-remix-gtk/package.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "daniruiz";
     repo = "flat-remix-gtk";
-    rev = finalAttrs.version;
-    sha256 = "sha256-EWe84bLG14RkCNbHp0S5FbUQ5/Ye/KbCk3gPTsGg9oQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-EWe84bLG14RkCNbHp0S5FbUQ5/Ye/KbCk3gPTsGg9oQ=";
   };
 
   dontBuild = true;

--- a/pkgs/by-name/fr/fragments/package.nix
+++ b/pkgs/by-name/fr/fragments/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Fragments";
-    rev = version;
+    tag = version;
     hash = "sha256-lTOO6ZQWImaFqYZ3qerYYHWj/eOLYU/2k2Wh/ju9Njw=";
   };
 

--- a/pkgs/by-name/gd/gdtoolkit_4/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_4/package.nix
@@ -16,7 +16,7 @@ let
         src = fetchFromGitHub {
           owner = "lark-parser";
           repo = "lark";
-          rev = version;
+          tag = version;
           hash = "sha256-Dc7wbMBY8CSeP4JE3hBk5m1lwzmCnNTkVoLdIukRw1Q=";
           fetchSubmodules = true;
         };

--- a/pkgs/by-name/gi/gitlab-ci-local/package.nix
+++ b/pkgs/by-name/gi/gitlab-ci-local/package.nix
@@ -18,7 +18,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "firecow";
     repo = "gitlab-ci-local";
-    rev = version;
+    tag = version;
     hash = "sha256-scZ6KqpO/E3Ycu6Nn5o/4LaEpSAOWim8mOqpByjZlZE=";
   };
 

--- a/pkgs/by-name/gi/gitprompt-rs/package.nix
+++ b/pkgs/by-name/gi/gitprompt-rs/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "9ary";
     repo = "gitprompt-rs";
-    rev = version;
+    tag = version;
     hash = "sha256-U0ylhgD86lbXvt6jMLaEQdL/zbcbXnfrA72FMEzBkN0=";
   };
 

--- a/pkgs/by-name/gl/glfw3/package.nix
+++ b/pkgs/by-name/gl/glfw3/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "glfw";
     repo = "GLFW";
-    rev = version;
+    tag = version;
     hash = "sha256-FcnQPDeNHgov1Z07gjFze0VMz2diOrpbKZCsI96ngz0=";
   };
 

--- a/pkgs/by-name/gl/glide-media-player/package.nix
+++ b/pkgs/by-name/gl/glide-media-player/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "philn";
     repo = "glide";
-    rev = version;
+    tag = version;
     hash = "sha256-gmBXUj6LxC7VDH/ni8neYivysagqcbI/UCUq9Ly3D24=";
   };
 

--- a/pkgs/by-name/gm/gmetronome/package.nix
+++ b/pkgs/by-name/gm/gmetronome/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     domain = "gitlab.gnome.org";
     owner = "dqpb";
     repo = "gmetronome";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-/UWOvVeZILDR29VjBK+mFJt1hzWcOljOr7J7+cMrKtM=";
   };
 

--- a/pkgs/by-name/gm/gmid/package.nix
+++ b/pkgs/by-name/gm/gmid/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "omar-polo";
     repo = "gmid";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-JyiGkVF9aRJXgWAwZEnGgaD+IiH3UzamfTAcWyN0now=";
   };
 

--- a/pkgs/by-name/gn/gnome-pomodoro/package.nix
+++ b/pkgs/by-name/gn/gnome-pomodoro/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "gnome-pomodoro";
     repo = "gnome-pomodoro";
-    rev = version;
+    tag = version;
     hash = "sha256-1G0Sv6uR4rE+/TZqEM57mCdBaXoJNpC0cznY4pnPEa4=";
   };
 

--- a/pkgs/by-name/gp/gpx-viewer/package.nix
+++ b/pkgs/by-name/gp/gpx-viewer/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DaveDavenport";
     repo = "gpx-viewer";
-    rev = version;
+    tag = version;
     hash = "sha256-6AChX0UEIrQExaq3oo9Be5Sr13+POHFph7pZegqcjio=";
   };
 

--- a/pkgs/by-name/gr/gradescope-submit/package.nix
+++ b/pkgs/by-name/gr/gradescope-submit/package.nix
@@ -11,7 +11,7 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "nmittu";
     repo = "gradescope-submit";
-    rev = version;
+    tag = version;
     hash = "sha256-BVNXipgw0wz3PRGYvur8jrXZw/6i0fZ+MOZHzXzlFOk=";
   };
 

--- a/pkgs/by-name/gr/graphite-gtk-theme/package.nix
+++ b/pkgs/by-name/gr/graphite-gtk-theme/package.nix
@@ -66,7 +66,7 @@ lib.checkListOfEnum "${pname}: theme variants"
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = "graphite-gtk-theme";
-      rev = version;
+      tag = version;
       hash = "sha256-TOIpQTYg+1DX/Tq5BMygxbUC0NpzPWBGDtOnnT55c1w=";
     };
 

--- a/pkgs/by-name/gt/gtk-doc/package.nix
+++ b/pkgs/by-name/gt/gtk-doc/package.nix
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "gtk-doc";
-    rev = version;
+    tag = version;
     hash = "sha256-EqU7lnBnOn3gR3hT95yjdTUb3cqX2XJK5UAKsFw2Q10=";
   };
 

--- a/pkgs/by-name/ha/hackneyed/package.nix
+++ b/pkgs/by-name/ha/hackneyed/package.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "Enthymeme";
     repo = "hackneyed-x11-cursors";
-    rev = version;
+    tag = version;
     hash = "sha256-gq+qBYm15satH/XXK1QYDVu2L2DvZ+2aYg/wDqncwmA=";
   };
 

--- a/pkgs/by-name/he/headlines/package.nix
+++ b/pkgs/by-name/he/headlines/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "caveman250";
     repo = "Headlines";
-    rev = version;
+    tag = version;
     hash = "sha256-wamow0UozX5ecKbXWOgsWCerInL4J0gK0+Muf+eoO9k=";
   };
 

--- a/pkgs/by-name/he/health/package.nix
+++ b/pkgs/by-name/he/health/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "health";
-    rev = version;
+    tag = version;
     hash = "sha256-PrNPprSS98yN8b8yw2G6hzTSaoE65VbsM3q7FVB4mds=";
   };
 

--- a/pkgs/by-name/hi/hid-tools/package.nix
+++ b/pkgs/by-name/hi/hid-tools/package.nix
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonPackage rec {
     domain = "gitlab.freedesktop.org";
     owner = "libevdev";
     repo = "hid-tools";
-    rev = version;
+    tag = version;
     hash = "sha256-h880jJcZDc9pIPf+nr30wu2i9y3saAKFZpooJ4MF67E=";
   };
 

--- a/pkgs/by-name/ho/hostapd-mana/package.nix
+++ b/pkgs/by-name/ho/hostapd-mana/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sensepost";
     repo = "hostapd-mana";
-    rev = version;
+    tag = version;
     hash = "sha256-co5LMJAUYSdcvhLv1gfjDvdVqdSXgjtFoiQ7+KxR07M=";
   };
 

--- a/pkgs/by-name/ii/iio-sensor-proxy/package.nix
+++ b/pkgs/by-name/ii/iio-sensor-proxy/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "hadess";
     repo = "iio-sensor-proxy";
-    rev = version;
+    tag = version;
     hash = "sha256-2N/4Fp6QtAhgEzX9cHEDJhFtRsyrtZ80I2jdHdeEmxA=";
   };
 

--- a/pkgs/by-name/ir/ir-standard-fonts/package.nix
+++ b/pkgs/by-name/ir/ir-standard-fonts/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "molaeiali";
     repo = "ir-standard-fonts";
-    rev = version;
+    tag = version;
     hash = "sha256-o1d8SBX3nf7g6Gh4OP+JRS+LNrHTQOIiHhW3VNCkDV0=";
   };
 

--- a/pkgs/by-name/jh/jhead/package.nix
+++ b/pkgs/by-name/jh/jhead/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Matthias-Wandel";
     repo = "jhead";
-    rev = version;
+    tag = version;
     hash = "sha256-d1cuy4kkwY/21UcpNN6judrFxGVyEH+b+0TaZw9hP2E=";
   };
 

--- a/pkgs/by-name/ji/jinja2-cli/package.nix
+++ b/pkgs/by-name/ji/jinja2-cli/package.nix
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mattrobenolt";
     repo = "jinja2-cli";
-    rev = version;
+    tag = version;
     hash = "sha256-67gYt0nZX+VTVaoSxVXGzbRiXD7EMsVBFWC8wHo+Vw0=";
   };
 

--- a/pkgs/by-name/jo/joularjx/package.nix
+++ b/pkgs/by-name/jo/joularjx/package.nix
@@ -13,7 +13,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "joular";
     repo = "joularjx";
-    rev = version;
+    tag = version;
     hash = "sha256-hr8a3Qr1LdFfGBLVJVkm6hhCW7knG4VpXj7nCtcptuU=";
   };
 

--- a/pkgs/by-name/ka/kata-runtime/package.nix
+++ b/pkgs/by-name/ka/kata-runtime/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "kata-containers";
     repo = "kata-containers";
-    rev = version;
+    tag = version;
     hash = "sha256-AjGqKJVrcfHLY0NosBWFOgKC3eiU9hsFXQsU+LM8XME=";
   };
 

--- a/pkgs/by-name/ki/kiwix/package.nix
+++ b/pkgs/by-name/ki/kiwix/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "kiwix";
     repo = "kiwix-desktop";
-    rev = version;
+    tag = version;
     hash = "sha256-oF2bXmb6oBXNUj91WtuDTWGrwB5JCuzBtuhfDBHIIKA=";
   };
 

--- a/pkgs/by-name/ko/koruri/package.nix
+++ b/pkgs/by-name/ko/koruri/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Koruri";
     repo = "Koruri";
-    rev = version;
+    tag = version;
     hash = "sha256-zL9UtT15mWvsXgGJqbTs6cOsQaoh/0AIAyQ5z7JpTXk=";
   };
 

--- a/pkgs/by-name/la/lavanda-gtk-theme/package.nix
+++ b/pkgs/by-name/la/lavanda-gtk-theme/package.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "Lavanda-gtk-theme";
-    rev = version;
+    tag = version;
     hash = "sha256-2ryhdgLHSNXdV9QesdB0rpXkr3i2vVqXWDDC5fNuL1c=";
   };
 

--- a/pkgs/by-name/li/libcpr/package.nix
+++ b/pkgs/by-name/li/libcpr/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "libcpr";
     repo = "cpr";
-    rev = version;
+    tag = version;
     hash = "sha256-kwbkdAeTpkEJbzvqpUQx007ZIBtwqOPG8n41TvFxeiM=";
   };
 

--- a/pkgs/by-name/li/libcpr_1_10_5/package.nix
+++ b/pkgs/by-name/li/libcpr_1_10_5/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "libcpr";
     repo = "cpr";
-    rev = version;
+    tag = version;
     hash = "sha256-mAuU2uF8d+aHvCmotgIrBi/pUp1jkP6G0f98M76zjOw=";
   };
 

--- a/pkgs/by-name/li/libhwy/package.nix
+++ b/pkgs/by-name/li/libhwy/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "highway";
-    rev = version;
+    tag = version;
     hash = "sha256-8QOk96Y3GIIvBUGIDikMgTylx8y5aCyr68/TP5w5ha4=";
   };
 

--- a/pkgs/by-name/li/libspatialaudio/package.nix
+++ b/pkgs/by-name/li/libspatialaudio/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "videolabs";
     repo = "libspatialaudio";
-    rev = version;
+    tag = version;
     hash = "sha256-sPnQPD41AceXM4uGqWXMYhuQv0TUkA6TZP8ChxUFIoI=";
   };
 

--- a/pkgs/by-name/li/libxc/package.nix
+++ b/pkgs/by-name/li/libxc/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "libxc";
     repo = "libxc";
-    rev = version;
+    tag = version;
     hash = versionHashes."${version}";
   };
 

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lsof-org";
     repo = "lsof";
-    rev = version;
+    tag = version;
     hash = "sha256-M/2xcii8ibGAI/6f34AE7aEb9fmn+iSWqWqnyDhg4CI=";
   };
 

--- a/pkgs/by-name/lv/lv_font_conv/package.nix
+++ b/pkgs/by-name/lv/lv_font_conv/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "lvgl";
     repo = "lv_font_conv";
-    rev = version;
+    tag = version;
     hash = "sha256-tm6xPOW0pOO02M10O1H7ww+yXWq/DJtbDmlfrJ6Lp4Y=";
   };
 

--- a/pkgs/by-name/ma/mailsy/package.nix
+++ b/pkgs/by-name/ma/mailsy/package.nix
@@ -10,7 +10,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "BalliAsghar";
     repo = "Mailsy";
-    rev = version;
+    tag = version;
     hash = "sha256-RnOWvu023SOcN83xEEkYFwgDasOmkMwSzJ/QYjvTBDo=";
   };
 

--- a/pkgs/by-name/ma/marked-man/package.nix
+++ b/pkgs/by-name/ma/marked-man/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "kapouer";
     repo = "marked-man";
-    rev = version;
+    tag = version;
     hash = "sha256-RzPKahYxBdWZi1SwIv7Ju1cAQ4s0ANkCivFJItPYGCY=";
   };
 

--- a/pkgs/by-name/ma/marwaita/package.nix
+++ b/pkgs/by-name/ma/marwaita/package.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "darkomarko42";
     repo = "marwaita";
-    rev = version;
+    tag = version;
     hash = "sha256-NFXvaKASWltskCSOidXDNVZpFpdpCTnuWjpfETxiI8U=";
   };
 

--- a/pkgs/by-name/ma/mathjax-node-cli/package.nix
+++ b/pkgs/by-name/ma/mathjax-node-cli/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "mathjax";
     repo = "mathjax-node-cli";
-    rev = version;
+    tag = version;
     hash = "sha256-jFSn/Ftm1iNOAmMadHYfy2jm0H/+hP2XCyyNbJqfhkY=";
   };
 

--- a/pkgs/by-name/md/mdzk/package.nix
+++ b/pkgs/by-name/md/mdzk/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "mdzk-rs";
     repo = "mdzk";
-    rev = version;
+    tag = version;
     hash = "sha256-V//tVcIzhCh03VjwMC+R2ynaOFm+dp6qxa0oqBfvGUs=";
   };
 

--- a/pkgs/by-name/me/mermaid-cli/package.nix
+++ b/pkgs/by-name/me/mermaid-cli/package.nix
@@ -16,7 +16,7 @@ buildNpmPackage {
   src = fetchFromGitHub {
     owner = "mermaid-js";
     repo = "mermaid-cli";
-    rev = version;
+    tag = version;
     hash = "sha256-OpYq0nOYCGTorzDxybsEjJmhL646wMBbQw3eHVxTuqU=";
   };
 

--- a/pkgs/by-name/mi/mint-themes/package.nix
+++ b/pkgs/by-name/mi/mint-themes/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-themes";
-    rev = version;
+    tag = version;
     hash = "sha256-pO2qotVR48VTKIS1IDqb9GwKTo/l1BV1Hk0w4Pf5V+U=";
   };
 

--- a/pkgs/by-name/mi/mint-x-icons/package.nix
+++ b/pkgs/by-name/mi/mint-x-icons/package.nix
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-x-icons";
-    rev = version;
+    tag = version;
     hash = "sha256-UNta7sj5xzZglYJekhxa0N/2RJU4cyqjX2fCFdWqoiY=";
   };
 

--- a/pkgs/by-name/mi/mint-y-icons/package.nix
+++ b/pkgs/by-name/mi/mint-y-icons/package.nix
@@ -15,7 +15,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "mint-y-icons";
-    rev = version;
+    tag = version;
     hash = "sha256-YciWUzvu+2krbSGz5mqpCVRE22T8/gl4Ln4rILB5Tq8=";
   };
 

--- a/pkgs/by-name/mo/modemmanager/package.nix
+++ b/pkgs/by-name/mo/modemmanager/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.freedesktop.org";
     owner = "mobile-broadband";
     repo = "ModemManager";
-    rev = version;
+    tag = version;
     hash = "sha256-rBLOqpx7Y2BB6/xvhIw+rDEXsLtePhHLBvfpSuJzQik=";
   };
 

--- a/pkgs/by-name/mo/mojave-gtk-theme/package.nix
+++ b/pkgs/by-name/mo/mojave-gtk-theme/package.nix
@@ -28,7 +28,7 @@ let
   main_src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "mojave-gtk-theme";
-    rev = version;
+    tag = version;
     hash = "sha256-uL4lO6aWiDfOQkhpTnr/iVx1fI7n/fx7WYr5jDWPfYM=";
   };
 

--- a/pkgs/by-name/mu/muscle/package.nix
+++ b/pkgs/by-name/mu/muscle/package.nix
@@ -11,7 +11,7 @@ gccStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rcedgar";
     repo = "muscle";
-    rev = version;
+    tag = version;
     hash = "sha256-NpnJziZXga/T5OavUt3nQ5np8kJ9CFcSmwyg4m6IJsk=";
   };
 

--- a/pkgs/by-name/ne/netcoredbg/package.nix
+++ b/pkgs/by-name/ne/netcoredbg/package.nix
@@ -31,7 +31,7 @@ let
   src = fetchFromGitHub {
     owner = "Samsung";
     repo = "netcoredbg";
-    rev = version;
+    tag = version;
     name = pname;
     inherit hash;
   };

--- a/pkgs/by-name/ne/networkmanager-l2tp/package.nix
+++ b/pkgs/by-name/ne/networkmanager-l2tp/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nm-l2tp";
     repo = "network-manager-l2tp";
-    rev = version;
+    tag = version;
     hash = "sha256-5EIG/5fexhrcOOQE+31+TJKMtINGVL+EI32m9tEhYVo=";
   };
 

--- a/pkgs/by-name/nh/nhentai/package.nix
+++ b/pkgs/by-name/nh/nhentai/package.nix
@@ -32,7 +32,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "RicterZ";
     repo = "nhentai";
-    rev = version;
+    tag = version;
     hash = "sha256-KwcaCeeGeR6qSfraSYyf4VEims9YWB6j3HmpT8XSePo=";
   };
 

--- a/pkgs/by-name/ni/nix-direnv/package.nix
+++ b/pkgs/by-name/ni/nix-direnv/package.nix
@@ -14,7 +14,7 @@ resholve.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-direnv";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-3qT5mSqHi+0cskdoOGPVbuSzkoWtwOHBVXUOL84dAM8=";
   };
 

--- a/pkgs/by-name/nu/numworks-epsilon/package.nix
+++ b/pkgs/by-name/nu/numworks-epsilon/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "numworks";
     repo = "epsilon";
-    rev = version;
+    tag = version;
     hash = "sha256-w9ddcULE1MrGnYcXA0qOg1elQv/eBhcXqhMSjWT3Bkk=";
   };
 

--- a/pkgs/by-name/nu/nuv/package.nix
+++ b/pkgs/by-name/nu/nuv/package.nix
@@ -25,7 +25,7 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "nuvolaris";
     repo = "nuv";
-    rev = version;
+    tag = version;
     hash = "sha256-MdnBvlA4S2Mi/bcbE+O02x+wvlIrsK1Zc0dySz4FB/w=";
   };
 

--- a/pkgs/by-name/oc/ocaml-top/package.nix
+++ b/pkgs/by-name/oc/ocaml-top/package.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "ocaml-top";
-    rev = version;
+    tag = version;
     hash = "sha256-xmPGGB/zUpfeAxUIhR1PhfoESAJq7sTpqHuf++EH3Lw=";
   };
 

--- a/pkgs/by-name/oc/ocsigen-i18n/package.nix
+++ b/pkgs/by-name/oc/ocsigen-i18n/package.nix
@@ -13,7 +13,7 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "besport";
     repo = "ocsigen-i18n";
-    rev = version;
+    tag = version;
     hash = "sha256-NIl1YUTws8Ff4nrqdhU7oS/TN0lxVQgrtyEZtpS1ojM=";
   };
 

--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -98,7 +98,7 @@ let
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint";
-            rev = version;
+            tag = version;
             hash = "sha256-X9+o3EpTtKAFiSmjOumRCDKNwBc9LVjvqyZqun3yDi8=";
           };
 

--- a/pkgs/by-name/of/office-code-pro/package.nix
+++ b/pkgs/by-name/of/office-code-pro/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "phooky";
     repo = "Office-Code-Pro";
-    rev = version;
+    tag = version;
     hash = "sha256-qzKTXYswkithZUJT0a3IifCq4RJFeKciZAPhYr2U1X4=";
   };
 

--- a/pkgs/by-name/op/opcua-commander/package.nix
+++ b/pkgs/by-name/op/opcua-commander/package.nix
@@ -15,7 +15,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "node-opcua";
     repo = "opcua-commander";
-    rev = version;
+    tag = version;
     hash = "sha256-qoBpYN0EiXiuhH+hXjVPK2ET8Psjz52rocohU8ccVIg=";
   };
 

--- a/pkgs/by-name/op/open-fprintd/package.nix
+++ b/pkgs/by-name/op/open-fprintd/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "uunicorn";
     repo = "open-fprintd";
-    rev = version;
+    tag = version;
     hash = "sha256-4TraOKvBc7ddqcY73aCuKgfwx4fNoaPHVG8so8Dc5Bw=";
   };
 

--- a/pkgs/by-name/op/openrefine/package.nix
+++ b/pkgs/by-name/op/openrefine/package.nix
@@ -16,7 +16,7 @@ let
   src = fetchFromGitHub {
     owner = "openrefine";
     repo = "openrefine";
-    rev = version;
+    tag = version;
     hash = "sha256-548vOJf0mlk1AuuMjEXpsiVjft6UbJrUxh5mSca8Xbw=";
   };
 

--- a/pkgs/by-name/or/orchard/package.nix
+++ b/pkgs/by-name/or/orchard/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "cirruslabs";
     repo = "orchard";
-    rev = version;
+    tag = version;
     hash = "sha256-Kf8RGYxgnXX9iEbZ9B0aRKUDQ5PgfyBfVk/C62zSrMU=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.

--- a/pkgs/by-name/or/orchis-theme/package.nix
+++ b/pkgs/by-name/or/orchis-theme/package.nix
@@ -43,7 +43,7 @@ lib.checkListOfEnum "${pname}: theme tweaks" validTweaks tweaks
     src = fetchFromGitHub {
       repo = "Orchis-theme";
       owner = "vinceliuice";
-      rev = version;
+      tag = version;
       hash = "sha256-+2/CsgJ+rdDpCp+r5B/zys3PtFgtnu+ohTEUOtJNd1Y=";
     };
 

--- a/pkgs/by-name/os/osmo-hnodeb/package.nix
+++ b/pkgs/by-name/os/osmo-hnodeb/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-hnodeb";
-    rev = version;
+    tag = version;
     hash = "sha256-Izivyw2HqRmrM68ehGqlIkJeuZ986d1WQ0yr6NWWTdA=";
   };
 

--- a/pkgs/by-name/os/osmo-iuh/package.nix
+++ b/pkgs/by-name/os/osmo-iuh/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "osmocom";
     repo = "osmo-iuh";
-    rev = version;
+    tag = version;
     hash = "sha256-3ADn0GSoXPXL1gD79JjD2hXNBN/v8aaEKgf5qFNGEJs=";
   };
 

--- a/pkgs/by-name/pa/pastebinit/package.nix
+++ b/pkgs/by-name/pa/pastebinit/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "pastebinit";
     repo = "pastebinit";
-    rev = version;
+    tag = version;
     hash = "sha256-vuAWkHlQM6QTWarThpSbY0qrxzej0GvLU0jT2JOS/qc=";
   };
 

--- a/pkgs/by-name/pd/pdfdiff/package.nix
+++ b/pkgs/by-name/pd/pdfdiff/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "cascremers";
     repo = "pdfdiff";
-    rev = version;
+    tag = version;
     hash = "sha256-NPki/PFm0b71Ksak1mimR4w6J2a0jBCbQDTMQR4uZFI=";
   };
 

--- a/pkgs/by-name/pe/perl-debug-adapter/package.nix
+++ b/pkgs/by-name/pe/perl-debug-adapter/package.nix
@@ -23,7 +23,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "Nihilus118";
     repo = "perl-debug-adapter";
-    rev = version;
+    tag = version;
     hash = "sha256-IXXKhk4rzsWSPA0RT0L3CZuKlgTWtweZ4dQtruTigRs=";
   };
 

--- a/pkgs/by-name/ph/photoprism/package.nix
+++ b/pkgs/by-name/ph/photoprism/package.nix
@@ -23,7 +23,7 @@ let
   src = fetchFromGitHub {
     owner = "photoprism";
     repo = "photoprism";
-    rev = version;
+    tag = version;
     hash = "sha256-8yg5CtvBtSKRaOUj9f+Db7rruXIVuF2cR50vZ+WUU6A=";
   };
 

--- a/pkgs/by-name/pi/pinta/package.nix
+++ b/pkgs/by-name/pi/pinta/package.nix
@@ -33,7 +33,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "PintaProject";
     repo = "Pinta";
-    rev = version;
+    tag = version;
     hash = "sha256-CTASSNMZneU0PQKsDZ/ZMwTkXdJNlVCafaDFqzmh2CM=";
   };
 

--- a/pkgs/by-name/po/polkit/package.nix
+++ b/pkgs/by-name/po/polkit/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "polkit-org";
     repo = "polkit";
-    rev = version;
+    tag = version;
     hash = "sha256-YTugETy0rqu/bv53jV1UeGqSK79bRXR52EJNcTblvzo=";
   };
 

--- a/pkgs/by-name/po/porn-vault/package.nix
+++ b/pkgs/by-name/po/porn-vault/package.nix
@@ -19,7 +19,7 @@ let
     src = fetchFromGitLab {
       owner = "porn-vault";
       repo = "izzy";
-      rev = version;
+      tag = version;
       hash = "sha256-UauA5mZi5a5QF7d17pKSzvyaWbeSuFjBrXEAxR3wNkk=";
     };
 

--- a/pkgs/by-name/pr/prometheus-ping-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-ping-exporter/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "czerwonk";
     repo = "ping_exporter";
-    rev = version;
+    tag = version;
     hash = "sha256-H+HcwDMnRgvEnbaI/tcS457Ir2Xtq30g44EYo4UPCE0=";
   };
 

--- a/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-restic-exporter/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ngosang";
     repo = "restic-exporter";
-    rev = version;
+    tag = version;
     hash = "sha256-b3TbBZqNJEAveNVf+6OGHU2G3UUyuSEjzFMPJVuxlBE=";
   };
 

--- a/pkgs/by-name/pr/prometheus-varnish-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-varnish-exporter/package.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "jonnenauha";
     repo = "prometheus_varnish_exporter";
-    rev = version;
+    tag = version;
     hash = "sha256-1sUzKLNkLP/eX0wYSestMAJpjAmX1iimjYoFYb6Mgpc=";
   };
 

--- a/pkgs/by-name/pr/protege/package.nix
+++ b/pkgs/by-name/pr/protege/package.nix
@@ -16,7 +16,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "protegeproject";
     repo = "protege";
-    rev = version;
+    tag = version;
     hash = "sha256-GplMEVEBYSTTzrGzbHlbQTXqJYka6r0QfBZFVCS7wCs=";
   };
 

--- a/pkgs/by-name/qo/qogir-theme/package.nix
+++ b/pkgs/by-name/qo/qogir-theme/package.nix
@@ -37,7 +37,7 @@ lib.checkListOfEnum "${pname}: theme variants" [ "default" "manjaro" "ubuntu" "a
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = "qogir-theme";
-      rev = version;
+      tag = version;
       hash = "sha256-LS1BE2jR08/JW2+rixYhTmctAfK2yZVWIE4QnAX9PDQ=";
     };
 

--- a/pkgs/by-name/qu/quickgui/package.nix
+++ b/pkgs/by-name/qu/quickgui/package.nix
@@ -12,7 +12,7 @@ flutter332.buildFlutterApplication rec {
   src = fetchFromGitHub {
     owner = "quickemu-project";
     repo = "quickgui";
-    rev = version;
+    tag = version;
     hash = "sha256-M2Qy66RqsjXg7ZpHwaXCN8qXRIsisnIyaENx3KqmUfQ=";
   };
 

--- a/pkgs/by-name/ra/radiance-vj/package.nix
+++ b/pkgs/by-name/ra/radiance-vj/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "zbanks";
     repo = "radiance";
-    rev = version;
+    tag = version;
     hash = "sha256-RWPcbUg7/gggPuUZLyMJ/m2S5GGfrdE6SWyXERIXsdk=";
   };
 

--- a/pkgs/by-name/ra/raspberrypifw/package.nix
+++ b/pkgs/by-name/ra/raspberrypifw/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
-    rev = version;
+    tag = version;
     hash = "sha256-U41EgEDny1R+JFktSC/3CE+2Qi7GJludj929ft49Nm0=";
   };
 

--- a/pkgs/by-name/re/realcugan-ncnn-vulkan/package.nix
+++ b/pkgs/by-name/re/realcugan-ncnn-vulkan/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nihui";
     repo = "realcugan-ncnn-vulkan";
-    rev = version;
+    tag = version;
     hash = "sha256-P3Y1B8m1+mpFinacwnvBE2vU150jj6Q12IS6QYNRZ6A=";
   };
   sourceRoot = "${src.name}/src";

--- a/pkgs/by-name/re/redhat-official-fonts/package.nix
+++ b/pkgs/by-name/re/redhat-official-fonts/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "RedHatOfficial";
     repo = "RedHatFont";
-    rev = version;
+    tag = version;
     hash = "sha256-r43KtMIedNitb5Arg8fTGB3hrRZoA8oUHVEL24k4LeQ=";
   };
 

--- a/pkgs/by-name/re/remind/package.nix
+++ b/pkgs/by-name/re/remind/package.nix
@@ -22,7 +22,7 @@ tcl.mkTclDerivation rec {
     domain = "git.skoll.ca";
     owner = "Skollsoft-Public";
     repo = "Remind";
-    rev = version;
+    tag = version;
     hash = "sha256-7zjQMnC4OwfwaqMlH9IABkwUw7RUKIQj2gl3rXKiRLI=";
   };
 

--- a/pkgs/by-name/re/reveal-md/package.nix
+++ b/pkgs/by-name/re/reveal-md/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "webpro";
     repo = "reveal-md";
-    rev = version;
+    tag = version;
     hash = "sha256-5lYC4v+Jvm1OdWrkU/cn1I1jd0B1C+AvACCiGUBv+h0=";
   };
 

--- a/pkgs/by-name/rh/rhodium-libre/package.nix
+++ b/pkgs/by-name/rh/rhodium-libre/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DunwichType";
     repo = "RhodiumLibre";
-    rev = version;
+    tag = version;
     hash = "sha256-YCQvUdjEAj4G71WCRCM0+NwiqRqwt1Ggeg9jb/oWEsY=";
   };
 

--- a/pkgs/by-name/ru/runelite/package.nix
+++ b/pkgs/by-name/ru/runelite/package.nix
@@ -18,7 +18,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "runelite";
     repo = "launcher";
-    rev = version;
+    tag = version;
     hash = "sha256-ckeZ/7rACyZ5j+zzC5hv1NaXTi9q/KvOzMPTDd1crHQ=";
   };
 

--- a/pkgs/by-name/sa/sabnzbd/package.nix
+++ b/pkgs/by-name/sa/sabnzbd/package.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sabnzbd";
     repo = "sabnzbd";
-    rev = version;
+    tag = version;
     hash = "sha256-wx3lNGeHsNvd+nLiI9jfIKHcsVstfjEpZry6o3xbWd4=";
   };
 

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "sagemath";
     repo = "sage";
-    rev = version;
+    tag = version;
     hash = "sha256-nYlBmKQ9TD5EAVvNwo8YzqAd5IUCpTU3kBTqUH21IxQ=";
   };
 

--- a/pkgs/by-name/sa/sassc/package.nix
+++ b/pkgs/by-name/sa/sassc/package.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "sass";
     repo = "sassc";
-    rev = finalAttrs.version;
-    sha256 = "sha256-jcs3+orRqKt9C3c2FTdeaj4H2rBP74lW3HF8CHSm7lQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-jcs3+orRqKt9C3c2FTdeaj4H2rBP74lW3HF8CHSm7lQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/sc/scalingo/package.nix
+++ b/pkgs/by-name/sc/scalingo/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "scalingo";
     repo = "cli";
-    rev = version;
+    tag = version;
     hash = "sha256-fLP7t1cgLOgU+xHLPFqDH+KbNuVxupuit5FBZ5iuQBE=";
   };
 

--- a/pkgs/by-name/sc/scenebuilder/package.nix
+++ b/pkgs/by-name/sc/scenebuilder/package.nix
@@ -22,7 +22,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "gluonhq";
     repo = "scenebuilder";
-    rev = version;
+    tag = version;
     hash = "sha256-YEcW1yQK6RKDqSstsrpdOqMt972ZagenGDxcJ/gP+SA=";
   };
 

--- a/pkgs/by-name/sd/sd-switch/package.nix
+++ b/pkgs/by-name/sd/sd-switch/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage {
   src = fetchFromSourcehut {
     owner = "~rycee";
     repo = "sd-switch";
-    rev = version;
+    tag = version;
     hash = "sha256-0cK5Gt/+M7IfPPthmx6Z11FymnsXagyT/PZtboQY72k=";
   };
 

--- a/pkgs/by-name/sh/shattered-pixel-dungeon/rat-king-adventure/default.nix
+++ b/pkgs/by-name/sh/shattered-pixel-dungeon/rat-king-adventure/default.nix
@@ -10,7 +10,7 @@ callPackage ../generic.nix rec {
   src = fetchFromGitHub {
     owner = "TrashboxBobylev";
     repo = "Rat-King-Adventure";
-    rev = version;
+    tag = version;
     hash = "sha256-6KmJRcYUjEdFym8nkCtg841CyKKYV1gACMJv/zOQ2Oc=";
   };
 

--- a/pkgs/by-name/sh/shortwave/package.nix
+++ b/pkgs/by-name/sh/shortwave/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Shortwave";
-    rev = version;
+    tag = version;
     hash = "sha256-MiaozChp5QF/Q0fCTCgnyGJLyIftTkMAbmfRQ/73QP8=";
   };
 

--- a/pkgs/by-name/sn/sn-pro/package.nix
+++ b/pkgs/by-name/sn/sn-pro/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "supernotes";
     repo = "sn-pro";
-    rev = version;
+    tag = version;
     hash = "sha256-H8YG7FMn03tiBxz5TZDzowicqtewfX6rYd03pdTPYSo=";
   };
 

--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -21,7 +21,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "SonarSource";
     repo = "sonarlint-language-server";
-    rev = version;
+    tag = version;
     hash = "sha256-0EFztL1hF1JaYc+6OUvmcPF9x5yA10Sy62f/Drmj4MU=";
   };
 

--- a/pkgs/by-name/sp/spatial-shell/package.nix
+++ b/pkgs/by-name/sp/spatial-shell/package.nix
@@ -12,7 +12,7 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "lthms";
     repo = "spatial-shell";
-    rev = version;
+    tag = version;
     hash = "sha256-OeNBP/jea1ABh/WpvCP7We+L20WoTfLZH71raH7bKPI=";
   };
 

--- a/pkgs/by-name/sr/src-cli/package.nix
+++ b/pkgs/by-name/sr/src-cli/package.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "sourcegraph";
     repo = "src-cli";
-    rev = version;
+    tag = version;
     hash = "sha256-Qn3yBShn3hC17GQVfv9sI1uhBWLi+d8gXBJX3pPgCsU=";
   };
 

--- a/pkgs/by-name/sr/srht-gen-oauth-tok/package.nix
+++ b/pkgs/by-name/sr/srht-gen-oauth-tok/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     domain = "entropic.network";
     owner = "~nessdoor";
     repo = "srht-gen-oauth-tok";
-    rev = version;
+    tag = version;
     hash = "sha256-GcqP3XbVw2sR5n4+aLUmA4fthNkuVAGnhV1h7suJYdI=";
   };
 

--- a/pkgs/by-name/st/structorizer/package.nix
+++ b/pkgs/by-name/st/structorizer/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fesch";
     repo = "Structorizer.Desktop";
-    rev = version;
+    tag = version;
     hash = "sha256-ur00Vq+bl+R5MBpmGQO8nX9rEVNMgih1OzWlpY0RDIk=";
   };
 

--- a/pkgs/by-name/su/super-slicer/package.nix
+++ b/pkgs/by-name/su/super-slicer/package.nix
@@ -83,7 +83,7 @@ let
         owner = "supermerill";
         repo = "SuperSlicer";
         inherit hash;
-        rev = version;
+        tag = version;
         fetchSubmodules = true;
       };
 

--- a/pkgs/by-name/sw/swayest-workstyle/package.nix
+++ b/pkgs/by-name/sw/swayest-workstyle/package.nix
@@ -10,7 +10,7 @@ let
   src = fetchFromGitHub {
     owner = "Lyr-7D1h";
     repo = "swayest_workstyle";
-    rev = version;
+    tag = version;
     hash = "sha256-V1vEGz2jZHPdeKL99ILeoWVsuxIMkDHHdzgY8kEe9yM=";
   };
 in

--- a/pkgs/by-name/ta/tagger/package.nix
+++ b/pkgs/by-name/ta/tagger/package.nix
@@ -21,7 +21,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "nlogozzo";
     repo = "NickvisionTagger";
-    rev = version;
+    tag = version;
     hash = "sha256-4OfByQYhLXmeFWxzhqt8d7pLUyuMLhDM20E2YcA9Q3s=";
   };
 

--- a/pkgs/by-name/ta/tarsnapper/package.nix
+++ b/pkgs/by-name/ta/tarsnapper/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "miracle2k";
     repo = "tarsnapper";
-    rev = version;
+    tag = version;
     hash = "sha256-5i9eum9hbh6VFhvEIDq5Uapy6JtIbf9jZHhRYZVoC1w=";
   };
 

--- a/pkgs/by-name/te/techmino/ccloader.nix
+++ b/pkgs/by-name/te/techmino/ccloader.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "26F-Studio";
     repo = "cold_clear_ai_love2d_wrapper";
-    rev = version;
+    tag = version;
     fetchSubmodules = true;
     hash = "sha256-sguV+Dw+etZH43tXZYL46NAdsI/qvyvGWCPUiTEjhy4=";
   };

--- a/pkgs/by-name/te/tela-icon-theme/package.nix
+++ b/pkgs/by-name/te/tela-icon-theme/package.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "tela-icon-theme";
-    rev = version;
+    tag = version;
     hash = "sha256-ufjKFlKJnmNwD2m1w+7JSBQij6ltxXWCpUEvVxECS98=";
   };
 

--- a/pkgs/by-name/te/tesh/package.nix
+++ b/pkgs/by-name/te/tesh/package.nix
@@ -16,7 +16,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "OceanSprint";
     repo = "tesh";
-    rev = version;
+    tag = version;
     hash = "sha256-GIwg7Cv7tkLu81dmKT65c34eeVnRR5MIYfNwTE7j2Vs=";
   };
 

--- a/pkgs/by-name/to/torrentstream/package.nix
+++ b/pkgs/by-name/to/torrentstream/package.nix
@@ -12,7 +12,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "trueromanus";
     repo = "TorrentStream";
-    rev = version;
+    tag = version;
     hash = "sha256-3lmQWx00Ulp0ZyQBEhFT+djHBi84foMlWGJEp/UOGek=";
   };
 

--- a/pkgs/by-name/tr/tree-from-tags/package.nix
+++ b/pkgs/by-name/tr/tree-from-tags/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "dbrock";
     repo = "bongo";
-    rev = version;
+    tag = version;
     hash = "sha256-G+6rRJLNBECxGc8WuaesXhrYqvEDy2Chpw4lWxO8X9s=";
   };
 

--- a/pkgs/by-name/tr/triton/package.nix
+++ b/pkgs/by-name/tr/triton/package.nix
@@ -14,7 +14,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "TritonDataCenter";
     repo = "node-triton";
-    rev = version;
+    tag = version;
     hash = "sha256-65GfN8nqr2hDz+QiBgIM/Jp5poITPUvHQYECjZMtBM4=";
   };
 

--- a/pkgs/by-name/um/umap/package.nix
+++ b/pkgs/by-name/um/umap/package.nix
@@ -25,7 +25,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "umap-project";
     repo = "umap";
-    rev = version;
+    tag = version;
     hash = "sha256-rM1o83/udkqiVD0nSiAjNVAzriJr2ztvSXh45wxmYzU=";
   };
 

--- a/pkgs/by-name/un/unsilence/package.nix
+++ b/pkgs/by-name/un/unsilence/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "lagmoellertim";
     repo = "unsilence";
-    rev = version;
+    tag = version;
     hash = "sha256-M4Ek1JZwtr7vIg14aTa8h4otIZnPQfKNH4pZE4GpiBQ=";
   };
 

--- a/pkgs/by-name/un/unstructured-api/package.nix
+++ b/pkgs/by-name/un/unstructured-api/package.nix
@@ -157,7 +157,7 @@ stdenvNoCC.mkDerivation {
   src = fetchFromGitHub {
     owner = "Unstructured-IO";
     repo = "unstructured-api";
-    rev = version;
+    tag = version;
     hash = "sha256-+OAq1cOpv/w2pF2SwP6ByvH8NNaPqOKK/rxclROuHS0=";
   };
 

--- a/pkgs/by-name/v2/v2ray-domain-list-community/package.nix
+++ b/pkgs/by-name/v2/v2ray-domain-list-community/package.nix
@@ -13,7 +13,7 @@ let
     src = fetchFromGitHub {
       owner = "v2fly";
       repo = "domain-list-community";
-      rev = version;
+      tag = version;
       hash = "sha256-OlR+lo2Xh3p/30RU7+ok3JWhYsB9FkGzXGIhccECeSk=";
     };
     vendorHash = "sha256-9tXv+rDBowxDN9gH4zHCr4TRbic4kijco3Y6bojJKRk=";

--- a/pkgs/by-name/vd/vdo/package.nix
+++ b/pkgs/by-name/vd/vdo/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "dm-vdo";
     repo = "vdo";
-    rev = version;
+    tag = version;
     hash = "sha256-y3u9f17jMV9dwhfJrsW/GOqszVNvPLDyETfku1t3Djo=";
   };
 

--- a/pkgs/by-name/vi/vimix-icon-theme/package.nix
+++ b/pkgs/by-name/vi/vimix-icon-theme/package.nix
@@ -30,7 +30,7 @@ lib.checkListOfEnum "vimix-icon-theme: color variants"
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = "vimix-icon-theme";
-      rev = version;
+      tag = version;
       hash = "sha256-HNwEqp6G9nZDIJo9b6FD4d5NSXUx523enENM0NVwviA=";
     };
 

--- a/pkgs/by-name/vl/vlang/package.nix
+++ b/pkgs/by-name/vl/vlang/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "vlang";
     repo = "v";
-    rev = version;
+    tag = version;
     hash = "sha256-iS9tXeEsEjxEpgJNjz/08MQfZkSfFZWHy0CMurITr+E=";
   };
 

--- a/pkgs/by-name/vv/vvvvvv/package.nix
+++ b/pkgs/by-name/vv/vvvvvv/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "TerryCavanagh";
     repo = "VVVVVV";
-    rev = version;
+    tag = version;
     hash = "sha256-IEspPNsKGWgukqmnb6nDORRetQp9jvUzJ/mSOTLGdmQ=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/we/web-ext/package.nix
+++ b/pkgs/by-name/we/web-ext/package.nix
@@ -13,7 +13,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "web-ext";
-    rev = version;
+    tag = version;
     hash = "sha256-QAPRRsgsmMC0ZlGUf+dO1kL/ezW6Fq4tDlQVZOuJ7eI=";
   };
 

--- a/pkgs/by-name/wg/wgnord/package.nix
+++ b/pkgs/by-name/wg/wgnord/package.nix
@@ -19,7 +19,7 @@ resholve.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "phirecc";
     repo = "wgnord";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-26cfYXtZVQ7kIRxY6oNGCqIjdw/hjwXhVKimVgolLgk=";
   };
 

--- a/pkgs/by-name/wh/whitesur-gtk-theme/package.nix
+++ b/pkgs/by-name/wh/whitesur-gtk-theme/package.nix
@@ -99,7 +99,7 @@ lib.checkListOfEnum "${pname}: window control buttons variants" [ "normal" "alt"
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = "whitesur-gtk-theme";
-      rev = version;
+      tag = version;
       hash = "sha256-tuon9XxMdrz9XNTp50sbss2gtx6H9hEZh8t2jSoqx28=";
     };
 

--- a/pkgs/by-name/wh/whitesur-kde/package.nix
+++ b/pkgs/by-name/wh/whitesur-kde/package.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "whitesur-kde";
-    rev = version;
+    tag = version;
     hash = "sha256-052mKpf8e5pSecMzaWB3McOZ/uAqp/XGJjcVWnlKPLE=";
   };
 

--- a/pkgs/by-name/wi/wifite2/package.nix
+++ b/pkgs/by-name/wi/wifite2/package.nix
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "kimocoder";
     repo = "wifite2";
-    rev = version;
+    tag = version;
     hash = "sha256-G2AKKZUDS2UQm95TEhGJIucyMRcm7oL0d3J8uduEQhw=";
   };
 

--- a/pkgs/by-name/wi/wireguard-vanity-keygen/package.nix
+++ b/pkgs/by-name/wi/wireguard-vanity-keygen/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "axllent";
     repo = "wireguard-vanity-keygen";
-    rev = version;
+    tag = version;
     hash = "sha256-5N+D1wVrqUvkyxXKzIZPRdSPpHcPZp1Fzo2AwYA7Ue8=";
   };
 

--- a/pkgs/by-name/wp/wprecon/package.nix
+++ b/pkgs/by-name/wp/wprecon/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "blackbinn";
     repo = "wprecon";
-    rev = version;
+    tag = version;
     hash = "sha256-23zJD3Nnkeko+J2FjPq5RA5dIjORMXvwt3wtAYiVlQs=";
   };
 

--- a/pkgs/by-name/xm/xmldiff/package.nix
+++ b/pkgs/by-name/xm/xmldiff/package.nix
@@ -9,7 +9,7 @@ let
   src = fetchFromGitHub {
     owner = "Shoobx";
     repo = "xmldiff";
-    rev = version;
+    tag = version;
     hash = "sha256-qn8gGultTSNKPUro6Ap4xJGcbpxV+lKgZFpKvyPdhtc=";
   };
 in

--- a/pkgs/by-name/xm/xmltoman/package.nix
+++ b/pkgs/by-name/xm/xmltoman/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "atsb";
     repo = "xmltoman";
-    rev = version;
+    tag = version;
     hash = "sha256-EmFdGIeBEcTY0Pqp7BJded9WB/DaXWcMNWh6aTsZlLg=";
   };
 

--- a/pkgs/by-name/ya/yadm/package.nix
+++ b/pkgs/by-name/ya/yadm/package.nix
@@ -37,7 +37,7 @@ resholve.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "yadm-dev";
     repo = "yadm";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-hDo6zs70apNhKmuvR+eD51FzuTLj3SL/wHQXqLMD9QE=";
   };
 

--- a/pkgs/by-name/ya/yas/package.nix
+++ b/pkgs/by-name/ya/yas/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "niXman";
     repo = "yas";
-    rev = version;
+    tag = version;
     hash = "sha256-2+CpftWOEnntYBCc1IoR5eySbmhrMVunpUTZRdQ5I+A=";
   };
 

--- a/pkgs/by-name/ye/yeetgif/package.nix
+++ b/pkgs/by-name/ye/yeetgif/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "sgreben";
     repo = "yeetgif";
-    rev = version;
+    tag = version;
     hash = "sha256-Z05GhtEPj3PLXpjF1wK8+pNUY3oDjbwZWQsYlTX14Rc=";
   };
 

--- a/pkgs/by-name/yu/yunfaavatar/package.nix
+++ b/pkgs/by-name/yu/yunfaavatar/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "yunfachi";
     repo = "yunfaAvatar";
-    rev = version;
+    tag = version;
     hash = "sha256-hCpbe+gW9hkiVOKq7a55n5s3bMpyCNGWiY3D2b4VYxg=";
   };
 

--- a/pkgs/by-name/yx/yx/package.nix
+++ b/pkgs/by-name/yx/yx/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "tomalok";
     repo = "yx";
-    rev = version;
+    tag = version;
     hash = "sha256-uuso+hsmdsB7VpIRKob8rfMaWvRMCBHvCFnYrHPC6iw=";
   };
 

--- a/pkgs/by-name/zn/zn_poly/package.nix
+++ b/pkgs/by-name/zn/zn_poly/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "sagemath";
     repo = "zn_poly";
-    rev = version;
+    tag = version;
     hash = "sha256-QBItcrrpOGj22/ShTDdfZjm63bGW2xY4c71R1q8abPE=";
   };
 

--- a/pkgs/by-name/zw/zwave-js-server/package.nix
+++ b/pkgs/by-name/zw/zwave-js-server/package.nix
@@ -12,7 +12,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "zwave-js";
     repo = "zwave-js-server";
-    rev = version;
+    tag = version;
     hash = "sha256-JmPO1faJgpJ+RjocvauP0EQGken61G59CLqQAZiRSUU=";
   };
 


### PR DESCRIPTION
This pull request updates the way GitHub sources are fetched in multiple package definitions. The main change is to consistently use the `tag` and `hash` attributes instead of `rev` and `sha256`, aligning with recent Nixpkgs conventions. Additionally, some attribute names are updated for clarity and correctness, and a minor fix is made to a changelog URL.

**Standardization of fetch attributes:**

* Replaced `rev` with `tag` and `sha256` with `hash` in all `fetchFromGitHub` expressions across many package files (e.g., `package.nix` files for `3proxy`, `6tunnel`, `9pfs`, `abi-compliance-checker`, `adapta-backgrounds`, `adapta-gtk-theme`, `blis`, `clipster`, `cloudlog`, `crawl`, `cryfs`, `cups-filters`, `db-rest`, `denaro`, etc.).

* Updated the `hash` values to use the new format where necessary, ensuring correct hash values with the new attribute.

**Consistency improvements:**

* Changed all instances of `rev = version;` to `tag = version;` for consistency and clarity.

**Other minor fixes:**

* Fixed a changelog URL in the `aircrack-ng` package to use the correct attribute (`tag` instead of `rev`).

These changes improve maintainability and reduce confusion by standardizing how source code is fetched from GitHub in the package definitions.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
