### PR TITLE
action-validator: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/ac/action-validator/package.nix
+++ b/pkgs/by-name/ac/action-validator/package.nix
@@ -3,23 +3,44 @@
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
+  gitMinimal,
+  makeWrapper,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "action-validator";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "mpalmer";
     repo = "action-validator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-irBK27De9W5BSNIQynguOY8oPgA7K03dleE/0YvY75o=";
+    hash = "sha256-E0kqEzqw902Wg7QQNzOrtHQO9riSmAvDNcWIP3XmLSY=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-w6qC4gJ06TfoQl2WD8lgOxSxUWyG6Z8ma9mUvvYlkTU=";
+  cargoHash = "sha256-F8bJclpDpOdVET/dSIUYyP4DFcnhJDR2CV8poZtykko=";
 
   passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  # The tests require a functional git installation and leaveDotGit appears broken https://github.com/NixOS/nixpkgs/issues/8567
+  preCheck = ''
+    git init -b main
+    git add --all # action-validator tests ignore unstaged files
+  '';
+
+  postCheck = ''
+    rm -rf .git
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/action-validator" \
+      --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
+  '';
 
   meta = {
     description = "Tool to validate GitHub Action and Workflow YAML files";

--- a/pkgs/by-name/ac/action-validator/package.nix
+++ b/pkgs/by-name/ac/action-validator/package.nix
@@ -23,6 +23,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
+  postPatch = ''
+    substituteInPlace Cargo.toml --replace-fail 'version = "0.0.0-git"' 'version = "${finalAttrs.version}"'
+  '';
+
   nativeBuildInputs = [ makeWrapper ];
 
   nativeCheckInputs = [ gitMinimal ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

action-validator received a new update in https://github.com/mpalmer/action-validator/releases/tag/v0.9.0. Full changes in https://github.com/mpalmer/action-validator/compare/v0.8.0...v0.9.0.

nix-packaging wise the meaningful change is that action-validator now shells out to `git ls-files`. Therefore I have wrapped it with `gitMinimal`.

~~Since some of the tests now assume they are 1) run in a git repository 2) have access to git cli, it seems like `doCheck = false;` is the right approach. I seem to recall that for reproducibility reasons Nix does not provide a `.git` in the build/test environment. Happy to be corrected.~~

Tried using `leaveDotGit`, but the tests would keep failing the same way. Searched other `package.nix` about it and found a `git init` pattern combined with `preCheck`/`postCheck`. With this tests pass consistently so I believe it's satisfactory.

This PR also adds a postPatch so that `action-validator -V` correctly reports its version. This is similar how the source repository dynamically updates the version in its CI pipelines before compiling.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs. (this is difficult to do exhaustively, I have read them in the past exhaustively, have skimmed them now, and I believe this should fit the expected pattern -- first real PR in this repo)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
