### PR TITLE
coreutils: skip flaky du tests

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -108,6 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
     # intermittent failures on builders, unknown reason
     sed '2i echo Skipping du basic test && exit 77' -i ./tests/du/basic.sh
 
+    # flaky on some filesystems due to non-deterministic disk usage
+    sed '2i echo Skipping du deref test && exit 77' -i ./tests/du/deref.sh
+    sed '2i echo Skipping du inacc-dir test && exit 77' -i ./tests/du/inacc-dir.sh
+
     # fails when syscalls related to acl not being available, e.g. in sandboxed environment
     sed '2i echo Skipping ls -al with acl test && exit 77' -i ./tests/ls/acl.sh
   ''


### PR DESCRIPTION
Fixes #508849

## Summary
Skip flaky du tests in coreutils.

## Problem
tests/du/deref.sh and tests/du/inacc-dir.sh can fail depending on
filesystem behavior due to non-deterministic disk usage.

Other du tests are already skipped in nixpkgs for similar reasons.

## Solution
Skip these tests, extending the existing skip list in postPatch.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review` on this PR
- [ ] Tested basic functionality of all binary files
- Nixpkgs Release Notes
  - [ ] Package update
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [ ] Fits contributing guidelines