### PR TITLE
nixos-rebuild-ng: don't resolve /run/current-system symlink for --diff

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -323,7 +323,7 @@ def build_and_activate_system(
     if args.diff:
         if current_config.exists():
             nix.diff_closures(
-                current_config=current_config.readlink(),
+                current_config=current_config,
                 new_config=path_to_config,
                 target_host=target_host,
             )


### PR DESCRIPTION
Fixes #508766.

Before running `nix store diff-closures`, `nixos-rebuild-ng` tried to read the symlink on the local system. While this provides for better logging, when paired with `--target-host`, it causes deploy failures as it tries to diff the config of the local system against the target. Even if the store path of the local system happens to be on the target, the diff is incorrect, as it's comparing two different systems against each other instead of the old and new closures on the target system.

Accordingly, we simply avoid resolving the symlink on the host system. If a future solution would like to fix this, it should make sure to do the reading for debug printing on the *target* sytem, not the local one.

I wasn't sure if this requires tests and if so, where the best place to add one is. If this is the desired, please let me know where the best place to test this is (Python tests? NixOS tests?) and I'll try to add one. :3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (picked on top of master, since I don't want to build the kernel)
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
