### PR TITLE
nerdctl: enable darwin and fix default data-root permission issue

### DIFF
--- a/pkgs/by-name/ne/nerdctl/package.nix
+++ b/pkgs/by-name/ne/nerdctl/package.nix
@@ -1,11 +1,12 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   makeWrapper,
   installShellFiles,
   buildkit,
-  cni-plugins,
+  cni-plugins ? null,
   writableTmpDirAsHomeHook,
   versionCheckHook,
   extraPackages ? [ ],
@@ -50,13 +51,14 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     wrapProgram $out/bin/nerdctl \
-      --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}" \
-      --prefix CNI_PATH : "${cni-plugins}/bin"
+      --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}"${lib.optionalString stdenv.hostPlatform.isLinux '' \
+      --prefix CNI_PATH : "${cni-plugins}/bin"''}
 
+    mkdir -p "$TMPDIR/nerdctl-data"
     installShellCompletion --cmd nerdctl \
-      --bash <($out/bin/nerdctl completion bash) \
-      --fish <($out/bin/nerdctl completion fish) \
-      --zsh <($out/bin/nerdctl completion zsh)
+      --bash <($out/bin/nerdctl --data-root "$TMPDIR/nerdctl-data" completion bash) \
+      --fish <($out/bin/nerdctl --data-root "$TMPDIR/nerdctl-data" completion fish) \
+      --zsh <($out/bin/nerdctl --data-root "$TMPDIR/nerdctl-data" completion zsh)
   '';
 
   doInstallCheck = true;
