### PR TITLE
[25.11] log4cxx: 1.5.0 -> 1.7.0

### DIFF
--- a/pkgs/by-name/lo/log4cxx/package.nix
+++ b/pkgs/by-name/lo/log4cxx/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "log4cxx";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "mirror://apache/logging/log4cxx/${version}/apache-${pname}-${version}.tar.gz";
-    hash = "sha256-qiP0fDFkqiz4SMIli0tLw3Lnlk1KPtR8K0pKkVxd+jc=";
+    hash = "sha256-R9doxXZcVyHPJ9Ug+H7ycikboPTg0yHHJzXVrshwGKc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/lo/log4cxx/package.nix
+++ b/pkgs/by-name/lo/log4cxx/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "log4cxx";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchurl {
-    url = "mirror://apache/logging/log4cxx/${version}/apache-${pname}-${version}.tar.gz";
-    hash = "sha256-R9doxXZcVyHPJ9Ug+H7ycikboPTg0yHHJzXVrshwGKc=";
+    url = "mirror://apache/logging/log4cxx/${version}/apache-log4cxx-${version}.tar.gz";
+    hash = "sha256-GHyFg29bLyf7Ho13x/Hyk5cl8fZJi3QrDdVpujCWX9I=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/lo/log4cxx/package.nix
+++ b/pkgs/by-name/lo/log4cxx/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation rec {
   pname = "log4cxx";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchurl {
     url = "mirror://apache/logging/log4cxx/${version}/apache-log4cxx-${version}.tar.gz";
-    hash = "sha256-GHyFg29bLyf7Ho13x/Hyk5cl8fZJi3QrDdVpujCWX9I=";
+    hash = "sha256-uUP/FwOT5M44GrTEkUOWEnv01E+4vR8OXvhFPzxNNkw=";
   };
 
   postPatch = ''


### PR DESCRIPTION
https://logging.apache.org/log4cxx/1.7.0/changelog.html#rel_1_7_0

Fixes https://github.com/NixOS/nixpkgs/issues/508880 / CVE-2026-40023

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 509357`
Commit: `375e8057598f4512b10d0435c7399a90e39b6f73`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>log4cxx</li>
    <li>miktex</li>
    <li>zkfuse</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
