### PR TITLE
proton-vpn-cli: 1.0.0 -> 1.0.1, python3Packages.proton-vpn-api-core: 4.19.1 -> 5.0.1, proton-vpn: 4.15.2 -> 4.15.3

### DIFF
--- a/pkgs/by-name/pr/proton-vpn-cli/package.nix
+++ b/pkgs/by-name/pr/proton-vpn-cli/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "proton-vpn-cli";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "proton-vpn-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TIS1vhiOaX0ADKD1WRiPv+WYj0LwHmUuqyctygpaBho=";
+    hash = "sha256-CkkytFC3Zr/l2EV5W70kssN1v11F23oZpDvf7JWqmvQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pr/proton-vpn/linux.nix
+++ b/pkgs/by-name/pr/proton-vpn/linux.nix
@@ -14,14 +14,14 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "proton-vpn";
-  version = "4.15.2";
+  version = "4.15.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "proton-vpn-gtk-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-spxlYITDo2TZp4Qv47/HmiIaGU07THZXLG5cFIFZrow=";
+    hash = "sha256-2v8BckNmm7Ecw+uAgOyfofHDPWgXkJJ8DmhMszb0tg0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/proton-vpn-api-core/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-api-core/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-api-core";
-  version = "4.19.1";
+  version = "5.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-api-core";
     rev = "v${version}";
-    hash = "sha256-PD/UQ+BoDO6firhlBJDRNrtiHgnp+4uIb8j+egXqxPA=";
+    hash = "sha256-XdQLgHKNqBNwY51niSiE1HHxLJ3efipS03IUiyHQCiY=";
   };
 
   postPatch = ''


### PR DESCRIPTION
This PR brings the Linux ProtonVPN packages to the latest upstream api-core major version. (v5.x)

The three packages are coupled via `debian/control` pins, so they should move together:
- `proton-vpn-gtk-app v4.15.3` pins `python3-proton-vpn-api-core (>= 5.0.0)`.
- `proton-vpn-cli v1.0.1` pins `python3-proton-vpn-api-core (>= 5.0.0)` at build time.
- `proton-vpn-api-core 5.0.0` is upstream's breaking release ("Packet capture groundwork"); `5.0.1` is the stabilizing patch.

Changes:
- `python3Packages.proton-vpn-api-core`: 4.19.1 → 5.0.1
- `proton-vpn-cli`: 1.0.0 → 1.0.1
- `proton-vpn` (Linux/GTK): 4.15.2 → 4.15.3

Already at upstream latest, confirmed unchanged by this PR:
- `python3Packages.proton-core` 0.7.0
- `python3Packages.proton-keyring-linux` 0.2.1
- `python3Packages.proton-vpn-daemon` 0.13.6
- `python3Packages.proton-vpn-local-agent` 1.6.1

Upstream references:
- https://github.com/ProtonVPN/proton-vpn-gtk-app/blob/v4.15.3/debian/control
- https://github.com/ProtonVPN/python-proton-vpn-api-core/blob/v5.0.1/versions.yml
- https://github.com/ProtonVPN/proton-vpn-cli/blob/v1.0.1/debian/control

Validation (x86_64-linux):
- `NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#proton-vpn .#proton-vpn-cli .#python3Packages.proton-vpn-api-core .#python3Packages.proton-vpn-daemon --no-link` all four derivations build on the current `master`; the GTK app's `pytestCheckHook` phase passes the upstream unit tests.
- `protonvpn --help` from the built `proton-vpn-cli` renders the top-level CLI banner with `1.0.1`.
- `protonvpn-app --help` / `protonvpn-app --version` from the built `proton-vpn` reach `APP:PROCESS_START` and print `4.15.3`, confirming the startup import graph resolves against api-core 5.0.1.
- GTK GUI end-to-end: the main window renders correctly, the login and system keyring flow works, and a VPN connect/disconnect completes successfully.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test