### PR TITLE
bazelisk: fix version injection

### DIFF
--- a/pkgs/by-name/ba/bazelisk/package.nix
+++ b/pkgs/by-name/ba/bazelisk/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X main.BazeliskVersion=${finalAttrs.version}"
+    "-X github.com/bazelbuild/bazelisk/core.BazeliskVersion=${finalAttrs.version}"
   ];
 
   meta = {

--- a/pkgs/by-name/ba/bazelisk/package.nix
+++ b/pkgs/by-name/ba/bazelisk/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/bazelbuild/bazelisk/core.BazeliskVersion=${finalAttrs.version}"
+    "-X github.com/bazelbuild/bazelisk/core.BazeliskVersion=v${finalAttrs.version}"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done
Updated `ldflags` to fix version injection, so that `bazelisk version` command shows the right version.

```
% nix run .#bazelisk -- version   
Bazelisk version: v1.28.1
WARNING: Invoking Bazel in batch mode since it is not invoked from within a workspace (below a directory having a MODULE.bazel file).
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
Build label: 9.0.1
Build target: @@//src/main/java/com/google/devtools/build/lib/bazel:BazelServer
Build time: Tue Mar 10 16:56:10 2026 (1773161770)
Build timestamp: 1773161770
Build timestamp as int: 1773161770
```
(previously it showed `Bazelisk version: development`)

It would be great to add `versionCheckHook` to verify that it is not broken, but the version command at the moment requires networking to download Bazel. bazelbuild/bazelisk#763 introduced a separate `bazelisk bazeliskVersion` command for that, but it is not released yet.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
