### PR TITLE
octavePackages.dicom: Add autoreconf and update 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/development/octave-modules/dicom/default.nix
+++ b/pkgs/development/octave-modules/dicom/default.nix
@@ -3,6 +3,8 @@
   lib,
   fetchFromGitHub,
   gdcm,
+  autoreconfHook,
+  pkg-config,
   cmake,
   nix-update-script,
 }:
@@ -19,14 +21,25 @@ buildOctavePackage rec {
   };
 
   nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
     cmake
   ];
-
-  dontUseCmakeConfigure = true;
 
   propagatedBuildInputs = [
     gdcm
   ];
+
+  dontUseCmakeConfigure = true;
+
+  preAutoreconf = ''
+    pushd src
+    # Removed these so autoreconf actually fires for our environment.
+    rm config.*
+  '';
+  postAutoreconf = ''
+    popd
+  '';
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
 

--- a/pkgs/development/octave-modules/dicom/default.nix
+++ b/pkgs/development/octave-modules/dicom/default.nix
@@ -11,13 +11,13 @@
 
 buildOctavePackage rec {
   pname = "dicom";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "gnu-octave";
     repo = "octave-dicom";
     tag = "release-${version}";
-    sha256 = "sha256-NNdcnIeHXDRmZZp0WvwGtfMJ4BSR6+aK6FVS0BG51U8=";
+    sha256 = "sha256-6FcHxNUOTvSzYqknD89G3IyKVQs/dH+heoA/5Sx4lyg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add `autoreconfHook` to force the Octave build system to compile the C++ that dicom requires. Dicom 0.7.2 uses some of the functionality the C++ files provide.

Builds on the auto-update to dicom in #508505.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
