### PR TITLE
lib/types: add types.record and use it for hot attrsOf-submodule options

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -168,6 +168,14 @@ checkConfigError() {
     fi
 }
 
+# types.record
+checkConfigOutput '^"alice"$' config.people.alice.name ./record.nix
+checkConfigOutput '^true$' config.people.alice.cool ./record.nix
+checkConfigOutput '^2019$' config.people.bob.since ./record.nix
+checkConfigOutput '^false$' config.people.bob.cool ./record.nix
+checkConfigError 'unknown field.s.: age' config.people.alice.name ./record.nix ./record-bad-field.nix
+checkConfigError 'is not of type .signed integer' config.people.alice.since ./record.nix ./record-bad-field-type.nix
+
 # Shorthand meta attribute does not duplicate the config
 checkConfigOutput '^"one two"$' config.result ./shorthand-meta.nix
 

--- a/lib/tests/modules/record-bad-field-type.nix
+++ b/lib/tests/modules/record-bad-field-type.nix
@@ -1,0 +1,3 @@
+{
+  people.alice.since = "forever";
+}

--- a/lib/tests/modules/record-bad-field.nix
+++ b/lib/tests/modules/record-bad-field.nix
@@ -1,0 +1,3 @@
+{
+  people.alice.age = 1;
+}

