### PR TITLE
sdformat: init at 0.2.0

### DIFF
--- a/pkgs/by-name/sd/sdformat/package.nix
+++ b/pkgs/by-name/sd/sdformat/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  util-linuxMinimal,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sdformat";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "profi200";
+    repo = "sdFormatLinux";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-AoAhP1dr+hQSnOpZC0oHt0j3fUVNVhD+3jWm6iMfskk=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  patches = [ ./remove-hardcoded-lsblk-path.diff ];
+
+  strictDeps = true;
+
+  makeFlags = [
+    "TARGET=${finalAttrs.pname}"
+    "LSBLK_PATH=${lib.getExe' util-linuxMinimal "lsblk"}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin ${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Format your SD card the way the SD Association intended";
+    homepage = "https://github.com/profi200/sdFormatLinux";
+    license = lib.licenses.mit;
+    mainProgram = finalAttrs.pname;
+    maintainers = with lib.maintainers; [ thiagokokada ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/sd/sdformat/remove-hardcoded-lsblk-path.diff
+++ b/pkgs/by-name/sd/sdformat/remove-hardcoded-lsblk-path.diff
@@ -1,0 +1,39 @@
+diff --git i/Makefile w/Makefile
+index c45b32b..258189c 100644
+--- i/Makefile
++++ w/Makefile
+@@ -5,7 +5,8 @@ TARGET   := $(notdir $(CURDIR))
+ BUILD    := build
+ INCLUDES := include
+ SOURCES  := source
+-DEFINES  := -D_FORTIFY_SOURCE=2
++LSBLK_PATH ?= /usr/bin/lsblk
++DEFINES  := -D_FORTIFY_SOURCE=2 -DLSBLK_PATH=\"$(LSBLK_PATH)\"
+ 
+ 
+ # Compiler settings
+diff --git i/source/blockdev.cpp w/source/blockdev.cpp
+index a179604..b4de5ef 100644
+--- i/source/blockdev.cpp
++++ w/source/blockdev.cpp
+@@ -7,6 +7,7 @@
+ #include <errno.h>
+ #include <fcntl.h>     // open()...
+ #include <linux/fs.h>  // BLKGETSIZE64...
++#include <limits.h>    // PATH_MAX
+ #include <sys/ioctl.h> // ioctl()...
+ #include <sys/stat.h>  // S_IRUSR, S_IWUSR...
+ #include <unistd.h>    // write(), close()...
+@@ -21,8 +22,10 @@
+ static int checkDevice(const char *const path)
+ {
+ 	int res = EINVAL; // By default assume the given path is not a suitable device.
+-	char cmd[64] = "/usr/bin/lsblk -dnr -oTYPE,HOTPLUG,PHY-SEC ";
+-	strncpy(&cmd[43], path, sizeof(cmd) - 43);
++	const char cmdPrefix[] = LSBLK_PATH " -dnr -oTYPE,HOTPLUG,PHY-SEC ";
++	char cmd[sizeof(cmdPrefix) + PATH_MAX];
++	memcpy(cmd, cmdPrefix, sizeof(cmdPrefix) - 1);
++	strncpy(&cmd[sizeof(cmdPrefix) - 1], path, sizeof(cmd) - sizeof(cmdPrefix));
+ 	cmd[sizeof(cmd) - 1] = '\0';
+ 	FILE *const p = ::popen(cmd, "r");
+ 	if(p == nullptr)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Small and useful utility to format SD cards correctly under Linux. I had some issues with setting up a SD card for a Nintendo DSi, and it seems that the issue was because the `mkdosfs` didn't exactly formatted the SD card correctly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
