### PR TITLE
coan: fix build with gcc15

### DIFF
--- a/pkgs/by-name/co/coan/fix-path-operator-plus.diff
+++ b/pkgs/by-name/co/coan/fix-path-operator-plus.diff
@@ -1,0 +1,11 @@
+diff --git a/src/path.h b/src/path.h
+--- a/src/path.h
++++ b/src/path.h
+@@ -232,7 +232,7 @@
+ 	 */
+ 	path operator+(std::string const & str) const {
+ 		path p(*this);
+-		p.append(str);
++		p.push_back(str);
+ 		return p;
+ 	}

--- a/pkgs/by-name/co/coan/package.nix
+++ b/pkgs/by-name/co/coan/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # fix compile error in configure.ac
     ./fix-big-endian-config-check.diff
+    # Fix GCC 15 build: path::operator+ calls a nonexistent append() member.
+    ./fix-path-operator-plus.diff
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/324212607
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
