### PR TITLE
dopewars: fix build with gcc15

### DIFF
--- a/pkgs/by-name/do/dopewars/0002-fix_gcc15.patch
+++ b/pkgs/by-name/do/dopewars/0002-fix_gcc15.patch
@@ -1,0 +1,26 @@
+diff --git a/src/gtkport/itemfactory.c b/src/gtkport/itemfactory.c
+index b7a8c3f..980682c 100644
+--- a/src/gtkport/itemfactory.c
++++ b/src/gtkport/itemfactory.c
+@@ -217,7 +217,7 @@ void dp_gtk_item_factory_create_item(DPGtkItemFactory *ifactory,
+   new_child->widget = menu_item;
+   if (entry->callback) {
+     g_signal_connect(G_OBJECT(menu_item), "activate",
+-                     entry->callback, callback_data);
++                     G_CALLBACK(entry->callback), callback_data);
+   }
+ 
+   if (parent) {
+diff --git a/src/gtkport/itemfactory.h b/src/gtkport/itemfactory.h
+index a1d5b1d..2702595 100644
+--- a/src/gtkport/itemfactory.h
++++ b/src/gtkport/itemfactory.h
+@@ -59,7 +59,7 @@ GtkItemFactory *dp_gtk_item_factory_new(const gchar *path,
+ 
+ typedef gchar *(*DPGtkTranslateFunc) (const gchar *path, gpointer func_data);
+ 
+-typedef void (*DPGtkItemFactoryCallback) ();
++typedef void (*DPGtkItemFactoryCallback) (GtkWidget *widget, gpointer data);
+ 
+ typedef struct _DPGtkItemFactoryEntry DPGtkItemFactoryEntry;
+ typedef struct _DPGtkItemFactory DPGtkItemFactory;

--- a/pkgs/by-name/do/dopewars/package.nix
+++ b/pkgs/by-name/do/dopewars/package.nix
@@ -34,8 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
   ];
 
-  # remove the denied setting of setuid bit permission
-  patches = [ ./0001-remove_setuid.patch ];
+  patches = [
+    # remove the denied setting of setuid bit permission
+    ./0001-remove_setuid.patch
+    # fix compilation errors with gcc15
+    ./0002-fix_gcc15.patch
+  ];
 
   # run dopewars with -f so that it finds its scoreboard file in ~/.local/share
   postInstall = ''


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322283491

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
