### PR TITLE
nerd-font-patcher: provide glyphnames.json

### DIFF
--- a/pkgs/by-name/ne/nerd-font-patcher/package.nix
+++ b/pkgs/by-name/ne/nerd-font-patcher/package.nix
@@ -21,12 +21,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
   patches = [
     ./use-nix-paths.patch
   ];
+  postPatch = ''
+    substituteInPlace font-patcher \
+      --replace-fail "'glyphnames.json'" "'../share/glyphnames.json'"
+  '';
 
   dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/bin $out/share $out/lib
     install -Dm755 font-patcher $out/bin/nerd-font-patcher
+    install -Dm644 glyphnames.json $out/share/glyphnames.json
     cp -ra src/glyphs $out/share/
     cp -ra bin/scripts/name_parser $out/lib/
   '';


### PR DESCRIPTION
I'm not 100% sure what this file is used for, but nerd-font-patcher
expects to be able to find it, and produces a warning message when it
can't.  This prevents that warning message appearing.

Install the file into $out/share, and patch the location in the
nerd-font-patcher script.  The upstream code expects the file in the
same directory as the executable, but I don't think it lives in
$out/bin.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
