### PR TITLE
libqmi: enable strictDeps

### DIFF
--- a/pkgs/by-name/li/libqmi/package.nix
+++ b/pkgs/by-name/li/libqmi/package.nix
@@ -15,6 +15,7 @@
   mesonEmulatorHook,
   libgudev,
   bash-completion,
+  bashNonInteractive,
   libmbim,
   libqrtr-glib,
   buildPackages,
@@ -41,6 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-bJbNfnKVJuhy/6EJgu5b7t6vxNTex/5heTzMzTzVREw=";
   };
 
+  depsBuildBuild = [
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     meson
     ninja
@@ -62,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     bash-completion
+    bashNonInteractive # otherwise $out/bin/qmi-network has impure #!/bin/sh shebang.
     libmbim
   ]
   ++ lib.optionals withIntrospection [
@@ -74,6 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withIntrospection [
     libqrtr-glib
   ];
+
+  strictDeps = true;
 
   mesonFlags = [
     "-Dudevdir=${placeholder "out"}/lib/udev"


### PR DESCRIPTION
The latest update seems to have broken the `strictDeps` build. 

This works but having these inputs duplicated between `buildInputs` and `nativeBuildInputs` feels weird? I'm always a bit confused by GNOME related stuff. Pointers would be appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
