### PR TITLE
treewide: fix icon by adding 512x512 image

### DIFF
--- a/pkgs/applications/misc/qtbitcointrader/default.nix
+++ b/pkgs/applications/misc/qtbitcointrader/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   libsForQt5,
+  imagemagick,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,7 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-u3+Kwn8KunYUpWCd55TQuVVfoSp8hdti93d6hk7Uqx8=";
   };
 
-  nativeBuildInputs = [ libsForQt5.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    libsForQt5.wrapQtAppsHook
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux imagemagick;
 
   buildInputs = [
     libsForQt5.qtbase
@@ -36,6 +40,11 @@ stdenv.mkDerivation (finalAttrs: {
       QtBitcoinTrader_Desktop.pro
 
     runHook postConfigure
+  '';
+
+  postFixup = lib.optionalString stdenv.isLinux ''
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert QtBitcoinTrader.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/QtBitcoinTrader.png
   '';
 
   meta = {

--- a/pkgs/by-name/ai/airgorah/package.nix
+++ b/pkgs/by-name/ai/airgorah/package.nix
@@ -11,6 +11,7 @@
   copyDesktopItems,
   makeDesktopItem,
   wrapGAppsHook4,
+  imagemagick,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
     copyDesktopItems
     wrapGAppsHook4
+    imagemagick
   ];
 
   buildInputs = [
@@ -42,6 +44,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postInstall = ''
     install -Dm644 icons/app_icon.png $out/share/icons/hicolor/1024x1024/apps/airgorah.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert icons/app_icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/airgorah.png
   '';
 
   desktopItems = [

--- a/pkgs/by-name/al/alisthelper/package.nix
+++ b/pkgs/by-name/al/alisthelper/package.nix
@@ -48,7 +48,9 @@ flutter341.buildFlutterApplication (finalAttrs: {
 
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/1024x1024/apps
-    magick assets/alisthelper.png -resize 1024x1024 $out/share/icons/hicolor/1024x1024/apps/alisthelper.png
+    magick convert assets/alisthelper.png -resize 1024x1024 $out/share/icons/hicolor/1024x1024/apps/alisthelper.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert assets/alisthelper.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/alisthelper.png
   '';
 
   passthru = {

--- a/pkgs/by-name/az/azuredatastudio/package.nix
+++ b/pkgs/by-name/az/azuredatastudio/package.nix
@@ -29,6 +29,7 @@
   pango,
   systemd,
   wrapGAppsHook3,
+  imagemagick,
   libxrandr,
   libxfixes,
   libxext,
@@ -118,6 +119,7 @@ stdenv.mkDerivation rec {
     makeWrapper
     copyDesktopItems
     wrapGAppsHook3
+    imagemagick
   ];
 
   buildInputs = [
@@ -130,6 +132,8 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     install -D ${targetPath}/resources/app/resources/linux/code.png $out/share/icons/hicolor/1024x1024/apps/azuredatastudio.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert ${targetPath}/resources/app/resources/linux/code.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/azuredatastudio.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ba/badlion-client/package.nix
+++ b/pkgs/by-name/ba/badlion-client/package.nix
@@ -3,6 +3,7 @@
   fetchurl,
   appimageTools,
   makeWrapper,
+  imagemagick,
 }:
 
 appimageTools.wrapAppImage rec {
@@ -19,11 +20,16 @@ appimageTools.wrapAppImage rec {
     };
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    imagemagick
+  ];
 
   extraInstallCommands = ''
     install -Dm444 ${src}/BadlionClient.desktop $out/share/applications/BadlionClient.desktop
     install -Dm444 ${src}/BadlionClient.png -t $out/share/icons/hicolor/1024x1024/apps
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert ${src}/BadlionClient.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/BadlionClient.png
     substituteInPlace $out/share/applications/BadlionClient.desktop \
       --replace-fail "Exec=AppRun --no-sandbox %U" "Exec=badlion-client"
     wrapProgram $out/bin/badlion-client \

--- a/pkgs/by-name/bl/blackvoxel/package.nix
+++ b/pkgs/by-name/bl/blackvoxel/package.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     install -Dm644 blackvoxel.png $out/share/icons/hicolor/1024x1024/apps/blackvoxel.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert blackvoxel.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/blackvoxel.png
   '';
 
   desktopItems = [

--- a/pkgs/by-name/bl/bluemail/package.nix
+++ b/pkgs/by-name/bl/bluemail/package.nix
@@ -16,6 +16,7 @@
   makeDesktopItem,
   makeWrapper,
   wrapGAppsHook3,
+  imagemagick,
   gcc-unwrapped,
   udev,
 }:
@@ -53,6 +54,7 @@ stdenv.mkDerivation rec {
     makeWrapper
     squashfsTools
     wrapGAppsHook3
+    imagemagick
   ];
 
   unpackPhase = ''
@@ -94,6 +96,9 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/icons/hicolor/1024x1024/apps
     ln -s $out/opt/bluemail/resources/assets/icons/bluemailx-icon.png $out/share/icons/hicolor/1024x1024/apps/bluemail.png
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert $out/opt/bluemail/resources/assets/icons/bluemailx-icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/bluemail.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -14,6 +14,7 @@
   autoPatchelfHook,
   copyDesktopItems,
   writeShellApplication,
+  imagemagick,
   commandLineArgs ? "",
   genericUpdater,
 }:
@@ -60,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoPatchelfHook
     copyDesktopItems
     makeBinaryWrapper
+    imagemagick
   ];
 
   desktopItems = [
@@ -88,6 +90,9 @@ stdenv.mkDerivation (finalAttrs: {
       --add-flags "-d $out/share/bombsquad"
 
     install -Dm755 ${bombsquadIcon} $out/share/icons/hicolor/1024x1024/apps/bombsquad.png
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert ${bombsquadIcon} -resize 512x512 $out/share/icons/hicolor/512x512/apps/bombsquad.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ch/cherry-studio/package.nix
+++ b/pkgs/by-name/ch/cherry-studio/package.nix
@@ -13,6 +13,7 @@
   cctools,
   autoPatchelfHook,
   pkg-config,
+  imagemagick,
   makeDesktopItem,
   nix-update-script,
   alsa-lib,
@@ -70,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isElf [
     autoPatchelfHook
     pkg-config
+    imagemagick
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
@@ -140,6 +142,8 @@ stdenv.mkDerivation (finalAttrs: {
         "cp -r dist/linux-unpacked/{resources,LICENSE*} $out/opt/cherry-studio"
     }
     install -Dm644 build/icon.png $out/share/icons/hicolor/1024x1024/apps/cherry-studio.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert build/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/cherry-studio.png
     makeWrapper ${lib.getExe electron} $out/bin/cherry-studio \
       --inherit-argv0 \
       --add-flags $out/opt/cherry-studio/resources/app.asar \

--- a/pkgs/by-name/cl/clockify/package.nix
+++ b/pkgs/by-name/cl/clockify/package.nix
@@ -2,6 +2,7 @@
   lib,
   appimageTools,
   fetchurl,
+  imagemagick,
 }:
 
 appimageTools.wrapType2 rec {
@@ -13,6 +14,8 @@ appimageTools.wrapType2 rec {
     hash = "sha256-cQP1QkF2uWGsCjYjVdxPFLL8atAjT6rPQbPqeNX0QqQ=";
   };
 
+  nativeBuildInputs = [ imagemagick ];
+
   extraInstallCommands =
     let
       appimageContents = appimageTools.extract { inherit pname version src; };
@@ -20,6 +23,9 @@ appimageTools.wrapType2 rec {
     ''
       install -Dm 444 ${appimageContents}/clockify.desktop -t $out/share/applications
       install -Dm 444 ${appimageContents}/clockify.png -t $out/share/icons/hicolor/1024x1024/apps
+
+      mkdir -p $out/share/icons/hicolor/512x512/apps
+      magick convert ${appimageContents}/clockify.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/clockify.png
 
       substituteInPlace $out/share/applications/clockify.desktop \
         --replace-fail 'Exec=AppRun' 'Exec=${pname}'

--- a/pkgs/by-name/gr/graphest/package.nix
+++ b/pkgs/by-name/gr/graphest/package.nix
@@ -14,6 +14,7 @@
   makeBinaryWrapper,
   nix-update-script,
   nodejs,
+  imagemagick,
   electron,
   gnum4,
   pkgsStatic,
@@ -60,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     yarnBuildHook
     yarnInstallHook
     nodejs
+    imagemagick
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin darwin.autoSignDarwinBinariesHook;
 
@@ -92,6 +94,8 @@ stdenv.mkDerivation (finalAttrs: {
       --inherit-argv0
 
     install -Dm444 build/icon.png $out/share/icons/hicolor/1024x1024/apps/graphest.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert build/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/graphest.png
     install -Dm444 ${./mime.xml} $out/share/mime/packages/graphest.xml
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/no/notable/package.nix
+++ b/pkgs/by-name/no/notable/package.nix
@@ -36,8 +36,10 @@ appimageTools.wrapType2 rec {
 
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/notable.desktop $out/share/applications/notable.desktop
-    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/notable.png \
-      $out/share/icons/hicolor/1024x1024/apps/notable.png
+    for size in 16 32 48 64 128 256 512 1024; do
+      install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/notable.png \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/notable.png
+    done
     substituteInPlace $out/share/applications/notable.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
     wrapProgram "$out/bin/${pname}" \

--- a/pkgs/by-name/sh/shipwright/package.nix
+++ b/pkgs/by-name/sh/shipwright/package.nix
@@ -240,6 +240,8 @@ stdenv.mkDerivation (finalAttrs: {
       mkdir -p $out/bin
       ln -s $out/lib/soh.elf $out/bin/soh
       install -Dm644 ../soh/macosx/sohIcon.png $out/share/icons/hicolor/1024x1024/apps/soh.png
+      mkdir -p $out/share/icons/hicolor/512x512/apps
+      magick convert ../soh/macosx/sohIcon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/soh.png
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       # Recreate the macOS bundle (without using cpack)

--- a/pkgs/by-name/sh/show-midi/package.nix
+++ b/pkgs/by-name/sh/show-midi/package.nix
@@ -12,6 +12,7 @@
   libxcursor,
   makeDesktopItem,
   copyDesktopItems,
+  imagemagick,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     copyDesktopItems
+    imagemagick
   ];
   buildInputs = [
     alsa-lib
@@ -60,6 +62,9 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dt $out/share/ShowMIDI/themes Themes/*
 
     install -D Design/icon.png $out/share/icons/hicolor/1024x1024/apps/show-midi.png
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert Design/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/show-midi.png
 
     mkdir -p $out/bin $out/lib/lv2 $out/lib/vst3
     cd Builds/LinuxMakefile/build/

--- a/pkgs/by-name/si/simple-live-app/package.nix
+++ b/pkgs/by-name/si/simple-live-app/package.nix
@@ -6,6 +6,7 @@
   mpv,
   makeDesktopItem,
   copyDesktopItems,
+  imagemagick,
 }:
 
 flutter332.buildFlutterApplication rec {
@@ -28,6 +29,7 @@ flutter332.buildFlutterApplication rec {
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
+    imagemagick
   ];
 
   buildInputs = [ mpv ];
@@ -45,6 +47,9 @@ flutter332.buildFlutterApplication rec {
 
   postInstall = ''
     install -Dm644 assets/logo.png $out/share/icons/hicolor/1024x1024/apps/simple-live-app.png
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert assets/logo.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/simple-live-app.png
   '';
 
   extraWrapProgramArgs = ''

--- a/pkgs/by-name/sn/snowemu/package.nix
+++ b/pkgs/by-name/sn/snowemu/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   makeDesktopItem,
+  imagemagick,
   SDL2,
   pkg-config,
   libxrandr,
@@ -31,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    imagemagick
   ];
 
   buildInputs = [
@@ -45,6 +47,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mv $out/bin/snow_frontend_egui $out/bin/snowemu
 
     install -Dm644 assets/snow_icon.png $out/share/icons/hicolor/1024x1024/apps/snowemu.png
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert assets/snow_icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/snowemu.png
 
     wrapProgram $out/bin/snowemu \
       --prefix LD_LIBRARY_PATH : ${

--- a/pkgs/by-name/so/solidtime-desktop/package.nix
+++ b/pkgs/by-name/so/solidtime-desktop/package.nix
@@ -4,6 +4,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   copyDesktopItems,
+  imagemagick,
   makeDesktopItem,
   makeWrapper,
   electron,
@@ -25,6 +26,7 @@ buildNpmPackage (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
+    imagemagick
   ];
 
   npmDepsHash = "sha256-y4bO2Rcr+JXkS+q1EbSjg3nNd3GCrB8A+t9ePJsE2L4=";
@@ -36,6 +38,9 @@ buildNpmPackage (finalAttrs: {
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/1024x1024
     cp -a build/icon.png $out/share/icons/hicolor/1024x1024/solidtime-desktop.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert build/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/solidtime-desktop.png
+
     cp -a . $out/share/solidtime-desktop
 
     makeWrapper ${lib.getExe electron} $out/bin/solidtime-desktop \

--- a/pkgs/by-name/te/termius/package.nix
+++ b/pkgs/by-name/te/termius/package.nix
@@ -13,6 +13,7 @@
   wrapGAppsHook3,
   writeScript,
   sqlite,
+  imagemagick,
 }:
 
 stdenv.mkDerivation rec {
@@ -52,6 +53,7 @@ stdenv.mkDerivation rec {
     squashfsTools
     makeWrapper
     wrapGAppsHook3
+    imagemagick
   ];
 
   buildInputs = [
@@ -76,6 +78,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/applications
     cp "${desktopItem}/share/applications/"* "$out/share/applications"
     install -Dm644 meta/gui/icon.png $out/share/icons/hicolor/1024x1024/termius-app.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert meta/gui/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/termius-app.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/th/thorium-reader/package.nix
+++ b/pkgs/by-name/th/thorium-reader/package.nix
@@ -7,6 +7,7 @@
   electron,
   copyDesktopItems,
   makeDesktopItem,
+  imagemagick,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -28,10 +29,13 @@ buildNpmPackage (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
+    imagemagick
   ];
 
   postInstall = ''
     install -Dpm644 resources/icon.png $out/share/icons/hicolor/1024x1024/apps/thorium-reader.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert resources/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/thorium-reader.png
 
     cp -r dist/* $out/lib/node_modules/EDRLab.ThoriumReader/
 

--- a/pkgs/by-name/tk/tk-safe/package.nix
+++ b/pkgs/by-name/tk/tk-safe/package.nix
@@ -15,6 +15,7 @@
   makeDesktopItem,
   makeWrapper,
   wrapGAppsHook3,
+  imagemagick,
   writeScript,
   udev,
 }:
@@ -47,6 +48,7 @@ stdenv.mkDerivation rec {
     makeWrapper
     squashfsTools
     wrapGAppsHook3
+    imagemagick
   ];
 
   unpackPhase = ''
@@ -82,6 +84,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/icons/hicolor/1024x1024/apps
     ln -s $out/opt/tk-safe/meta/gui/icon.png $out/share/icons/hicolor/1024x1024/apps/tk-safe.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert $out/opt/tk-safe/meta/gui/icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/tk-safe.png
 
     runHook postInstall
   '';

--- a/pkgs/by-name/tt/tts-mod-vault/package.nix
+++ b/pkgs/by-name/tt/tts-mod-vault/package.nix
@@ -8,6 +8,7 @@
   yq-go,
   nix-update-script,
   _experimental-update-script-combinators,
+  imagemagick,
 }:
 
 flutter341.buildFlutterApplication (finalAttrs: {
@@ -34,7 +35,10 @@ flutter341.buildFlutterApplication (finalAttrs: {
     })
   ];
 
-  nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+  ];
 
   preBuild = ''
     echo 'SUPABASE_URL=https://pdrmmvvtindfbpxlcdps.supabase.co' > .env
@@ -43,6 +47,8 @@ flutter341.buildFlutterApplication (finalAttrs: {
 
   postInstall = ''
     install -m 444 -D assets/icon/tts_mod_vault_icon.png $out/share/icons/hicolor/1024x1024/apps/tts_mod_vault.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert assets/icon/tts_mod_vault_icon.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/tts_mod_vault.png
   '';
 
   passthru = {

--- a/pkgs/by-name/ve/venera/package.nix
+++ b/pkgs/by-name/ve/venera/package.nix
@@ -10,6 +10,7 @@
   _experimental-update-script-combinators,
   nix-update-script,
   dart,
+  imagemagick,
 }:
 
 flutter341.buildFlutterApplication (finalAttrs: {
@@ -27,7 +28,10 @@ flutter341.buildFlutterApplication (finalAttrs: {
 
   gitHashes = lib.importJSON ./git-hashes.json;
 
-  nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+  ];
 
   buildInputs = [ webkitgtk_4_1 ];
 
@@ -51,6 +55,8 @@ flutter341.buildFlutterApplication (finalAttrs: {
 
   postInstall = ''
     install -D --mode=0644 debian/gui/venera.png $out/share/icons/hicolor/1024x1024/apps/venera.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert debian/gui/venera.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/venera.png
   '';
 
   extraWrapProgramArgs = ''

--- a/pkgs/by-name/vo/volanta/package.nix
+++ b/pkgs/by-name/vo/volanta/package.nix
@@ -3,6 +3,7 @@
   fetchurl,
   lib,
   makeWrapper,
+  imagemagick,
   writeShellScript,
   common-updater-scripts,
   nix-update,
@@ -20,13 +21,18 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    imagemagick
+  ];
 
   # Note: Volanta needs the env variable APPIMAGE=true to be set in order to work at all.
   extraInstallCommands = ''
     install -m 444 -D ${appImageContents}/volanta.desktop $out/share/applications/volanta.desktop
     install -m 444 -D ${appImageContents}/volanta.png \
       $out/share/icons/hicolor/1024x1024/apps/volanta.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert ${appImageContents}/volanta.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/volanta.png
     substituteInPlace $out/share/applications/volanta.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=env APPIMAGE=true volanta'
     wrapProgram $out/bin/volanta \

--- a/pkgs/by-name/wi/winbox4/build-from-zip.nix
+++ b/pkgs/by-name/wi/winbox4/build-from-zip.nix
@@ -14,6 +14,7 @@
   makeWrapper,
   stdenvNoCC,
   unzip,
+  imagemagick,
   writeShellApplication,
   libxcb-wm,
   libxcb-render-util,
@@ -42,6 +43,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # makeBinaryWrapper does not support --run
     makeWrapper
     unzip
+    imagemagick
   ];
 
   buildInputs = [
@@ -62,6 +64,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     install -Dm644 "assets/img/winbox.png" -t "$out/share/icons/hicolor/1024x1024/apps"
+
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert "assets/img/winbox.png" -resize 512x512 "$out/share/icons/hicolor/512x512/apps/winbox.png"
+
     install -Dm755 "WinBox" "$out/bin/WinBox"
 
     wrapProgram "$out/bin/WinBox" --run "${lib.getExe finalAttrs.migrationScript}"

--- a/pkgs/by-name/wi/windterm/package.nix
+++ b/pkgs/by-name/wi/windterm/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   unzip,
   autoPatchelfHook,
+  imagemagick,
   fontconfig,
   freetype,
   libGL,
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     unzip
     makeWrapper
     autoPatchelfHook
+    imagemagick
   ];
 
   buildInputs = [
@@ -80,6 +82,8 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
     install -Dm644 $out/app/windterm/license.txt $out/share/licenses/windterm/license.txt
     install -Dm644 $out/app/windterm/windterm.png -t $out/share/icons/hicolor/1024x1024/apps
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert $out/app/windterm/windterm.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/windterm.png
     substituteInPlace $out/app/windterm/windterm.desktop \
       --replace-fail "/usr/bin/" ""
     install -Dm644 $out/app/windterm/windterm.desktop $out/share/applications/windterm.desktop

--- a/pkgs/by-name/wo/wootility/package.nix
+++ b/pkgs/by-name/wo/wootility/package.nix
@@ -3,6 +3,7 @@
   fetchurl,
   lib,
   makeWrapper,
+  imagemagick,
 }:
 
 let
@@ -17,7 +18,10 @@ in
 appimageTools.wrapType2 {
   inherit pname version src;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    imagemagick
+  ];
 
   extraInstallCommands =
     let
@@ -29,6 +33,8 @@ appimageTools.wrapType2 {
 
       install -Dm444 ${contents}/wootility.desktop -t $out/share/applications
       install -Dm444 ${contents}/wootility.png -t $out/share/icons/hicolor/1024x1024/apps
+      mkdir -p $out/share/icons/hicolor/512x512/apps
+      magick convert ${contents}/wootility.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/wootility.png
       substituteInPlace $out/share/applications/wootility.desktop \
         --replace-fail 'Exec=AppRun --no-sandbox' 'Exec=wootility'
     '';

--- a/pkgs/by-name/wo/wox/package.nix
+++ b/pkgs/by-name/wo/wox/package.nix
@@ -22,6 +22,7 @@
   xdg-utils,
   copyDesktopItems,
   makeDesktopItem,
+  imagemagick,
 }:
 
 let
@@ -168,6 +169,7 @@ buildGoModule {
     pkg-config
     autoPatchelfHook
     copyDesktopItems
+    imagemagick
   ];
 
   buildInputs = [
@@ -207,6 +209,8 @@ buildGoModule {
 
   postInstall = ''
     install -Dm644 ../assets/app.png $out/share/icons/hicolor/1024x1024/apps/wox.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    magick convert ../assets/app.png -resize 512x512 $out/share/icons/hicolor/512x512/apps/wox.png
   '';
 
   meta = metaCommon // {

--- a/pkgs/by-name/zo/zoho-mail-desktop/package.nix
+++ b/pkgs/by-name/zo/zoho-mail-desktop/package.nix
@@ -2,6 +2,7 @@
   lib,
   appimageTools,
   fetchurl,
+  imagemagick,
 }:
 
 let
@@ -24,9 +25,10 @@ appimageTools.wrapType2 {
   extraInstallCommands = ''
     install -Dm444 ${appimageContents}/zoho-mail-desktop.desktop \
       $out/share/applications/zoho-mail-desktop.desktop
-
-    install -Dm444 ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/zoho-mail-desktop.png \
-      $out/share/icons/hicolor/1024x1024/apps/zoho-mail-desktop.png
+    for size in 16 32 48 64 128 256 512 1024; do
+      install -Dm444 ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/zoho-mail-desktop.png \
+        $out/share/icons/hicolor/''${size}x''${size}/apps/zoho-mail-desktop.png
+    done
 
     substituteInPlace $out/share/applications/zoho-mail-desktop.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=${pname}'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
