### PR TITLE
spout2pw: init at 0.2.3, obs-pwvideo: init at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15521,6 +15521,14 @@
     githubId = 591860;
     name = "Lionello Lunesu";
   };
+  liquidnya = {
+    name = "Alice ✨🌙 Luna";
+    github = "liquidnya";
+    githubId = 7364785;
+    email = "alice@liquidnya.dev";
+    matrix = "@liquidnya:matrix.org";
+    keys = [ { fingerprint = "7C2D E075 FA93 D61C C9A7  876F 7966 C19E 32F9 EF06"; } ];
+  };
   lisanna-dettwyler = {
     email = "lisanna.dettwyler@gmail.com";
     github = "lisanna-dettwyler";

--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -66,6 +66,8 @@
 
   obs-plugin-countdown = qt6Packages.callPackage ./obs-plugin-countdown.nix { };
 
+  obs-pwvideo = callPackage ./obs-pwvideo.nix { };
+
   obs-recursion-effect = callPackage ./obs-recursion-effect.nix { };
 
   obs-replay-source = qt6Packages.callPackage ./obs-replay-source.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-pwvideo.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-pwvideo.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  obs-studio,
+  pipewire,
+  pkg-config,
+  libdrm,
+  libGL,
+}:
+stdenv.mkDerivation rec {
+  pname = "obs-pwvideo";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "hoshinolina";
+    repo = "obs-pwvideo";
+    rev = version;
+    sha256 = "sha256-CCzeK5JyCWnIcty5xaDV5uCxvrMVx50f8SoLZnlF658=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+  buildInputs = [
+    obs-studio
+    pipewire
+    libdrm
+    libGL
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_LIBDIR=./lib"
+    "-DCMAKE_INSTALL_DATADIR=./share"
+  ];
+
+  meta = {
+    description = "OBS generic PipeWire video source";
+    homepage = "https://github.com/hoshinolina/obs-pwvideo";
+    maintainers = with lib.maintainers; [
+      liquidnya
+    ];
+    license = lib.licenses.gpl2Plus;
+    inherit (obs-studio.meta) platforms;
+  };
+}

