### PR TITLE
cfr: build from source

### DIFF
--- a/pkgs/by-name/cf/cfr/package.nix
+++ b/pkgs/by-name/cf/cfr/package.nix
@@ -1,39 +1,54 @@
 {
   lib,
-  stdenv,
+  fetchFromGitHub,
+  jre_headless,
   makeWrapper,
-  fetchurl,
-  jre,
+  maven,
+  jdk11,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+maven.buildMavenPackage rec {
   pname = "cfr";
   version = "0.152";
 
-  src = fetchurl {
-    url = "https://www.benf.org/other/cfr/cfr_${finalAttrs.version}.jar";
-    sha256 = "sha256-9obo897Td9e8h9IWqQ6elRLfQVbnWwbGVaFmSK6HZbI=";
+  src = fetchFromGitHub {
+    owner = "leibnitz27";
+    repo = "cfr";
+    tag = version;
+    hash = "sha256-bT/qlMD2aNhW9i4DEYymSbfKqtE/m1m6h5UkbFIyj4E=";
   };
+
+  # Otherwise fails, because the .git folder is stripped
+  mvnParameters = "-Dmaven.gitcommitid.skip=true";
+
+  mvnJdk = jdk11;
+
+  mvnHash = "sha256-PmTltYQzdla3d3ozh1QBXAlnMcy/0SxknRFN9ULdszY=";
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildCommand = ''
-    jar=$out/share/java/cfr_${finalAttrs.version}.jar
-    install -Dm444 $src $jar
-    makeWrapper ${jre}/bin/java $out/bin/cfr --add-flags "-jar $jar"
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/cfr
+    install -Dm644 target/cfr-${version}.jar $out/share/cfr
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/cfr \
+      --add-flags "-jar $out/share/cfr/cfr-${version}.jar"
+
+    runHook postInstall
   '';
 
   meta = {
     description = "Another java decompiler";
-    mainProgram = "cfr";
     longDescription = ''
       CFR will decompile modern Java features - Java 8 lambdas (pre and post
       Java beta 103 changes), Java 7 String switches etc, but is written
       entirely in Java 6.
     '';
-    homepage = "http://www.benf.org/other/cfr/";
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    homepage = "https://github.com/leibnitz27/cfr";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "cfr";
   };
-})
+}

--- a/pkgs/by-name/cf/cfr/package.nix
+++ b/pkgs/by-name/cf/cfr/package.nix
@@ -1,39 +1,54 @@
 {
   lib,
-  stdenv,
+  fetchFromGitHub,
+  jre_headless,
   makeWrapper,
-  fetchurl,
-  jre,
+  maven,
+  jdk11,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+maven.buildMavenPackage (finalAttrs: {
   pname = "cfr";
   version = "0.152";
 
-  src = fetchurl {
-    url = "https://www.benf.org/other/cfr/cfr_${finalAttrs.version}.jar";
-    sha256 = "sha256-9obo897Td9e8h9IWqQ6elRLfQVbnWwbGVaFmSK6HZbI=";
+  src = fetchFromGitHub {
+    owner = "leibnitz27";
+    repo = "cfr";
+    tag = finalAttrs.version;
+    hash = "sha256-bT/qlMD2aNhW9i4DEYymSbfKqtE/m1m6h5UkbFIyj4E=";
   };
+
+  # Otherwise fails, because the .git folder is stripped
+  mvnParameters = "-Dmaven.gitcommitid.skip=true";
+
+  mvnJdk = jdk11;
+
+  mvnHash = "sha256-JvmOCMmZJIeIaYkGvhwRPGK/Q1LCHSVJFRF7WIBJFDg=";
 
   nativeBuildInputs = [ makeWrapper ];
 
-  buildCommand = ''
-    jar=$out/share/java/cfr_${finalAttrs.version}.jar
-    install -Dm444 $src $jar
-    makeWrapper ${jre}/bin/java $out/bin/cfr --add-flags "-jar $jar"
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/cfr
+    install -Dm644 target/cfr-${finalAttrs.version}.jar $out/share/cfr
+
+    makeWrapper ${lib.getExe jre_headless} $out/bin/cfr \
+      --add-flags "-jar $out/share/cfr/cfr-${finalAttrs.version}.jar"
+
+    runHook postInstall
   '';
 
   meta = {
     description = "Another java decompiler";
-    mainProgram = "cfr";
     longDescription = ''
       CFR will decompile modern Java features - Java 8 lambdas (pre and post
       Java beta 103 changes), Java 7 String switches etc, but is written
       entirely in Java 6.
     '';
-    homepage = "http://www.benf.org/other/cfr/";
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    homepage = "https://github.com/leibnitz27/cfr";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ letgamer ];
+    mainProgram = "cfr";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR Changes the Java Decompiler CFR to be built from source instead of fetching the JAR.
I also tested it by decompiling Burpsuite.

Related to: https://github.com/NixOS/nixpkgs/issues/81418

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
