### PR TITLE
neovim-unwrapped: `ln -sf` grammars instead  of `ln -s`

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -238,7 +238,7 @@ stdenv.mkDerivation (
     ''
     + lib.concatStrings (
       lib.mapAttrsToList (language: grammar: ''
-        ln -s \
+        ln -sf \
           ${grammar}/parser \
           $out/lib/nvim/parser/${language}.so
       '') finalAttrs.treesitter-parsers


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
When building neovim from
https://github.com/nix-community/neovim-nightly-overlay/ I get these
nagging warnings:

```
➜ cmakeConfigurePhase && buildPhase 
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/c.so': Le fichier existe
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/lua.so': Le fichier existe
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/markdown.so': Le fichier existe
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/markdown_inline.so': Le fichier existe
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/query.so': Le fichier existe
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/vim.so': Le fichier existe
ln: failed to create symbolic link '/home/teto/neovim/neovim/outputs/out/lib/nvim/parser/vimdoc.so': Le fichier existe
```

This doesn't change anything in sandbox, just makes development shells
quieter
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
