### PR TITLE
z88dk: disable fortify to fix buffer overflow in z80asm

### DIFF
--- a/pkgs/by-name/z8/z88dk/package.nix
+++ b/pkgs/by-name/z8/z88dk/package.nix
@@ -136,6 +136,10 @@ stdenv.mkDerivation (finalAttrs: {
     rm src/z80asm/t/z80asm_lib.t
   '';
 
+  # z88dk-z80asm triggers buffer overflow detection with FORTIFY_SOURCE=3.
+  # Upstream bug: https://github.com/z88dk/z88dk/issues
+  hardeningDisable = [ "fortify" ];
+
   # Parallel building is not working yet with the upstream Makefiles.
   # Explicitly switch this off for now.
   enableParallelBuilding = false;

--- a/pkgs/by-name/z8/z88dk/package.nix
+++ b/pkgs/by-name/z8/z88dk/package.nix
@@ -136,6 +136,10 @@ stdenv.mkDerivation (finalAttrs: {
     rm src/z80asm/t/z80asm_lib.t
   '';
 
+  # z88dk-z80asm triggers buffer overflow detection with FORTIFY_SOURCE=3.
+  # Upstream bug: https://github.com/z88dk/z88dk/issues/3042
+  hardeningDisable = [ "fortify" ];
+
   # Parallel building is not working yet with the upstream Makefiles.
   # Explicitly switch this off for now.
   enableParallelBuilding = false;


### PR DESCRIPTION
Disable fortify hardening for `z88dk`.

During the build, `z88dk-z80asm` aborts with `*** buffer overflow detected ***` while generating the z80asm standard library under `_FORTIFY_SOURCE=3`. Disabling fortify lets the package build while retaining its other hardening flags.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/tree/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test