### PR TITLE
buildUBOOT: allow overriding defconfig with extraConfig

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -120,9 +120,9 @@ let
         configurePhase = ''
           runHook preConfigure
 
-          make -j$NIX_BUILD_CORES ${defconfig}
+          cat $extraConfigPath >> configs/${defconfig}
 
-          cat $extraConfigPath >> .config
+          make -j$NIX_BUILD_CORES ${defconfig}
 
           runHook postConfigure
         '';

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -118,9 +118,9 @@ let
         configurePhase = ''
           runHook preConfigure
 
-          make -j$NIX_BUILD_CORES ${defconfig}
+          printf "%s" "$extraConfig" >> configs/${defconfig}
 
-          printf "%s" "$extraConfig" >> .config
+          make -j$NIX_BUILD_CORES ${defconfig}
 
           runHook postConfigure
         '';


### PR DESCRIPTION
Append extraConfig to defconfig rather than the generated .config file.
Allows extraConfig overriding exist defconfig and also auto complete missing config items running make $defconfig


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
