### PR TITLE
maintainers: drop pneumaticat

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21632,12 +21632,6 @@
     githubId = 579773;
     name = "Philip Nelson";
   };
-  pneumaticat = {
-    email = "kevin@potatofrom.space";
-    github = "kliu128";
-    githubId = 11365056;
-    name = "Kevin Liu";
-  };
   pnmadelaine = {
     name = "Paul-Nicolas Madelaine";
     email = "pnm@pnm.tf";

--- a/pkgs/by-name/au/autokey/package.nix
+++ b/pkgs/by-name/au/autokey/package.nix
@@ -70,7 +70,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/autokey/autokey";
     description = "Desktop automation utility for Linux and X11";
     license = with lib.licenses; [ gpl3 ];
-    maintainers = with lib.maintainers; [ pneumaticat ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/fi/firebird-emu/package.nix
+++ b/pkgs/by-name/fi/firebird-emu/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/nspire-emus/firebird/releases/tag/v${finalAttrs.version}";
     description = "Third-party multi-platform emulator of the ARM-based TI-Nspire™ calculators";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ pneumaticat ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/he/helmfile/package.nix
+++ b/pkgs/by-name/he/helmfile/package.nix
@@ -57,7 +57,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://helmfile.readthedocs.io/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      pneumaticat
       yurrriq
     ];
   };

--- a/pkgs/by-name/rd/rdocker/package.nix
+++ b/pkgs/by-name/rd/rdocker/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     description = "Securely control a remote docker daemon CLI using ssh forwarding, no SSL setup needed";
     mainProgram = "rdocker";
     homepage = "https://github.com/dvddarias/rdocker";
-    maintainers = [ lib.maintainers.pneumaticat ];
+    maintainers = [ ];
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-chinese/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/mike-fabian/ibus-table-chinese";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ pneumaticat ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Akliu128) since 2019 despite 75 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2020-01-01+user-review-requested%3Akliu128). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@kliu128 if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