@@ -82,6 +84,6 @@ buildGoModule (finalAttrs: {
       developer-guy
       jk
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ne/nerdctl/package.nix
+++ b/pkgs/by-name/ne/nerdctl/package.nix
@@ -49,6 +49,88 @@ buildGoModule (finalAttrs: {
   # Many checks require a containerd socket and running nerdctl after it's built
   doCheck = false;
 
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    cat > pkg/defaults/defaults_darwin.go <<'EOF'
+    /*
+       Copyright The containerd Authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+    */
+
+    // This is a dummy file to allow usage of library functions
+    // on Darwin-based systems.
+    // All functions and variables are empty/no-ops
+
+    package defaults
+
+    import (
+      "os"
+      "path/filepath"
+
+      gocni "github.com/containerd/go-cni"
+    )
+
+    const (
+      AppArmorProfileName = ""
+      SeccompProfileName  = ""
+      Runtime             = ""
+    )
+
+    func CNIPath() string {
+      return gocni.DefaultCNIDir
+    }
+
+    func CNIRuntimeDir() (string, error) {
+      return "/var/run/cni", nil
+    }
+
+    func CNINetConfPath() string {
+      return gocni.DefaultNetDir
+    }
+
+    func DataRoot() string {
+      if home, err := os.UserHomeDir(); err == nil && home != "" {
+        return filepath.Join(home, ".local", "share", "nerdctl")
+      }
+      return "/var/lib/nerdctl"
+    }
+
+    func CgroupManager() string {
+      return ""
+    }
+
+    func CgroupnsMode() string {
+      return ""
+    }
+
+    func NerdctlTOML() string {
+      return "/etc/nerdctl/nerdctl.toml"
+    }
+
+    func HostsDirs() []string {
+      return []string{}
+    }
+
+    func HostGatewayIP() string {
+      return ""
+    }
+
+    func CDISpecDirs() []string {
+      return []string{"/etc/cdi", "/var/run/cdi"}
+    }
+    EOF
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/nerdctl \
       --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}"${lib.optionalString stdenv.hostPlatform.isLinux '' \

--- a/pkgs/by-name/ne/nerdctl/package.nix
+++ b/pkgs/by-name/ne/nerdctl/package.nix
@@ -49,92 +49,13 @@ buildGoModule (finalAttrs: {
   # Many checks require a containerd socket and running nerdctl after it's built
   doCheck = false;
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    cat > pkg/defaults/defaults_darwin.go <<'EOF'
-    /*
-       Copyright The containerd Authors.
-
-       Licensed under the Apache License, Version 2.0 (the "License");
-       you may not use this file except in compliance with the License.
-       You may obtain a copy of the License at
-
-           http://www.apache.org/licenses/LICENSE-2.0
-
-       Unless required by applicable law or agreed to in writing, software
-       distributed under the License is distributed on an "AS IS" BASIS,
-       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-       See the License for the specific language governing permissions and
-       limitations under the License.
-    */
-
-    // This is a dummy file to allow usage of library functions
-    // on Darwin-based systems.
-    // All functions and variables are empty/no-ops
-
-    package defaults
-
-    import (
-      "os"
-      "path/filepath"
-
-      gocni "github.com/containerd/go-cni"
-    )
-
-    const (
-      AppArmorProfileName = ""
-      SeccompProfileName  = ""
-      Runtime             = ""
-    )
-
-    func CNIPath() string {
-      return gocni.DefaultCNIDir
-    }
-
-    func CNIRuntimeDir() (string, error) {
-      return "/var/run/cni", nil
-    }
-
-    func CNINetConfPath() string {
-      return gocni.DefaultNetDir
-    }
-
-    func DataRoot() string {
-      if home, err := os.UserHomeDir(); err == nil && home != "" {
-        return filepath.Join(home, ".local", "share", "nerdctl")
-      }
-      return "/var/lib/nerdctl"
-    }
-
-    func CgroupManager() string {
-      return ""
-    }
-
-    func CgroupnsMode() string {
-      return ""
-    }
-
-    func NerdctlTOML() string {
-      return "/etc/nerdctl/nerdctl.toml"
-    }
-
-    func HostsDirs() []string {
-      return []string{}
-    }
-
-    func HostGatewayIP() string {
-      return ""
-    }
-
-    func CDISpecDirs() []string {
-      return []string{"/etc/cdi", "/var/run/cdi"}
-    }
-    EOF
-  '';
-
   postInstall = ''
     wrapProgram $out/bin/nerdctl \
-      --prefix PATH : "${lib.makeBinPath ([ buildkit ] ++ extraPackages)}"${lib.optionalString stdenv.hostPlatform.isLinux '' \
-      --prefix CNI_PATH : "${cni-plugins}/bin"''}
+      --prefix PATH : "${
+        lib.makeBinPath ([ buildkit ] ++ extraPackages)
+      }"${lib.optionalString stdenv.hostPlatform.isLinux ''
+        \
+             --prefix CNI_PATH : "${cni-plugins}/bin"''}
 
     mkdir -p "$TMPDIR/nerdctl-data"
     installShellCompletion --cmd nerdctl \


### PR DESCRIPTION
## Summary

This updates `pkgs/by-name/ne/nerdctl/package.nix` to make `nerdctl` usable on Darwin.

### Changes

- enable Darwin in `meta.platforms`
- make Linux-only CNI integration conditional:
  - `cni-plugins` is optional
  - `CNI_PATH` wrapper env is set only on Linux
- fix Darwin runtime behavior where `nerdctl` fails with:
  - `mkdir /var/lib/nerdctl: permission denied`
- for Darwin, patch upstream default data root to:
  - `$HOME/.local/share/nerdctl`
  - fallback to `/var/lib/nerdctl` if home cannot be resolved
- keep completion generation working in build sandbox by invoking completion with a temporary data-root

## Why

`nerdctl` currently evaluates/builds as Linux-only and on Darwin defaults to `/var/lib/nerdctl`, which is not writable for regular users and causes immediate fatal startup.

## Result

On Darwin, `nerdctl` can be installed and started as a normal user without requiring root-writable `/var/lib`.

## Testing

Tested on `x86_64-darwin`:

- `nix build ...#nerdctl` succeeds
- `nerdctl --version` succeeds
- running `nerdctl` no longer fails with `/var/lib/nerdctl: permission denied`

Linux behavior is unchanged (Linux-only CNI wiring remains Linux-only).

## Review request

I would appreciate review from someone who is familiar with both `nerdctl` internals and `nixpkgs` packaging conventions, especially around Darwin defaults and runtime data-root behavior.
