### PR TITLE
metube: init at 2026.04.09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11022,6 +11022,13 @@
     githubId = 6109326;
     name = "David Hummel";
   };
+  hunterwilkins2 = {
+    email = "hunter.wilkins2@gmail.com";
+    github = "hunterwilkins2";
+    githubId = 25823814;
+    name = "Hunter Wilkins";
+    keys = [ { fingerprint = "9B79 A09C 931E 7133 7251  2FAD A779 5001 1DE3 1C9E"; } ];
+  };
   husjon = {
     name = "Jon Erling Hustadnes";
     email = "jonerling.hustadnes+nixpkgs@proton.me";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -76,6 +76,8 @@
 
 - [pyroscope](https://github.com/grafana/pyroscope), a continuous profiling platform. that allows for performance debugging. Available as [services.pyroscope](#opt-services.pyroscope.enable)
 
+- [metube](https://github.com/alexta69/metube), a self-hosted video downloader for YouTube and other sites. Available as [services.metube](#opt-services.metube.enable).
+
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).
 
 - [dsearch](https://github.com/AvengeMedia/danksearch), a fast filesystem search service with fuzzy matching. Available as [programs.dsearch](#opt-programs.dsearch.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1705,6 +1705,7 @@
   ./services/web-apps/mediagoblin.nix
   ./services/web-apps/mediawiki.nix
   ./services/web-apps/meme-bingo-web.nix
+  ./services/web-apps/metube.nix
   ./services/web-apps/microbin.nix
   ./services/web-apps/miniflux.nix
   ./services/web-apps/misskey.nix

--- a/nixos/modules/services/web-apps/metube.nix
+++ b/nixos/modules/services/web-apps/metube.nix
@@ -1,0 +1,134 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.metube;
+in
+{
+  meta.maintainers = with lib.maintainers; [ hunterwilkins2 ];
+
+  options = {
+    services.metube = {
+      enable = lib.mkEnableOption "MeTube, self-hosted video downloader";
+
+      package = lib.mkPackageOption pkgs "metube" { };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "metube";
+        description = "User which will own the downloaded files";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "metube";
+        description = "Group with will own the downloaded files";
+      };
+
+      openPorts = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Open the web ui port in the firewall";
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule { freeformType = with lib.types; attrsOf str; };
+        default = { };
+        example = {
+          PORT = "8081";
+          MAX_CONCURRENT_DOWNLOADS = 5;
+          DOWNLOAD_DIR = "/home/<user>/Downloads";
+          OUTPUT_TEMPLATE = "%(title)s.%(ext)s";
+          DEFAULT_THEME = "dark";
+        };
+        description = ''
+          Additional configuration for MeTube, see
+          <https://github.com/alexta69/metube/tree/master?tab=readme-ov-file#%EF%B8%8F-configuration-via-environment-variables>
+          for supported values. `DOWNLOAD_DIR` is required.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings.DOWNLOAD_DIR != "";
+        message = "services.metube.settings.DOWNLOAD_DIR must be set";
+      }
+    ];
+
+    services.metube.settings = {
+      PORT = lib.mkDefault "8081";
+      STATE_DIR = "/var/lib/metube";
+      TEMP_DIR = "/tmp";
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.settings.DOWNLOAD_DIR} 0755 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    users.users = lib.optionalAttrs (cfg.user == "metube") {
+      metube = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.optionalAttrs (cfg.group == "metube") {
+      metube = { };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openPorts [ (lib.toInt cfg.settings.PORT) ];
+
+    systemd.services.metube = {
+      description = "MeTube";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.settings;
+      serviceConfig = {
+        Type = "simple";
+        StateDirectory = "metube";
+        StateDirectoryMode = "750";
+        ReadWritePaths = [ cfg.settings.DOWNLOAD_DIR ];
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/metube";
+        Restart = "on-failure";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false;
+        MountAPIVFS = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = 022;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -956,6 +956,7 @@ in
   merecat = runTest ./merecat.nix;
   meshtasticd = runTest ./networking/meshtasticd.nix;
   metabase = runTest ./metabase.nix;
+  metube = runTest ./metube.nix;
   mihomo = runTest ./mihomo.nix;
   mimir = runTest ./mimir.nix;
   mindustry = runTest ./mindustry.nix;

--- a/nixos/tests/metube.nix
+++ b/nixos/tests/metube.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+{
+  name = "metube";
+  meta.maintainers = with lib.maintainers; [ hunterwilkins2 ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.metube.enable = true;
+      services.metube.settings.DOWNLOAD_DIR = "/downloads";
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("metube.service")
+    machine.wait_for_open_port(8081)
+    machine.succeed("curl --fail http://localhost:8081/")
+  '';
+}

--- a/pkgs/by-name/me/metube/package.nix
+++ b/pkgs/by-name/me/metube/package.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  stdenvNoCC,
+  fetchPnpmDeps,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_10,
+  ffmpeg-full,
+  aria2,
+  curl,
+  unzip,
+  nixosTests,
+}:
+let
+  pname = "metube";
+  version = "2026.04.09";
+
+  src = fetchFromGitHub {
+    owner = "alexta69";
+    repo = "metube";
+    tag = version;
+    hash = "sha256-v4O6IBjB4C1MF+amWLdFL8ZEtx318HmTaL+rirgTbtI=";
+  };
+
+  metube-ui = stdenvNoCC.mkDerivation {
+    pname = "${pname}-ui";
+    inherit src version;
+    __structuredAttrs = true;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpmConfigHook
+      pnpm_10
+    ];
+
+    sourceRoot = "${src.name}/ui";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (metube-ui)
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      pnpm = pnpm_10;
+      fetcherVersion = 3;
+      hash = "sha256-5cNctxndShhDYCM2sfYK3rqxGOwil1mrw1eDcN8AXAI=";
+    };
+
+    postBuild = ''
+      pnpm run build
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/dist
+      cp -r dist/metube $out/dist
+      runHook postInstall
+    '';
+  };
+in
+python3Packages.buildPythonApplication {
+  inherit pname src version;
+  __structuredAttrs = true;
+
+  pyproject = true;
+  build-system = [ python3Packages.uv-build ];
+
+  dependencies = with python3Packages; [
+    aiohttp
+    python-socketio
+    yt-dlp
+    mutagen
+    curl-cffi
+    watchfiles
+  ];
+
+  postPatch = ''
+    touch app/__init__.py
+    substituteInPlace app/main.py --replace-fail "if __name__ == '__main__':" "def main():"
+    find app -name "*.py" -print0 | while IFS= read -r -d "" file; do
+      substituteInPlace "$file" \
+        --replace "from ytdl import" "from .ytdl import" \
+        --replace "from dl_formats import" "from .dl_formats import" \
+        --replace "from state_store import" "from .state_store import" \
+        --replace "from subscriptions import" "from .subscriptions import"
+    done
+
+    cat >> pyproject.toml << EOF
+    [project.scripts]
+    metube = "app.main:main"
+
+    [build-system]
+    requires = ["uv_build"]
+    build-backend = "uv_build"
+
+    [tool.uv.build-backend]
+    module-root = "."
+    module-name = "app"
+    EOF
+  '';
+
+  postFixup = ''
+    mkdir -p $out/share/ui
+    cp -r ${metube-ui}/dist $out/share/ui
+  '';
+
+  makeWrapperArgs = [
+    "--set"
+    "BASE_DIR"
+    "${placeholder "out"}/share"
+    "--prefix"
+    "PATH"
+    ":"
+    "${lib.makeBinPath [
+      ffmpeg-full
+      aria2
+      curl
+      unzip
+    ]}"
+  ];
+
+  passthru.tests.metube = nixosTests.metube;
+
+  meta = {
+    description = "Self-hosted video downloader for YouTube and other sites";
+    license = lib.licenses.agpl3Only;
+    homepage = "https://github.com/alexta69/metube";
+    changelog = "https://github.com/alexta69/metube/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ hunterwilkins2 ];
+    mainProgram = "metube";
+    platforms = with lib.platforms; darwin ++ linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added [metube](https://github.com/alexta69/metube) self-hosted video downloader package. See [supportedsites.md](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md) for a list of sites that can be downloaded from. 

When testing the package locally you must set `DOWNLOAD_DIR`, `TEMP_DIR`, and `STATE_DIR` environment variables to a non-readonly path. Access the site at http://localhost:8081/

```bash
DOWNLOAD_DIR=$PWD \
TEMP_DIR=$PWD \
STATE_DIR=$PWD \
./result/bin/metube
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
