### PR TITLE
treewide: remove nobody/nogroup [part 1]

### DIFF
--- a/nixos/modules/hardware/cpu/x86-msr.nix
+++ b/nixos/modules/hardware/cpu/x86-msr.nix
@@ -45,13 +45,13 @@ in
       owner = mkOption {
         type = str;
         default = "root";
-        example = "nobody";
+        example = "alice";
         description = "Owner ${set}";
       };
       group = mkOption {
         type = str;
         default = defaultGroup;
-        example = "nobody";
+        example = "users";
         description = "Group ${set}";
       };
       mode = mkOption {

--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -111,7 +111,8 @@ in
       type = lib.types.lines;
       default = "";
       example = lib.literalExpression ''
-        sed 's/skgid meadow/skgid nogroup/g' -i ruleset.conf
+        # replace users/groups that don't exist in the test
+        sed 's/skgid meadow/skgid root/g' -i ruleset.conf
       '';
       description = ''
         This script gets run before the ruleset is checked. It can be used to

--- a/nixos/modules/services/networking/ocserv.nix
+++ b/nixos/modules/services/networking/ocserv.nix
@@ -34,8 +34,8 @@ in
         auth = "plain[passwd=./sample.passwd]"
         tcp-port = 443
         udp-port = 443
-        run-as-user = nobody
-        run-as-group = nogroup
+        run-as-user = ocserv
+        run-as-group = ocserv
         socket-file = /run/ocserv-socket
         server-cert = certs/server-cert.pem
         server-key = certs/server-key.pem

--- a/nixos/modules/services/web-servers/mighttpd2.nix
+++ b/nixos/modules/services/web-servers/mighttpd2.nix
@@ -24,10 +24,8 @@ in
         # IP address or "*"
         Host: *
         Debug_Mode: Yes # Yes or No
-        # If available, "nobody" is much more secure for User:.
-        User: root
-        # If available, "nobody" is much more secure for Group:.
-        Group: root
+        User: mighttpd2
+        Group: mighttpd2
         Pid_File: /run/mighty.pid
         Logging: Yes # Yes or No
         Log_File: /var/log/mighty # The directory must be writable by User:

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -197,7 +197,7 @@ let
             Override the username or UID (and optionally groupname or GID) used
             in the container.
           '';
-          example = "nobody:nogroup";
+          example = "alice:users";
         };
 
         volumes = mkOption {

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -273,6 +273,11 @@ in
       # add a virtual wlan interface
       boot.kernelModules = [ "mac80211_hwsim" ];
 
+      users.users.alice = {
+        isNormalUser = true;
+        group = "users";
+      };
+
       # wireless client
       networking.wireless = {
         enable = lib.mkOverride 0 true;
@@ -283,7 +288,7 @@ in
     };
 
     testScript = ''
-      wpa_cli = "sudo -u nobody -g wpa_supplicant wpa_cli"
+      wpa_cli = "sudo -u alice -g wpa_supplicant wpa_cli"
 
       with subtest("Daemon is running and accepting connections"):
           machine.wait_for_unit("wpa_supplicant-wlan1.service")

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -121,7 +121,6 @@ rec {
     inherit
       buildImage
       buildLayeredImage
-      fakeNss
       pullImage
       shadowSetup
       buildImageWithNixDb

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -11,7 +11,6 @@
   pkgs,
   buildImage,
   buildLayeredImage,
-  fakeNss,
   pullImage,
   shadowSetup,
   buildImageWithNixDb,
@@ -27,11 +26,37 @@ let
   };
   evalMinimalConfig = module: nixosLib.evalModules { modules = [ module ]; };
 
+  nonRootShadowSetup =
+    {
+      user,
+      uid,
+      gid ? uid,
+    }:
+    with pkgs;
+    [
+      (writeTextDir "etc/shadow" ''
+        root:!x:::::::
+        ${user}:!:::::::
+      '')
+      (writeTextDir "etc/passwd" ''
+        root:x:0:0::/root:${runtimeShell}
+        ${user}:x:${toString uid}:${toString gid}::/home/${user}:
+      '')
+      (writeTextDir "etc/group" ''
+        root:x:0:
+        ${user}:x:${toString gid}:
+      '')
+      (writeTextDir "etc/gshadow" ''
+        root:x::
+        ${user}:x::
+      '')
+    ];
+
   nginxArguments =
     let
       nginxPort = "80";
       nginxConf = pkgs.writeText "nginx.conf" ''
-        user nobody nobody;
+        user nginx nginx;
         daemon off;
         error_log /dev/stdout info;
         pid /dev/null;
@@ -55,9 +80,12 @@ let
       name = "nginx-container";
       tag = "latest";
       contents = [
-        fakeNss
         pkgs.nginx
-      ];
+      ]
+      ++ nonRootShadowSetup {
+        uid = 999;
+        user = "nginx";
+      };
 
       extraCommands = ''
         mkdir -p tmp/nginx_client_body