--- a/lib/tests/modules/record.nix
+++ b/lib/tests/modules/record.nix
@@ -1,0 +1,35 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+  person = types.record {
+    fields = {
+      since = {
+        type = types.int;
+      };
+      name = {
+        type = types.str;
+      };
+      cool = {
+        type = types.bool;
+        default = true;
+      };
+    };
+    finalise =
+      {
+        name,
+        self,
+        fields,
+      }:
+      {
+        name = lib.mkDefault name;
+      };
+  };
+in
+{
+  options.people = mkOption { type = types.attrsOf person; };
+  config.people.alice.since = 2016;
+  config.people.bob = {
+    since = 2019;
+    cool = false;
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1127,6 +1127,139 @@ rec {
       nestedTypes.elemType = elemType;
     };
 
+  # A lightweight typed record: a fixed set of named, typed fields with
+  # optional defaults. Unlike `submodule`, this performs no `evalModules`
+  # fixpoint, no imports resolution, no `_module.args` plumbing and no
+  # unmatched-definitions tree walk — it merely runs `mergeDefinitions`
+  # once per declared field. Intended for heavily-instantiated
+  # `attrsOf (submodule …)` options whose element modules are pure data.
+  #
+  # `fields.<name>` is an attrset with at least `type`, optionally
+  # `default`, `description`, `example`, `defaultText`, `internal`,
+  # `visible`.
+  #
+  # `finalise` (optional) is `{ name, self, fields }: { <fieldName> = <def>; … }`
+  # and supplies extra per-instance definitions (e.g. derived defaults that
+  # depend on the `attrsOf` key or on sibling fields). `self` is the final
+  # merged record (lazy fixpoint), `fields.<name>` is the per-field
+  # `mergeDefinitions` result (exposing `.isDefined` / `.highestPrio`).
+  record =
+    {
+      fields,
+      finalise ? null,
+      description ? "record",
+      # File(s) declaring this record, used for the manual's
+      # "declared by" links since there are no real `mkOption` calls.
+      declarations ? [ ],
+    }@args:
+    let
+      fieldNames = attrNames fields;
+    in
+    mkOptionType {
+      name = "record";
+      inherit description;
+      descriptionClass = "noun";
+      check = isAttrs;
+      merge =
+        loc: defs:
+        let
+          name = last loc;
+          # Push the definition's file down onto each field value so that
+          # per-field `mergeDefinitions` can attribute errors correctly.
+          pushed = map (
+            def:
+            mapAttrs (_: v: {
+              inherit (def) file;
+              value = v;
+            }) def.value
+          ) defs;
+          byField = zipAttrsWith (_: ds: ds) pushed;
+          unknown = builtins.removeAttrs byField fieldNames;
+
+          extra =
+            if finalise == null then
+              { }
+            else
+              finalise {
+                inherit name;
+                self = final;
+                fields = fieldMerges;
+              };
+
+          fieldDefs =
+            n: field:
+            (byField.${n} or [ ])
+            ++ lib.optional (extra ? ${n}) {
+              file = "finalise of record `${showOption loc}'";
+              value = extra.${n};
+            }
+            ++ lib.optional (field ? default) {
+              file = "default of record field `${showOption (loc ++ [ n ])}'";
+              value = lib.mkOptionDefault field.default;
+            };
+
+          fieldMerges = mapAttrs (
+            n: field: mergeDefinitions (loc ++ [ n ]) field.type (fieldDefs n field)
+          ) fields;
+
+          final = mapAttrs (_: m: m.mergedValue) fieldMerges;
+        in
+        if unknown != { } then
+          throw ''
+            A definition for option `${showOption loc}' has unknown field(s): ${concatStringsSep ", " (attrNames unknown)}
+            Known fields: ${concatStringsSep ", " fieldNames}
+            Definition values:${showDefs (concatLists (builtins.attrValues unknown))}''
+        else
+          final;
+      emptyValue = {
+        value = { };
+      };
+      # Produce option-like stubs so the docs generator (which uses
+      # `collect isOption`) keeps rendering sub-options as before.
+      getSubOptions =
+        prefix:
+        mapAttrs (
+          n: field:
+          {
+            _type = "option";
+            loc = prefix ++ [ n ];
+            isDefined = field ? default;
+            declarations = field.declarations or declarations;
+            declarationPositions = [ ];
+            definitions = [ ];
+            files = [ ];
+            options = [ ];
+            type = field.type;
+            description = field.description or null;
+            internal = field.internal or false;
+            visible = field.visible or true;
+            readOnly = false;
+          }
+          // optionalAttrs (field ? default) { inherit (field) default; }
+          // optionalAttrs (field ? defaultText) { inherit (field) defaultText; }
+          // optionalAttrs (field ? example) { inherit (field) example; }
+          // optionalAttrs (field ? default || field ? defaultText) {
+            value = field.default or (throw "no default");
+          }
+        ) fields;
+      nestedTypes = mapAttrs (_: f: f.type) fields;
+      functor = defaultFunctor "record" // {
+        type = lib.types.record;
+        payload = args;
+        binOp =
+          lhs: rhs:
+          if lhs.finalise or null != null && rhs.finalise or null != null then
+            null
+          else
+            {
+              fields = lhs.fields // rhs.fields;
+              declarations = (lhs.declarations or [ ]) ++ (rhs.declarations or [ ]);
+              finalise = if lhs.finalise or null != null then lhs.finalise or null else rhs.finalise or null;
+              description = lhs.description or rhs.description or "record";
+            };
+      };
+    };
+
   # A submodule (like typed attribute set). See NixOS manual.
   submodule =
     modules:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1202,7 +1202,9 @@ rec {
             n: field: mergeDefinitions (loc ++ [ n ]) field.type (fieldDefs n field)
           ) fields;
 
-          final = mapAttrs (_: m: m.mergedValue) fieldMerges;
+          final = mapAttrs (
+            n: m: if fields.${n} ? apply then fields.${n}.apply m.mergedValue else m.mergedValue
+          ) fieldMerges;
         in
         if unknown != { } then
           throw ''

--- a/nixos/lib/systemd-types.nix
+++ b/nixos/lib/systemd-types.nix
@@ -8,6 +8,7 @@ let
   inherit (systemdUtils.lib)
     automountConfig
     makeUnit
+    unitNameType
     mountConfig
     pathConfig
     sliceConfig
@@ -20,7 +21,6 @@ let
     ;
 
   inherit (systemdUtils.unitOptions)
-    concreteUnitOptions
     stage1AutomountOptions
     stage1CommonUnitOptions
     stage1MountOptions
@@ -116,16 +116,116 @@ in
 
 {
   units = attrsOf (
-    submodule (
-      { name, config, ... }:
-      {
-        options = concreteUnitOptions;
-        config = {
-          name = mkDefault name;
-          unit = mkDefault (makeUnit name config);
+    lib.types.record {
+      declarations = [ ./systemd-unit-options.nix ];
+      description = "systemd unit";
+      fields = {
+
+        enable = {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            If set to false, this unit will be a symlink to
+            /dev/null. This is primarily useful to prevent specific
+            template instances
+            (e.g. `serial-getty@ttyS0`) from being
+            started. Note that `enable=true` does not
+            make a unit start by default at boot; if you want that, see
+            `wantedBy`.
+          '';
         };
-      }
-    )
+
+        name = {
+          type = lib.types.str;
+          description = ''
+            The name of this systemd unit, including its extension.
+            This can be used to refer to this unit from other systemd units.
+          '';
+        };
+
+        overrideStrategy = {
+          type = lib.types.enum [
+            "asDropinIfExists"
+            "asDropin"
+          ];
+          default = "asDropinIfExists";
+          description = ''
+            Defines how unit configuration is provided for systemd:
+
+            `asDropinIfExists` creates a unit file when no unit file is provided by the package
+            otherwise it creates a drop-in file named `overrides.conf`.
+
+            `asDropin` creates a drop-in file named `overrides.conf`.
+            Mainly needed to define instances for systemd template units (e.g. `systemd-nspawn@mycontainer.service`).
+
+            See also {manpage}`systemd.unit(5)`.
+          '';
+        };
+
+        requiredBy = {
+          type = lib.types.listOf unitNameType;
+          default = [ ];
+          description = ''
+            Units that require (i.e. depend on and need to go down with) this unit.
+            As discussed in the `wantedBy` option description this also creates
+            `.requires` symlinks automatically.
+          '';
+        };
+
+        upheldBy = {
+          type = lib.types.listOf unitNameType;
+          default = [ ];
+          description = ''
+            Keep this unit running as long as the listed units are running. This is a continuously
+            enforced version of wantedBy.
+          '';
+        };
+
+        wantedBy = {
+          type = lib.types.listOf unitNameType;
+          default = [ ];
+          description = ''
+            Units that want (i.e. depend on) this unit. The default method for
+            starting a unit by default at boot time is to set this option to
+            `["multi-user.target"]` for system services. Likewise for user units
+            (`systemd.user.<name>.*`) set it to `["default.target"]` to make a unit
+            start by default when the user `<name>` logs on.
+
+            This option creates a `.wants` symlink in the given target that exists
+            statelessly without the need for running `systemctl enable`.
+            The `[Install]` section described in {manpage}`systemd.unit(5)` however is
+            not supported because it is a stateful process that does not fit well
+            into the NixOS design.
+          '';
+        };
+
+        aliases = {
+          type = lib.types.listOf unitNameType;
+          default = [ ];
+          description = "Aliases of that unit.";
+        };
+
+        text = {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Text of this systemd unit.";
+        };
+
+        unit = {
+          type = lib.types.unspecified;
+          internal = true;
+          description = "The generated unit.";
+        };
+
+      };
+
+      finalise =
+        { name, self, ... }:
+        {
+          name = mkDefault name;
+          unit = mkDefault (makeUnit name self);
+        };
+    }
   );
 
   services = attrsOf (submodule [

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -36,6 +36,7 @@ let
     mkIf
     mkMerge
     mkOption
+    mkOptionDefault
     mkRenamedOptionModule
     optional
     optionals
@@ -129,435 +130,441 @@ let
     password (i.e. via {command}`login` command).
   '';
 
-  userOpts =
-    { name, config, ... }:
-    {
+  field = id;
 
-      options = {
+  userOpts = types.record {
+    declarations = [ ./users-groups.nix ];
+    description = "user account configuration";
+    fields = {
 
-        enable = mkOption {
-          type = types.bool;
-          default = true;
-          example = false;
-          description = ''
-            If set to false, the user account will not be created. This is useful for when you wish to conditionally
-            disable user accounts.
-          '';
-        };
-
-        name = mkOption {
-          type = types.passwdEntry types.str;
-          apply =
-            x:
-            assert (
-              stringLength x < 32 || abort "Username '${x}' is longer than 31 characters which is not allowed!"
-            );
-            x;
-          description = ''
-            The name of the user account. If undefined, the name of the
-            attribute set will be used.
-          '';
-        };
-
-        description = mkOption {
-          type = types.passwdEntry types.str;
-          default = "";
-          example = "Alice Q. User";
-          description = ''
-            A short description of the user account, typically the
-            user's full name.  This is actually the “GECOS” or “comment”
-            field in {file}`/etc/passwd`.
-          '';
-        };
-
-        uid = mkOption {
-          type = with types; nullOr int;
-          default = null;
-          description = ''
-            The account UID. If the UID is null, a free UID is picked on
-            activation.
-          '';
-        };
-
-        isSystemUser = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Indicates if the user is a system user or not. This option
-            only has an effect if {option}`uid` is
-            {option}`null`, in which case it determines whether
-            the user's UID is allocated in the range for system users
-            (below 1000) or in the range for normal users (starting at
-            1000).
-            Exactly one of `isNormalUser` and
-            `isSystemUser` must be true.
-          '';
-        };
-
-        isNormalUser = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Indicates whether this is an account for a “real” user.
-            This automatically sets {option}`group` to `users`,
-            {option}`createHome` to `true`,
-            {option}`home` to {file}`/home/«username»`,
-            {option}`useDefaultShell` to `true`,
-            and {option}`isSystemUser` to `false`.
-            Exactly one of `isNormalUser` and `isSystemUser` must be true.
-          '';
-        };
-
-        group = mkOption {
-          type = types.str;
-          apply =
-            x:
-            assert (
-              stringLength x < 32 || abort "Group name '${x}' is longer than 31 characters which is not allowed!"
-            );
-            x;
-          default = "";
-          description = "The user's primary group.";
-        };
-
-        extraGroups = mkOption {
-          type = types.listOf types.str;
-          default = [ ];
-          description = "The user's auxiliary groups.";
-        };
-
-        home = mkOption {
-          type = types.passwdEntry types.path;
-          default = "/var/empty";
-          description = "The user's home directory.";
-        };
-
-        homeMode = mkOption {
-          type = types.strMatching "[0-7]{1,5}";
-          default = "700";
-          description = "The user's home directory mode in numeric format. See {manpage}`chmod(1)`. The mode is only applied if {option}`users.users.<name>.createHome` is true.";
-        };
-
-        cryptHomeLuks = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          description = ''
-            Path to encrypted luks device that contains
-            the user's home directory.
-          '';
-        };
-
-        pamMount = mkOption {
-          type = with types; attrsOf str;
-          default = { };
-          description = ''
-            Attributes for user's entry in
-            {file}`pam_mount.conf.xml`.
-            Useful attributes might include `path`,
-            `options`, `fstype`, and `server`.
-            See <https://pam-mount.sourceforge.net/pam_mount.conf.5.html>
-            for more information.
-          '';
-        };
-
-        shell = mkOption {
-          type = types.nullOr (types.either types.shellPackage (types.passwdEntry types.path));
-          default = pkgs.shadow;
-          defaultText = literalExpression "pkgs.shadow";
-          example = literalExpression "pkgs.bashInteractive";
-          description = ''
-            The path to the user's shell. Can use shell derivations,
-            like `pkgs.bashInteractive`. Don’t
-            forget to enable your shell in
-            `programs` if necessary,
-            like `programs.zsh.enable = true;`.
-          '';
-        };
-
-        ignoreShellProgramCheck = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            By default, nixos will check that programs.SHELL.enable is set to
-            true if the user has a custom shell specified. If that behavior isn't
-            required and there are custom overrides in place to make sure that the
-            shell is functional, set this to true.
-          '';
-        };
-
-        subUidRanges = mkOption {
-          type = with types; listOf (submodule subordinateUidRange);
-          default = [ ];
-          example = [
-            {
-              startUid = 1000;
-              count = 1;
-            }
-            {
-              startUid = 100001;
-              count = 65534;
-            }
-          ];
-          description = ''
-            Subordinate user ids that user is allowed to use.
-            They are set into {file}`/etc/subuid` and are used
-            by `newuidmap` for user namespaces.
-          '';
-        };
-
-        subGidRanges = mkOption {
-          type = with types; listOf (submodule subordinateGidRange);
-          default = [ ];
-          example = [
-            {
-              startGid = 100;
-              count = 1;
-            }
-            {
-              startGid = 1001;
-              count = 999;
-            }
-          ];
-          description = ''
-            Subordinate group ids that user is allowed to use.
-            They are set into {file}`/etc/subgid` and are used
-            by `newgidmap` for user namespaces.
-          '';
-        };
-
-        autoSubUidGidRange = mkOption {
-          type = types.bool;
-          default = false;
-          example = true;
-          description = ''
-            Automatically allocate subordinate user and group ids for this user.
-            Allocated range is currently always of size 65536.
-          '';
-        };
-
-        createHome = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether to create the home directory and ensure ownership as well as
-            permissions to match the user.
-          '';
-        };
-
-        useDefaultShell = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            If true, the user's shell will be set to
-            {option}`users.defaultUserShell`.
-          '';
-        };
-
-        hashedPassword = mkOption {
-          type = with types; nullOr (passwdEntry str);
-          default = null;
-          description = ''
-            Specifies the hashed password for the user.
-
-            ${passwordDescription}
-            ${hashedPasswordDescription}
-          '';
-        };
-
-        password = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          description = ''
-            Specifies the (clear text) password for the user.
-            Warning: do not set confidential information here
-            because it is world-readable in the Nix store. This option
-            should only be used for public accounts.
-
-            ${passwordDescription}
-          '';
-        };
-
-        hashedPasswordFile = mkOption {
-          type = with types; nullOr str;
-          default = config.passwordFile;
-          defaultText = literalExpression "null";
-          description = ''
-            The full path to a file that contains the hash of the user's
-            password. The password file is read on each system activation. The
-            file should contain exactly one line, the salted password hash
-            produced by `mkpasswd`.
-
-            ${passwordDescription}
-          '';
-        };
-
-        passwordFile = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          visible = false;
-          description = "Deprecated alias of hashedPasswordFile";
-        };
-
-        initialHashedPassword = mkOption {
-          type = with types; nullOr (passwdEntry str);
-          default = null;
-          description = ''
-            Specifies the initial hashed password for the user, i.e. the
-            hashed password assigned if the user does not already
-            exist. If {option}`users.mutableUsers` is true, the
-            password can be changed subsequently using the
-            {command}`passwd` command. Otherwise, it's
-            equivalent to setting the {option}`hashedPassword` option.
-
-            ${passwordDescription}
-            ${hashedPasswordDescription}
-          '';
-        };
-
-        initialPassword = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          description = ''
-            Specifies the initial password for the user, i.e. the
-            password assigned if the user does not already exist. If
-            {option}`users.mutableUsers` is true, the password
-            can be changed subsequently using the
-            {command}`passwd` command. Otherwise, it's
-            equivalent to setting the {option}`password`
-            option. The same caveat applies: the password specified here
-            is world-readable in the Nix store, so it should only be
-            used for guest accounts or passwords that will be changed
-            promptly.
-
-            ${passwordDescription}
-          '';
-        };
-
-        packages = mkOption {
-          type = types.listOf types.package;
-          default = [ ];
-          example = literalExpression "[ pkgs.firefox pkgs.thunderbird ]";
-          description = ''
-            The set of packages that should be made available to the user.
-            This is in contrast to {option}`environment.systemPackages`,
-            which adds packages to all users.
-          '';
-        };
-
-        expires = mkOption {
-          type = types.nullOr (types.strMatching "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}");
-          default = null;
-          description = ''
-            Set the date on which the user's account will no longer be
-            accessible. The date is expressed in the format YYYY-MM-DD, or null
-            to disable the expiry.
-            A user whose account is locked must contact the system
-            administrator before being able to use the system again.
-          '';
-        };
-
-        linger = mkOption {
-          type = types.nullOr types.bool;
-          example = true;
-          default = null;
-          description = ''
-            Whether to enable or disable lingering for this user.  Without
-            lingering, user units will not be started until the user logs in,
-            and may be stopped on logout depending on the settings in
-            {file}`logind.conf`.
-
-            By default, NixOS will not manage lingering, new users will default
-            to not lingering, and lingering can be configured imperatively using
-            `loginctl enable-linger` or `loginctl disable-linger`. Setting
-            this option to `true` or `false` is the declarative equivalent of
-            running `loginctl enable-linger` or `loginctl disable-linger`
-            respectively.
-          '';
-        };
+      enable = field {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = ''
+          If set to false, the user account will not be created. This is useful for when you wish to conditionally
+          disable user accounts.
+        '';
       };
 
-      config = mkMerge [
-        {
-          name = mkDefault name;
-          shell = mkIf config.useDefaultShell (mkDefault cfg.defaultUserShell);
-        }
-        (mkIf config.isNormalUser {
-          group = mkDefault "users";
-          createHome = mkDefault true;
-          home = mkDefault "${cfg.defaultUserHome}/${config.name}";
-          homeMode = mkDefault "700";
-          useDefaultShell = mkDefault true;
-          isSystemUser = mkDefault false;
-        })
+      name = field {
+        type = types.passwdEntry types.str;
+        defaultText = literalExpression "\"\u2039name\u203a\"";
+        apply =
+          x:
+          assert (
+            stringLength x < 32 || abort "Username '${x}' is longer than 31 characters which is not allowed!"
+          );
+          x;
+        description = ''
+          The name of the user account. If undefined, the name of the
+          attribute set will be used.
+        '';
+      };
+
+      description = field {
+        type = types.passwdEntry types.str;
+        default = "";
+        example = "Alice Q. User";
+        description = ''
+          A short description of the user account, typically the
+          user's full name.  This is actually the “GECOS” or “comment”
+          field in {file}`/etc/passwd`.
+        '';
+      };
+
+      uid = field {
+        type = with types; nullOr int;
+        default = null;
+        description = ''
+          The account UID. If the UID is null, a free UID is picked on
+          activation.
+        '';
+      };
+
+      isSystemUser = field {
+        type = types.bool;
+        default = false;
+        description = ''
+          Indicates if the user is a system user or not. This option
+          only has an effect if {option}`uid` is
+          {option}`null`, in which case it determines whether
+          the user's UID is allocated in the range for system users
+          (below 1000) or in the range for normal users (starting at
+          1000).
+          Exactly one of `isNormalUser` and
+          `isSystemUser` must be true.
+        '';
+      };
+
+      isNormalUser = field {
+        type = types.bool;
+        default = false;
+        description = ''
+          Indicates whether this is an account for a “real” user.
+          This automatically sets {option}`group` to `users`,
+          {option}`createHome` to `true`,
+          {option}`home` to {file}`/home/«username»`,
+          {option}`useDefaultShell` to `true`,
+          and {option}`isSystemUser` to `false`.
+          Exactly one of `isNormalUser` and `isSystemUser` must be true.
+        '';
+      };
+
+      group = field {
+        type = types.str;
+        apply =
+          x:
+          assert (
+            stringLength x < 32 || abort "Group name '${x}' is longer than 31 characters which is not allowed!"
+          );
+          x;
+        default = "";
+        description = "The user's primary group.";
+      };
+
+      extraGroups = field {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "The user's auxiliary groups.";
+      };
+
+      home = field {
+        type = types.passwdEntry types.path;
+        default = "/var/empty";
+        description = "The user's home directory.";
+      };
+
+      homeMode = field {
+        type = types.strMatching "[0-7]{1,5}";
+        default = "700";
+        description = "The user's home directory mode in numeric format. See {manpage}`chmod(1)`. The mode is only applied if {option}`users.users.<name>.createHome` is true.";
+      };
+
+      cryptHomeLuks = field {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Path to encrypted luks device that contains
+          the user's home directory.
+        '';
+      };
+
+      pamMount = field {
+        type = with types; attrsOf str;
+        default = { };
+        description = ''
+          Attributes for user's entry in
+          {file}`pam_mount.conf.xml`.
+          Useful attributes might include `path`,
+          `options`, `fstype`, and `server`.
+          See <https://pam-mount.sourceforge.net/pam_mount.conf.5.html>
+          for more information.
+        '';
+      };
+
+      shell = field {
+        type = types.nullOr (types.either types.shellPackage (types.passwdEntry types.path));
+        default = pkgs.shadow;
+        defaultText = literalExpression "pkgs.shadow";
+        example = literalExpression "pkgs.bashInteractive";
+        description = ''
+          The path to the user's shell. Can use shell derivations,
+          like `pkgs.bashInteractive`. Don’t
+          forget to enable your shell in
+          `programs` if necessary,
+          like `programs.zsh.enable = true;`.
+        '';
+      };
+
+      ignoreShellProgramCheck = field {
+        type = types.bool;
+        default = false;
+        description = ''
+          By default, nixos will check that programs.SHELL.enable is set to
+          true if the user has a custom shell specified. If that behavior isn't
+          required and there are custom overrides in place to make sure that the
+          shell is functional, set this to true.
+        '';
+      };
+
+      subUidRanges = field {
+        type = types.listOf subordinateUidRange;
+        default = [ ];
+        example = [
+          {
+            startUid = 1000;
+            count = 1;
+          }
+          {
+            startUid = 100001;
+            count = 65534;
+          }
+        ];
+        description = ''
+          Subordinate user ids that user is allowed to use.
+          They are set into {file}`/etc/subuid` and are used
+          by `newuidmap` for user namespaces.
+        '';
+      };
+
+      subGidRanges = field {
+        type = types.listOf subordinateGidRange;
+        default = [ ];
+        example = [
+          {
+            startGid = 100;
+            count = 1;
+          }
+          {
+            startGid = 1001;
+            count = 999;
+          }
+        ];
+        description = ''
+          Subordinate group ids that user is allowed to use.
+          They are set into {file}`/etc/subgid` and are used
+          by `newgidmap` for user namespaces.
+        '';
+      };
+
+      autoSubUidGidRange = field {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Automatically allocate subordinate user and group ids for this user.
+          Allocated range is currently always of size 65536.
+        '';
+      };
+
+      createHome = field {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to create the home directory and ensure ownership as well as
+          permissions to match the user.
+        '';
+      };
+
+      useDefaultShell = field {
+        type = types.bool;
+        default = false;
+        description = ''
+          If true, the user's shell will be set to
+          {option}`users.defaultUserShell`.
+        '';
+      };
+
+      hashedPassword = field {
+        type = with types; nullOr (passwdEntry str);
+        default = null;
+        description = ''
+          Specifies the hashed password for the user.
+
+          ${passwordDescription}
+          ${hashedPasswordDescription}
+        '';
+      };
+
+      password = field {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Specifies the (clear text) password for the user.
+          Warning: do not set confidential information here
+          because it is world-readable in the Nix store. This option
+          should only be used for public accounts.
+
+          ${passwordDescription}
+        '';
+      };
+
+      hashedPasswordFile = field {
+        type = with types; nullOr str;
+        defaultText = literalExpression "null";
+        description = ''
+          The full path to a file that contains the hash of the user's
+          password. The password file is read on each system activation. The
+          file should contain exactly one line, the salted password hash
+          produced by `mkpasswd`.
+
+          ${passwordDescription}
+        '';
+      };
+
+      passwordFile = field {
+        type = with types; nullOr str;
+        default = null;
+        visible = false;
+        description = "Deprecated alias of hashedPasswordFile";
+      };
+
+      initialHashedPassword = field {
+        type = with types; nullOr (passwdEntry str);
+        default = null;
+        description = ''
+          Specifies the initial hashed password for the user, i.e. the
+          hashed password assigned if the user does not already
+          exist. If {option}`users.mutableUsers` is true, the
+          password can be changed subsequently using the
+          {command}`passwd` command. Otherwise, it's
+          equivalent to setting the {option}`hashedPassword` option.
+
+          ${passwordDescription}
+          ${hashedPasswordDescription}
+        '';
+      };
+
+      initialPassword = field {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Specifies the initial password for the user, i.e. the
+          password assigned if the user does not already exist. If
+          {option}`users.mutableUsers` is true, the password
+          can be changed subsequently using the
+          {command}`passwd` command. Otherwise, it's
+          equivalent to setting the {option}`password`
+          option. The same caveat applies: the password specified here
+          is world-readable in the Nix store, so it should only be
+          used for guest accounts or passwords that will be changed
+          promptly.
+
+          ${passwordDescription}
+        '';
+      };
+
+      packages = field {
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExpression "[ pkgs.firefox pkgs.thunderbird ]";
+        description = ''
+          The set of packages that should be made available to the user.
+          This is in contrast to {option}`environment.systemPackages`,
+          which adds packages to all users.
+        '';
+      };
+
+      expires = field {
+        type = types.nullOr (types.strMatching "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}");
+        default = null;
+        description = ''
+          Set the date on which the user's account will no longer be
+          accessible. The date is expressed in the format YYYY-MM-DD, or null
+          to disable the expiry.
+          A user whose account is locked must contact the system
+          administrator before being able to use the system again.
+        '';
+      };
+
+      linger = field {
+        type = types.nullOr types.bool;
+        example = true;
+        default = null;
+        description = ''
+          Whether to enable or disable lingering for this user.  Without
+          lingering, user units will not be started until the user logs in,
+          and may be stopped on logout depending on the settings in
+          {file}`logind.conf`.
+
+          By default, NixOS will not manage lingering, new users will default
+          to not lingering, and lingering can be configured imperatively using
+          `loginctl enable-linger` or `loginctl disable-linger`. Setting
+          this option to `true` or `false` is the declarative equivalent of
+          running `loginctl enable-linger` or `loginctl disable-linger`
+          respectively.
+        '';
+      };
+    };
+
+    finalise =
+      { name, self, ... }:
+      let
+        ifNormal = mkIf self.isNormalUser;
+      in
+      {
+        name = mkDefault name;
+        shell = mkIf self.useDefaultShell (mkDefault cfg.defaultUserShell);
+        hashedPasswordFile = mkOptionDefault self.passwordFile;
+
+        group = ifNormal (mkDefault "users");
+        createHome = ifNormal (mkDefault true);
+        home = ifNormal (mkDefault "${cfg.defaultUserHome}/${self.name}");
+        homeMode = ifNormal (mkDefault "700");
+        useDefaultShell = ifNormal (mkDefault true);
+        isSystemUser = ifNormal (mkDefault false);
+        autoSubUidGidRange = mkIf (
+          self.isNormalUser && self.subUidRanges == [ ] && self.subGidRanges == [ ]
+        ) (mkDefault true);
+
         # If !mutableUsers, setting ‘initialPassword’ is equivalent to
         # setting ‘password’ (and similarly for hashed passwords).
-        (mkIf (!cfg.mutableUsers && config.initialPassword != null) {
-          password = mkDefault config.initialPassword;
-        })
-        (mkIf (!cfg.mutableUsers && config.initialHashedPassword != null) {
-          hashedPassword = mkDefault config.initialHashedPassword;
-        })
-        (mkIf (config.isNormalUser && config.subUidRanges == [ ] && config.subGidRanges == [ ]) {
-          autoSubUidGidRange = mkDefault true;
-        })
-      ];
+        password = mkIf (!cfg.mutableUsers && self.initialPassword != null) (
+          mkDefault self.initialPassword
+        );
+        hashedPassword = mkIf (!cfg.mutableUsers && self.initialHashedPassword != null) (
+          mkDefault self.initialHashedPassword
+        );
+      };
+  };
+
+  groupOpts = types.record {
+    declarations = [ ./users-groups.nix ];
+    description = "group configuration";
+    fields = {
+
+      name = field {
+        defaultText = literalExpression "\"\u2039name\u203a\"";
+        type = types.passwdEntry types.str;
+        description = ''
+          The name of the group. If undefined, the name of the attribute set
+          will be used.
+        '';
+      };
+
+      gid = field {
+        type = with types; nullOr int;
+        default = null;
+        description = ''
+          The group GID. If the GID is null, a free GID is picked on
+          activation.
+        '';
+      };
+
+      members = field {
+        type = with types; listOf (passwdEntry str);
+        default = [ ];
+        description = ''
+          The user names of the group members, added to the
+          `/etc/group` file.
+        '';
+      };
 
     };
 
-  groupOpts =
-    { name, config, ... }:
-    {
-
-      options = {
-
-        name = mkOption {
-          type = types.passwdEntry types.str;
-          description = ''
-            The name of the group. If undefined, the name of the attribute set
-            will be used.
-          '';
-        };
-
-        gid = mkOption {
-          type = with types; nullOr int;
-          default = null;
-          description = ''
-            The group GID. If the GID is null, a free GID is picked on
-            activation.
-          '';
-        };
-
-        members = mkOption {
-          type = with types; listOf (passwdEntry str);
-          default = [ ];
-          description = ''
-            The user names of the group members, added to the
-            `/etc/group` file.
-          '';
-        };
-
-      };
-
-      config = {
+    finalise =
+      { name, self, ... }:
+      {
         name = mkDefault name;
 
         members = mapAttrsToList (n: u: u.name) (
-          filterAttrs (n: u: u.enable && elem config.name u.extraGroups) cfg.users
+          filterAttrs (n: u: u.enable && elem self.name u.extraGroups) cfg.users
         );
       };
+  };
 
-    };
-
-  subordinateUidRange = {
-    options = {
-      startUid = mkOption {
+  subordinateUidRange = types.record {
+    declarations = [ ./users-groups.nix ];
+    fields = {
+      startUid = field {
         type = types.int;
         description = ''
           Start of the range of subordinate user ids that user is
           allowed to use.
         '';
       };
-      count = mkOption {
+      count = field {
         type = types.int;
         default = 1;
         description = "Count of subordinate user ids";
@@ -565,16 +572,17 @@ let
     };
   };
 
-  subordinateGidRange = {
-    options = {
-      startGid = mkOption {
+  subordinateGidRange = types.record {
+    declarations = [ ./users-groups.nix ];
+    fields = {
+      startGid = field {
         type = types.int;
         description = ''
           Start of the range of subordinate group ids that user is
           allowed to use.
         '';
       };
-      count = mkOption {
+      count = field {
         type = types.int;
         default = 1;
         description = "Count of subordinate group ids";
@@ -724,7 +732,7 @@ in
 
     users.users = mkOption {
       default = { };
-      type = with types; attrsOf (submodule userOpts);
+      type = types.attrsOf userOpts;
       example = {
         alice = {
           uid = 1234;
@@ -748,7 +756,7 @@ in
         students.gid = 1001;
         hackers = { };
       };
-      type = with types; attrsOf (submodule groupOpts);
+      type = types.attrsOf groupOpts;
       description = ''
         Additional groups to be created automatically by the system.
       '';

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -24,101 +24,103 @@ let
     All other values are rendered as key-value pairs.
   '';
 
-  mkRulesTypeOption =
-    type:
-    lib.mkOption {
-      # These options are experimental and subject to breaking changes without notice.
-      description = ''
-        PAM `${type}` rules for this service.
+  pamRuleType = lib.types.record {
+    declarations = [ ./pam.nix ];
+    fields =
+      let
+        field = lib.id;
+      in
+      {
+        name = field {
+          type = lib.types.str;
+          description = ''
+            Name of this rule.
+          '';
+          internal = true;
+        };
+        enable = field {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Whether this rule is added to the PAM service config file.
+          '';
+        };
+        order = field {
+          type = lib.types.int;
+          description = ''
+            Order of this rule in the service file. Rules are arranged in ascending order of this value.
 
-        Attribute keys are the name of each rule.
-      '';
-      type = lib.types.attrsOf (
-        lib.types.submodule (
-          { name, config, ... }:
-          {
-            options = {
-              name = lib.mkOption {
-                type = lib.types.str;
-                description = ''
-                  Name of this rule.
-                '';
-                internal = true;
-                readOnly = true;
-              };
-              enable = lib.mkOption {
-                type = lib.types.bool;
-                default = true;
-                description = ''
-                  Whether this rule is added to the PAM service config file.
-                '';
-              };
-              order = lib.mkOption {
-                type = lib.types.int;
-                description = ''
-                  Order of this rule in the service file. Rules are arranged in ascending order of this value.
+            ::: {.warning}
+            The `order` values for the built-in rules are subject to change. If you assign a constant value to this option, a system update could silently reorder your rule. You could be locked out of your system, or your system could be left wide open. When using this option, set it to a relative offset from another rule's `order` value:
 
-                  ::: {.warning}
-                  The `order` values for the built-in rules are subject to change. If you assign a constant value to this option, a system update could silently reorder your rule. You could be locked out of your system, or your system could be left wide open. When using this option, set it to a relative offset from another rule's `order` value:
+            ```nix
+            {
+              security.pam.services.login.rules.auth.foo.order =
+                config.security.pam.services.login.rules.auth.unix.order + 10;
+            }
+            ```
+            :::
+          '';
+        };
+        control = field {
+          type = lib.types.str;
+          description = ''
+            Indicates the behavior of the PAM-API should the module fail to succeed in its authentication task. See `control` in {manpage}`pam.conf(5)` for details.
+          '';
+        };
+        modulePath = field {
+          type = lib.types.str;
+          description = ''
+            Either the full filename of the PAM to be used by the application (it begins with a '/'), or a relative pathname from the default module location. See `module-path` in {manpage}`pam.conf(5)` for details.
+          '';
+        };
+        args = field {
+          type = lib.types.listOf lib.types.str;
+          description = ''
+            Tokens that can be used to modify the specific behavior of the given PAM. Such arguments will be documented for each individual module. See `module-arguments` in {manpage}`pam.conf(5)` for details.
 
-                  ```nix
-                  {
-                    security.pam.services.login.rules.auth.foo.order =
-                      config.security.pam.services.login.rules.auth.unix.order + 10;
-                  }
-                  ```
-                  :::
-                '';
-              };
-              control = lib.mkOption {
-                type = lib.types.str;
-                description = ''
-                  Indicates the behavior of the PAM-API should the module fail to succeed in its authentication task. See `control` in {manpage}`pam.conf(5)` for details.
-                '';
-              };
-              modulePath = lib.mkOption {
-                type = lib.types.str;
-                description = ''
-                  Either the full filename of the PAM to be used by the application (it begins with a '/'), or a relative pathname from the default module location. See `module-path` in {manpage}`pam.conf(5)` for details.
-                '';
-              };
-              args = lib.mkOption {
-                type = lib.types.listOf lib.types.str;
-                description = ''
-                  Tokens that can be used to modify the specific behavior of the given PAM. Such arguments will be documented for each individual module. See `module-arguments` in {manpage}`pam.conf(5)` for details.
+            Escaping rules for spaces and square brackets are automatically applied.
 
-                  Escaping rules for spaces and square brackets are automatically applied.
+            {option}`settings` are automatically added as {option}`args`. It's recommended to use the {option}`settings` option whenever possible so that arguments can be overridden.
+          '';
+        };
+        settings = field {
+          type = moduleSettingsType;
+          default = { };
+          description = ''
+            Settings to add as `module-arguments`.
 
-                  {option}`settings` are automatically added as {option}`args`. It's recommended to use the {option}`settings` option whenever possible so that arguments can be overridden.
-                '';
-              };
-              settings = lib.mkOption {
-                type = moduleSettingsType;
-                default = { };
-                description = ''
-                  Settings to add as `module-arguments`.
+            ${moduleSettingsDescription}
+          '';
+        };
+      };
+    finalise =
+      { name, self, ... }:
+      {
+        inherit name;
+        # Formats an attrset of settings as args for use as `module-arguments`.
+        args = lib.concatLists (
+          lib.flip lib.mapAttrsToList self.settings (
+            name: value:
+            if lib.isBool value then
+              lib.optional value name
+            else
+              lib.optional (value != null) "${name}=${toString value}"
+          )
+        );
+      };
+  };
 
-                  ${moduleSettingsDescription}
-                '';
-              };
-            };
-            config = {
-              inherit name;
-              # Formats an attrset of settings as args for use as `module-arguments`.
-              args = lib.concatLists (
-                lib.flip lib.mapAttrsToList config.settings (
-                  name: value:
-                  if lib.isBool value then
-                    lib.optional value name
-                  else
-                    lib.optional (value != null) "${name}=${toString value}"
-                )
-              );
-            };
-          }
-        )
-      );
-    };
+  mkRulesTypeField = type: {
+    # These options are experimental and subject to breaking changes without notice.
+    description = ''
+      PAM `${type}` rules for this service.
+
+      Attribute keys are the name of each rule.
+    '';
+    type = lib.types.attrsOf pamRuleType;
+    default = { };
+  };
 
   package = config.security.pam.package;
   parentConfig = config;
@@ -167,8 +169,9 @@ let
             You may freely use this option within `nixpkgs`, and future changes will account for those use sites.
             :::
           '';
-          type = lib.types.submodule {
-            options = lib.genAttrs [ "account" "auth" "password" "session" ] mkRulesTypeOption;
+          type = lib.types.record {
+            declarations = [ ./pam.nix ];
+            fields = lib.genAttrs [ "account" "auth" "password" "session" ] mkRulesTypeField;
           };
         };
 

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -50,34 +50,34 @@ let
     in
     lib.types.strMatching mode // { description = "file mode string"; };
 
-  wrapperType = lib.types.submodule (
-    { name, config, ... }:
-    {
-      options.enable = lib.mkOption {
+  wrapperType = lib.types.record {
+    declarations = [ ./default.nix ];
+    fields = {
+      enable = {
         type = lib.types.bool;
         default = true;
         description = "Whether to enable the wrapper.";
       };
-      options.source = lib.mkOption {
+      source = {
         type = lib.types.path;
         description = "The absolute path to the program to be wrapped.";
       };
-      options.program = lib.mkOption {
+      program = {
         type = with lib.types; nullOr str;
-        default = name;
+        defaultText = lib.literalExpression "‹name›";
         description = ''
           The name of the wrapper program. Defaults to the attribute name.
         '';
       };
-      options.owner = lib.mkOption {
+      owner = {
         type = lib.types.str;
         description = "The owner of the wrapper program.";
       };
-      options.group = lib.mkOption {
+      group = {
         type = lib.types.str;
         description = "The group of the wrapper program.";
       };
-      options.permissions = lib.mkOption {
+      permissions = {
         type = fileModeType;
         default = "u+rx,g+x,o+x";
         example = "a+rx";
@@ -86,7 +86,7 @@ let
           symbolic or numeric file mode understood by {command}`chmod`.
         '';
       };
-      options.capabilities = lib.mkOption {
+      capabilities = {
         type = lib.types.commas;
         default = "";
         description = ''
@@ -106,18 +106,23 @@ let
           :::
         '';
       };
-      options.setuid = lib.mkOption {
+      setuid = {
         type = lib.types.bool;
         default = false;
         description = "Whether to add the setuid bit the wrapper program.";
       };
-      options.setgid = lib.mkOption {
+      setgid = {
         type = lib.types.bool;
         default = false;
         description = "Whether to add the setgid bit the wrapper program.";
       };
-    }
-  );
+    };
+    finalise =
+      { name, ... }:
+      {
+        program = lib.mkOptionDefault name;
+      };
+  };
 
   ###### Activation script for the setcap wrappers
   mkSetcapProgram =

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -8,6 +8,20 @@ let
 
   cfg = config.networking.firewall;
 
+  portRange = lib.types.record {
+    declarations = [ ./firewall.nix ];
+    fields = {
+      from = {
+        type = lib.types.port;
+        description = "The start of the port range, inclusive.";
+      };
+      to = {
+        type = lib.types.port;
+        description = "The end of the port range, inclusive.";
+      };
+    };
+  };
+
   canonicalizePortList = ports: lib.unique (builtins.sort builtins.lessThan ports);
 
   commonOptions = {
@@ -26,7 +40,7 @@ let
     };
 
     allowedTCPPortRanges = lib.mkOption {
-      type = lib.types.listOf (lib.types.attrsOf lib.types.port);
+      type = lib.types.listOf portRange;
       default = [ ];
       example = [
         {
@@ -51,7 +65,7 @@ let
     };
 
     allowedUDPPortRanges = lib.mkOption {
-      type = lib.types.listOf (lib.types.attrsOf lib.types.port);
+      type = lib.types.listOf portRange;
       default = [ ];
       example = [
         {

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -91,53 +91,58 @@ let
 
   nssModulesPath = config.system.nssModules.path;
 
-  userOptions = {
+  userOptions = lib.types.record {
+    declarations = [ ./sshd.nix ];
+    fields.openssh = {
+      type = lib.types.submodule {
+        options.authorizedKeys = {
+          keys = lib.mkOption {
+            type = lib.types.listOf lib.types.singleLineStr;
+            default = [ ];
+            description = ''
+              A list of verbatim OpenSSH public keys that should be added to the
+              user's authorized keys. The keys are added to a file that the SSH
+              daemon reads in addition to the the user's authorized_keys file.
+              You can combine the `keys` and
+              `keyFiles` options.
+              Warning: If you are using `NixOps` then don't use this
+              option since it will replace the key required for deployment via ssh.
+            '';
+            example = [
+              "ssh-rsa AAAAB3NzaC1yc2etc/etc/etcjwrsh8e596z6J0l7 example@host"
+              "ssh-ed25519 AAAAC3NzaCetcetera/etceteraJZMfk3QPfQ foo@bar"
+            ];
+          };
 
-    options.openssh.authorizedKeys = {
-      keys = lib.mkOption {
-        type = lib.types.listOf lib.types.singleLineStr;
-        default = [ ];
-        description = ''
-          A list of verbatim OpenSSH public keys that should be added to the
-          user's authorized keys. The keys are added to a file that the SSH
-          daemon reads in addition to the the user's authorized_keys file.
-          You can combine the `keys` and
-          `keyFiles` options.
-          Warning: If you are using `NixOps` then don't use this
-          option since it will replace the key required for deployment via ssh.
-        '';
-        example = [
-          "ssh-rsa AAAAB3NzaC1yc2etc/etc/etcjwrsh8e596z6J0l7 example@host"
-          "ssh-ed25519 AAAAC3NzaCetcetera/etceteraJZMfk3QPfQ foo@bar"
-        ];
+          keyFiles = lib.mkOption {
+            type = lib.types.listOf lib.types.path;
+            default = [ ];
+            description = ''
+              A list of files each containing one OpenSSH public key that should be
+              added to the user's authorized keys. The contents of the files are
+              read at build time and added to a file that the SSH daemon reads in
+              addition to the the user's authorized_keys file. You can combine the
+              `keyFiles` and `keys` options.
+            '';
+          };
+        };
+
+        options.authorizedPrincipals = lib.mkOption {
+          type = with lib.types; listOf lib.types.singleLineStr;
+          default = [ ];
+          description = ''
+            A list of verbatim principal names that should be added to the user's
+            authorized principals.
+          '';
+          example = [
+            "example@host"
+            "foo@bar"
+          ];
+        };
       };
-
-      keyFiles = lib.mkOption {
-        type = lib.types.listOf lib.types.path;
-        default = [ ];
-        description = ''
-          A list of files each containing one OpenSSH public key that should be
-          added to the user's authorized keys. The contents of the files are
-          read at build time and added to a file that the SSH daemon reads in
-          addition to the the user's authorized_keys file. You can combine the
-          `keyFiles` and `keys` options.
-        '';
-      };
+      default = { };
+      description = "OpenSSH-related user configuration.";
     };
-
-    options.openssh.authorizedPrincipals = lib.mkOption {
-      type = with lib.types; listOf lib.types.singleLineStr;
-      default = [ ];
-      description = ''
-        A list of verbatim principal names that should be added to the user's
-        authorized principals.
-      '';
-      example = [
-        "example@host"
-        "foo@bar"
-      ];
-    };
-
   };
 
   authKeysFiles =
@@ -694,7 +699,7 @@ in
     };
 
     users.users = lib.mkOption {
-      type = with lib.types; attrsOf (submodule userOptions);
+      type = lib.types.attrsOf userOptions;
     };
 
   };

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -47,12 +47,11 @@ let
     type = attrsWith' "config-name" (
       attrsWith' "path" (
         attrsWith' "tmpfiles-type" (
-          types.submodule (
-            { name, config, ... }:
-            {
-              options.type = mkOption {
+          types.record {
+            declarations = [ ./tmpfiles.nix ];
+            fields = {
+              type = {
                 type = types.str;
-                default = name;
                 defaultText = "‹tmpfiles-type›";
                 example = "d";
                 description = ''
@@ -66,7 +65,7 @@ let
                   {manpage}`tmpfiles.d(5)`
                 '';
               };
-              options.mode = mkOption {
+              mode = {
                 type = types.str;
                 default = "-";
                 example = "0755";
@@ -74,7 +73,7 @@ let
                   The file access mode to use when creating this file or directory.
                 '';
               };
-              options.user = mkOption {
+              user = {
                 type = types.str;
                 default = "-";
                 example = "root";
@@ -87,7 +86,7 @@ let
                   invokes systemd-tmpfiles is used.
                 '';
               };
-              options.group = mkOption {
+              group = {
                 type = types.str;
                 default = "-";
                 example = "root";
@@ -100,7 +99,7 @@ let
                   invokes systemd-tmpfiles is used.
                 '';
               };
-              options.age = mkOption {
+              age = {
                 type = types.str;
                 default = "-";
                 example = "10d";
@@ -113,7 +112,7 @@ let
                   If set to `"-"` no automatic clean-up is done.
                 '';
               };
-              options.argument = mkOption {
+              argument = {
                 type = types.str;
                 default = "";
                 example = "";
@@ -125,8 +124,13 @@ let
                   {manpage}`tmpfiles.d(5)`
                 '';
               };
-            }
-          )
+            };
+            finalise =
+              { name, ... }:
+              {
+                type = lib.mkOptionDefault name;
+              };
+          }
         )
       )
     );

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -119,120 +119,122 @@ in
 
       type =
         with lib.types;
-        attrsOf (
-          submodule (
+        attrsOf (record {
+          declarations = [ ./etc.nix ];
+          fields =
+            let
+              field = lib.id;
+            in
+            {
+
+              enable = field {
+                type = lib.types.bool;
+                default = true;
+                description = ''
+                  Whether this /etc file should be generated.  This
+                  option allows specific /etc files to be disabled.
+                '';
+              };
+
+              target = field {
+                type = lib.types.str;
+                description = ''
+                  Name of symlink (relative to
+                  {file}`/etc`).  Defaults to the attribute
+                  name.
+                '';
+              };
+
+              text = field {
+                default = null;
+                type = lib.types.nullOr lib.types.lines;
+                description = "Text of the file.";
+              };
+
+              source = field {
+                type = lib.types.path;
+                description = "Path of the source file.";
+              };
+
+              mode = field {
+                type = lib.types.str;
+                default = "symlink";
+                example = "0600";
+                description = ''
+                  If set to something else than `symlink`,
+                  the file is copied instead of symlinked, with the given
+                  file mode.
+                '';
+              };
+
+              uid = field {
+                default = 0;
+                type = lib.types.int;
+                description = ''
+                  UID of created file. Only takes effect when the file is
+                  copied (that is, the mode is not 'symlink').
+                '';
+              };
+
+              gid = field {
+                default = 0;
+                type = lib.types.int;
+                description = ''
+                  GID of created file. Only takes effect when the file is
+                  copied (that is, the mode is not 'symlink').
+                '';
+              };
+
+              user = field {
+                defaultText = lib.literalExpression ''"+''${toString uid}"'';
+                type = lib.types.str;
+                description = ''
+                  User name of file owner.
+
+                  Only takes effect when the file is copied (that is, the
+                  mode is not `symlink`).
+
+                  When `services.userborn.enable`, this option has no effect.
+                  You have to assign a `uid` instead. Otherwise this option
+                  takes precedence over `uid`.
+                '';
+              };
+
+              group = field {
+                defaultText = lib.literalExpression ''"+''${toString gid}"'';
+                type = lib.types.str;
+                description = ''
+                  Group name of file owner.
+
+                  Only takes effect when the file is copied (that is, the
+                  mode is not `symlink`).
+
+                  When `services.userborn.enable`, this option has no effect.
+                  You have to assign a `gid` instead. Otherwise this option
+                  takes precedence over `gid`.
+                '';
+              };
+
+            };
+
+          finalise =
             {
               name,
-              config,
-              options,
-              ...
+              self,
+              fields,
             }:
             {
-              options = {
-
-                enable = lib.mkOption {
-                  type = lib.types.bool;
-                  default = true;
-                  description = ''
-                    Whether this /etc file should be generated.  This
-                    option allows specific /etc files to be disabled.
-                  '';
-                };
-
-                target = lib.mkOption {
-                  type = lib.types.str;
-                  description = ''
-                    Name of symlink (relative to
-                    {file}`/etc`).  Defaults to the attribute
-                    name.
-                  '';
-                };
-
-                text = lib.mkOption {
-                  default = null;
-                  type = lib.types.nullOr lib.types.lines;
-                  description = "Text of the file.";
-                };
-
-                source = lib.mkOption {
-                  type = lib.types.path;
-                  description = "Path of the source file.";
-                };
-
-                mode = lib.mkOption {
-                  type = lib.types.str;
-                  default = "symlink";
-                  example = "0600";
-                  description = ''
-                    If set to something else than `symlink`,
-                    the file is copied instead of symlinked, with the given
-                    file mode.
-                  '';
-                };
-
-                uid = lib.mkOption {
-                  default = 0;
-                  type = lib.types.int;
-                  description = ''
-                    UID of created file. Only takes effect when the file is
-                    copied (that is, the mode is not 'symlink').
-                  '';
-                };
-
-                gid = lib.mkOption {
-                  default = 0;
-                  type = lib.types.int;
-                  description = ''
-                    GID of created file. Only takes effect when the file is
-                    copied (that is, the mode is not 'symlink').
-                  '';
-                };
-
-                user = lib.mkOption {
-                  default = "+${toString config.uid}";
-                  type = lib.types.str;
-                  description = ''
-                    User name of file owner.
-
-                    Only takes effect when the file is copied (that is, the
-                    mode is not `symlink`).
-
-                    When `services.userborn.enable`, this option has no effect.
-                    You have to assign a `uid` instead. Otherwise this option
-                    takes precedence over `uid`.
-                  '';
-                };
-
-                group = lib.mkOption {
-                  default = "+${toString config.gid}";
-                  type = lib.types.str;
-                  description = ''
-                    Group name of file owner.
-
-                    Only takes effect when the file is copied (that is, the
-                    mode is not `symlink`).
-
-                    When `services.userborn.enable`, this option has no effect.
-                    You have to assign a `gid` instead. Otherwise this option
-                    takes precedence over `gid`.
-                  '';
-                };
-
-              };
-
-              config = {
-                target = lib.mkDefault name;
-                source = lib.mkIf (config.text != null) (
-                  let
-                    name' = "etc-" + lib.replaceStrings [ "/" ] [ "-" ] name;
-                  in
-                  lib.mkDerivedConfig options.text (pkgs.writeText name')
-                );
-              };
-
-            }
-          )
-        );
+              target = lib.mkDefault name;
+              user = lib.mkOptionDefault "+${toString self.uid}";
+              group = lib.mkOptionDefault "+${toString self.gid}";
+              source = lib.mkIf (self.text != null) (
+                let
+                  name' = "etc-" + lib.replaceStrings [ "/" ] [ "-" ] name;
+                in
+                lib.mkOverride fields.text.defsFinal'.highestPrio (pkgs.writeText name' self.text)
+              );
+            };
+        });
 
     };
 


### PR DESCRIPTION
`types.record` is a fixed set of named, typed fields with optional
defaults and an optional `finalise` hook for derived defaults that
depend on the attrsOf key or sibling fields.

Unlike `submodule` it runs no evalModules fixpoint, no imports
resolution, no `_module.args` plumbing and no unmatched-definitions
tree walk; it just runs `mergeDefinitions` once per declared field.
This makes it a drop-in for heavily-instantiated
`attrsOf (submodule ...)` options whose element modules are pure data,
where the per-instance module fixpoint dominates evaluation.

`getSubOptions` emits option-shaped stubs so the manual's sub-option
listing keeps working.

This PR also converts the obvious in-tree users:

- `environment.etc.<name>`
- `systemd.tmpfiles.settings.<name>.<path>.<type>`
- `security.wrappers.<name>`
- `networking.firewall.allowed{TCP,UDP}PortRanges.*`
- `systemd.units.<name>` (and user/initrd variants)
- `security.pam.services.<name>.rules.<type>.<rule>`
- `users.users.<name>` / `users.groups.<name>`

Per-module numbers and the (minor) behavioural narrowing are in the
individual commit messages. `system.build.toplevel` of a docs-disabled
minimal system is bit-identical before/after.

Effect on a real-world config
([`nixosConfigurations.eve`](https://github.com/Mic92/dotfiles/tree/56e100f2217d9da89fce6aa97634e9d0d659c2bc/machines/eve):
151 etc,
235 units, 51 users, 74 groups, 24 pam services, 18 wrappers, ~12k drv
closure), `NIX_SHOW_STATS` on `…toplevel.drvPath`:

```
nrThunks         40639356 -> 35264254  (-13.2%)
nrFunctionCalls  25936194 -> 21854585  (-15.7%)
gc.totalBytes      4009MB -> 3673MB     (-8.4%)
maxRSS             3251MB -> 2885MB    (-11.3%)
cpuTime (med/5)    44.23s -> 43.31s     (-2.1%)
```

(measured together with #509195; the singleton fast-path contributes
~70k of the ~5.4M thunks saved, the rest is `types.record`.)

Prior art / discussion: #257511, #334680, #437972.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
