### PR TITLE
sonoscli: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11787,6 +11787,11 @@
     github = "j0xaf";
     githubId = 932697;
   };
+  j10ccc = {
+    name = "popWheat";
+    github = "j10ccc";
+    githubId = 49830650;
+  };
   j1nxie = {
     email = "rylie@rylie.moe";
     name = "Nguyen Pham Quoc An";

--- a/pkgs/by-name/so/sonoscli/package.nix
+++ b/pkgs/by-name/so/sonoscli/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sonoscli";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "sonoscli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9ouRJ0Rr+W5Kx9BltgW29Jo1Jq7Hb/un4XBkq+0in9o=";
+  };
+
+  vendorHash = "sha256-hocnLCzWN8srQcO3BMNkd2lt0m54Qe7sqAhUxVZlz1k=";
+
+  subPackages = [ "cmd/sonos" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd sonos \
+      --bash <($out/bin/sonos completion bash) \
+      --fish <($out/bin/sonos completion fish) \
+      --zsh  <($out/bin/sonos completion zsh)
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Control Sonos speakers from your terminal over LAN (UPnP/SOAP)";
+    longDescription = ''
+      sonoscli is a modern Go CLI to control Sonos speakers over your local
+      network using UPnP/SOAP. Features include reliable SSDP discovery,
+      coordinator-aware playback controls, grouping, queue management,
+      favorites, scenes, Spotify integration via SMAPI, and live event watching.
+    '';
+    homepage = "https://github.com/steipete/sonoscli";
+    changelog = "https://github.com/steipete/sonoscli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "sonos";
+    maintainers = with lib.maintainers; [ j10ccc ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add `sonoscli` ([steipete/sonoscli](https://github.com/steipete/sonoscli)), a Go CLI tool for controlling Sonos speakers from the terminal over LAN using UPnP/SOAP.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test