### PR TITLE
openclaw: 2026.4.2 -> 2026.4.9

### DIFF
--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -102,7 +102,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Remove broken symlinks created by pnpm workspace linking in extensions
     find $libdir/extensions -xtype l -delete
     # Remove symlinks pointing back to the build sandbox
-    find $libdir/dist/extensions -type l -lname '/build/*' -delete
+    find $libdir/dist/extensions -type l -lname "$NIX_BUILD_TOP/*" -delete
 
     makeWrapper ${lib.getExe nodejs_22} $out/bin/openclaw \
       --add-flags "$libdir/dist/index.js" \

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -11,7 +11,7 @@
   versionCheckHook,
   rolldown,
   installShellFiles,
-  version ? "2026.4.2",
+  version ? "2026.4.9",
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "openclaw";
@@ -21,10 +21,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "openclaw";
     repo = "openclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wVS2OuBNrF1yWjmINxde0kC5mvY2QUUtwYpYrZcARkI=";
+    hash = "sha256-wqvLBe+cEoo0x096fK6qKR8bDs4QHPTlxK5e64K4yls=";
   };
 
-  pnpmDepsHash = "sha256-aHepSWiQ4+UyjPHBF+4+M9/nFrgfCw422q671saJM+U=";
+  pnpmDepsHash = "sha256-mdppNeJVf0Def0GohiKks6W3uzsaoJUYJo/ggGmypKQ=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
@@ -58,10 +58,27 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     chmod -R u+w node_modules/rolldown node_modules/@rolldown/pluginutils \
       node_modules/.pnpm/node_modules/rolldown node_modules/.pnpm/node_modules/@rolldown/pluginutils
 
-    # In Nix sandbox, npm install has no network access. Patch the staging
-    # script to accept version-mismatched deps from root node_modules
-    # instead of falling back to npm install.
-    sed -i 's/if (installedVersion === null || !dependencyVersionSatisfied(spec, installedVersion)) {/if (installedVersion === null) {/' scripts/stage-bundled-plugin-runtime-deps.mjs
+    # In Nix sandbox, npm install has no network access.
+    # 1) Skip missing/mismatched deps in closure walk instead of aborting.
+    # 2) Never fall through to the npm-install path.
+    substituteInPlace scripts/stage-bundled-plugin-runtime-deps.mjs \
+      --replace-fail \
+        'if (installedVersion === null || !dependencyVersionSatisfied(spec, installedVersion)) {
+          return null;
+        }' \
+        'if (installedVersion === null || !dependencyVersionSatisfied(spec, installedVersion)) {
+          continue;
+        }' \
+      --replace-fail \
+        'stageInstalledRootRuntimeDeps({ fingerprint, packageJson, pluginDir, repoRoot })
+      ) {
+        return;
+      }' \
+        'stageInstalledRootRuntimeDeps({ fingerprint, packageJson, pluginDir, repoRoot })
+      ) {
+        return;
+      }
+      return; // nix: sandbox has no npm'
     pnpm build
     pnpm ui:build
 
@@ -76,7 +93,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
 
     cp --reflink=auto -r package.json dist node_modules $libdir/
-    cp --reflink=auto -r assets docs skills patches extensions $libdir/
+    cp --reflink=auto -r assets docs skills patches extensions qa $libdir/
 
     rm -f $libdir/node_modules/.pnpm/node_modules/clawdbot \
       $libdir/node_modules/.pnpm/node_modules/moltbot \
@@ -84,6 +101,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     # Remove broken symlinks created by pnpm workspace linking in extensions
     find $libdir/extensions -xtype l -delete
+    # Remove symlinks pointing back to the build sandbox
+    find $libdir/dist/extensions -type l -lname '/build/*' -delete
 
     makeWrapper ${lib.getExe nodejs_22} $out/bin/openclaw \
       --add-flags "$libdir/dist/index.js" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
