### PR TITLE
nixos/tpm2: Documentation changes

### DIFF
--- a/nixos/modules/security/tpm2.md
+++ b/nixos/modules/security/tpm2.md
@@ -82,10 +82,19 @@ security.tpm2 = {
     tctiEnvironment.interface = "tabrmd";
 }
 ```
+
+Or to use the Linux kernel resource manager:
+```
+security.tpm2 = {
+    enable = true;
+    pkcs11.enable = true;
+
+    tctiEnvironment.enable = true;
+}
+```
 `enable = true;` is required for any tpm functionality other than the raw character device and kernel resource manager to be available.
 
 `abrmd.enable = true;` causes the tpm2-abrmd program (the user-space resource manager) to run as a systemd service.
-Generally you want this because the user-space resource manager gets more frequent updates than the kernel-space RM, and there aren't any kernel RM features that are unavailable in the user-space RM.
 
 `pkcs11.enable = true;` makes the PKCS11 tool and libraries available in the system path.
 Generally you want this because it's unlikely to cause problems and it's required by one of the more common TPM use cases, which is protecting an ssh key using the TPM.

--- a/nixos/modules/security/tpm2.md
+++ b/nixos/modules/security/tpm2.md
@@ -59,6 +59,9 @@ So the raw tpm character device, the kernel RM, and `tabrmd` are all "TCTIs".
 The ESAPI library speaks the client side of the TCTI protocol, and can be connected to any server TCTI.
 All of the other libraries or programs that work with TPM all use ESAPI under the hood, and so a common characteristic among all these libraries is that you will find you need to configure them in some way as to which TCTI they should be talking to.
 
+A TPM-enabled system should choose to enable either the Linux kernel resource manager or the `tabrmd` resource manager. The tpm2-software group does not have absolute guidance on this, but the userspace resource manager supports an anti-contention feature known as session un-gapping but has not seen recent development.
+The kernel resource manager has seen more active development and is the resource manager of choice in immutable distributions such as Fedora Silverblue.
+
 #### Higher Level Interfaces {#module-security-tpm2-introduction-hli}
 
 As alluded to previously, there are a number of ways of speaking the client side TCTI that all amount to wrappers around ESAPI. They include:
@@ -75,6 +78,16 @@ A typical configuration is:
 ```
 security.tpm2 = {
     enable = true;
+    pkcs11.enable = true;
+
+    tctiEnvironment.enable = true;
+}
+```
+
+Or to use the `tpm2-abrmd` resource manager:
+```
+security.tpm2 = {
+    enable = true;
     abrmd.enable = true;
     pkcs11.enable = true;
 
@@ -85,7 +98,6 @@ security.tpm2 = {
 `enable = true;` is required for any tpm functionality other than the raw character device and kernel resource manager to be available.
 
 `abrmd.enable = true;` causes the tpm2-abrmd program (the user-space resource manager) to run as a systemd service.
-Generally you want this because the user-space resource manager gets more frequent updates than the kernel-space RM, and there aren't any kernel RM features that are unavailable in the user-space RM.
 
 `pkcs11.enable = true;` makes the PKCS11 tool and libraries available in the system path.
 Generally you want this because it's unlikely to cause problems and it's required by one of the more common TPM use cases, which is protecting an ssh key using the TPM.


### PR DESCRIPTION
The current documentation regarding TPM2 setup (added in #440251) includes a recommendation to enable the `tpm2-abrmd` daemon. While `tpm2-abrmd` could be useful to some NixOS users, the justification in the docs (that it receives updates at a more frequent rate than the Linux kernel) is not very persuasive, as the [tpm2-abrmd](https://github.com/tpm2-software/tpm2-abrmd) project has not received any code updates in many years, while the Linux kernel's TPM resource manager has continued to receive updates in that time.

Other Linux distributions that ship with TPM2 support (including immutable OSes such as [Fedora Silverblue](https://pagure.io/workstation-ostree-config/tree/main)) do not include the tpm2-abrmd package, so I don't think it makes sense to explicitly recommend it to users without a different reason to do so.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
