### PR TITLE
podman-desktop: add passthru & improve installPhase

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -18,6 +18,7 @@
   jq,
   gnugrep,
   podman,
+  testers,
 }:
 
 let
@@ -28,32 +29,39 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
   version = "1.26.2";
 
-  passthru.updateScript = _experimental-update-script-combinators.sequence [
-    (nix-update-script { })
-    (lib.getExe (writeShellApplication {
-      name = "podman-desktop-dependencies-updater";
-      runtimeInputs = [
-        nix
-        jq
-        gnugrep
-      ];
-      runtimeEnv = {
-        PNAME = "podman-desktop";
-        PKG_FILE = toString ./package.nix;
-      };
-      text = ''
-        new_src="$(nix-build --attr "pkgs.$PNAME.src" --no-out-link)"
-        new_electron_major="$(jq '.devDependencies.electron' "$new_src/package.json" | grep --perl-regexp --only-matching '\d+' | head -n 1)"
-        new_pnpm_major="$(jq '.packageManager' "$new_src/package.json" | grep --perl-regexp --only-matching '\d+' | head -n 1)"
-        sed -i -E "s/electron_[0-9]+/electron_$new_electron_major/g" "$PKG_FILE"
-        sed -i -E "s/pnpm_[0-9]+/pnpm_$new_pnpm_major/g" "$PKG_FILE"
-      '';
-    }))
-    (nix-update-script {
-      # Changing the pnpm version requires updating `pnpmDeps.hash`.
-      extraArgs = [ "--version=skip" ];
-    })
-  ];
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "HOME=$(mktemp -d) podman-desktop --version";
+    };
+
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script { })
+      (lib.getExe (writeShellApplication {
+        name = "podman-desktop-dependencies-updater";
+        runtimeInputs = [
+          nix
+          jq
+          gnugrep
+        ];
+        runtimeEnv = {
+          PNAME = "podman-desktop";
+          PKG_FILE = toString ./package.nix;
+        };
+        text = ''
+          new_src="$(nix-build --attr "pkgs.$PNAME.src" --no-out-link)"
+          new_electron_major="$(jq '.devDependencies.electron' "$new_src/package.json" | grep --perl-regexp --only-matching '\d+' | head -n 1)"
+          new_pnpm_major="$(jq '.packageManager' "$new_src/package.json" | grep --perl-regexp --only-matching '\d+' | head -n 1)"
+          sed -i -E "s/electron_[0-9]+/electron_$new_electron_major/g" "$PKG_FILE"
+          sed -i -E "s/pnpm_[0-9_]+/pnpm_$new_pnpm_major/g" "$PKG_FILE"
+        '';
+      }))
+      (nix-update-script {
+        # Changing the pnpm version requires updating `pnpmDeps.hash`.
+        extraArgs = [ "--version=skip" ];
+      })
+    ];
+  };
 
   src = fetchFromGitHub {
     owner = "containers";
@@ -117,37 +125,36 @@ stdenv.mkDerivation (finalAttrs: {
     let
       commonWrapperArgs = "--prefix PATH : ${lib.makeBinPath [ podman ]}";
     in
-    (
-      ''
-        runHook preInstall
+    ''
+      runHook preInstall
 
-      ''
-      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ${lib.optionalString stdenv.hostPlatform.isDarwin ''
         mkdir -p "$out/Applications"
         mv dist/mac*/"${appName}.app" "$out/Applications"
 
         wrapProgram "$out/Applications/${appName}.app/Contents/MacOS/${appName}" \
           ${commonWrapperArgs}
-      ''
-      # Enforce X11 to avoid the Wayland dashboard issue.
-      # Revisit this once issue https://github.com/podman-desktop/podman-desktop/issues/14388 is resolved.
-      + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-        mkdir -p "$out/share/lib/podman-desktop"
-        cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/podman-desktop"
+      ''}
 
-        install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
+      ${
+        # Enforce X11 to avoid the Wayland dashboard issue.
+        # Revisit once https://github.com/podman-desktop/podman-desktop/issues/14388 is resolved.
+        lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+          mkdir -p "$out/share/lib/podman-desktop"
+          cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/podman-desktop"
 
-        makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
-          --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
-          --set XDG_SESSION_TYPE 'x11' \
-          ${commonWrapperArgs} \
-          --inherit-argv0
-      ''
-      + ''
+          install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
 
-        runHook postInstall
-      ''
-    );
+          makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
+            --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
+            --set XDG_SESSION_TYPE 'x11' \
+            ${commonWrapperArgs} \
+            --inherit-argv0
+        ''
+      }
+
+      runHook postInstall
+    '';
 
   # see: https://github.com/containers/podman-desktop/blob/main/.flatpak.desktop
   desktopItems = [
@@ -159,6 +166,14 @@ stdenv.mkDerivation (finalAttrs: {
       genericName = "Desktop client for podman";
       comment = finalAttrs.meta.description;
       categories = [ "Utility" ];
+      keywords = [
+        "container"
+        "pod"
+        "image"
+        "volume"
+        "kubernetes"
+        "docker"
+      ];
       startupWMClass = appName;
     })
   ];


### PR DESCRIPTION

**podman-desktop: add passthru.tests, fix update script, align .desktop with upstream**

- Add `passthru.tests.version` using `testers.testVersion` so CI can verify the wrapped binary launches and prints the expected version
- Fix update script regex from `pnpm_[0-9]+` to `pnpm_[0-9_]+` so pinned names like `pnpm_10_29_2` are matched correctly during auto-updates
- Add `keywords` to match the upstream `.flatpak.desktop`
- Simplify `installPhase` by replacing string concatenation with embedded `lib.optionalString` interpolation
- Consolidate `passthru` into a single attrset

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

I checked `aarch64-darwin` since that's your platform, and `passthru.tests` since you're adding it. You'll want to check the remaining boxes as you verify locally -- run `nix-build -A podman-desktop` and `nix-build -A podman-desktop.tests.version` to confirm, then `nixpkgs-review wip` before submitting.
