### PR TITLE
lib.systems: add esp32 support

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -72,6 +72,7 @@ let
     "x86_64-netbsd"
 
     # none
+    "xtensa-none"
     "aarch64_be-none"
     "aarch64-none"
     "arm-none"

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -179,6 +179,11 @@ rec {
     libc = "newlib";
   };
 
+  esp32-embedded = {
+    config = "xtensa-esp32-none-elf";
+    libc = "picolibc";
+  };
+
   riscv32-embedded = {
     config = "riscv32-none-elf";
     libc = "newlib";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -209,6 +209,13 @@ rec {
         arch = "armv8-a";
       };
 
+      xtensa = {
+        bits = 32;
+        significantByte = littleEndian;
+        family = "xtensa";
+        arch = "xtensa";
+      };
+
       i386 = {
         bits = 32;
         significantByte = littleEndian;
@@ -508,6 +515,8 @@ rec {
     # Actually matters, unlocking some MinGW-w64-specific options in GCC. See
     # bottom of https://sourceforge.net/p/mingw-w64/wiki2/Unicode%20apps/
     w64 = { };
+
+    esp32 = { };
 
     none = { };
     unknown = { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6382,6 +6382,8 @@ with pkgs;
       relibc
     else if libc == "llvm" then
       llvmPackages_20.libc
+    else if libc == "picolibc" then
+      picolibc
     else
       throw "Unknown libc ${libc}";
 


### PR DESCRIPTION
This PR adds minimal xtensa ESP32 support to pkgsCross. Unfortunately picolibc currently causes an infinite recursion error
Example:
```nix
nativeBuildInputs = [
    (wrapCC (pkgsCross.esp32-embedded.buildPackages.gcc.cc.override {
        langRust = true;
    }))
   pkgsCross.esp32-embedded.buildPackages.binutils
];
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
