### PR TITLE
zoom-us: 6.7.5.6891 -> 7.0.0.1666 , drop maintainership

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -54,25 +54,25 @@ let
   # Zoom versions are released at different times per platform and often with different versions.
   # We write them on three lines like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.7.5.75246";
-  versions.x86_64-darwin = "6.7.5.75246";
+  versions.aarch64-darwin = "7.0.0.77593";
+  versions.x86_64-darwin = "7.0.0.77593";
 
   # This is the fallback version so that evaluation can produce a meaningful result.
-  versions.x86_64-linux = "6.7.5.6891";
+  versions.x86_64-linux = "7.0.0.1666";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-oNeoW7WNq9ES4lJjc+zGrQs/yJ2E7DSsh33hEiU1RSE=";
+      hash = "sha256-YSUaM8YAJHigm4M9W34/bD164M8f/hbhtcmHyUwFN20=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-2D8Q0rRluBM0UpXL5QN3a67b0X1iIW67YWZvVqsl4Qg=";
+      hash = "sha256-jIKBCrnvF101WJm8Tcpi2R5jRsqRXH7NQVGkSTnAeMA=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-Qy4o3vbgiAjKUGWMFi8rNqyDAohG7TgwX69jKVWTWeY=";
+      hash = "sha256-aPQ44znQfxcjGnUpON5RRj3+SG+IDaBa/s0khwj/AIo=";
     };
   };
 
@@ -160,41 +160,37 @@ let
     pkgs:
     [
       pkgs.alsa-lib
-      pkgs.at-spi2-atk
-      pkgs.at-spi2-core
       pkgs.atk
       pkgs.cairo
-      pkgs.coreutils
       pkgs.cups
       pkgs.dbus
       pkgs.expat
       pkgs.fontconfig
       pkgs.freetype
-      pkgs.gdk-pixbuf
       pkgs.glib
-      pkgs.glib.dev
       pkgs.gtk3
+      pkgs.ibus
       pkgs.libGL
       pkgs.libGLU
+      pkgs.libatomic_ops
       pkgs.libdrm
       pkgs.libgbm
       pkgs.libkrb5
+      pkgs.libsm
+      pkgs.libxi
       pkgs.libxkbcommon
+      pkgs.libxslt
+      pkgs.mesa
+      pkgs.mesa-demos
       pkgs.nspr
       pkgs.nss
       pkgs.pango
       pkgs.pciutils
       pkgs.pipewire
-      pkgs.procps
-      pkgs.qt5.qt3d
-      pkgs.qt5.qtgamepad
-      pkgs.qt5.qtlottie
-      pkgs.qt5.qtmultimedia
-      pkgs.qt5.qtremoteobjects
-      pkgs.qt5.qtxmlpatterns
+      pkgs.qt6.qtbase
+      pkgs.qt6.qtdeclarative
       pkgs.stdenv.cc.cc
       pkgs.udev
-      pkgs.util-linux
       pkgs.wayland
       pkgs.libx11
       pkgs.libxcomposite
@@ -212,6 +208,7 @@ let
       pkgs.libxcb-render-util
       pkgs.libxcb-wm
       pkgs.zlib
+      pkgs.zstd
     ]
     ++ lib.optionals pulseaudioSupport [
       pkgs.libpulseaudio

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -148,7 +148,6 @@ let
       maintainers = with lib.maintainers; [
         philiptaron
         ryan4yin
-        yarny
       ];
       mainProgram = "zoom";
     };


### PR DESCRIPTION
*   This pull-request is intended to take over from https://github.com/NixOS/nixpkgs/pull/508720 .  This is a major upgrade where many dependencies need to be replaced.  See the commit message for more explanations.

    In particular, I couldn't find `libQt6Bodymovin.so.6`, but things seem to work without it.

*   My access to a zoom license is about to disappear.  I will probably use zoom for meetings hosted by others from time to time.  But my ability to test anything will be severly limited.  So I guess I should give up my maintainership.  If there is anything broken and I *can* fix it, I will certainly post a pull request. I will also post reviews if I'm (maybe temporaily) in the position to test.

    Dear co-maintainers @philiptaron , @ryan4yin, I hope that's OK for you.

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More: Tested with Plasma6/X11/Pulseaudio on current NixOS 25.11 (unchecked means "not tested"):

- [x] sidebar loads and shows some content  (cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "collected" by zoom: microphone test shows amplitude and repeats the audio
- [x] audio is produced: "Test speaker" generates audible ting-a-ling
- [x] other participant's audio in video conference is audible
- [x] other participants can hear me
- [x] other participant's camera picture is received/shown
- [x] other participants can see my camera picture
- [x] other participant's screen share is received/shown
- [x] other participants can see my screen sharing
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/issues/116355 )
- [x] receiving an image via in-meeting chat is possible (cf. https://github.com/NixOS/nixpkgs/issues/452768 )
- [x] settings dialog is shown/useable (cf. https://github.com/NixOS/nixpkgs/pull/410244 )
- [ ] SSO works
- [x] reading team chat messages works
- [ ] writing team chat messages works
- [ ] Pipewire
- [ ] Wayland
- [ ] xdg-desktop-portal (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Darwin

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `ac8206b020529fd1acd463c89633e1215cae44dd`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>zoom-us</li>
  </ul>
</details>