### PR TITLE
wayqt: 0.3.0-unstable-2026-01-05 -> 0.3.0-unstable-2026-03-03

### DIFF
--- a/pkgs/development/libraries/wayqt/default.nix
+++ b/pkgs/development/libraries/wayqt/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  replaceVars,
   meson,
   pkg-config,
   ninja,
@@ -13,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayqt";
-  version = "0.3.0-unstable-2026-01-05";
+  version = "0.3.0-unstable-2026-03-03";
 
   src = fetchFromGitLab {
     owner = "desktop-frameworks";
     repo = "wayqt";
-    rev = "2750cd93a3110bff6345f9e2a1a3090a3e3f7203";
-    hash = "sha256-WGIZ3OgeGkQWEzc/m0/Moo9Qgr3vg4dFfQhba2vx0do=";
+    rev = "a7dfc9c682dce2721ddd84c17738619a95a23998";
+    hash = "sha256-rC4Gdhr8mkL2V3bMWprMRo75AIhk9OJsoWjlBUnILEA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- https://hydra.nixos.org/build/324245639
- Relevant commit: https://gitlab.com/desktop-frameworks/wayqt/-/commit/a7dfc9c682dce2721ddd84c17738619a95a23998

It's a bit strange that the current wayqt version is based off a PR not a merged commit.
The latest commit fixes build problem on meson changes.
`qtgreet` builds and loads up after this fix.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
