### PR TITLE
nixos/nginx: fix forceSSL sending text/html Content-Type on redirect

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -460,6 +460,7 @@ let
             server_name ${vhost.serverName} ${concatStringsSep " " vhost.serverAliases};
 
             location / {
+              more_clear_headers "Content-Type";
               return ${toString vhost.redirectCode} https://$host$request_uri;
             }
             ${acmeLocation}
@@ -1437,7 +1438,8 @@ in
 
     services.nginx.additionalModules =
       optional cfg.recommendedBrotliSettings pkgs.nginxModules.brotli
-      ++ lib.optional cfg.experimentalZstdSettings pkgs.nginxModules.zstd;
+      ++ lib.optional cfg.experimentalZstdSettings pkgs.nginxModules.zstd
+      ++ lib.optional (lib.any (vhost: vhost.forceSSL) vhostsConfigs) pkgs.nginxModules.moreheaders;
 
     services.nginx.virtualHosts.localhost = mkIf cfg.statusPage {
       serverAliases = [ "127.0.0.1" ] ++ lib.optional config.networking.enableIPv6 "[::1]";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1073,6 +1073,7 @@ in
   nginx-auth = runTest ./nginx-auth.nix;
   nginx-etag = runTest ./nginx-etag.nix;
   nginx-etag-compression = runTest ./nginx-etag-compression.nix;
+  nginx-forcessl = runTest ./nginx-forcessl.nix;
   nginx-globalredirect = runTest ./nginx-globalredirect.nix;
   nginx-http3 = import ./nginx-http3.nix { inherit pkgs runTest; };
   nginx-mime = runTest ./nginx-mime.nix;

--- a/nixos/tests/nginx-forcessl.nix
+++ b/nixos/tests/nginx-forcessl.nix
@@ -1,0 +1,52 @@
+{ lib, ... }:
+let
+  hosts = "192.168.2.101 acme.test";
+in
+{
+  name = "nginx-forcessl";
+  meta.maintainers = with lib.maintainers; [ kiara ];
+
+  nodes.server =
+    { pkgs, ... }:
+    {
+      networking = {
+        interfaces.eth1.ipv4.addresses = [
+          {
+            address = "192.168.2.101";
+            prefixLength = 24;
+          }
+        ];
+        extraHosts = hosts;
+        firewall.allowedTCPPorts = [
+          80
+          443
+        ];
+      };
+
+      security.pki.certificates = [
+        (builtins.readFile ./common/acme/server/ca.cert.pem)
+      ];
+
+      services.nginx = {
+        enable = true;
+        virtualHosts."acme.test" = {
+          forceSSL = true;
+          sslCertificate = ./common/acme/server/acme.test.cert.pem;
+          sslCertificateKey = ./common/acme/server/acme.test.key.pem;
+          root = pkgs.runCommandLocal "testdir" { } ''
+            mkdir "$out"
+            echo hello > "$out/index.html"
+          '';
+        };
+      };
+    };
+
+  testScript = ''
+    server.wait_for_unit("nginx")
+    server.wait_for_open_port(80)
+
+    # The forceSSL redirect should not set a Content-Type header
+    server.succeed("curl -si http://acme.test/ | grep -i '^HTTP/[0-9.]\\+ 301'")
+    server.fail("curl -si http://acme.test/ | grep -i '^Content-Type:'")
+  '';
+}


### PR DESCRIPTION
The forceSSL redirect server block causes nginx to set `Content-Type: text/html` on redirect responses, since that is nginx's default MIME type. Set `default_type ""` in the redirect server block so no Content-Type header is sent on redirects, where it is not meaningful.

closes #383878.

disclaimer i used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
