### PR TITLE
nixos/rspamd: Add localsLua option to rspamd module

### DIFF
--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -241,6 +241,10 @@ let
       name = "rspamd.local.lua";
       path = cfg.localLuaRules;
     })
+    ++ (mapAttrsToList (name: file: {
+      name = "lua.local.d/${name}";
+      path = file.source;
+    }) (filterFiles cfg.localsLua))
     ++ [
       {
         name = "rspamd.conf";
@@ -343,6 +347,14 @@ in
         description = ''
           Path of file to link to {file}`/etc/rspamd/rspamd.local.lua` for local
           rules written in Lua
+        '';
+      };
+
+      localsLua = mkOption {
+        type = with types; attrsOf (submodule (configFileModule "localsLua"));
+        default = { };
+        description = ''
+          Local Lua files, written into {file}`/etc/rspamd/lua.local.d/{name}`.
         '';
       };
 


### PR DESCRIPTION
Add localsLua option to pass multiple Lua rule files to rspamd.

Having all Lua rules within a single file (`rspamd.local.lua`) could be not desirable for a large ruleset - multiple smaller files are easier to have a look at. This change implements loading mechanism supported by Rspamd out of the box: https://github.com/rspamd/rspamd/blob/c7fe8501d85acf46e512dbb1cf3021673e14c17c/rules/rspamd.lua#L56

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
