### PR TITLE
tlshd: add modular service and test

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -20,6 +20,7 @@ let
   modularServicesModule = {
     options = {
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
+      "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
       "<imports = [ pkgs.snid.services.default ]>" = fakeSubmodule pkgs.snid.services.default;
     };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1655,6 +1655,7 @@ in
   tinydns = runTest ./tinydns.nix;
   tinyproxy = runTest ./tinyproxy.nix;
   tinywl = runTest ./tinywl.nix;
+  tlshd = runTest ./tlshd.nix;
   tlsrpt = runTest ./tlsrpt.nix;
   tmate-ssh-server = runTest ./tmate-ssh-server.nix;
   tomcat = runTest ./tomcat.nix;

--- a/nixos/tests/tlshd.nix
+++ b/nixos/tests/tlshd.nix
@@ -1,0 +1,93 @@
+{ lib, pkgs, ... }:
+let
+  runWithOpenSSL =
+    name: cmd:
+    pkgs.runCommand name {
+      buildInputs = [ pkgs.openssl ];
+    } cmd;
+
+  caKey = runWithOpenSSL "ca.key" "openssl ecparam -name prime256v1 -genkey -noout -out $out";
+  caCert = runWithOpenSSL "ca.crt" ''
+    openssl req -new -x509 -sha256 -key ${caKey} -out $out -subj "/CN=Test CA" -days 36500
+  '';
+
+  serverKey = runWithOpenSSL "server.key" "openssl ecparam -name prime256v1 -genkey -noout -out $out";
+  serverCert = runWithOpenSSL "server.crt" ''
+    openssl req -new -sha256 -key ${serverKey} -out server.csr -subj "/CN=server"
+    openssl x509 -req -in server.csr -CA ${caCert} -CAkey ${caKey} \
+      -CAcreateserial -out $out -days 36500 -sha256
+  '';
+
+  clientKey = runWithOpenSSL "client.key" "openssl ecparam -name prime256v1 -genkey -noout -out $out";
+  clientCert = runWithOpenSSL "client.crt" ''
+    openssl req -new -sha256 -key ${clientKey} -out client.csr -subj "/CN=client"
+    openssl x509 -req -in client.csr -CA ${caCert} -CAkey ${caKey} \
+      -CAcreateserial -out $out -days 36500 -sha256
+  '';
+in
+{
+  _class = "nixosTest";
+  name = "tlshd";
+
+  nodes = {
+    server =
+      { pkgs, ... }:
+      {
+        system.services.tlshd = {
+          imports = [ pkgs.ktls-utils.services.default ];
+          tlshd.settings = {
+            "authenticate.server" = {
+              "x509.certificate" = toString serverCert;
+              "x509.private_key" = toString serverKey;
+              "x509.truststore" = toString caCert;
+            };
+          };
+        };
+
+        services.nfs.server = {
+          enable = true;
+          exports = ''
+            /export 192.168.1.0/24(rw,no_root_squash,no_subtree_check,xprtsec=mtls)
+          '';
+          createMountPoints = true;
+        };
+
+        networking.firewall.enable = false;
+      };
+
+    client =
+      { pkgs, ... }:
+      {
+        system.services.tlshd = {
+          imports = [ pkgs.ktls-utils.services.default ];
+          tlshd.settings = {
+            "authenticate.client" = {
+              "x509.certificate" = toString clientCert;
+              "x509.private_key" = toString clientKey;
+              "x509.truststore" = toString caCert;
+            };
+          };
+        };
+
+        virtualisation.fileSystems."/mnt/nfs" = {
+          device = "server:/export";
+          fsType = "nfs";
+          options = [ "xprtsec=mtls" ];
+        };
+
+        networking.firewall.enable = false;
+      };
+  };
+
+  testScript = ''
+    start_all()
+    server.wait_for_unit("nfs-server.service")
+    server.wait_for_unit("tlshd.service")
+    client.wait_for_unit("tlshd.service")
+    client.wait_for_unit("mnt-nfs.mount")
+    client.wait_until_succeeds("echo 'hello from client' > /mnt/nfs/test.txt")
+    server.wait_until_succeeds("grep 'hello from client' /export/test.txt")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ tomfitzhenry ];
+}

--- a/pkgs/by-name/kt/ktls-utils/package.nix
+++ b/pkgs/by-name/kt/ktls-utils/package.nix
@@ -11,6 +11,7 @@
   systemd,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   nix-update-script,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -47,7 +48,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.nixos = nixosTests.tlshd;
+    services.default = {
+      imports = [ (lib.modules.importApply ./service.nix { }) ];
+      tlshd.package = finalAttrs.finalPackage;
+    };
+  };
 
   meta = {
     description = "TLS handshake utilities for in-kernel TLS consumers";

--- a/pkgs/by-name/kt/ktls-utils/service.nix
+++ b/pkgs/by-name/kt/ktls-utils/service.nix
@@ -1,0 +1,75 @@
+# Non-module dependencies (`importApply`)
+{ }:
+
+# Service module
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkOption
+    types
+    ;
+  cfg = config.tlshd;
+
+  configFile = config.configData."tlshd.conf".path;
+in
+{
+  # https://nixos.org/manual/nixos/unstable/#modular-services
+  _class = "service";
+
+  options.tlshd = {
+    package = mkOption {
+      description = "Package to use for tlshd.";
+      defaultText = lib.literalMD "The `ktls-utils` package that provided this module.";
+      type = types.package;
+    };
+
+    settings = mkOption {
+      description = ''
+        Configuration for tlshd in INI format.
+        See {manpage}`tlshd.conf(5)` for available options.
+      '';
+      type = types.attrsOf (types.attrsOf types.str);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "authenticate.server" = {
+            "x509.certificate" = "/var/lib/tlshd/cert.pem";
+            "x509.private_key" = "/var/lib/tlshd/key.pem";
+            "x509.truststore" = "/var/lib/tlshd/truststore.pem";
+          };
+        }
+      '';
+    };
+  };
+
+  config = {
+    configData."tlshd.conf".text = lib.generators.toINI { } cfg.settings;
+
+    process.argv = [
+      (getExe cfg.package)
+      "--config"
+      configFile
+    ];
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      description = "Handshake service for kernel TLS consumers";
+      documentation = [ "man:tlshd(8)" ];
+      unitConfig.DefaultDependencies = false;
+      before = [ "remote-fs-pre.target" ];
+      wantedBy = [ "remote-fs.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        DynamicUser = true;
+        AmbientCapabilities = [ "CAP_NET_ADMIN" ];
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
This adds a [modular service](https://github.com/NixOS/nixpkgs/blob/master/nixos/README-modular-services.md) for [`tlshd`](https://github.com/oracle/ktls-utils): " The tlshd program implements a user agent that services TLS handshake requests on behalf of kernel TLS consumers.".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
