### PR TITLE
multi-gitter: init at 0.63.0

### DIFF
--- a/pkgs/by-name/mu/multi-gitter/package.nix
+++ b/pkgs/by-name/mu/multi-gitter/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  installShellFiles,
+  stdenv,
+  testers,
+}:
+buildGoModule (finalAttrs: {
+  pname = "multi-gitter";
+  version = "0.63.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lindell";
+    repo = "multi-gitter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Uwq6xHOb8LvWdbkxbOVxE6O6o89O+ZGLgGeDFhj2/2s=";
+  };
+
+  vendorHash = "sha256-1D8OUCxp6ATmomWHbrtAk+pA18GOGytN6voS/ywk6Ak=";
+
+  # the below packages compile into development and testing utilities
+  excludedPackages = [
+    "tools/docs"
+    "tools/readme-docs"
+    "tests/scripts/adder"
+    "tests/scripts/changer"
+    "tests/scripts/manual-committer"
+    "tests/scripts/printer"
+    "tests/scripts/pwd"
+    "tests/scripts/remover"
+  ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  # These subtests assume macOS /private symlink resolution for TMPDIR,
+  # which doesn't hold in the Nix build sandbox.
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-skip=TestTable/go_custom_clone_dir_with_absolute_path|TestTable/cmd_custom_clone_dir_with_absolute_path"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=unknown"
+    "-X main.date=unknown"
+  ];
+
+  nativeBuildInputs = lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd multi-gitter \
+      --bash <($out/bin/multi-gitter completion bash) \
+      --fish <($out/bin/multi-gitter completion fish) \
+      --zsh <($out/bin/multi-gitter completion zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "multi-gitter version";
+  };
+
+  meta = {
+    description = "Update multiple repositories in bulk with one command";
+    homepage = "https://github.com/lindell/multi-gitter";
+    changelog = "https://github.com/lindell/multi-gitter/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ t-monaghan ];
+    mainProgram = "multi-gitter";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update multiple repositories in bulk with one command 

https://github.com/lindell/multi-gitter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
