### PR TITLE
schemesh: fix build on darwin

### DIFF
--- a/pkgs/by-name/sc/schemesh/package.nix
+++ b/pkgs/by-name/sc/schemesh/package.nix
@@ -20,6 +20,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Tt3pxzti/Vv5JiP0kiplv6gOPiFU75tKoKyvpEPPztw=";
   };
 
+  postPatch = ''
+    # https://github.com/cosmos72/schemesh/commit/696ba7c24737cd436bb4d8bfa9ec1ea517681403
+    substituteInPlace c/dir.c --replace-fail PATH_MAX 1024
+  '';
+
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # error initializing POSIX subsystem: dup2(0, tty_fd) failed with error Bad file descriptor
+    ulimit -n 128
+  '';
+
   buildInputs = [
     chez
     libuuid
@@ -30,12 +40,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [ "prefix=$(out)" ];
 
+  # Chez Scheme .so files are fasl (compiled Scheme) not ELF/Mach-O;
+  # stripping them corrupts the fasl header, causing "incompatible fasl-object version"
+  dontStrip = true;
+
   meta = {
     description = "A Unix shell and Lisp REPL, fused together";
     homepage = "https://github.com/cosmos72/schemesh";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.sikmir ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     mainProgram = "schemesh";
   };
 })


### PR DESCRIPTION
thanks to @xofyarg (https://github.com/cosmos72/schemesh/issues/34#issuecomment-4231026013)

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
