### PR TITLE
kubesess: init at 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11066,7 +11066,7 @@
     name = "Yugen";
   };
   i077 = {
-    email = "nixpkgs@imranhossa.in";
+    email = "nixpkgs@imranh.org";
     github = "i077";
     githubId = 2789926;
     name = "Imran Hossain";

--- a/pkgs/by-name/ku/kubesess/package.nix
+++ b/pkgs/by-name/ku/kubesess/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  kubectl,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kubesess";
+  version = "3.0.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Ramilito";
+    repo = "kubesess";
+    tag = finalAttrs.version;
+    hash = "sha256-lb1fUPJjns8SXfvausGY9CChjsR6NpRSYkcOutbOt8c=";
+  };
+
+  # set_default_context & set_default_namespace tests call kubectl
+  nativeBuildInputs = [ kubectl ];
+
+  cargoHash = "sha256-DV/dniWxSbOxad+ovtHtz9l+icT93isLewqHu6MHoiQ=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Kubectl plugin managing sessions";
+    homepage = "https://github.com/Ramilito/kubesess";
+    changelog = "https://github.com/Ramilito/kubesess/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ i077 ];
+    mainProgram = "kubesess";
+  };
+})


### PR DESCRIPTION
kubesess is a per-shell Kubernetes context switcher. https://github.com/Ramilito/kubesess

This PR also updates my email address in maintainers-list.nix.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
