### PR TITLE
shapelib: 1.6.2 → 1.6.3

### DIFF
--- a/pkgs/by-name/sh/shapelib/package.nix
+++ b/pkgs/by-name/sh/shapelib/package.nix
@@ -2,27 +2,16 @@
   lib,
   stdenv,
   fetchurl,
-  fetchDebianPatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "shapelib";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchurl {
     url = "https://download.osgeo.org/shapelib/shapelib-${version}.tar.gz";
-    hash = "sha256-S3SjbO2U6ae+pAEVfmZK3cxb4lHn33+I1GdDYdoBLCE=";
+    hash = "sha256-P/Xq0Yym0v4knw6As2HhrWeCFlEVJo7UpYx4CmDB4Os=";
   };
-
-  patches = [
-    # Fix build with gcc 15
-    (fetchDebianPatch {
-      inherit pname version;
-      debianRevision = "1";
-      patch = "gcc-15.patch";
-      hash = "sha256-ubd8L2hxSAxTDiOSToVHGLHkpGOap5bnozdVdv9VgCQ=";
-    })
-  ];
 
   doCheck = true;
   preCheck = ''


### PR DESCRIPTION
https://github.com/OSGeo/shapelib/releases/tag/v1.6.3

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
