### PR TITLE
nono: 0.5.0 -> 0.35.0

### DIFF
--- a/pkgs/by-name/no/nono/package.nix
+++ b/pkgs/by-name/no/nono/package.nix
@@ -6,6 +6,8 @@
   pkg-config,
 
   dbus,
+
+  writableTmpDirAsHomeHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -26,6 +28,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [
     dbus
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
   ];
 
   meta = {

--- a/pkgs/by-name/no/nono/package.nix
+++ b/pkgs/by-name/no/nono/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
 
@@ -32,6 +33,29 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
+  ];
+
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    # panics with "Deny-within-allow overlap on Linux ... Landlock cannot enforce this. ..."
+    # landlock is linux only
+    "--skip=policy::tests::test_all_groups_no_deny_within_allow_overlap"
+    # panics with "exact-path fallback must not recursively cover descendants"
+    "--skip=capability_ext::tests::test_from_profile_allow_file_falls_back_to_exact_directory_when_present"
+
+    # env_vars
+    # don't work inside of the /nix dir
+    # unsure why home is still under /nix with writableTmpDirAsHomeHook
+    # Sandbox initialization failed: Refusing to grant '/nix' (source: group:system_read_macos) because it overlaps protected nono state root '/nix/build/nix-<ID>/.home/.nono'.
+    "--skip=allow_net_overrides_profile_external_proxy"
+    "--skip=cli_flag_overrides_env_var"
+    "--skip=env_nono_allow_comma_separated"
+    "--skip=env_nono_block_net"
+    "--skip=env_nono_block_net_accepts_true"
+    "--skip=env_nono_network_profile"
+    "--skip=env_nono_profile"
+    "--skip=env_nono_upstream_bypass_comma_separated"
+    "--skip=env_nono_upstream_proxy"
+    "--skip=legacy_env_nono_net_block_still_works"
   ];
 
   meta = {

--- a/pkgs/by-name/no/nono/package.nix
+++ b/pkgs/by-name/no/nono/package.nix
@@ -10,16 +10,15 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nono";
-  version = "0.5.0";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "always-further";
     repo = "nono";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-32PiM84dwZ3dPIAIak1DL3iencguXCzehFCDsulDyhI=";
+    hash = "sha256-/bKquUbVMM1e/YPcuSb0vW4tX/3yNDUxmaBWHKFw+Qs=";
   };
-
-  cargoHash = "sha256-nE0vVBThXnqo8VnFCkOyqhpZZ40MIkXSqUoJUZcDVhE=";
+  cargoHash = "sha256-ibGIpH6Ls9nxtF6rRl+dZBbbmVRXDQA6vpPI/jzpDqI=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Version bump for package nono from 0.5.0 to 0.34.0
nono: Kernel-enforced agent sandbox for LLM workloads - https://github.com/always-further/nono

## Things done

Updated the version number, updated hash values for fetchFromGithub and cargoHash, along with adding some pre-checks set tmp dir used for nono's tests.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Edit: Bump to 0.34.0