### PR TITLE
splice: defer per-output spliceReal recursion behind genAttrs

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -52,12 +52,15 @@ let
             getOutputs (lib.optionalAttrs success value);
           getOutputs =
             value: lib.genAttrs (value.outputs or (lib.optional (value ? out) "out")) (output: value.${output});
+          outputNames = defaultValue.outputs or (lib.optional (defaultValue ? out) "out");
+          outputSplice = spliceReal (
+            mapCrossIndex tryGetOutputs value' // { hostTarget = getOutputs value'.hostTarget; }
+          );
         in
         # The derivation along with its outputs, which we recur
         # on to splice them together.
         if lib.isDerivation defaultValue then
-          augmentedValue
-          // spliceReal (mapCrossIndex tryGetOutputs value' // { hostTarget = getOutputs value'.hostTarget; })
+          augmentedValue // lib.genAttrs outputNames (out: outputSplice.${out})
         else if lib.isAttrs defaultValue then
           spliceReal value'
         else


### PR DESCRIPTION
Fixes #338231. Follow-up to #506578 and #506588 (already merged).

@zimbatm's automated research tooling flagged this commit as a likely performance win. I was tasked to validate the numbers and double-check the design before upstreaming.

Performance is indeed better (details below), but validating it also revealed a **latent correctness bug** in `spliceReal`, e.g., we show that `libgcc` output was leaking into the cross-spliced package set.

## Semantic changes

When a spliced value is a derivation, in the current code `//` forces its right-hand side immediately: `spliceReal(...)` was called eagerly for every spliced derivation, even when no `.dev`/`.doc` output was ever accessed. With ~300 cross-spliced packages this recursed hundreds of times unconditionally.

After this patch, `lib.genAttrs` creates one thunk per output name. `outputSplice` is only forced when a specific output attribute is selected (`pkg.dev`, `pkg.doc`, ...). Accessing `pkg` or `pkg.drvPath` never triggers any thunk.

## Bug fixed

Changing from `//`-merge to `genAttrs` also fixed a general class of incorrect output leaks in `spliceReal`. The old code merged output names across *all* cross-indices (`buildBuild`, `buildHost`, ..., `hostTarget`). Any output key present in a non-hostTarget index but absent in the `hostTarget` package would silently bleed into the spliced set, resolving to the wrong derivation.

The concrete manifestation we can demonstrate: `pkgsBuildBuild.gcc.cc` has `"libgcc"` as a real derivation output; the `cross-gcc` does not, it provides it via `passthru.libgcc`. So `"libgcc"` from the native index leaked in, and `splicedPackages.gccForLibs.libgcc` resolved to `gcc-15.2.0-libgcc` (x86_64) instead of the correct cross package. This is one example; any package where native and cross versions differ in their output sets could be affected similarly.

The fix limits `outputNames` to `defaultValue.outputs` (`hostTarget` only), so no non-`hostTarget` output key can bleed across. `.libgcc` falls back to `cross-gcc.passthru.libgcc = libgcc-aarch64-unknown-linux-gnu-15.2.0`.

How to verify the fix:

```bash
EXPR='let pkgs = import ./. { localSystem = "x86_64-linux"; crossSystem = "aarch64-linux"; };
  in pkgs.__splicedPackages.gccForLibs.libgcc.name'
nix-instantiate --eval -E "$EXPR"
# before: "gcc-15.2.0"                              <- native x86_64, wrong
# after:  "libgcc-aarch64-unknown-linux-gnu-15.2.0" <- correct
```

**Why this didn't cause obvious failures?** Some mitigations conspired here:

1. **Search-order luck:** the correct aarch64 `libgcc_s.so.1` appeared at
   position 3 in the linker's `-L` list; the leaked x86_64 path was at position 5.
2. **`--as-needed`:** `clang+libunwind` builds rarely need `libgcc_s`, so the
   linker dropped the entry and neither path entered the `RUNPATH`.
3. **`patchelf --shrink-rpath`:** `fixupPhase` silently removed `RUNPATH` entries
   for unneeded libraries, cleaning up the x86_64 contamination.

<details>
<summary>Bypassing both mitigations and see the contamination directly</summary>

```nix
let pkgs = import ./. { localSystem = "x86_64-linux"; crossSystem = "aarch64-linux"; };
in pkgs.llvmPackages.stdenv.mkDerivation {
  name = "hello-cross-broken";
  dontFixup = true;  # skip patchelf --shrink-rpath
  dontUnpack = true;
  buildPhase = ''
    echo 'int main(){}' > hello.c
    $CC -Wl,--no-as-needed -lgcc_s -o hello hello.c  # force libgcc_s into NEEDED
  '';
  installPhase = "mkdir -p $out/bin && cp hello $out/bin/hello";
}
```

```bash
# save the above expression as hello-cross-broken.nix, then:
nix-build hello-cross-broken.nix -o result  # once in master, once with this patch
readelf -d result/bin/hello | grep RUNPATH
# before: .../aarch64-gcc-lib/.../lib:.../gcc-15.2.0-libgcc/lib         <- x86_64 in RUNPATH
# after:  .../aarch64-gcc-lib/.../lib:.../libgcc-aarch64-...-15.2.0/lib <- correct
```

</details>

