### PR TITLE
gram: init at 2.1.0

### DIFF
--- a/pkgs/by-name/gr/gram/package.nix
+++ b/pkgs/by-name/gr/gram/package.nix
@@ -1,0 +1,212 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  protobuf,
+  fontconfig,
+  libgit2,
+  openssl,
+  sqlite,
+  zlib,
+  zstd,
+  libxkbcommon,
+  wayland,
+  libxcb,
+  stdenv,
+  libGL,
+  vulkan-loader,
+  envsubst,
+  nix-update-script,
+  cargo-about,
+  versionCheckHook,
+  cargo-bundle,
+  git,
+  testers,
+  writableTmpDirAsHomeHook,
+
+  buildRemoteServer ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gram";
+  version = "1.2.1";
+
+  outputs = [
+    "out"
+  ]
+  ++ lib.optionals buildRemoteServer [
+    "remote_server"
+  ];
+
+  src = fetchFromCodeberg {
+    owner = "GramEditor";
+    repo = "gram";
+    tag = finalAttrs.version;
+    hash = "sha256-tKG6k3/TX0Gz197Zc6UrrMUuhOdr7XjYOBGBv/jA6rE=";
+  };
+
+  patches = [
+    # sqlez: Open named in-memory databases as SQLite URIs
+    # required for passing tests in newer sqlite versions
+    (fetchpatch {
+      url = "https://codeberg.org/GramEditor/gram/commit/74510b9d5341b14eb2e01cf565132e2b006dc266.patch";
+      hash = "sha256-GJXLdcSQQ13lgPSJ3e+GV6MKsYLIePq5bZQuGoE1Www=";
+    })
+  ];
+
+  postPatch = ''
+    # The generate-licenses script wants a specific version of cargo-about eventhough
+    # newer versions work just as well.
+    substituteInPlace script/generate-licenses \
+      --replace-fail '$CARGO_ABOUT_VERSION' '${cargo-about.version}'
+  '';
+
+  cargoHash = "sha256-XBdLRHW3v8m8KyPG4XxXTkN6BUc3FVd0jakvZDFaGaU=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cargo-about
+    cmake
+    pkg-config
+    protobuf
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cargo-bundle
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    libgit2
+    openssl
+    sqlite
+    zlib
+    zstd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
+    libxcb
+    libxkbcommon
+  ];
+
+  cargoBuildFlags = [
+    "--package=gram"
+    "--package=cli"
+  ]
+  ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
+
+  # Required on darwin because we don't have access to the proprietary Metal shader compiler.
+  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
+
+  env = {
+    ALLOW_MISSING_LICENSES = true;
+    OPENSSL_NO_VENDOR = true;
+    LIBGIT2_NO_VENDOR = true;
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    RELEASE_VERSION = finalAttrs.version;
+  };
+
+  preBuild = ''
+    bash script/generate-licenses
+  '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  useNextest = true;
+
+  remoteServerExecutableName = "gram-remote-server-stable-${finalAttrs.version}";
+  installPhase = ''
+    runHook preInstall
+
+    release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # cargo-bundle expects the binary in target/release
+    mv $release_target/gram target/release/gram
+
+    pushd crates/gram
+    # Note that this is GNU sed, while Gram's bundle-mac uses BSD sed
+    sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
+    export CARGO_BUNDLE_SKIP_BUILD=true
+    app_path=$(cargo bundle --release | xargs)
+    popd
+
+    mkdir -p $out/Applications $out/bin
+    # Gram expects git next to its own binary
+    ln -s ${lib.getExe git} $app_path/Contents/MacOS/git
+    mv $release_target/cli $app_path/Contents/MacOS/cli
+    mv $app_path $out/Applications/
+
+    # Physical location of the CLI must be inside the app bundle as this is used
+    # to determine which app to start
+    ln -s $out/Applications/Gram.app/Contents/MacOS/cli $out/bin/gram
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm755 $release_target/gram $out/libexec/gram-editor
+    install -Dm755 $release_target/cli $out/bin/gram
+
+    install -Dm644 $src/crates/gram/resources/app.liten.Gram.svg $out/share/icons/hicolor/scalable/apps/app.liten.Gram.svg
+    install -Dm644 $src/crates/gram/resources/app.liten.Gram-symbolic.svg $out/share/icons/hicolor/scalable/apps/app.liten.Gram-symbolic.svg
+
+    # See https://codeberg.org/GramEditor/gram/src/branch/main/crates/gram/resources/gram.desktop.in
+    (
+      export DO_STARTUP_NOTIFY="true"
+      export APP_CLI="gram"
+      export APP_ICON="app.liten.Gram"
+      export APP_NAME="Gram"
+      export APP_ARGS="%U"
+      mkdir -p "$out/share/applications"
+      ${lib.getExe envsubst} < "crates/gram/resources/gram.desktop.in" > "$out/share/applications/app.liten.Gram.desktop"
+    )
+  ''
+  + lib.optionalString buildRemoteServer ''
+    install -Dm755 $release_target/remote_server $remote_server/bin/${finalAttrs.remoteServerExecutableName}
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/libexec/gram-editor --add-rpath ${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+      ]
+    }
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      remoteServerVersion = testers.testVersion {
+        package = finalAttrs.finalPackage.remote_server;
+        command = "${finalAttrs.remoteServerExecutableName} version";
+      };
+    };
+  };
+
+  meta = {
+    description = "Powerful and modern source code editor";
+    homepage = "https://gram.liten.app/";
+    changelog = "https://codeberg.org/GramEditor/gram/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      niklaskorz
+    ];
+    mainProgram = "gram";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/gr/gram/package.nix
+++ b/pkgs/by-name/gr/gram/package.nix
@@ -1,0 +1,202 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  cmake,
+  pkg-config,
+  protobuf,
+  fontconfig,
+  libgit2,
+  openssl,
+  sqlite,
+  zlib,
+  zstd,
+  libxkbcommon,
+  wayland,
+  libxcb,
+  stdenv,
+  libGL,
+  vulkan-loader,
+  envsubst,
+  nix-update-script,
+  cargo-about,
+  versionCheckHook,
+  cargo-bundle,
+  git,
+  testers,
+  writableTmpDirAsHomeHook,
+
+  buildRemoteServer ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gram";
+  version = "2.1.0";
+
+  outputs = [
+    "out"
+  ]
+  ++ lib.optionals buildRemoteServer [
+    "remote_server"
+  ];
+
+  src = fetchFromCodeberg {
+    owner = "GramEditor";
+    repo = "gram";
+    tag = finalAttrs.version;
+    hash = "sha256-9MfNGl0bk8RBkYutHFMnAEiAQVnUBQguQUkyt+O0vnY=";
+  };
+
+  postPatch = ''
+    # The generate-licenses script wants a specific version of cargo-about eventhough
+    # newer versions work just as well.
+    substituteInPlace script/generate-licenses \
+      --replace-fail '$CARGO_ABOUT_VERSION' '${cargo-about.version}'
+  '';
+
+  cargoHash = "sha256-sUSkXYZ81CFwxzDiT0Va0VnWVKlVS683DVHLZeoSJ4w=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cargo-about
+    cmake
+    pkg-config
+    protobuf
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cargo-bundle
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    libgit2
+    openssl
+    sqlite
+    zlib
+    zstd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
+    libxcb
+    libxkbcommon
+  ];
+
+  cargoBuildFlags = [
+    "--package=gram"
+    "--package=cli"
+  ]
+  ++ lib.optionals buildRemoteServer [ "--package=remote_server" ];
+
+  # Required on darwin because we don't have access to the proprietary Metal shader compiler.
+  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
+
+  env = {
+    ALLOW_MISSING_LICENSES = true;
+    OPENSSL_NO_VENDOR = true;
+    LIBGIT2_NO_VENDOR = true;
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    RELEASE_VERSION = finalAttrs.version;
+  };
+
+  preBuild = ''
+    bash script/generate-licenses
+  '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  useNextest = true;
+
+  remoteServerExecutableName = "gram-remote-server-stable-${finalAttrs.version}";
+  installPhase = ''
+    runHook preInstall
+
+    release_target="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # cargo-bundle expects the binary in target/release
+    mv $release_target/gram target/release/gram
+
+    pushd crates/gram
+    # Note that this is GNU sed, while Gram's bundle-mac uses BSD sed
+    sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
+    export CARGO_BUNDLE_SKIP_BUILD=true
+    app_path=$(cargo bundle --release | xargs)
+    popd
+
+    mkdir -p $out/Applications $out/bin
+    # Gram expects git next to its own binary
+    ln -s ${lib.getExe git} $app_path/Contents/MacOS/git
+    mv $release_target/cli $app_path/Contents/MacOS/cli
+    mv $app_path $out/Applications/
+
+    # Physical location of the CLI must be inside the app bundle as this is used
+    # to determine which app to start
+    ln -s $out/Applications/Gram.app/Contents/MacOS/cli $out/bin/gram
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm755 $release_target/gram $out/libexec/gram-editor
+    install -Dm755 $release_target/cli $out/bin/gram
+
+    install -Dm644 $src/crates/gram/resources/app.liten.Gram.svg $out/share/icons/hicolor/scalable/apps/app.liten.Gram.svg
+    install -Dm644 $src/crates/gram/resources/app.liten.Gram-symbolic.svg $out/share/icons/hicolor/scalable/apps/app.liten.Gram-symbolic.svg
+
+    # See https://codeberg.org/GramEditor/gram/src/branch/main/crates/gram/resources/gram.desktop.in
+    (
+      export DO_STARTUP_NOTIFY="true"
+      export APP_CLI="gram"
+      export APP_ICON="app.liten.Gram"
+      export APP_NAME="Gram"
+      export APP_ARGS="%U"
+      mkdir -p "$out/share/applications"
+      ${lib.getExe envsubst} < "crates/gram/resources/gram.desktop.in" > "$out/share/applications/app.liten.Gram.desktop"
+    )
+  ''
+  + lib.optionalString buildRemoteServer ''
+    install -Dm755 $release_target/remote_server $remote_server/bin/${finalAttrs.remoteServerExecutableName}
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/libexec/gram-editor --add-rpath ${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+      ]
+    }
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      remoteServerVersion = testers.testVersion {
+        package = finalAttrs.finalPackage.remote_server;
+        command = "${finalAttrs.remoteServerExecutableName} version";
+      };
+    };
+  };
+
+  meta = {
+    description = "Powerful and modern source code editor";
+    homepage = "https://gram-editor.com";
+    changelog = "https://codeberg.org/GramEditor/gram/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      niklaskorz
+    ];
+    mainProgram = "gram";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> Gram is a powerful and modern source code editor. It features solid performance and is highly configurable, yet comes with batteries included out of the box. Gram supports many popular programming languages and file formats, and can use Zed extensions to support additional languages. Other features include built-in documentation, debugger support via the DAP protocol, source control using git and more. Gram started as a [fork](https://gram.liten.app/why/) of the Zed editor.

Note that Gram is a hard fork of Zed, so using a shared package definition for both does not make sense down the road. They already differ significantly (e.g., Zed needs livekit-libwebrtc while Gram removed all collaboration features).

I intentionally left out an FHS variant as Gram encourages you to bring your own binaries and compile extensions yourself, which fits the NixOS model much better than Zed does.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
