### PR TITLE
denemo: 2.6.43 -> 2.6.49

### DIFF
--- a/pkgs/by-name/de/denemo/package.nix
+++ b/pkgs/by-name/de/denemo/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchgit,
+  fetchDebianPatch,
   pkg-config,
   libjack2,
   gettext,
@@ -26,14 +27,14 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "denemo";
-  version = "2.6.43";
+  version = "2.6.49";
 
   src = fetchgit {
     url = "https://git.savannah.gnu.org/git/denemo.git";
-    rev = "b04ead1d3efeee036357cf36898b838a96ec5332";
-    hash = "sha256-XMFbPk70JqUHWBPEK8rjr70iMs49RNyaaCUGnYlLf2E=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TUdaGOChqwK3fAmdaP9Lg2FGrEWF0yjwqsRXK7h/83Y=";
   };
 
   buildInputs = [
@@ -58,6 +59,30 @@ stdenv.mkDerivation {
   # error by default in GCC 14
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
+  patches = [
+    (fetchDebianPatch {
+      pname = "denemo";
+      version = "2.6.49";
+      debianRevision = "0.2";
+      patch = "0002-Prevent-incompatible-pointer-types.patch";
+      hash = "sha256-l1eXjQieH5ySqwaTJAE8lUq/FsB//cl02Wgt0TRQBMo=";
+    })
+    (fetchDebianPatch {
+      pname = "denemo";
+      version = "2.6.49";
+      debianRevision = "0.2";
+      patch = "0013-Fix-FTBFS-with-GCC-14.patch";
+      hash = "sha256-H3hRmAPazYRkwQI97vNR9kpV0lYpIiAXyMfrnJl+lNo=";
+    })
+    (fetchDebianPatch {
+      pname = "denemo";
+      version = "2.6.49";
+      debianRevision = "0.2";
+      patch = "0014-Fix-FTBFS-with-GCC-15.patch";
+      hash = "sha256-UG/YZWp+twJdvqiXR4NfB3knm04lAyICh5/LHN2pm54=";
+    })
+  ];
+
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix PATH : "${lilypond}/bin"
@@ -80,4 +105,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.olynch ];
   };
-}
+})


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/325287490

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
