### PR TITLE
lazycommit: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -3,19 +3,26 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  stdenv,
+  writableTmpDirAsHomeHook,
 }:
 buildGoModule rec {
   pname = "lazycommit";
-  version = "1.4.0";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "m7medvision";
     repo = "lazycommit";
     tag = "v${version}";
-    hash = "sha256-DD3DXTev8WHNkAYDrPY2PISuA8WwKuK0GCLebpn01Rg=";
+    hash = "sha256-tS5jWucT4/1YRAXySUnElEkjaF2+Bl7O3taSzZf2NF0=";
   };
 
   vendorHash = "sha256-4OPCUWXxsAnzxsqZPHhjvhxQQf5Knm7nGqrdjH4I4YY=";
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  # Error reading config file: open /nix/build/nix-53143-2282724270/.home/.config/.lazycommit.yaml: no such file or directory
+  checkFlags = lib.optional stdenv.hostPlatform.isDarwin "-skip=^TestSetEndpoint_Validation$";
 
   ldflags = [
     "-X main.version=${version}"

--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -6,14 +6,14 @@
   stdenv,
   writableTmpDirAsHomeHook,
 }:
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "lazycommit";
   version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "m7medvision";
     repo = "lazycommit";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-tS5jWucT4/1YRAXySUnElEkjaF2+Bl7O3taSzZf2NF0=";
   };
 
@@ -25,7 +25,7 @@ buildGoModule rec {
   checkFlags = lib.optional stdenv.hostPlatform.isDarwin "-skip=^TestSetEndpoint_Validation$";
 
   ldflags = [
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
     "-X main.buildSource=nix"
   ];
 
@@ -41,11 +41,11 @@ buildGoModule rec {
   meta = {
     description = "Simple cli for generating git commits";
     homepage = "https://github.com/m7medvision/lazycommit";
-    changelog = "https://github.com/m7medvision/lazycommit/releases/tag/v${version}";
+    changelog = "https://github.com/m7medvision/lazycommit/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       m7medvision
     ];
     mainProgram = "lazycommit";
   };
-}
+})


### PR DESCRIPTION
Release: https://github.com/m7medVision/lazycommit/releases/tag/v1.4.2
Diff: https://github.com/m7medVision/lazycommit/compare/v1.4.0...v1.4.2

  This also fixes these hydra build (Click to go to Hydra):
[![](https://hydra-banner.harinn.dev/build/326198952)](https://hydra.nixos.org/build/326198952)
[![](https://hydra-banner.harinn.dev/build/326198951)](https://hydra.nixos.org/build/326198951)
[![](https://hydra-banner.harinn.dev/build/325818193)](https://hydra.nixos.org/build/325818193)
[![](https://hydra-banner.harinn.dev/build/325818192)](https://hydra.nixos.org/build/325818192)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
