### PR TITLE
logseq: enable text_input_v3 protocol

### DIFF
--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -253,7 +253,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${lib.getExe electron} $out/bin/logseq \
         --add-flags $out/share/logseq/resources/app \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
         --set-default LOCAL_GIT_DIRECTORY ${git} \
         --inherit-argv0
   ''


### PR DESCRIPTION
For those wayland compositors that don't support v1 protocol.