So indeed _(and that's what put me on the track of chasing this bug in the first place)_, this PR makes changes in cross-build `drvPath` hashes, they reflect the bug fix, e.g., it is visible with `qt6Packages.qtbase`, `systemd`, `matplotlib`, `opencv4`, etc. _(since their transitive dependents now get the correct aarch64 `libgcc` in their closure)_

## Performances

`NIX_SHOW_STATS=1`, averaged over 3 runs, cross `x86_64 -> aarch64` against current `master` (that already includes #506578 and #506588).

This PR alone (**CppNix 2.31.3**):

| package      | master  | +this PR | cpu   | nrFuncCalls               | nrOpUpdCopied         |
|--------------|---------|----------|-------|---------------------------|-----------------------|
| requests     | 0.701s  | 0.615s   | -12%  | 651,358 -> 586,281 (-10%) | 12.5M -> 9.0M (-28%)  |
| numpy        | 0.941s  | 0.672s   | -29%  | 753,614 -> 683,141 (-9%)  | 15.5M -> 10.2M (-34%) |
| scipy        | 1.030s  | 0.750s   | -27%  | 910,969 -> 800,714 (-12%) | 16.4M -> 10.8M (-34%) |
| scikit-learn | 1.574s  | 1.159s   | -26%  | 1,343,214 -> 1,170,023 (-13%) | 18.8M -> 12.8M    |
| matplotlib   | 1.669s  | 1.262s   | -24%  | 1,466,413 -> 1,284,376 (-12%) | 21.8M -> 14.2M    |
| pandas       | 0.995s  | 0.688s   | -31%  | 800,452 -> 719,950 (-10%) | 16.9M -> 10.6M (-37%) |
| jax          | 1.030s  | 0.764s   | -26%  | 927,800 -> 811,247 (-13%) | 16.5M -> 10.9M        |
| transformers | 1.448s  | 1.128s   | -22%  | 1,174,748 -> 1,043,952 (-11%) | 19.5M -> 13.7M    |
| torch        | 2.316s  | 1.813s   | -22%  | 1,948,820 -> 1,734,417 (-11%) | 25.8M -> 17.2M    |
| opencv4      | 2.569s  | 2.059s   | -20%  | 2,356,694 -> 2,091,746 (-11%) | 26.5M -> 19.0M    |

The `nrOpUpdateValuesCopied` drop (28-37%) is the direct consequence of eliminating the eager `//` merge on every spliced derivation.

This PR alone (**Lix 2.94.1**, `nrFuncCalls` identical to CppNix above, omitted for brevity):

| package      | master  | +this PR | cpu   |
|--------------|---------|----------|-------|
| requests     | 0.794s  | 0.557s   | -30%  |
| numpy        | 0.875s  | 0.611s   | -30%  |
| scipy        | 0.950s  | 0.712s   | -25%  |
| scikit-learn | 1.487s  | 1.094s   | -26%  |
| matplotlib   | 1.557s  | 1.183s   | -24%  |
| pandas       | 0.910s  | 0.662s   | -27%  |
| jax          | 0.988s  | 0.703s   | -29%  |
| transformers | 1.367s  | 1.009s   | -26%  |
| torch        | 2.185s  | 1.698s   | -22%  |
| opencv4      | 2.454s  | 1.952s   | -20%  |

**Memory usage** (addressing #338231, Lix 2.94.1):

| expression             | master  | +this PR   | gain  |
|------------------------|---------|------------|-------|
| native python3         | 129 MB  | 129 MB     | 0%    |
| cross python3+requests | 462 MB  | 353 MB     | -24%  |
| cross python3+pandas   | 467 MB  | 411 MB     | -12%  |
| cross python3+torch    | 660 MB  | 486 MB     | -26%  |
| cross python3+opencv4  | 684 MB  | 525 MB     | -25%  |

The original issue reported 7,445 MB. The native/cross ratio drops from ~5x to ~3-4x.

All **3 PRs combined** (#506578 + #506588 + this PR, Lix 2.94.1):

| package      | before any PR | after all 3 | cpu    | nrFuncCalls gain         |
|--------------|---------------|-------------|--------|--------------------------|
| requests     | 0.921s        | 0.569s      | -38%   | 1,090,317 -> 586,281 (-46%) |
| numpy        | 1.013s        | 0.630s      | -38%   | 1,307,367 -> 683,141 (-48%) |
| scipy        | 1.273s        | 0.709s      | -44%   | 1,491,643 -> 800,714 (-46%) |
| scikit-learn | 1.559s        | 1.089s      | -30%   | 1,964,145 -> 1,170,023 (-40%) |
| matplotlib   | 1.722s        | 1.176s      | -32%   | 2,165,141 -> 1,284,376 (-41%) |
| pandas       | 1.280s        | 0.649s      | -49%   | 1,408,734 -> 719,950 (-49%) |
| jax          | 1.302s        | 0.702s      | -46%   | 1,509,343 -> 811,247 (-46%) |
| transformers | 1.512s        | 1.061s      | -30%   | 1,830,657 -> 1,043,952 (-43%) |
| torch        | 2.390s        | 1.704s      | -29%   | 2,729,359 -> 1,734,417 (-36%) |
| opencv4      | 2.597s        | 1.949s      | -25%   | 3,146,351 -> 2,091,746 (-34%) |

<details>
<summary>Reproducing these numbers</summary>

```bash
# Quick check on the original reproducer from #338231:
NIX_SHOW_STATS=1 nix-instantiate --eval -E \
  'let pkgs = import ./. { localSystem = "x86_64-linux"; crossSystem = "aarch64-linux"; };
   in (pkgs.python3.withPackages (ps: [ ps.requests ])).drvPath' 2>&1 \
  | grep -E "cpuTime|nrFuncCalls|nrOpUpdCopied"

# Memory (GNU time):
command time -v nix-instantiate --eval -E \
  'let pkgs = import ./. { localSystem = "x86_64-linux"; crossSystem = "aarch64-linux"; };
   in (pkgs.python3.withPackages (ps: [ ps.requests ])).drvPath' 2>&1 \
  | grep "Maximum resident"
```

</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR: found **zero native package changes**,
  which is expected, the patch only affects cross-compiled packages _(native `drvPaths`
  are byte-identical before and after)_