### PR TITLE
gitbutler-cli: init at 0.19.7

### DIFF
--- a/pkgs/by-name/gi/gitbutler-cli/package.nix
+++ b/pkgs/by-name/gi/gitbutler-cli/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  cmake,
+  dbus,
+  fetchFromGitHub,
+  git,
+  libgit2,
+  makeWrapper,
+  nix-update-script,
+  openssl,
+  perl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gitbutler-cli";
+  version = "0.19.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gitbutlerapp";
+    repo = "gitbutler";
+    tag = "release/${finalAttrs.version}";
+    hash = "sha256-ppl1noikPwTvG/XT7iYG41+9ZZO8i0x2L+odeEzRP1s=";
+  };
+
+  cargoHash = "sha256-xW/eO+AQQUBN2MrixNx3LKhwMookkKuX5LF4DSWQKKY=";
+
+  # `but` needs `gitbutler-git-askpass` and `gitbutler-git-setsid` for push/fetch operations
+  cargoBuildFlags = [
+    "--package=but"
+    "--package=gitbutler-git"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "but"
+    "--"
+    # TUI tests require filesystem/git access unavailable in the sandbox
+    "--skip=command::legacy::status::tui::tests"
+    # Archive at 'tests/fixtures/generated-archives/[...].tar' not found [..] Error: No such file or directory (os error 2)
+    "--skip=merge_first_branch_into_gb_local_and_verify_rebase"
+    "--skip=json_output_with_dangling_commits"
+    "--skip=two_dangling_commits_different_branches"
+  ];
+
+  buildFeatures = [
+    "packaged-but-distribution"
+  ];
+
+  # cargo-auditable fails because `but-db` uses `dep:tokio`
+  auditable = false;
+
+  nativeBuildInputs = [
+    cmake # Required by `aws-lc-sys` crate
+    makeWrapper
+    perl # Required by `aws-lc-sys` crate
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux dbus; # Required by `libdbus-sys` via `keyring` crate
+
+  nativeCheckInputs = [ git ];
+
+  # Place helper binaries alongside `but` so it can find them at runtime
+  postInstall = ''
+    mkdir -p $out/libexec/gitbutler-cli
+    mv $out/bin/but $out/libexec/gitbutler-cli/but
+    mv $out/bin/gitbutler-git-askpass $out/libexec/gitbutler-cli/gitbutler-git-askpass
+    mv $out/bin/gitbutler-git-setsid $out/libexec/gitbutler-cli/gitbutler-git-setsid
+    makeWrapper $out/libexec/gitbutler-cli/but $out/bin/but
+  '';
+
+  env = {
+    # task tracing requires Tokio to be built with RUSTFLAGS="--cfg tokio_unstable"
+    RUSTFLAGS = "--cfg tokio_unstable";
+
+    OPENSSL_NO_VENDOR = true;
+    LIBGIT2_NO_VENDOR = 1;
+  };
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "release/(.*)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Git CLI client `but` for simultaneous branches on top of your existing workflow";
+    homepage = "https://gitbutler.com";
+    changelog = "https://github.com/gitbutlerapp/gitbutler/releases/tag/release/${finalAttrs.version}";
+    license = lib.licenses.fsl11Mit;
+    maintainers = with lib.maintainers; [
+      ejiektpobehuk
+      getchoo
+      techknowlogick
+    ];
+    mainProgram = "but";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/gi/gitbutler/package.nix
+++ b/pkgs/by-name/gi/gitbutler/package.nix
@@ -40,8 +40,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   # Let Tauri know what version we're building and deactivate the built-in updater
-  # Note: .bundle.externalBin doesn't include `"but"` at the moment
-  #       as that'd require more build adjustments
+  # Note: .bundle.externalBin doesn't include `"but"` - the `but` CLI
+  #       is packaged separately as `gitbutler-cli`
   postPatch = ''
     tauriConfRelease="crates/gitbutler-tauri/tauri.conf.release.json"
     jq '.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds the GitButler CLI `but` as a standalone package. The `but` binary is built from the same upstream monorepo as the gitbutler desktop app but packaged separately to keep dependencies minimal — the CLI doesn't need WebKitGTK, Node.js, pnpm, or turbo. And to enable updating them separatly when there are problems with one of the packages.

The `packaged-but-distribution` feature flag is enabled to disable the built-in self-updater.

There is a problem with version reporting inside the app:
```sh
$ /nix/store/8fipc5k61w542d23a42b3hvp98x6n5g8-gitbutler-cli-0.19.7/bin/but --version
but dev
```

Related:
- NixOS/nixpkgs#500438 — prior gitbutler-cli attempt by @Daholli (closed)
- NixOS/nixpkgs#506283 — bundled `but` into the desktop app update by @Mrmaxmeier (closed; superseded by NixOS/nixpkgs#499189)
- https://github.com/NixOS/nixpkgs/pull/506283#issuecomment-4183667699 encouraging a separate but CLI PR

I'm not sure if this is allowed but I've listed `gitbutler` maintainers as maintainers for the cli version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