@@ -596,46 +624,18 @@ rec {
   };
 
   # buildLayeredImage with non-root user
-  bashLayeredWithUser =
-    let
-      nonRootShadowSetup =
-        {
-          user,
-          uid,
-          gid ? uid,
-        }:
-        with pkgs;
-        [
-          (writeTextDir "etc/shadow" ''
-            root:!x:::::::
-            ${user}:!:::::::
-          '')
-          (writeTextDir "etc/passwd" ''
-            root:x:0:0::/root:${runtimeShell}
-            ${user}:x:${toString uid}:${toString gid}::/home/${user}:
-          '')
-          (writeTextDir "etc/group" ''
-            root:x:0:
-            ${user}:x:${toString gid}:
-          '')
-          (writeTextDir "etc/gshadow" ''
-            root:x::
-            ${user}:x::
-          '')
-        ];
-    in
-    pkgs.dockerTools.buildLayeredImage {
-      name = "bash-layered-with-user";
-      tag = "latest";
-      contents = [
-        pkgs.bash
-        pkgs.coreutils
-      ]
-      ++ nonRootShadowSetup {
-        uid = 999;
-        user = "somebody";
-      };
+  bashLayeredWithUser = pkgs.dockerTools.buildLayeredImage {
+    name = "bash-layered-with-user";
+    tag = "latest";
+    contents = [
+      pkgs.bash
+      pkgs.coreutils
+    ]
+    ++ nonRootShadowSetup {
+      uid = 999;
+      user = "somebody";
     };
+  };
 
   # basic example, with cross compilation
   cross =

--- a/pkgs/build-support/fetchfossil/builder.sh
+++ b/pkgs/build-support/fetchfossil/builder.sh
@@ -6,7 +6,7 @@ echo "Cloning Fossil $url [$rev] into $out"
 export HOME=$(pwd)
 
 # We must explicitly set the admin user for the clone to something reasonable.
-fossil clone -A nobody "$url" fossil-clone.fossil
+fossil clone -A $(whoami) "$url" fossil-clone.fossil
 
 mkdir fossil-clone
 WORKDIR=$(pwd)

--- a/pkgs/build-support/fetchfossil/nix-prefetch-fossil
+++ b/pkgs/build-support/fetchfossil/nix-prefetch-fossil
@@ -77,7 +77,7 @@ export HOME="$tmpPath"
 echo "Fetching Fossil repository $url at revision $rev..." >&2
 
 # Clone the repository
-fossil clone -A nobody "$url" "$tmpPath/fossil-clone.fossil" >&2
+fossil clone -A $(whoami) "$url" "$tmpPath/fossil-clone.fossil" >&2
 
 # Create directory for checkout
 checkoutDir="$tmpPath/checkout"

--- a/pkgs/by-name/po/povray/package.nix
+++ b/pkgs/by-name/po/povray/package.nix
@@ -51,10 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
     cd unix
     ./prebuild.sh
     cd ..
+    export HOME=$TMPDIR
     sed -i -e 's/^povconfuser.*/povconfuser=$(TMPDIR)\/povray/' Makefile.{am,in}
     sed -i -e 's/^povuser.*/povuser=$(TMPDIR)\/.povray/' Makefile.{am,in}
-    sed -i -e 's/^povowner.*/povowner=nobody/' Makefile.{am,in}
-    sed -i -e 's/^povgroup.*/povgroup=nogroup/' Makefile.{am,in}
   '';
 
   # https://github.com/POV-Ray/povray/issues/460

--- a/pkgs/by-name/ro/rofi-unwrapped/package.nix
+++ b/pkgs/by-name/ro/rofi-unwrapped/package.nix
@@ -47,10 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = ''
     patchShebangs "script"
-
-    # root not present in build /etc/passwd
-    substituteInPlace test/helper-expand.c \
-      --replace-fail "~root" "~nobody"
   '';
 
   depsBuildBuild = [
@@ -100,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "xcb" x11Support)
   ];
 
-  doCheck = false;
+  doCheck = true;
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Removing uses of nobody/nogroup (see https://github.com/NixOS/nixpkgs/issues/55370).
These are the easy parts: mostly documentation, examples and one-shot commands.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
