### PR TITLE
podman-desktop: 1.23.1 -> 1.26.2

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   copyDesktopItems,
-  electron_39,
+  electron_41,
   nodejs,
   pnpm_10,
   fetchPnpmDeps,
@@ -21,12 +21,12 @@
 }:
 
 let
-  electron = electron_39;
+  electron = electron_41;
   appName = "Podman Desktop";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.23.1";
+  version = "1.26.2";
 
   passthru.updateScript = _experimental-update-script-combinators.sequence [
     (nix-update-script { })
@@ -59,22 +59,26 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "containers";
     repo = "podman-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-08boCPsuT09OileZUWhB8awXWHrlJzoER2Bx0WXeOHU=";
+    hash = "sha256-VVyKC1z7YECZlbTaFaq2OwGg0k22qBbn/HEOYiJ8fcw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 2;
-    hash = "sha256-nBjAmXzjR0qGCM91UAonQKP0NG7+DXImueSbhbnMK/k=";
+    hash = "sha256-tCp5qLZVo93H8VIToU3mkmwNsVXOAd1IEsL6RlazPXo=";
   };
 
   patches = [
     # podman should be installed with nix; disable auto-installation
     ./extension-no-download-podman.patch
+    ./system-defaults-dir.patch
   ];
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    ELECTRON_OVERRIDE_DIST_PATH = electron.dist;
+  };
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -166,6 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       booxter
+      kaynetik
     ];
     inherit (electron.meta) platforms;
     mainProgram = "podman-desktop";

--- a/pkgs/by-name/po/podman-desktop/system-defaults-dir.patch
+++ b/pkgs/by-name/po/podman-desktop/system-defaults-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/product.json b/product.json
+index 74b7299ee93..a80fe7373bc 100644
+--- a/product.json
++++ b/product.json
+@@ -8,7 +8,7 @@
+     "managed": {
+       "macOS": "/Library/Application Support/io.podman_desktop.PodmanDesktop",
+       "windows": "%PROGRAMDATA%\\Podman Desktop",
+-      "linux": "/usr/share/podman-desktop",
++      "linux": "/etc/podman-desktop",
+       "flatpak": "/run/host/usr/share/podman-desktop"
+     }
+   },


### PR DESCRIPTION
Backport of #507978 to `release-25.11`. Manual cherry-pick - the automated one failed due to intermediate master-only commits (pnpm pinning, env block refactor, system-defaults-dir patch). Resolved against the release-25.11 base using `pnpm_10`.

Includes fix for [CVE-2026-34045](https://nvd.nist.gov/vuln/detail/CVE-2026-34045). Fixes #507930.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
