### PR TITLE
gmrender-resurrect: migrate to by-name

### DIFF
--- a/pkgs/by-name/gm/gmrender-resurrect/package.nix
+++ b/pkgs/by-name/gm/gmrender-resurrect/package.nix
@@ -5,12 +5,7 @@
   autoreconfHook,
   pkg-config,
   makeWrapper,
-  gstreamer,
-  gst-plugins-base,
-  gst-plugins-good,
-  gst-plugins-bad,
-  gst-plugins-ugly,
-  gst-libav,
+  gst_all_1,
   libupnp,
 }:
 
@@ -25,6 +20,16 @@ let
     gst-plugins-ugly
     gst-libav
   ];
+
+  inherit (gst_all_1)
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-plugins-ugly
+    gst-libav
+    ;
+
 in
 stdenv.mkDerivation {
   pname = "gmrender-resurrect";

--- a/pkgs/by-name/gm/gmrender-resurrect/package.nix
+++ b/pkgs/by-name/gm/gmrender-resurrect/package.nix
@@ -5,17 +5,21 @@
   autoreconfHook,
   pkg-config,
   makeWrapper,
-  gstreamer,
-  gst-plugins-base,
-  gst-plugins-good,
-  gst-plugins-bad,
-  gst-plugins-ugly,
-  gst-libav,
+  gst_all_1,
   libupnp,
 }:
 
 let
   version = "0.3.1";
+
+  inherit (gst_all_1)
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-plugins-ugly
+    gst-libav
+    ;
 
   pluginPath = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
     gstreamer
@@ -25,6 +29,7 @@ let
     gst-plugins-ugly
     gst-libav
   ];
+
 in
 stdenv.mkDerivation {
   pname = "gmrender-resurrect";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2391,17 +2391,6 @@ with pkgs;
 
   glogg = libsForQt5.callPackage ../tools/text/glogg { };
 
-  gmrender-resurrect = callPackage ../tools/networking/gmrender-resurrect {
-    inherit (gst_all_1)
-      gstreamer
-      gst-plugins-base
-      gst-plugins-good
-      gst-plugins-bad
-      gst-plugins-ugly
-      gst-libav
-      ;
-  };
-
   gnome-panel-with-modules = callPackage ../by-name/gn/gnome-panel/wrapper.nix { };
 
   dapl = callPackage ../development/interpreters/dzaima-apl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2281,17 +2281,6 @@ with pkgs;
 
   gitlab-workhorse = callPackage ../by-name/gi/gitlab/gitlab-workhorse { };
 
-  gmrender-resurrect = callPackage ../tools/networking/gmrender-resurrect {
-    inherit (gst_all_1)
-      gstreamer
-      gst-plugins-base
-      gst-plugins-good
-      gst-plugins-bad
-      gst-plugins-ugly
-      gst-libav
-      ;
-  };
-
   gnome-panel-with-modules = callPackage ../by-name/gn/gnome-panel/wrapper.nix { };
 
   dapl = callPackage ../development/interpreters/dzaima-apl {


### PR DESCRIPTION
This pull request refactors how the `gmrender-resurrect` package is defined and referenced in the Nixpkgs repository, improving maintainability and consistency with other packages. The most important changes are:

**Package organization and naming:**

* Renamed and moved the `gmrender-resurrect` package definition from `pkgs/tools/networking/gmrender-resurrect/default.nix` to `pkgs/by-name/gm/gmrender-resurrect/package.nix`, aligning with the by-name directory structure.

**Dependency management:**

* Updated the package definition to use the `gst_all_1` attribute set for GStreamer dependencies, making dependency management more consistent and reducing duplication.

**Package reference cleanup:**

* Removed the explicit `gmrender-resurrect` package definition from `pkgs/top-level/all-packages.nix`, as it is now handled through the by-name mechanism.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
