### PR TITLE
fish: nixos/programs/fish: remove references to __fish_datadir

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -199,16 +199,16 @@ in
             ''
           else
             indentFishFile "nixos-env-preinit.fish" ''
-              # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
-              # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
-              set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d $__fish_datadir/functions
+              # This happens before embedded:config.fish sets fish_function_path, so it is currently
+              # unset. We set it and then completely erase it, leaving its configuration to embedded:config.fish
+              set fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d
 
               # source the NixOS environment config
               if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]
                 fenv source ${config.system.build.setEnvironment}
               end
 
-              # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
+              # clear fish_function_path so that it will be correctly set when we return to embedded:config.fish
               set -e fish_function_path
             '';
       }

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -105,11 +105,10 @@ let
 
     test -n "$NIX_PROFILES"
     and begin
-      # We ensure that __extra_* variables are read in $__fish_datadir/config.fish
-      # with a preference for user-configured data by making sure the package-specific
-      # data comes last. Files are loaded/sourced in encounter order, duplicate
-      # basenames get skipped, so we assure this by prepending Nix profile paths
-      # (ordered in reverse of the $NIX_PROFILE variable)
+      # We ensure that __extra_* variables are read in embedded:config.fish with a preference for
+      # user-configured data by making sure the package-specific data comes last. Files are
+      # loaded/sourced in encounter order, duplicate basenames get skipped, so we assure this by
+      # prepending Nix profile paths (ordered in reverse of the $NIX_PROFILE variable)
       #
       # Note that at this point in evaluation, there is nothing whatsoever on the
       # fish_function_path. That means we don't have most fish builtins, e.g., `eval`.
@@ -135,12 +134,12 @@ let
   # `begin; begin; …; end; end` but that's ok.
   sourceWithFenv = path: ''
     begin # fenv
-      # This happens before $__fish_datadir/config.fish sets fish_function_path, so it is currently
-      # unset. We set it and then completely erase it, leaving its configuration to $__fish_datadir/config.fish
-      set fish_function_path ${fishPlugins.foreign-env}/share/fish/vendor_functions.d $__fish_datadir/functions
+      # This happens before embedded:config.fish sets fish_function_path, so it is currently unset.
+      # We set it and then completely erase it, leaving its configuration to embedded:config.fish
+      set fish_function_path ${fishPlugins.foreign-env}/share/fish/vendor_functions.d
       fenv source ${lib.escapeShellArg path}
       set -l fenv_status $status
-      # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
+      # clear fish_function_path so that it will be correctly set when we return to embedded:config.fish
       set -e fish_function_path
       test $fenv_status -eq 0
     end # fenv


### PR DESCRIPTION
__fish_datadir was renamed to __fish_data_dir in fish 3.0b1, see the release notes in `fish-doc(1)`:

> fish 3.0b1 (released December 11, 2018)
>   ...
> Notable non-backward compatible changes
>   ...
>   • The internal variables __fish_datadir and __fish_sysconfdir are
>     now known as __fish_data_dir and __fish_sysconf_dir respectively.

That this has kept working (?) all the while might possibly be an indication that this could have been removed a little over seven years ago.

With the release of fish 4.2.0 the contest of __fish_data_dir is also no longer used (with the exception of HTML docs, and `vendor_*.d`), as the standalone build mode is now enabled by default. Fish refers to embedded files by prefixing them with "embedded:", see `$ type cd`: `# Defined in embedded:functions/cd.fish @ line 5`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
