### PR TITLE
kyverno-chainsaw: fix build with go 1.26

### DIFF
--- a/pkgs/by-name/ky/kyverno-chainsaw/go-1.26-testdeps-modulepath.patch
+++ b/pkgs/by-name/ky/kyverno-chainsaw/go-1.26-testdeps-modulepath.patch
@@ -1,0 +1,15 @@
+diff --git a/pkg/runner/internal/test_deps.go b/pkg/runner/internal/test_deps.go
+index f7728f3..90dbca5 100644
+--- a/pkg/runner/internal/test_deps.go
++++ b/pkg/runner/internal/test_deps.go
+@@ -41,6 +41,10 @@ func (*TestDeps) ImportPath() string {
+ 	return ""
+ }
+ 
++func (*TestDeps) ModulePath() string {
++	return ""
++}
++
+ func (*TestDeps) StartTestLog(w io.Writer) {}
+ 
+ func (*TestDeps) StopTestLog() error {

--- a/pkgs/by-name/ky/kyverno-chainsaw/package.nix
+++ b/pkgs/by-name/ky/kyverno-chainsaw/package.nix
@@ -2,7 +2,6 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  kyverno-chainsaw,
   lib,
   nix-update-script,
   stdenv,
@@ -16,7 +15,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "kyverno";
     repo = "chainsaw";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wHwjcpcum3ByBGYUxJ38Qi0RliQUmAIBYmE7t3gEonI=";
   };
 
@@ -44,7 +43,7 @@ buildGoModule (finalAttrs: {
   '';
 
   passthru.tests.version = testers.testVersion {
-    package = kyverno-chainsaw;
+    package = finalAttrs.finalPackage;
     command = "chainsaw version";
     version = "v${finalAttrs.version}";
   };

--- a/pkgs/by-name/ky/kyverno-chainsaw/package.nix
+++ b/pkgs/by-name/ky/kyverno-chainsaw/package.nix
@@ -20,6 +20,8 @@ buildGoModule (finalAttrs: {
     hash = "sha256-wHwjcpcum3ByBGYUxJ38Qi0RliQUmAIBYmE7t3gEonI=";
   };
 
+  patches = [ ./go-1.26-testdeps-modulepath.patch ];
+
   vendorHash = "sha256-lG+odKD1TGQ7GTh/y9ogREtY59T8fvN/6FyKsdgsU0M=";
 
   subPackages = [ "." ];


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/324246668)](https://hydra.nixos.org/build/324246668)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
