### PR TITLE
assimp: 6.0.2 -> 6.0.4

### DIFF
--- a/pkgs/by-name/as/assimp/package.nix
+++ b/pkgs/by-name/as/assimp/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "assimp";
-  version = "6.0.2";
+  version = "6.0.4";
   outputs = [
     "out"
     "lib"
@@ -21,18 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "assimp";
     repo = "assimp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ixtqK+3iiL17GEbEVHz5S6+gJDDQP7bVuSfRMJMGEOY=";
+    hash = "sha256-ryTgsN0z9BZBz7i9aUMKuneN5oqfxpduwJlb+Q0q3Mk=";
   };
-
-  patches = [
-    # Fix build with gcc15
-    # https://github.com/assimp/assimp/pull/6283
-    (fetchpatch {
-      name = "assimp-fix-invalid-vector-gcc15.patch";
-      url = "https://github.com/assimp/assimp/commit/59bc03d931270b6354690512d0c881eec8b97678.patch";
-      hash = "sha256-O+JPwcOdyFtmFE7eZojHo1DUavF5EhLYlUyxtYo/KF4=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -58,6 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64;
   checkPhase = ''
     runHook preCheck
+    # https://github.com/assimp/assimp/issues/6270 - test requires /var/tmp
+    mkdir -p /var/tmp
     bin/unit
     runHook postCheck
   '';


### PR DESCRIPTION
Updates assimp to 6.0.4. FIxes at least several CVE (CVE-2025-15538 , CVE-2025-11277, CVE-2025-11275, CVE-2025-11274).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
