### PR TITLE
dockerTools: fix failing `etc` test case

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -803,6 +803,10 @@ rec {
           }
         )
       );
+      etcCmd = pkgs.writeScript "etc-cmd" ''
+        #!${pkgs.busybox}/bin/sh
+        ${pkgs.busybox}/bin/cat /etc/some-config-file
+      '';
     in
     pkgs.dockerTools.streamLayeredImage {
       name = "etc";
@@ -812,10 +816,7 @@ rec {
         mkdir -p /etc
         ${nixosCore.config.system.build.etcActivationCommands}
       '';
-      config.Cmd = pkgs.writeScript "etc-cmd" ''
-        #!${pkgs.busybox}/bin/sh
-        ${pkgs.busybox}/bin/cat /etc/some-config-file
-      '';
+      config.Cmd = [ etcCmd ];
     };
 
   # Example export of the bash image


### PR DESCRIPTION
The `etc` sub-test in `nixos.tests.docker-tools` has been failing with the following error since 2025-12-11:

> docker: Error response from daemon: could not deserialize image config: json: cannot unmarshal string into Go struct field DockerOCIImageConfig.config.ImageConfig.Cmd of type []string

The failing test is the only example with `config.Cmd` defined as a string, all others use string lists.

It seems to coincide with the upgrade from docker v28 to v29 that made it more strict when parsing manifests.

## Things done

The `etc` example has been fixed.

## Possible improvements

This test is still passing on `25.11` since docker v28 is still the default, maybe there should be some logic to automatically wrap commands defined as strings in a list. 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
