### PR TITLE
cc-switch: init at 5.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10372,6 +10372,12 @@
     githubId = 9850776;
     name = "Hans-Jörg Schurr";
   };
+  haoxian = {
+    email = "haoxianhan@gmail.com";
+    github = "haoxianhan";
+    githubId = 3611408;
+    name = "haoxian";
+  };
   HaoZeke = {
     email = "r95g10@gmail.com";
     github = "HaoZeke";

--- a/pkgs/by-name/cc/cc-switch/package.nix
+++ b/pkgs/by-name/cc/cc-switch/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cc-switch";
+  version = "5.3.0";
+
+  src = fetchFromGitHub {
+    owner = "saladday";
+    repo = "cc-switch-cli";
+    tag = "v${version}";
+    hash = "sha256-bOvPM/eAhDlqa+ib26aKbYpGxm96bpfa3hQYTcRz6pg=";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+  cargoLock = {
+    lockFile = "${src}/src-tauri/Cargo.lock";
+  };
+
+  preCheck = ''
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+    export CC_SWITCH_TEST_HOME="$HOME"
+    export HOSTNAME="cc-switch-nix"
+  '';
+  # install_script tests spawn runtime-generated helper scripts with a hard-coded
+  # /usr/bin/env shebang, which is unavailable in pure Nix sandboxes.
+  checkFlags = [
+    "--skip=install_script_requires_force_for_non_tty_overwrite"
+    "--skip=install_script_force_overwrites_and_warns_about_shadowed_path"
+    "--skip=install_script_supports_linux_glibc_override"
+    "--skip=install_script_falls_back_to_glibc_when_musl_download_fails"
+  ];
+
+  meta = {
+    description = "CLI manager for Claude Code, Codex, Gemini, OpenCode, and OpenClaw";
+    homepage = "https://github.com/saladday/cc-switch-cli";
+    license = lib.licenses.mit;
+    mainProgram = "cc-switch";
+    maintainers = with lib.maintainers; [ haoxian ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/cc/cc-switch/package.nix
+++ b/pkgs/by-name/cc/cc-switch/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cc-switch";
   version = "5.3.0";
 
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "saladday";
     repo = "cc-switch-cli";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bOvPM/eAhDlqa+ib26aKbYpGxm96bpfa3hQYTcRz6pg=";
   };
 
@@ -45,4 +45,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ haoxian ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/cc/cc-switch/package.nix
+++ b/pkgs/by-name/cc/cc-switch/package.nix
@@ -8,6 +8,8 @@ rustPlatform.buildRustPackage rec {
   pname = "cc-switch";
   version = "5.3.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "saladday";
     repo = "cc-switch-cli";
@@ -17,9 +19,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = "src-tauri";
-  cargoLock = {
-    lockFile = "${src}/src-tauri/Cargo.lock";
-  };
+  cargoHash = "sha256-+I01hJIg7aG7dwDsXa1fpUWjl3xch2Nnx4ROAtPDV3Y=";
 
   preCheck = ''
     export HOME="$TMPDIR/home"
@@ -27,6 +27,7 @@ rustPlatform.buildRustPackage rec {
     export CC_SWITCH_TEST_HOME="$HOME"
     export HOSTNAME="cc-switch-nix"
   '';
+
   # install_script tests spawn runtime-generated helper scripts with a hard-coded
   # /usr/bin/env shebang, which is unavailable in pure Nix sandboxes.
   checkFlags = [


### PR DESCRIPTION
cc-switch is a CLI manager for Claude Code, Codex, Gemini, OpenCode, and OpenClaw.

The package builds from the upstream `v5.3.0` tag with `rustPlatform.buildRustPackage`, using `cargoRoot = "src-tauri"` and the upstream `src-tauri/Cargo.lock`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
