### PR TITLE
ntfsprogs-plus: enable `strictDeps` and `__structuredAttrs`

### DIFF
--- a/pkgs/by-name/nt/ntfsprogs-plus/package.nix
+++ b/pkgs/by-name/nt/ntfsprogs-plus/package.nix
@@ -30,17 +30,19 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    # autoreconf will not succeed without libgcrypt, maybe due to leftover checks from ntfs-3g?
+    libgcrypt
   ];
 
   # We don't need GnuTLS despite the configure warning about its absence,
   # because ntfsdecrypt from ntfs-3g is not used in ntfsprogs-plus and is not built.
   # See: https://github.com/search?q=repo%3Antfsprogs-plus%2Fntfsprogs-plus%20gnutls&type=code
-  buildInputs = [
-    # autoreconf will not succeed without libgcrypt, maybe due to leftover checks from ntfs-3g?
-    libgcrypt
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ libuuid ]
-  ++ lib.optionals (!stdenv.hostPlatform.isGnu) [ gettext ];
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [ libuuid ]
+    ++ lib.optionals (!stdenv.hostPlatform.isGnu) [ gettext ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   configureFlags = [ "--exec-prefix=\${prefix}" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
