### PR TITLE
nixos/installer/plasma6: disable KWallet in live ISO to unblock Wi-Fi auth

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix
@@ -54,4 +54,14 @@
       }
     '';
 
+  # Auto-login leaves pam_kwallet with no password to unlock the wallet,
+  # so plasma-nm blocks indefinitely when saving Wi-Fi PSKs via Secret
+  # Service and the installer GUI hangs on "waiting for authorization".
+  # The live session has no secrets worth persisting.
+  # https://github.com/NixOS/nixpkgs/issues/219346
+  environment.etc."xdg/kwalletrc".text = ''
+    [Wallet]
+    Enabled=false
+  '';
+
 }


### PR DESCRIPTION
The Plasma 6 graphical installer ISO auto-logs-in user `nixos` with no password. nixpkgs wires up pam_kwallet5 for Plasma 6, but with no login password the wallet has nothing to unlock with and stays locked — so when plasma-nm goes through the Secret Service path to store a Wi-Fi PSK from the NetworkManager applet, the call blocks and the installer GUI hangs on "waiting for authorization".

The live session has no secrets worth persisting, so disable KWallet outright via /etc/xdg/kwalletrc. Verified on a ThinkPad live boot from USB: the Plasma NM applet can now create connections and connect.

Fixes #219346


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Built and flashed to USB, ran on ThinkPad, confirmed the fix works. Verified the changes persist in the live session. Verified ability to connect to Wifi on LiveSession without password error.