### PR TITLE
Update Purescript to v0.15.16

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -10,21 +10,9 @@
 # from justinwoo/easy-purescript-nix
 # https://github.com/justinwoo/easy-purescript-nix/blob/d383972c82620a712ead4033db14110497bc2c9c/purs.nix
 
-let
-  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
-
-  patchelf =
-    libPath:
-    lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      chmod u+w $PURS
-      patchelf --interpreter ${dynamic-linker} --set-rpath ${libPath} $PURS
-      chmod u-w $PURS
-    '';
-
-in
 stdenv.mkDerivation rec {
   pname = "purescript";
-  version = "0.15.15";
+  version = "0.15.16";
 
   # These hashes can be updated automatically by running the ./update.sh script.
   src =
@@ -33,19 +21,19 @@ stdenv.mkDerivation rec {
       sources = {
         "x86_64-linux" = fetchurl {
           url = url + "linux64.tar.gz";
-          sha256 = "1w4jgjpfhaw3gkx9sna64lq9m030x49w4lwk01ik5ci0933imzj3";
+          sha256 = "08lfyddh914z7v2ph6im88g9hjvs6z60ldfmiyg5252fibxrxnj4";
         };
         "aarch64-linux" = fetchurl {
           url = url + "linux-arm64.tar.gz";
-          sha256 = "1ws5h337xq0l06zrs9010h6wj2hq5cqk5ikp9arq7hj7lxf43vn5";
+          sha256 = "1wr7m59v7nakyzgnq2rbm4a8x0dm8arlx0lhi9hwkn70qv2m7ldq";
         };
         "x86_64-darwin" = fetchurl {
           url = url + "macos.tar.gz";
-          sha256 = "178ix54k2yragcgn0j8z1cfa78s1qbh1bsx3v9jnngby8igr6yn3";
+          sha256 = "1djq37w7vhfmvk61cx8rmlckzkh90aywc2v60rqiq938ljvzsnwz";
         };
         "aarch64-darwin" = fetchurl {
           url = url + "macos-arm64.tar.gz";
-          sha256 = "0bi231z1yhb7kjfn228wjkj6rv9lgpagz9f4djr2wy3kqgck4xg0";
+          sha256 = "1i7w6a9j1k3v1c20g9jxd2v2jr7nsx54lp02zdhc5vr6w89mmwb3";
         };
       };
     in
@@ -64,7 +52,6 @@ stdenv.mkDerivation rec {
     PURS="$out/bin/purs"
 
     install -D -m555 -T purs $PURS
-    ${patchelf libPath}
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     mkdir -p $out/share/bash-completion/completions

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -10,21 +10,9 @@
 # from justinwoo/easy-purescript-nix
 # https://github.com/justinwoo/easy-purescript-nix/blob/d383972c82620a712ead4033db14110497bc2c9c/purs.nix
 
-let
-  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
-
-  patchelf =
-    libPath:
-    lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      chmod u+w $PURS
-      patchelf --interpreter ${dynamic-linker} --set-rpath ${libPath} $PURS
-      chmod u-w $PURS
-    '';
-
-in
 stdenv.mkDerivation rec {
   pname = "purescript";
-  version = "0.15.15";
+  version = "0.15.16";
 
   # These hashes can be updated automatically by running the ./update.sh script.
   src =
@@ -33,15 +21,15 @@ stdenv.mkDerivation rec {
       sources = {
         "x86_64-linux" = fetchurl {
           url = url + "linux64.tar.gz";
-          sha256 = "1w4jgjpfhaw3gkx9sna64lq9m030x49w4lwk01ik5ci0933imzj3";
+          sha256 = "08lfyddh914z7v2ph6im88g9hjvs6z60ldfmiyg5252fibxrxnj4";
         };
         "aarch64-linux" = fetchurl {
           url = url + "linux-arm64.tar.gz";
-          sha256 = "1ws5h337xq0l06zrs9010h6wj2hq5cqk5ikp9arq7hj7lxf43vn5";
+          sha256 = "1wr7m59v7nakyzgnq2rbm4a8x0dm8arlx0lhi9hwkn70qv2m7ldq";
         };
         "aarch64-darwin" = fetchurl {
           url = url + "macos-arm64.tar.gz";
-          sha256 = "0bi231z1yhb7kjfn228wjkj6rv9lgpagz9f4djr2wy3kqgck4xg0";
+          sha256 = "1i7w6a9j1k3v1c20g9jxd2v2jr7nsx54lp02zdhc5vr6w89mmwb3";
         };
       };
     in
@@ -60,7 +48,6 @@ stdenv.mkDerivation rec {
     PURS="$out/bin/purs"
 
     install -D -m555 -T purs $PURS
-    ${patchelf libPath}
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     mkdir -p $out/share/bash-completion/completions

--- a/pkgs/development/compilers/purescript/purescript/update.sh
+++ b/pkgs/development/compilers/purescript/purescript/update.sh
@@ -29,10 +29,6 @@ old_linux_arm_version_hash="$(nix-prefetch-url "https://github.com/purescript/pu
 echo "v${old_version} linux tarball hash (current version): $old_linux_arm_version_hash"
 new_linux_arm_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${new_version}/linux-arm64.tar.gz")"
 echo "v${new_version} linux tarball hash: $new_linux_arm_version_hash"
-old_darwin_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${old_version}/macos.tar.gz")"
-echo "v${old_version} darwin tarball hash (current version): $old_darwin_version_hash"
-new_darwin_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${new_version}/macos.tar.gz")"
-echo "v${new_version} darwin tarball hash: $new_darwin_version_hash"
 old_darwin_arm_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${old_version}/macos-arm64.tar.gz")"
 echo "v${old_version} darwin arm tarball hash (current version): $old_darwin_arm_version_hash"
 new_darwin_arm_version_hash="$(nix-prefetch-url "https://github.com/purescript/purescript/releases/download/v${new_version}/macos-arm64.tar.gz")"
@@ -42,7 +38,6 @@ echo
 echo "Replacing version and hashes in ${purescript_derivation_file}."
 sed -i -e "s/${old_linux_version_hash}/${new_linux_version_hash}/" "$purescript_derivation_file"
 sed -i -e "s/${old_linux_arm_version_hash}/${new_linux_arm_version_hash}/" "$purescript_derivation_file"
-sed -i -e "s/${old_darwin_version_hash}/${new_darwin_version_hash}/" "$purescript_derivation_file"
 sed -i -e "s/${old_darwin_arm_version_hash}/${new_darwin_arm_version_hash}/" "$purescript_derivation_file"
 sed -i -e "s/${old_version}/${new_version}/" "$purescript_derivation_file"
 echo


### PR DESCRIPTION
Update Purescript to v0.15.16, and remove patchelf as binaries are now statically linked.


## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
