### PR TITLE
meteor: 2.7.3 -> 3.4, adopt

### DIFF
--- a/pkgs/by-name/me/meteor/main.patch
+++ b/pkgs/by-name/me/meteor/main.patch
@@ -1,10 +1,10 @@
 diff --git a/tools/cli/main.js b/tools/cli/main.js
-index 84f94bc..4fbda17 100644
+index 03a9633..86f37ec 100644
 --- a/tools/cli/main.js
 +++ b/tools/cli/main.js
-@@ -554,6 +554,44 @@
-     }).await());
-   } // Now exec; we're not coming back.
+@@ -530,6 +530,45 @@ var oldSpringboard = async function (toolsVersion) {
+   // process, so that the springboarded process can reestablish it.
+   await catalog.official.closePermanently();
  
 +  // BEGIN HACK
 +  // patch shebang:
@@ -44,13 +44,7 @@ index 84f94bc..4fbda17 100644
 +  patchelf("mongodb", "bin", "mongo");
 +  patchelf("mongodb", "bin", "mongod");
 +  // END HACK
-
-   require('kexec')(executable, newArgv);
-
-@@ -1485,4 +1523,4 @@
-
-   process.exit(ret);
- }).run();
--//# sourceMappingURL=main.js.map
-\ No newline at end of file
-+//# sourceMappingURL=main.js.map
++
+   // Now exec; we're not coming back.
+   require('kexec')(cmd, newArgv);
+   throw Error('exec failed?');

--- a/pkgs/by-name/me/meteor/package.nix
+++ b/pkgs/by-name/me/meteor/package.nix
@@ -114,6 +114,8 @@ stdenv.mkDerivation {
     done
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Complete open source platform for building web and mobile apps in pure JavaScript";
     homepage = "https://www.meteor.com/";

--- a/pkgs/by-name/me/meteor/package.nix
+++ b/pkgs/by-name/me/meteor/package.nix
@@ -132,7 +132,7 @@ stdenv.mkDerivation {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.mit;
     platforms = builtins.attrNames srcs;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
     mainProgram = "meteor";
   };
 }

--- a/pkgs/by-name/me/meteor/package.nix
+++ b/pkgs/by-name/me/meteor/package.nix
@@ -5,23 +5,28 @@
   zlib,
   curl,
   xz,
+  openssl,
   patchelf,
   runtimeShell,
 }:
 
 let
-  version = "2.7.3";
+  version = "3.4";
 
   inherit (stdenv.hostPlatform) system;
 
   srcs = {
     x86_64-linux = fetchurl {
-      url = "https://static-meteor.netdna-ssl.com/packages-bootstrap/${version}/meteor-bootstrap-os.linux.x86_64.tar.gz";
-      sha256 = "sha256-ovsE7jUJIKf96WEoITXECUlPo+o1tEKvHzCc7Xgj614=";
+      url = "https://static.meteor.com/packages-bootstrap/${version}/meteor-bootstrap-os.linux.x86_64.tar.gz";
+      hash = "sha256-tzzRN9UAH7+BM3fs76U5H20vD0LGMpdrMDDiJtchgEg=";
     };
     x86_64-darwin = fetchurl {
-      url = "https://static-meteor.netdna-ssl.com/packages-bootstrap/${version}/meteor-bootstrap-os.osx.x86_64.tar.gz";
-      sha256 = "11206dbda50a680fdab7044def7ea68ea8f4a9bca948ca56df91fe1392b2ac16";
+      url = "https://static.meteor.com/packages-bootstrap/${version}/meteor-bootstrap-os.osx.x86_64.tar.gz";
+      hash = "sha256-Z9Had9hscEjxHch19KCYUTqN4OikYLfz1tqEpyxw2Y8=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://static.meteor.com/packages-bootstrap/${version}/meteor-bootstrap-os.osx.arm64.tar.gz";
+      hash = "sha256-AT7njZTgf/WTHlvLEbF3dXKNoqyqHy8KloBQ4gsbPuM=";
     };
   };
 in
@@ -67,23 +72,27 @@ stdenv.mkDerivation {
     chmod +x $out/bin/meteor
   '';
 
-  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+  postFixup = ''
+    # Remove dangling symlinks
+    find $out -xtype l -ls -exec rm {} \;
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     # Patch Meteor to dynamically fixup shebangs and ELF metadata where
     # necessary.
     pushd $out
     patch -p1 < ${./main.patch}
     popd
     substituteInPlace $out/tools/cli/main.js \
-      --replace "@INTERPRETER@" "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --replace "@RPATH@" "${
+      --replace-fail "@INTERPRETER@" "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --replace-fail "@RPATH@" "${
         lib.makeLibraryPath [
-          stdenv.cc.cc
-          zlib
           curl
+          stdenv.cc.cc
           xz
+          zlib
         ]
       }" \
-      --replace "@PATCHELF@" "${patchelf}/bin/patchelf"
+      --replace-fail "@PATCHELF@" "${patchelf}/bin/patchelf"
 
     # Patch node.
     patchelf \
@@ -92,15 +101,16 @@ stdenv.mkDerivation {
       $out/dev_bundle/bin/node
 
     # Patch mongo.
-    for p in $out/dev_bundle/mongodb/bin/mongo{,d}; do
+    for p in $out/dev_bundle/mongodb/bin/mongo{d,s}; do
       patchelf \
         --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
         --set-rpath "$(patchelf --print-rpath $p):${
           lib.makeLibraryPath [
-            stdenv.cc.cc
-            zlib
             curl
+            openssl
+            stdenv.cc.cc
             xz
+            zlib
           ]
         }" \
         $p

--- a/pkgs/by-name/me/meteor/update.sh
+++ b/pkgs/by-name/me/meteor/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash common-updater-scripts curl nix-update
+
+releaseInfo=$(curl https://install.meteor.com)
+latestVersion=$(grep <<<"$releaseInfo" -oP 'RELEASE="\K[^"]+')
+currentVersion=$(nix eval --raw -f . meteor.version)
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+   echo "package is up-to-date"
+   exit 0
+fi
+
+systems=$(nix eval --json -f . meteor.meta.platforms | jq --raw-output '.[]')
+for system in $systems; do
+  hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix eval --raw -f . meteor.src.url --system "$system")))
+  update-source-version meteor $latestVersion $hash --system=$system --ignore-same-version --ignore-same-hash
+done


### PR DESCRIPTION
diff: https://github.com/meteor/meteor/compare/release-2.7.3...release-3.4

Closes #508559

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
