### PR TITLE
python3Packages.attrs-strict: fix tests

### DIFF
--- a/pkgs/development/python-modules/attrs-strict/default.nix
+++ b/pkgs/development/python-modules/attrs-strict/default.nix
@@ -26,6 +26,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-dDOD4Y57E+i8D0S4q+C6t7zjBTsS8q2UFiS22Dsp0Z8=";
   };
 
+  patches = [
+    # Upstream PR: https://github.com/bloomberg/attrs-strict/pull/117
+    ./fix-tests.patch
+  ];
+
   build-system = [
     setuptools
     setuptools-scm
@@ -39,13 +44,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
-
-  disabledTests = [
-    # AssertionError: Regex pattern did not match
-    "test_real_types"
-    "test_recursive"
-    "test_union_when_type_is_not_specified_raises"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/attrs-strict/fix-tests.patch
+++ b/pkgs/development/python-modules/attrs-strict/fix-tests.patch
@@ -1,0 +1,73 @@
+diff --git a/tests/test_auto_attribs__py3.py b/tests/test_auto_attribs__py3.py
+index 67b3ff8..8241f9d 100644
+--- a/tests/test_auto_attribs__py3.py
++++ b/tests/test_auto_attribs__py3.py
+@@ -28,9 +28,13 @@ from attrs_strict import type_validator
+             None,
+             0xBAD,
+             "Value of value 2989 is not of type {}".format(
+-                "typing.Optional[str]"
+-                if sys.version_info == (2, 7) or sys.version_info > (3, 9)
+-                else "typing.Union[str, NoneType]"
++                "str | None"
++                if sys.version_info >= (3, 14)
++                else (
++                    "typing.Optional[str]"
++                    if sys.version_info == (2, 7) or sys.version_info > (3, 9)
++                    else "typing.Union[str, NoneType]"
++                )
+             ),
+         ),
+     ],
+@@ -75,9 +79,13 @@ def test_recursive():
+     Self(Self())
+     Self(Self(None))
+     type_repr = (
+-        "typing.Optional[test_auto_attribs__py3.Self]"
+-        if sys.version_info == (2, 7) or sys.version_info > (3, 9)
+-        else "typing.Union[test_auto_attribs__py3.Self, NoneType]"
++        "test_auto_attribs__py3.Self | None"
++        if sys.version_info >= (3, 14)
++        else (
++            "typing.Optional[test_auto_attribs__py3.Self]"
++            if sys.version_info == (2, 7) or sys.version_info > (3, 9)
++            else "typing.Union[test_auto_attribs__py3.Self, NoneType]"
++        )
+     )
+     msg = f"Value of parent 17 is not of type {type_repr}"
+     with pytest.raises(ValueError, match=re.escape(msg)):
+diff --git a/tests/test_union.py b/tests/test_union.py
+index e1b11a9..49d7c20 100644
+--- a/tests/test_union.py
++++ b/tests/test_union.py
+@@ -16,16 +16,26 @@ from attrs_strict import type_validator
+         (
+             2.0,
+             Union[int, str],
+-            "Value of foo 2.0 is not of type typing.Union[int, str]",
++            (
++                "Value of foo 2.0 is not of type {}".format(
++                    "int | str"
++                    if sys.version_info >= (3, 14)
++                    else "typing.Union[int, str]"
++                )
++            ),
+         ),
+         (
+             [1, 2, "p"],
+             List[Union[None, int]],
+             (
+                 "Value of foo p is not of type {} in [1, 2, 'p']".format(
+-                    "typing.Optional[int]"
+-                    if sys.version_info >= (3, 9)
+-                    else "typing.Union[NoneType, int]"
++                    "None | int"
++                    if sys.version_info >= (3, 14)
++                    else (
++                        "typing.Optional[int]"
++                        if sys.version_info >= (3, 9)
++                        else "typing.Union[NoneType, int]"
++                    )
+                 )
+             ),
+         ),


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fix expected error message for python 3.14.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Tracking: https://github.com/NixOS/nixpkgs/issues/475732
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
