### PR TITLE
ghunt: 2.3.4 -> 2.3.5

### DIFF
--- a/pkgs/by-name/gh/ghunt/package.nix
+++ b/pkgs/by-name/gh/ghunt/package.nix
@@ -6,7 +6,7 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "ghunt";
-  version = "2.3.4";
+  version = "2.3.5";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -14,8 +14,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     repo = "ghunt";
     # The newer releases aren't git-tagged to we just take the
     # commit with the version bump
-    rev = "e8b0669cabb410dc40fb76b8d5d386a3a83fe08c";
-    hash = "sha256-Zd0kpyr+Hkbh5MH3q3lrkH3liXw95sKRX+SZhsUVUhI=";
+    rev = "5ee893929c51c7a8a665b199bbae04ce85a662b4";
+    hash = "sha256-pBH8Uhh+Yg9rrX8duEPLf/+JF5PR4I5zUhQ4EMiyk7A=";
   };
 
   pythonRelaxDeps = true;


### PR DESCRIPTION
Resolves #509059 

This is preemptive because this release is not yet in pypi, but it seems like the maintainer is preparing to make a release on this commit. (see https://github.com/mxrch/GHunt/issues/591#issuecomment-4219610608)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
