### PR TITLE
flutterPackages: don't specify root certs file

### DIFF
--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -42,7 +42,6 @@
   wrapGAppsHook3,
   writableTmpDirAsHomeHook,
   fd,
-  cacert,
   moreutils,
   writeTextFile,
   supportedTargetFlutterPlatforms,
@@ -297,7 +296,7 @@ stdenv.mkDerivation (finalAttrs: {
         builtins.concatStringsSep " " (map (flag: "-Wl,${flag}") linkerFlags)
       }' \
       ''${gappsWrapperArgs[@]} \
-      --add-flags "--disable-dart-dev --packages='${flutter-tools.pubcache}/package_config.json' --root-certs-file='${cacert}/etc/ssl/certs/ca-bundle.crt' $out/bin/cache/flutter_tools.snapshot"
+      --add-flags "--disable-dart-dev --packages='${flutter-tools.pubcache}/package_config.json' $out/bin/cache/flutter_tools.snapshot"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Currently, when running `flutter doctor`, Flutter errors out while checking network connectivity because it can't find the root certs file (see https://github.com/NixOS/nixpkgs/issues/507700#flutter-doctor:~:text=3)%0A%3Casynchronous%20suspension%3E-,flutter%20doctor,-%5B%E2%9C%93%5D%20Flutter%20(Channel%20stable).

This PR just removes the option that is passed to `dart` when executing `flutter` that sets that file. This is how it was before #500309.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
