### PR TITLE
monaspace: 1.301 -> 1.400

### DIFF
--- a/pkgs/by-name/mo/monaspace/fonts.toml
+++ b/pkgs/by-name/mo/monaspace/fonts.toml
@@ -1,38 +1,38 @@
-version = "1.301"
+version = "1.400"
 baseUrl = "https://github.com/githubnext/monaspace/releases/download"
 fontFamily = "monaspace"
 
 [[fonts]]
-hash = "sha256-/A5/zipWaaSpTGUBVZOE0EihJY9tu0JAH+6+gyHbDxo="
+hash = "sha256-wbgCQQZuWU7A486z4cVS9mfWc+O5u+As23bVgUNevzw="
 variant = "static"
 destination = "opentype"
 
 [[fonts]]
-hash = "sha256-7O0qRA12ELPNs4919aW5rUdLs/XaLTJNthL+4Gjlx90="
+hash = "sha256-vxwVk3iVZksjYfTl2OQLvwiw6DP3aXMlM99v2f9oZ4I="
 variant = "frozen"
 destination = "truetype"
 
 [[fonts]]
-hash = "sha256-cPAQBgrxIFXRjBRK9kvt3uYwewi5Lw/ryiwjUeVJWD4="
+hash = "sha256-n3SwICKrE05gwLlEskexQQoo/NVODQxwps1JVfjGGY0="
 variant = "variable"
 destination = "truetype"
 
 [[fonts]]
-hash = "sha256-3/JOe+aSSA2vxnKHjSwkxukqNYMajsIuQ68IJvY07XI="
+hash = "sha256-utqL4skUY/HUASsJ9rMDPkJ0nLwLJu/ayqCk7sVJjKg="
 variant = "nerdfonts"
 destination = "opentype"
 
 [[fonts]]
-hash = "sha256-1VtGSqDSRaVfyCWP+ZQtiji/076JdZmRSI0nlzqcuHo="
+hash = "sha256-6gjRUavugl9yGUo8vbliojV6MePeKocByiUrfeHbVLg="
 variant = "webfont-nerdfonts"
 destination = "woff"
 
 [[fonts]]
-hash = "sha256-mlK1kCun8/rUsDpNh3+dD+mDqvNdCMdIe8u9Y8ORhJ0="
+hash = "sha256-T1etH3HllVNw0bLpqi0i4jaNvjaiUu4jk32X02wY++s="
 variant = "webfont-static"
 destination = "woff"
 
 [[fonts]]
-hash = "sha256-aHLPmQzPiA8HQFsz9u6UH0b8kINx/fQ74GcPDs+a1ys="
+hash = "sha256-BmipeKGHFaEGkNbf++Td/59Ay42/33M785aZbjrZirU="
 variant = "webfont-variable"
 destination = "woff"


### PR DESCRIPTION
Updated the monaspace font to the latest version. [Release Notes](https://github.com/githubnext/monaspace/releases/tag/v1.400).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
