### PR TITLE
open-watcom-v2-unwrapped: 0-unstable-2025-11-15 -> 0-unstable-2026-04-11, disable strictflexarrays1 to fix build

### DIFF
--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -17,13 +17,13 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "${finalAttrs.passthru.prettyName}-unwrapped";
   # nixpkgs-update: no auto update
-  version = "0-unstable-2025-11-15";
+  version = "0-unstable-2026-04-11";
 
   src = fetchFromGitHub {
     owner = "open-watcom";
     repo = "open-watcom-v2";
-    rev = "fe2ddbd2e5833a85d9ccd3937b304f3f41e44f98";
-    hash = "sha256-jv7d5DopGZDnVFQX/t0D9cZSTwgMvcb4kqCnLJSWmNI=";
+    rev = "e724d4a0e7cc1593ae2430e07a62352b7852dd68";
+    hash = "sha256-Xu0oCNO8WyIwe12CjDWXP+2LUzexZcw6Rgzpb80M5cA=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/open-watcom/v2.nix
+++ b/pkgs/development/compilers/open-watcom/v2.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '-static' ""
   '';
 
+  # https://github.com/open-watcom/open-watcom-v2/issues/1608
+  hardeningDisable = [ "strictflexarrays1" ];
+
   nativeBuildInputs = lib.optionals withDocs [
     dosbox # running prebuilt WGML tool to create docs
     ghostscript


### PR DESCRIPTION
Updated source from `0-unstable-2025-11-15` to `0-unstable-2026-04-11`.
Disabled `strictflexarrays1` hardening to fix build failure.

Upstream issue: https://github.com/open-watcom/open-watcom-v2/issues/1608

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test