### PR TITLE
schroot: adapt to boost 1.89

### DIFF
--- a/pkgs/by-name/sc/schroot/boost-1.89.patch
+++ b/pkgs/by-name/sc/schroot/boost-1.89.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,7 +59,7 @@
+ 
+ include(FindBoost)
+ find_package(Boost REQUIRED
+-             COMPONENTS filesystem system iostreams program_options regex)
++             COMPONENTS filesystem iostreams program_options regex)
+ 
+ # HEADER CHECKS
+ include(CheckIncludeFileCXX)

--- a/pkgs/by-name/sc/schroot/package.nix
+++ b/pkgs/by-name/sc/schroot/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation {
     ./fix-absolute-paths.patch
     ./fix-boost-includes.patch
     ./bump-cmake-minimum.patch
+    ./boost-1.89.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
fix failing build: adapt to boost 1.89

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

