### PR TITLE
[Backport release-25.11] freetube: 0.23.15 -> 0.24.0

### DIFF
--- a/pkgs/by-name/fr/freetube/package.nix
+++ b/pkgs/by-name/fr/freetube/package.nix
@@ -20,13 +20,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "freetube";
-  version = "0.23.15";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "FreeTubeApp";
     repo = "FreeTube";
     tag = "v${finalAttrs.version}-beta";
-    hash = "sha256-tYRvR75qbJwt6U4KzT9jrJjO5UznpoALqhUTDkeUlzI=";
+    hash = "sha256-4XyN7ENsDwLNB/dt7pp8z0sbdmHSNIyVEHlp5GXIues=";
   };
 
   # Darwin requires writable Electron dist
@@ -45,11 +45,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     (replaceVars ./patch-build-script.patch {
       electron-version = electron.version;
     })
+    ./targets.patch
   ];
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-sxDlPB3CWbFAm3WZ6AlwuVu/4UFR9Stl3q0wpkUXPPU=";
+    hash = "sha256-9rO/XYfOf1TEQOpb5clCfdTiuDeynpnk6L4WpcIIWGk=";
   };
 
   nativeBuildInputs = [
@@ -69,7 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     makeWrapper ${lib.getExe electron} $out/bin/freetube \
       --add-flags "$out/share/freetube/resources/app.asar" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
     install -D _icons/icon.svg $out/share/icons/hicolor/scalable/apps/freetube.svg
   ''

--- a/pkgs/by-name/fr/freetube/patch-build-script.patch
+++ b/pkgs/by-name/fr/freetube/patch-build-script.patch
@@ -1,13 +1,13 @@
-diff --git a/_scripts/ebuilder.config.js b/_scripts/ebuilder.config.js
-index 14d0d9df1..c5fc569c8 100644
---- a/_scripts/ebuilder.config.js
-+++ b/_scripts/ebuilder.config.js
-@@ -1,6 +1,8 @@
- const { name, productName } = require('../package.json')
+diff --git a/_scripts/ebuilder.config.mjs b/_scripts/ebuilder.config.mjs
+index bef1f6f1d..d2ee86611 100644
+--- a/_scripts/ebuilder.config.mjs
++++ b/_scripts/ebuilder.config.mjs
+@@ -2,6 +2,8 @@ import packageDetails from '../package.json' with { type: 'json' }
  
- const config = {
+ /** @type {import('electron-builder').Configuration} */
+ export default {
 +  electronVersion: "@electron-version@",
 +  electronDist: "electron-dist",
-   appId: `io.freetubeapp.${name}`,
-   copyright: 'Copyleft © 2020-2025 freetubeapp@protonmail.com',
+   appId: `io.freetubeapp.${packageDetails.name}`,
+   copyright: 'Copyleft © 2020-2026 freetubeapp@protonmail.com',
    // asar: false,

--- a/pkgs/by-name/fr/freetube/targets.patch
+++ b/pkgs/by-name/fr/freetube/targets.patch
@@ -1,0 +1,22 @@
+diff --git a/_scripts/build.mjs b/_scripts/build.mjs
+index 1617f1ad5..b9a1de43b 100644
+--- a/_scripts/build.mjs
++++ b/_scripts/build.mjs
+@@ -14,7 +14,7 @@ if (platform === 'darwin') {
+     arch = Arch.arm64
+   }
+ 
+-  targets = Platform.MAC.createTarget(['DMG', 'zip', '7z'], arch)
++  targets = Platform.MAC.createTarget(['dir'], arch)
+ } else if (platform === 'win32') {
+   let arch = Arch.x64
+ 
+@@ -34,7 +34,7 @@ if (platform === 'darwin') {
+     arch = Arch.armv7l
+   }
+ 
+-  targets = Platform.LINUX.createTarget(['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'], arch)
++  targets = Platform.LINUX.createTarget(['dir'], arch)
+ }
+ 
+ const output = await build({ targets, config, publish: 'never' })


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/505648 to 25.11

https://github.com/FreeTubeApp/FreeTube/releases/tag/v0.24.0-beta Diff: https://github.com/FreeTubeApp/FreeTube/compare/v0.23.15-beta...v0.24.0-beta (cherry picked from commit 208a7d472039e701c44ad0f462210ed74df3093f)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
