### PR TITLE
swiftformat: 0.60.1 -> 0.61.0

### DIFF
--- a/pkgs/by-name/sw/swiftformat/package.nix
+++ b/pkgs/by-name/sw/swiftformat/package.nix
@@ -1,24 +1,21 @@
 {
-  stdenv,
   lib,
   fetchFromGitHub,
   swift,
-  swiftformat,
   swiftpm,
-  testers,
   versionCheckHook,
   nix-update-script,
 }:
 
 swift.stdenv.mkDerivation rec {
   pname = "swiftformat";
-  version = "0.60.1";
+  version = "0.61.0";
 
   src = fetchFromGitHub {
     owner = "nicklockwood";
     repo = "SwiftFormat";
     rev = version;
-    sha256 = "sha256-IOtp+TBcWPb6RR47AoITtR+7xAulP+ZQcWukX5YYnVc=";
+    sha256 = "sha256-+57Cuok7hIXaTZi699sIoqORFgFWEXfzl8P4sJkwFNE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION

## Things done

Update https://github.com/nicklockwood/SwiftFormat/releases/tag/0.61.0

Works fine on `aarch64-darwin`:
```console
$ nix-build -A swiftformat
/nix/store/q5gg5z7j7r7w50s0gdn8sr01448sf532-swiftformat-0.61.0
$ ./result/bin/swiftformat --version
0.61.0
$ echo "class test{}" > test.swift
$ ./result/bin/swiftformat --swiftversion 5.8 test.swift
Running SwiftFormat...
SwiftFormat completed in 0.01s.
1/1 files formatted.
$ cat test.swift
class test {}
$ ./result/bin/swiftformat --swiftversion 5.8 test.swift
Running SwiftFormat...
SwiftFormat completed in 0s.
0/1 files formatted.
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
