### PR TITLE
phonon: disable experimental library to fix build with newer clang

### DIFF
--- a/pkgs/development/libraries/phonon/default.nix
+++ b/pkgs/development/libraries/phonon/default.nix
@@ -55,14 +55,13 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    [
-      "-fPIC"
-    ]
-    ++ lib.optionals stdenv.cc.isClang [
-      "-Wno-error=enum-constexpr-conversion"
-    ]
-  );
+  cmakeFlags = [
+    # The experimental library uses out-of-range enum casts that newer clang
+    # rejects as a hard error (not just a warning), so -Wno-error doesn't help.
+    (lib.cmakeBool "PHONON_BUILD_EXPERIMENTAL" false)
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-fPIC";
 
   cmakeBuildType = if debug then "Debug" else "Release";
 

--- a/pkgs/kde/misc/phonon/default.nix
+++ b/pkgs/kde/misc/phonon/default.nix
@@ -33,6 +33,8 @@ mkKdeDerivation rec {
   cmakeFlags = [
     "-DPHONON_BUILD_QT5=0"
     "-DPHONON_BUILD_QT6=1"
+    # Newer Clang rejects the experimental library's out-of-range enum casts.
+    (lib.cmakeBool "PHONON_BUILD_EXPERIMENTAL" false)
   ];
 
   meta.license = with lib.licenses; [


### PR DESCRIPTION
Phonon 4.12.0 builds its experimental library by default. Its headers use out of range enum casts such as `static_cast<ObjectDescriptionType>(0xfffffffe)`, which is rejected by newer clang.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

Validation:

```console
nix-build --no-out-link -A kdePackages.phonon
nix-instantiate --eval -A pkgsCross.aarch64-darwin.kdePackages.phonon.name
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
