### PR TITLE
boxfs: fix build with gcc15

### DIFF
--- a/pkgs/by-name/bo/boxfs/package.nix
+++ b/pkgs/by-name/bo/boxfs/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
   patches = [
     ./work-around-API-borkage.patch
     ./libapp-include-ctype.diff
+    ./use-stdbool.patch
   ];
 
   buildInputs = [

--- a/pkgs/by-name/bo/boxfs/use-stdbool.patch
+++ b/pkgs/by-name/bo/boxfs/use-stdbool.patch
@@ -1,0 +1,18 @@
+diff --git a/tmp/orig_base.h b/libapp/libapp/base.h
+index 7d8abdb..2f42b03 100644
+--- a/tmp/orig_base.h
++++ b/libapp/libapp/base.h
+@@ -1,12 +1,7 @@
+ #ifndef APP_BASE_H
+ #define APP_BASE_H
+ 
+-#ifndef __cplusplus
+-typedef enum {
+-        false = 0,
+-        true = 1
+-} bool;
+-#endif
++#include <stdbool.h>
+ 
+ #define ASSERT(clause) if( !clause) { fprintf(stderr, "Assertion '%s' failed at %s:%d\n", #clause, __FILE__, __LINE__ ); exit(-1); }
+ 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322272002

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
