### PR TITLE
glfw3-minecraft: switch to LWJGL-CI/glfw

### DIFF
--- a/pkgs/by-name/gl/glfw3-minecraft/0001-Key-Modifiers-Fix.patch
+++ b/pkgs/by-name/gl/glfw3-minecraft/0001-Key-Modifiers-Fix.patch
@@ -1,0 +1,27 @@
+From b8bab445726c957b65ed4b623c507314f4ace1f9 Mon Sep 17 00:00:00 2001
+From: BoyOrigin <ahmadyasinfikri@gmail.com>
+Date: Mon, 18 Sep 2023 01:39:37 +0700
+Subject: [PATCH 1/6] Key Modifiers Fix
+
+---
+ src/wl_window.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 107d163f..5721989e 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -1382,7 +1382,9 @@ static void inputText(_GLFWwindow* window, uint32_t scancode)
+         {
+             const int mods = _glfw.wl.xkb.modifiers;
+             const int plain = !(mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT));
+-            _glfwInputChar(window, codepoint, mods, plain);
++
++            if (plain)
++                _glfwInputChar(window, codepoint, mods, plain);
+         }
+     }
+ }
+-- 
+2.53.0
+

--- a/pkgs/by-name/gl/glfw3-minecraft/0002-Fix-Window-size-on-unset-fullscreen.patch
+++ b/pkgs/by-name/gl/glfw3-minecraft/0002-Fix-Window-size-on-unset-fullscreen.patch
@@ -1,0 +1,25 @@
+From 5dadfc9f80ac350b81174bc8e3c74d8553807aba Mon Sep 17 00:00:00 2001
+From: BoyOrigin <ahmadyasinfikri@gmail.com>
+Date: Mon, 18 Sep 2023 01:37:44 +0700
+Subject: [PATCH 2/6] Fix Window size on unset fullscreen
+
+---
+ src/wl_window.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 5721989e..702133d4 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2989,6 +2989,8 @@ void _glfwSetWindowSizeWayland(_GLFWwindow* window, int width, int height)
+             libdecor_state_free(frameState);
+         }
+ 
++        _glfwInputWindowSize(window, width, height);
++
+         if (window->wl.visible)
+             _glfwInputWindowDamage(window);
+     }
+-- 
+2.53.0
+

--- a/pkgs/by-name/gl/glfw3-minecraft/0003-Avoid-error-on-startup.patch
+++ b/pkgs/by-name/gl/glfw3-minecraft/0003-Avoid-error-on-startup.patch
@@ -1,0 +1,28 @@
+From 8c52d5b2fd07cf2fbfc379faf629d9e5b1e9a808 Mon Sep 17 00:00:00 2001
+From: FayBoy <ahmadyasinfikri@gmail.com>
+Date: Thu, 7 Mar 2024 03:05:59 +0700
+Subject: [PATCH 3/6] Avoid error on startup
+
+This is an exclusive fix for older version of Minecraft that is using LWJGL3.
+---
+ src/wl_window.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 702133d4..7a56d532 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2941,8 +2941,8 @@ void _glfwSetWindowTitleWayland(_GLFWwindow* window, const char* title)
+ void _glfwSetWindowIconWayland(_GLFWwindow* window,
+                                int count, const GLFWimage* images)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the window icon");
++    fprintf(stderr,
++            "[GLFW] Wayland: The platform does not support setting the window icon\n");
+ }
+ 
+ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
+-- 
+2.53.0
+

--- a/pkgs/by-name/gl/glfw3-minecraft/0004-Dismiss-warnings-about-window-position-being-unavail.patch
+++ b/pkgs/by-name/gl/glfw3-minecraft/0004-Dismiss-warnings-about-window-position-being-unavail.patch
@@ -1,4 +1,8 @@
-Dismiss warnings about window position being unavailable on Wayland.
+From ef1c430bf2f10a1f08a163a3c3b33c0b935dbbb0 Mon Sep 17 00:00:00 2001
+From: Mark Wagie <mark.wagie@proton.me>
+Date: Mon, 13 Apr 2026 14:05:12 +0800
+Subject: [PATCH 4/6] Dismiss warnings about window position being unavailable
+ on Wayland.
 
 In addition to the other glfw patches, this one is required on certain
 compositors such as niri and waywall to be able to launch Minecraft at
