### PR TITLE
rustlock: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13113,6 +13113,12 @@
     github = "jorsn";
     githubId = 4646725;
   };
+  JorySeverijnse = {
+    name = "Jory Severijnse";
+    email = "jory@severijnse.eu";
+    github = "JorySeverijnse";
+    githubId = 117462355;
+  };
   joscha = {
     name = "Joscha Loos";
     email = "j.loos@posteo.net";

--- a/pkgs/by-name/ru/rustlock/package.nix
+++ b/pkgs/by-name/ru/rustlock/package.nix
@@ -45,6 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/JorySeverijnse/rustlock";
     license = licenses.gpl3Only;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ JorySeverijnse ];
     mainProgram = "rustlock";
   };
 })

--- a/pkgs/by-name/ru/rustlock/package.nix
+++ b/pkgs/by-name/ru/rustlock/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cairo,
+  pam,
+  gdk-pixbuf,
+  librsvg,
+  pango,
+  libxkbcommon,
+  dbus,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rustlock";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "JorySeverijnse";
+    repo = "rustlock";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-mfQcMCUDncEZ/4qzMna//uzhtrow4axnuTnF88wnvi0=";
+  };
+
+  cargoHash = "sha256-AXWEf4xRARcuOn/rEMhNfNNC6HY/1BZtQSZetX15Eqs=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    cairo
+    pam
+    gdk-pixbuf
+    librsvg
+    pango
+    libxkbcommon
+    dbus
+  ];
+
+  meta = with lib; {
+    description = "A high-performance Wayland screen locker written in Rust";
+    homepage = "https://github.com/JorySeverijnse/rustlock";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    mainProgram = "rustlock";
+  };
+})

--- a/pkgs/by-name/ru/rustlock/package.nix
+++ b/pkgs/by-name/ru/rustlock/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "JorySeverijnse";
     repo = "rustlock";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-mfQcMCUDncEZ/4qzMna//uzhtrow4axnuTnF88wnvi0=";
   };
 
@@ -40,12 +40,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     dbus
   ];
 
-  meta = with lib; {
+  meta = {
     description = "A high-performance Wayland screen locker written in Rust";
     homepage = "https://github.com/JorySeverijnse/rustlock";
     license = licenses.gpl3Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ JorySeverijnse ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ JorySeverijnse ];
     mainProgram = "rustlock";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding my own tool to the nix packages and adding myself as a maintainer
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
