### PR TITLE
maski: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16527,6 +16527,13 @@
     githubId = 7802795;
     name = "Manoj Karthick";
   };
+  ManUtopiK = {
+    email = "emmanuel.salomon@gmail.com";
+    matrix = "@ManUtopiK:matrix.org";
+    github = "ManUtopiK";
+    githubId = 188172;
+    name = "Emmanuel Salomon";
+  };
   maolonglong = {
     email = "shaolong.chen@outlook.it";
     github = "maolonglong";

--- a/pkgs/by-name/ma/maski/package.nix
+++ b/pkgs/by-name/ma/maski/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "maski";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ManUtopiK";
+    repo = "maski";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-NLao3RtN+1/Mb/SnP+WA0fYa6pu/+5wyTOwlWp0BAbQ=";
+  };
+
+  cargoHash = "sha256-CnoXPGn0n8SiAkEFZq6xrbiNDx/jOAIh2/w42l1Zfb0=";
+
+  meta = {
+    description = "Interactive TUI for mask — browse and run maskfile commands with fuzzy search";
+    homepage = "https://github.com/ManUtopiK/maski";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ManUtopiK ];
+    mainProgram = "maski";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ma/maski/package.nix
+++ b/pkgs/by-name/ma/maski/package.nix
@@ -8,6 +8,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "maski";
   version = "0.1.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "ManUtopiK";
     repo = "maski";


### PR DESCRIPTION
maski is an interactive TUI for the `mask` task runner. It lets you
browse and run maskfile commands with fuzzy search, hierarchical
navigation, and a rich markdown preview panel (rendered via the
bundled md4x C library — fetched as a git submodule).

Upstream: https://github.com/ManUtopiK/maski

I am the upstream author of maski and also adding myself as the
maintainer in this PR.

---

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For new packages please match the [nixpkgs review checklist](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)
- [x] Tested, as applicable:
  - [x] `nix-build -A maski` from a clean checkout
  - [x] `./result/bin/maski --help` runs
  - [x] `cargoCheckHook` unit tests pass (2/2)
- [x] Tested basic functionality of the package
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc