### PR TITLE
yaziPlugins.{clipboard,yafg}: init

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "clipboard.yazi";
+  version = "0-unstable-2026-02-10";
+
+  src = fetchFromGitHub {
+    owner = "XYenon";
+    repo = "clipboard.yazi";
+    rev = "3b9681091b783d6bc5d07172afd6159060a7db63";
+    hash = "sha256-8p2RC8F8JH1K36HebJM58stHX+lFLD+KYQxfdJm06y0=";
+  };
+
+  meta = {
+    description = "Clipboard sync plugin for Yazi that copies yanked file paths to the system clipboard";
+    homepage = "https://github.com/XYenon/clipboard.yazi";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ xyenon ];
+  };
+}

--- a/pkgs/by-name/ya/yazi/plugins/yafg/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yafg/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "yafg.yazi";
+  version = "0-unstable-2026-01-10";
+
+  src = fetchFromGitHub {
+    owner = "XYenon";
+    repo = "yafg.yazi";
+    rev = "dd03b133d6cd1ff92368360558da193517169f9e";
+    hash = "sha256-xTZ+6KRr85A4QpPWAE9QN1AnUVnCw/tvRvsWOmmayao=";
+  };
+
+  meta = {
+    description = "Fuzzy find and grep plugin for Yazi file manager with interactive ripgrep and fzf search";
+    homepage = "https://github.com/XYenon/yafg.yazi";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ xyenon ];
+  };
+}


### PR DESCRIPTION
https://github.com/XYenon/clipboard.yazi
https://github.com/XYenon/yafg.yazi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
