### PR TITLE
urxvt-tabbedex: 22.32 → 26.16.1

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-tabbedex/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-tabbedex/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "urxvt-tabbedex";
-  version = "22.32";
+  version = "26.16.1";
 
   src = fetchFromGitHub {
     owner = "mina86";
     repo = "urxvt-tabbedex";
     rev = "v${version}";
-    sha256 = "sha256-4+4iPFoy1j5xjXRM5kBauhff44Y7/ik/+ZLZ1prc+Xo=";
+    sha256 = "sha256-e/t7AnP7nXkkazK6Oe6mw2Adf5wxR31/nFKeSaCpy/4";
   };
 
   nativeBuildInputs = [ perl ];


### PR DESCRIPTION
Release notes:
* https://github.com/mina86/urxvt-tabbedex/releases/tag/v26.16.1
* https://github.com/mina86/urxvt-tabbedex/releases/tag/v26.16
* https://github.com/mina86/urxvt-tabbedex/releases/tag/v26.15
* https://github.com/mina86/urxvt-tabbedex/releases/tag/v26.09

TL;DR: Spurious border which can appear in some cases has been fixed, window sizing has been improved, and `tabbed.tabbedex-rs-prefix` is no longer respected (all resources must now use `tabbedex` as prefix).

## Things done

Tested with:

    docker run --rm -v $(pwd):/work -w /work nixos/nix nix-build -E '
        with import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") {};
        callPackage ./default.nix {}
    '

This was originally <https://github.com/NixOS/nixpkgs/pull/507650>, but I’ve accidentally deleted the branch rather than updating it.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
