### PR TITLE
{dapl,dapl-native}: migrate to by-name

### DIFF
--- a/pkgs/by-name/da/dapl-native/package.nix
+++ b/pkgs/by-name/da/dapl-native/package.nix
@@ -1,0 +1,13 @@
+{
+  dapl,
+  graalvmPackages,
+  stdenv,
+  buildNativeImage ? true,
+  graalvm ? graalvmPackages.graalvm-ce,
+}:
+
+dapl.override {
+  inherit buildNativeImage;
+  jre = graalvm;
+  stdenvNoCC = stdenv;
+}

--- a/pkgs/by-name/da/dapl/package.nix
+++ b/pkgs/by-name/da/dapl/package.nix
@@ -1,13 +1,17 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
-  jdk,
+  jre,
   makeWrapper,
-  buildNativeImage ? true,
+  buildNativeImage ? false,
 }:
 
-stdenv.mkDerivation rec {
+let
+  jdk = jre;
+in
+
+stdenvNoCC.mkDerivation rec {
   pname = "dapl" + lib.optionalString buildNativeImage "-native";
   version = "0.2.0+date=2021-10-16";
 
@@ -75,7 +79,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = [ ];
     inherit (jdk.meta) platforms;
-    broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dapl-native.x86_64-darwin
+    broken = stdenvNoCC.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dapl-native.x86_64-darwin
   };
 }
 # TODO: Processing app

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2400,11 +2400,6 @@ with pkgs;
 
   gnome-panel-with-modules = callPackage ../by-name/gn/gnome-panel/wrapper.nix { };
 
-  dapl = callPackage ../development/interpreters/dzaima-apl {
-    buildNativeImage = false;
-    stdenv = stdenvNoCC;
-    jdk = jre;
-  };
   dapl-native = callPackage ../development/interpreters/dzaima-apl {
     buildNativeImage = true;
     jdk = graalvmPackages.graalvm-ce;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2400,11 +2400,6 @@ with pkgs;
 
   gnome-panel-with-modules = callPackage ../by-name/gn/gnome-panel/wrapper.nix { };
 
-  dapl-native = callPackage ../development/interpreters/dzaima-apl {
-    buildNativeImage = true;
-    jdk = graalvmPackages.graalvm-ce;
-  };
-
   gnucap-full = gnucap.withPlugins (p: [ p.verilog ]);
 
   gnugrep = callPackage ../tools/text/gnugrep { };


### PR DESCRIPTION
This pull request refactors the packaging of the `dapl` (Dzaima APL) interpreter to improve maintainability and align with Nixpkgs conventions. The main changes involve moving and renaming files, updating the build logic, and simplifying how `dapl` and its native image variant are defined.

**Refactoring and package reorganization:**

* Moved and renamed the `dapl` package definition from `pkgs/development/interpreters/dzaima-apl/default.nix` to `pkgs/by-name/da/dapl/package.nix`, and updated the code to use `stdenvNoCC` and `jre` instead of `stdenv` and `jdk` for improved clarity and correctness.
* Removed direct references to `dapl` and `dapl-native` from `pkgs/top-level/all-packages.nix`, likely in favor of the new by-name structure.

**Native image build improvements:**

* Added a new `pkgs/by-name/da/dapl-native/package.nix` file to define the native image build of `dapl` using GraalVM, leveraging the override mechanism for cleaner configuration.

These changes make the package definitions more modular and easier to maintain, while also aligning with current Nixpkgs best practices.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
