### PR TITLE
rimsort: 1.0.73 -> 1.0.76, add update script

### DIFF
--- a/pkgs/by-name/ri/rimsort/package.nix
+++ b/pkgs/by-name/ri/rimsort/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   fetchzip,
   makeBinaryWrapper,
+  nix-update-script,
 
   makeDesktopItem,
   copyDesktopItems,
@@ -16,13 +17,13 @@
 }:
 let
   pname = "rimsort";
-  version = "1.0.73";
+  version = "1.0.76";
 
   src = fetchFromGitHub {
     owner = "RimSort";
     repo = "RimSort";
-    rev = "v${version}";
-    hash = "sha256-xNmJ1XvnLTKhicVchzG9CQtRVoZjRkBEvfn/WWesDRU=";
+    tag = "v${version}";
+    hash = "sha256-EO1j4GPRQSB+QEF4tB87x4nCUKpdWU9aGlDFghwxar0=";
     fetchSubmodules = true;
   };
 
@@ -49,14 +50,15 @@ let
     }).run;
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname;
   inherit version;
+  inherit src;
 
   unpackPhase = ''
     runHook preUnpack
 
-    cp -r ${src} source
+    cp -r ${finalAttrs.src} source
     chmod -R 755 source
     cp ${steamworksSrc}/redistributable_bin/linux64/libsteam_api.so source/
 
@@ -168,6 +170,14 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      # To skip checking the pre-release 'Edge' release as 'vEdge'.
+      "--version-regex"
+      "v([0-9.]+)"
+    ];
+  };
+
   meta = {
     description = "Open source mod manager for the video game RimWorld";
     homepage = "https://github.com/RimSort/RimSort";
@@ -186,4 +196,4 @@ stdenv.mkDerivation {
     # steamworksSrc is x86_64-linux only
     platforms = [ "x86_64-linux" ];
   };
-}
+})


### PR DESCRIPTION
Following the merging of #496387, this PR updates rimsort to the latest version and adds the update script from #447734.

Supersedes #447734.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
