### PR TITLE
openapi-generator-cli: use more idiomatic formats.json instead of toFile/toJSON

### DIFF
--- a/pkgs/by-name/op/openapi-generator-cli/example.nix
+++ b/pkgs/by-name/op/openapi-generator-cli/example.nix
@@ -2,6 +2,7 @@
   openapi-generator-cli,
   fetchurl,
   runCommand,
+  formats,
 }:
 
 runCommand "openapi-generator-cli-test"
@@ -11,12 +12,10 @@ runCommand "openapi-generator-cli-test"
       url = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/14c0908becbccd78252be49bd92be8c53cd2b9e3/examples/v3.0/petstore.yaml";
       hash = "sha256-q2D1naR41KwxLNn6vMbL0G+Pl1q4oaDCApsqQfZf7dU=";
     };
-    config = builtins.toFile "config.json" (
-      builtins.toJSON {
-        elmVersion = "0.19";
-        elmPrefixCustomTypeVariants = false;
-      }
-    );
+    config = (formats.json { }).generate "config.json" {
+      elmVersion = "0.19";
+      elmPrefixCustomTypeVariants = false;
+    };
   }
   ''
     openapi-generator-cli generate \


### PR DESCRIPTION
This also avoids `toFile`, which runs at eval time.

Followup to https://github.com/NixOS/nixpkgs/pull/502700 .

Inspired by https://github.com/NixOS/nixpkgs/pull/503515 .


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
