### PR TITLE
python3Packages.janim: init at 4.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11516,6 +11516,11 @@
     name = "Andrew Plaza";
     keys = [ { fingerprint = "843D 72A9 EB79 A869 2C58  5B3A E773 8A7A 0F5C DB89"; } ];
   };
+  instable = {
+    github = "code-instable";
+    githubId = 68656923;
+    name = "Code Instable";
+  };
   Intuinewin = {
     email = "antoinelabarussias@gmail.com";
     github = "Intuinewin";

--- a/pkgs/by-name/un/undock/package.nix
+++ b/pkgs/by-name/un/undock/package.nix
@@ -5,13 +5,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "undock";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "crazy-max";
     repo = "undock";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sFH6+2Ncg8B+Vxs2IyRurwJdzKiKRwmQKIoxjKY8+JE=";
+    hash = "sha256-ZjvF7BvjL/IZ25JDO4P9ELPdgCrGc9b+ldqFOx/i0ic=";
   };
 
   vendorHash = null;

--- a/pkgs/development/python-modules/janim/default.nix
+++ b/pkgs/development/python-modules/janim/default.nix
@@ -164,7 +164,6 @@ buildPythonPackage (finalAttrs: {
       of other rich features.  Inspired by manim (3Blue1Brown's animation engine).
     '';
     homepage = "https://github.com/jkjkil4/JAnim";
-    documentation = "https://janim.rtfd.io";
     changelog = "https://github.com/jkjkil4/JAnim/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/development/python-modules/janim/default.nix
+++ b/pkgs/development/python-modules/janim/default.nix
@@ -1,0 +1,175 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  stdenv,
+  # build-system
+  flit-core,
+  # dependencies
+  attrs,
+  numpy,
+  pyquaternion,
+  colour,
+  rich,
+  moderngl,
+  pyopengl,
+  tqdm,
+  psutil,
+  skia-pathops,
+  fonttools,
+  freetype-py,
+  pillow,
+  svgelements,
+  typst,
+  # optional-dependencies (gui)
+  enableGui ? true,
+  pyside6,
+  qdarkstyle,
+  beautifulsoup4,
+  sounddevice,
+  wrapQtAppsHook,
+  qtbase,
+  # optional-dependencies (test)
+  opencv4,
+  coverage,
+  # tests
+  pytestCheckHook,
+  # runtime
+  ffmpeg,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "janim";
+  version = "4.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.12";
+
+  src = fetchFromGitHub {
+    owner = "jkjkil4";
+    repo = "JAnim";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QUsuy2oFNqmRDVjJew8OxYZny3/qBJHfmBG8SCjOPkM=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies =
+    [
+      attrs
+      numpy
+      pyquaternion
+      colour
+      rich
+      moderngl
+      pyopengl
+      tqdm
+      psutil
+      skia-pathops
+      fonttools
+      freetype-py
+      pillow
+      svgelements
+      typst
+    ]
+    ++ lib.optionals enableGui ([
+        pyside6
+        qdarkstyle
+        beautifulsoup4
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        sounddevice
+      ]);
+
+  # PySide6 pulls in Qt6 libraries that need plugin paths (platforms,
+  # imageformats, etc.) set via environment variables.  wrapQtAppsHook
+  # normally does this by wrapping every executable it finds, but
+  # buildPythonPackage already wraps scripts with its own Python-aware
+  # wrapper.  Two competing wrappers cause double-wrapping and broken
+  # shebangs.  Setting dontWrapQtApps = true disables the automatic Qt
+  # wrapping and instead we forward the qtWrapperArgs (which contain
+  # QT_PLUGIN_PATH, QML2_IMPORT_PATH, XDG_DATA_DIRS, etc.) into the
+  # Python makeWrapper call via makeWrapperArgs.
+  nativeBuildInputs = lib.optionals enableGui [
+    wrapQtAppsHook
+  ];
+  buildInputs = lib.optionals enableGui [
+    qtbase
+  ];
+
+  dontWrapQtApps = true;
+
+  optional-dependencies = {
+    gui =
+      [
+        pyside6
+        qdarkstyle
+        beautifulsoup4
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        sounddevice
+      ];
+    test = [
+      opencv4
+      coverage
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  doCheck = true;
+  pytestFlagsArray = [
+    "test/utils"
+    "test/component"
+    "test/items"
+    "test/anims"
+    # test/examples excluded: needs pre-generated reference PNGs and an OpenGL context
+  ];
+
+  preCheck = ''
+    cat > conftest.py << 'EOF'
+    import unittest.mock
+    import psutil
+    # psutil.sensors_battery() reads /sys/class/power_supply which is
+    # unavailable in the Nix sandbox; patch it before janim.utils.config loads
+    psutil.sensors_battery = unittest.mock.Mock(return_value=None)
+    EOF
+  '';
+
+  pythonImportsCheck = ["janim"];
+
+  makeWrapperArgs =
+    [
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath [ffmpeg])
+    ]
+    ++ lib.optionals enableGui [
+      # Splice in the Qt wrapper arguments so that the single Python
+      # wrapper also carries the QT_PLUGIN_PATH and friends that Qt
+      # needs at runtime.
+      "\${qtWrapperArgs[@]}"
+    ];
+
+  meta = {
+    description = "Programmatic animation engine for creating precise and smooth animations with real-time feedback";
+    longDescription = ''
+      JAnim is a programmatic animation engine for creating precise and smooth
+      animations.  It supports real-time editing, live preview, and a wide range
+      of other rich features.  Inspired by manim (3Blue1Brown's animation engine).
+    '';
+    homepage = "https://github.com/jkjkil4/JAnim";
+    documentation = "https://janim.rtfd.io";
+    changelog = "https://github.com/jkjkil4/JAnim/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      instable
+    ];
+    mainProgram = "janim";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7791,6 +7791,13 @@ self: super: with self; {
 
   jamo = callPackage ../development/python-modules/jamo { };
 
+  janim = callPackage ../development/python-modules/janim {
+    inherit (pkgs.qt6) wrapQtAppsHook qtbase;
+    pyquaternion = pyquaternion.overridePythonAttrs {
+      doCheck = false;
+    };
+  };
+
   janus = callPackage ../development/python-modules/janus { };
 
   jaraco-abode = callPackage ../development/python-modules/jaraco-abode { };


### PR DESCRIPTION
JAnim is a programmatic animation engine for creating precise and smooth animations with real-time preview. Inspired by manim (3Blue1Brown's engine).
- Homepage: https://github.com/jkjkil4/JAnim
- GUI support via PySide6/Qt6 (optional, enabled by default)
- ffmpeg in PATH for render output
- Qt wrapper args forwarded through makeWrapperArgs (dontWrapQtApps pattern)
- 38 non-GL unit tests enabled; render/example tests excluded (require OpenGL context and pre-generated reference images)
- psutil.sensors_battery patched in preCheck (reads /sys, unavailable in sandbox)

- Added instable (code-instable on github) as maintainer (new nixpkgs contributor).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

### Basic functionality
- help:
```
❯ ./result/bin/janim --help
usage: janim [-h] [--lang LANG] [-v]
             [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
             {run,write,examples,tool} ...

Programmatic animation engine for creating precise and
smooth animations with real-time feedback

positional arguments:
  {run,write,examples,tool}
    run                 Run timeline(s) from specific file
    write               Generate media file(s) of
                        timeline(s) from specific file
    examples            Show examples of JAnim
    tool                Run useful tools

options:
  -h, --help            show this help message and exit
  --lang LANG           Language code, e.g., en, zh_CN
  -v, --version
  --loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        Set the logging level (default:
                        INFO)
```

- GUI test:
	- properly worked on my machine (NVIDIA, proprietary drivers, wayland-hyprland)	
```
❯ QT_QPA_PLATFORM=xcb ./result/bin/janim run bubble.py BubbleSort -c wnd_pos UR
[07:56:04 PM] INFO     ======                       cli.py:45              INFO     Building "BubbleSort"  timeline.py:212
              INFO     Finished building      timeline.py:256
                       "BubbleSort" in 0.05 s
              INFO     ======                       cli.py:52
              INFO     Constructing window          cli.py:53
              INFO     Finished constructing in     cli.py:71
                       0.19 s
              INFO     ======                       cli.py:72
```
using [package example on repo's README](https://github.com/jkjkil4/JAnim) as `bubble.py`
```python
from janim.imports import *
import numpy as np

class BubbleSort(Timeline):
    def construct(self):
        # define items
        heights = np.linspace(1.0, 6.0, 5)
        np.random.seed(123456)
        np.random.shuffle(heights)
        rects = [
            Rect(1, height,
                 fill_alpha=0.5)
            for height in heights
        ]

        group = Group(*rects)
        group.points.arrange(aligned_edge=DOWN)

        # do animations
        self.show(group)

        for i in range(len(heights) - 1, 0, -1):
            for j in range(i):
                rect1, rect2 = rects[j], rects[j + 1]

                self.play(
                    rect1.anim.color.set(BLUE),
                    rect2.anim.color.set(BLUE),
                    duration=0.15
                )

                if heights[j] > heights[j + 1]:
                    x1 = rect1.points.box.x
                    x2 = rect2.points.box.x

                    self.play(
                        rect1.anim.points.set_x(x2),
                        rect2.anim.points.set_x(x1),
                        duration=0.3
                    )

                    heights[[j, j + 1]] = heights[[j + 1, j]]
                    rects[j], rects[j + 1] = rect2, rect1

                self.play(
                    rect1.anim.color.set(WHITE),
                    rect2.anim.color.set(WHITE),
                    duration=0.15
                )
```

---

note: this is a first time new package contribution, feel free to comment on what could be done better