### PR TITLE
nixos/{pipewire,wireplumber}: add LADSPA plugin path setup

### DIFF
--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -83,6 +83,21 @@ let
     paths = cfg.extraLv2Packages ++ requiredLv2Packages;
     pathsToLink = [ "/lib/lv2" ];
   };
+
+  requiredLadspaPackages = flatten (
+    concatMap (p: attrByPath [ "passthru" "requiredLadspaPackages" ] [ ] p) configPackages
+  );
+
+  ladspaPlugins = pkgs.buildEnv {
+    name = "pipewire-ladspa-plugins";
+    paths = cfg.extraLadspaPackages ++ requiredLadspaPackages;
+    pathsToLink = [ "/lib/ladspa" ];
+  };
+
+  pluginsEnv = {
+    LV2_PATH = "${lv2Plugins}/lib/lv2";
+    LADSPA_PATH = "${ladspaPlugins}/lib/ladspa";
+  };
 in
 {
   meta.teams = [ teams.freedesktop ];
@@ -286,8 +301,8 @@ in
           List of packages that provide PipeWire configuration, in the form of
           `share/pipewire/*/*.conf` files.
 
-          LV2 dependencies will be picked up from config packages automatically
-          via `passthru.requiredLv2Packages`.
+          LV2/LADSPA dependencies will be picked up from config packages automatically
+          via `passthru.requiredLv2Packages`/`passthru.requiredLadspaPackages`.
         '';
       };
 
@@ -302,6 +317,22 @@ in
           Config packages have their required LV2 plugins added automatically,
           so they don't need to be specified here. Config packages need to set
           `passthru.requiredLv2Packages` for this to work.
+
+          [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
+        '';
+      };
+
+      extraLadspaPackages = mkOption {
+        type = listOf package;
+        default = [ ];
+        example = literalExpression "[ pkgs.noisetorch-ladspa ]";
+        description = ''
+          List of packages that provide LADSPA plugins in `lib/ladspa` that should
+          be made available to PipeWire for [filter chains][wiki-filter-chain].
+
+          Config packages have their required LADSPA plugins added automatically,
+          so they don't need to be specified here. Config packages need to set
+          `passthru.requiredLadspaPackages` for this to work.
 
           [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
         '';
@@ -366,13 +397,9 @@ in
     systemd.user.sockets.pipewire.enable = !cfg.systemWide;
     systemd.user.services.pipewire.enable = !cfg.systemWide;
 
-    systemd.services.pipewire.environment.LV2_PATH = mkIf cfg.systemWide "${lv2Plugins}/lib/lv2";
-    systemd.user.services.pipewire.environment.LV2_PATH = mkIf (
-      !cfg.systemWide
-    ) "${lv2Plugins}/lib/lv2";
-    systemd.user.services.filter-chain.environment.LV2_PATH = mkIf (
-      !cfg.systemWide
-    ) "${lv2Plugins}/lib/lv2";
+    systemd.services.pipewire.environment = mkIf cfg.systemWide pluginsEnv;
+    systemd.user.services.pipewire.environment = mkIf (!cfg.systemWide) pluginsEnv;
+    systemd.user.services.filter-chain.environment = pluginsEnv;
 
     # Mask pw-pulse if it's not wanted
     systemd.services.pipewire-pulse.enable = cfg.pulse.enable && cfg.systemWide;

--- a/nixos/modules/services/desktops/pipewire/wireplumber.nix
+++ b/nixos/modules/services/desktops/pipewire/wireplumber.nix
@@ -200,8 +200,8 @@ in
           List of packages that provide WirePlumber configuration, in the form of
           `share/wireplumber/*/*.conf` files.
 
-          LV2 dependencies will be picked up from config packages automatically
-          via `passthru.requiredLv2Packages`.
+          LV2/LADSPA dependencies will be picked up from config packages automatically
+          via `passthru.requiredLv2Packages`/`passthru.requiredLadspaPackages`.
         '';
       };
 
@@ -216,6 +216,22 @@ in
           Config packages have their required LV2 plugins added automatically,
           so they don't need to be specified here. Config packages need to set
           `passthru.requiredLv2Packages` for this to work.
+
+          [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
+        '';
+      };
+
+      extraLadspaPackages = mkOption {
+        type = listOf package;
+        default = [ ];
+        example = literalExpression "[ pkgs.noisetorch-ladspa ]";
+        description = ''
+          List of packages that provide LADSPA plugins in `lib/ladspa` that should
+          be made available to WirePlumber for [filter chains][wiki-filter-chain].
+
+          Config packages have their required LADSPA plugins added automatically,
+          so they don't need to be specified here. Config packages need to set
+          `passthru.requiredLadspaPackages` for this to work.
 
           [wiki-filter-chain]: https://docs.pipewire.org/page_module_filter_chain.html
         '';
@@ -270,6 +286,25 @@ in
         paths = cfg.extraLv2Packages ++ requiredLv2Packages;
         pathsToLink = [ "/lib/lv2" ];
       };
+
+      requiredLadspaPackages = flatten (
+        concatMap (p: attrByPath [ "passthru" "requiredLadspaPackages" ] [ ] p) configPackages
+      );
+
+      ladspaPlugins = pkgs.buildEnv {
+        name = "pipewire-ladspa-plugins";
+        paths = cfg.extraLadspaPackages ++ requiredLadspaPackages;
+        pathsToLink = [ "/lib/ladspa" ];
+      };
+
+      pluginsEnv = {
+        XDG_DATA_DIRS = makeSearchPath "share" [
+          configs
+          cfg.package
+        ];
+        LV2_PATH = "${lv2Plugins}/lib/lv2";
+        LADSPA_PATH = "${ladspaPlugins}/lib/ladspa";
+      };
     in
     mkIf cfg.enable {
       assertions = [
@@ -289,25 +324,14 @@ in
       systemd.services.wireplumber.wantedBy = [ "pipewire.service" ];
       systemd.user.services.wireplumber.wantedBy = [ "pipewire.service" ];
 
-      systemd.services.wireplumber.environment = mkIf pwCfg.systemWide {
-        # Force WirePlumber to use system dbus.
-        DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/dbus/system_bus_socket";
+      systemd.services.wireplumber.environment = mkIf pwCfg.systemWide (
+        pluginsEnv
+        // {
+          # Force WirePlumber to use system dbus.
+          DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/dbus/system_bus_socket";
+        }
+      );
 
-        # Make WirePlumber find our config/script files and lv2 plugins required by those
-        # (but also the configs/scripts shipped with WirePlumber)
-        XDG_DATA_DIRS = makeSearchPath "share" [
-          configs
-          cfg.package
-        ];
-        LV2_PATH = "${lv2Plugins}/lib/lv2";
-      };
-
-      systemd.user.services.wireplumber.environment = mkIf (!pwCfg.systemWide) {
-        XDG_DATA_DIRS = makeSearchPath "share" [
-          configs
-          cfg.package
-        ];
-        LV2_PATH = "${lv2Plugins}/lib/lv2";
-      };
+      systemd.user.services.wireplumber.environment = mkIf (!pwCfg.systemWide) pluginsEnv;
     };
 }


### PR DESCRIPTION
Pipewire 1.6.3 (in staging-next) will refuse to load plugins from outside LADSPA_PATH, so we need to add this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
