### PR TITLE
python313Packages.requests-random-user-agent: init at 2025.01.19

### DIFF
--- a/pkgs/development/python-modules/requests-random-user-agent/default.nix
+++ b/pkgs/development/python-modules/requests-random-user-agent/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+  pytestCheckHook,
+  pytest-httpbin,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "requests-random-user-agent";
+  version = "2025.01.19";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DavidWittman";
+    repo = "requests-random-user-agent";
+    tag = finalAttrs.version;
+    hash = "sha256-El/aibqEyx5diVTOe/4PEFB7KRfKqUJGPar6j6hZyIc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "requests_random_user_agent" ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_request"
+    "test_request_different_without_session"
+    "test_request_without_session"
+  ];
+
+  meta = {
+    description = "Configures the requests library to randomly select a desktop User-Agent";
+    homepage = "https://github.com/DavidWittman/requests-random-user-agent";
+    changelog = "https://github.com/DavidWittman/requests-random-user-agent/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16764,6 +16764,10 @@ self: super: with self; {
 
   requests-pkcs12 = callPackage ../development/python-modules/requests-pkcs12 { };
 
+  requests-random-user-agent =
+    callPackage ../development/python-modules/requests-random-user-agent
+      { };
+
   requests-ratelimiter = callPackage ../development/python-modules/requests-ratelimiter { };
 
   requests-toolbelt = callPackage ../development/python-modules/requests-toolbelt { };


### PR DESCRIPTION
Configures the requests library to randomly select a desktop User-Agent

https://github.com/DavidWittman/requests-random-user-agent

Splitted out from https://github.com/NixOS/nixpkgs/pull/479162
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
