### PR TITLE
nuxmv: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/by-name/nu/nuxmv/package.nix
+++ b/pkgs/by-name/nu/nuxmv/package.nix
@@ -8,17 +8,17 @@
 
 stdenv.mkDerivation rec {
   pname = "nuxmv";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchurl {
-    url = "https://es-static.fbk.eu/tools/nuxmv/downloads/nuXmv-${version}-${
-      if stdenv.hostPlatform.isDarwin then "macosx64" else "linux64"
-    }.tar.gz";
+    url = "https://nuxmv.fbk.eu/downloads/nuXmv-${version}-${
+      if stdenv.hostPlatform.isDarwin then "macos-universal" else "linux64"
+    }.tar.xz";
     sha256 =
       if stdenv.hostPlatform.isDarwin then
-        "sha256-48I+FhJUUam1nMCMMM47CwGO82BYsNz0eHDHXBfqO2E="
+        "sha256-3AoXEPCunzbhYjjUCzXc9m+CPTVwE70udMCfbpucbdU="
       else
-        "sha256-Gf+QgAjTrysZj7qTtt1wcQPganDtO0YtRY4ykhLPzVo=";
+        "sha256-x9/sQ3SbyyMMhX7+gQmbldhouU79n4G8zr5UKjBqfIM=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
     platforms = [
       "x86_64-linux"
       "x86_64-darwin"
+      "aarch64-darwin"
     ];
   };
 }


### PR DESCRIPTION
Update nuxmv from 2.0.0 to 2.1.0.

Changes: upstream moved download URL to a new endpoint and switched to .tar.xz. macOS binary is now universal (added aarch64-darwin support).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test