### PR TITLE
python313Packages.ignorant: init at 1.2

### DIFF
--- a/pkgs/development/python-modules/ignorant/default.nix
+++ b/pkgs/development/python-modules/ignorant/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  beautifulsoup4,
+  buildPythonPackage,
+  fetchPypi,
+  httpx,
+  setuptools,
+  termcolor,
+  tqdm,
+  trio,
+}:
+
+buildPythonPackage rec {
+  pname = "ignorant";
+  version = "1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-SLjED08uI+RjX+E0WHTQceReTEaY9WLPhXR3n0fP080=";
+  };
+
+  pythonRemoveDeps = [
+    # https://github.com/megadose/ignorant/pull/37
+    "argparse"
+    # https://github.com/megadose/ignorant/pull/36
+    "bs4"
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    beautifulsoup4
+    httpx
+    termcolor
+    tqdm
+    trio
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "ignorant" ];
+
+  meta = {
+    description = "Module to check if a phone number is used on different sites";
+    homepage = "https://pypi.org/project/ignorant/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7390,6 +7390,8 @@ self: super: with self; {
 
   ignite = callPackage ../development/python-modules/ignite { };
 
+  ignorant = callPackage ../development/python-modules/ignorant { };
+
   igraph = callPackage ../development/python-modules/igraph { inherit (pkgs) igraph; };
 
   ihcsdk = callPackage ../development/python-modules/ihcsdk { };


### PR DESCRIPTION
Module to check if a phone number is use

https://github.com/megadose/ignorant

Splitted out from #479162
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
