### PR TITLE
snowflake-cli: 3.11.0 -> 3.13.1, fix build/tests

### DIFF
--- a/pkgs/by-name/sn/snowflake-cli/generate-json-schema-kwargs.patch
+++ b/pkgs/by-name/sn/snowflake-cli/generate-json-schema-kwargs.patch
@@ -1,0 +1,15 @@
+snowflake-cli is subclassing pydantic's GenerateJsonSchema without passing on unrecognized kwargs to the superclass, this broke when nixpkgs's pydanctic moved to 2.12 which added "union_format" as new input arg
+Due to various flaws in the python ecosystem nixpkgs cannot reuse uv or other python lockfiles and has to approximate dependencies. This patch decouples the code more from minor changes between pydantic versions
+--- a/src/snowflake/cli/_app/dev/docs/project_definition_generate_json_schema.py
++++ b/src/snowflake/cli/_app/dev/docs/project_definition_generate_json_schema.py
+@@ -38,8 +38,8 @@ class ProjectDefinitionProperty:
+
+
+ class ProjectDefinitionGenerateJsonSchema(GenerateJsonSchema):
+-    def __init__(self, by_alias: bool = False, ref_template: str = ""):
+-        super().__init__(by_alias, "{model}")
++    def __init__(self, by_alias: bool = False, ref_template: str = "",**kwargs):
++        super().__init__(by_alias, "{model}",**kwargs)
+         self._remapped_definitions: Dict[str, Any] = {}
+
+     def generate(self, schema, mode="validation"):

--- a/pkgs/by-name/sn/snowflake-cli/package.nix
+++ b/pkgs/by-name/sn/snowflake-cli/package.nix
@@ -8,20 +8,22 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "snowflake-cli";
-  version = "3.11.0";
+  version = "3.13.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snowflakedb";
     repo = "snowflake-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dJc5q3vE1G6oJq9V4JSPaSyODxKDyhprIwBo39Nu/bA=";
+    hash = "sha256-2cZ9tRcQ/sWHkkSXMZ9pXP4zM3OsNbKr2kR/Ob/F9Hk=";
   };
 
   build-system = with python3Packages; [
-    hatch-vcs
     hatchling
-    pip
+  ];
+
+  patches = [
+    ./generate-json-schema-kwargs.patch
   ];
 
   nativeBuildInputs = [ installShellFiles ];
@@ -43,6 +45,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
     prompt-toolkit
     snowflake-core
     snowflake-connector-python
