### PR TITLE
osmium-tool: 1.19.0 → 1.19.1

### DIFF
--- a/pkgs/by-name/os/osmium-tool/package.nix
+++ b/pkgs/by-name/os/osmium-tool/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   installShellFiles,
   pandoc,
@@ -18,22 +17,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osmium-tool";
-  version = "1.19.0";
+  version = "1.19.1";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "osmium-tool";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-x5qEW4DqOw/vA+IuZA7VC5WRn+uDOZ6dJhyJoi7UKOA=";
+    hash = "sha256-WPNXzS5XiCWSA5iycPqulybQtVED9oVfAsRz0WYmApA=";
   };
-
-  patches = [
-    # Fix apply-changes-version-on-version-timestamp test
-    (fetchpatch {
-      url = "https://github.com/osmcode/osmium-tool/commit/e58501ed1570f19340173c668568790369214d46.patch";
-      hash = "sha256-VhdwY1DpfTQAx24Qck0a96GGnEGfg4T27wSeGO1zdng=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
https://github.com/osmcode/osmium-tool/compare/v1.19.0...v1.19.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
