### PR TITLE
nixos/lustrate: init module, for systemd initrd

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1904,6 +1904,7 @@
   ./system/boot/loader/refind/refind.nix
   ./system/boot/loader/systemd-boot/systemd-boot.nix
   ./system/boot/luksroot.nix
+  ./system/boot/lustrate.nix
   ./system/boot/modprobe.nix
   ./system/boot/networkd.nix
   ./system/boot/nix-store-veritysetup.nix

--- a/nixos/modules/system/boot/lustrate.nix
+++ b/nixos/modules/system/boot/lustrate.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.boot.initrd.systemd;
+in
+
+{
+  options = {
+    boot.initrd.systemd.lustrate.enable = lib.mkEnableOption "lustration" // {
+      description = ''
+        Whether to enable lustration in the systemd initrd. This is used for
+        installation from another distribution. Please see [the manual] for
+        more details.
+
+        This option only has an effect if systemd initrd is enabled with the
+        `boot.initrd.systemd.enable` option. If systemd initrd is disabled,
+        lustration is always available.
+
+        Warning: Lustration may interact unexpectedly with complex filesystem
+        setups. Use with caution.
+
+        [the manual]: https://nixos.org/manual/nixos/stable#sec-installing-from-other-distro
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.lustrate.enable) {
+    boot.initrd.systemd.services.lustrate = {
+      description = "Lustration of the root filesystem";
+
+      unitConfig = {
+        ConditionPathExists = [ "/sysroot/etc/NIXOS_LUSTRATE" ];
+
+        # We need to lustrate after /sysroot is mounted, but before anything
+        # else is mounted on top.
+        Requires = [ "sysroot.mount" ];
+        After = [
+          "sysroot.mount"
+          "systemd-repart.service"
+        ];
+        Before = [
+          "initrd-root-fs.target"
+          "systemd-volatile-root.service"
+        ];
+      };
+      requiredBy = [ "initrd-root-fs.target" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        StandardOutput = "journal+console";
+        StandardError = "journal+console";
+      };
+
+      path = [ pkgs.coreutils ];
+      script = ''
+        # Duplicated from NixOS nixos/modules/system/boot/stage-1-init.sh for
+        # maximum chance of being functionally compatible, and so that
+        # stage-1-init.sh can be removed later.
+
+        lustrateRoot () {
+          local root="$1"
+
+          echo
+          echo -e "\e[1;33m<<< ${config.system.nixos.distroName} is now lustrating the root filesystem (cruft goes to /old-root) >>>\e[0m"
+          echo
+
+          mkdir -m 0755 -p "$root/old-root.tmp"
+
+          echo
+          echo "Moving impurities out of the way:"
+          for d in "$root"/*
+          do
+              [ "$d" == "$root/nix"          ] && continue
+              [ "$d" == "$root/boot"         ] && continue # Don't render the system unbootable
+              [ "$d" == "$root/old-root.tmp" ] && continue
+
+              mv -v "$d" "$root/old-root.tmp"
+          done
+
+          # Use .tmp to make sure subsequent invocations don't clash
+          mv -v "$root/old-root.tmp" "$root/old-root"
+
+          mkdir -m 0755 -p "$root/etc"
+          touch "$root/etc/NIXOS"
+
+          exec 4< "$root/old-root/etc/NIXOS_LUSTRATE"
+
+          echo
+          echo "Restoring selected impurities:"
+          while read -u 4 keeper; do
+              dirname="$(dirname "$keeper")"
+              mkdir -m 0755 -p "$root/$dirname"
+              cp -av "$root/old-root/$keeper" "$root/$keeper"
+          done
+
+          exec 4>&-
+        }
+
+        set -euo pipefail
+
+        # Should be checked by systemd, but I find this convenient for testing
+        [ -f "/sysroot/etc/NIXOS_LUSTRATE" ] || exit 0
+        lustrateRoot /sysroot
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -912,6 +912,7 @@ in
   lomiri-system-settings = runTest ./lomiri-system-settings.nix;
   lorri = handleTest ./lorri/default.nix { };
   luks = runTest ./luks.nix;
+  lustrate = runTest ./lustrate.nix;
   lvm2 = handleTest ./lvm2 { };
   lxc = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./lxc;
   lxd-image-server = runTest ./lxd-image-server.nix;

--- a/nixos/tests/lustrate.nix
+++ b/nixos/tests/lustrate.nix
@@ -1,0 +1,27 @@
+{ lib, ... }:
+{
+  name = "lustrate";
+
+  nodes.machine = {
+    boot.initrd.systemd = {
+      enable = true;
+      lustrate.enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.start(allow_reboot=True)
+
+    # Lustrate if /etc/NIXOS_LUSTRATE exists
+    machine.succeed("touch /foo")
+    machine.succeed("touch /etc/NIXOS_LUSTRATE")
+    machine.reboot()
+    machine.succeed("ls -l /old-root")
+    machine.fail("ls -l /foo")
+
+    # That should have also deleted /etc/NIXOS_LUSTRATE, so don't lustrate again
+    machine.succeed("touch /bar")
+    machine.reboot()
+    machine.succeed("ls -l /bar")
+  '';
+}


### PR DESCRIPTION
This really basically just works, and I expect at least a handful of users would really want to keep using lustration in the systemd stage-1 only future as a followup to #435781, to set up cloud VMs or stuff. So... it's something?

Draft for now. I need to think about the details a bit more.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