+    # Upstream code is using `pip` as a python module in some Snowpark-related
+    # plugins, when there is a need to build a dependency closure from packages
+    # on PyPi.
+    # Example:
+    # https://github.com/snowflakedb/snowflake-cli/blob/1caafee58fd1a8ae6d8788c33b86f637c263a29e/src/snowflake/cli/_plugins/snowpark/package_utils.py#L223
+    # It's invoking `pip` as `python -m pip`, so `pip` needs to be in
+    # dependencies.
+    pip
   ];
 
   nativeCheckInputs = with python3Packages; [
@@ -75,11 +85,71 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_if_bundling_dependencies_resolves_requirements" # impure?
     "test_silent_output_help" # Snapshot needs update? Diff between received and snapshot is the word 'TABLE' moving down a line
     "test_new_connection_can_be_added_as_default" # Snapshot needs update? Diff between received and snapshot is an empty line
+
+    # These snapshots seem to be broken
+    "test_command_with_global_options"
+    "test_command_without_any_options"
+    "test_command_with_connection_options"
+
+  ]
+  # Looks like these tests do not work with the sandbox on Darwin
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "test_allow_comments_at_source_url"
+    "test_mixed_recursion"
+    "test_parse_source_invalid_url"
+    "test_parse_source_url"
+    "test_recursion_from_url"
+    "test_source_missing_url"
   ];
 
   disabledTestPaths = [
     "tests/app/test_version_check.py"
     "tests/nativeapp/test_sf_sql_facade.py"
+    # Tests don't work as of v3.12.0
+    # They either break sandbox by requiring network access or have outdated snapshots
+    "tests/api/commands/test_snow_typer.py::test_enabled_command_is_visible"
+    "tests/api/commands/test_snow_typer.py::test_enabled_command_is_not_visible" # snapshot
+    "tests/auth/test_auth.py::test_rotate" # snapshot
+    "tests/auth/test_auth.py::test_rotate_only_public_key_set" # snapshot
+    "tests/auth/test_auth.py::test_rotate_other_public_key_set_options[KEY-KEY]" # snapshot
+    "tests/auth/test_auth.py::test_rotate_other_public_key_set_options[None-KEY]" # snapshot
+    "tests/auth/test_auth.py::test_rotate_with_password" # snapshot
+    "tests/auth/test_auth.py::test_setup" # snapshot
+    "tests/auth/test_auth.py::test_setup_connection_already_exists" # snapshot
+    "tests/auth/test_auth.py::test_setup_error_if_any_public_key_is_set" # snapshot
+    "tests/auth/test_auth.py::test_setup_overwrite_connection" # snapshot
+    "tests/auth/test_auth.py::test_setup_with_password" # snapshot
+    "tests/stage/test_stage.py::test_stage_create_encryption"
+    "tests/test_connection.py::test_connection_can_be_added_with_existing_paths_in_arguments"
+    "tests/test_connection.py::test_connection_can_be_added_with_existing_paths_in_prompt[10]"
+    "tests/test_connection.py::test_connection_can_be_added_with_existing_paths_in_prompt[9]"
+    "tests/test_connection.py::test_connection_remove_all"
+    "tests/test_connection.py::test_connection_remove_one"
+    "tests/test_connection.py::test_connection_remove_some" # snapshot
+    "tests/test_connection.py::test_fails_if_existing_connection"
+    "tests/test_connection.py::test_file_paths_have_to_exist_when_given_in_arguments[-k]" # sandbox
+    "tests/test_connection.py::test_file_paths_have_to_exist_when_given_in_arguments[-t]"
+    "tests/test_connection.py::test_file_paths_have_to_exist_when_given_in_prompt[10]"
+    "tests/test_connection.py::test_generate_jwt_with_passphrase[]" # snapshot
+    "tests/test_connection.py::test_if_password_callback_is_called_only_once_from_arguments"
+    "tests/test_connection.py::test_if_password_callback_is_called_only_once_from_prompt"
+    "tests/test_connection.py::test_if_whitespaces_are_stripped_from_connection_name"
+    "tests/test_connection.py::test_new_connection_add_prompt_handles_default_values" # snapshot
+    "tests/test_connection.py::test_new_connection_add_prompt_handles_prompt_override"
+    "tests/test_connection.py::test_new_connection_can_be_added"
+    "tests/test_connection.py::test_new_connection_is_added_to_connections_toml"
+    "tests/test_connection.py::test_new_connection_with_jwt_auth"
+    "tests/test_connection.py::test_port_has_cannot_be_float"
+    "tests/test_connection.py::test_port_has_cannot_be_string"
+    "tests/test_connection.py::test_second_connection_not_update_default_connection"
+    "tests/test_connection.py::test_session_and_master_tokens"
+    "tests/test_connection.py::test_token_file_path_tokens"
+    "tests/test_docs_generation_output.py::test_flags_have_default_values" # snapshot
+    "tests/test_config.py::test_too_wide_permissions_on_custom_config_file_causes_warning" # trying to chmod files inside read-only source or trying to get into a tmp dir
+    "tests/test_config.py::test_no_error_when_init_from_non_default_config" # bad chmod in tmp
+    "tests/test_init.py::test_init_default_values"
+    "tests/test_init.py::test_rename_project"
+    "tests/test_init.py::test_variables_flags"
   ];
 
   pythonRelaxDeps = true;
