### PR TITLE
readwise-cli: init at 0.5.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20073,6 +20073,12 @@
     githubId = 30825096;
     name = "Ning Zhang";
   };
+  o-love = {
+    email = "olabradalove@gmail.com";
+    github = "o-love";
+    githubId = 36935375;
+    name = "Oscar Love";
+  };
   o0th = {
     email = "o0th@pm.me";
     name = "Sabato Luca Guadagno";

--- a/pkgs/by-name/re/readwise-cli/package.nix
+++ b/pkgs/by-name/re/readwise-cli/package.nix
@@ -1,0 +1,29 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+}:
+
+buildNpmPackage {
+  pname = "readwise-cli";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "readwiseio";
+    repo = "readwise-cli";
+    rev = "v0.5.5";
+    hash = "sha256-oPyhsKyaZRogn5y1JIJH0js0yrk5E298QEpIC9/4xXc=";
+  };
+
+  npmDepsHash = "sha256-eupjqOEE77pNzY9DBJdYdDraJtUVhbojaG/QCW+m+jw=";
+
+  meta = {
+    description = "Command-line interface for Readwise and Reader";
+    homepage = "https://github.com/readwiseio/readwise-cli";
+    mainProgram = "readwise";
+    # No LICENSE file in the upstream repository
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ o-love ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/re/readwise-cli/package.nix
+++ b/pkgs/by-name/re/readwise-cli/package.nix
@@ -4,18 +4,22 @@
   lib,
 }:
 
-buildNpmPackage {
+buildNpmPackage (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "readwise-cli";
   version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "readwiseio";
     repo = "readwise-cli";
-    rev = "v0.5.5";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-oPyhsKyaZRogn5y1JIJH0js0yrk5E298QEpIC9/4xXc=";
   };
 
   npmDepsHash = "sha256-eupjqOEE77pNzY9DBJdYdDraJtUVhbojaG/QCW+m+jw=";
+
+  prePatch = "export npmDeps";
 
   meta = {
     description = "Command-line interface for Readwise and Reader";
@@ -26,4 +30,4 @@ buildNpmPackage {
     maintainers = with lib.maintainers; [ o-love ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Add `readwise-cli` — a command-line interface for Readwise and Reader, written in TypeScript. Allows users to search documents & highlights, manage reading lists, and tag/organize documents from the terminal.

The upstream repository (`readwiseio/readwise-cli`) contains no LICENSE file, so this is marked `unfree`.

Been working on it through my [overlay](https://github.com/o-love/olove-nix-overlay/blob/main/pkgs/readwise-cli/default.nix).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test