### PR TITLE
xtrkcad: init at 5.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15972,6 +15972,12 @@
     githubId = 41804945;
     name = "Luke Schenk";
   };
+  luke-elsdon = {
+    email = "luke.elsdon@gmail.com";
+    github = "Luke-Elsdon";
+    githubId = 20634389;
+    name = "Luke Elsdon";
+  };
   lukebfox = {
     email = "lbentley-fox1@sheffield.ac.uk";
     github = "lukebfox";

--- a/pkgs/by-name/xt/xtrkcad/package.nix
+++ b/pkgs/by-name/xt/xtrkcad/package.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Model Railway CAD program ";
     mainProgram = "xtrkcad";
     license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ luke-elsdon ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/xt/xtrkcad/package.nix
+++ b/pkgs/by-name/xt/xtrkcad/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchhg,
+  mercurial,
+  cmake,
+  libgcc,
+  pkg-config,
+  gtk2,
+  libzip,
+  libnxml,
+  inkscape,
+  doxygen,
+  pandoc,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xtrkcad";
+  version = "5.3.1";
+
+  src = fetchhg {
+    url = "http://hg.code.sf.net/p/xtrkcad-fork/xtrkcad";
+    hash = "sha256-QtR122kC+Nqo5shw3xE/8nrHTBSgdBGLt5xBKTs5+KE=";
+  };
+
+  buildInputs = [
+    cmake
+    mercurial
+    libgcc
+    pkg-config
+    inkscape
+    gtk2
+    libzip
+    libnxml
+    inkscape
+    doxygen
+    pandoc
+  ];
+
+  meta = {
+    homepage = "https://sourceforge.net/projects/xtrkcad-fork/";
+    description = "Model Railway CAD program ";
+    mainProgram = "xtrkcad";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Created package for xtrkcad: https://sourceforge.net/projects/xtrkcad-fork/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
