### PR TITLE
json-schema-catalog-rs-formats: use more idiomatic formats.json instead of toFile/toJSON

### DIFF
--- a/pkgs/by-name/js/json-schema-catalog-rs/test-run.nix
+++ b/pkgs/by-name/js/json-schema-catalog-rs/test-run.nix
@@ -1,18 +1,18 @@
 {
   json-schema-catalog-rs,
   runCommand,
+  writeText,
+  formats,
 }:
 let
 
-  sample = builtins.toFile "example-schema.json" (
-    builtins.toJSON {
-      "$schema" = "http://json-schema.org/draft-07/schema#";
-      "$id" = "https://example.com/example-2.9.json";
-      "title" = "Example Schema";
-    }
-  );
+  sample = (formats.json { }).generate "example-schema.json" {
+    "$schema" = "http://json-schema.org/draft-07/schema#";
+    "$id" = "https://example.com/example-2.9.json";
+    "title" = "Example Schema";
+  };
 
-  expectedOutput = builtins.toFile "expected-output" ''
+  expectedOutput = writeText "expected-output" ''
     {
       "groups": [
         {


### PR DESCRIPTION
This also avoids toFile running at eval time.

Followup to https://github.com/NixOS/nixpkgs/pull/498508 , inspired by https://github.com/NixOS/nixpkgs/pull/503515 .

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
