### PR TITLE
wolfssl: 5.9.0 -> 5.9.1

### DIFF
--- a/pkgs/by-name/wo/wolfssl/package.nix
+++ b/pkgs/by-name/wo/wolfssl/package.nix
@@ -18,13 +18,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wolfssl-${variant}";
-  version = "5.9.0";
+  version = "5.9.1";
 
   src = fetchFromGitHub {
     owner = "wolfSSL";
     repo = "wolfssl";
     tag = "v${finalAttrs.version}-stable";
-    hash = "sha256-Ov59Zt0UskADQThdzr9wni2junSpy3jiABWpiGr8xtg=";
+    hash = "sha256-FyEb94hsO2BaTEi1CJRfCsUiT1xyWCzu7Uys81g2CBE=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Changelog: https://github.com/wolfSSL/wolfssl/releases/tag/v5.9.1-stable

Fixes a ton of CVEs:
- [Critical] CVE-2026-5194
- [High] CVE-2026-5264
- [High] CVE-2026-5263
- [High] CVE-2026-5295
- [High] CVE-2026-5466
- [High] CVE-2026-5477
- [High] CVE-2026-5447
- [High] CVE-2026-5500
- [High] CVE-2026-5501
- [High] CVE-2026-5503
- [Med] CVE-2026-5392
- [Med] CVE-2026-5446
- [Med] CVE-2026-5460
- [Med] CVE-2026-5504
- [Med] CVE-2026-5507
- [Low] CVE-2026-5187
- [Low] CVE-2026-5188
- [Low] CVE-2026-5448
- [Low] CVE-2026-5772
- [Low] CVE-2026-5778

Also [Med] CVE-2026-5393 but our builds aren't affected by this.
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
