### PR TITLE
nixos/drupal: synchronize config sync yamls from src into drupal state dir

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -328,4 +328,4 @@ gnuradioMinimal.override {
 
 - The builder `php.buildComposerProject2` for PHP applications has been improved for better reliability and stability.
 
-- The `services.drupal` module has a few improvements aimed at making it better for installing custom Drupal instances, namely a `webRoot` option and a some new settings for managing variable content and filepaths.
+- The `services.drupal` module has a few improvements aimed at making it better for installing custom Drupal instances, namely a new `webRoot` option for identifying custom webroots in source code, a new `configRoot` option for identifying and synchronizing config yamls onto NixOS, and a some new settings for managing variable content and filepaths.

--- a/nixos/modules/services/web-apps/drupal.nix
+++ b/nixos/modules/services/web-apps/drupal.nix
@@ -23,10 +23,12 @@ let
     mkPackageOption
     nameValuePair
     optionalAttrs
+    optionalString
     types
     ;
   inherit (lib.strings)
     removePrefix
+    removeSuffix
     ;
   inherit (pkgs)
     mariadb
@@ -51,7 +53,13 @@ let
         runHook preInstall
 
         mkdir -p $out
-        rsync -aq * $out/ --exclude=${removePrefix "/" cfg.webRoot}/sites --exclude=sites
+        EXCLUDES="--exclude=${removePrefix "/" cfg.webRoot}/sites --exclude=sites"
+
+        if [ ! -z "${cfg.configRoot}" ]; then
+          EXCLUDES="$EXCLUDES --exclude=${removePrefix "/" cfg.configRoot}"
+        fi
+
+        rsync -aq * $out/ $EXCLUDES
 
         runHook postInstall
       '';
@@ -80,6 +88,26 @@ let
         runHook postInstall
       '';
     });
+
+  configSync =
+    hostName: cfg:
+    optionalString (cfg.configRoot != "") (
+      stdenv.mkDerivation (finalAttrs: {
+        pname = "drupal-config-${hostName}";
+        name = "drupal-config-${hostName}";
+        src = cfg.package;
+        buildInputs = with pkgs; [ rsync ];
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/config
+          rsync -a ./share/php/${cfg.package.pname}${cfg.configRoot}/* $out/config/
+
+          runHook postInstall
+        '';
+      })
+    );
 
   drupalSettings =
     hostName: cfg:
@@ -136,13 +164,22 @@ let
     hostName: cfg:
     pkgs.writeShellApplication {
       name = "drupal-state-init-${hostName}";
-      excludeShellChecks = [ "SC2194" ];
+      excludeShellChecks = [
+        "SC2194"
+        "SC2157"
+      ];
       runtimeInputs = with pkgs; [ rsync ];
       text = ''
         echo "Updating the sites directory for ${hostName}..."
         rsync -auq "${sites hostName cfg}/sites/" "${cfg.stateDir}/sites/" \
           --exclude "*/files" \
           --delete-before
+
+        if [ ! -z "${cfg.configRoot}" ]; then
+          echo "Updating config sync directory for ${hostName}..."
+          rsync -auq "${configSync hostName cfg}/config/" "${removeSuffix "/sync" cfg.configSyncDir}" \
+            --delete-before
+        fi
 
         if [ ! -d "${cfg.filesDir}" ]; then
           echo "Preparing files directory..."
@@ -221,6 +258,10 @@ let
             The location of the user-managed Drupal config sync directory.
             Drupal will both read from and write to this directory when executing
             configuration management operations.
+
+            This option differs from the `configRoot` option,
+            which this service uses to discover
+            the location of the config sync directory in the package's source code.
           '';
         };
 
@@ -229,10 +270,30 @@ let
           default = "";
           description = ''
             An optional path string with a leading slash
-            indicating the location of the Drupal webroot relative to the
-            project root directory, if one exists.
+            indicating the location of the Drupal webroot
+            in your package's source code.
+
+            The path relative to the project root directory.
           '';
           example = "/web";
+        };
+
+        configRoot = mkOption {
+          type = types.str;
+          default = "";
+          description = ''
+            An optional path string with a leading slash
+            indicating the location of the config sync directory on
+            the Drupal package. Your package will probably have a config sync
+            directory if it has been significantly customized.
+
+            The path must be relative to the project root directory.
+
+            This option differs from the `configSyncDir` option, which
+            tells this service where to create a user-writeable config directory
+            on NixOS.
+          '';
+          example = "/config";
         };
 
         extraConfig = mkOption {


### PR DESCRIPTION
Similar to the previous work done on the `/sites` directory (https://github.com/NixOS/nixpkgs/pull/506644), this PR focuses on making it possible to populate and synchronize the contents of the `config/sync` directory between the package source code and the NixOS state directory.

During runtime, Drupal looks into the `config/sync` directory (often located at that location in the project root) in order see if it has database changes that it needs to import or export. This is pretty similar to how both Ruby on Rails and Django think of "migrations" as being database changes that you can save as code. Admins can choose to export the current database configuration into this directory at any time if there was a qualifying change on the nixos-based Drupal instance. Admins are then responsible for taking the changes to that directory and committing them to source code by some means.

However, what was lacking was a tool to synchronize incoming config changes from a custom package into the already existing nixos-based Drupal instance.

This PR addresses that by optionally creating a new derivation to store the contents of `config` (only when the new `configRoot` option has a value), and then an already existing systemd service uses rsync to place those new config yamls into the directory identified by the `configSyncDir` option.

I've also tried to be mindful of presrving all of the contents of the `config` directory from the upstream package. This makes it ideal for use with tools like the[ Config Split module](https://www.drupal.org/project/config_split) where it's a common convention to place different conditional configuration splits in directories along `config/sync`, like `config/local`, `config/dev`, and `config/live`.


This also solves https://github.com/NixOS/nixpkgs/issues/508028

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
