### PR TITLE
Update Go version from 1.26.1 to 1.26.2

### DIFF
--- a/pkgs/development/compilers/go/1.26.nix
+++ b/pkgs/development/compilers/go/1.26.nix
@@ -25,11 +25,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.26.1";
+  version = "1.26.2";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-MXIpPQSyCdwRRGmOe6E/BHf2uoxf/QvmbCD9vJeF37s=";
+    hash = "sha256-LpHrtpR6lulDb7KzkmqIAu/mOm03Xf/sT4Kqnb1v1Ds=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Updated go and ran it

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:

- Patch release
- Updated source hash
- Builds successfully on x86_64-linux