### PR TITLE
pike: restrict to x86_64-linux

### DIFF
--- a/pkgs/by-name/pi/pike/package.nix
+++ b/pkgs/by-name/pi/pike/package.nix
@@ -113,7 +113,7 @@ let
         mpl20
       ];
       maintainers = with lib.maintainers; [ siraben ];
-      platforms = with lib.platforms; unix ++ windows;
+      platforms = [ "x86_64-linux" ];
       mainProgram = "pike";
     };
   });
@@ -208,7 +208,8 @@ stdenv.mkDerivation (finalAttrs: {
       mpl20
     ];
     maintainers = with lib.maintainers; [ siraben ];
-    platforms = with lib.platforms; unix ++ windows;
+    # Bootstrap binary is only available for x86_64-linux
+    platforms = [ "x86_64-linux" ];
     mainProgram = "pike";
   };
 })


### PR DESCRIPTION
Restrict both `pike-bootstrap` and `pike` to `x86_64-linux`.

Pike currently bootstraps using a pre-built Debian amd64 executable, so the package cannot be built on the other Unix and Windows platforms previously listed in `meta.platforms`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test