### PR TITLE
zed-editor: fixes and corrections

### DIFF
--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -3,13 +3,9 @@
   rustPlatform,
   fetchFromGitHub,
   cmake,
-  copyDesktopItems,
-  curl,
-  perl,
   pkg-config,
   protobuf,
   fontconfig,
-  freetype,
   libgit2,
   openssl,
   sqlite,
@@ -19,10 +15,8 @@
   alsa-lib,
   libxkbcommon,
   wayland,
-  libglvnd,
   libxcb,
   stdenv,
-  makeFontsConf,
   vulkan-loader,
   envsubst,
   nix-update-script,
@@ -31,8 +25,6 @@
   buildFHSEnv,
   cargo-bundle,
   git,
-  apple-sdk_15,
-  darwinMinVersionHook,
   makeBinaryWrapper,
   nodejs,
   libGL,
@@ -42,12 +34,8 @@
   testers,
   writableTmpDirAsHomeHook,
 
-  withGLES ? false,
   buildRemoteServer ? true,
-  zed-editor,
 }:
-
-assert withGLES -> stdenv.hostPlatform.isLinux;
 
 let
   channel = "stable";
@@ -106,8 +94,6 @@ let
         '';
       };
     };
-
-  gpu-lib = if withGLES then libglvnd else vulkan-loader;
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zed-editor";
@@ -152,14 +138,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-vFBkjos+Wa0E1li8t4ZCVnRq7q5XSQQe2fx0QqgaCiM=";
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     cmake
-    copyDesktopItems
-    curl
-    perl
     pkg-config
     protobuf
-    rustPlatform.bindgenHook
     cargo-about
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ makeBinaryWrapper ]
@@ -168,16 +152,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   dontUseCmakeConfigure = true;
 
   buildInputs = [
-    curl
-    fontconfig
-    freetype
     libgit2
-    openssl
     sqlite
     zlib
     zstd
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
+    fontconfig
+    openssl
     glib
     alsa-lib
     libxkbcommon
@@ -187,12 +169,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libGL
     libx11
     libxext
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    apple-sdk_15
-    # ScreenCaptureKit, required by livekit, is only available on 12.3 and up:
-    # https://developer.apple.com/documentation/screencapturekit
-    (darwinMinVersionHook "12.3")
   ];
 
   cargoBuildFlags = [
@@ -216,20 +192,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     ALLOW_MISSING_LICENSES = true;
+    OPENSSL_NO_VENDOR = true;
+    LIBGIT2_NO_VENDOR = true;
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
     ZSTD_SYS_USE_PKG_CONFIG = true;
-    FONTCONFIG_FILE = makeFontsConf {
-      fontDirectories = [
-        "${finalAttrs.src}/assets/fonts/plex-mono"
-        "${finalAttrs.src}/assets/fonts/plex-sans"
-      ];
-    };
     # Setting this environment variable allows to disable auto-updates
     # https://zed.dev/docs/development/linux#notes-for-packaging-zed
     ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
     # Used by `zed --version`
     RELEASE_VERSION = finalAttrs.version;
     LK_CUSTOM_WEBRTC = livekit-libwebrtc;
-    RUSTFLAGS = lib.optionalString withGLES "--cfg gles";
   };
 
   preBuild = ''
@@ -237,8 +209,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    patchelf --add-rpath ${gpu-lib}/lib $out/libexec/*
-    patchelf --add-rpath ${wayland}/lib $out/libexec/*
+    patchelf $out/libexec/zed-editor --add-rpath ${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+      ]
+    }
     wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs ]}
   '';
 
@@ -259,21 +236,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mv $release_target/zed target/release/zed
 
     pushd crates/zed
-
     # Note that this is GNU sed, while Zed's bundle-mac uses BSD sed
     sed -i "s/package.metadata.bundle-stable/package.metadata.bundle/" Cargo.toml
     export CARGO_BUNDLE_SKIP_BUILD=true
     app_path=$(cargo bundle --release | xargs)
-
-    # We're not using Zed's fork of cargo-bundle, so we must manually append their plist extensions
-    # Remove closing tags from Info.plist (last two lines)
-    head -n -2 $app_path/Contents/Info.plist > Info.plist
-    # Append extensions
-    cat resources/info/*.plist >> Info.plist
-    # Add closing tags
-    printf "</dict>\n</plist>\n" >> Info.plist
-    mv Info.plist $app_path/Contents/Info.plist
-
     popd
 
     mkdir -p $out/Applications $out/bin
@@ -290,7 +256,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm755 $release_target/zed $out/libexec/zed-editor
     install -Dm755 $release_target/cli $out/bin/zeditor
 
-    install -Dm644 $src/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/1024x1024@2x/apps/zed.png
+    install -Dm644 $src/crates/zed/resources/app-icon@2x.png $out/share/icons/hicolor/512x512@2x/apps/zed.png
     install -Dm644 $src/crates/zed/resources/app-icon.png $out/share/icons/hicolor/512x512/apps/zed.png
 
     # extracted from https://github.com/zed-industries/zed/blob/v0.141.2/script/bundle-linux (envsubst)
@@ -342,9 +308,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
         package = finalAttrs.finalPackage.remote_server;
         command = "${finalAttrs.remoteServerExecutableName} version";
       };
-    }
-    // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-      withGles = zed-editor.override { withGLES = true; };
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A few things I have been meaning to correct for a while and a few others that I only noticed [while packaging Gram](https://github.com/NixOS/nixpkgs/pull/508631).

- OpenGL is now supported without a feature flag, thanks to the wgpu renderer
- cargo-bundle has merged Zed's changes, so our Info.plist patching is obsolete
- libgit2, openssl and sqlite weren't actually using our provided versions and still compiled the vendored variants, which is now fixed by setting the according environment variables
- some dependencies are now obsolete or always were Linux-specific, so I have (re)moved them accordingly

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
