### PR TITLE
jolt-tui: init at 1.2.0

### DIFF
--- a/pkgs/by-name/jo/jolt-tui/package.nix
+++ b/pkgs/by-name/jo/jolt-tui/package.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jolt-tui";
+  version = "1.2.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jordond";
+    repo = "jolt";
+    tag = finalAttrs.version;
+    hash = "sha256-A8X06Y7Ujl2rN4+op6ixbWaL4Tx9Toj6+jSgRhRcDRM=";
+  };
+
+  cargoHash = "sha256-5SKyKTQXqcRsmvyHfq4i7RcGiL+3lENcEXU1FgTGsek=";
+
+  cargoBuildFlags = [ "--package=jolt-tui" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Terminal-based battery and energy monitor";
+    homepage = "https://getjolt.sh";
+    changelog = "https://github.com/jordond/jolt/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "jolt";
+    maintainers = with lib.maintainers; [ EpicEric ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Jolt is a terminal-based battery and energy monitor for macOS and Linux.

- Website: https://getjolt.sh
- Repository: https://github.com/jordond/jolt

A bunch of modifications were made from the original flake, such as removing unneeded dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
