### PR TITLE
mealie: 3.12.0 -> 3.16.0

### DIFF
--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/frontend/yarn.lock";
-    hash = "sha256-aYgTdHrorLNBYVNwVyYSTfAqtvn1JB0FBAkoem0vNSU=";
+    hash = "sha256-F1dhdBHfT9N1Ejk7WLyz2BbKlTPfqqEDNi7ZTL3phWY=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
     runHook preBuild
 
     export NUXT_TELEMETRY_DISABLED=1
-    yarn --offline generate --env production
+    yarn --offline generate
     runHook postBuild
   '';
 

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -12,12 +12,12 @@
 }:
 
 let
-  version = "3.12.0";
+  version = "3.16.0";
   src = fetchFromGitHub {
     owner = "mealie-recipes";
     repo = "mealie";
     tag = "v${version}";
-    hash = "sha256-HjXEoLrjmf4ZfBm6/7f5SJzH7nHSKiMOOMRVrYW0vKY=";
+    hash = "sha256-DUwLCe221MQb6AEYNxNDWXoaEdf9q/dNklOXJncnnJ4=";
   };
 
   frontend = callPackage (import ./mealie-frontend.nix src version) { };
@@ -54,6 +54,7 @@ pythonpkgs.buildPythonApplication rec {
       freezegun
       html2text
       httpx
+      httpx-curl-cffi
       ingredient-parser-nlp
       isodate
       itsdangerous
@@ -83,6 +84,7 @@ pythonpkgs.buildPythonApplication rec {
       typing-extensions
       tzdata
       uvicorn
+      yt-dlp
     ]
     ++ uvicorn.optional-dependencies.standard;
 
@@ -90,7 +92,7 @@ pythonpkgs.buildPythonApplication rec {
     rm -rf dev # Do not need dev scripts & code
 
     substituteInPlace pyproject.toml \
-     --replace-fail '"setuptools==82.0.0"' '"setuptools"'
+     --replace-fail '"setuptools==82.0.1"' '"setuptools"'
 
     substituteInPlace mealie/__init__.py \
       --replace-fail '__version__ = ' '__version__ = "v${version}" #'

--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -14,6 +14,7 @@
 
   # tests
   anyio,
+  a2wsgi,
   dirty-equals,
   flask,
   inline-snapshot,
@@ -21,6 +22,8 @@
   pwdlib,
   pyjwt,
   pytest-asyncio,
+  pytest-xdist,
+  pytest-timeout,
   pytestCheckHook,
   sqlalchemy,
   trio,
@@ -42,14 +45,14 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.128.0";
+  version = "0.135.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tiangolo";
     repo = "fastapi";
     tag = version;
-    hash = "sha256-qUTSqTe9mQzfuwqsTCQY6u7Tcnh9XNy4tr5o0/qFFLs=";
+    hash = "sha256-sE5d+MgmP9L+MUosRBsR+KSJkcC9i2EOOtKHq0sXjRM=";
   };
 
   build-system = [ pdm-backend ];
@@ -99,6 +102,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     anyio
+    a2wsgi
     dirty-equals
     flask
     inline-snapshot
@@ -107,6 +111,8 @@ buildPythonPackage rec {
     pyjwt
     pytestCheckHook
     pytest-asyncio
+    pytest-xdist
+    pytest-timeout
     trio
     sqlalchemy
   ]
@@ -132,6 +138,8 @@ buildPythonPackage rec {
     # Don't test docs and examples
     "docs_src"
     "tests/test_tutorial/test_sql_databases"
+    "tests/test_tutorial/test_static_files"
+    "tests/test_tutorial/test_custom_docs_ui"
     # Infinite recursion with strawberry-graphql
     "tests/test_tutorial/test_graphql/test_tutorial001.py"
   ];

--- a/pkgs/development/python-modules/httpx-curl-cffi/default.nix
+++ b/pkgs/development/python-modules/httpx-curl-cffi/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pdm-backend,
+  curl-cffi,
+  httpx,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "httpx-curl-cffi";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "httpx_curl_cffi";
+    inherit (finalAttrs) version;
+    hash = "sha256-F37plo6doUJAcBeBbMP7CKsoGxNPdzqTWbakZQpsgfM=";
+  };
+
+  build-system = [
+    pdm-backend
+  ];
+
+  dependencies = [
+    curl-cffi
+    httpx
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "httpx_curl_cffi"
+  ];
+
+  meta = {
+    description = "Httpx transport for curl_cffi (python bindings for curl-impersonate";
+    homepage = "https://pypi.org/project/httpx-curl-cffi";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ xanderio ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7224,6 +7224,8 @@ self: super: with self; {
 
   httpx-auth = callPackage ../development/python-modules/httpx-auth { };
 
+  httpx-curl-cffi = callPackage ../development/python-modules/httpx-curl-cffi { };
+
   httpx-ntlm = callPackage ../development/python-modules/httpx-ntlm { };
 
   httpx-oauth = callPackage ../development/python-modules/httpx-oauth { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Contains security fix for https://github.com/mealie-recipes/mealie/pull/7474

> Fixes a path traversal vulnerability (CWE-22). A crafted migration archive with archive-controlled image paths could cause shutil.copy2 to read arbitrary local files into recipe storage, which could then be downloaded by the attacker via the export endpoint.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
