### PR TITLE
bilibili-video-downloader: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23902,6 +23902,12 @@
     githubId = 40308458;
     name = "rwxd";
   };
+  rxda = {
+    email = "sxfscool@gmail.com";
+    github = "rxda";
+    githubId = 19545808;
+    name = "rxda";
+  };
   rxiao = {
     email = "ben.xiao@me.com";
     github = "benxiao";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24643,6 +24643,12 @@
     githubId = 40308458;
     name = "rwxd";
   };
+  rxda = {
+    email = "sxfscool@gmail.com";
+    github = "rxda";
+    githubId = 19545808;
+    name = "rxda";
+  };
   rxiao = {
     email = "ben.xiao@me.com";
     github = "benxiao";

--- a/pkgs/by-name/bi/bilibili-video-downloader/package.nix
+++ b/pkgs/by-name/bi/bilibili-video-downloader/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  rustPlatform,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  nodejs,
+  pnpm_9,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  wrapGAppsHook4,
+  webkitgtk_4_1,
+  openssl,
+  ffmpeg,
+  cargo-tauri,
+  glib-networking,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bilibili-video-downloader";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lanyeeee";
+    repo = "bilibili-video-downloader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l0+CTu5jl3EzpBFmvqnrS3a7lwaV4zRtZV8GKH5Wwi4=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+    hash = "sha256-/+HML4CEJFVGgjLys0lzLIM1QTNBSK4HMJ+oxPS53qQ=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    nodejs
+    pnpm_9
+    pnpmConfigHook
+    cargo-tauri.hook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    ffmpeg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+    webkitgtk_4_1
+    glib-networking
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  preBuild = ''
+    rm -rf src-tauri/ffmpeg
+    mkdir -p src-tauri/ffmpeg
+    ln -s ${ffmpeg}/bin/ffmpeg src-tauri/ffmpeg/com.lanyeeee.bilibili-video-downloader-ffmpeg-${stdenv.hostPlatform.config}
+    pnpm build
+  '';
+
+  cargoHash = "sha256-ICZtSWDWho3UVTMVb4CfAbOSopKXyQEJ/A15BGBLdr0=";
+
+  postInstall = ''
+    install -Dm644 src-tauri/icons/128x128.png $out/share/icons/hicolor/128x128/apps/bilibili-video-downloader.png
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/bilibili-video-downloader.desktop <<EOF
+    [Desktop Entry]
+    Name=Bilibili Video Downloader
+    Exec=bilibili-video-downloader
+    Icon=bilibili-video-downloader
+    Type=Application
+    Terminal=false
+    Categories=Video;
+    EOF
+  '';
+
+  meta = {
+    description = "Gui tool for downloading Bilibili videos";
+    homepage = "https://github.com/lanyeeee/bilibili-video-downloader";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      rxda
+    ];
+    mainProgram = "bilibili-video-downloader";
+  };
+})

--- a/pkgs/by-name/bi/bilibili-video-downloader/package.nix
+++ b/pkgs/by-name/bi/bilibili-video-downloader/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  rustPlatform,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  nodejs,
+  pnpm_11,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  wrapGAppsHook4,
+  webkitgtk_4_1,
+  openssl,
+  ffmpeg,
+  cargo-tauri,
+  glib-networking,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bilibili-video-downloader";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lanyeeee";
+    repo = "bilibili-video-downloader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l0+CTu5jl3EzpBFmvqnrS3a7lwaV4zRtZV8GKH5Wwi4=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-kwORI+j+GSBvuyLdlBmVFYMwyIoYgv2QYhKpBwn+RSE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    nodejs
+    pnpm_11
+    pnpmConfigHook
+    cargo-tauri.hook
+    wrapGAppsHook4
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    ffmpeg
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+    webkitgtk_4_1
+    glib-networking
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  preBuild = ''
+    rm -rf src-tauri/ffmpeg
+    mkdir -p src-tauri/ffmpeg
+    ln -s ${ffmpeg}/bin/ffmpeg src-tauri/ffmpeg/com.lanyeeee.bilibili-video-downloader-ffmpeg-${stdenv.hostPlatform.config}
+    pnpm build
+  '';
+
+  cargoHash = "sha256-ICZtSWDWho3UVTMVb4CfAbOSopKXyQEJ/A15BGBLdr0=";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "bilibili-video-downloader";
+      exec = "bilibili-video-downloader";
+      icon = "bilibili-video-downloader";
+      desktopName = "Bilibili Video Downloader";
+      comment = finalAttrs.meta.description;
+      categories = [ "Video" ];
+    })
+  ];
+
+  meta = {
+    description = "Gui tool for downloading Bilibili videos";
+    homepage = "https://github.com/lanyeeee/bilibili-video-downloader";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      rxda
+    ];
+    mainProgram = "bilibili-video-downloader";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
