### PR TITLE
python3Packages.gradient: overhaul package

### DIFF
--- a/pkgs/development/python-modules/gradient/default.nix
+++ b/pkgs/development/python-modules/gradient/default.nix
@@ -1,83 +1,56 @@
 {
   lib,
-  attrs,
-  boto3,
   buildPythonPackage,
-  click-completion,
-  click-didyoumean,
-  click-help-colors,
-  colorama,
-  fetchPypi,
-  gradient-statsd,
-  gradient-utils,
-  gql,
-  halo,
-  marshmallow,
-  progressbar2,
-  pyopenssl,
-  pyyaml,
-  requests,
-  requests-toolbelt,
-  terminaltables,
-  websocket-client,
+  fetchFromGitHub,
+  hatchling,
+  hatch-fancy-pypi-readme,
+  httpx,
+  pydantic,
+  typing-extensions,
+  anyio,
+  distro,
+  sniffio,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gradient";
   version = "3.10.1";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-TL9Jbo9UvQhgG9aT3wjLD8DvTY48Os04DdaUfNAwcu4=";
+  src = fetchFromGitHub {
+    owner = "digitalocean";
+    repo = "gradient-python";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Psre4HdF4/cgQ5CcM3H6PC+6asej4Is4+932Gvym774=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace 'attrs<=' 'attrs>=' \
-      --replace 'colorama==' 'colorama>=' \
-      --replace 'gql[requests]==3.0.0a6' 'gql' \
-      --replace 'PyYAML==5.*' 'PyYAML' \
-      --replace 'marshmallow<' 'marshmallow>=' \
-      --replace 'websocket-client==0.57.*' 'websocket-client'
+    substituteInPlace pyproject.toml \
+      --replace-fail "hatchling==1.26.3" "hatchling"
   '';
 
-  propagatedBuildInputs = [
-    attrs
-    boto3
-    click-completion
-    click-didyoumean
-    click-help-colors
-    colorama
-    gql
-    gradient-statsd
-    gradient-utils
-    halo
-    marshmallow
-    progressbar2
-    pyopenssl
-    pyyaml
-    requests
-    requests-toolbelt
-    terminaltables
-    websocket-client
+  nativeBuildInputs = [
+    hatchling
+    hatch-fancy-pypi-readme
   ];
 
-  # Tries to use /homeless-shelter to mimic container usage, etc
-  doCheck = false;
+  dependencies = [
+    httpx
+    pydantic
+    typing-extensions
+    anyio
+    distro
+    sniffio
+  ];
 
-  # marshmallow.exceptions.StringNotCollectionError: "only" should be a collection of strings.
-  # Support for marshmallow > 3
-  # pythonImportsCheck = [
-  #   "gradient"
-  # ];
+  pythonImportsCheck = [ "gradient" ];
 
   meta = {
-    description = "Command line interface for Gradient";
+    description = "Python API library for Gradient";
     mainProgram = "gradient";
-    homepage = "https://github.com/Paperspace/gradient-cli";
-    license = lib.licenses.isc;
+    homepage = "https://github.com/digitalocean/gradient-python";
+    license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Completely overhauled the package:
- switched from fetchPypi to fetchFromGitHub
- switched from setutools to pyproject
- fixed the Metadata Links and License


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
