### PR TITLE
python3Packages.pykefcontrol: init at 0.9

### DIFF
--- a/pkgs/development/python-modules/pykefcontrol/default.nix
+++ b/pkgs/development/python-modules/pykefcontrol/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  aiohttp,
+  pythonOlder,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "pykefcontrol";
+  version = "0.9";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "N0ciple";
+    repo = "pykefcontrol";
+    tag = version;
+    hash = "sha256-V/uYzzUv/PslfZ/zSSAK4j6kI9lLQOXBN1AG0rjRrpg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.8"' 'version = "0.9"'
+  '';
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiohttp
+    requests
+  ];
+
+  # Upstream does not ship tests.
+  doCheck = false;
+
+  pythonImportsCheck = [ "pykefcontrol" ];
+
+  meta = {
+    description = "Python library for controlling KEF LS50 Wireless II, LSX II, and LS60 speakers";
+    homepage = "https://github.com/N0ciple/pykefcontrol";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ imalison ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14066,6 +14066,8 @@ self: super: with self; {
     inherit (pkgs.llvmPackages) openmp;
   };
 
+  pykefcontrol = callPackage ../development/python-modules/pykefcontrol { };
+
   pykeepass = callPackage ../development/python-modules/pykeepass { };
 
   pykerberos = callPackage ../development/python-modules/pykerberos { krb5-c = pkgs.krb5; };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14066,9 +14066,9 @@ self: super: with self; {
     inherit (pkgs.llvmPackages) openmp;
   };
 
-  pykefcontrol = callPackage ../development/python-modules/pykefcontrol { };
-
   pykeepass = callPackage ../development/python-modules/pykeepass { };
+
+  pykefcontrol = callPackage ../development/python-modules/pykefcontrol { };
 
   pykerberos = callPackage ../development/python-modules/pykerberos { krb5-c = pkgs.krb5; };
 


### PR DESCRIPTION
Adds `python3Packages.pykefcontrol`, a Python library for controlling KEF LS50 Wireless II, LSX II, and LS60 speakers.

Upstream's `0.9` tag still ships `version = "0.8"` in `pyproject.toml`, so the derivation patches that to `0.9` to keep the built wheel metadata aligned with the tagged source.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
