### PR TITLE
spitbol: init at 4.0f

### DIFF
--- a/pkgs/by-name/sp/spitbol/package.nix
+++ b/pkgs/by-name/sp/spitbol/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  nasm,
+  stdenv,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "spitbol";
+  version = "4.0f";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "spitbol";
+    repo = "x64";
+    tag = "v${version}";
+    hash = "sha256-x7TUHgx/ar8TfWkfySBsEGaMnrB4bVEeRiuqvMqYLrY=";
+  };
+
+  nativeBuildInputs = [
+    nasm
+    installShellFiles
+  ];
+
+  # Fix buflen macro collision with glibc headers
+  postPatch = ''
+    substituteInPlace osint/extern32.h \
+      --replace-fail '# define buflen 512' '# define SPITBOL_BUFLEN 512'
+  '';
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  # Bootstrap instead of using prebuilt ./bin/sbl
+  buildPhase = ''
+    runHook preBuild
+    make bootsbl
+    make BASEBOL=./bootsbl spitbol
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 sbl $out/bin/spitbol
+    installManPage spitbol.1
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SPeedy ImplemenTation of snoBOL4";
+    homepage = "https://github.com/spitbol/x64";
+    license = lib.licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ slotThe ];
+    mainProgram = "spitbol";
+  };
+}


### PR DESCRIPTION
A fast compiler for snobol 4 ([gh](https://github.com/spitbol/x64)).

I'm not sure about the package name, perhaps `spitbolx64` would be more accurate, but this is already sort of encoded in the allowed platforms… I don't think there are any spitbol-esque compilers for snobol versions lower than 4, so `spitbol4` seems overkill as well

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

  ```
  --------- Report for 'x86_64-linux' ---------
  2 packages built:
  spitbol spitbol.man
  ```

- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
