### PR TITLE
tcl9Packages: init

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -130,6 +130,7 @@ let
 
     passthru = rec {
       inherit release version;
+      isTcl9 = lib.versions.major version == "9";
       libPrefix = "tcl${release}";
       libdir = "lib/${libPrefix}";
       tclPackageHook = callPackage (

--- a/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
@@ -81,5 +81,6 @@ tcl.mkTclDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "expect";
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/in/incrtcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/in/incrtcl/package.nix
@@ -46,5 +46,6 @@ mkTclDerivation rec {
     license = lib.licenses.tcltk;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/le/lexec/package.nix
+++ b/pkgs/development/tcl-modules/by-name/le/lexec/package.nix
@@ -3,6 +3,7 @@
   mkTclDerivation,
   fetchzip,
   autoreconfHook,
+  tcl,
 }:
 
 mkTclDerivation {
@@ -24,5 +25,6 @@ mkTclDerivation {
     license = lib.licenses.tcltk;
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/rl/rl_json/package.nix
+++ b/pkgs/development/tcl-modules/by-name/rl/rl_json/package.nix
@@ -4,40 +4,30 @@
   fetchFromGitHub,
   autoreconfHook,
   tcl,
+  pandoc,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rl_json";
-  version = "0.15.7";
+  version = "0.16";
 
   src = fetchFromGitHub {
     owner = "RubyLane";
     repo = "rl_json";
     tag = finalAttrs.version;
-    hash = "sha256-6Y6bq/Lm6KCFFV3RF6v4fVPEN1LO+jE2xZV50a8zyng=";
+    hash = "sha256-rXr7x9Cr+gD938+NEPguvYVWH5s9bKccMobuZsb0IQY=";
     fetchSubmodules = true;
   };
 
-  # The vendored libtommath conflicts with tclTomMath.
-  # Replacing it with tclTomMath fixes the issue.
-  # https://github.com/RubyLane/rl_json/issues/57
-  # The switch to a vendored libtommath was done in 0.15.4 in commit
-  # https://github.com/RubyLane/rl_json/commit/9294d533f4d81288acf53045666b1587cf7fbf92
-  # "for proper bignum handling", but the commit message doesn't explain what's wrong
-  # with tclTomMath's bignum handling and all tests pass anyway.
   postPatch = ''
-    rm -r deps/libtommath
-    substituteInPlace Makefile.in \
-      --replace-fail 'deps: local/lib/libtommath.a' 'deps:'
-    substituteInPlace configure.ac \
-      --replace-fail -ltommath ""
-    substituteInPlace generic/rl_jsonInt.h \
-      --replace-fail '#include <tommath.h>' '#include <tclTomMath.h>'
+    mkdir doc/.build
+    cp doc/json.md.in doc/.build/json.md.in
   '';
 
   nativeBuildInputs = [
     autoreconfHook
     tcl.tclPackageHook
+    pandoc
   ];
 
   configureFlags = [
@@ -46,8 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--includedir=${placeholder "out"}/include"
     "--datarootdir=${placeholder "out"}/share"
   ];
-
-  env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   doCheck = true;
 

--- a/pkgs/development/tcl-modules/by-name/tc/tcl-fcgi/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcl-fcgi/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   mkTclDerivation,
   tclx,
+  tcl,
 }:
 
 mkTclDerivation {
@@ -31,5 +32,6 @@ mkTclDerivation {
     license = lib.licenses.bsd2;
     platforms = tclx.meta.platforms;
     maintainers = with lib.maintainers; [ nat-418 ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tc/tclcurl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclcurl/package.nix
@@ -3,6 +3,7 @@
   mkTclDerivation,
   fetchFromGitHub,
   curl,
+  tcl,
 }:
 
 mkTclDerivation rec {
@@ -29,5 +30,6 @@ mkTclDerivation rec {
     changelog = "https://github.com/flightaware/tclcurl-fa/blob/master/ChangeLog.txt";
     license = lib.licenses.tcltk;
     maintainers = with lib.maintainers; [ fgaz ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tc/tclmagick/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tclmagick/package.nix
@@ -3,6 +3,7 @@
   mkTclDerivation,
   fetchzip,
   graphicsmagick,
+  tcl,
   tk,
 }:
 
@@ -34,5 +35,6 @@ mkTclDerivation rec {
     homepage = "http://www.graphicsmagick.org/TclMagick/doc/";
     license = lib.licenses.tcltk;
     maintainers = with lib.maintainers; [ fgaz ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tc/tcltls/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcltls/package.nix
@@ -3,6 +3,7 @@
   fetchurl,
   mkTclDerivation,
   openssl,
+  tcl,
 }:
 
 mkTclDerivation rec {
@@ -28,5 +29,6 @@ mkTclDerivation rec {
     maintainers = [ lib.maintainers.agbrooks ];
     license = lib.licenses.tcltk;
     platforms = lib.platforms.unix;
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tc/tcludp/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tc/tcludp/package.nix
@@ -2,6 +2,7 @@
   lib,
   mkTclDerivation,
   fetchfossil,
+  tcl,
 }:
 
 mkTclDerivation rec {
@@ -35,5 +36,6 @@ mkTclDerivation rec {
     homepage = "https://core.tcl-lang.org/tcludp";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fgaz ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/ti/tix/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ti/tix/package.nix
@@ -60,5 +60,6 @@ tcl.mkTclDerivation {
       bsd2 # tix
       gpl2 # patches from portage
     ];
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/development/tcl-modules/by-name/tk/tkimg/package.nix
+++ b/pkgs/development/tcl-modules/by-name/tk/tkimg/package.nix
@@ -1,20 +1,20 @@
 {
   lib,
-  fetchsvn,
+  fetchzip,
   tcl,
   tcllib,
   tk,
   libx11,
+  zlib,
 }:
 
 tcl.mkTclDerivation rec {
   pname = "tkimg";
-  version = "623";
+  version = "2.1.1";
 
-  src = fetchsvn {
-    url = "svn://svn.code.sf.net/p/tkimg/code/trunk";
-    rev = version;
-    sha256 = "sha256-6GlkqYxXmMGjiJTZS2fQNVSimcKc1BZ/lvzvtkhty+o=";
+  src = fetchzip {
+    url = "mirror://sourceforge/tkimg/tkimg/Img-${version}.tar.gz";
+    hash = "sha256-TRtE2/BVrYgkdKtbF06UjLvokokgLGQ/EKDLxhz2Ckw=";
   };
 
   configureFlags = [
@@ -26,6 +26,7 @@ tcl.mkTclDerivation rec {
   buildInputs = [
     libx11
     tcllib
+    zlib
   ];
 
   meta = {

--- a/pkgs/development/tcl-modules/by-name/ve/vectcl/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ve/vectcl/package.nix
@@ -2,6 +2,7 @@
   lib,
   mkTclDerivation,
   fetchFromGitHub,
+  tcl,
 }:
 
 mkTclDerivation rec {
@@ -22,5 +23,6 @@ mkTclDerivation rec {
     description = "Numeric array and linear algebra extension for Tcl";
     maintainers = with lib.maintainers; [ fgaz ];
     license = lib.licenses.tcltk;
+    broken = tcl.isTcl9;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5249,8 +5249,21 @@ with pkgs;
   tcl-8_6 = callPackage ../development/interpreters/tcl/8.6.nix { };
   tcl-9_0 = callPackage ../development/interpreters/tcl/9.0.nix { };
 
-  # We don't need versioned package sets thanks to the tcl stubs mechanism
-  tclPackages = recurseIntoAttrs (callPackage ./tcl-packages.nix { });
+  tclPackages = dontRecurseIntoAttrs tcl8Packages;
+  # We don't need minor-versioned package sets thanks to the tcl stubs mechanism.
+  # Major versions have bigger incompatibilities and need package sets.
+  tcl8Packages = recurseIntoAttrs (
+    callPackage ./tcl-packages.nix {
+      tcl = tcl-8_6;
+      tk = tk-8_6;
+    }
+  );
+  tcl9Packages = recurseIntoAttrs (
+    callPackage ./tcl-packages.nix {
+      tcl = tcl-9_0;
+      tk = tk-9_0;
+    }
+  );
 
   tclreadline = tclPackages.tclreadline;
 


### PR DESCRIPTION
Still missing documentation. If I don't end up adding it here it will be added in a future pr.

The updates to rl_json and tkimg add tcl9 compatibility.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
