### PR TITLE
 nixos/logind: only enable if systemd-logind was built 

### DIFF
--- a/nixos/modules/system/boot/systemd/logind.nix
+++ b/nixos/modules/system/boot/systemd/logind.nix
@@ -6,6 +6,10 @@
 }:
 {
   options.services.logind = {
+    enable = lib.mkEnableOption "the `systemd-logind` login service" // {
+      default = config.systemd.package.withLogind;
+      defaultText = lib.literalExpression "config.systemd.package.withLogind";
+    };
     settings.Login = lib.mkOption {
       description = ''
         Settings option for systemd-logind.
@@ -40,7 +44,7 @@
     };
   };
 
-  config = {
+  config = lib.mkIf config.services.logind.enable {
     systemd.additionalUpstreamSystemUnits = [
       "systemd-logind.service"
       "autovt@.service"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -843,6 +843,7 @@ stdenv.mkDerivation (finalAttrs: {
       withImportd
       withKmod
       withLocaled
+      withLogind
       withMachined
       withNetworkd
       withNspawn


### PR DESCRIPTION
systemd-logind.service is, at present, unconditionally included by the NixOS module. For server-side and particularly container applications, logind is not needed at all and could be omitted from the build... except that this would break the module, which is un-turn-off-able.

As the module can simply never work if the provided systemd doesn't come with logind, have the logind module auto-disable itself in this configuration. In the future, maybe there could be an explicit enable/disable toggle to the module, but it's quite niche: you need to really really only want one version of the systemd package built/present, which must include logind, while simultaneously really really wanting logind to not even be started.

I'm not sure if this will trigger rebuilds or not; if it's causing mass rebuilds, I'll switch the target branch. I'm also not sure if I should be bundling the NixOS change with its necessary Nixpkgs prerequisite

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
