### PR TITLE
miranda: use gcc14Stdenv to fix build

### DIFF
--- a/pkgs/by-name/mi/miranda/package.nix
+++ b/pkgs/by-name/mi/miranda/package.nix
@@ -1,11 +1,11 @@
 {
-  stdenv,
   lib,
   fetchzip,
   fetchpatch,
+  gcc14Stdenv,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "miranda";
   version = "2.066";
 


### PR DESCRIPTION
GCC 15 defaults to C23 which rejects K&R C. Using `-std=gnu17` works around C23 but triggers an ICE (SSA corruption) at `-O2`. Use `gcc14Stdenv` to avoid both.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin