### PR TITLE
doc: Clarify requirements to add maintainers to packages

### DIFF
--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -89,7 +89,7 @@ For details, see [Source provenance](#sec-meta-sourceProvenance).
 
 ### `maintainers` {#var-meta-maintainers}
 
-A list of the maintainers of this Nix expression. Maintainers are defined in [`nixpkgs/maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix). There is no restriction to becoming a maintainer, just add yourself to that list in a separate commit titled “maintainers: add alice” in the same pull request, and reference maintainers with `maintainers = with lib.maintainers; [ alice bob ]`.
+A list of the maintainers of this Nix expression. Maintainers are defined in [`nixpkgs/maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix). To become a maintainer, add yourself to that list in a separate commit titled “maintainers: add alice” in the same pull request, and reference maintainers with `maintainers = with lib.maintainers; [ alice bob ]`. Additions to `meta.maintainers` are privileged changes and should follow the maintainer policy in [`maintainers/README.md`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-become-a-maintainer).
 
 ### `teams` {#var-meta-teams}
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -95,7 +95,7 @@ For details, see [Source provenance](#sec-meta-sourceProvenance).
 
 ### `maintainers` {#var-meta-maintainers}
 
-A list of the maintainers of this Nix expression. Maintainers are defined in [`nixpkgs/maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix). There is no restriction to becoming a maintainer, just add yourself to that list in a separate commit titled “maintainers: add alice” in the same pull request, and reference maintainers with `maintainers = with lib.maintainers; [ alice bob ]`.
+A list of the maintainers of this Nix expression. Maintainers are defined in [`nixpkgs/maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix). To become a maintainer, add yourself to that list in a separate commit titled “maintainers: add alice” in the same pull request, and reference maintainers with `maintainers = with lib.maintainers; [ alice bob ]`. Additions to `meta.maintainers` are privileged changes and should follow the maintainer policy in [`maintainers/README.md`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#how-to-become-a-maintainer).
 
 ### `teams` {#var-meta-teams}
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -31,6 +31,14 @@ Commit access to the Nixpkgs repository is not required for that.
 
 In order to do so, add yourself to the [`maintainer-list.nix`](./maintainer-list.nix), and then to the desired package's `meta.maintainers` list, and send a PR with the changes.
 
+Adding someone to `meta.maintainers` is not a simple mechanical change, even for packages that currently have no maintainers.
+Maintainers can use the [nixpkgs-merge-bot](../ci/README.md#nixpkgs-merge-bot) to merge certain pull requests for packages they maintain, including their own backports, so maintainer additions grant real privileges and must be reviewed accordingly.
+
+Reviewers and committers are responsible for making sure maintainer additions receive deliberate review before merging.
+If the package already has maintainers, that includes making sure the current maintainers are notified on the PR, that their consent is collected, and that they are given time to reply before merging.
+For most packages, that means waiting at least a week, just like for other non-endorsed changes affecting a maintained package.
+For sensitive packages, such as security-critical or core infrastructure packages, special attention may be needed and the appropriate level of review should be negotiated with the existing maintainers or relevant teams.
+
 If you're adding yourself as a maintainer as part of another PR (in which you become a maintainer of a package, for example), make your change to
 `maintainer-list.nix` in a separate commit titled `maintainers: add <handle>`.
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -31,6 +31,15 @@ Commit access to the Nixpkgs repository is not required for that.
 
 In order to do so, add yourself to the [`maintainer-list.nix`](./maintainer-list.nix), and then to the desired package's `meta.maintainers` list, and send a PR with the changes.
 
+Adding someone to `meta.maintainers` is not a simple mechanical change, even for packages that currently have no maintainers.
+Maintainers can use the [nixpkgs-merge-bot](../ci/README.md#nixpkgs-merge-bot) to merge certain pull requests for packages they maintain, including their own backports, so maintainer additions grant real privileges and must be reviewed accordingly.
+
+Reviewers and committers are responsible for making sure maintainer additions receive deliberate review before merging.
+If the package already has maintainers, that includes making sure the current maintainers are notified on the PR and given a reasonable chance to support or object to the addition before merging.
+For most packages, that means waiting at least a week, just like for other non-endorsed changes affecting a maintained package.
+Lack of response after a reasonable waiting period should not block the PR by itself; reviewers and committers may move forward if the addition otherwise received adequate review.
+For sensitive packages, such as security-critical or core infrastructure packages, special attention may be needed and the appropriate level of review should be negotiated with the existing maintainers or relevant teams when possible.
+
 If you're adding yourself as a maintainer as part of another PR (in which you become a maintainer of a package, for example), make your change to
 `maintainer-list.nix` in a separate commit titled `maintainers: add <handle>`.
 


### PR DESCRIPTION
This change makes it explicit that adding new maintainers to packages
has real world implications and hence requires special reviewer
attention as well as current maintainers' consent.

Context: https://github.com/NixOS/nixpkgs/pull/508528

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
