### PR TITLE
github-copilot-cli: fix shell errors inside `nix develop` environments

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/package.nix
+++ b/pkgs/by-name/gi/github-copilot-cli/package.nix
@@ -4,6 +4,7 @@
   autoPatchelfHook,
   fetchurl,
   makeBinaryWrapper,
+  bash,
   versionCheckHook,
 }:
 
@@ -40,7 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     # Filename must explictly be "copilot" for internal self-referencing
     makeWrapper $out/libexec/copilot $out/bin/copilot \
-      --add-flags "--no-auto-update"
+      --add-flags "--no-auto-update" \
+      --prefix PATH : "${lib.makeBinPath [ bash ]}"
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A `nix develop` environment (note: `nix-shell` environments work fine however) adds a
non-interactive bash (`bashNonInteractive`) to early in `PATH`, which breaks copilot's shell
commands with errors like:
```bash
❯ Try running a series of commands and see if you see their output

● Running a few diagnostic shell commands (pwd, ls, uname, date, whoami, id, env, git status, df) to capture their output. This shows current directory contents and basic system info. Now
  executing the commands.

● Run diagnostic shell commands (shell)
  │ pwd ; echo '--- ls -la ---' ; ls -la --color=never || true ; echo '--- uname -a ---' ; uname -a || true ; echo '--- date ---' ; date -u || true ; echo '--- whoami ---' ; whoami || true ;
  │ echo '--- id ---' ; id || true ; echo '--- env (head) ---' ; env | sort | head -n 50 || true ; echo '--- git status ---' ; git --no-pager status || true ; echo '--- df -h . ---' ; df -h .
  │ || true
  └ 1 line...

✗ Read shell output Waiting up to 2 seconds for command output
  └ Invalid shell ID: 0. Please supply a valid shell ID to read output from.

    <no active shell sessions>
```

Adding the interactive bash to the wrapper makes its `bash` resolve to the proper one

See github/copilot-cli#1428

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
