### PR TITLE
nixos-rebuild-ng: use typed CLI arguments

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -6,8 +6,9 @@ from typing import Final, assert_never
 
 from . import nix, services
 from .constants import EXECUTABLE, WITH_SHELL_FILES
-from .models import Action, BuildAttr, Flake, GroupedNixArgs, Profile
+from .models import Action, BuildAttr, Flake, GroupedNixArgs, NixOSRebuildArgs, Profile
 from .process import Remote
+from .typing import create_type_validator
 from .utils import LogFormatter
 
 logger: Final = logging.getLogger(__name__)
@@ -215,9 +216,12 @@ def get_main_parser() -> argparse.ArgumentParser:
 
 def parse_args(
     argv: list[str],
-) -> tuple[argparse.Namespace, GroupedNixArgs]:
+) -> tuple[NixOSRebuildArgs, GroupedNixArgs]:
     parser, sub_parsers = get_parser()
-    args = parser.parse_args(argv[1:])
+
+    args_validator = create_type_validator(NixOSRebuildArgs)
+    args = args_validator(vars(parser.parse_args(argv[1:])))
+
     grouped_nix_args = GroupedNixArgs.from_parsed_args_groups(
         {
             group: parser.parse_known_args(argv[1:])[0]
@@ -241,8 +245,8 @@ def parse_args(
         logger.setLevel(logging.DEBUG)
 
     # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L56
-    if args.action == Action.DRY_RUN.value:
-        args.action = Action.DRY_BUILD.value
+    if args.action == Action.DRY_RUN:
+        args.action = Action.DRY_BUILD
 
     if args.ask_sudo_password:
         args.sudo = True
@@ -268,28 +272,28 @@ def parse_args(
     if (
         args.action
         in (
-            Action.DRY_BUILD.value,  # --diff breaks dry-build
-            Action.EDIT.value,
-            Action.LIST_GENERATIONS.value,
-            Action.REPL.value,
+            Action.DRY_BUILD,  # --diff breaks dry-build
+            Action.EDIT,
+            Action.LIST_GENERATIONS,
+            Action.REPL,
         )
         and args.diff
     ):
         parser_warn(f"--diff is a no-op with '{args.action}'")
         args.diff = False
 
-    if args.action == Action.EDIT.value and (args.file or args.attr):
+    if args.action == Action.EDIT and (args.file or args.attr):
         parser.error(f"--file and --attr are not supported with '{args.action}'")
 
     if (args.target_host or args.build_host) and args.action not in (
-        Action.SWITCH.value,
-        Action.BOOT.value,
-        Action.TEST.value,
-        Action.BUILD.value,
-        Action.DRY_BUILD.value,
-        Action.DRY_ACTIVATE.value,
-        Action.BUILD_VM.value,
-        Action.BUILD_VM_WITH_BOOTLOADER.value,
+        Action.SWITCH,
+        Action.BOOT,
+        Action.TEST,
+        Action.BUILD,
+        Action.DRY_BUILD,
+        Action.DRY_ACTIVATE,
+        Action.BUILD_VM,
+        Action.BUILD_VM_WITH_BOOTLOADER,
     ):
         parser.error(
             f"--target-host/--build-host is not supported with '{args.action}'"
@@ -304,10 +308,10 @@ def parse_args(
         if args.flake or args.file or args.attr:
             parser.error("--store-path cannot be used with --flake, --file, or --attr")
         if args.action not in (
-            Action.SWITCH.value,
-            Action.BOOT.value,
-            Action.TEST.value,
-            Action.DRY_ACTIVATE.value,
+            Action.SWITCH,
+            Action.BOOT,
+            Action.TEST,
+            Action.DRY_ACTIVATE,
         ):
             parser.error(f"--store-path cannot be used with '{args.action}'")
         if args.flake is None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -237,31 +237,39 @@ def parse_args(
             parser.print_help()
             parser.exit()
 
-    def parser_warn(msg: str) -> None:
-        print(f"{parser.prog}: warning: {msg}", file=sys.stderr)
-
     # verbose affects both nix commands and this script, debug only this script
     if args.v or args.debug:
         logger.setLevel(logging.DEBUG)
 
+    def parser_warn(msg: str) -> None:
+        print(f"{parser.prog}: warning: {msg}", file=sys.stderr)
+
+    # Arguments that are modified by this function
+    action = args.action
+    sudo = args.sudo
+    install_bootloader = args.install_bootloader
+    no_reexec = args.no_reexec
+    diff = args.diff
+    flake = args.flake
+
     # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L56
-    if args.action == Action.DRY_RUN:
-        args.action = Action.DRY_BUILD
+    if action == Action.DRY_RUN:
+        action = Action.DRY_BUILD
 
     if args.ask_sudo_password:
-        args.sudo = True
+        sudo = True
 
     if args.install_grub:
         parser_warn("--install-grub is deprecated, use --install-bootloader instead")
-        args.install_bootloader = True
+        install_bootloader = True
 
     if args.use_remote_sudo:
         parser_warn("--use-remote-sudo is deprecated, use --sudo instead")
-        args.sudo = True
+        sudo = True
 
     if args.fast:
         parser_warn("--fast is deprecated, use --no-reexec instead")
-        args.no_reexec = True
+        no_reexec = True
 
     if args.no_ssh_tty:
         parser_warn("--no-ssh-tty is deprecated, SSH's TTY is never used anymore")
@@ -270,22 +278,22 @@ def parse_args(
         parser_warn("--no-build-nix is deprecated, we do not build nix anymore")
 
     if (
-        args.action
+        action
         in (
             Action.DRY_BUILD,  # --diff breaks dry-build
             Action.EDIT,
             Action.LIST_GENERATIONS,
             Action.REPL,
         )
-        and args.diff
+        and diff
     ):
-        parser_warn(f"--diff is a no-op with '{args.action}'")
-        args.diff = False
+        parser_warn(f"--diff is a no-op with '{action}'")
+        diff = False
 
-    if args.action == Action.EDIT and (args.file or args.attr):
-        parser.error(f"--file and --attr are not supported with '{args.action}'")
+    if action == Action.EDIT and (args.file or args.attr):
+        parser.error(f"--file and --attr are not supported with '{action}'")
 
-    if (args.target_host or args.build_host) and args.action not in (
+    if (args.target_host or args.build_host) and action not in (
         Action.SWITCH,
         Action.BOOT,
         Action.TEST,
@@ -295,30 +303,40 @@ def parse_args(
         Action.BUILD_VM,
         Action.BUILD_VM_WITH_BOOTLOADER,
     ):
-        parser.error(
-            f"--target-host/--build-host is not supported with '{args.action}'"
-        )
+        parser.error(f"--target-host/--build-host is not supported with '{action}'")
 
-    if args.flake and (args.file or args.attr):
+    if flake and (args.file or args.attr):
         parser.error("--flake cannot be used with --file or --attr")
 
     if args.store_path:
         if args.rollback:
             parser.error("--store-path and --rollback are mutually exclusive")
-        if args.flake or args.file or args.attr:
+        if flake or args.file or args.attr:
             parser.error("--store-path cannot be used with --flake, --file, or --attr")
-        if args.action not in (
+        if action not in (
             Action.SWITCH,
             Action.BOOT,
             Action.TEST,
             Action.DRY_ACTIVATE,
         ):
-            parser.error(f"--store-path cannot be used with '{args.action}'")
-        if args.flake is None:
+            parser.error(f"--store-path cannot be used with '{action}'")
+        if flake is None:
             # Disable flake auto-detection since we're using a pre-built store path
-            args.flake = False
+            flake = False
 
-    return args, grouped_nix_args
+    normalized_args = args_validator(
+        {
+            **vars(args),
+            "action": action,
+            "sudo": sudo,
+            "install_bootloader": install_bootloader,
+            "no_reexec": no_reexec,
+            "diff": diff,
+            "flake": flake,
+        }
+    )
+
+    return normalized_args, grouped_nix_args
 
 
 def execute(argv: list[str]) -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -196,6 +196,46 @@ class GroupedNixArgs:
         )
 
 
+@dataclass
+class NixOSRebuildArgs:
+    # The fields in this class are equivalent to CLI arguments.
+    #
+    # However, this list is not exhaustive and there are many arguments that
+    # are not present here. Instead, we prefer to only include the ones that are
+    # relevant for the logic of the program, and pass the rest as flags to the
+    # Nix commands (see `GroupedNixArgs`).
+
+    v: int
+    help: bool
+    debug: bool
+    file: str | None
+    attr: str | None
+    flake: str | bool | None
+    install_bootloader: bool
+    profile_name: str
+    specialisation: str | None
+    rollback: bool
+    store_path: str | None
+    upgrade: bool
+    upgrade_all: bool
+    json: bool
+    ask_sudo_password: bool
+    sudo: bool
+    no_reexec: bool
+    build_host: str | None
+    target_host: str | None
+    image_variant: str | None
+    diff: bool
+    action: Action | None
+
+    # Deprecated options
+    install_grub: bool
+    use_remote_sudo: bool
+    no_ssh_tty: bool
+    fast: bool
+    no_build_nix: bool
+
+
 @dataclass(frozen=True)
 class Profile:
     name: str

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -196,7 +196,7 @@ class GroupedNixArgs:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class NixOSRebuildArgs:
     # The fields in this class are equivalent to CLI arguments.
     #

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -280,7 +280,7 @@ def find_file(file: str, nix_flags: Args | None = None) -> Path | None:
 
 def get_build_image_name(
     build_attr: BuildAttr,
-    image_variant: str,
+    attr: str,
     instantiate_flags: Args | None = None,
 ) -> str:
     path = (
@@ -300,7 +300,7 @@ def get_build_image_name(
               value = import {path};
               set = if builtins.isFunction value then value {{}} else value;
             in
-              set.{build_attr.to_attr("config.system.build.images", image_variant, "passthru", "filePath")}
+              set.{build_attr.to_attr(attr, "passthru", "filePath")}
             """),
             *dict_to_flags(instantiate_flags),
         ],
@@ -312,7 +312,7 @@ def get_build_image_name(
 
 def get_build_image_name_flake(
     flake: Flake,
-    image_variant: str,
+    attr: str,
     eval_flags: Args | None = None,
 ) -> str:
     r = run_wrapper(
@@ -321,9 +321,7 @@ def get_build_image_name_flake(
             *FLAKE_FLAGS,
             "eval",
             "--json",
-            flake.to_attr(
-                "config.system.build.images", image_variant, "passthru", "filePath"
-            ),
+            flake.to_attr(attr, "passthru", "filePath"),
             *dict_to_flags(eval_flags),
         ],
         stdout=PIPE,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import os
@@ -14,6 +13,7 @@ from .models import (
     Flake,
     GroupedNixArgs,
     ImageVariants,
+    NixOSRebuildArgs,
     NixOSRebuildError,
     Profile,
 )
@@ -28,7 +28,7 @@ logger: Final = logging.getLogger(__name__)
 
 def reexec(
     argv: list[str],
-    args: argparse.Namespace,
+    args: NixOSRebuildArgs,
     grouped_nix_args: GroupedNixArgs,
 ) -> None:
     if os.environ.get(NIXOS_REBUILD_REEXEC_ENV):
@@ -84,17 +84,19 @@ def reexec(
                 os.execve(current, argv, os.environ | {NIXOS_REBUILD_REEXEC_ENV: "1"})
 
 
-def _validate_image_variant(image_variant: str, variants: ImageVariants) -> None:
+def _validate_image_variant(image_variant: str | None, variants: ImageVariants) -> str:
     if image_variant not in variants:
         raise NixOSRebuildError(
             "please specify one of the following supported image variants via "
             "--image-variant:\n" + "\n".join(f"- {v}" for v in variants)
         )
 
+    return image_variant
+
 
 def _get_system_attr(
     action: Action,
-    args: argparse.Namespace,
+    args: NixOSRebuildArgs,
     flake: Flake | None,
     build_attr: BuildAttr,
     grouped_nix_args: GroupedNixArgs,
@@ -105,15 +107,15 @@ def _get_system_attr(
                 flake,
                 eval_flags=grouped_nix_args.flake_eval_flags,
             )
-            _validate_image_variant(args.image_variant, variants)
-            attr = f"config.system.build.images.{args.image_variant}"
+            variant = _validate_image_variant(args.image_variant, variants)
+            attr = f"config.system.build.images.{variant}"
         case Action.BUILD_IMAGE:
             variants = nix.get_build_image_variants(
                 build_attr,
                 instantiate_flags=grouped_nix_args.common_flags,
             )
-            _validate_image_variant(args.image_variant, variants)
-            attr = f"config.system.build.images.{args.image_variant}"
+            variant = _validate_image_variant(args.image_variant, variants)
+            attr = f"config.system.build.images.{variant}"
         case Action.BUILD_VM:
             attr = "config.system.build.vm"
         case Action.BUILD_VM_WITH_BOOTLOADER:
@@ -126,7 +128,7 @@ def _get_system_attr(
 
 def _rollback_system(
     action: Action,
-    args: argparse.Namespace,
+    args: NixOSRebuildArgs,
     target_host: Remote | None,
     profile: Profile,
 ) -> Path:
@@ -143,6 +145,8 @@ def _rollback_system(
                 path_to_config = maybe_path_to_config
             else:
                 raise NixOSRebuildError("could not find previous generation")
+        case _:
+            raise AssertionError("Unexpected action to rollback system", action)
 
     return path_to_config
 
@@ -213,7 +217,8 @@ def _build_system(
 def _activate_system(
     path_to_config: Path,
     action: Action,
-    args: argparse.Namespace,
+    args: NixOSRebuildArgs,
+    attr: str,
     target_host: Remote | None,
     profile: Profile,
     flake: Flake | None,
@@ -262,13 +267,13 @@ def _activate_system(
             if flake:
                 image_name = nix.get_build_image_name_flake(
                     flake,
-                    args.image_variant,
+                    attr,
                     eval_flags=grouped_nix_args.flake_eval_flags,
                 )
             else:
                 image_name = nix.get_build_image_name(
                     build_attr,
-                    args.image_variant,
+                    attr,
                     instantiate_flags=grouped_nix_args.common_flags,
                 )
             disk_path = path_to_config / image_name
@@ -277,7 +282,7 @@ def _activate_system(
 
 def build_and_activate_system(
     action: Action,
-    args: argparse.Namespace,
+    args: NixOSRebuildArgs,
     build_host: Remote | None,
     target_host: Remote | None,
     profile: Profile,
@@ -336,6 +341,7 @@ def build_and_activate_system(
         path_to_config=path_to_config,
         action=action,
         args=args,
+        attr=attr,
         target_host=target_host,
         profile=profile,
         flake=flake,
@@ -355,7 +361,7 @@ def edit(flake: Flake | None, grouped_nix_args: GroupedNixArgs) -> None:
 
 
 def list_generations(
-    args: argparse.Namespace,
+    args: NixOSRebuildArgs,
     profile: Profile,
 ) -> None:
     generations = nix.list_generations(profile)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/typing.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/typing.py
@@ -1,0 +1,113 @@
+import dataclasses
+import types
+from collections.abc import Callable, Mapping
+from enum import Enum
+from typing import Any, Literal, get_origin
+
+
+def try_assign(
+    cls: type | types.UnionType,
+    value: Any,  # noqa: ANN401 - this function really accepts any value here
+) -> tuple[Literal[True], Any] | tuple[Literal[False], None]:
+    """
+    Check if a value is assignable to a type, and if so, return the value with the correct type.
+    """
+
+    origin = get_origin(cls)
+
+    if origin is None:
+        assert isinstance(cls, type), "Only basic types should have no origin"
+
+        if isinstance(value, cls):
+            return True, value
+
+        if issubclass(cls, Enum):
+            if value in cls:
+                return True, cls(value)
+
+        return False, None
+
+    if origin is types.UnionType:
+        assert isinstance(cls, types.UnionType), (
+            "Union types should have origin of UnionType"
+        )
+
+        for member in cls.__args__:
+            result = try_assign(member, value)
+            if result[0]:
+                return result
+
+        return False, None
+
+    raise NotImplementedError(f"Unsupported type: {cls}")
+
+
+def extract_init_fields(type_cls: type) -> list[dataclasses.Field[Any]]:
+    if not dataclasses.is_dataclass(type_cls):
+        raise TypeError("type_cls must be a dataclass")
+
+    extracted_fields = list[dataclasses.Field[Any]]()
+
+    for field in dataclasses.fields(type_cls):
+        if not field.init:
+            continue
+
+        if isinstance(field.type, str):
+            raise NotImplementedError(
+                f"String type annotations are not supported: {field.name} in {type_cls}"
+            )
+
+        extracted_fields.append(field)
+
+    return extracted_fields
+
+
+def create_type_validator[T](type_cls: type[T]) -> Callable[[Mapping[str, Any]], T]:
+    """
+    Create a function that takes a mapping of string keys to any values, and
+    returns an instance of the given type_cls.
+
+    If the values are not assignable to the types of the attributes of type_cls,
+    raises a TypeError with a detailed error message.
+    """
+
+    fields = extract_init_fields(type_cls)
+
+    def validate_python(args: Mapping[str, Any]) -> T:
+        typed_args = dict[str, Any]()
+        validation_errors = list[tuple[str, str]]()
+
+        for field in fields:
+            assert not isinstance(field.type, str), (
+                "String type annotations should have been rejected by extract_init_fields"
+            )
+
+            provided_value = None
+            if field.name in args:
+                provided_value = args.get(field.name)
+            elif field.default is not dataclasses.MISSING:
+                provided_value = field.default
+            elif field.default_factory is not dataclasses.MISSING:
+                provided_value = field.default_factory()
+
+            is_assignable, typed_value = try_assign(field.type, provided_value)
+
+            if not is_assignable:
+                validation_errors.append(
+                    (
+                        field.name,
+                        f"type {type(provided_value)} is not assignable to type {field.type}",
+                    )
+                )
+            else:
+                typed_args[field.name] = typed_value
+
+        if validation_errors:
+            raise TypeError(
+                f"Type validation of {type_cls} failed with the following errors:\n\n"
+                + "\n".join(f"  - {attr}: {error}" for attr, error in validation_errors)
+            )
+
+        return type_cls(**typed_args)
+
+    return validate_python

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/helpers.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/helpers.py
@@ -14,3 +14,15 @@ def get_qualified_name(
         f"Non-internal module '{name}' called with 'get_qualified_name'"
     )
     return name
+
+
+def assert_raises(
+    func: Callable[..., Any],
+    exception: type[BaseException] = Exception,
+) -> None:
+    try:
+        func()
+        raise AssertionError("Expected exception was not raised")
+    except exception as e:
+        if isinstance(e, AssertionError):
+            raise

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -88,7 +88,7 @@ def test_parse_args() -> None:
     assert r1.install_bootloader is True
     assert r1.install_grub is True
     assert r1.profile_name == "system"
-    assert r1.action == "switch"
+    assert r1.action == nr.models.Action.SWITCH
     assert nr.utils.dict_to_flags(g1.common_flags) == [
         "--option",
         "foo1",
@@ -142,7 +142,7 @@ def test_parse_args() -> None:
     assert nr.logger.level == logging.DEBUG
     assert r2.v == 3
     assert r2.flake is False
-    assert r2.action == "dry-build"
+    assert r2.action == nr.models.Action.DRY_BUILD
     assert r2.file == "foo"
     assert r2.attr == "bar"
     assert nr.utils.dict_to_flags(g2.common_flags) == [

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_typing.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_typing.py
@@ -1,0 +1,42 @@
+import enum
+from dataclasses import dataclass
+
+import nixos_rebuild.typing as t
+from tests import helpers
+
+
+def test_try_assign() -> None:
+    assert t.try_assign(int, 1) == (True, 1)
+    assert t.try_assign(str, True) == (False, None)
+    assert t.try_assign(str | bool, "foo") == (True, "foo")
+    assert t.try_assign(str | None, None) == (True, None)
+    assert t.try_assign(str | None, 123) == (False, None)
+
+    class MyEnum(enum.Enum):
+        A = "foo"
+        B = "bar"
+
+    assert t.try_assign(MyEnum, "foo") == (True, MyEnum.A)
+    assert t.try_assign(MyEnum, "baz") == (False, None)
+
+
+def test_create_type_validator() -> None:
+    @dataclass(kw_only=True)
+    class FooBar:
+        foo: str
+        bar: int = 0
+        baz: str | None
+
+    foobar_validator = t.create_type_validator(FooBar)
+    assert foobar_validator({"foo": "bar"}) == FooBar(foo="bar", bar=0, baz=None)
+    assert foobar_validator({"foo": "baz", "bar": 10}) == FooBar(
+        foo="baz", bar=10, baz=None
+    )
+    assert foobar_validator({"foo": "baz", "baz": "a str"}) == FooBar(
+        foo="baz", bar=0, baz="a str"
+    )
+
+    helpers.assert_raises(lambda: t.create_type_validator(int))
+    helpers.assert_raises(lambda: foobar_validator({"foo": 1}))
+    helpers.assert_raises(lambda: foobar_validator({"foo": "bar", "bar": "not an int"}))
+    helpers.assert_raises(lambda: foobar_validator({"foo": "bar", "baz": True}))


### PR DESCRIPTION
Creates a model for the nixos-rebuild arguments.

Furthermore, adds a function to dynamically validate that the arguments provided are assignable to the types provided in the model, ensuring that both stay in sync. Pydantic could have been used instead (which would remove ~80 lines from this PR), but I opted not to do so to avoid adding a dependency on `pydantic` for `nixos-rebuild-ng`.

Furthermore, fixes some small type issues that arose when statically checking the types of the project (although the existing type issues did not affect the correctness of the program).

The main motivation for this is to keep track of what arguments are being used, what types they are expected to have, and to allow operations such as "Find All References" or "Rename All References", as well as generate type errors when an argument that doesn't exist is used. I came across this while thinking about adding a few flags and deprecating some others to add support for `doas`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
