### PR TITLE
rimgo: 1.2.6 -> 1.4.1

### DIFF
--- a/pkgs/by-name/ri/rimgo/package.nix
+++ b/pkgs/by-name/ri/rimgo/package.nix
@@ -2,22 +2,23 @@
   lib,
   fetchFromCodeberg,
   buildGoModule,
-  tailwindcss_3,
+  tailwindcss_4,
+  nix-update-script,
 }:
 buildGoModule (finalAttrs: {
   pname = "rimgo";
-  version = "1.2.6";
+  version = "1.4.1";
 
   src = fetchFromCodeberg {
     owner = "rimgo";
     repo = "rimgo";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PBzbCiRIDrtKH3j6jxmylPpwafR5qgRYDHgYP1m/+Ok=";
+    hash = "sha256-0P2+U4wXiFybpGzV7IB1DXZWC+qIdeQtR6mtiYrrih0=";
   };
 
-  vendorHash = "sha256-nk1Pl9K62RjmBUgTlbp3u6cCoiEwpUHavfT3Oy0iyGU=";
+  vendorHash = "sha256-unqml6T50BTBzYXXGcL4cc+q9qJJ9W2b2flPBPheBpk=";
 
-  nativeBuildInputs = [ tailwindcss_3 ];
+  nativeBuildInputs = [ tailwindcss_4 ];
 
   preBuild = ''
     tailwindcss -i static/tailwind.css -o static/app.css -m
@@ -28,6 +29,8 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X codeberg.org/rimgo/rimgo/pages.VersionInfo=${finalAttrs.version}"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Alternative frontend for Imgur";


### PR DESCRIPTION
up and working on https://rimgo.quantenzitrone.eu

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
