### PR TITLE
giff: init at 1.2.0

### DIFF
--- a/pkgs/by-name/gi/giff/package.nix
+++ b/pkgs/by-name/gi/giff/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "giff";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "bahdotsh";
+    repo = "giff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oBZp0+tAYuAcj5vNXs2phW85Y+67WnH2CJiZ7cNpWpE=";
+  };
+
+  cargoHash = "sha256-IjXdWp5LdxIxfj2NL1EdxGh29L8Q/ExqX8yNHFStT1M=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-based Git diff viewer with interactive rebase capabilities";
+    homepage = "https://github.com/bahdotsh/giff";
+    changelog = "https://github.com/bahdotsh/giff/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "giff";
+  };
+})

--- a/pkgs/by-name/gi/giff/package.nix
+++ b/pkgs/by-name/gi/giff/package.nix
@@ -29,7 +29,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/bahdotsh/giff";
     changelog = "https://github.com/bahdotsh/giff/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kpbaks ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      kpbaks
+    ];
     mainProgram = "giff";
   };
 })

--- a/pkgs/by-name/gi/giff/package.nix
+++ b/pkgs/by-name/gi/giff/package.nix
@@ -7,6 +7,8 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "giff";
   version = "1.2.0";
 

--- a/pkgs/by-name/gi/giff/package.nix
+++ b/pkgs/by-name/gi/giff/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "giff";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "bahdotsh";
     repo = "giff";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oBZp0+tAYuAcj5vNXs2phW85Y+67WnH2CJiZ7cNpWpE=";
+    hash = "sha256-ESmURQ7MAJ/Sv6ISdh+WF/XVtsGUTCRc7DzDwqBuXCM=";
   };
 
-  cargoHash = "sha256-IjXdWp5LdxIxfj2NL1EdxGh29L8Q/ExqX8yNHFStT1M=";
+  cargoHash = "sha256-094QMCEI4ShTqlfYZUxCUUd/Fx9kmATHKuJPKqGxw7s=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/502251

I included above PR in this PR, so that the contribution of @kpbaks is not "lost". I added myself as maintainer as well and updated to the latest release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
