### PR TITLE
mupdf: 1.27.0 -> 1.27.2

### DIFF
--- a/pkgs/by-name/mu/mupdf/package.nix
+++ b/pkgs/by-name/mu/mupdf/package.nix
@@ -72,12 +72,12 @@ let
   });
 in
 stdenv.mkDerivation rec {
-  version = "1.27.0";
+  version = "1.27.2";
   pname = "mupdf";
 
   src = fetchurl {
     url = "https://mupdf.com/downloads/archive/${pname}-${version}-source.tar.gz";
-    hash = "sha256-riRCQW3kmRgtN6UmxvorrMejvtWoiNETygSERITf58Y=";
+    hash = "sha256-VThnsTUwPcTCWrZ8XyNNjpAKDjbmboSE2ZrcBf4ehzc=";
   };
 
   patches = [


### PR DESCRIPTION
MuPDF 1.27.2 Release (2026-02-20)

Add ImageMask operation in image rewriter.
SText vector merging, and 'fuzzy-vectors' option.
SText corruption fixes.
SText Depth First Search iterator fixes.

MuPDF 1.27.1 Release (2026-02-05)

Several optimizations, tweaks, and fixes to the structured text device text extraction.
Improve table-hunting code in structured text device.
Import image-rafting code from layout project to the structured text device.
Fix bug causing FitR link destination rectangles to remain untransformed.
Fix bug causing xps rendering to enter eternal loop.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
