### PR TITLE
icu: patch pkgconfig paths too

### DIFF
--- a/pkgs/development/libraries/icu/make-icu.nix
+++ b/pkgs/development/libraries/icu/make-icu.nix
@@ -143,6 +143,7 @@ let
 
           substituteInPlace "$dev/bin/icu-config" \
             ${lib.concatMapStringsSep " " (r: "--replace '${r.from}' '${r.to}'") replacements}
+          substituteInPlace "$out/lib/pkgconfig/icu-uc.pc" --replace-fail "$out/lib" "$dev/lib"
         ''
       );
 


### PR DESCRIPTION
When trying to package something which uses pkgdata from icu in the build, pkgdata fails with
```
Unable to open or read "/nix/store/jbv3jyjphdk3pnklwjj8m1y4i6688y7r-icu4c-78.2/lib/icu/78.2/pkgdata.inc" option file. status = U_FILE_ACCESS_ERROR.
```
The correct path is `/nix/store/hjisxwmr8qalsic92mlk838vxdx6yx72-icu4c-78.2-dev/lib/icu/pkgdata.inc`, as returned by `icu-config --incpkgdatafile` which we already patch. \
`pkgdata` on the other hand [tries to get the path from pkg-config first](https://github.com/unicode-org/icu/blob/3377fe3dc221b9eb090ac407a996bb5d764e0b6b/icu4c/source/tools/pkgdata/pkgdata.cpp#L2175), which we *don't* patch, so it contains the non-dev libdir, which doesn't have `pkgdata.inc`.

Patching the .pc post-install seemed simplest, but I'm not super familiar with the setup here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
