### PR TITLE
remarkable-tablet-driver: init at unstable-2025-10-28

### DIFF
--- a/pkgs/by-name/re/remarkable-tablet-driver/package.nix
+++ b/pkgs/by-name/re/remarkable-tablet-driver/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  libssh,
+}:
+
+stdenv.mkDerivation {
+  pname = "remarkable-tablet-driver";
+  version = "unstable-2025-10-28";
+
+  src = fetchFromGitHub {
+    owner = "FreeCap23";
+    repo = "reMarkable-tablet-driver";
+    rev = "dab7a35c2fc82a8c9173b9685dcda4a45d881165";
+    sha256 = "sha256-AQhDKzxN+Gkuv0W+P53Xh4pM/iiq8zvKacPXMPYlbW8=";
+  };
+
+  # Build errors when format hardening is enabled:
+  #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libssh
+  ];
+
+  meta = with lib; {
+    description = "A userspace tablet driver on Linux for the reMarkable Paper Table";
+    mainProgram = "rmTabletDriver";
+    homepage = "https://github.com/FreeCap23/reMarkable-tablet-driver";
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}

--- a/pkgs/by-name/re/remarkable-tablet-driver/package.nix
+++ b/pkgs/by-name/re/remarkable-tablet-driver/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  libssh,
+}:
+
+stdenv.mkDerivation {
+  pname = "remarkable-tablet-driver";
+  version = "unstable-2025-10-28";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "FreeCap23";
+    repo = "reMarkable-tablet-driver";
+    rev = "dab7a35c2fc82a8c9173b9685dcda4a45d881165";
+    sha256 = "sha256-AQhDKzxN+Gkuv0W+P53Xh4pM/iiq8zvKacPXMPYlbW8=";
+  };
+
+  # Build errors when format hardening is enabled:
+  #   cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libssh
+  ];
+
+  meta = with lib; {
+    description = "A userspace tablet driver on Linux for the reMarkable Paper Table";
+    mainProgram = "rmTabletDriver";
+    homepage = "https://github.com/FreeCap23/reMarkable-tablet-driver";
+    platforms = platforms.linux;
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ pamplemousse ];
+  };
+}


### PR DESCRIPTION
Added the [`remarkable-tablet-driver`](https://github.com/FreeCap23/reMarkable-tablet-driver) package, which allows to use the ReMarkable tablet input as a PC input.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