@@ -11,10 +15,15 @@ strict error callbacks are used.
 Original get-position fix by: uku <hi@uku.moe>
 Expanded to include set-position, inspired by Prior5151's fix on AUR.
 https://aur.archlinux.org/packages/glfw-wayland-minecraft-cursorfix#comment-1013099
+---
+ src/wl_window.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 7a56d532..a98cf04f 100644
 --- a/src/wl_window.c
 +++ b/src/wl_window.c
-@@ -2236,16 +2236,16 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
+@@ -2950,16 +2950,16 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
      // A Wayland client is not aware of its position, so just warn and leave it
      // as (0, 0)
  
@@ -35,3 +44,6 @@ https://aur.archlinux.org/packages/glfw-wayland-minecraft-cursorfix#comment-1013
  }
  
  void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)
+-- 
+2.53.0
+

--- a/pkgs/by-name/gl/glfw3-minecraft/0005-Fix-test-native-target.patch
+++ b/pkgs/by-name/gl/glfw3-minecraft/0005-Fix-test-native-target.patch
@@ -1,0 +1,29 @@
+From 3bb8e8c91fe9f8c4226db2140c73380511588fb1 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Mon, 13 Apr 2026 14:06:11 +0800
+Subject: [PATCH 5/6] Fix test native target
+
+---
+ tests/CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index bd977e3a..7146ac96 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -58,8 +58,11 @@ if (GLFW_BUILD_X11 OR GLFW_BUILD_WAYLAND)
+     target_compile_definitions(input_text PRIVATE FONTCONFIG_ENABLED)
+ endif()
+ 
+-set(GUI_ONLY_BINARIES empty gamma icon input_text inputlag joysticks native tearing threads
++set(GUI_ONLY_BINARIES empty gamma icon input_text inputlag joysticks tearing threads
+     timeout title triangle-vulkan window)
++if (WIN32)
++    list(APPEND GUI_ONLY_BINARIES native)
++endif()
+ set(CONSOLE_BINARIES allocator clipboard events msaa glfwinfo iconify monitors
+     reopen cursor)
+ 
+-- 
+2.53.0
+

--- a/pkgs/by-name/gl/glfw3-minecraft/0006-Implement-glfwSetCursorPosWayland-via-pointer-constr.patch
+++ b/pkgs/by-name/gl/glfw3-minecraft/0006-Implement-glfwSetCursorPosWayland-via-pointer-constr.patch
@@ -1,0 +1,150 @@
+From 9f070bf3585ef06dec3a3b7784d269c7cd6b229a Mon Sep 17 00:00:00 2001
+From: FayBoy <ahmadyasinfikri@gmail.com>
+Date: Mon, 13 Apr 2026 14:08:01 +0800
+Subject: [PATCH 6/6] Implement glfwSetCursorPosWayland via pointer constraints
+
+---
+ src/CMakeLists.txt |  1 -
+ src/wl_init.c      | 12 ------------
+ src/wl_platform.h  |  6 ++++--
+ src/wl_window.c    | 29 +++++++++++++++++++++--------
+ 4 files changed, 25 insertions(+), 23 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3021a55a..4d1b9ccb 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -101,7 +101,6 @@ if (GLFW_BUILD_WAYLAND)
+         generate_wayland_protocol("viewporter.xml")
+         generate_wayland_protocol("xdg-shell.xml")
+         generate_wayland_protocol("idle-inhibit-unstable-v1.xml")
+-        generate_wayland_protocol("pointer-warp-v1.xml")
+         generate_wayland_protocol("pointer-constraints-unstable-v1.xml")
+         generate_wayland_protocol("relative-pointer-unstable-v1.xml")
+         generate_wayland_protocol("fractional-scale-v1.xml")
+diff --git a/src/wl_init.c b/src/wl_init.c
+index a35ec789..c79cf2b6 100644
+--- a/src/wl_init.c
++++ b/src/wl_init.c
+@@ -52,7 +52,6 @@
+ #include "fractional-scale-v1-client-protocol.h"
+ #include "xdg-activation-v1-client-protocol.h"
+ #include "idle-inhibit-unstable-v1-client-protocol.h"
+-#include "pointer-warp-v1-client-protocol.h"
+ #include "text-input-unstable-v1-client-protocol.h"
+ #include "text-input-unstable-v3-client-protocol.h"
+ 
+@@ -97,10 +96,6 @@
+ #include "idle-inhibit-unstable-v1-client-protocol-code.h"
+ #undef types
+ 
+-#define types _glfw_pointer_warp_types
+-#include "pointer-warp-v1-client-protocol-code.h"
+-#undef types
+-
+ #define types _glfw_text_input_v1_types
+ #include "text-input-unstable-v1-client-protocol-code.h"
+ #undef types
+@@ -219,13 +214,6 @@ static void registryHandleGlobal(void* userData,
+                              &wp_fractional_scale_manager_v1_interface,
+                              1);
+     }
+-    else if (strcmp(interface, "wp_pointer_warp_v1") == 0)
+-    {
+-        _glfw.wl.pointerWarp =
+-            wl_registry_bind(registry, name,
+-                             &wp_pointer_warp_v1_interface,
+-                             1);
+-    }
+     else if (strcmp(interface, "zwp_text_input_manager_v1") == 0)
+     {
+         _glfw.wl.textInputManagerV1 =
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index 084519d2..95dbac78 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -142,7 +142,6 @@ struct wl_output;
+ #define xdg_activation_token_v1_interface _glfw_xdg_activation_token_v1_interface
+ #define wl_surface_interface _glfw_wl_surface_interface
+ #define wp_fractional_scale_v1_interface _glfw_wp_fractional_scale_v1_interface
+-#define wp_pointer_warp_v1_interface _glfw_pointer_warp_v1_interface
+ 
+ #define GLFW_WAYLAND_WINDOW_STATE         _GLFWwindowWayland  wl;
+ #define GLFW_WAYLAND_LIBRARY_WINDOW_STATE _GLFWlibraryWayland wl;
+@@ -435,6 +434,10 @@ typedef struct _GLFWwindowWayland
+         uint32_t                    buttonPressSerial;
+         const char*                 cursorName;
+     } fallback;
++
++    double                      askedCursorPosX, askedCursorPosY;
++    GLFWbool                    didAskForSetCursorPos;
++
+     struct zwp_text_input_v1* textInputV1;
+     struct zwp_text_input_v3* textInputV3;
+     struct {
+@@ -465,7 +468,6 @@ typedef struct _GLFWlibraryWayland
+     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
+     struct xdg_activation_v1*               activationManager;
+     struct wp_fractional_scale_manager_v1*  fractionalScaleManager;
+-    struct wp_pointer_warp_v1*  pointerWarp;
+     struct zwp_text_input_manager_v1*       textInputManagerV1;
+     struct zwp_text_input_manager_v3*       textInputManagerV3;
+ 
+diff --git a/src/wl_window.c b/src/wl_window.c
+index a98cf04f..20b20663 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -53,7 +53,6 @@
+ #include "xdg-activation-v1-client-protocol.h"
+ #include "idle-inhibit-unstable-v1-client-protocol.h"
+ #include "fractional-scale-v1-client-protocol.h"
+-#include "pointer-warp-v1-client-protocol.h"
+ #include "text-input-unstable-v1-client-protocol.h"
+ #include "text-input-unstable-v3-client-protocol.h"
+ 
+@@ -3387,14 +3386,17 @@ void _glfwGetCursorPosWayland(_GLFWwindow* window, double* xpos, double* ypos)
+ 
+ void _glfwSetCursorPosWayland(_GLFWwindow* window, double x, double y)
+ {
+-    if (!_glfw.wl.pointerWarp)
+-    {
+-        _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The compositor does not support setting the cursor position");
+-        return;
++    if (window->wl.lockedPointer) {
++        zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
++                                                       wl_fixed_from_double(x),
++                                                       wl_fixed_from_double(y));
++        window->wl.cursorPosX = x;
++        window->wl.cursorPosY = y;
++    } else {
++        window->wl.didAskForSetCursorPos = GLFW_TRUE;
++        window->wl.askedCursorPosX = x;
++        window->wl.askedCursorPosY = y;
+     }
+-
+-    wp_pointer_warp_v1_warp_pointer(_glfw.wl.pointerWarp, window->wl.surface, _glfw.wl.pointer, wl_fixed_from_double(x), wl_fixed_from_double(y), _glfw.wl.pointerEnterSerial);
+ }
+ 
+ void _glfwSetCursorModeWayland(_GLFWwindow* window, int mode)
+@@ -3628,6 +3630,17 @@ static const struct zwp_relative_pointer_v1_listener relativePointerListener =
+ static void lockedPointerHandleLocked(void* userData,
+                                       struct zwp_locked_pointer_v1* lockedPointer)
+ {
++    _GLFWwindow* window = userData;
++
++    if (window->wl.didAskForSetCursorPos)
++    {
++        window->wl.didAskForSetCursorPos = GLFW_FALSE;
++        zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
++                                                       wl_fixed_from_double(window->wl.askedCursorPosX),
++                                                       wl_fixed_from_double(window->wl.askedCursorPosY));
++        window->wl.cursorPosX = window->wl.askedCursorPosX;
++        window->wl.cursorPosY = window->wl.askedCursorPosY;
++    }
+ }
+ 
+ static void lockedPointerHandleUnlocked(void* userData,
+-- 
+2.53.0
+

--- a/pkgs/by-name/gl/glfw3-minecraft/package.nix
+++ b/pkgs/by-name/gl/glfw3-minecraft/package.nix
@@ -1,0 +1,35 @@
+{
+  glfw3,
+  fetchFromGitHub,
+}:
+glfw3.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    pname = "glfw-minecraft";
+    version = "3.5-unstable-2026-04-02";
+
+    src = fetchFromGitHub {
+      owner = "LWJGL-CI";
+      repo = "GLFW";
+      rev = "0e6ee09b1c777968eb5a1da924794c6f4602fdc8";
+      hash = "sha256-/H0Rscp4zTXn5k3A+134fzVzBdtfZ6q/3DJytuRshLc=";
+    };
+
+    patches = (prevAttrs.patches or [ ]) ++ [
+      # suppresses ctrl/alt text input on wayland
+      ./0001-Key-Modifiers-Fix.patch
+      # reports window size after leaving fullscreen
+      ./0002-Fix-Window-size-on-unset-fullscreen.patch
+      # downgrades wayland icon unsupported error to warning
+      ./0003-Avoid-error-on-startup.patch
+
+      # downgrades wayland window position unsupported errors to warnings
+      ./0004-Dismiss-warnings-about-window-position-being-unavail.patch
+      # keeps native test target windows-only
+      ./0005-Fix-test-native-target.patch
+
+      # pointer warp support is poor across compositors; use pointer constraints instead
+      # https://wayland.app/protocols/pointer-warp-v1#compositor-support
+      ./0006-Implement-glfwSetCursorPosWayland-via-pointer-constr.patch
+    ];
+  }
+)

