### PR TITLE
optiland: init at 0.6.0

### DIFF
--- a/pkgs/by-name/op/optiland/package.nix
+++ b/pkgs/by-name/op/optiland/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenvNoCC,
+  python3Packages,
+  qt6,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "optiland-python-env";
+  # Inheriting src too, to hint nix-update
+  inherit (python3Packages.optiland) version src;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+  ];
+  buildInputs = [
+    qt6.qtbase
+  ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  passthru = {
+    pythonPaths = python3Packages.requiredPythonModules (
+      [
+        python3Packages.optiland
+        python3Packages.python
+      ]
+      ++ python3Packages.optiland.passthru.optional-dependencies.gui
+      ++ python3Packages.optiland.passthru.optional-dependencies.torch
+    );
+    pythonPath =
+      lib.makeSearchPathOutput "out" python3Packages.python.sitePackages
+        finalAttrs.finalPackage.passthru.pythonPaths;
+    makeWrapperArgs = [
+      # leaving here room for potential additional arguments
+    ];
+  };
+
+  # Modelded after `python.buildEnv`'s postBuild, but we don't link paths at
+  # all, only create $out/bin/optiland (and potentially more) executable(s).
+  buildPhase = ''
+    mkdir -p $out/bin
+    cd ${python3Packages.optiland}/bin
+    for prg in *; do
+      if [ -f "$prg" ] && [ -x "$prg" ]; then
+        makeWrapper "${python3Packages.optiland}/bin/$prg" "$out/bin/$prg" \
+          --set NIX_PYTHONPREFIX "$out" \
+          --set NIX_PYTHONEXECUTABLE "${placeholder "out"}/bin/${python3Packages.python.executable}" \
+          --set NIX_PYTHONPATH ${finalAttrs.finalPackage.passthru.pythonPath} \
+          --set PYTHONNOUSERSITE "true" \
+          ${lib.concatStringsSep " " finalAttrs.finalPackage.passthru.makeWrapperArgs}
+      fi
+    done
+  '';
+
+  dontInstall = true;
+
+  meta = python3Packages.optiland.meta // {
+    description = python3Packages.optiland.meta.description + "; The GUI";
+    mainProgram = "optiland";
+  };
+})

--- a/pkgs/development/python-modules/optiland/default.nix
+++ b/pkgs/development/python-modules/optiland/default.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  matplotlib,
+  numba,
+  numpy,
+  pandas,
+  pyyaml,
+  requests,
+  scipy,
+  seaborn,
+  tabulate,
+  typing-extensions,
+  vtk,
+
+  # tests
+  pytestCheckHook,
+
+  # optional-dependencies
+  pyside6,
+  qtconsole,
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "optiland";
+  version = "0.6.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "HarrisonKramer";
+    repo = "optiland";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s+EFsfj+3VIgpqhBv8f6IblyxfxXHWnO/i1lO3bEke4=";
+  };
+
+  patches = [
+    # wayland is not supported, see:
+    # https://github.com/optiland/optiland/issues/556
+    (fetchpatch {
+      url = "https://github.com/optiland/optiland/commit/9644df6e06bd24c5a3a7cf36c8df9dd83050bccc.patch";
+      hash = "sha256-a74Z7rp3ji3+9lM8Q/RttMIzwlRBki1N2Y0YtBiVaEA=";
+    })
+    # A fixup for the above, see:
+    #
+    # - https://github.com/optiland/optiland/pull/564#discussion_r3106831922
+    # - https://github.com/optiland/optiland/pull/568
+    (fetchpatch {
+      url = "https://github.com/optiland/optiland/commit/652922bce5e1854f1d067e292422d95dee129a46.patch";
+      hash = "sha256-9O+DNbqBDDSAaRkwCy3o76lwy5MJ7WHQqzfcN1fcmnE=";
+    })
+  ];
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    matplotlib
+    numba
+    numpy
+    pandas
+    pyyaml
+    requests
+    scipy
+    seaborn
+    tabulate
+    typing-extensions
+    vtk
+  ];
+
+  passthru = {
+    optional-dependencies = {
+      gui = [
+        pyside6
+        qtconsole
+      ];
+      torch = [
+        torch
+      ];
+    };
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  # No need for optional-dependencies.gui, as the relevant tests requiring the
+  # gui dependencies are disabled below.
+  ++ finalAttrs.finalPackage.passthru.optional-dependencies.torch;
+
+  disabledTestPaths = [
+    # From some reason, importing pyside6 during tests causes a core dump of the
+    # python interpreter, so we disable all GUI tests.
+    "tests/gui/"
+  ];
+
+  pythonImportsCheck = [
+    "optiland"
+  ];
+
+  meta = {
+    description = "Comprehensive optical design, optimization, and analysis in Python, including GPU-accelerated and differentiable ray tracing via PyTorch";
+    homepage = "https://github.com/HarrisonKramer/optiland";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    # Intentionally not setting optiland meta.mainProgram, as it is not
+    # functional without additional qt6 and python libraries available. See
+    # pkgs/by-name/op/optiland/package.nix for a derivation with a working GUI.
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11851,6 +11851,8 @@ self: super: with self; {
 
   optax = callPackage ../development/python-modules/optax { };
 
+  optiland = callPackage ../development/python-modules/optiland { };
+
   optimistix = callPackage ../development/python-modules/optimistix { };
 
   optimum = callPackage ../development/python-modules/optimum { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test