### PR TITLE
nixos/firewall-nftables: add flowtableOffload option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -347,6 +347,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - IPVLAN interfaces can now be configured through the `networking.ipvlans` option in the networking module.
 
+- The nftables-based firewall now supports [nf_flowtable](https://docs.kernel.org/networking/nf_flowtable.html) offloading via [`networking.firewall.flowtableOffload`](#opt-networking.firewall.flowtableOffload), offloading established forwarded connections to the kernel fast path (with opportunistic hardware offload where supported).
+
 - `services.caddy` now supports setting `httpPort` and `httpsPort` and opening them in the firewall via `openFirewall`.
 
 - The latest available version of Nextcloud is v33 (available as `pkgs.nextcloud33`). The installation logic is as follows:

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -56,6 +56,16 @@ in
           This option only works with the nftables based firewall.
         '';
       };
+
+      flowtableOffload = lib.mkEnableOption ''
+        nf_flowtable offloading for forwarded connections. Established
+        connections traversing the forward chain are offloaded to the
+        kernel flowtable fast path, with opportunistic hardware offload
+        where the NIC driver supports it.
+
+        This option only works with the nftables based firewall and
+        requires {option}`networking.firewall.filterForward` to be enabled
+      '';
     };
   };
 
@@ -76,6 +86,10 @@ in
       {
         assertion = config.networking.nftables.rulesetFile == null;
         message = "networking.nftables.rulesetFile conflicts with the firewall";
+      }
+      {
+        assertion = !cfg.flowtableOffload || cfg.filterForward;
+        message = "networking.firewall.flowtableOffload requires networking.firewall.filterForward to be enabled";
       }
     ];
 
@@ -181,8 +195,19 @@ in
       }
 
       ${lib.optionalString cfg.filterForward ''
+        ${lib.optionalString cfg.flowtableOffload ''
+          flowtable f {
+            hook ingress priority filter
+            flags offload
+          }
+        ''}
+
         chain forward {
           type filter hook forward priority filter; policy drop;
+
+          ${lib.optionalString cfg.flowtableOffload ''
+            ct state established flow add @f
+          ''}
 
           ct state vmap {
             invalid : drop,


### PR DESCRIPTION
Enables nf_flowtable offloading for forwarded connections - declares a flowtable with offload flags enabled and a flow rule addition at the top of the forward chain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
