### PR TITLE
[release-25.11] maintainers/github-teams.json: sync from master manually

### DIFF
--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -228,6 +228,7 @@
       "kloenk": 12898828,
       "konradmalik": 13033392,
       "kubukoz": 894884,
+      "lilyball": 714,
       "lutzmor": 9321736,
       "magistau": 43097806,
       "maljub01": 350635,
@@ -266,6 +267,7 @@
       "willcohen": 5185341,
       "willjr": 5904828,
       "wldhx": 15619766,
+      "yamashitax": 99486674,
       "yeongsheng-tan": 809030,
       "youhaveme9": 58213083,
       "yzx9": 41458459,
@@ -276,9 +278,11 @@
   "documentation-team": {
     "description": "Owns the standards, tooling, and processes that keep NixOS documentation reliable.",
     "id": 6590023,
-    "maintainers": {},
+    "maintainers": {
+      "hsjobeki": 50398876
+    },
     "members": {
-      "hsjobeki": 50398876,
+      "friedow": 17351844,
       "wamirez": 24505474
     },
     "name": "Documentation Team"
@@ -507,7 +511,6 @@
     "id": 5536808,
     "maintainers": {
       "johanot": 998763,
-      "offlinehacker": 585547,
       "saschagrunert": 695473,
       "srhb": 219362
     },
@@ -562,7 +565,6 @@
     "members": {
       "Ericson2314": 1055245,
       "emilazy": 18535642,
-      "lovek323": 265084,
       "rrbutani": 7833358,
       "sternenseemann": 3154475
     },
@@ -614,9 +616,8 @@
     },
     "members": {
       "aanderse": 7755101,
-      "jnsgruk": 668505,
-      "megheaiulian": 1788114,
-      "mkg20001": 7735145
+      "herbetom": 15121114,
+      "megheaiulian": 1788114
     },
     "name": "LXC"
   },
@@ -682,12 +683,11 @@
     "description": "Maintain the official Nix formatter and apply it to Nixpkgs: https://nixos.org/community/teams/formatting/",
     "id": 9676823,
     "maintainers": {
-      "infinisil": 20525370,
+      "MattSturgeon": 5046562,
       "jfly": 277474
     },
     "members": {
       "0x4A6F": 9675338,
-      "MattSturgeon": 5046562,
       "Sereja313": 112060595,
       "dyegoaurelio": 42411160
     },
@@ -714,7 +714,7 @@
     "id": 3620128,
     "maintainers": {
       "jopejoe1": 34899572,
-      "leona-ya": 11006031
+      "yayayayaka": 73759599
     },
     "members": {},
     "name": "nixos-release-managers"
@@ -937,7 +937,9 @@
       "balsoft": 18467667,
       "infinisil": 20525370
     },
-    "members": {},
+    "members": {
+      "pyrox0": 35778371
+    },
     "name": "Security review"
   },
   "static": {
@@ -979,7 +981,8 @@
     "description": "Maintain systemd for NixOS",
     "id": 3894007,
     "maintainers": {
-      "flokli": 183879
+      "flokli": 183879,
+      "nikstur": 61635709
     },
     "members": {
       "ElvishJerricco": 1365692,


### PR DESCRIPTION
Seems to be more out of sync than the auto-backport would fix.

Closes: #500534

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
