### PR TITLE
bip: fix build with gcc15

### DIFF
--- a/pkgs/by-name/bi/bip/package.nix
+++ b/pkgs/by-name/bi/bip/package.nix
@@ -7,6 +7,7 @@
   bison,
   flex,
   openssl,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -27,9 +28,13 @@ stdenv.mkDerivation {
 
   postPatch = ''
     # Drop blanket -Werror to avoid build failure on fresh toolchains
-    # and libraries. Without the cnage build fails on gcc-13 and on
+    # and libraries. Without the change build fails on gcc-13 and on
     # openssl-3.
     substituteInPlace src/Makefile.am --replace-fail ' -Werror ' ' '
+    # Fix incompatible function pointer type for cmp in list_t
+    # The cmp function pointer is declared as taking no arguments but is
+    # used with qsort-style callback signature (const void *, const void *)
+    substituteInPlace src/util.h --replace-fail 'int (*cmp)()' 'int (*cmp)(const void *, const void *)'
   '';
 
   nativeBuildInputs = [
@@ -43,6 +48,10 @@ stdenv.mkDerivation {
   ];
 
   enableParallelBuilding = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
 
   meta = {
     description = "IRC proxy (bouncer)";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322271176

Added version check.
Not absolutely sure if it is working correctly.
I can get it startup and connects to a server successfully. But I can't get my IRC client to connect to it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
