### PR TITLE
ocelot: init at 0.5.2

### DIFF
--- a/pkgs/by-name/oc/ocelot/package.nix
+++ b/pkgs/by-name/oc/ocelot/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ocelot";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "xrelkd";
+    repo = "ocelot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z0RKEHeDhHjZtqXWueASMgiqnFRNsPe2rdoC7LZ/Mh8=";
+  };
+
+  cargoHash = "sha256-rJoIElM7fYg+oEV5idUNGys88x6dFeO4Ux8TxJKNqPU=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd ocelot \
+      --bash <($out/bin/ocelot completions bash) \
+      --fish <($out/bin/ocelot completions fish) \
+      --zsh  <($out/bin/ocelot completions zsh)
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Process supervisor and init system written in Rust Programming Language";
+    homepage = "https://github.com/xrelkd/ocelot";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ xrelkd ];
+    mainProgram = "ocelot";
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`ocelot` is a minimalist process supervisor and init system written in the Rust Programming Language.
It is specifically designed to act as a lightweight PID 1 process in containerized environments, ensuring that zombie processes are reaped and system signals are handled gracefully.

- [ocelot](https://github.com/xrelkd/ocelot)
- [README.md](https://github.com/xrelkd/ocelot/blob/v0.5.0/README.md)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
