### PR TITLE
ao3downloader: 2026.2.0 -> 2026.4.2, fix build

### DIFF
--- a/pkgs/by-name/ao/ao3downloader/package.nix
+++ b/pkgs/by-name/ao/ao3downloader/package.nix
@@ -8,14 +8,14 @@
 # https://github.com/nianeyna/ao3downloader/blob/f8399bb8aca276ae7359157b90afd13925c90056/pyproject.toml#L8
 python312Packages.buildPythonApplication (finalAttrs: {
   pname = "ao3downloader";
-  version = "2026.2.0";
+  version = "2026.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nianeyna";
     repo = "ao3downloader";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NrVzRYNxvy8LOvXy0/1go0wEQyLt56inu+f93UFX1CM=";
+    hash = "sha256-fxrNaApc+vfvQ6JvQBY5PurlCMe5ZapJFl+zbRp/k20=";
   };
 
   build-system = with python312Packages; [


### PR DESCRIPTION
diff: https://github.com/nianeyna/ao3downloader/compare/v2026.2.0...v2026.4.2
nfd: https://nfd.1l.is/?selected=ao3downloader

While `ao3downloader` doesn't officially support Python 3.13, it is required for one of the dependencies `standard-imghdr`. It builds and runs fine with the unsupported Python 3.13. The package fails to build otherwise. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and xother READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
