### PR TITLE
surfpool: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -145,6 +145,12 @@
     githubId = 67933444;
     keys = [ { fingerprint = "B39E B98E 8860 DAFB 0567  0073 A614 B7D2 5134 987A"; } ];
   };
+  _0xgsvs = {
+    email = "venkat.subrahmanyam.34@gmail.com";
+    name = "0xgsvs";
+    github = "0xgsvs";
+    githubId = 161702876;
+  };
   _0xMillyByte = {
     email = "emilia.daelman@gmail.com";
     name = "Emilia Daelman";

--- a/pkgs/by-name/su/surfpool/package.nix
+++ b/pkgs/by-name/su/surfpool/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchzip,
+  pkg-config,
+  versionCheckHook,
+  openssl,
+}:
+
+let
+  studioUiVersion = "v0.1.0";
+  studioUi = fetchzip {
+    url = "https://github.com/solana-foundation/surfpool-web-ui/releases/download/${studioUiVersion}/studio-dist.zip";
+    hash = "sha256-uZZpaAIg7f+ji5yonwNbAxbxi+4x7g5V4xKWUXNn1UI=";
+    stripRoot = false;
+  };
+in
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "surfpool-cli";
+  version = "1.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "solana-foundation";
+    repo = "surfpool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PGCzlnu7YxueQ16uae2818I9vXWdMRFRGaFzg2DIIgo=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-ephKNAJ9PtTz/EN9dGFn6LnIySU0g/GNz8Jg9JDKTSI=";
+
+  postPatch = ''
+    # instead of downloading the surfpool-web-ui at build time, we fetch it beforehand and use it
+    # https://github.com/solana-foundation/surfpool/pull/628
+    substituteInPlace crates/studio/build.rs \
+      --replace-fail \
+        'let url = match env::var("STUDIO_UI_VERSION") {' \
+        'if let Ok(dist_path) = env::var("STUDIO_UI_DIST") {
+            let src = std::path::Path::new(&dist_path);
+            fn copy_dir(s: &std::path::Path, d: &std::path::Path) {
+                std::fs::create_dir_all(d).unwrap();
+                for e in std::fs::read_dir(s).unwrap() {
+                    let e = e.unwrap();
+                    if e.file_type().unwrap().is_dir() { copy_dir(&e.path(), &d.join(e.file_name())); }
+                    else { std::fs::copy(e.path(), d.join(e.file_name())).unwrap(); }
+                }
+            }
+            copy_dir(src, &asset_dir);
+            return;
+        }
+        let url = match env::var("STUDIO_UI_VERSION") {'
+  '';
+
+  env = {
+    RUSTFLAGS = "-Aunused";
+    OPENSSL_NO_VENDOR = 1;
+    STUDIO_UI_DIST = "${studioUi}";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Surfpool is where developers start their Solana journey";
+    homepage = "https://www.surfpool.run/";
+    longDescription = ''
+      Surfpool is a drop-in replacement for solana-test-validator that lets
+      developers spin up local Solana networks mirroring mainnet state without
+      downloading the entire chain. It includes a built-in web UI (Surfpool Studio)
+      served directly from the binary, Infrastructure as Code for declarative
+      program deployment, transaction inspection, time travel, cheatcodes, and
+      an MCP server for agentic workflows
+    '';
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ _0xgsvs ];
+    mainProgram = "surfpool";
+  };
+})


### PR DESCRIPTION
🌊 Overview
Surfpool is your drop-in replacement for solana-test-validator, designed for builders who want to work with real mainnet state — without downloading the entire chain.

But Surfpool goes further: it introduces Infrastructure as Code for Solana, empowering developers to define, deploy, and operate both on-chain and off-chain infrastructure declaratively and reproducibly.

It’s built local-first and offline-ready, so you can spin up networks on your laptop — and then promote the exact same setup to the cloud when it’s showtime.

Homepage: https://www.surfpool.run
Repo: https://github.com/solana-foundation/surfpool

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
