### PR TITLE
gts: fix Darwin build by setting -std=gnu17.

### DIFF
--- a/pkgs/by-name/gt/gts/package.nix
+++ b/pkgs/by-name/gt/gts/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ gettext ];
   propagatedBuildInputs = [ glib ];
 
-  env = {
-    # Doesn't build on Darwin with -std=gnu23. Apply uniformly as C standard target is something unlikely to vary across platforms.
+  env = lib.optionalAttrs stdenv.isDarwin {
+    # Doesn't build on Darwin with -std=gnu23.
     NIX_CFLAGS_COMPILE = "-std=gnu17";
   };
 

--- a/pkgs/by-name/gt/gts/package.nix
+++ b/pkgs/by-name/gt/gts/package.nix
@@ -32,6 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ gettext ];
   propagatedBuildInputs = [ glib ];
 
+  env = {
+    # Doesn't build on Darwin with -std=gnu23. Apply uniformly as C standard target is something unlikely to vary across platforms.
+    NIX_CFLAGS_COMPILE = "-std=gnu17";
+  };
+
   doCheck = false; # fails with "permission denied"
 
   preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''


### PR DESCRIPTION
The autotools bump has meant various packages are being built with  -std=gnu23, often for the first time. I haven't nailed down the exact  cause of the breakage, but it's not terribly surprising that code from  2006 isn't coping, so just set it to gnu17 instead (unconditionally for  simplicity).

Hoping to fix a bunch of failures for #507470.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - @reckenrode has checked that this idea makes it work on Darwin, but not this exact PR
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
