### PR TITLE
home-assistant: 2026.4.1 -> 2026.4.2

### DIFF
--- a/pkgs/development/python-modules/aiocomelit/default.nix
+++ b/pkgs/development/python-modules/aiocomelit/default.nix
@@ -5,7 +5,7 @@
   colorlog,
   fetchFromGitHub,
   pint,
-  poetry-core,
+  setuptools,
   pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "aiocomelit";
-  version = "2.0.1";
+  version = "2.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -22,10 +22,10 @@ buildPythonPackage rec {
     owner = "chemelli74";
     repo = "aiocomelit";
     tag = "v${version}";
-    hash = "sha256-RlSDSxJZ6xD0ifqGT4l2Jkfzo64rrrLCE/yykeJNaYs=";
+    hash = "sha256-k/p6z+flMvmuwwHqPH9Aw/ai761kbT+HQUXVNKeqk0U=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ setuptools ];
 
   dependencies = [
     aiohttp

--- a/pkgs/development/python-modules/axis/default.nix
+++ b/pkgs/development/python-modules/axis/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "axis";
-  version = "67";
+  version = "68";
   pyproject = true;
 
   disabled = pythonOlder "3.14";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "Kane610";
     repo = "axis";
     tag = "v${version}";
-    hash = "sha256-Zfhz3AtiMSF5yNF+Z7++3O1oof5hyfues3u4bToFBYk=";
+    hash = "sha256-2a7zGgWc0QxxjCCg5yCfcepzLhEfvASv/Y8mDgl4y8M=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "opower";
-  version = "0.18.0";
+  version = "0.18.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tronikos";
     repo = "opower";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZkYZsML3xBMGNNhwVzOuUmVeRU/aJnHld6hSACuhTxc=";
+    hash = "sha256-Wy2FPWRSlxNEhqCfRwUyIxUCIdRJDIFICTJxM08+Xno=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pylitterbot/default.nix
+++ b/pkgs/development/python-modules/pylitterbot/default.nix
@@ -9,21 +9,23 @@
   pycognito,
   pyjwt,
   pytest-aiohttp,
+  pytest-cov-stub,
   pytest-freezegun,
+  pytest-timeout,
   pytestCheckHook,
   uv-dynamic-versioning,
 }:
 
 buildPythonPackage rec {
   pname = "pylitterbot";
-  version = "2025.2.0";
+  version = "2025.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "natekspencer";
     repo = "pylitterbot";
     tag = version;
-    hash = "sha256-o5A4AWil6FeHjUBgbHaA010kszhuncHHzf8+CH4QL0c=";
+    hash = "sha256-EK2QiQMHhA69p7xnyeYE+kru0k7eL9EilkAUAN6LukU=";
   };
 
   build-system = [
@@ -41,7 +43,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     aioresponses
     pytest-aiohttp
+    pytest-cov-stub
     pytest-freezegun
+    pytest-timeout
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/python-bsblan/default.nix
+++ b/pkgs/development/python-modules/python-bsblan/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-bsblan";
-  version = "5.1.3";
+  version = "5.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "liudger";
     repo = "python-bsblan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2Rynat0eXAWzlCBUJAvKrAFPLl74FMr2r1KtKPBlwYw=";
+    hash = "sha256-97Hgsu0ipX5oSAZdCikaWhj6g3gEom/Is2wnm6vpblY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/qbusmqttapi/default.nix
+++ b/pkgs/development/python-modules/qbusmqttapi/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "qbusmqttapi";
-  version = "1.4.2";
+  version = "1.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Qbus-iot";
     repo = "qbusmqttapi";
     tag = "v${version}";
-    hash = "sha256-8TNtfBxJcSwlcAgKF6Gvn+e4NGbOIE3JWBAgFKmNyKA=";
+    hash = "sha256-qwvgc80YIluIwb2532KBnVT8pOkn7a2T9FWX4Z5bG+A=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/securetar/default.nix
+++ b/pkgs/development/python-modules/securetar/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "securetar";
-  version = "2026.2.0";
+  version = "2026.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "securetar";
     tag = version;
-    hash = "sha256-76JZN0Y9uW0+HUX+j1aCIz9qOjogZ0KXOXXK8rR8Z/4=";
+    hash = "sha256-y2Ow272094Qrn52LGYkuRcjaR6d0C6bF12g7W6AwSMI=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/velbus-aio/default.nix
+++ b/pkgs/development/python-modules/velbus-aio/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "velbus-aio";
-  version = "2026.2.0";
+  version = "2026.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Cereal2nd";
     repo = "velbus-aio";
     tag = finalAttrs.version;
-    hash = "sha256-lQl5f7O6ZMfYGleyOESSbW87RPS7eBi3YZqCAcQfLow=";
+    hash = "sha256-bFR4iZdvkY8pg4OzAH7E0vEw7E5kyEII2iLfeG5p3OQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "zha";
-  version = "1.1.1";
+  version = "1.1.2";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha";
     tag = version;
-    hash = "sha256-hr+FeBVQ1yqQGOhhTBd4c1g6OEntGaPPuHt1/nD+HKE=";
+    hash = "sha256-GPl3nXi24ukNHDE81keyu8m1xgS0MSRdo7ULxy6foGQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zinvolt/default.nix
+++ b/pkgs/development/python-modules/zinvolt/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "zinvolt";
-  version = "0.4.1";
+  version = "0.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-zinvolt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b6NWEk2sn0LpCd2qTpcU4pVH01FzMNHM6ybQU24mN1c=";
+    hash = "sha256-psZ9/V/bBGGvKdKxuvncJzJOB1jolYTeNw2XOJmxfco=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.4.1";
+  version = "2026.4.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "andrew-codechimp";
   domain = "battery_notes";
-  version = "3.4.1";
+  version = "3.4.3";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "HA-Battery-Notes";
     tag = version;
-    hash = "sha256-1FRGNtNjX1YBUmnH9G2CoejkJKvIaWIMegvzdfFx76I=";
+    hash = "sha256-ftIq0PbTVJ1xuCyHH9MCfxA56x2ZNsPwCjCdivWMwZw=";
   };
 
   # has no tests

