### PR TITLE
grove: init at 0.13.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30099,6 +30099,12 @@
     githubId = 908716;
     name = "Zach Coyle";
   };
+  zachthieme = {
+    name = "Zach Thieme";
+    email = "zach@techsage.org";
+    github = "zachthieme";
+    githubId = 590418;
+  };
   ZachDavies = {
     name = "Zach Davies";
     email = "zdmalta@proton.me";

--- a/pkgs/by-name/gr/grove/package.nix
+++ b/pkgs/by-name/gr/grove/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "grove";
+  version = "0.13.1";
+
+  src = fetchFromGitHub {
+    owner = "zachthieme";
+    repo = "grove";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-O2PIgKkFTOg84WYNvNWcgtkjZprQV8dWmuCCFz61gns=";
+  };
+
+  vendorHash = "sha256-s5odRE+tm4K7dEDJVKVF/3882c6dCygOldJCMqt0wNM=";
+
+  frontend = buildNpmPackage {
+    pname = "grove-frontend";
+    inherit (finalAttrs) src version;
+
+    sourceRoot = "${finalAttrs.src.name}/web";
+
+    npmDepsHash = "sha256-b2B6e2nW0tzrNCMGgUOoVNOP3umLh86viHKQ8OPMd44=";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/* $out/
+      runHook postInstall
+    '';
+  };
+
+  preBuild = ''
+    mkdir -p web/dist
+    cp -r ${finalAttrs.frontend}/* web/dist/
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/zachthieme/grove/cmd.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Interactive web-based org chart planner with CSV/XLSX import and drag-and-drop editing";
+    homepage = "https://github.com/zachthieme/grove";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ zachthieme ];
+    mainProgram = "grove";
+  };
+})


### PR DESCRIPTION
Interactive web-based org chart planner with CSV/XLSX import and drag-and-drop editing. Go backend with embedded React frontend via `go:embed`.

Homepage: https://github.com/zachthieme/grove

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test