### PR TITLE
your_spotify: 1.16.0 -> 1.19.0

### DIFF
--- a/pkgs/by-name/yo/your_spotify/client.nix
+++ b/pkgs/by-name/yo/your_spotify/client.nix
@@ -3,33 +3,39 @@
   src,
   version,
   meta,
-  offlineCache,
+  pnpmDeps,
   apiEndpoint ? "http://localhost:3000",
-  yarnConfigHook,
-  yarnBuildHook,
+  pnpmConfigHook,
+  pnpm_9,
   nodejs,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "your_spotify_client";
-  inherit version src offlineCache;
+  inherit version src pnpmDeps;
 
   nativeBuildInputs = [
-    yarnConfigHook
-    yarnBuildHook
+    pnpmConfigHook
+    pnpm_9
     nodejs
   ];
 
   API_ENDPOINT = "${apiEndpoint}";
-  preBuild = ''
+
+  buildPhase = ''
+    runHook preBuild
+
     pushd ./apps/client/
-  '';
-  postBuild = ''
+    pnpm run build
+
+    export NODE_ENV=production
     substituteInPlace scripts/run/variables.sh --replace-quiet '/app/apps/client/' "./"
     chmod +x ./scripts/run/variables.sh
     patchShebangs --build ./scripts/run/variables.sh
     ./scripts/run/variables.sh
     popd
+
+    runHook postBuild
   '';
 
   installPhase = ''
@@ -40,4 +46,4 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   inherit meta;
-})
+}

--- a/pkgs/by-name/yo/your_spotify/package.nix
+++ b/pkgs/by-name/yo/your_spotify/package.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchYarnDeps,
-  yarnConfigHook,
-  yarnBuildHook,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_9,
   nodejs,
   makeWrapper,
   callPackage,
@@ -14,50 +14,47 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "your_spotify_server";
-  version = "1.16.0";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "Yooooomi";
     repo = "your_spotify";
     tag = finalAttrs.version;
-    hash = "sha256-eVKBrYE6U80G1SS/7nIl4fZb2BELb9lQizKcdcEIJIM=";
+    hash = "sha256-zyvTahfOq7KXgVqD178hrlqO7YjsjLyuw+pm6PMhJt0=";
   };
 
-  offlineCache = fetchYarnDeps {
-    yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-JP5enfy8yyMjZpp0U72S0uR5zJkhpvxog38icOBtQRQ=";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+    hash = "sha256-KI5ZFU8u1R4QKTXn6mGVi+ziAocgOyyutKqmUOIn+dI=";
   };
 
   nativeBuildInputs = [
     makeWrapper
-    yarnConfigHook
-    yarnBuildHook
+    pnpmConfigHook
+    pnpm_9
     nodejs
   ];
 
-  preBuild = ''
+  buildPhase = ''
+    runHook preBuild
     pushd ./apps/server/
-  '';
-  postBuild = ''
+    pnpm run build
     popd
-    rm -r node_modules
-    export NODE_ENV="production"
-    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
-    patchShebangs node_modules/
+    runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share/your_spotify
-    cp -r node_modules $out/share/your_spotify/node_modules
-    rm $out/share/your_spotify/node_modules/@your_spotify/{client,dev,server}
-    cp -r ./apps/server/{lib,package.json} $out
+    cp -r apps/server/build $out/share/your_spotify/
     mkdir -p $out/bin
     makeWrapper ${lib.escapeShellArg (lib.getExe nodejs)} "$out/bin/your_spotify_migrate" \
-      --add-flags "$out/lib/migrations.js" --set NODE_PATH "$out/share/your_spotify/node_modules"
+      --add-flags "$out/share/your_spotify/build/index.js" --add-flags "--migrate"
     makeWrapper ${lib.escapeShellArg (lib.getExe nodejs)} "$out/bin/your_spotify_server" \
-      --add-flags "$out/lib/index.js" --set NODE_PATH "$out/share/your_spotify/node_modules"
+      --add-flags "$out/share/your_spotify/build/index.js"
 
     runHook postInstall
   '';
@@ -67,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       inherit (finalAttrs)
         src
         version
-        offlineCache
+        pnpmDeps
         meta
         ;
     };


### PR DESCRIPTION
Switched the build systemd from yarn to pnpm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
