### PR TITLE
flutterPackages: remove gradle-wrapper.properties

### DIFF
--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -248,6 +248,13 @@ stdenv.mkDerivation (finalAttrs: {
       if [ "${artifact.path}" != "$temp_path" ]; then
         rm --recursive --force "$temp_path"
       fi
+      ${
+        # Gradle Wrapper requires some files to be removed
+        # https://github.com/flutter/flutter/blob/81c87ea165df95681eb3a07e1f442983bf0e0e17/packages/flutter_tools/lib/src/flutter_cache.dart#L562-L563
+        lib.optionalString (
+          artifact.target == "bin/cache/artifacts/gradle_wrapper"
+        ) ''rm "$target_path/NOTICE" "$target_path/gradle/wrapper/gradle-wrapper.properties"''
+      }
     '') artifacts}
 
     cp --recursive . $out


### PR DESCRIPTION
Removes the gradle-wrapper.properties and NOTICE files from the gradle wrapper cached artifact.

This is also done in the upstream flutter_tools package: https://github.com/flutter/flutter/blob/81c87ea165df95681eb3a07e1f442983bf0e0e17/packages/flutter_tools/lib/src/flutter_cache.dart#L562-L563

Fixes #507712.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
