### PR TITLE
yarn-zpm: 6.0.0-rc.15 -> 6.0.0-rc.16

### DIFF
--- a/pkgs/by-name/ya/yarn-zpm/package.nix
+++ b/pkgs/by-name/ya/yarn-zpm/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yarn-zpm";
-  version = "6.0.0-rc.15";
+  version = "6.0.0-rc.16";
 
   src = fetchFromGitHub {
     owner = "yarnpkg";
     repo = "zpm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2HIEZR8gfze1Xf0LIQiMxjXAjs2NfZrs0mf/l/uku4U=";
+    hash = "sha256-51KnGFT+6DwESpYii6dkYCGwT62ZrDCPDL1S4wANmWQ=";
   };
 
-  cargoHash = "sha256-gDgJ2u0Rm8pOB/XILy69qQCFSB5DbqbQI/LcVf/97Ng=";
+  cargoHash = "sha256-hwbOT5xpSSyQb3ChaXUJPNvJs38MI8Bd37h8T6GktgQ=";
 
   cargoBuildFlags = [ "--package=zpm" ];
   cargoTestFlags = [ "--package=zpm" ];


### PR DESCRIPTION
## Things done

Update https://github.com/yarnpkg/zpm/releases/tag/v6.0.0-rc.16

Tested on `aarch64-darwin`:

```console
$ nix-build -A yarn-zpm
/nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16
$ cd /tmp
$ mkdir test-package
$ cd test-package
$ /nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16/bin/yarn -v
6.0.0-rc.16.local
$ /nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16/bin/yarn init
➤ · Yarn 6.0.0-rc.16.local
➤ ┌ Installing packages
➤ └ Completed in 4ms
➤ ┌ Linking the project
➤ └ Completed in 4ms
$ /nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16/bin/yarn add express
➤ · Yarn 6.0.0-rc.16.local
➤ ┌ Installing packages
➤ │ Resolved 83 packages, fetched 4 packages (406.15 KiB)
➤ └ Completed in 1s 607ms
➤ ┌ Linking the project
➤ └ Completed in 4ms
$ nix shell nixpkgs#nodejs --command /nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16/bin/yarn node -p "require('express/package.json').version"
5.2.1
$ cat package.json 
{
  "dependencies": {
    "express": "^5.2.1"
  },
  "name": "test-package"
}
$ mv yarn.lock yarn-lock.json
$ nix shell nixpkgs#nodejs --command /nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16/bin/yarn node -p "require('./yarn-lock.json').__metadata"
{ version: 9 }
$ nix shell nixpkgs#nodejs --command /nix/store/xw4hxn5zwdb61m0v7vzbj8xgg5yv1nr2-yarn-zpm-6.0.0-rc.16/bin/yarn node -p "Object.keys(require('./yarn-lock.json').entries).find(i => i.includes('express'))"
express@npm:^5.2.1
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
