### PR TITLE
iio-niri: 1.3.0 -> 2.0.0

### DIFF
--- a/nixos/modules/services/misc/iio-niri.nix
+++ b/nixos/modules/services/misc/iio-niri.nix
@@ -32,7 +32,7 @@ in
     extraArgs = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      description = "Extra arguments to pass to IIO-Niri.";
+      description = "Extra arguments to pass to `iio-niri listen`.";
     };
   };
 
@@ -49,7 +49,7 @@ in
       after = [ cfg.niriUnit ];
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${getExe cfg.package} ${escapeShellArgs cfg.extraArgs}";
+        ExecStart = "${getExe cfg.package} listen ${escapeShellArgs cfg.extraArgs}";
         Restart = "on-failure";
       };
     };

--- a/pkgs/by-name/ii/iio-niri/package.nix
+++ b/pkgs/by-name/ii/iio-niri/package.nix
@@ -1,30 +1,40 @@
 {
   rustPlatform,
+  stdenv,
   lib,
   fetchFromGitHub,
   dbus,
   pkg-config,
+  installShellFiles,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "iio-niri";
-  version = "1.3.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "Zhaith-Izaliel";
     repo = "iio-niri";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tbCiG/u350U7UbYDV5gWczDQd//RosNHuzB/cP9Dyyo=";
+    hash = "sha256-foE+bPJANKWmPSt3s8BOqEIXGZoFNWRJT731xf5sr1M=";
   };
 
-  cargoHash = "sha256-JnjBnqZXRhxUClvC2hIW898AwwEOS/ELrsrjY2dV3Is=";
+  cargoHash = "sha256-y3Sv3JWg252XbuIqEioNagaQ99Vr9x1OfrFC6Jl4kSY=";
 
   nativeBuildInputs = [
     pkg-config
+    installShellFiles
   ];
 
   buildInputs = [
     dbus
   ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd iio-niri \
+      --bash <($out/bin/iio-niri completions bash) \
+      --zsh <($out/bin/iio-niri completions zsh) \
+      --fish <($out/bin/iio-niri completions fish)
+  '';
 
   meta = {
     description = "Listen to iio-sensor-proxy and updates Niri output orientation depending on the accelerometer orientation";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR updates IIO-Niri to 2.0.0 ([changelog](https://github.com/Zhaith-Izaliel/iio-niri/releases/tag/v2.0.0)) and add the shell completions it generates. Since 2.0.0 induces a breaking change in the CLI, the module has been updated to preserve the old behavior.

I am not sure if I need to make a release note since, besides the shell completions, the package and module didn't change much.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
