### PR TITLE
_389-ds-base: use cargoSetupHook and remove hard-coded vendor path

### DIFF
--- a/pkgs/by-name/_3/_389-ds-base/0001-remove-hard-coded-vendor-paths.patch
+++ b/pkgs/by-name/_3/_389-ds-base/0001-remove-hard-coded-vendor-paths.patch
@@ -1,0 +1,26 @@
+From 815bf49134f9dc049080b0ec4eb2fd807c23086b Mon Sep 17 00:00:00 2001
+From: azban <me@azban.net>
+Date: Mon, 6 Apr 2026 19:49:19 -0600
+Subject: [PATCH 1/2] remove hard-coded vendor paths
+
+Hard-coded vendored sources is not compatible with fetchCargoVendor.
+
+Signed-off-by: azban <me@azban.net>
+---
+ .cargo/config.toml.in | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/.cargo/config.toml.in b/.cargo/config.toml.in
+index d7d8ff4d4..e69de29bb 100644
+--- a/.cargo/config.toml.in
++++ b/.cargo/config.toml.in
+@@ -1,6 +0,0 @@
+-[source.crates-io]
+-registry = "https://github.com/rust-lang/crates.io-index"
+-@rust_vendor_sources@
+-
+-[source.vendored-sources]
+-directory = "./vendor"
+-- 
+2.51.2
+

--- a/pkgs/by-name/_3/_389-ds-base/package.nix
+++ b/pkgs/by-name/_3/_389-ds-base/package.nix
@@ -57,11 +57,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/389ds/389-ds-base/commit/1701419551c246e9dc21778b118220eeb2258125.patch";
       hash = "sha256-trzY/fDH3rs66DWbWI+PY46tIC9ShuVqspMHqEEKZYA=";
     })
+    ./0001-remove-hard-coded-vendor-paths.patch
   ];
 
+  cargoRoot = "src";
+
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    sourceRoot = "${finalAttrs.src.name}/src";
+    inherit (finalAttrs) src cargoRoot;
     name = "389-ds-base-${finalAttrs.version}";
     hash = "sha256-pNzMQjeBpmzFg6oWCxhLDmKGUKIW6jGmZQWai5Yunjc=";
   };
@@ -74,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     cargo
     rustc
+    rustPlatform.cargoSetupHook
   ]
   ++ lib.optional withCockpit rsync;
 
@@ -104,10 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     ./autogen.sh --prefix="$out"
-  '';
-
-  preBuild = ''
-    ln -s ${finalAttrs.cargoDeps} ./vendor
   '';
 
   configureFlags = [


### PR DESCRIPTION
This was not previously not using cargoSetupHook and therefore had a faulty configuration when building subpackages with vendored packages. This fixes that and removes a hard-coded vendor path from the source cargo config which was interfering with the generated configuration.

Resolves #507008
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
