### PR TITLE
docker: add option to prune all volumes when auto pruning

### DIFF
--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -157,6 +157,14 @@ in
           Whether to periodically prune Docker resources. If enabled, a
           systemd timer will run `docker system prune -f`
           as specified by the `dates` option.
+
+          NOTE: by default this does not prune volumes. Anonymous volumes
+          can be pruned by passing "--volumes" to [autoPrune.flags](#opt-virtualisation.docker.autoPrune.flags).
+
+          To prune all volumes (not just anonymous ones) [`autoPrune.allVolumes.enable`](#opt-virtualisation.docker.autoPrune.allVolumes.enable)
+          must be used.
+
+          See [upstream documentation](https://docs.docker.com/reference/cli/docker/system/prune/#description) for further information.
         '';
       };
 
@@ -205,6 +213,28 @@ in
           useful to catch up on missed runs of the service when the
           system was powered down.
         '';
+      };
+
+      allVolumes = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to periodically prune all Docker volumes when auto pruning other docker resources
+            by running {command}`docker volume prune --force --all`
+
+            To prune only anonymous volumes, instead pass `--volumes` to `autoPrune.flags`
+          '';
+        };
+
+        flags = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "--filter=label=<label>" ];
+          description = ''
+            Any additional flags passed to {command}`docker volume prune --force --all`.
+          '';
+        };
       };
     };
 
@@ -312,15 +342,29 @@ in
 
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = utils.escapeSystemdExecArgs (
-            [
-              (lib.getExe cfg.package)
-              "system"
-              "prune"
-              "-f"
-            ]
-            ++ cfg.autoPrune.flags
-          );
+          ExecStart = [
+            (utils.escapeSystemdExecArgs (
+              [
+                (lib.getExe cfg.package)
+                "system"
+                "prune"
+                "-f"
+              ]
+              ++ cfg.autoPrune.flags
+            ))
+          ]
+          ++ (optionals cfg.autoPrune.allVolumes.enable [
+            (utils.escapeSystemdExecArgs (
+              [
+                (lib.getExe cfg.package)
+                "volume"
+                "prune"
+                "--force"
+                "--all"
+              ]
+              ++ cfg.autoPrune.allVolumes.flags
+            ))
+          ]);
         };
 
         startAt = optional cfg.autoPrune.enable cfg.autoPrune.dates;
@@ -341,6 +385,10 @@ in
             cfg.enableNvidia && pkgs.stdenv.hostPlatform.isx86_64
             -> config.hardware.graphics.enable32Bit or false;
           message = "Option enableNvidia on x86_64 requires 32-bit support libraries";
+        }
+        {
+          assertion = cfg.autoPrune.allVolumes.enable -> cfg.autoPrune.enable;
+          message = "Option autoPrune.allVolumes.enable requires autoPrune.enable";
         }
       ];
 

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -157,6 +157,14 @@ in
           Whether to periodically prune Docker resources. If enabled, a
           systemd timer will run `docker system prune -f`
           as specified by the `dates` option.
+
+          NOTE: by default this does not prune volumes. Anonymous volumes
+          can be pruned by passing "--volumes" to [autoPrune.flags](#opt-virtualisation.docker.autoPrune.flags).
+
+          To prune all volumes (not just anonymous ones) `autoPrune.allVolumes.enable` [autoPrune.allVolumes.enable](#opt-virtualisation.docker.autoPrune.allVolumes.enable)
+          must be used.
+
+          https://docs.docker.com/reference/cli/docker/system/prune/#description
         '';
       };
 
@@ -205,6 +213,28 @@ in
           useful to catch up on missed runs of the service when the
           system was powered down.
         '';
+      };
+
+      allVolumes = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to periodically prune all Docker volumes when auto pruning other docker resources
+            by running {command}`docker volume prune --force --all`
+
+            To prune only anonymous volumes, instead pass `--volumes` to `autoPrune.flags`
+          '';
+        };
+
+        flags = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "--filter=label=<label>" ];
+          description = ''
+            Any additional flags passed to {command}`docker volume prune --force --all`.
+          '';
+        };
       };
     };
 
