### PR TITLE
python3Packages.exceptiongroup: update repr patch after 3.14 backport

### DIFF
--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -2,11 +2,11 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   flit-scm,
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
-  isPy313,
   typing-extensions,
 }:
 
@@ -22,14 +22,19 @@ buildPythonPackage rec {
     hash = "sha256-3WInufN+Pp6vB/Gik6e8V1a34Dr/oiH3wDMB+2lHRMM=";
   };
 
-  # CPython fixed https://github.com/python/cpython/issues/141732 in
-  # https://github.com/python/cpython/pull/141736, but exceptiongroup 1.3.1,
-  # including its test suite, still matches the old repr behavior.
-  # The CPython fix has only been backported to 3.13 so far, where it was
-  # first included in version 3.13.12, so we only need to patch for 3.13
-  # and 3.15+.
-  # Upstream issue: https://github.com/agronholm/exceptiongroup/issues/154
-  patches = lib.optional (isPy313 || pythonAtLeast "3.15") ./match-repr-fix.patch;
+  patches = [
+    # CPython fixed https://github.com/python/cpython/issues/141732 in
+    # https://github.com/python/cpython/pull/141736 (backported to Python 3.13+),
+    # but exceptiongroup 1.3.1, including its test suite, still matches the old
+    # repr behavior.
+    # Upstream issue: https://github.com/agronholm/exceptiongroup/issues/154
+    # Upstream PR: https://github.com/agronholm/exceptiongroup/pull/155
+    (fetchpatch {
+      name = "match-repr-fix.patch";
+      url = "https://github.com/agronholm/exceptiongroup/commit/0c6cfbf677f6b50df17311cfdad01e9ff17310aa.patch";
+      hash = "sha256-EeYu1/JKYRDwdq8+n38RrdogipNzX0ate1trDs1Z3c0=";
+    })
+  ];
 
   build-system = [ flit-scm ];
 


### PR DESCRIPTION
> [!NOTE]
> Waiting for the CPython updates in https://github.com/NixOS/nixpkgs/pull/508075

https://github.com/python/cpython/pull/141736 was finally backported to CPython 3.14 in https://github.com/python/cpython/pull/144445, which landed in CPython 3.14.4, causing our build of `python314Packages.exceptiongroup` to fail.

In the meantime, exceptiongroup fixed `BaseExceptionGroup.__repr__` on their end to match CPython behavior (https://github.com/agronholm/exceptiongroup/pull/155), so we can use that patch instead.

For more context, see https://github.com/NixOS/nixpkgs/pull/487915.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.exceptiongroup` on top of https://github.com/NixOS/nixpkgs/pull/508075
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
