### PR TITLE
agentop: init at 0.1.2

### DIFF
--- a/pkgs/by-name/ag/agentop/package.nix
+++ b/pkgs/by-name/ag/agentop/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "agentop";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "mohitmishra786";
+    repo = "agentop";
+    rev = "v${version}";
+    hash = "sha256-7Wm9Y4M3saVRnRKZlfIlHbL5xTbVBms9BiwvBtblqlY=";
+  };
+
+  vendorHash = "sha256-xGmv9sg+MsAR3dpjBr4LlHoLTQig8MsfkwuimJoE/ow=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  meta = {
+    description = "Terminal dashboard for AI coding assistant sessions — token usage, cost, and cache efficiency";
+    homepage = "https://github.com/mohitmishra786/agentop";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "agentop";
+  };
+}

--- a/pkgs/by-name/ag/agentop/package.nix
+++ b/pkgs/by-name/ag/agentop/package.nix
@@ -5,28 +5,30 @@
 }:
 buildGoModule rec {
   pname = "agentop";
-  version = "0.1.1";
+  version = "0.1.2";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mohitmishra786";
     repo = "agentop";
     rev = "v${version}";
-    hash = "sha256-7Wm9Y4M3saVRnRKZlfIlHbL5xTbVBms9BiwvBtblqlY=";
+    hash = "sha256-lJEWh6SRVekOFsKsuQE88VEoskQAvHm1rPtMq1RQbho=";
   };
 
-  vendorHash = "sha256-xGmv9sg+MsAR3dpjBr4LlHoLTQig8MsfkwuimJoE/ow=";
+  vendorHash = "sha256-AR1IpxAlwRK1uH3iBXMstIZJ/eIV9yeSYtYY2Q29rLg=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X main.Version=${version}"
+    "-X github.com/agentop-dev/agentop/cmd.Version=${version}"
   ];
 
   meta = {
     description = "Terminal dashboard for AI coding assistant sessions — token usage, cost, and cache efficiency";
     homepage = "https://github.com/mohitmishra786/agentop";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
     mainProgram = "agentop";
   };
 }


### PR DESCRIPTION
agentop is a terminal dashboard for AI coding assistant sessions. It reads Claude Code session data from \`~/.claude/projects/\` and displays token usage, cost, and cache efficiency in a clean terminal UI — similar in spirit to \`htop\` / \`duf\` but for AI token consumption.

- Homepage: https://github.com/mohitmishra786/agentop
- License: MIT
- Single static Go binary, no runtime dependencies
- No network calls, reads local data only

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test