### PR TITLE
python3Packages.connect-box3: init at 0.2.1

### DIFF
--- a/pkgs/by-name/co/connect-box/package.nix
+++ b/pkgs/by-name/co/connect-box/package.nix
@@ -1,0 +1,5 @@
+{ python3Packages }:
+
+(python3Packages.toPythonApplication python3Packages.connect-box3).overrideAttrs {
+  __structuredAttrs = true;
+}

--- a/pkgs/development/python-modules/connect-box3/default.nix
+++ b/pkgs/development/python-modules/connect-box3/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  cyclopts,
+  fetchFromGitHub,
+  hatchling,
+  httpx,
+  mashumaro,
+  pytest-asyncio,
+  pytest-httpx,
+  pytestCheckHook,
+  rich,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "connect-box3";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-ecosystem";
+    repo = "python-connect-box3";
+    tag = finalAttrs.version;
+    hash = "sha256-eLrCMziV/+maLIded1n0248Xb14uVBps/gzTUz8NMMc=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    cyclopts
+    httpx
+    mashumaro
+    rich
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-httpx
+  ];
+
+  pythonImportsCheck = [ "connect_box3" ];
+
+  meta = {
+    description = "Interact with a Connect Box 3 modem/router";
+    homepage = "https://github.com/home-assistant-ecosystem/python-connect-box3";
+    changelog = "https://github.com/home-assistant-ecosystem/python-connect-box3/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "connect-box";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3160,6 +3160,8 @@ self: super: with self; {
 
   connect-box = callPackage ../development/python-modules/connect-box { };
 
+  connect-box3 = callPackage ../development/python-modules/connect-box3 { };
+
   connected-components-3d = callPackage ../development/python-modules/connected-components-3d { };
 
   connection-pool = callPackage ../development/python-modules/connection-pool { };


### PR DESCRIPTION
Interact with a Connect Box 3 modem/router

https://github.com/home-assistant-ecosystem/python-connect-box3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
