### PR TITLE
elektroid: 3.2.3 -> 3.3.2

### DIFF
--- a/pkgs/by-name/el/elektroid/package.nix
+++ b/pkgs/by-name/el/elektroid/package.nix
@@ -10,23 +10,20 @@
   libsndfile,
   libzip,
   pkg-config,
+  rubberband,
   stdenv,
   zlib,
 }:
 
-let
-  version = "3.2.3";
-in
-stdenv.mkDerivation {
-  inherit version;
-
+stdenv.mkDerivation (finalAttrs: {
   pname = "elektroid";
+  version = "3.3.2";
 
   src = fetchFromGitHub {
     owner = "dagargo";
     repo = "elektroid";
-    rev = version;
-    hash = "sha256-gK6WQA0KenyksLLFHejCXDTpBm2uhJwn6/E4TXUdeJ8=";
+    rev = finalAttrs.version;
+    hash = "sha256-ozpc2+sXOedmYYXdIH6HibGszLyKsT8QYS0Trhem6kI=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +39,7 @@ stdenv.mkDerivation {
     libsamplerate
     libsndfile
     libzip
+    rubberband
     zlib
   ];
 
@@ -51,4 +49,4 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ camelpunch ];
   };
-}
+})


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322285491
- Changelog: https://github.com/dagargo/elektroid/releases/tag/3.3.2
- Diff: https://github.com/dagargo/elektroid/compare/3.2.3...3.3.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
