### PR TITLE
nchat: 5.13.17 → 5.14.44

### DIFF
--- a/pkgs/by-name/nc/nchat/fix-darwin.patch
+++ b/pkgs/by-name/nc/nchat/fix-darwin.patch
@@ -1,34 +1,95 @@
-diff --git i/CMakeLists.txt w/CMakeLists.txt
-index ceff715b..143659fb 100644
---- i/CMakeLists.txt
-+++ w/CMakeLists.txt
-@@ -31,30 +31,6 @@ endif()
+diff --git c/CMakeLists.txt i/CMakeLists.txt
+index bc227885..143382b3 100644
+--- c/CMakeLists.txt
++++ i/CMakeLists.txt
+@@ -30,91 +30,6 @@ endif()
+ # Platform specifics
  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
    add_definitions(-D_XOPEN_SOURCE_EXTENDED)
- 
+-
 -  # ncurses
--  execute_process(COMMAND sh "-c"
--                  "command -v brew &> /dev/null && brew --prefix ncurses 2> /dev/null | tr -d '\n'"
--                  OUTPUT_VARIABLE NCURSES_ROOT_DIR)
--  if (EXISTS "${NCURSES_ROOT_DIR}")
--    message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (detected).")
+-  if (DEFINED NCURSES_ROOT_DIR AND EXISTS "${NCURSES_ROOT_DIR}")
+-    message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (user-specified)")
 -  else()
--    set(NCURSES_ROOT_DIR /opt/local)
--    message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (default).")
+-    execute_process(COMMAND sh "-c"
+-                    "command -v brew &> /dev/null && brew --prefix ncurses 2> /dev/null | tr -d '\n'"
+-                    OUTPUT_VARIABLE NCURSES_ROOT_DIR)
+-    if (EXISTS "${NCURSES_ROOT_DIR}")
+-      message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (homebrew)")
+-    else()
+-      foreach(FALLBACK_DIR /opt/homebrew/opt/ncurses /usr/local/opt/ncurses)
+-        if (EXISTS "${FALLBACK_DIR}")
+-          set(NCURSES_ROOT_DIR "${FALLBACK_DIR}")
+-          break()
+-        endif()
+-      endforeach()
+-      if (EXISTS "${NCURSES_ROOT_DIR}")
+-        message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (fallback)")
+-      elseif (EXISTS "/opt/local")
+-        set(NCURSES_ROOT_DIR "/opt/local")
+-        message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (macports)")
+-      endif()
+-    endif()
 -  endif()
--  list(APPEND CMAKE_PREFIX_PATH ${NCURSES_ROOT_DIR})
+-  if (EXISTS "${NCURSES_ROOT_DIR}")
+-    list(APPEND CMAKE_PREFIX_PATH ${NCURSES_ROOT_DIR})
+-  endif()
 -
 -  # openssl
--  execute_process(COMMAND sh "-c"
--                  "command -v brew &> /dev/null && brew --prefix openssl 2> /dev/null | tr -d '\n'"
--                  OUTPUT_VARIABLE OPENSSL_ROOT_DIR)
--  if (EXISTS "${OPENSSL_ROOT_DIR}")
--    message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (detected).")
+-  if (DEFINED OPENSSL_ROOT_DIR AND EXISTS "${OPENSSL_ROOT_DIR}")
+-    message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (user-specified)")
 -  else()
--    set(OPENSSL_ROOT_DIR /opt/local)
--    message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (default).")
+-    execute_process(COMMAND sh "-c"
+-                    "command -v brew &> /dev/null && brew --prefix openssl 2> /dev/null | tr -d '\n'"
+-                    OUTPUT_VARIABLE OPENSSL_ROOT_DIR)
+-    if (EXISTS "${OPENSSL_ROOT_DIR}")
+-      message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (homebrew)")
+-    else()
+-      foreach(FALLBACK_DIR /opt/homebrew/opt/openssl /usr/local/opt/openssl)
+-        if (EXISTS "${FALLBACK_DIR}")
+-          set(OPENSSL_ROOT_DIR "${FALLBACK_DIR}")
+-          break()
+-        endif()
+-      endforeach()
+-      if (EXISTS "${OPENSSL_ROOT_DIR}")
+-        message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (fallback)")
+-      elseif (EXISTS "/opt/local")
+-        set(OPENSSL_ROOT_DIR "/opt/local")
+-        message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (macports)")
+-      endif()
+-    endif()
 -  endif()
--  list(APPEND CMAKE_PREFIX_PATH ${OPENSSL_ROOT_DIR})
+-  if (EXISTS "${OPENSSL_ROOT_DIR}")
+-    list(APPEND CMAKE_PREFIX_PATH ${OPENSSL_ROOT_DIR})
+-  endif()
+-
+-  # sqlite
+-  if (DEFINED SQLITE_ROOT_DIR AND EXISTS "${SQLITE_ROOT_DIR}")
+-    message(STATUS "SQLite cmake prefix '${SQLITE_ROOT_DIR}' (user-specified)")
+-  else()
+-    execute_process(COMMAND sh "-c"
+-                    "command -v brew &> /dev/null && brew --prefix sqlite 2> /dev/null | tr -d '\n'"
+-                    OUTPUT_VARIABLE SQLITE_ROOT_DIR)
+-    if (EXISTS "${SQLITE_ROOT_DIR}")
+-      message(STATUS "SQLite cmake prefix '${SQLITE_ROOT_DIR}' (homebrew)")
+-    else()
+-      foreach(FALLBACK_DIR /opt/homebrew/opt/sqlite /usr/local/opt/sqlite)
+-        if (EXISTS "${FALLBACK_DIR}")
+-          set(SQLITE_ROOT_DIR "${FALLBACK_DIR}")
+-          break()
+-        endif()
+-      endforeach()
+-      if (EXISTS "${SQLITE_ROOT_DIR}")
+-        message(STATUS "SQLite cmake prefix '${SQLITE_ROOT_DIR}' (fallback)")
+-      elseif (EXISTS "/opt/local")
+-        set(SQLITE_ROOT_DIR "/opt/local")
+-        message(STATUS "SQLite cmake prefix '${SQLITE_ROOT_DIR}' (macports)")
+-      endif()
+-    endif()
+-  endif()
+-  if (EXISTS "${SQLITE_ROOT_DIR}")
+-    list(APPEND CMAKE_PREFIX_PATH ${SQLITE_ROOT_DIR})
+-  endif()
 -
  elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
    add_compile_definitions(_XOPEN_SOURCE_EXTENDED)