@@ -312,15 +342,29 @@ in
 
         serviceConfig = {
           Type = "oneshot";
-          ExecStart = utils.escapeSystemdExecArgs (
-            [
-              (lib.getExe cfg.package)
-              "system"
-              "prune"
-              "-f"
-            ]
-            ++ cfg.autoPrune.flags
-          );
+          ExecStart = [
+            (utils.escapeSystemdExecArgs (
+              [
+                (lib.getExe cfg.package)
+                "system"
+                "prune"
+                "-f"
+              ]
+              ++ cfg.autoPrune.flags
+            ))
+          ]
+          ++ (optionals cfg.autoPrune.allVolumes.enable [
+            (utils.escapeSystemdExecArgs (
+              [
+                (lib.getExe cfg.package)
+                "volume"
+                "prune"
+                "--force"
+                "--all"
+              ]
+              ++ cfg.autoPrune.allVolumes.flags
+            ))
+          ]);
         };
 
         startAt = optional cfg.autoPrune.enable cfg.autoPrune.dates;
@@ -341,6 +385,10 @@ in
             cfg.enableNvidia && pkgs.stdenv.hostPlatform.isx86_64
             -> config.hardware.graphics.enable32Bit or false;
           message = "Option enableNvidia on x86_64 requires 32-bit support libraries";
+        }
+        {
+          assertion = cfg.autoPrune.allVolumes.enable -> cfg.autoPrune.enable;
+          message = "Option autoPrune.allVolumes.enable requires autoPrune.enable";
         }
       ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -462,6 +462,7 @@ in
   dnsdist = import ./dnsdist.nix { inherit pkgs runTest; };
   doas = runTest ./doas.nix;
   docker = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./docker.nix;
+  docker-autoprune = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./docker-autoprune.nix;
   docker-registry = runTest ./docker-registry.nix;
   docker-rootless = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./docker-rootless.nix;
   docker-tools = runTestOn [ "x86_64-linux" ] ./docker-tools.nix;

--- a/nixos/tests/docker-autoprune.nix
+++ b/nixos/tests/docker-autoprune.nix
@@ -1,0 +1,57 @@
+# This test validates the docker autoprune service, testing whether
+# the default configuration cleans up images, while leaving volumes intact
+# and whether the allVolumes option enables cleaning up volumes as well
+{ pkgs, ... }:
+{
+  name = "docker";
+
+  nodes = {
+    prune =
+      { pkgs, ... }:
+      {
+        virtualisation.docker = {
+          enable = true;
+          package = pkgs.docker;
+          autoPrune = {
+            enable = true;
+          };
+        };
+      };
+    prunevolumes =
+      { pkgs, ... }:
+      {
+        virtualisation.docker = {
+          enable = true;
+          package = pkgs.docker;
+          autoPrune = {
+            enable = true;
+            allVolumes.enable = true;
+          };
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("Check whether autoPrune works. Volumes should be left unpruned."):
+      prune.wait_for_unit("sockets.target")
+      prune.succeed("docker network create testnetwork")
+      prune.succeed("docker network list --format json | grep testnetwork")
+      prune.succeed("docker volume create testvolume")
+      prune.succeed("docker volume list --format json | grep testvolume")
+
+      prune.succeed("systemctl start -v docker-prune")
+      prune.fail("docker network list --format json | grep testnetwork")
+      # the volume has been left alone
+      prune.succeed("docker volume list --format json | grep testvolume")
+
+    with subtest("Check whether autoPrune including volumes works"):
+      prunevolumes.wait_for_unit("sockets.target")
+      prunevolumes.succeed("docker volume create testvolume")
+      prunevolumes.succeed("docker volume list --format json | grep testvolume")
+
+      prunevolumes.succeed("systemctl start -v docker-prune")
+      prunevolumes.fail("docker volume list --format json | grep testvolume")
+  '';
+}


### PR DESCRIPTION
it is not possible to prune all volumes using `docker system prune`, the best that can be done is the removal of anonymous volumes using the `--volumes` flag
https://docs.docker.com/reference/cli/docker/system/prune/#description

add new option `autoPrune.allVolumes.enable` which runs `docker volume prune --all --force` when the system prune service runs. https://docs.docker.com/reference/cli/docker/volume/prune/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
