### PR TITLE
unxip: init at 3.0

### DIFF
--- a/pkgs/by-name/un/unxip/package.nix
+++ b/pkgs/by-name/un/unxip/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  getopt,
+  stdenv,
+  swift,
+  swiftpm,
+  swiftPackages,
+  versionCheckHook,
+  xz, # liblzma
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unxip";
+  version = "3.0";
+
+  src = fetchFromGitHub {
+    owner = "saagarjha";
+    repo = "unxip";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-GpiJ4F+VMrVSgNACMuCTixWd32eco3eaSKZotP4INT8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    swift
+    swiftpm
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    zlib
+    xz
+    getopt
+    swiftPackages.Foundation
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    binPath="$(swiftpmBinPath)"
+    mkdir -p $out/bin
+    cp $binPath/unxip $out/bin/
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Fast Xcode unarchiver";
+    homepage = "https://github.com/saagarjha/unxip";
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ DimitarNestorov ];
+    mainProgram = "unxip";
+  };
+})


### PR DESCRIPTION
## Things done

Added https://github.com/saagarjha/unxip

Closes #230390

<img width="1586" height="676" alt="image" src="https://github.com/user-attachments/assets/a37a35b6-9f65-4226-b5e6-188a3813d1eb" />



- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
