### PR TITLE
home-assistant-custom-lovelace-modules.light-entity-card: 6.1.3 -> 6.3.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/light-entity-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/light-entity-card/package.nix
@@ -6,18 +6,16 @@
 
 buildNpmPackage rec {
   pname = "light-entity-card";
-  version = "6.1.3";
+  version = "6.3.1";
 
   src = fetchFromGitHub {
     owner = "ljmerza";
     repo = "light-entity-card";
-    tag = version;
-    hash = "sha256-DtpNKcnxMWbKwfIwo9R2g2Vux9oAjTI0URixGC41qeA=";
+    tag = "v${version}";
+    hash = "sha256-Y25jtbKJNTVi6XUHntm2AtIzuht96/o5l+uScwEE9So=";
   };
 
-  npmDepsHash = "sha256-EZDTWtn3joikwiC5Kfn94+tXRDpBhMDHqHozfIkfbJ0=";
-
-  env.NODE_OPTIONS = "--openssl-legacy-provider";
+  npmDepsHash = "sha256-Sl2TgA73Wq1n//lqokLC7iHcE1Oqt+ZP6MT+Deidhn0=";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