@@ -112,7 +182,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   meta = {
-    changelog = "https://github.com/snowflakedb/snowflake-cli/blob/main/RELEASE-NOTES.md";
+    changelog = "https://github.com/snowflakedb/snowflake-cli/blob/${finalAttrs.src.tag}/RELEASE-NOTES.md";
     homepage = "https://docs.snowflake.com/en/developer-guide/snowflake-cli-v2/index";
     description = "Command-line tool explicitly designed for developer-centric workloads in addition to SQL operations";
     license = lib.licenses.asl20;

--- a/pkgs/development/python-modules/snowflake-connector-python/default.nix
+++ b/pkgs/development/python-modules/snowflake-connector-python/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
+  aioboto3,
+  aiohttp,
   asn1crypto,
   buildPythonPackage,
   boto3,
   botocore,
   certifi,
-  cffi,
   charset-normalizer,
   cryptography,
   cython,
@@ -20,10 +21,12 @@
   pyarrow,
   pyjwt,
   pyopenssl,
+  pytest-asyncio,
   pytest-xdist,
   pytestCheckHook,
   pytz,
   requests,
+  responses,
   setuptools,
   sortedcontainers,
   tomlkit,
@@ -32,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "snowflake-connector-python";
-  version = "4.2.0";
+  version = "4.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snowflakedb";
     repo = "snowflake-connector-python";
     tag = "v${version}";
-    hash = "sha256-u2DIgW0W9oXSif2lIDqhlIopaXzQRS0x6tyHiYPGFLM=";
+    hash = "sha256-bJK6U5lomcPMGeKEmv+9m+uM5+3GJKKUA3dEwP/ynVo=";
   };
 
   build-system = [
@@ -49,10 +52,7 @@ buildPythonPackage rec {
 
   dependencies = [
     asn1crypto
-    boto3
-    botocore
     certifi
-    cffi
     charset-normalizer
     cryptography
     filelock
@@ -69,11 +69,14 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    "cffi"
     "pyopenssl"
   ];
 
   optional-dependencies = {
+    boto = [
+      boto3
+      botocore
+    ];
     pandas = [
       pandas
       pyarrow
@@ -86,10 +89,15 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
+    aioboto3
+    aiohttp
     numpy
+    pytest-asyncio
     pytest-xdist
     pytestCheckHook
-  ];
+    responses
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
 
   disabledTestPaths = [
     # Tests require encrypted secrets, see
@@ -107,6 +115,21 @@ buildPythonPackage rec {
     # AssertionError: /build/source/.wiremock/wiremock-standalone.jar does not exist
     "test/unit/test_programmatic_access_token.py"
     "test/unit/test_oauth_token.py"
+    "test/unit/test_proxies.py"
+    "test/unit/aio/test_programmatic_access_token_async.py"
+    "test/unit/aio/test_oauth_token_async.py"
+    "test/unit/aio/test_proxies_async.py"
+    # aio tests that connect to the internet
+    "test/unit/aio/test_connection_async_unit.py::test_invalid_backoff_policy"
+    "test/unit/aio/test_ocsp.py"
+    "test/unit/aio/test_s3_util_async.py::test_download_retry_exceeded_error"
+    "test/unit/aio/test_s3_util_async.py::test_accelerate_in_china_endpoint"
+    "test/unit/aio/test_s3_util_async.py::test_get_header_expiry_error"
+    "test/unit/aio/test_s3_util_async.py::test_upload_expiry_error"
+    "test/unit/aio/test_s3_util_async.py::test_download_expiry_error"
+    # snowflake.connector.errors.ProgrammingError: 251008: 251008: Failed to load private key:
+    # argument 'password': Cannot convert "<class 'int'>" instance to a buffer.
+    "test/unit/aio/test_auth_keypair_async.py::test_auth_keypair"
   ];
 
   disabledTests = [
@@ -116,6 +139,8 @@ buildPythonPackage rec {
     # Missing .wiremock/wiremock-standalone.jar
     "test_wiremock"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [
     "snowflake"


### PR DESCRIPTION
Depends on #501900 (which this is based on top of)

This PR is mostly an adaptation of the abandoned PR #445841 .
Since the current version 3.16 requires the as-of-yet unpackaged "snowflake-snowpark-python", I've decided to try and  get the existing update work over the finish line, since the current master version fails both due to its dependency snowflake-connector-python not building (#501900 fixes this), but also fragile extra tests failing now due to slight changes in other dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
