### PR TITLE
python3Packages.pysteamauth2: init at 1.1.9

### DIFF
--- a/pkgs/development/python-modules/pysteamauth2/default.nix
+++ b/pkgs/development/python-modules/pysteamauth2/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  aiohttp,
+  bitstring,
+  protobuf,
+  pydantic,
+  rsa,
+  urllib3,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pysteamauth2";
+  version = "1.1.9";
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-0MDKRAeVJSHy/VjlOk2RwOT4eb8JBkolVSqiZkwOOZ8=";
+  };
+
+  # relax dependency versions
+  postPatch = ''
+    sed -i -E 's/==[0-9\.]+//g' setup.py
+  '';
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    bitstring
+    protobuf
+    pydantic
+    rsa
+    urllib3
+  ];
+
+  pythonImportsCheck = [ "pysteamauth" ];
+
+  meta = {
+    description = "Asynchronous python library for Steam authorization using protobuf";
+    homepage = "https://github.com/AdiEcho/pysteamauth";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15147,6 +15147,8 @@ self: super: with self; {
 
   pystatgrab = callPackage ../development/python-modules/pystatgrab { };
 
+  pysteamauth2 = callPackage ../development/python-modules/pysteamauth2 { };
+
   pystemd = callPackage ../development/python-modules/pystemd { inherit (pkgs) systemd; };
 
   pystemmer = callPackage ../development/python-modules/pystemmer { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
