### PR TITLE
python3Packages.emv: refactored code

### DIFF
--- a/pkgs/development/python-modules/emv/default.nix
+++ b/pkgs/development/python-modules/emv/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   click,
   pyscard,
   pycountry,
@@ -10,27 +10,29 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "emv";
   version = "1.0.14";
   pyproject = true;
 
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "russss";
     repo = "python-emv";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-MnaeQZ0rA3i0CoUA6HgJQpwk5yo4rm9e+pc5XzRd1eg=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail '"enum-compat==0.0.3",' "" \
-      --replace-fail '"argparse==1.4.0",' "" \
-      --replace-fail "click==7.1.2" "click" \
-      --replace-fail "pyscard==2.0.0" "pyscard" \
-      --replace-fail "pycountry==20.7.3" "pycountry" \
-      --replace-fail "terminaltables==3.1.0" "terminaltables"
-  '';
+  pythonRelaxDeps = [
+    "click"
+    "pyscard"
+    "pycountry"
+    "terminaltables"
+  ];
+
+  pythonRemoveDeps = [
+    "enum-compat"
+    "argparse"
+  ];
 
   build-system = [ setuptools ];
 
@@ -47,10 +49,10 @@ buildPythonPackage rec {
 
   meta = {
     description = "Implementation of the EMV chip-and-pin smartcard protocol";
-    homepage = "https://github.com/russss/python-emv";
-    changelog = "https://github.com/russss/python-emv/releases/tag/v${version}";
+    homepage = "https://codeberg.org/russss/python-emv/";
+    changelog = "https://codeberg.org/russss/python-emv/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lukegb ];
     mainProgram = "emvtool";
   };
-}
+})


### PR DESCRIPTION
Switched to Codeberg, because the Repository was officially moved to Codeberg: https://codeberg.org/russss/python-emv
Switched to finalAttrs
Switched to pythonRelaxDeps and pythonRemoveDeps


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
