### PR TITLE
task-keeper: 0.30.1 -> 0.33.0

### DIFF
--- a/pkgs/by-name/ta/task-keeper/package.nix
+++ b/pkgs/by-name/ta/task-keeper/package.nix
@@ -2,34 +2,86 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  just,
   openssl,
   pkg-config,
+  runCommand,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "task-keeper";
-  version = "0.30.1";
+  version = "0.33.0";
 
   src = fetchFromGitHub {
     owner = "linux-china";
     repo = "task-keeper";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/ZmwCvoYdX733c5QkUE0KuUdHeibJkXD5wNHR7Cr7aU=";
+    hash = "sha256-pSMF0ORwHUV9H6RAMRaEt/A61MVIj5cQcsY+wDDyAwk=";
+  };
+
+  patches = [
+    # https://github.com/linux-china/task-keeper/pull/20
+    ./version.patch
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
-  cargoHash = "sha256-Z56p2jeHvNAT4Pwl8kt1l9RopYCKk5Tt/XWZ7AqIFYw=";
+  cargoHash = "sha256-leQpeB145seO2mPg+eqA3S5ATbRBzsXj9cWNsVpXF+U=";
 
   # tests depend on many packages (java, node, python, sbt, ...) - which I'm not currently willing to set up 😅
   doCheck = false;
+
+  passthru = {
+    tests = {
+      makefile =
+        runCommand "task-keeper-makefile-test"
+          {
+            nativeBuildInputs = [ finalAttrs.finalPackage ];
+          }
+          ''
+            printf "nix-test-task:\n\techo 2047" > Makefile
+            tk > output.txt
+            grep -qF -- "make: Makefile" output.txt
+            grep -qF -- "-- nix-test-task" output.txt
+            tk nix-test-task > output.txt
+            grep -qF -- "[tk] execute nix-test-task from make" output.txt
+            grep -qF -- "echo 2047" output.txt
+            touch $out
+          '';
+      justfile =
+        runCommand "task-keeper-justfile-test"
+          {
+            nativeBuildInputs = [
+              finalAttrs.finalPackage
+              just
+            ];
+          }
+          ''
+            printf "nix-test-just-task:\n\techo 4095" > Justfile
+            tk > output.txt
+            grep -qF -- "just: Justfile" output.txt
+            grep -qF -- "-- nix-test-just-task" output.txt
+            tk nix-test-just-task > stdout.txt 2> stderr.txt
+            grep -qF -- "[tk] execute nix-test-just-task from just" stdout.txt
+            grep -qF -- "echo 4095" stderr.txt
+            touch $out
+          '';
+    };
+  };
 
   meta = {
     homepage = "https://github.com/linux-china/task-keeper";
     description = "CLI to manage tasks from different task runners or package managers";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ tennox ];
+    maintainers = with lib.maintainers; [
+      tennox
+      DimitarNestorov
+    ];
     mainProgram = "tk";
   };
 })

--- a/pkgs/by-name/ta/task-keeper/version.patch
+++ b/pkgs/by-name/ta/task-keeper/version.patch
@@ -1,0 +1,13 @@
+diff --git a/src/app.rs b/src/app.rs
+index 77eaee4..daf3633 100644
+--- a/src/app.rs
++++ b/src/app.rs
+@@ -1,7 +1,7 @@
+ //! clap App for command cli
+ use clap::{Command, Arg, ArgAction};
+ 
+-pub const VERSION: &str = "0.32.0";
++pub const VERSION: &str = "0.33.0";
+ 
+ pub fn build_app() -> Command {
+     Command::new("tk")


### PR DESCRIPTION
## Things done

Update https://github.com/linux-china/task-keeper/releases/tag/v0.33.0

Tested manually, all good:

```console
$ nix-build -A task-keeper
/nix/store/sk9b7qwcgpfcljw7c1flaz7jyb8f2bjz-task-keeper-0.33.0
$ ./result/bin/tk --version
tk 0.33.0
$ echo -e "test\n\techo test" > Makefile
$ ./result/bin/tk
Available task runners:
  make: Makefile - https://www.gnu.org/software/make
    -- test
$ ./result/bin/tk test
[tk] execute test from make
echo test
test
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
