### PR TITLE
pyload-ng: add knownVulnerabilities

### DIFF
--- a/pkgs/by-name/py/pyload-ng/package.nix
+++ b/pkgs/by-name/py/pyload-ng/package.nix
@@ -68,5 +68,15 @@ python3.pkgs.buildPythonApplication rec {
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ ruby0b ];
     mainProgram = "pyload";
+    knownVulnerabilities = [
+      "CVE-2026-29778"
+      "CVE-2026-33314"
+      "CVE-2026-33509"
+      "CVE-2026-35463"
+      "CVE-2026-35464"
+      "CVE-2026-35586"
+      "CVE-2026-35592"
+      "CVE-2026-40071"
+    ];
   };
 }


### PR DESCRIPTION
The package was dropped on master due to numerous vulnerabilities, this adds them to the package metadata in 25.11. See #502033.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
