### PR TITLE
python3Packages.pynfsclient: switch to Pennyw0rth Fork

### DIFF
--- a/pkgs/development/python-modules/pynfsclient/default.nix
+++ b/pkgs/development/python-modules/pynfsclient/default.nix
@@ -1,29 +1,21 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  pythonAtLeast,
+  fetchFromGitHub,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pynfsclient";
-  version = "0.1.5";
+  version = "1.0.6";
   pyproject = true;
 
-  disabled = pythonAtLeast "3.13";
-
-  src = fetchPypi {
-    pname = "pyNfsClient";
-    inherit version;
-    hash = "sha256-xgZL08NlMCpSkALQwklh7Xq16bK2Sm2hAynbrIWsgaU=";
+  src = fetchFromGitHub {
+    owner = "Pennyw0rth";
+    repo = "NfsClient";
+    rev = "v${version}";
+    hash = "sha256-9PV/RpK/rOI9jpTDy0FmkXY2Cf54vve6j1kM5dcZgV8=";
   };
-
-  postPatch = ''
-    # HISTORY.md is missing
-    substituteInPlace setup.py \
-      --replace-fail "HISTORY.md" "README.rst"
-  '';
 
   build-system = [ setuptools ];
 
@@ -33,9 +25,13 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pyNfsClient" ];
 
   meta = {
-    description = "Pure python NFS client";
-    homepage = "https://pypi.org/project/pyNfsClient/";
+    description = "Pure python library to simulate NFS client";
+    homepage = "https://github.com/Pennyw0rth/NfsClient";
+    changelog = "https://github.com/Pennyw0rth/NfsClient/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      letgamer
+    ];
   };
 }

--- a/pkgs/development/python-modules/pynfsclient/default.nix
+++ b/pkgs/development/python-modules/pynfsclient/default.nix
@@ -5,7 +5,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pynfsclient";
   version = "1.0.6";
   pyproject = true;
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Pennyw0rth";
     repo = "NfsClient";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-9PV/RpK/rOI9jpTDy0FmkXY2Cf54vve6j1kM5dcZgV8=";
   };
 
@@ -27,11 +27,11 @@ buildPythonPackage rec {
   meta = {
     description = "Pure python library to simulate NFS client";
     homepage = "https://github.com/Pennyw0rth/NfsClient";
-    changelog = "https://github.com/Pennyw0rth/NfsClient/releases/tag/v${version}";
+    changelog = "https://github.com/Pennyw0rth/NfsClient/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab
       letgamer
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I propose switching the pynfsclient library to the actively maintained Pennyw0rth Fork, as the upstream Version hasn't seen a release since 2019.
This will also unblock this issue:
https://github.com/CharmingYang0/NfsClient/issues/11
And will also allow us to bump Netexec to python3.13: https://github.com/NixOS/nixpkgs/pull/424176

Related to: https://github.com/NixOS/nixpkgs/issues/81418

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
