### PR TITLE
python312Packages.mobi: exclude standard-imghdr to fix build

### DIFF
--- a/pkgs/development/python-modules/mobi/default.nix
+++ b/pkgs/development/python-modules/mobi/default.nix
@@ -6,6 +6,7 @@
   hatchling,
   standard-imghdr,
   pytestCheckHook,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -28,6 +29,8 @@ buildPythonPackage rec {
     loguru
     standard-imghdr
   ];
+
+  pythonRemoveDeps = lib.optionals (pythonOlder "3.13") [ "standard-imghdr" ];
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
Our `standard-*` packages are set up to be null on the Python versions that still include the corresponding module in the standard library. However, since mobi depends on standard-imghdr unconditionally, using the package on versions of Python that still have imghdr in the standard library fails to build due to the following sequence of steps:

1. Something calls `python312Packages.mobi`.
2. `standard-imghdr` in the dependencies resolves to `null`, since `imghdr` is still in the standard library on Python 3.12 and we have the `standard-imghdr` package set to be null on versions of Python where `imghdr` is in the standard library.
3. `pythonRuntimeDepsCheck` runs.
4. `pythonRuntimeDepsCheck` sees `Requires-Dist: standard-imghdr` in mobi's distinfo metadata and checks whether the package is installed.
5. It is not, so the runtime deps check fails the build.

We solve this issue by removing `standard-imghdr` from the list of dependencies on versions of Python where the package is set to `null` (those versions that have `imghdr` in the standard library). The package continues to work because it will transparently import the standard library version of `imghdr`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
