### PR TITLE
openroad: 26Q1 -> 26Q2

### DIFF
--- a/pkgs/by-name/op/openroad/package.nix
+++ b/pkgs/by-name/op/openroad/package.nix
@@ -44,23 +44,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openroad";
-  version = "26Q1";
+  version = "26Q2";
 
   src = fetchFromGitHub {
     owner = "The-OpenROAD-Project";
     repo = "OpenROAD";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-DMyoqDse9W6ahOajEINzFpgLsSKam/I1mQkRSSKepI8=";
+    hash = "sha256-dB9PfPlp6vZ9+Th8LJE65BW9YeuUL0G4JtjzQxg6UpQ=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "fix-openroad-commit-2a8b2c7.patch";
-      url = "https://github.com/The-OpenROAD-Project/OpenROAD/commit/2a8b2c7dcda87679a69df323b2ada5f3a21554ea.patch";
-      hash = "sha256-vgmVpr+vHbOd8UUUUyJ8sTKi0Y7CWYatF006WX4+zFI=";
-    })
-  ];
 
   nativeBuildInputs = [
     bison
@@ -103,6 +95,34 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ libx11 ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
+
+  patches = [
+    # Fix UB in OpenSTA dcalc tests: fake Pin* pointers dereference via
+    # PinIdLess comparator, crashing with GCC 15's hardened vector bounds check.
+    # https://github.com/The-OpenROAD-Project/OpenSTA/pull/346
+    (fetchpatch {
+      url = "https://github.com/gonsolo/OpenSTA/commit/0e40b4f8a1c4b6af7225da31cd88a1d29d8a04a2.patch";
+      hash = "sha256-W9USjqp/hL1s3w3nKVMo/a5aSkeQ4Lp7gqASbZSlo9Y=";
+      stripLen = 1;
+      extraPrefix = "src/sta/";
+    })
+    # Feature-test std::from_chars to fix aarch64-darwin build where
+    # libcxx marks from_chars unavailable (macOS 26.0).
+    # https://github.com/The-OpenROAD-Project/OpenSTA/commit/a5921d1ca
+    (fetchpatch {
+      url = "https://github.com/The-OpenROAD-Project/OpenSTA/commit/a5921d1ca964971ada83be2c7c65bb84504fe179.patch";
+      hash = "sha256-j9BneXSIya/euYiol16swmrFkXTDZNTQwq3tPFkCLH0=";
+      stripLen = 1;
+      extraPrefix = "src/sta/";
+    })
+    # Replace deprecated sprintf with snprintf in Logger::error.
+    # macOS Apple SDK 14.4+ marks sprintf as deprecated, breaking -Werror builds.
+    # https://github.com/The-OpenROAD-Project/OpenROAD/pull/10127
+    (fetchpatch {
+      url = "https://github.com/The-OpenROAD-Project/OpenROAD/commit/2a9191bc5b2841a0c357886a2a1bc3ac0fe5271a.patch";
+      hash = "sha256-lxFZvybfG0Qpg1TyKdfZhKLYI3DSCYDE54ta6EnDBDo=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs etc/


### PR DESCRIPTION
https://github.com/The-OpenROAD-Project/OpenROAD/releases/tag/26Q2