--- a/pkgs/by-name/gl/glfw3/package.nix
+++ b/pkgs/by-name/gl/glfw3/package.nix
@@ -19,33 +19,20 @@
   wayland-protocols,
   libxkbcommon,
   libdecor,
-  withMinecraftPatch ? false,
 }:
-let
+stdenv.mkDerivation (finalAttrs: {
+  pname = "glfw";
   version = "3.4";
-  minecraftPatches = fetchFromGitHub {
-    owner = "BoyOrigin";
-    repo = "glfw-wayland";
-    rev = "f62b4ae8f93149fd754cadecd51d8b1a07d20522";
-    hash = "sha256-kvWP34rOD4HSTvnKb33nvVquTGZoqP8/l+8XQ0h3b7Y=";
-  };
-in
-stdenv.mkDerivation {
-  pname = "glfw${lib.optionalString withMinecraftPatch "-minecraft"}";
-  inherit version;
 
   src = fetchFromGitHub {
     owner = "glfw";
     repo = "GLFW";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-FcnQPDeNHgov1Z07gjFze0VMz2diOrpbKZCsI96ngz0=";
   };
 
   # Fix linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
-  patches = [ ./x11.patch ] ++ (lib.optional withMinecraftPatch ./window-position.patch);
-  prePatch = lib.optionalString withMinecraftPatch ''
-    patches+=(${minecraftPatches}/patches/*.patch)
-  '';
+  patches = [ ./x11.patch ];
 
   propagatedBuildInputs = lib.optionals (!stdenv.hostPlatform.isWindows) [ libGL ];
 
@@ -108,4 +95,4 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6343,10 +6343,6 @@ with pkgs;
   ghcid = haskellPackages.ghcid.bin;
   glfw = glfw3;
 
-  glfw3-minecraft = callPackage ../by-name/gl/glfw3/package.nix {
-    withMinecraftPatch = true;
-  };
-
   glibc = callPackage ../development/libraries/glibc (
     if stdenv.hostPlatform != stdenv.buildPlatform then
       {


### PR DESCRIPTION
Starting from MC 26.1 and later, Mojang’s published builds appear to be based on [lwjgl-ci/glfw](https://github.com/LWJGL-CI/glfw), which includes several patches that are not yet in upstream GLFW (for example, IME support).  

If we keep using unpatched upstream GLFW, we may hit runtime errors like:
```
at org.lwjgl.system.Checks.check(Checks.java:188)
at org.lwjgl.glfw.GLFW.nglfwSetPreeditCallback(GLFW.java:1911)
at org.lwjgl.glfw.GLFW.glfwSetPreeditCallback(GLFW.java:1920)
at com.mojang.blaze3d.platform.InputConstants.setupKeyboardCallbacks(InputConstants.java:473)
at net.minecraft.client.KeyboardHandler.setup(KeyboardHandler.java:643)
at net.minecraft.client.Minecraft.<init>(Minecraft.java:561)
```

So I think we should switch back from that upstream baseline for compatibility with current Minecraft/LWJGL expectations.

Also, patch [0002](https://github.com/BoyOrigin/glfw-wayland/blob/main/patches/0002-Fix-duplicate-pointer-scroll-events.patch) is no longer necessary in the current fork:
- 0002 (Fix-duplicate-pointer-scroll-events): Wayland `pointer-scroll` handling has been refactored in the current code (pending/frame event path), so this old patch no longer applies and its original context is obsolete.

As for patch [0003](https://github.com/BoyOrigin/glfw-wayland/blob/main/patches/0003-Implement-glfwSetCursorPosWayland.patch), while the current upstream/LWJGL-CI Wayland cursor positioning implementation supersedes the old one in principle, the `pointer warp` [implementation](https://github.com/LWJGL-CI/glfw/commit/3dd05ab6d09405425177706da5fcba9756eafb2c) is only supported by 4 of the 18 compositors recorded on [wayland.app](https://wayland.app/protocols/pointer-warp-v1#compositor-support). Since we had previously been using BoyOrigin's 0003 implementation of `glfwSetCursorPosWayland` via `pointer constraints`, and that approach has [16/18 compositor coverage](https://wayland.app/protocols/pointer-constraints-unstable-v1#compositor-support), I patched and switched back to the `pointer constraints` implementation for compatibility reason. Thanks to @tildejustin for pointing this out.


References:
- https://github.com/BoyOrigin/glfw-wayland/issues/29
- https://minecraft.wiki/w/Java_Edition_26.1_Snapshot_8
- https://github.com/NixOS/nixpkgs/pull/508813


Tested 1.19.2 and 26.2-snapshot-2 with prismlauncher.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
