### PR TITLE
remarkable-toolchain: fix noBrokenSymlinks check

### DIFF
--- a/pkgs/by-name/re/remarkable-toolchain/package.nix
+++ b/pkgs/by-name/re/remarkable-toolchain/package.nix
@@ -28,6 +28,11 @@ stdenv.mkDerivation (finalAttrs: {
   dontUnpack = true;
   dontBuild = true;
 
+  # The sysroot contains symlinks that point to paths only valid on the
+  # target device (e.g. /var/lock -> /run/lock), which is expected for a
+  # cross-compilation toolchain.
+  dontCheckForBrokenSymlinks = true;
+
   installPhase = ''
     mkdir -p $out
     ENVCLEANED=1 $src -y -d $out


### PR DESCRIPTION
## Summary
- The extracted sysroot contains symlinks pointing to paths only valid on the target device (e.g. `/var/lock` -> `/run/lock`)
- These dangling symlinks are expected for a cross-compilation toolchain
- Skip the broken symlinks check with `dontCheckForBrokenSymlinks`

## Test plan
- [x] `nix-build -A remarkable-toolchain` on x86_64-linux