--- a/pkgs/by-name/sp/spout2pw/0001-mesa.patch
+++ b/pkgs/by-name/sp/spout2pw/0001-mesa.patch
@@ -1,0 +1,33 @@
+diff --git a/misc/spout2pw.sh b/misc/spout2pw.sh
+index 70e1b99..26b5c71 100755
+--- a/misc/spout2pw.sh
++++ b/misc/spout2pw.sh
+@@ -96,6 +96,7 @@ check_pipewire() {
+ 
+ find_gbm_backends() {
+     gbm_backend_paths="
++        @MESA_PATH@/lib
+         /usr/lib/x86_64-linux-gnu/GL/lib
+         /usr/lib/x86_64-linux-gnu
+         /usr/lib64
+@@ -224,8 +225,7 @@ setup_umu() {
+     done
+ 
+     if [ "$UMU_NO_RUNTIME" != 1 ]; then
+-        steamrt_checkpath
+-        gbm_steamrt_workaround "$runtimepath"
++        export GBM_BACKENDS_PATH="$gbm_backends"
+     fi
+ 
+     if [ -n "$WINEPREFIX" ]; then
+@@ -281,9 +281,7 @@ setup_steam() {
+     fi
+ 
+     if [[ ! "$1" == */proton ]] && [ "$steam_runtime" = 1 ]; then
+-        runtimepath="$(echo "$STEAM_COMPAT_TOOL_PATHS" | cut -d: -f2)"
+-        steamrt_checkpath
+-        gbm_steamrt_workaround "$runtimepath"
++        export GBM_BACKENDS_PATH="$gbm_backends"
+     fi
+ 
+     log "Steam Proton launch command: ${launch_cmd[@]}"

--- a/pkgs/by-name/sp/spout2pw/0002-pipewire.patch
+++ b/pkgs/by-name/sp/spout2pw/0002-pipewire.patch
@@ -1,0 +1,35 @@
+diff --git a/meson.build b/meson.build
+index aa27927..3511709 100644
+--- a/meson.build
++++ b/meson.build
+@@ -60,7 +60,7 @@ libfunnel_proj = subproject(
+     'test_apps=false',
+     'egl=false',
+     'default_library=static',
+-    'static_pipewire=true',
++    'static_pipewire=false',
+   ]
+ )
+ 
+@@ -87,7 +87,6 @@ unix_compiler_args = [ '-DWINE_UNIX_LIB' ] + unix_include_args
+ unix_link_args = [
+   '-l:ntdll.so',
+   '-Wl,--whole-archive',
+-  '-Wl,' + get_option('libpipewire_static_lib'),
+   '-Wl,--no-whole-archive',
+ ]
+ 
+@@ -100,11 +99,13 @@ windows_deps = [
+ ]
+ 
+ vulkan = dependency('vulkan', native: true)
++pipewire = dependency('libpipewire-0.3', native: true)
+ 
+ unix_deps = [
+   funnel,
+   funnel_vk,
+   vulkan,
++  pipewire,
+ ]
+ 
+ foreach p : unix_lib_paths

--- a/pkgs/by-name/sp/spout2pw/0003-spout2pw-path.patch
+++ b/pkgs/by-name/sp/spout2pw/0003-spout2pw-path.patch
@@ -1,0 +1,13 @@
+diff --git a/misc/spout2pw.sh b/misc/spout2pw.sh
+index 0737cc7..26b5c71 100755
+--- a/misc/spout2pw.sh
++++ b/misc/spout2pw.sh
+@@ -1,7 +1,7 @@
+ #!/usr/bin/env bash
+ set -E
+ 
+-spout2pw="$(dirname "$(realpath "$0")")"
++spout2pw="@SPOUT2PW_PATH@/share/spout2pw"
+ 
+ setup_logging() {
+     zenity=

--- a/pkgs/by-name/sp/spout2pw/0004-spout2pw-usage.patch
+++ b/pkgs/by-name/sp/spout2pw/0004-spout2pw-usage.patch
@@ -1,0 +1,18 @@
+diff --git a/misc/spout2pw.sh b/misc/spout2pw.sh
+index 26b5c71..eec68bd 100755
+--- a/misc/spout2pw.sh
++++ b/misc/spout2pw.sh
+@@ -304,11 +304,11 @@ usage() {
+     show_info \
+ "Usage:
+ 
+-   $0 umu-run app.exe
++   spout2pw umu-run app.exe
+ 
+ or set the Steam launch flags to:
+ 
+-   $(realpath "$0") %command%"
++   spout2pw %command%"
+ }
+ 
+ validate_paths() {

--- a/pkgs/by-name/sp/spout2pw/0005-tools-package.patch
+++ b/pkgs/by-name/sp/spout2pw/0005-tools-package.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/package.sh b/tools/package.sh
+index 5126089..d80119e 100644
+--- a/tools/package.sh
++++ b/tools/package.sh
+@@ -1,7 +1,7 @@
+ #!/bin/bash
+ set -e
+ 
+-PKGDIR="${MESON_BUILD_ROOT}/pkg"
++PKGDIR="$out/share/spout2pw"
+ 
+ mkdir -p "$PKGDIR"
+ cd "$PKGDIR"

--- a/pkgs/by-name/sp/spout2pw/package.nix
+++ b/pkgs/by-name/sp/spout2pw/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  cmake,
+  pkgsCross,
+  wine64,
+  mesa,
+  pkg-config,
+  libgbm,
+  libdrm,
+  vulkan-loader,
+  pipewire,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spout2pw";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "hoshinolina";
+    repo = "spout2pw";
+    rev = finalAttrs.version;
+    fetchSubmodules = true;
+    sha256 = "sha256-BpO5YkLPXHYubB4zFIIRo+uDcN/B6HWXyH6FUCF0T3s=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    cmake
+    pkgsCross.mingwW64.buildPackages.gcc
+    wine64
+  ];
+
+  depsBuildBuild = [
+    pkg-config
+    libgbm
+    libdrm
+    vulkan-loader
+    pipewire
+  ];
+
+  patches = [
+    ./0001-mesa.patch
+    ./0002-pipewire.patch
+    ./0003-spout2pw-path.patch
+    ./0004-spout2pw-usage.patch
+    ./0005-tools-package.patch
+  ];
+
+  postPatch = ''
+    patchShebangs --build tools/get_wine_path.sh
+    chmod +x tools/package.sh
+    patchShebangs --build tools/package.sh
+  '';
+
+  mesonFlags = [
+    "--cross-file=${finalAttrs.src}/misc/x86_64-w64-mingw32.txt"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s $out/share/spout2pw/spout2pw.sh $out/bin/spout2pw
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/share/spout2pw/spout2pw.sh \
+      --replace-fail '@MESA_PATH@' "${mesa}" \
+      --replace-fail '@SPOUT2PW_PATH@' "$out"
+  '';
+
+  meta = {
+    description = "Spout2 to PipeWire video bridge";
+    homepage = "https://spout2pw.lina.yt/";
+    mainProgram = "spout2pw";
+    maintainers = with lib.maintainers; [
+      liquidnya
+    ];
+    license = lib.licenses.lgpl21Plus;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds the following packages by @hoshinolina to nixpkgs:

- spout2pw ([Homepage](https://spout2pw.lina.yt/)) ([GitHub](https://github.com/hoshinolina/spout2pw))
- obs-pwvideo ([GitHub](https://github.com/hoshinolina/obs-pwvideo))

These packages can be used together to stream a video from a Windows game or application directly to OBS Studio by using [spout](https://spout.zeal.co/).
For example it can be used to transfer a video stream from [VNyan](https://suvidriel.itch.io/vnyan) and [VTube Studio](https://denchisoft.com/) ([VTuber](https://en.wikipedia.org/wiki/VTuber) software) directly to OBS Studio with a transparent background!
Using regular screen capture (instead of these packages) can not capture the application without the background.

## Manual tests

I tested the following configurations:

|     OBS Studio through → | home-manager |  flatpak  |
|---:|---|---|
| VNyan through umu-launcher | :heavy_check_mark: | :heavy_check_mark: |
| VNyan through Steam  | :heavy_check_mark:    | :heavy_check_mark:  |
| VTube Studio through Steam  | :heavy_check_mark:  | :heavy_check_mark:  |

My setups were as follows:

### OBS Studio through home-manager

I installed OBS through [home-manager](https://nix-community.github.io/home-manager/) like this:

```nix
{ pkgs, ... }:
{
  programs.obs-studio = {
    enable = true;
    plugins = with pkgs.obs-studio-plugins; [
      obs-pwvideo
    ];
  };
}
```

To run OBS I used:
```bash
obs
```

### OBS Studio through flatpak

I installed flatpak using:

```nix
{
  services.flatpak.enable = true;
}
```

Then I run the following commands to install OBS Studio:

```bash
flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
flatpak install flathub com.obsproject.Studio
flatpak install com.obsproject.Studio.Plugin.OBSPWVideo
```

To run OBS I used:
```bash
flatpak run com.obsproject.Studio
```

### Windows applications using spout

I installed spout2pw through [home-manager](https://nix-community.github.io/home-manager/) using:
```nix
{ pkgs, ... }:
{
  home.packages = with pkgs; [
    spout2pw
  ];
}
```

I installed steam by using `programs.steam` as [a NixOS module](https://github.com/liquidnya/infrastructure/blob/086cfeab02723609a930d25392b37f7ed84bfe89/modules/programs/steam/nixos.nix).

### VNyan through umu-launcher

I used:

```bash
nix shell nixpkgs#umu-launcher
spout2pw umu-run "/path/to/vnyan-1.6.8b/VNyan.exe" -portable -p test-profile
```

Note that the application has to be run once without `spout2pw` to install proton/wine and then can be started with `spout2pw`.

### VNyan through Steam

I added VNyan as an external application and then used the Proton Experimental compatibility and use `spout2pw %command% -portable -p test-profile` as the launch options.

### VTube Studio through Steam

I installed VTube Studio on steam and just used the following launch options: `spout2pw %command%`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
