### PR TITLE
python3Packages.certihound: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/certihound/default.nix
+++ b/pkgs/development/python-modules/certihound/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  ldap3,
+  impacket,
+  cryptography,
+  pydantic,
+  click,
+  rich,
+}:
+
+buildPythonPackage rec {
+  pname = "certihound";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ERJ5fbYikhKLwchSIBe5s4KF/1HsXZ1O00QnYXAe+ps=";
+  };
+
+  dependencies = [
+    ldap3
+    impacket
+    cryptography
+    pydantic
+    click
+    rich
+  ];
+
+  # Tests are stripped in pypi
+  doCheck = false;
+
+  pythonImportsCheck = [ "certihound" ];
+
+  meta = {
+    homepage = "https://github.com/0x0Trace/Certihound";
+    description = "Active Directory Certificate Services (ADCS) enumeration library with BloodHound CE v6 export support";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ letgamer ];
+  };
+}

--- a/pkgs/development/python-modules/certihound/default.nix
+++ b/pkgs/development/python-modules/certihound/default.nix
@@ -8,6 +8,7 @@
   pydantic,
   click,
   rich,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -19,6 +20,8 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-ERJ5fbYikhKLwchSIBe5s4KF/1HsXZ1O00QnYXAe+ps=";
   };
+
+  build-system = [ setuptools ];
 
   dependencies = [
     ldap3

--- a/pkgs/development/python-modules/certihound/default.nix
+++ b/pkgs/development/python-modules/certihound/default.nix
@@ -11,13 +11,13 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "certihound";
   version = "0.3.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-ERJ5fbYikhKLwchSIBe5s4KF/1HsXZ1O00QnYXAe+ps=";
   };
 
@@ -43,4 +43,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ letgamer ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2609,6 +2609,8 @@ self: super: with self; {
 
   certifi = callPackage ../development/python-modules/certifi { };
 
+  certihound = callPackage ../development/python-modules/certihound { };
+
   certipy = callPackage ../development/python-modules/certipy { };
 
   certipy-ad = callPackage ../development/python-modules/certipy-ad { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds Certihound: https://github.com/0x0Trace/Certihound

A Active Directory Certificate Services (ADCS) enumeration library with BloodHound CE v6 export support.

This is needed as Netexec depends on it since Version 1.5.1: https://github.com/Pennyw0rth/NetExec/pull/1054

Related to: https://github.com/NixOS/nixpkgs/issues/81418

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
