### PR TITLE
tfenv: namespace install tree under share/tfenv

### DIFF
--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -33,22 +33,17 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/lib $out/libexec $out/share
+    mkdir -p $out/bin $out/share/tfenv $out/share/doc/tfenv
 
-    cp -r lib/* $out/lib/
-    cp -r libexec/* $out/libexec/
-    cp -r share/* $out/share/
+    cp -r bin lib libexec share CHANGELOG.md $out/share/tfenv/
 
-    install -m0644 CHANGELOG.md $out/CHANGELOG.md
-
-    install -m0755 bin/tfenv $out/bin/tfenv
-    install -m0755 bin/terraform $out/bin/terraform
+    ln -s $out/share/tfenv/CHANGELOG.md $out/share/doc/tfenv/CHANGELOG.md
 
     runHook postInstall
   '';
 
   postFixup = ''
-    for f in $out/bin/* $out/libexec/*; do
+    for f in $out/share/tfenv/bin/* $out/share/tfenv/libexec/*; do
       [ -f "$f" ] || continue
       wrapProgram "$f" \
         --prefix PATH : "${
@@ -62,6 +57,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           ]
         }"
     done
+
+    ln -s $out/share/tfenv/bin/tfenv $out/bin/tfenv
+    ln -s $out/share/tfenv/bin/terraform $out/bin/terraform
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Move the entire upstream layout (`bin/`, `lib/`, `libexec/`, `share/`, `CHANGELOG.md`) into `$out/share/tfenv/` and symlink entry-point binaries into `$out/bin/`. 
This prevents profile-level collisions (e.g. `$out/lib/helpers.sh`, `$out/share/hashicorp-keys.pgp`) when multiple packages are merged into a single profile.

`CHANGELOG.md` is symlinked into `$out/share/doc/tfenv/` for conventional doc discovery.

Signed-off-by: kaynetik <aleksandar@nesovic.dev>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
