### PR TITLE
miranda: use gcc14Stdenv to fix build

### DIFF
--- a/pkgs/by-name/mi/miranda/package.nix
+++ b/pkgs/by-name/mi/miranda/package.nix
@@ -1,10 +1,13 @@
 {
-  stdenv,
   lib,
   fetchzip,
   fetchpatch,
+  gcc14Stdenv,
 }:
 
+let
+  stdenv = gcc14Stdenv;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "miranda";
   version = "2.066";


### PR DESCRIPTION
## Summary
- GCC 15 defaults to C23 which rejects K&R-style C code
- Using `-std=gnu17` avoids C23 issues but triggers an internal compiler error (SSA corruption) at `-O2`
- Switch to `gcc14Stdenv` to avoid both issues

## Test plan
- [x] `nix-build -A miranda` on x86_64-linux