### PR TITLE
python3Packages.pandera: 0.28.1 -> 0.30.1

### DIFF
--- a/pkgs/development/python-modules/pandera/default.nix
+++ b/pkgs/development/python-modules/pandera/default.nix
@@ -22,6 +22,7 @@
   dask,
   duckdb,
   fastapi,
+  frictionless,
   geopandas,
   hypothesis,
   ibis-framework,
@@ -41,16 +42,16 @@
   rich,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pandera";
-  version = "0.28.1";
+  version = "0.30.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "unionai-oss";
     repo = "pandera";
-    tag = "v${version}";
-    hash = "sha256-PXcLJwebJ6BQ4nUtXUZFGb0vQp/g6jj+afewTTMt84s=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JmD8p0Syt/Tgf9LiMWeug1dSPp4cyd7BtBfo6yi08xg=";
   };
 
   build-system = [
@@ -58,7 +59,7 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 
   dependencies = [
     packaging
@@ -77,7 +78,7 @@ buildPythonPackage rec {
         io = [
           pyyaml
           black
-          #frictionless # not in nixpkgs
+          frictionless
         ];
         # pyspark expression does not define optional-dependencies.connect:
         #pyspark = [ pyspark ] ++ pyspark.optional-dependencies.connect;
@@ -121,7 +122,7 @@ buildPythonPackage rec {
     pytestCheckHook
     rich
   ]
-  ++ optional-dependencies.all;
+  ++ finalAttrs.passthru.optional-dependencies.all;
 
   disabledTestPaths = [
     "tests/fastapi/test_app.py" # tries to access network
@@ -167,8 +168,8 @@ buildPythonPackage rec {
   meta = {
     description = "Light-weight, flexible, and expressive statistical data testing library";
     homepage = "https://pandera.readthedocs.io";
-    changelog = "https://github.com/unionai-oss/pandera/releases/tag/${src.tag}";
+    changelog = "https://github.com/unionai-oss/pandera/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/unionai-oss/pandera/compare/v0.28.1...v0.30.1
Changelog: https://github.com/unionai-oss/pandera/releases/tag/v0.30.1

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test