### PR TITLE
shishi: enable strictDeps

### DIFF
--- a/pkgs/by-name/sh/shishi/package.nix
+++ b/pkgs/by-name/sh/shishi/package.nix
@@ -30,7 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   separateDebugInfo = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    libgcrypt
+    pkg-config
+  ];
+
   buildInputs = [
     libgcrypt
     libgpg-error
@@ -78,6 +82,8 @@ stdenv.mkDerivation (finalAttrs: {
     -e 's,\(-lgpg-error\),-L${libgpg-error.out}/lib \1,' \
     -e 's,\(-ltasn1\),-L${libtasn1.out}/lib \1,'
   '';
+
+  strictDeps = true;
 
   meta = {
     homepage = "https://www.gnu.org/software/shishi/";

--- a/pkgs/by-name/sh/shishi/package.nix
+++ b/pkgs/by-name/sh/shishi/package.nix
@@ -39,10 +39,15 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     libgpg-error
     libtasn1
-    # TODO use lib.optional instead of setting packages to null
-    (if usePam then pam else null)
-    (if useLibidn then libidn else null)
-    (if useGnutls then gnutls else null)
+  ]
+  ++ lib.optionals usePam [
+    pam
+  ]
+  ++ lib.optionals useLibidn [
+    libidn
+  ]
+  ++ lib.optionals useGnutls [
+    gnutls
   ];
 
   configureFlags = [


### PR DESCRIPTION
Also tested with `nix-build -A pkgsCross.aarch64-multiplatform.shishi` .

Might as well resolve the TODO if we're doing a rebuild anyway?

Using `optionals` instead of `optional` is my own stylistic choice - I've seen too many bad examples where `optional` was erroneously used to concatenate a list - but it doesn't matter that much so I can change that to `optional` if you want.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
