### PR TITLE
openjump: 2.3.0 → 2.4.0

### DIFF
--- a/pkgs/by-name/op/openjump/package.nix
+++ b/pkgs/by-name/op/openjump/package.nix
@@ -14,12 +14,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openjump";
-  version = "2.3.0";
-  revision = "r5279%5Bd24616e%5D";
+  version = "2.4.0";
+  revision = "r5303%5B6c9a02d%5D";
 
   src = fetchurl {
     url = "mirror://sourceforge/jump-pilot/OpenJUMP/${finalAttrs.version}/OpenJUMP-Portable-${finalAttrs.version}-${finalAttrs.revision}-PLUS.zip";
-    hash = "sha256-IO44iGnFQt/ir1WlvBrEHjdC+0DZTfJIVAJgRcxrFMI=";
+    hash = "sha256-MBP4zZTKHj3WooQvo6nQzhiAw9nO9gAJybSL2rc1mnc=";
   };
 
   # TODO: build from source
@@ -59,7 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://www.openjump.org/";
     license = lib.licenses.gpl2;
     mainProgram = "OpenJump";
-    maintainers = [ ];
     teams = [ lib.teams.geospatial ];
     platforms = jre.meta.platforms;
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];


### PR DESCRIPTION
https://sourceforge.net/p/jump-pilot/news/2025/01/openjump-240-released/

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
