### PR TITLE
models: init at 0.11.4

### DIFF
--- a/pkgs/by-name/mo/models/package.nix
+++ b/pkgs/by-name/mo/models/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "models";
+  version = "0.11.4";
+
+  src = fetchFromGitHub {
+    owner = "arimxyer";
+    repo = "models";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AsSuxRXJvYtJkVISYyZ7lPz/ouMyDFBv3EGVi12WJ74=";
+  };
+
+  cargoHash = "sha256-qAomuqDkcj/t4LVaRGIeX1+j6MEgv1rSH3JtCTHm2As=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI and CLI for browsing AI models, benchmarks, coding agents, and statuses for AI providers";
+    homepage = "https://github.com/arimxyer/models";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nemeott ];
+    mainProgram = "models";
+  };
+})


### PR DESCRIPTION
Added [models](https://github.com/arimxyer/models), which is a "TUI and CLI for browsing AI models, benchmarks, coding agents, and statuses for AI providers." Seems pretty useful for trying to find a model provider and comparing model benchmarks easily.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
