### PR TITLE
hmcl: add libxkbcommon and jdk 25, don't use system glfw by default

### DIFF
--- a/pkgs/by-name/hm/hmcl/package.nix
+++ b/pkgs/by-name/hm/hmcl/package.nix
@@ -10,7 +10,7 @@
   copyDesktopItems,
   desktopToDarwinBundle,
   jdk,
-  jdk17,
+  jdk25,
   hmclJdk ? jdk.override {
     # Required by jar file
     enableJavaFX = true;
@@ -21,13 +21,14 @@
   },
   minecraftJdks ? [
     hmclJdk
-    jdk17
+    jdk25
   ],
   libxxf86vm,
   libxtst,
   libxrandr,
   libxext,
   libxcursor,
+  libxkbcommon,
   libx11,
   xrandr,
   glib,
@@ -152,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxxf86vm
     libxext
     libxcursor
+    libxkbcommon
     libxrandr
     libxtst
     libpulseaudio
@@ -192,7 +194,6 @@ stdenv.mkDerivation (finalAttrs: {
         lib.makeBinPath (minecraftJdks ++ lib.optional stdenv.hostPlatform.isLinux xrandr)
       }" \
       --run 'cd $HOME' \
-      ${lib.optionalString stdenv.hostPlatform.isLinux ''--prefix JAVA_TOOL_OPTIONS " " "-Dorg.lwjgl.glfw.libname=${lib.getLib glfw3'}/lib/libglfw.so"''} \
       ''${gappsWrapperArgs[@]}
   '';
 
@@ -212,6 +213,15 @@ stdenv.mkDerivation (finalAttrs: {
       Hello Minecraft! Launcher (HMCL) is a free, open-source, and cross-platform Minecraft launcher.
       It provides comprehensive support for managing multiple game versions and mod loaders,
       including Forge, NeoForge, Fabric, Quilt, LiteLoader, and OptiFine.
+
+      Starting with Minecraft 26.1, Wayland support can be enabled
+      by adding the JDK arguments -DMC_DEBUG_ENABLED and
+      -DMC_DEBUG_PREFER_WAYLAND. If needed, configure them in
+      HMCL -> Advanced Settings -> JVM Options -> JVM Arguments.
+
+      Users who are still on an older version and want to use Wayland should
+      enable HMCL -> Advanced Settings -> Workaround -> Use System GLFW.
+      Otherwise, keep it disabled.
     '';
     maintainers = with lib.maintainers; [
       daru-san


### PR DESCRIPTION
LWJGL uses its own glfw fork, and Minecraft 26.1 will crash if you use the system one.

For those who prefer to use Wayland, you can add `-DMC_DEBUG_ENABLED` and `-DMC_DEBUG_PREFER_WAYLAND` on JVM arguments to enable Wayland support, and LWJGL requires libxkbcommon to work on Wayland.

For those who still need system glfw, you can enable it in the advanced settings of HMCL.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
