### PR TITLE
java-language-server: 0.2.46 -> 0.2.49

### DIFF
--- a/pkgs/by-name/ja/java-language-server/package.nix
+++ b/pkgs/by-name/ja/java-language-server/package.nix
@@ -20,19 +20,19 @@ let
 in
 maven.buildMavenPackage {
   pname = "java-language-server";
-  version = "0.2.46";
+  version = "0.2.47-unstable-2026-03-21";
 
   src = fetchFromGitHub {
     owner = "georgewfraser";
     repo = "java-language-server";
     # commit hash is used as owner sometimes forgets to set tags. See https://github.com/georgewfraser/java-language-server/issues/104
-    rev = "d7f4303cd233cdad84daffbb871dd4512a2c8da2";
-    sha256 = "sha256-BIcfwz+pLQarnK8XBPwDN2nrdvK8xqUo0XFXk8ZV/h0=";
+    rev = "ba0df8e008757d340ac263ea394a52745111422f";
+    hash = "sha256-UBdBxDUv1je11Lt4sv+iCjmMfHTfi9GJth5LNT4DIq4=";
   };
 
   mvnFetchExtraArgs.dontConfigure = true;
   mvnJdk = jdk_headless;
-  mvnHash = "sha256-2uthmSjFQ43N5lgV11DsxuGce+ZptZsmRLTgjDo0M2w=";
+  mvnHash = "sha256-mSjz5OM/tMZuiX4kmB1DprvQuIP4EzeDpAr4oQ5T11s=";
 
   nativeBuildInputs = [
     jdk_headless

--- a/pkgs/by-name/ja/java-language-server/package.nix
+++ b/pkgs/by-name/ja/java-language-server/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  jdk_headless,
+  jdk25_headless,
   maven,
   makeWrapper,
 }:
@@ -20,22 +20,22 @@ let
 in
 maven.buildMavenPackage {
   pname = "java-language-server";
-  version = "0.2.46";
+  version = "0.2.49";
 
   src = fetchFromGitHub {
     owner = "georgewfraser";
     repo = "java-language-server";
     # commit hash is used as owner sometimes forgets to set tags. See https://github.com/georgewfraser/java-language-server/issues/104
-    rev = "d7f4303cd233cdad84daffbb871dd4512a2c8da2";
-    sha256 = "sha256-BIcfwz+pLQarnK8XBPwDN2nrdvK8xqUo0XFXk8ZV/h0=";
+    rev = "58daaa29a0e2fe22764283607da6801cf8b493b9";
+    hash = "sha256-rHtnsZxcZKq1IGZJXE8nkv2iyS09kuNlqaVsRWpMwjM=";
   };
 
   mvnFetchExtraArgs.dontConfigure = true;
-  mvnJdk = jdk_headless;
-  mvnHash = "sha256-xxTR+2E+4nIkGwxCk0B+f0//rLdlqO/nwRaArxt3u8U=";
+  mvnJdk = jdk25_headless;
+  mvnHash = "sha256-mSjz5OM/tMZuiX4kmB1DprvQuIP4EzeDpAr4oQ5T11s=";
 
   nativeBuildInputs = [
-    jdk_headless
+    jdk25_headless
     makeWrapper
   ];
 


### PR DESCRIPTION
diff: https://github.com/georgewfraser/java-language-server/compare/d7f4303cd233cdad84daffbb871dd4512a2c8da2...58daaa29a0e2fe22764283607da6801cf8b493b9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
