### PR TITLE
ioq3-scion: fix build with gcc15

### DIFF
--- a/pkgs/by-name/io/ioq3-scion/package.nix
+++ b/pkgs/by-name/io/ioq3-scion/package.nix
@@ -18,8 +18,11 @@ ioquake3.overrideAttrs (old: {
     rev = "a21c257b9ad1d897f6c31883511c3f422317aa0a";
     hash = "sha256-CBy3Av/mkFojXr0tAXPRWKwLeQJPebazXQ4wzKEmx0I=";
   };
+  # gcc15
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
   meta = {
     description = "ioquake3 with support for path aware networking";
     maintainers = with lib.maintainers; [ matthewcroughan ];
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/322332489

Only checked compilation. I don't have the data files to properly test it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
