### PR TITLE
pythonPackages.certipy: relax beautifulsoup4

### DIFF
--- a/pkgs/development/python-modules/certipy-ad/default.nix
+++ b/pkgs/development/python-modules/certipy-ad/default.nix
@@ -39,6 +39,7 @@ buildPythonPackage (finalAttrs: {
     "ldap3"
     "pycryptodome"
     "pyopenssl"
+    "beautifulsoup4"
   ];
 
   build-system = [ setuptools ];


### PR DESCRIPTION
When trying to build I got an runtime dependency error for beautifulsoup4

> Successfully built certipy_ad-5.0.3-py3-none-any.whl
> Finished creating a wheel...
> /build/source/dist /build/source
> Unpacking to: unpacked/certipy_ad-5.0.3...OK
> Repacking wheel as ./certipy_ad-5.0.3-py3-none-any.whl...OK
> /build/source
> Finished executing pypaBuildPhase
> Running phase: pythonRuntimeDepsCheckHook
> Executing pythonRuntimeDepsCheck
> Checking runtime dependencies for certipy_ad-5.0.3-py3-none-any.whl
>   - beautifulsoup4~=4.13.4 not satisfied by version 4.14.3

I fixed it for my local config using:
```nix
(certipy.overrideAttrs (prev: {
  pythonRelaxDeps = prev.pythonRelaxDeps ++ [ "beautifulsoup4" ];
}))
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
