### PR TITLE
emacs: update vendored patch for Emacs bug#77143 and bug#80744

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/elpa2nix.el
+++ b/pkgs/applications/editors/emacs/build-support/elpa2nix.el
@@ -1,13 +1,12 @@
 (require 'package)
 (package-initialize)
 
-;; TODO remove this patch when Emacs bug#77143 is fixed
-;; see that bug for more info
+;; TODO remove this patch when Emacs bug#77143 and bug#80744 are fixed
 (defun package--description-file (dir)
   "Return package description file name for package DIR."
   (concat (let ((subdir (file-name-nondirectory
                          (directory-file-name dir))))
-            (if (string-match "\\([^.].*?\\)-\\([0-9]+\\(?:[.][0-9]+\\|\\(?:pre\\|beta\\|alpha\\|snapshot\\)[0-9]+\\)*\\)\\'" subdir)
+            (if (string-match "\\([^.].*?\\)-\\([0-9]+\\(?:[.][0-9]+\\|\\(?:pre\\|beta\\|alpha\\|snapshot\\)[0-9]*\\)*\\)\\'" subdir)
                 (match-string 1 subdir) subdir))
           "-pkg.el"))
 

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
@@ -20,21 +20,5 @@ in
       yasnippet
     ]
   );
-
-  p4-16-mode = super.p4-16-mode.overrideAttrs {
-    # workaround https://github.com/NixOS/nixpkgs/issues/301795
-    prePatch = ''
-      mkdir tmp-untar-dir
-      pushd tmp-untar-dir
-
-      tar --extract --verbose --file=$src
-      content_directory=$(echo p4-16-mode-*)
-      cp --verbose $content_directory/p4-16-mode-pkg.el $content_directory/p4-pkg.el
-      src=$PWD/$content_directory.tar
-      tar --create --verbose --file=$src $content_directory
-
-      popd
-    '';
-  };
   # keep-sorted end
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
