### PR TITLE
requireFile: don't perform Bash expansion

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -105,6 +105,8 @@
 
 - `nodePackages.wavedrom-cli` has been removed, as it was unmaintained within nixpkgs.
 
+- `requireFile` now treats any `message` or `url` argument as a literal string, rather than subjecting it to Bash here-doc expansion.  This allows including strings like `$PWD` in the message without needing to know about and handle the undocumented Bash expansion.
+
 - `nodePackages.browserify` has been removed, as it was unmaintained within nixpkgs.
 
 - `nodePackages.sass` has been removed, as it was unmaintained within nixpkgs.

--- a/nixos/modules/services/games/quake3-server.nix
+++ b/nixos/modules/services/games/quake3-server.nix
@@ -34,8 +34,8 @@ let
       cp baseq3/pak*.pk3 /tmp/baseq3
       nix-store --add-fixed sha256 --recursive /tmp/baseq3
 
-      Alternatively you can set services.quake3-server.baseq3 to a path and copy the baseq3 directory into
-      $services.quake3-server.baseq3/.q3a/
+      Alternatively you can set services.quake3-server.baseq3 to a path and
+      copy the baseq3 directory into the .q3a subdirectory of that path.
     '';
   };
 

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation rec {
       Once you have downloaded the file, please use the following command and re-run the
       installation:
 
-      nix-prefetch-url file://\$PWD/${name}
+      nix-prefetch-url file://$PWD/${name}
     '';
   };
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -928,14 +928,7 @@ rec {
         outputHash = hash_;
         preferLocalBuild = true;
         builder = writeScript "restrict-message" ''
-          source ${stdenvNoCC}/setup
-          cat <<_EOF_
-
-          ***
-          ${msg}
-          ***
-
-          _EOF_
+          printf '%s' ${lib.escapeShellArg msg}
           exit 1
         '';
       }

--- a/pkgs/by-name/an/andyetitmoves/package.nix
+++ b/pkgs/by-name/an/andyetitmoves/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation rec {
           message = ''
             We cannot download the commercial version automatically, as you require a license.
             Once you bought a license, you need to add your downloaded version to the nix store.
-            You can do this by using "nix-prefetch-url file:///\$PWD/${commercialName}" in the
-            directory where yousaved it.
+            You can do this by using "nix-prefetch-url file:///$PWD/${commercialName}" in the
+            directory where you saved it.
           '';
           name = commercialName;
           sha256 =

--- a/pkgs/by-name/dx/dxx-rebirth/assets.nix
+++ b/pkgs/by-name/dx/dxx-rebirth/assets.nix
@@ -23,7 +23,7 @@ let
           Once you have downloaded the file, please use the following command and re-run the
           installation:
 
-          nix-prefetch-url file://\$PWD/${name}
+          nix-prefetch-url file://$PWD/${name}
         '';
       };
 

--- a/pkgs/by-name/ke/keeperrl/package.nix
+++ b/pkgs/by-name/ke/keeperrl/package.nix
@@ -38,7 +38,7 @@ let
 
       Then add this archive to the nix store with
 
-      "nix-prefetch-url file://\$PWD/${name}".
+      "nix-prefetch-url file://$PWD/${name}".
     '';
     sha256 = "0115pxdzdyma2vicxgr0j21pp82gxdyrlj090s8ihp0b50f0nlll";
   };

--- a/pkgs/by-name/ki/kinect-audio-setup/package.nix
+++ b/pkgs/by-name/ki/kinect-audio-setup/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
       In order to install the Kinect Audio Firmware, you need to download the
       non-redistributable firmware from Microsoft.
       The firmware is available at ${firmwareUrl} and the license at ${licenseUrl} .
-      Save the file as UACFirmware and use "nix-prefetch-url file://\$PWD/UACFirmware" to
+      Save the file as UACFirmware and use "nix-prefetch-url file://$PWD/UACFirmware" to
       add it to the Nix store.
     '';
   };

--- a/pkgs/by-name/si/silverfort-client/package.nix
+++ b/pkgs/by-name/si/silverfort-client/package.nix
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     message = ''
       Due to the commercial license of Silverfort, Nix is unable to download
       Silverfort automatically. Please download ${name} manually and add it
-      to the Nix store using \`nix-prefetch-url file:///\$PWD/${name}\`.
+      to the Nix store using `nix-prefetch-url file:///$PWD/${name}`.
       It is recommended to add this file to the garbage collector root
       to prevent grabage collection.
     '';

--- a/pkgs/by-name/uq/uqm/3dovideo.nix
+++ b/pkgs/by-name/uq/uqm/3dovideo.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
       The reason for this is because the 3DO uses its own proprietary disk
       format.
 
-      Save the file as videos.tar and use "nix-prefetch-url file://\$PWD/${name}" to
+      Save the file as videos.tar and use "nix-prefetch-url file://$PWD/${name}" to
       add it to the Nix store.
 
       [*] ${helper}/bin/uqm3donix CDIMAGE ${name}

--- a/pkgs/by-name/wo/worldofgoo/package.nix
+++ b/pkgs/by-name/wo/worldofgoo/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   helpMsg = ''
     We cannot download the full version automatically, as you require a license.
     Once you have bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://\$PWD/${pname}.Linux.${version}.sh"
+    You can do this by using "nix-prefetch-url file://$PWD/${pname}.Linux.${version}.sh"
     in the directory where you saved it.
   '';
 

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   goBuyItNow = ''
     We cannot download the full version automatically, as you require a license.
     Once you bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://\$PWD/vessel-${version}-bin" in the
+    You can do this by using "nix-prefetch-url file://$PWD/vessel-${version}-bin" in the
     directory where you saved it.
   '';
 

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -43,8 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
       Once you have downloaded the file, please use the following
       commands and re-run the installation:
 
-      mv \$PWD/"DisplayLink USB Graphics Software for Ubuntu6.2-EXE.zip" \$PWD/${name}
-      nix-prefetch-url file://\$PWD/${name}
+      mv $PWD/"DisplayLink USB Graphics Software for Ubuntu6.2-EXE.zip" $PWD/${name}
+      nix-prefetch-url file://$PWD/${name}
 
       Alternatively, you can use the following command to download the
       file directly:


### PR DESCRIPTION
When printing the error message with instructions to manually obtain a
fixed-output derivation using requireFile, simply `cat` the instructions
from a temporary file containing those instructions, rather than using
them in a context where Bash expansion will be performed.

This permits passing instructions that contain characters that Bash
would normally expand without needing to escape them (or even know that
they need escaping from Bash), for example instructions referencing
`$PWD`.

Document this in the current release notes, and update existing
requireFile calls that perform this now-unnecessary escaping.  In
passing, fix up a couple of minor message errors.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Tested error appearance on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
