### PR TITLE
nixos/i18n/input-method: disallow gtk{2,3}.dev in closure

### DIFF
--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -23,11 +23,16 @@ let
         allowSubstitutes = false;
         buildInputs = [
           cfg.package
+          pkgs.gtk2.dev
+        ];
+
+        disallowedReferences = [
+          pkgs.gtk2.dev
         ];
       }
       ''
         mkdir -p $out/etc/gtk-2.0/
-        GTK_PATH=${cfg.package}/lib/gtk-2.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${lib.getExe' pkgs.gtk2.dev "gtk-query-immodules-2.0"} > $out/etc/gtk-2.0/immodules.cache
+        GTK_PATH=${cfg.package}/lib/gtk-2.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} gtk-query-immodules-2.0 > $out/etc/gtk-2.0/immodules.cache
       '';
 
   gtk3_cache =
@@ -37,11 +42,16 @@ let
         allowSubstitutes = false;
         buildInputs = [
           cfg.package
+          pkgs.gtk3.dev
+        ];
+
+        disallowedReferences = [
+          pkgs.gtk3.dev
         ];
       }
       ''
         mkdir -p $out/etc/gtk-3.0/
-        GTK_PATH=${cfg.package}/lib/gtk-3.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${lib.getExe' pkgs.gtk3.dev "gtk-query-immodules-3.0"} > $out/etc/gtk-3.0/immodules.cache
+        GTK_PATH=${cfg.package}/lib/gtk-3.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} gtk-query-immodules-3.0 > $out/etc/gtk-3.0/immodules.cache
       '';
 
 in

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -23,11 +23,16 @@ let
         allowSubstitutes = false;
         buildInputs = [
           cfg.package
+          pkgs.gtk2
+        ];
+
+        disallowedReferences = [
+          (lib.getDev pkgs.gtk2)
         ];
       }
       ''
         mkdir -p $out/etc/gtk-2.0/
-        GTK_PATH=${cfg.package}/lib/gtk-2.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${lib.getExe' pkgs.gtk2.dev "gtk-query-immodules-2.0"} > $out/etc/gtk-2.0/immodules.cache
+        GTK_PATH=${cfg.package}/lib/gtk-2.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} gtk-query-immodules-2.0 > $out/etc/gtk-2.0/immodules.cache
       '';
 
   gtk3_cache =
@@ -37,11 +42,16 @@ let
         allowSubstitutes = false;
         buildInputs = [
           cfg.package
+          pkgs.gtk3
+        ];
+
+        disallowedReferences = [
+          (lib.getDev pkgs.gtk3)
         ];
       }
       ''
         mkdir -p $out/etc/gtk-3.0/
-        GTK_PATH=${cfg.package}/lib/gtk-3.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} ${lib.getExe' pkgs.gtk3.dev "gtk-query-immodules-3.0"} > $out/etc/gtk-3.0/immodules.cache
+        GTK_PATH=${cfg.package}/lib/gtk-3.0/ ${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} gtk-query-immodules-3.0 > $out/etc/gtk-3.0/immodules.cache
       '';
 
 in


### PR DESCRIPTION
The gtk-query-immodules-{2,3}.0 util writes argv[0] to its stdout in a comment (i.e., "# Created by ..."). This results in a reference to pkgs.gtk{2,3}.dev being present in the closure.

This commit avoids this issue by adding the pkgs.gtk{2,3}.dev to path and calling gtk-query-immodules-{2,3}.0 without its full path.

Furthermore, pkgs.gtk{2,3}.dev is added to disallowedReferences to avoid future regressions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
