### PR TITLE
nixos/drupal: change state directory modules and themes symlinks

### DIFF
--- a/nixos/modules/services/web-apps/drupal.nix
+++ b/nixos/modules/services/web-apps/drupal.nix
@@ -66,8 +66,8 @@ let
 
       postInstall = ''
         ln -s ${cfg.stateDir}/sites $out/share/php/${cfg.package.pname}${cfg.webRoot}
-        ln -s ${cfg.modulesDir} $out/share/php/${cfg.package.pname}/modules
-        ln -s ${cfg.themesDir} $out/share/php/${cfg.package.pname}/themes
+        ln -s ${cfg.modulesDir} $out/share/php/${cfg.package.pname}${cfg.webRoot}/modules/nixos-modules
+        ln -s ${cfg.themesDir} $out/share/php/${cfg.package.pname}${cfg.webRoot}/themes/nixos-themes
       '';
     });
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR is one half bugfix and one half improvement. it changes the location of where two symlinks in user space connect to the Drupal package in `/nix/store`.

**The Bugfix Part**
The symlinks in the drupal package in `/nix/store` were not being placed in the proper location with respect to the web root, if one is provided via the new `webRoot` option.

Users who implement the `webRoot` option would have seen the symlinks appear in the project root instead of the webroot, which, although supported by Drupal, is not the expected location.

**The Improvement Part**
Now, symlinks for the `modules` and `themes` directories are placed placed in the existing `modules` and `themes` directories with respect to the webroot. Furthermore, the directory names that end up in those directories are prefixed with `nixos-`.

The old behavior would have seen paths like this:
`/nix/store/<package hash>-drupal/sites/php/<pname>/web/modules/modules`

The new behavior now makes `modules` and `themes` paths like this:
`/nix/store/<package hash>-drupal/sites/php/<pname>/web/modules/nixos-modules`

The nested directory structure is supported by drupal, so this will work for the same reason that the `modules/contrib` and `modules/custom` pattern works, and is now a widely accepted pattern.

This will help signal to users that their nixos-specific modules are living in a and are being linked from a specific, understood space.

Although not a huge change, it will make it easier for site builders to understand where certain modules are coming from.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
