### PR TITLE
python3Packages.ibis-framework: fix build against duckdb 1.5.1

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -144,6 +144,10 @@ buildPythonPackage (finalAttrs: {
   pytestFlags = [
     "--benchmark-disable"
     "-Wignore::FutureWarning"
+    # DeprecationWarning: fetch_arrow_table() is deprecated, use to_arrow_table() instead.
+    "-Wignore:fetch_arrow_table:DeprecationWarning"
+    # DeprecationWarning: fetch_record_batch() is deprecated, use to_arrow_reader() instead.
+    "-Wignore:fetch_record_batch:DeprecationWarning"
   ]
   ++ lib.optionals (pythonAtLeast "3.14") [
     # DeprecationWarning: '_UnionGenericAlias' is deprecated and slated for removal in Python 3.17
@@ -185,6 +189,12 @@ buildPythonPackage (finalAttrs: {
 
     # assert 0 == 3 (tests edge case behavior of databases)
     "test_self_join_with_generated_keys"
+
+    # _duckdb.BinderException: DECIMAL type width must be between 1 and 38
+    "test_decimal_literal[duckdb-decimal-big]"
+
+    # AssertionError: joining an empty array returns '' instead of NULL in duckdb 1.5
+    "test_empty_array_string_join[duckdb]"
 
     # https://github.com/ibis-project/ibis/issues/11929
     # AssertionError: value does not match the expected value


### PR DESCRIPTION
duckdb-python 1.5.0 deprecated `fetch_arrow_table` and `fetch_record_batch`, which ibis 12.0.0 still calls; combined with ibis's `filterwarnings = ["error", ...]` test config, every duckdb-backend test errors at setup with `SystemError: <built-in function __import__> returned a result with an exception set` (hydra build [326319049](https://hydra.nixos.org/build/326319049)).

- `-Wignore:fetch_arrow_table:DeprecationWarning`
- `-Wignore:fetch_record_batch:DeprecationWarning`
- `disabledTests`: `test_decimal_literal[duckdb-decimal-big]` (`_duckdb.BinderException: DECIMAL width must be between 1 and 38`) and `test_empty_array_string_join[duckdb]` (duckdb 1.5 returns `''` instead of `NULL` for empty-array join)

surfaced following:

- #505056 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
