### PR TITLE
gh-cherry-pick: 1.2.0 -> 1.3.1

### DIFF
--- a/pkgs/by-name/gh/gh-cherry-pick/package.nix
+++ b/pkgs/by-name/gh/gh-cherry-pick/package.nix
@@ -5,14 +5,14 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gh-cherry-pick";
-  version = "1.2.0";
+  version = "1.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "PerchunPak";
     repo = "gh-cherry-pick";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EiXWgiCV99k3810nCWA+AnlLjG8VKRCPnns9KtfGxqY=";
+    hash = "sha256-plNxOYLfKWLjN5RR1g2VOJWgyrzXdgI0MDJYe05XcCk=";
   };
 
   build-system = with python3Packages; [
@@ -20,18 +20,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     uv-dynamic-versioning
   ];
 
-  pythonRelaxDeps = [
-    "attrs"
-    "trio"
-  ];
-
   dependencies = with python3Packages; [
-    attrs
     cyclopts
     httpx
-    loguru
-    trio
-    typing-extensions
   ];
 
   nativeCheckInputs = with python3Packages; [
@@ -39,7 +30,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pytest
     pytest-cov-stub
     pytest-mock
-    pytest-trio
   ];
 
   pythonImportsCheck = [ "gh_cherry_pick" ];

--- a/pkgs/by-name/gh/gh-cherry-pick/package.nix
+++ b/pkgs/by-name/gh/gh-cherry-pick/package.nix
@@ -27,7 +27,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = with python3Packages; [
     pytestCheckHook
-    pytest
     pytest-cov-stub
     pytest-mock
   ];


### PR DESCRIPTION
https://github.com/PerchunPak/gh-cherry-pick: Cherry-pick commits across GitHub repositories using only the GitHub API

Changelog:
- https://github.com/PerchunPak/gh-cherry-pick/releases/tag/v1.3.0
- https://github.com/PerchunPak/gh-cherry-pick/releases/tag/v1.3.1

Diff: https://github.com/PerchunPak/gh-cherry-pick/compare/v1.2.0...v1.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
