### PR TITLE
iio-sensor-proxy: 3.8 -> 3.9

### DIFF
--- a/pkgs/by-name/ii/iio-sensor-proxy/package.nix
+++ b/pkgs/by-name/ii/iio-sensor-proxy/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch,
   glib,
   cmake,
   libxml2,
@@ -14,19 +13,18 @@
   polkit,
   udevCheckHook,
   libssc,
-  libqmi,
 }:
 
 stdenv.mkDerivation rec {
   pname = "iio-sensor-proxy";
-  version = "3.8";
+  version = "3.9";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "hadess";
     repo = "iio-sensor-proxy";
     rev = version;
-    hash = "sha256-ZVaV4Aj4alr5eP3uz6SunpeRsMOo8YcZMqCcB0DUYGY=";
+    hash = "sha256-2N/4Fp6QtAhgEzX9cHEDJhFtRsyrtZ80I2jdHdeEmxA=";
   };
 
   postPatch = ''
@@ -34,14 +32,6 @@ stdenv.mkDerivation rec {
     substituteInPlace data/meson.build \
       --replace 'polkit_policy_directory' "'$out/share/polkit-1/actions'"
   '';
-
-  patches = [
-    # https://gitlab.freedesktop.org/hadess/iio-sensor-proxy/-/merge_requests/381
-    (fetchpatch {
-      url = "https://gitlab.postmarketos.org/postmarketOS/pmaports/-/raw/af17d8f3a7572ed2be40d5a28c6ce08c74bd36c7/temp/iio-sensor-proxy/0001-iio-sensor-proxy-depend-on-libssc.patch";
-      hash = "sha256-faOpfR6qit68R2b+sk9/k4XeA6Ao5UuerrfFzMaD3MM=";
-    })
-  ];
 
   buildInputs = [
     libgudev
@@ -63,7 +53,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     (lib.mesonOption "udevrulesdir" "${placeholder "out"}/lib/udev/rules.d")
     (lib.mesonOption "systemdsystemunitdir" "${placeholder "out"}/lib/systemd/system")
-    (lib.mesonBool "ssc-support" true)
+    (lib.mesonOption "ssc-support" "enabled")
   ];
 
   doInstallCheck = true;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