--- a/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
@@ -15,13 +15,13 @@
 buildHomeAssistantComponent rec {
   owner = "amitfin";
   domain = "oref_alert";
-  version = "6.15.2";
+  version = "6.17.1";
 
   src = fetchFromGitHub {
     owner = "amitfin";
     repo = "oref_alert";
     tag = "v${version}";
-    hash = "sha256-2JWvTbnG8PNLLzTGAyz/u7oVCC3reHWYn9utawxIp1s=";
+    hash = "sha256-vpRVTxstuNL29C8cl+B4U/jTDfIOLYepGmr1uYjylYQ=";
   };
 
   # Do not publish cards, currently broken, attempting to write to nix store.

--- a/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
@@ -17,13 +17,13 @@
 buildHomeAssistantComponent rec {
   owner = "bramstroker";
   domain = "powercalc";
-  version = "1.20.11";
+  version = "1.20.12";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "homeassistant-powercalc";
     tag = "v${version}";
-    hash = "sha256-FDCdB0Un7B51yJNGaRi1sCY/XNurGbySwxe6mZtkH60=";
+    hash = "sha256-kOxY/7JjDHbQC7adfcRDgDJnvU2TRyaKYXxfmo/cXPQ=";
   };
 
   dependencies = [ numpy ];

--- a/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya_local/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "make-all";
   domain = "tuya_local";
-  version = "2026.3.3";
+  version = "2026.4.0";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "tuya-local";
     tag = version;
-    hash = "sha256-cQA2lv8O/17GHLKjJktC4ox1ZEtW7ngS1X+zeJgUeHc=";
+    hash = "sha256-7Q7bkyWLIv6m8d3XaKaoiBIXcOeb/1YcL4kfl0HfUZY=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -253,7 +253,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.4.1";
+  hassVersion = "2026.4.2";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -274,13 +274,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-Cowd0vNtWeh5XTNZQxkLqZtYZjfbdw/6FhuIGs1cNQ4=";
+    hash = "sha256-dMkTuFEWlWAVptNEiYbBbqUM4ymXMfBAAyRsvzkcWls=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-5nEhbXFZp4u8zTw00fd2W3PBafPhynPzpmF6Dj+G7Mo=";
+    hash = "sha256-eRdwYU/D4AjGbIfNbumBUBfbsr/P0i1k0KRaC5+1jfg=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260325.6";
+  version = "20260325.7";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-YGIJW+MCiTzFlQkUEjtxMvYpYgvJJZXyslin7Zw1jRU=";
+    hash = "sha256-0OQM+UNI1QX3V53OQ57NuDXr05BllaYRjKnNrFXpwDc=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.322";
+  version = "0.13.323";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-5SnDNnFdMFIT9f4+vbSk/F34lM2sWxkgk+IyqRqbT0Y=";
+    hash = "sha256-kYBtVhvmH7Jt7rJw54D8dbeo/PboEZh/o8lt62IoYvU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.4.1";
+  version = "2026.4.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-jU1257IfLevROsRXHmx6jmq3ud0WhpsuiXaUm0tLKgc=";
+    hash = "sha256-IBzRmkKxh6jozVpkQdsTkOubHOjNPNirnitsZJ39oIg=";
   };
 
   build-system = [

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -266,5 +266,5 @@ in
     callPackages ../build-support/prefer-remote-fetch/tests.nix { }
   );
 
-  home-assistant-component-tests = recurseIntoAttrs pkgs.home-assistant.tests.components;
+  home-assistant-components = recurseIntoAttrs pkgs.home-assistant.tests.components;
 }


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2026.4.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
