### PR TITLE
grpc: 1.78.0 -> 1.80.0

### DIFF
--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -25,7 +25,7 @@
 # nixpkgs-update: no auto update
 stdenv.mkDerivation (finalAttrs: {
   pname = "grpc";
-  version = "1.78.0"; # N.B: if you change this, please update:
+  version = "1.80.0"; # N.B: if you change this, please update:
   # pythonPackages.grpcio
   # pythonPackages.grpcio-channelz
   # pythonPackages.grpcio-health-checking
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "grpc";
     repo = "grpc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hupso9w++lYtAMoLS/qVmUYqZyQAX3rH0I8zCLyBo40=";
+    hash = "sha256-/dpTRG5JcZY2VAsqOYNIpFW7ouSy/eC2STulP7qdSYg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/grpcio-channelz/default.nix
+++ b/pkgs/development/python-modules/grpcio-channelz/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-channelz";
-  version = "1.78.0";
+  version = "1.80.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_channelz";
     inherit version;
-    hash = "sha256-5E/gR414spB1xtJYuMUQdhnAZGXAE6sYSeW+9JOvFT4=";
+    hash = "sha256-fs6As480ti6Q5uHFqghYXwwPE8GpyI6vdNioZxw6n6E=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/grpcio-health-checking/default.nix
+++ b/pkgs/development/python-modules/grpcio-health-checking/default.nix
@@ -11,13 +11,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-health-checking";
-  version = "1.78.0";
+  version = "1.80.0";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "grpcio_health_checking";
     inherit version;
-    hash = "sha256-eFJtXGC5uZ/RiVS4n4bXADPHAulq1szJdJuvFhNpebM=";
+    hash = "sha256-LMXwi8i4FrhlWrb1nHFFAGO6IHZtMeIaST6RLjVgyLE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/grpcio-reflection/default.nix
+++ b/pkgs/development/python-modules/grpcio-reflection/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-reflection";
-  version = "1.78.0";
+  version = "1.80.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_reflection";
     inherit version;
-    hash = "sha256-5uYMC4XbzfljtNTRUMDx0ji6iR2AW1dcUsA2XQf8DEA=";
+    hash = "sha256-6cdqq8QyQnmUW3C8dqPUG8T5OWv/zxz8EBGlccLFYiE=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-status";
-  version = "1.78.0";
+  version = "1.80.0";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "grpcio_status";
     inherit version;
-    hash = "sha256-o0z9KBAb/qhLWqD5NrS0IwGekhOIKQcWavazvdxZ4Yk=";
+    hash = "sha256-33OAKkyJo+qIqir/lx6Ib8zOFivC5lEUCLPWehRDgc0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio-testing/default.nix
+++ b/pkgs/development/python-modules/grpcio-testing/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-testing";
-  version = "1.78.0";
+  version = "1.80.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_testing";
     inherit version;
-    hash = "sha256-BuQoB75GlJvciDOaA6cQ7AVbBta8ghy1ljZuUWWRU8w=";
+    hash = "sha256-+1rVfED/36l3MEPfo46MN3Oa+ONHHxZwoh54BRzRmv0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -13,13 +13,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-tools";
-  version = "1.78.0";
+  version = "1.80.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_tools";
     inherit version;
-    hash = "sha256-Sw3YZWAnQxbhVdklFYJ2+FZFCBkwiLxD4g0/Xf+Vays=";
+    hash = "sha256-JgUrGcbODc9S0QJElq6j4r36hkFZ8G3HuXsi0EGpSyY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -18,12 +18,12 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio";
-  version = "1.78.0";
+  version = "1.80.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-c4K5UYlUbzdcF09TpfqHPO+RxLgAX6oFzFs77qnE8cU=";
+    hash = "sha256-KayhXt0GiMIroB18wBywANcrIDP0o8cqgaGbVv0UMlc=";
   };
 
   postPatch = ''


### PR DESCRIPTION

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
