### PR TITLE
noto-fonts-cjk-{sans,serif}-static noto-fonts-lgc-plus: migrate to by-name

### DIFF
--- a/pkgs/by-name/no/noto-fonts-cjk-sans-static/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-sans-static/package.nix
@@ -1,0 +1,7 @@
+{
+  noto-fonts-cjk-sans,
+}:
+
+noto-fonts-cjk-sans.override {
+  static = true;
+}

--- a/pkgs/by-name/no/noto-fonts-cjk-serif-static/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-serif-static/package.nix
@@ -1,0 +1,7 @@
+{
+  noto-fonts-cjk-serif,
+}:
+
+noto-fonts-cjk-serif.override {
+  static = true;
+}

--- a/pkgs/by-name/no/noto-fonts-lgc-plus/package.nix
+++ b/pkgs/by-name/no/noto-fonts-lgc-plus/package.nix
@@ -1,0 +1,22 @@
+{
+  noto-fonts,
+}:
+
+noto-fonts.override {
+  suffix = "-lgc-plus";
+
+  variants = [
+    "Noto Sans"
+    "Noto Serif"
+    "Noto Sans Mono"
+    "Noto Music"
+    "Noto Sans Symbols"
+    "Noto Sans Symbols 2"
+    "Noto Sans Math"
+  ];
+
+  longDescription = ''
+    This package provides the Noto Fonts, but only for latin, greek
+    and cyrillic scripts, as well as some extra fonts.
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9043,10 +9043,6 @@ with pkgs;
 
   mplus-outline-fonts = recurseIntoAttrs (callPackage ../data/fonts/mplus-outline-fonts { });
 
-  noto-fonts-cjk-sans-static = callPackage ../by-name/no/noto-fonts-cjk-sans/package.nix {
-    static = true;
-  };
-
   openmoji-color = callPackage ../data/fonts/openmoji { fontFormats = [ "glyf_colr_0" ]; };
 
   openmoji-black = callPackage ../data/fonts/openmoji { fontFormats = [ "glyf" ]; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9051,23 +9051,6 @@ with pkgs;
     static = true;
   };
 
-  noto-fonts-lgc-plus = callPackage ../by-name/no/noto-fonts/package.nix {
-    suffix = "-lgc-plus";
-    variants = [
-      "Noto Sans"
-      "Noto Serif"
-      "Noto Sans Mono"
-      "Noto Music"
-      "Noto Sans Symbols"
-      "Noto Sans Symbols 2"
-      "Noto Sans Math"
-    ];
-    longDescription = ''
-      This package provides the Noto Fonts, but only for latin, greek
-      and cyrillic scripts, as well as some extra fonts.
-    '';
-  };
-
   openmoji-color = callPackage ../data/fonts/openmoji { fontFormats = [ "glyf_colr_0" ]; };
 
   openmoji-black = callPackage ../data/fonts/openmoji { fontFormats = [ "glyf" ]; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9043,10 +9043,6 @@ with pkgs;
 
   mplus-outline-fonts = recurseIntoAttrs (callPackage ../data/fonts/mplus-outline-fonts { });
 
-  noto-fonts-cjk-serif-static = callPackage ../by-name/no/noto-fonts-cjk-serif/package.nix {
-    static = true;
-  };
-
   noto-fonts-cjk-sans-static = callPackage ../by-name/no/noto-fonts-cjk-sans/package.nix {
     static = true;
   };


### PR DESCRIPTION
This pull request refactors the packaging of several Noto font variants to improve maintainability and consistency. The main changes involve moving the configuration for the static and LGC-plus variants of Noto fonts into their own dedicated package files, rather than inlining their definitions in the top-level package list.

Font packaging refactor:

* Moved the static variant configuration for `noto-fonts-cjk-sans` into its own package file (`pkgs/by-name/no/noto-fonts-cjk-sans-static/package.nix`), using the `.override` method to set `static = true`.
* Moved the static variant configuration for `noto-fonts-cjk-serif` into its own package file (`pkgs/by-name/no/noto-fonts-cjk-serif-static/package.nix`), using the `.override` method to set `static = true`.
* Moved the LGC-plus variant configuration for `noto-fonts` into its own package file (`pkgs/by-name/no/noto-fonts-lgc-plus/package.nix`), specifying the appropriate variants and a long description.

Top-level package list cleanup:

* Removed the inlined definitions for `noto-fonts-cjk-sans-static`, `noto-fonts-cjk-serif-static`, and `noto-fonts-lgc-plus` from `pkgs/top-level/all-packages.nix`, as these are now handled by the new dedicated package files.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
