### PR TITLE
neovim-unwrapped: enable treesitter tests

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -19,6 +19,7 @@
   procps ? null,
   versionCheckHook,
   nix-update-script,
+  writableTmpDirAsHomeHook,
 
   # now defaults to false because some tests can be flaky (clipboard etc), see
   # also: https://github.com/neovim/neovim/issues/16233
@@ -161,22 +162,18 @@ stdenv.mkDerivation (
       unibilium
       utf8proc
     ]
-    ++ lib.optionals finalAttrs.finalPackage.doCheck [
-      glibcLocales
-      procps
-    ]
     ++ lib.optionals (stdenv.hostPlatform.libc != "glibc") [
       # Provide libintl for non-glibc platforms
       gettext
     ];
 
-    doCheck = false;
+    doCheck = true;
 
     # to be exhaustive, one could run
     # make oldtests too
     checkPhase = ''
       runHook preCheck
-      make functionaltest
+      make functionaltest__treesitter
       runHook postCheck
     '';
 
@@ -219,6 +216,7 @@ stdenv.mkDerivation (
       # third-party/CMakeLists.txt is not read at all.
       (lib.cmakeBool "USE_BUNDLED" false)
       (lib.cmakeBool "ENABLE_TRANSLATIONS" true)
+      (lib.cmakeBool "USE_BUNDLED_BUSTED" false)
     ]
     ++ (
       if lua.pkgs.isLuaJIT then
@@ -252,6 +250,12 @@ stdenv.mkDerivation (
 
     nativeInstallCheckInputs = [
       versionCheckHook
+      lua.pkgs.busted
+      writableTmpDirAsHomeHook
+      glibcLocales
+
+      # needs git for vim.pack tests as well
+      procps
     ];
     versionCheckProgram = "${placeholder "out"}/bin/nvim";
     doInstallCheck = true;


### PR DESCRIPTION
The full `functionaltest` fails for various reasons.  We dont have to run all of it but we can try enabling some of it, starting with the treesitter tests.
Right now removing the treesitter parsers trigger no error so it's easy to either not see an error in their installation of a version mismatch. Running the tests should help mitigate this shortcoming.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
