### PR TITLE
zinit: use $man and normalize install permissions

### DIFF
--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -34,20 +34,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     # Source files
     mkdir -p $out/share/zinit
-    install -m0644 zinit{,-side,-install,-autoload,-additional}.zsh _zinit $out/share/zinit
-    install -m0755 share/git-process-output.zsh $out/share/zinit
-    install -m0644 share/rpm2cpio.zsh $out/share/zinit
+    install -m0444 zinit{,-side,-install,-autoload,-additional}.zsh _zinit $out/share/zinit
+    install -m0555 share/git-process-output.zsh $out/share/zinit
+    install -m0444 share/rpm2cpio.zsh $out/share/zinit
 
     # Autocompletion
     installShellCompletion --zsh _zinit
 
     # Manpage
-    mkdir -p ${placeholder "man"}/share/man/man{1..9}
+    # otherwsise zinit tries to create them in the nix store
+    mkdir -p $man/share/man/man{1..9}
     installManPage doc/zinit.1
 
     mkdir -p $doc/share/doc/zinit
-    install -m0644 doc/zsdoc/*.adoc $doc/share/doc/zinit
-    install -m0644 doc/HACKING.md $doc/share/doc/zinit
+    install -m0444 doc/zsdoc/*.adoc $doc/share/doc/zinit
+    install -m0444 doc/HACKING.md $doc/share/doc/zinit
 
     runHook postInstall
   '';
@@ -55,8 +56,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postFixup = ''
     substituteInPlace $out/share/zinit/zinit.zsh \
       --replace-fail zinit.1 zinit.1.gz \
-      --replace-fail "\''${ZINIT[BIN_DIR]}/doc" ${placeholder "man"}/share/man/man1 \
-      --replace-fail "ZINIT[MAN_DIR]:=\''${ZPFX}/man" "ZINIT[MAN_DIR]:=${placeholder "man"}/share/man"
+      --replace-fail "\''${ZINIT[BIN_DIR]}/doc" $man/share/man/man1 \
+      --replace-fail "ZINIT[MAN_DIR]:=\''${ZPFX}/man" "ZINIT[MAN_DIR]:=$man/share/man"
   '';
 
   passthru = {


### PR DESCRIPTION
Use $man directly to avoid placeholder side effects.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
