### PR TITLE
faugus-launcher: 1.16.6 -> 1.20.4

### DIFF
--- a/pkgs/by-name/fa/faugus-launcher/package.nix
+++ b/pkgs/by-name/fa/faugus-launcher/package.nix
@@ -6,26 +6,26 @@
   lib,
   libayatana-appindicator,
   libcanberra-gtk3,
+  lsfg-vk,
   meson,
   ninja,
   nix-update-script,
   python3Packages,
   umu-launcher,
-  lsfg-vk,
   wrapGAppsHook3,
   xdg-utils,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "faugus-launcher";
-  version = "1.16.6";
+  version = "1.18.10";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Faugus";
     repo = "faugus-launcher";
     tag = finalAttrs.version;
-    hash = "sha256-VVLq11jq7fGKgQske/FnQEkwcneuKWOvXFr4eUGHYTw=";
+    hash = "sha256-MSy3iuMLUCr6fLASHyNmQXNdNaKnOHcLfHMZWmhStkw=";
   };
 
   nativeBuildInputs = [
@@ -42,24 +42,25 @@ python3Packages.buildPythonApplication (finalAttrs: {
   dependencies = with python3Packages; [
     pillow
     psutil
+    pygame
     pygobject3
     requests
     vdf
   ];
 
   postPatch = ''
-    substituteInPlace faugus_launcher.py \
-      --replace-fail "PathManager.find_binary('faugus-run')" "'$out/bin/.faugus-run-wrapped'" \
-      --replace-fail "PathManager.find_binary('faugus-proton-manager')" "'$out/bin/.faugus-proton-manager-wrapped'" \
+    substituteInPlace faugus-launcher \
+      --replace-fail "/usr/bin/python3" "${python3Packages.python.interpreter}"
+
+    substituteInPlace faugus/launcher.py \
       --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'" \
       --replace-fail "/usr/lib/extensions/vulkan/lsfgvk/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so" \
-      --replace-fail "/usr/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so" \
-      --replace-fail 'Exec={faugus_run}' 'Exec=faugus-run'
+      --replace-fail "/usr/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so"
 
-    substituteInPlace faugus_run.py \
+    substituteInPlace faugus/runner.py \
       --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'"
 
-    substituteInPlace faugus_shortcut.py \
+    substituteInPlace faugus/shortcut.py \
       --replace-fail "/usr/lib/extensions/vulkan/lsfgvk/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so" \
       --replace-fail "/usr/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so"
   '';
@@ -69,6 +70,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   preFixup = ''
     makeWrapperArgs+=(
       "''${gappsWrapperArgs[@]}"
+      --suffix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:$PYTHONPATH"
       --suffix PATH : "${
         lib.makeBinPath [
           icoextract
@@ -79,6 +81,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
         ]
       }"
     )
+    wrapProgram $out/bin/faugus-launcher ''${makeWrapperArgs[@]}
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/fa/faugus-launcher/package.nix
+++ b/pkgs/by-name/fa/faugus-launcher/package.nix
@@ -6,26 +6,27 @@
   lib,
   libayatana-appindicator,
   libcanberra-gtk3,
+  lsfg-vk,
   meson,
   ninja,
   nix-update-script,
   python3Packages,
   umu-launcher,
-  lsfg-vk,
+  vulkan-tools,
   wrapGAppsHook3,
   xdg-utils,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "faugus-launcher";
-  version = "1.16.6";
+  version = "1.20.4";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Faugus";
     repo = "faugus-launcher";
     tag = finalAttrs.version;
-    hash = "sha256-VVLq11jq7fGKgQske/FnQEkwcneuKWOvXFr4eUGHYTw=";
+    hash = "sha256-Kt6ZZ5yivbRzlgV+ovWiZVolxjmquAifJ/0lk1oL4fA=";
   };
 
   nativeBuildInputs = [
@@ -42,24 +43,25 @@ python3Packages.buildPythonApplication (finalAttrs: {
   dependencies = with python3Packages; [
     pillow
     psutil
+    pygame
     pygobject3
     requests
     vdf
   ];
 
   postPatch = ''
-    substituteInPlace faugus_launcher.py \
-      --replace-fail "PathManager.find_binary('faugus-run')" "'$out/bin/.faugus-run-wrapped'" \
-      --replace-fail "PathManager.find_binary('faugus-proton-manager')" "'$out/bin/.faugus-proton-manager-wrapped'" \
+    substituteInPlace faugus-launcher \
+      --replace-fail "/usr/bin/python3" "${python3Packages.python.interpreter}"
+
+    substituteInPlace faugus/launcher.py \
       --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'" \
       --replace-fail "/usr/lib/extensions/vulkan/lsfgvk/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so" \
-      --replace-fail "/usr/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so" \
-      --replace-fail 'Exec={faugus_run}' 'Exec=faugus-run'
+      --replace-fail "/usr/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so"
 
-    substituteInPlace faugus_run.py \
+    substituteInPlace faugus/runner.py \
       --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'"
 
-    substituteInPlace faugus_shortcut.py \
+    substituteInPlace faugus/shortcut.py \
       --replace-fail "/usr/lib/extensions/vulkan/lsfgvk/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so" \
       --replace-fail "/usr/lib/liblsfg-vk.so" "${lsfg-vk}/lib/liblsfg-vk.so"
   '';
@@ -69,16 +71,19 @@ python3Packages.buildPythonApplication (finalAttrs: {
   preFixup = ''
     makeWrapperArgs+=(
       "''${gappsWrapperArgs[@]}"
+      --suffix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:$PYTHONPATH"
       --suffix PATH : "${
         lib.makeBinPath [
           icoextract
           imagemagick
           libcanberra-gtk3
           umu-launcher
+          vulkan-tools
           xdg-utils
         ]
       }"
     )
+    wrapProgram $out/bin/faugus-launcher ''${makeWrapperArgs[@]}
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There was more file renaming in here: https://github.com/Faugus/faugus-launcher/compare/1.17.4...1.17.5

The main program is now a bash script so there's a manual `wrapProgram` in place. Not too many other changes. It does come with the benefit of not having to worry about calling on wrapped python files that tend to break when called upon during python's runtime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
