### PR TITLE
 actual-server: add updateScript

### DIFF
--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -130,7 +130,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit (finalAttrs) offlineCache;
+    inherit translations;
     tests = nixosTests.actual;
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/ac/actual-server/update.sh
+++ b/pkgs/by-name/ac/actual-server/update.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts coreutils git jq nix-prefetch-github yarn-berry.yarn-berry-fetcher
+
+set -o errexit -o nounset -o pipefail
+
+package="actual-server"
+owner="actualbudget"
+repo="actual"
+translations_repo="translations"
+package_dir="pkgs/by-name/${package::2}/${package}"
+
+#
+# package
+#
+
+current_version=$(nix-instantiate --eval --expr "with import ./. {}; ${package}.version" --raw)
+echo "Current version: ${current_version}"
+
+latest_version=$(list-git-tags --url="https://github.com/${owner}/${repo}" | grep -oP '^v\K[0-9.]+$' | sort --version-sort | tail --lines=1)
+echo "Latest version: ${latest_version}"
+
+if [[ "${current_version}" == "${latest_version}" ]]; then
+  echo "${package} is up to date: ${current_version}"
+  exit 0
+fi
+
+echo "Updating ${package} from ${current_version} to ${latest_version}…"
+
+update-source-version "${package}" "${latest_version}"
+
+#
+# translations
+#
+
+echo "Updating translations repo"
+old_translations_rev=$(nix-instantiate --eval --expr "with import ./. {}; ${package}.translations.rev" --raw)
+old_translations_hash=$(nix-instantiate --eval --expr "with import ./. {}; ${package}.translations.outputHash" --raw)
+
+translations_rev=$(git ls-remote "https://github.com/${owner}/${translations_repo}" HEAD | cut -f1)
+echo "Latest translations rev: ${translations_rev}"
+
+translations_hash=$(nix-prefetch-github --json --rev "${translations_rev}" "${owner}" "${translations_repo}" | jq --raw-output .hash)
+echo "Translations hash: ${translations_hash}"
+
+sed -i "s|${old_translations_rev}|${translations_rev}|" "${package_dir}/package.nix"
+sed -i "s|${old_translations_hash}|${translations_hash}|" "${package_dir}/package.nix"
+
+#
+# yarn deps
+#
+
+echo "Regenerating missing-hashes.json…"
+src_path=$(nix-build --attr "${package}.src" --no-link)
+yarn-berry-fetcher missing-hashes "${src_path}/yarn.lock" >"${package_dir}/missing-hashes.json"
+
+echo "Updating offline cache hash…"
+update-source-version "${package}" --ignore-same-version --source-key=offlineCache
+
+echo "Done."


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Why does generating missing hashes take so long? Is it just me, or does this take hours for others?

Anyway, I'd added written this script and done the update locally but was too late for the version bump. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
