### PR TITLE
[25.11] kamailio: 6.0.3 -> 6.0.6

### DIFF
--- a/pkgs/by-name/ka/kamailio/package.nix
+++ b/pkgs/by-name/ka/kamailio/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kamailio";
-  version = "6.0.3";
+  version = "6.0.4";
 
   src = fetchurl {
     url = "https://www.kamailio.org/pub/kamailio/${finalAttrs.version}/src/kamailio-${finalAttrs.version}_src.tar.gz";
-    hash = "sha256-ljxwsspk8IAchUnMUbTi8bf05zrp1KcBRcXE1bTaEYQ=";
+    hash = "sha256-34Ps3i1tnSVc/JLBjSRXGY8ZRSmXhGqNy3v+c3autuY=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ka/kamailio/package.nix
+++ b/pkgs/by-name/ka/kamailio/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kamailio";
-  version = "6.0.4";
+  version = "6.0.5";
 
   src = fetchurl {
     url = "https://www.kamailio.org/pub/kamailio/${finalAttrs.version}/src/kamailio-${finalAttrs.version}_src.tar.gz";
-    hash = "sha256-34Ps3i1tnSVc/JLBjSRXGY8ZRSmXhGqNy3v+c3autuY=";
+    hash = "sha256-LEpl8MTkNULs0EJCO2/IKe4Vqwmlauf0QbdCfWvOGzA=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/ka/kamailio/package.nix
+++ b/pkgs/by-name/ka/kamailio/package.nix
@@ -22,11 +22,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kamailio";
-  version = "6.0.5";
+  version = "6.0.6";
 
   src = fetchurl {
     url = "https://www.kamailio.org/pub/kamailio/${finalAttrs.version}/src/kamailio-${finalAttrs.version}_src.tar.gz";
-    hash = "sha256-LEpl8MTkNULs0EJCO2/IKe4Vqwmlauf0QbdCfWvOGzA=";
+    hash = "sha256-MuQpDGgTydAomr6ewt6ROOEuA4EXkhin/tN0rYE+zEg=";
   };
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/kamailio/kamailio/releases/tag/6.0.6  
https://github.com/kamailio/kamailio/releases/tag/6.0.5  
https://github.com/kamailio/kamailio/releases/tag/6.0.4  

Fixes https://github.com/NixOS/nixpkgs/issues/508237 / CVE-2026-39863
Fixes https://github.com/NixOS/nixpkgs/issues/508236 / CVE-2026-39864

Not-cherry-picked-because: unstable will be bumped to 6.1.x

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 509376`
Commit: `463fb18f8d321b747e93726e25e0fe9f9f937452`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>kamailio</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
