### PR TITLE
dosbox: fix darwin build

### DIFF
--- a/pkgs/by-name/do/dosbox/package.nix
+++ b/pkgs/by-name/do/dosbox/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL
   ];
 
-  depsBuildBuild = [
+  depsBuildBuild = lib.optionals (!stdenv.buildPlatform.isDarwin) [
     binutils # build calls `ar`
   ];
 


### PR DESCRIPTION
On Darwin, GNU `binutils` in `depsBuildBuild` provides a GNU `ar` that produces archives in GNU format. Apple's linker doesn't understand this format -it silently ignores the .a files, leading to undefined symbols and a link failure.

The fix makes `binutils` conditional on non-Darwin, since Darwin's toolchain already provides a compatible `ar` via `cctools`.

I'm fixing this as part of making  `open-watcom-v2` build on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
