### PR TITLE
gupnp-tools: Work around `xmlIndentTreeOutput` deprecation

### DIFF
--- a/pkgs/by-name/gu/gupnp-tools/package.nix
+++ b/pkgs/by-name/gu/gupnp-tools/package.nix
@@ -42,6 +42,11 @@ stdenv.mkDerivation (finalAttrs: {
     gtksourceview4
   ];
 
+  mesonFlags = [
+    # Work around https://gitlab.gnome.org/GNOME/gupnp-tools/-/issues/29
+    "-Dc_args=-Wno-error=deprecated-declarations"
+  ];
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gupnp-tools";


### PR DESCRIPTION
libxml 2.15.1 deprecated the thread local variable. However, it is not necessary.
I am fixing it upstream https://gitlab.gnome.org/GNOME/gupnp-tools/-/merge_requests/8
but until then, let’s add a workaround.


Fixes: https://github.com/NixOS/nixpkgs/issues/464829

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
