### PR TITLE
gradle: workaround for multiple console arguments error

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/gradle/setup-hook.sh
@@ -4,7 +4,7 @@ gradleConfigureHook() {
     fi
     export GRADLE_USER_HOME
     export TERM=dumb
-    gradleFlagsArray+=(--no-daemon --console plain --init-script "${gradleInitScript:-@init_script@}")
+    gradleFlagsArray+=(--no-daemon -Dorg.gradle.console=plain --init-script "${gradleInitScript:-@init_script@}")
     if [ -n "${MITM_CACHE_CA-}" ]; then
         if [ -z "${MITM_CACHE_KEYSTORE-}" ]; then
             MITM_CACHE_KEYSTORE="$MITM_CACHE_CERT_DIR/keystore"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## log


```
                                                                                                                              
Running phase: configurePhase                                                                                                                                                                                      
@nix { "action": "setPhase", "phase": "configurePhase" }                                                                                                                                                           
gradle: enabled parallel installing                                                                                                                                                                                
Running phase: buildPhase                                                                                                                                                                                          
@nix { "action": "setPhase", "phase": "buildPhase" }                                                                                                                                                               
gradleBuildPhase flags: -Dorg.gradle.java.home=/nix/store/lj3j2ihszr7yfnxz4h32vdhknhjf8s4h-openjdk-headless-25.0.2+10/lib/openjdk -Dorg.gradle.java.installations.auto-download=false -Dorg.gradle.java.installatio
ns.paths=/nix/store/lj3j2ihszr7yfnxz4h32vdhknhjf8s4h-openjdk-headless-25.0.2+10 -Dandroid.aapt2FromMavenOverride=/nix/store/hbh79wn5wmfz9m1mk8qxl71yq83pd4f1-android-sdk-env/share/android-sdk/build-tools/36.0.0/a
apt2 -Dorg.gradle.project.android.aapt2FromMavenOverride=/nix/store/hbh79wn5wmfz9m1mk8qxl71yq83pd4f1-android-sdk-env/share/android-sdk/build-tools/36.0.0/aapt2 --no-daemon --console plain --init-script /nix/stor
e/r6fzha8vwb6vh2nn1s6w9a2kjm5izdba-init.gradle --offline -xapp:lint -xapp:lintAnalyzeDebug -xapp:lintAnalyzeDebugAndroidTest -xapp:lintAnalyzeDebugUnitTest -xapp:lintAnalyzeRelease -xapp:lintDebug -xapp:lintFix 
-xapp:lintFixDebug -xapp:lintFixRelease -xapp:lintRelease -xapp:lintReportDebug -xapp:lintReportRelease -xapp:lintVitalAnalyzeRelease -xapp:lintVitalRelease -xapp:lintVitalReportRelease :app:assembleRelease --pa
rallel --max-workers 24                                                                                                                                                                                            

Welcome to Gradle 9.4.1!

Here are the highlights of this release:
 - Java 26 support
 - Non-class-based JVM tests
 - Enhanced console progress bar

For more details see https://docs.gradle.org/9.4.1/release-notes.html


Multiple arguments were provided for command-line option '--console'.

To see more detail about a task, run gradlew help --task <task>

```

I can confirm that the error is gone after this change.

see gradle issue https://github.com/gradle/gradle/issues/30913#issuecomment-3177897769