### PR TITLE
ocf-resource-agents: enable strictDeps, modernize

### DIFF
--- a/pkgs/by-name/oc/ocf-resource-agents/package.nix
+++ b/pkgs/by-name/oc/ocf-resource-agents/package.nix
@@ -24,15 +24,15 @@ let
     forOCF = true;
   };
 
-  resource-agentsForOCF = stdenv.mkDerivation rec {
+  resource-agentsForOCF = stdenv.mkDerivation (finalAttrs: {
     pname = "resource-agents";
     version = "4.10.0";
 
     src = fetchFromGitHub {
       owner = "ClusterLabs";
       repo = "resource-agents";
-      rev = "v${version}";
-      sha256 = "0haryi3yrszdfpqnkfnppxj1yiy6ipah6m80snvayc7v0ss0wnir";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-OVoOtAb7MK+21QBVA9WNxkcfZL/Xumnxde3r7Ef0WUE=";
     };
 
     patches = [
@@ -75,7 +75,7 @@ let
         astro
       ];
     };
-  };
+  });
 
 in
 

--- a/pkgs/by-name/oc/ocf-resource-agents/package.nix
+++ b/pkgs/by-name/oc/ocf-resource-agents/package.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   fetchpatch,
   autoreconfHook,
+  bashNonInteractive,
   pkg-config,
   python3,
   glib,
@@ -47,12 +48,15 @@ let
     nativeBuildInputs = [
       autoreconfHook
       pkg-config
+      python3
     ];
 
     buildInputs = [
+      bashNonInteractive
       glib
-      python3
     ];
+
+    strictDeps = true;
 
     env.NIX_CFLAGS_COMPILE = toString (
       lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12") [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
