### PR TITLE
Revert "maintainers: init kaynetik"

### DIFF
--- a/nixos/modules/services/security/yubikey-agent.nix
+++ b/nixos/modules/services/security/yubikey-agent.nix
@@ -14,7 +14,6 @@ in
   meta.maintainers = with lib.maintainers; [
     philandstuff
     rawkode
-    kaynetik
   ];
 
   options = {

--- a/pkgs/by-name/ag/age-plugin-yubikey/package.nix
+++ b/pkgs/by-name/ag/age-plugin-yubikey/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       kranzes
       vtuan10
       adamcstephens
-      kaynetik
     ];
   };
 })

--- a/pkgs/by-name/ag/age/package.nix
+++ b/pkgs/by-name/ag/age/package.nix
@@ -80,9 +80,6 @@ buildGoModule (finalAttrs: {
     description = "Modern encryption tool with small explicit keys";
     license = lib.licenses.bsd3;
     mainProgram = "age";
-    maintainers = with lib.maintainers; [
-      tazjin
-      kaynetik
-    ];
+    maintainers = with lib.maintainers; [ tazjin ];
   };
 })

--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -72,7 +72,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       sciencentistguy
       _0x4A6F
       rvdp
-      kaynetik
     ];
     mainProgram = "atuin";
   };

--- a/pkgs/by-name/ba/bazel-buildtools/package.nix
+++ b/pkgs/by-name/ba/bazel-buildtools/package.nix
@@ -41,7 +41,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       elasticdog
-      kaynetik
     ];
     teams = [ lib.teams.bazel ];
   };

--- a/pkgs/by-name/ba/bazelisk/package.nix
+++ b/pkgs/by-name/ba/bazelisk/package.nix
@@ -32,9 +32,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/bazelbuild/bazelisk";
     changelog = "https://github.com/bazelbuild/bazelisk/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      elasticdog
-      kaynetik
-    ];
+    maintainers = with lib.maintainers; [ elasticdog ];
   };
 })

--- a/pkgs/by-name/ez/eza/package.nix
+++ b/pkgs/by-name/ez/eza/package.nix
@@ -75,7 +75,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       cafkafk
       _9glenda
       sigmasquadron
-      kaynetik
     ];
     platforms = with lib.platforms; unix ++ windows;
   };

--- a/pkgs/by-name/k9/k9s/package.nix
+++ b/pkgs/by-name/k9/k9s/package.nix
@@ -78,7 +78,6 @@ buildGoModule (finalAttrs: {
       qjoly
       devusb
       ryan4yin
-      kaynetik
     ];
   };
 })

--- a/pkgs/by-name/la/lazygit/package.nix
+++ b/pkgs/by-name/la/lazygit/package.nix
@@ -46,7 +46,6 @@ buildGoModule (finalAttrs: {
       khaneliman
       starsep
       sigmasquadron
-      kaynetik
     ];
     mainProgram = "lazygit";
   };

--- a/pkgs/by-name/po/podman-compose/package.nix
+++ b/pkgs/by-name/po/podman-compose/package.nix
@@ -43,10 +43,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/containers/podman-compose";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      sikmir
-      kaynetik
-    ];
+    maintainers = [ lib.maintainers.sikmir ];
     teams = [ lib.teams.podman ];
     mainProgram = "podman-compose";
   };

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -170,7 +170,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       booxter
-      kaynetik
     ];
     inherit (electron.meta) platforms;
     mainProgram = "podman-desktop";

--- a/pkgs/by-name/ri/ripgrep/package.nix
+++ b/pkgs/by-name/ri/ripgrep/package.nix
@@ -70,7 +70,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       globin
       ma27
       zowoq
-      kaynetik
     ];
     mainProgram = "rg";
     platforms = lib.platforms.all;

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -66,7 +66,6 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       Scrumplex
       mic92
-      kaynetik
     ];
     license = lib.licenses.mpl20;
   };

--- a/pkgs/by-name/tf/tflint/package.nix
+++ b/pkgs/by-name/tf/tflint/package.nix
@@ -61,9 +61,6 @@ buildGo125Module (finalAttrs: {
     homepage = "https://github.com/terraform-linters/tflint";
     changelog = "https://github.com/terraform-linters/tflint/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [
-      momeemt
-      kaynetik
-    ];
+    maintainers = with lib.maintainers; [ momeemt ];
   };
 })

--- a/pkgs/by-name/tf/tfsec/package.nix
+++ b/pkgs/by-name/tf/tfsec/package.nix
@@ -38,7 +38,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab
-      kaynetik
     ];
   };
 })

--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -113,7 +113,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       ethancedwards8
       fpletz
-      kaynetik
     ];
   };
 })

--- a/pkgs/by-name/wi/wireguard-tools/package.nix
+++ b/pkgs/by-name/wi/wireguard-tools/package.nix
@@ -90,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       zx2c4
       ma27
-      kaynetik
     ];
     mainProgram = "wg";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/wi/wireguard-ui/package.nix
+++ b/pkgs/by-name/wi/wireguard-ui/package.nix
@@ -75,10 +75,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/ngoduykhanh/wireguard-ui";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      bot-wxt1221
-      kaynetik
-    ];
+    maintainers = with lib.maintainers; [ bot-wxt1221 ];
     mainProgram = "wireguard-ui";
   };
 })

--- a/pkgs/by-name/zo/zoxide/package.nix
+++ b/pkgs/by-name/zo/zoxide/package.nix
@@ -76,7 +76,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       SuperSandro2000
       matthiasbeyer
       ryan4yin
-      kaynetik
     ];
     mainProgram = "zoxide";
   };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#505665

(**edit**: To clarify, I am not against kaynetik from being added as maintainer for any of these packages. This is only a matter of whether the *method* in #505665 was proper.)

I was notified of this PR that was merged about a week ago. I believe this was merged without proper consideration from existing maintainers,  affects many important packages, and adds someone who is fairly new to the ecosystem.

Notably, adding someone to `meta.maintainers` is not risk-free: It allows use of the merge bot for anything under `pkgs/by-name` to merge r-ryantm auto updates. I don't think anything @kaynetik has specifically done anything wrong, but they have shown a pretty alarming haphazardness for some recent actions (requesting committership extremely early, and self-adding as maintainer for 19 packages without, I believe, fully understanding the consequences) that's exactly the kind of thing you should not do with nixpkgs-merge-bot.

I appreciate your well-intention to help. Even if you're not listed under `meta.maintainers` you can still send package update PRs and test any PRs you come across.

With regards to whether to revert or not, I would appreciate if existing maintainers of these packages could chime in about your thoughts.