### PR TITLE
clementine: migrate to by-name, remove old protobuf

### DIFF
--- a/pkgs/by-name/cl/clementine/package.nix
+++ b/pkgs/by-name/cl/clementine/package.nix
@@ -7,14 +7,10 @@
   chromaprint,
   gettext,
   gst_all_1,
-  liblastfm,
-  qtbase,
-  qtx11extras,
-  qttools,
+  libsForQt5,
   taglib_1,
   fftw,
   glew,
-  qjson,
   sqlite,
   libgpod,
   libplist,
@@ -26,12 +22,9 @@
   pcre,
   projectm_3,
   protobuf,
-  qca-qt5,
   pkg-config,
   sparsehash,
   config,
-  wrapQtAppsHook,
-  gst_plugins,
   util-linuxMinimal,
   libunwind,
   libselinux,
@@ -46,6 +39,13 @@ let
   withMTP = config.clementine.mtp or true;
   withCD = config.clementine.cd or true;
   withCloud = config.clementine.cloud or true;
+
+  gst_plugins = with gst_all_1; [
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gst-libav
+  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "clementine";
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
     util-linuxMinimal
     libunwind
     libselinux
@@ -80,16 +80,16 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-bad
     gst_all_1.gstreamer
     gvfs
-    liblastfm
+    libsForQt5.liblastfm
     libpulseaudio
     pcre
     projectm_3
     protobuf
-    qca-qt5
-    qjson
-    qtbase
-    qtx11extras
-    qttools
+    libsForQt5.qca-qt5
+    libsForQt5.qjson
+    libsForQt5.qtbase
+    libsForQt5.qtx11extras
+    libsForQt5.qttools
     sqlite
     taglib_1
     alsa-lib

--- a/pkgs/by-name/cl/clementine/package.nix
+++ b/pkgs/by-name/cl/clementine/package.nix
@@ -7,14 +7,11 @@
   chromaprint,
   gettext,
   gst_all_1,
-  liblastfm,
-  qtbase,
-  qtx11extras,
-  qttools,
+  qt5,
+  libsForQt5,
   taglib_1,
   fftw,
   glew,
-  qjson,
   sqlite,
   libgpod,
   libplist,
@@ -26,12 +23,9 @@
   pcre,
   projectm_3,
   protobuf,
-  qca-qt5,
   pkg-config,
   sparsehash,
   config,
-  wrapQtAppsHook,
-  gst_plugins,
   util-linuxMinimal,
   libunwind,
   libselinux,
@@ -46,6 +40,13 @@ let
   withMTP = config.clementine.mtp or true;
   withCD = config.clementine.cd or true;
   withCloud = config.clementine.cloud or true;
+
+  gst_plugins = with gst_all_1; [
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
+    gst-libav
+  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "clementine";
@@ -61,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
     util-linuxMinimal
     libunwind
     libselinux
@@ -80,16 +81,16 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-bad
     gst_all_1.gstreamer
     gvfs
-    liblastfm
+    libsForQt5.liblastfm
     libpulseaudio
     pcre
     projectm_3
     protobuf
-    qca-qt5
-    qjson
-    qtbase
-    qtx11extras
-    qttools
+    libsForQt5.qca-qt5
+    libsForQt5.qjson
+    qt5.qtbase
+    qt5.qtx11extras
+    qt5.qttools
     sqlite
     taglib_1
     alsa-lib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1979,16 +1979,6 @@ with pkgs;
   ceph-client = ceph.client;
   ceph-dev = ceph;
 
-  clementine = libsForQt5.callPackage ../applications/audio/clementine {
-    gst_plugins = with gst_all_1; [
-      gst-plugins-base
-      gst-plugins-good
-      gst-plugins-ugly
-      gst-libav
-    ];
-    protobuf = protobuf_21;
-  };
-
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
     citrix_workspace_25_08_10
     ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1924,16 +1924,6 @@ with pkgs;
   ceph-client = ceph.client;
   ceph-dev = ceph;
 
-  clementine = libsForQt5.callPackage ../applications/audio/clementine {
-    gst_plugins = with gst_all_1; [
-      gst-plugins-base
-      gst-plugins-good
-      gst-plugins-ugly
-      gst-libav
-    ];
-    protobuf = protobuf_21;
-  };
-
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
     citrix_workspace_26_01_0
     citrix_workspace_25_08_10


### PR DESCRIPTION
This pull request refactors the packaging of `clementine` by moving its definition to the `pkgs/by-name` directory, updating its dependencies to use `libsForQt5`, and cleaning up redundant or outdated dependency specifications. The changes improve maintainability and consistency with modern Nixpkgs practices.

**Refactoring and Dependency Updates:**

* Moved the `clementine` package definition from `pkgs/applications/audio/clementine/default.nix` to `pkgs/by-name/cl/clementine/package.nix` for better organization.
* Updated most Qt and related dependencies to use the `libsForQt5` attribute set (e.g., `libsForQt5.qtbase`, `libsForQt5.qjson`), replacing direct references and simplifying dependency management. 

* Removed redundant or unnecessary dependencies such as `qjson`, `qtbase`, `qtx11extras`, `qttools`, and `qca-qt5` from the main input lists, relying instead on `libsForQt5`.

**Build and Plugin Handling:**

* Moved the definition of `gst_plugins` into the package file and removed its override from `all-packages.nix`, centralizing plugin management.

* Switched to using `libsForQt5.wrapQtAppsHook` in `nativeBuildInputs` for improved Qt application wrapping.

**Top-level Package Cleanup:**

* Removed the custom `clementine` override from `pkgs/top-level/all-packages.nix`, as configuration is now handled in the package file.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