--- a/pkgs/by-name/nc/nchat/go-libs-build.patch
+++ b/pkgs/by-name/nc/nchat/go-libs-build.patch
@@ -1,22 +1,22 @@
-diff --git i/CMakeLists.txt w/CMakeLists.txt
-index a1928ee3..26157e56 100644
---- i/CMakeLists.txt
-+++ w/CMakeLists.txt
-@@ -126,10 +126,6 @@ message(STATUS "Static Go: ${HAS_STATICGOLIB}")
+diff --git c/CMakeLists.txt i/CMakeLists.txt
+index bc227885..d37cafe9 100644
+--- c/CMakeLists.txt
++++ i/CMakeLists.txt
+@@ -182,10 +182,6 @@ message(STATUS "Static Go: ${HAS_STATICGOLIB}")
  
  # Check Golang version for whatsmeow minimum requirement
  set(GO_VERSION_MIN 1.23)
 -execute_process(COMMAND bash "-c" "go version 2> /dev/null | cut -c14- | cut -d' ' -f1 | tr -d '\n'" OUTPUT_VARIABLE GO_VERSION)
 -if((HAS_WHATSAPP OR HAS_SIGNAL) AND (NOT GO_VERSION VERSION_GREATER_EQUAL GO_VERSION_MIN))
--  message(FATAL_ERROR "Go version ${GO_VERSION} (need >= ${GO_VERSION_MIN} to build WhatsApp or Signal).")
+-  message(FATAL_ERROR "Go version ${GO_VERSION} (need >= ${GO_VERSION_MIN} to build WhatsApp or Signal)")
 -endif()
  
  # Check Little/Big Endian for tdlib requirement
  test_big_endian(IS_BIG_ENDIAN)
-diff --git i/lib/tgchat/ext/td/CMakeLists.txt w/lib/tgchat/ext/td/CMakeLists.txt
-index 795f1f4b..7e41549c 100644
---- i/lib/tgchat/ext/td/CMakeLists.txt
-+++ w/lib/tgchat/ext/td/CMakeLists.txt
+diff --git c/lib/tgchat/ext/td/CMakeLists.txt i/lib/tgchat/ext/td/CMakeLists.txt
+index f65c6e45..46b08fdd 100644
+--- c/lib/tgchat/ext/td/CMakeLists.txt
++++ i/lib/tgchat/ext/td/CMakeLists.txt
 @@ -140,7 +140,6 @@ if (CLANG OR GCC)
  endif()
  
@@ -25,10 +25,10 @@ index 795f1f4b..7e41549c 100644
  message(STATUS "Git state: ${TD_GIT_COMMIT_HASH}")
  
  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/td/telegram/GitCommitHash.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/td/telegram/GitCommitHash.cpp" @ONLY)
-diff --git i/lib/wmchat/CMakeLists.txt w/lib/wmchat/CMakeLists.txt
+diff --git c/lib/wmchat/CMakeLists.txt i/lib/wmchat/CMakeLists.txt
 index 84a42ef9..556df050 100644
---- i/lib/wmchat/CMakeLists.txt
-+++ w/lib/wmchat/CMakeLists.txt
+--- c/lib/wmchat/CMakeLists.txt
++++ i/lib/wmchat/CMakeLists.txt
 @@ -20,8 +20,8 @@ install(TARGETS wmchat DESTINATION ${CMAKE_INSTALL_LIBDIR})
  target_common_config(wmchat)
  

--- a/pkgs/by-name/nc/nchat/package.nix
+++ b/pkgs/by-name/nc/nchat/package.nix
@@ -17,13 +17,13 @@
 }:
 
 let
-  version = "5.13.17";
+  version = "5.14.44";
 
   src = fetchFromGitHub {
     owner = "d99kris";
     repo = "nchat";
     tag = "v${version}";
-    hash = "sha256-VSya6s3/+vII/M76tHmeJEZh7/gv9L5tYdILuthdO5s=";
+    hash = "sha256-gG0YkahHP/6KjM+5uzdTRxsonn83cxlJDvdn5HE3h0Q=";
   };
 
   libcgowm = buildGoModule {
@@ -31,7 +31,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}/lib/wmchat/go";
-    vendorHash = "sha256-lfy7uHH3rLYx6kzIy72ftEiO1CkJkEr7rRXHhuFU/ac=";
+    vendorHash = "sha256-5Id5+DehV2juLJnEHYvcI67/ykFUQehSrfFW+toZRM0=";
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
https://github.com/d99kris/nchat/releases/tag/v5.14.44

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
