### PR TITLE
kmscon: 9.3.3 -> 9.3.4, nixos/kmscon: remove dependency on agetty

### DIFF
--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -25,50 +25,28 @@ let
     text = cfg.extraConfig;
   };
 
-  baseLoginOptions = "-p -- \\u";
+  baseLoginOptions = "-p";
 
-  agettyCmd =
+  loginCmd =
     enableAutologin:
-    "${lib.getExe' pkgs.util-linux "agetty"} ${
-      lib.escapeShellArgs (
-        [
-          "--login-program"
-          (toString gettyCfg.loginProgram)
-          "--login-options"
-          # these options are passed as a single parameter
-          "${lib.optionalString enableAutologin "-f "}${baseLoginOptions}"
-        ]
-        ++ lib.optionals enableAutologin [
-          "--autologin"
-          gettyCfg.autologinUser
-        ]
-        ++ gettyCfg.extraArgs
-        ++ [
-          "--8bits"
-          "--noclear"
-          "--"
-          "-"
-        ]
-      )
-    } $TERM";
+    "${gettyCfg.loginProgram} ${baseLoginOptions}${lib.optionalString enableAutologin " -f -- ${gettyCfg.autologinUser}"}";
 
-  loginScript = pkgs.writers.writeDash "kmscon-login" ''
-    kms_tty=
-    active_tty_file=/sys/class/tty/tty0/active
-    if [ -f "$active_tty_file" ]; then
-      read -r kms_tty < "$active_tty_file"
-    fi
+  loginScript = pkgs.writers.writeDash "kmscon-login" (
+    lib.optionalString (gettyCfg.autologinUser != null && gettyCfg.autologinOnce) ''
+      kms_tty=
+      active_tty_file=/sys/class/tty/tty0/active
+      if [ -f "$active_tty_file" ]; then
+        read -r kms_tty < "$active_tty_file"
+      fi
 
-    ${lib.optionalString (gettyCfg.autologinUser != null && gettyCfg.autologinOnce) ''
       autologged="/run/kmscon.autologged"
       if [ "$kms_tty" = tty1 ] && [ ! -f "$autologged" ]; then
         touch "$autologged"
-        exec ${agettyCmd true}
+        exec ${loginCmd true}
       fi
-    ''}
-
-    exec ${agettyCmd (gettyCfg.autologinUser != null && !gettyCfg.autologinOnce)}
-  '';
+    ''
+    + "exec ${loginCmd (gettyCfg.autologinUser != null && !gettyCfg.autologinOnce)}"
+  );
 in
 {
   imports = [
@@ -182,32 +160,28 @@ in
 
     systemd.suppressedSystemUnits = [ "getty@.service" ];
 
-    services.kmscon.extraConfig =
-      let
-        xkb = optionals cfg.useXkbConfig (
-          lib.mapAttrsToList (n: v: "xkb-${n}=${v}") (
-            lib.filterAttrs (
-              n: v:
-              builtins.elem n [
-                "layout"
-                "model"
-                "options"
-                "variant"
-              ]
-              && v != ""
-            ) config.services.xserver.xkb
-          )
-        );
-        render = optionals cfg.hwRender [
-          "drm"
-          "hwaccel"
-        ];
-        fonts =
-          optional (cfg.fonts != null)
-            "font-name=${lib.concatMapStringsSep ", " (f: f.name) cfg.fonts}";
-        term = optional (cfg.term != null) "term=${cfg.term}";
-      in
-      lib.concatLines (xkb ++ render ++ fonts ++ term);
+    services.kmscon.extraConfig = lib.concatLines (
+      optionals cfg.useXkbConfig (
+        lib.mapAttrsToList (n: v: "xkb-${n}=${v}") (
+          lib.filterAttrs (
+            n: v:
+            builtins.elem n [
+              "layout"
+              "model"
+              "options"
+              "variant"
+            ]
+            && v != ""
+          ) config.services.xserver.xkb
+        )
+      )
+      ++ optionals cfg.hwRender [
+        "drm"
+        "hwaccel"
+      ]
+      ++ optional (cfg.fonts != null) "font-name=${lib.concatMapStringsSep ", " (f: f.name) cfg.fonts}"
+      ++ optional (cfg.term != null) "term=${cfg.term}"
+    );
 
     hardware.graphics.enable = mkIf cfg.hwRender true;
 

--- a/nixos/tests/kmscon.nix
+++ b/nixos/tests/kmscon.nix
@@ -31,7 +31,7 @@
   enableOCR = true;
 
   testScript = ''
-    machine.start()
+    machine.wait_for_unit("default.target")
 
     with subtest("ensure we can open a tty"):
       machine.wait_for_text("alice@machine")

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -29,13 +29,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kmscon";
-  version = "9.3.3";
+  version = "9.3.4";
 
   src = fetchFromGitHub {
     owner = "kmscon";
     repo = "kmscon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-U9jDlZb5aBzQ7IErtLsajxcN1W5/8/eNwhGIuz7aUCw=";
+    hash = "sha256-S6a/m2gfYOsacq4uq3d05WZPH1C8RQowmZM7f6On4ic=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/li/libtsm/package.nix
+++ b/pkgs/by-name/li/libtsm/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libtsm";
-  version = "4.4.3";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "kmscon";
     repo = "libtsm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AKwS088lP3dByKh3dQRW76+L6ouD8EmVms2qWIC5IiE=";
+    hash = "sha256-5Lv/Hb0FGWARk3Wv3IuAbtCDII7qOMmcZSmKTkgTEsc=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/kmscon/kmscon/releases/tag/v9.3.4
kmscon 9.3.4 can display /etc/issue, so agetty is no longer required.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
