### PR TITLE
dillo-plus: fix build with gcc15

### DIFF
--- a/pkgs/by-name/di/dillo-plus/package.nix
+++ b/pkgs/by-name/di/dillo-plus/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchDebianPatch,
   fltk,
   giflib,
   libjpeg,
@@ -22,6 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "7d093e6bddcb3338938ea5959844e62ff1f9b76f";
     hash = "sha256-7DZ+Ruu1sb+yKHSigdFEVe0xkrsQXSQ2esPhujD3Qrc=";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "dillo";
+      version = "3.0.5";
+      debianRevision = "7.2";
+      patch = "gcc-15.patch";
+      hash = "sha256-DFtR5h8N/vl0Lv5tRHgO2Lz0719ORGog02r0zSYMVYU=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -51,6 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ fgaz ];
     mainProgram = "dillo";
-    platforms = lib.platforms.all;
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322282556

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
