### PR TITLE
yaziPlugins: init split-tabs

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+
+mkYaziPlugin {
+  pname = "split-tabs.yazi";
+  version = "0-unstable-2026-04-09";
+
+  src = fetchFromGitHub {
+    owner = "terrakok";
+    repo = "split-tabs.yazi";
+    rev = "3f297277ed79cef5d22ea19883ce4d22e40c45a8";
+    hash = "sha256-exa9I5GaF5T2dBnKIcB1gSdtdp2QlzbHv2J9FGxfpBM=";
+  };
+
+  meta = {
+    description = "Yazi plugin that provides a dual-pane view by splitting the screen between two tabs";
+    homepage = "https://github.com/terrakok/split-tabs.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
