### PR TITLE
maia2: init at 0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16444,6 +16444,16 @@
     githubId = 117918464;
     keys = [ { fingerprint = "B5ED 595C 8C7E 133C 6B68  63C8 CFEF 1E35 0351 F72D"; } ];
   };
+  malix = {
+    name = "Malix - Alix Brunet";
+    github = "Malix-Labs";
+    githubId = 76160668;
+    email = "alixbrunetcontact+nixpkgs@gmail.com";
+    keys = [
+      { fingerprint = "cgtiI0dV+OGTuIFFuuCPWZPgF5OaiSkmZzobIdoWQO0"; } # SSH
+      { fingerprint = "369E2AB995539B6F30AAC24C600394C79ED874E5"; } # OpenPGP
+    ];
+  };
   malo = {
     email = "mbourgon@gmail.com";
     github = "malob";

--- a/pkgs/development/python-modules/maia2/default.nix
+++ b/pkgs/development/python-modules/maia2/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  chess,
+  einops,
+  flit-core,
+  gdown,
+  numpy,
+  pandas,
+  pyyaml,
+  pyzstd,
+  requests,
+  torch,
+  tqdm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "maia2";
+  version = "0.9";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-hiU5/xgR0JpvDzq1NEaG8VidSZL6FXcn0xFW26IlHNE=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    chess
+    einops
+    gdown
+    numpy
+    pandas
+    pyyaml
+    pyzstd
+    requests
+    torch
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "maia2" ];
+
+  meta = {
+    description = "Unified model for human-AI alignment in chess";
+    homepage = "https://github.com/CSSLab/maia2";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malix ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9419,6 +9419,8 @@ self: super: with self; {
 
   mahotas = callPackage ../development/python-modules/mahotas { };
 
+  maia2 = callPackage ../development/python-modules/maia2 { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   mailcap-fix = callPackage ../development/python-modules/mailcap-fix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10302,6 +10302,8 @@ self: super: with self; {
 
   mahotas = callPackage ../development/python-modules/mahotas { };
 
+  maia2 = callPackage ../development/python-modules/maia2 { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   mailbits = callPackage ../development/python-modules/mailbits { };


### PR DESCRIPTION
Add the maia2 Python package from CSSLab.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[maia2]: https://github.com/CSSLab/maia2