### PR TITLE
gleam: patch to fix CVE-2026-32146

### DIFF
--- a/pkgs/by-name/gl/gleam/0001-fix-CVE-2026-32146.patch
+++ b/pkgs/by-name/gl/gleam/0001-fix-CVE-2026-32146.patch
@@ -1,0 +1,205 @@
+From 7f5bc4876da656686f44098a91c903f5c0b1b6ab Mon Sep 17 00:00:00 2001
+From: azban <me@azban.net>
+Date: Sun, 12 Apr 2026 16:05:56 -0600
+Subject: [PATCH 1/2] fix CVE-2026-32146
+
+This applies a modified version of the upstream patch because there is a conflict in the change log.
+
+Signed-off-by: azban <me@azban.net>
+---
+ compiler-core/src/config.rs                   | 97 +++++++++++++++++--
+ ...core__config__invalid_dependency_name.snap | 18 ++++
+ ...__config__invalid_dev_dependency_name.snap | 18 ++++
+ 3 files changed, 123 insertions(+), 10 deletions(-)
+ create mode 100644 compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap
+ create mode 100644 compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap
+
+diff --git a/compiler-core/src/config.rs b/compiler-core/src/config.rs
+index 77dd4bc98..2e6dd4a5a 100644
+--- a/compiler-core/src/config.rs
++++ b/compiler-core/src/config.rs
+@@ -163,9 +163,17 @@ pub struct PackageConfig {
+     pub description: EcoString,
+     #[serde(default, alias = "docs")]
+     pub documentation: Docs,
+-    #[serde(default, serialize_with = "ordered_map")]
++    #[serde(
++        default,
++        serialize_with = "ordered_map",
++        deserialize_with = "dependencies_map::deserialize"
++    )]
+     pub dependencies: Dependencies,
+-    #[serde(default, rename = "dev-dependencies", serialize_with = "ordered_map")]
++    #[serde(
++        default, alias = "dev-dependencies",
++        serialize_with = "ordered_map",
++        deserialize_with = "dependencies_map::deserialize"
++    )]
+     pub dev_dependencies: Dependencies,
+     #[serde(default)]
+     pub repository: Option<Repository>,
+@@ -362,6 +370,34 @@ aide_generator = { git = "git@github.com:crowdhailer/aide.git", ref = "f559c5bc"
+     insta::assert_snapshot!(insta::internals::AutoName, error.pretty_string());
+ }
+ 
++#[test]
++fn invalid_dependency_name() {
++    let toml = r#"
++name = "wibble"
++version = "1.0.0"
++
++[dependencies]
++Hello = "> 1.0.0"
++"#;
++    let error = deserialise_config("gleam.toml", toml.into())
++        .expect_err("should fail to deserialise because invalid name");
++    insta::assert_snapshot!(insta::internals::AutoName, error.pretty_string());
++}
++
++#[test]
++fn invalid_dev_dependency_name() {
++    let toml = r#"
++name = "wibble"
++version = "1.0.0"
++
++[dev_dependencies]
++"yes." = "> 1.0.0"
++"#;
++    let error = deserialise_config("gleam.toml", toml.into())
++        .expect_err("should fail to deserialise because invalid name");
++    insta::assert_snapshot!(insta::internals::AutoName, error.pretty_string());
++}
++
+ #[test]
+ fn locked_no_manifest() {
+     let mut config = PackageConfig::default();
+@@ -1065,11 +1101,8 @@ mod uri_serde_default_https {
+ 
+ mod package_name {
+     use ecow::EcoString;
+-    use regex::Regex;
+     use serde::Deserializer;
+-    use std::{fmt, sync::OnceLock};
+-
+-    static PACKAGE_NAME_PATTERN: OnceLock<Regex> = OnceLock::new();
++    use std::fmt;
+ 
+     pub fn deserialize<'de, D>(deserializer: D) -> Result<EcoString, D::Error>
+     where
+@@ -1091,10 +1124,7 @@ mod package_name {
+         where
+             E: serde::de::Error,
+         {
+-            if PACKAGE_NAME_PATTERN
+-                .get_or_init(|| Regex::new("^[a-z][a-z0-9_]*$").expect("Package name regex"))
+-                .is_match(value)
+-            {
++            if super::is_valid_package_name(value) {
+                 Ok(value.into())
+             } else {
+                 let error =
+@@ -1105,6 +1135,53 @@ mod package_name {
+     }
+ }
+ 
++mod dependencies_map {
++    use ecow::EcoString;
++    use serde::{Deserialize, Deserializer, de};
++    use std::collections::HashMap;
++
++    pub fn deserialize<'de, D, V>(deserializer: D) -> Result<HashMap<EcoString, V>, D::Error>
++    where
++        D: Deserializer<'de>,
++        V: Deserialize<'de>,
++    {
++        struct DependenciesVisitor<V>(std::marker::PhantomData<V>);
++
++        impl<'de, V: Deserialize<'de>> de::Visitor<'de> for DependenciesVisitor<V> {
++            type Value = HashMap<EcoString, V>;
++
++            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
++                write!(f, "a map with valid package name keys")
++            }
++
++            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
++                let mut dependencies = HashMap::new();
++                while let Some(key) = map.next_key::<EcoString>()? {
++                    if !super::is_valid_package_name(&key) {
++                        return Err(de::Error::invalid_value(
++                            de::Unexpected::Str(&key),
++                            &"a package name containing only lowercase letter, numbers, and underscores",
++                        ));
++                    }
++                    let _: Option<_> = dependencies.insert(key, map.next_value()?);
++                }
++                Ok(dependencies)
++            }
++        }
++
++        deserializer.deserialize_map(DependenciesVisitor(std::marker::PhantomData))
++    }
++}
++
++fn is_valid_package_name(name: &str) -> bool {
++    use regex::Regex;
++    use std::sync::OnceLock;
++    static PACKAGE_NAME_PATTERN: OnceLock<Regex> = OnceLock::new();
++    PACKAGE_NAME_PATTERN
++        .get_or_init(|| Regex::new("^[a-z][a-z0-9_]*$").expect("Package name regex"))
++        .is_match(name)
++}
++
+ #[test]
+ fn name_with_dash() {
+     let input = r#"
+diff --git a/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap b/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap
+new file mode 100644
+index 000000000..999f05736
+--- /dev/null
++++ b/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap
+@@ -0,0 +1,18 @@
++---
++source: compiler-core/src/config.rs
++assertion_line: 385
++expression: error.pretty_string()
++---
++error: File IO failure
++
++An error occurred while trying to parse this file:
++
++    gleam.toml
++
++The error message from the file IO library was:
++
++    TOML parse error at line 5, column 1
++  |
++5 | [dependencies]
++  | ^^^^^^^^^^^^^^
++invalid value: string "Hello", expected a package name containing only lowercase letter, numbers, and underscores
+diff --git a/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap b/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap
+new file mode 100644
+index 000000000..10a5b99b7
+--- /dev/null
++++ b/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap
+@@ -0,0 +1,18 @@
++---
++source: compiler-core/src/config.rs
++assertion_line: 399
++expression: error.pretty_string()
++---
++error: File IO failure
++
++An error occurred while trying to parse this file:
++
++    gleam.toml
++
++The error message from the file IO library was:
++
++    TOML parse error at line 5, column 1
++  |
++5 | [dev_dependencies]
++  | ^^^^^^^^^^^^^^^^^^
++invalid value: string "yes.", expected a package name containing only lowercase letter, numbers, and underscores
+-- 
+2.51.2
+

--- a/pkgs/by-name/gl/gleam/0002-fix-tests-for-CVE-2026-32416.patch
+++ b/pkgs/by-name/gl/gleam/0002-fix-tests-for-CVE-2026-32416.patch
@@ -1,0 +1,63 @@
+From a352dc2a1fdc8f33b76b240d392319e5fbf338d0 Mon Sep 17 00:00:00 2001
+From: azban <me@azban.net>
+Date: Sun, 12 Apr 2026 17:01:49 -0600
+Subject: [PATCH 2/2] fix tests for CVE-2026-32416
+
+There were changes in the patch for fixing CVE-2026-32416 that relied on more recent changes. This changes the new test expectations to be based on code from the 1.13.0 release.
+
+Signed-off-by: azban <me@azban.net>
+---
+ compiler-core/src/config.rs                                   | 4 ++--
+ .../gleam_core__config__invalid_dependency_name.snap          | 2 +-
+ .../gleam_core__config__invalid_dev_dependency_name.snap      | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/compiler-core/src/config.rs b/compiler-core/src/config.rs
+index 2e6dd4a5a..9b727f5d7 100644
+--- a/compiler-core/src/config.rs
++++ b/compiler-core/src/config.rs
+@@ -170,7 +170,7 @@ pub struct PackageConfig {
+     )]
+     pub dependencies: Dependencies,
+     #[serde(
+-        default, alias = "dev-dependencies",
++        default, rename = "dev-dependencies",
+         serialize_with = "ordered_map",
+         deserialize_with = "dependencies_map::deserialize"
+     )]
+@@ -390,7 +390,7 @@ fn invalid_dev_dependency_name() {
+ name = "wibble"
+ version = "1.0.0"
+ 
+-[dev_dependencies]
++[dev-dependencies]
+ "yes." = "> 1.0.0"
+ "#;
+     let error = deserialise_config("gleam.toml", toml.into())
+diff --git a/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap b/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap
+index 999f05736..0f9da5124 100644
+--- a/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap
++++ b/compiler-core/src/snapshots/gleam_core__config__invalid_dependency_name.snap
+@@ -1,6 +1,6 @@
+ ---
+ source: compiler-core/src/config.rs
+-assertion_line: 385
++assertion_line: 384
+ expression: error.pretty_string()
+ ---
+ error: File IO failure
+diff --git a/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap b/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap
+index 10a5b99b7..935314d48 100644
+--- a/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap
++++ b/compiler-core/src/snapshots/gleam_core__config__invalid_dev_dependency_name.snap
+@@ -13,6 +13,6 @@ The error message from the file IO library was:
+ 
+     TOML parse error at line 5, column 1
+   |
+-5 | [dev_dependencies]
++5 | [dev-dependencies]
+   | ^^^^^^^^^^^^^^^^^^
+ invalid value: string "yes.", expected a package name containing only lowercase letter, numbers, and underscores
+-- 
+2.51.2
+

--- a/pkgs/by-name/gl/gleam/package.nix
+++ b/pkgs/by-name/gl/gleam/package.nix
@@ -27,6 +27,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-TzHjXW9sSbOJv7PrUaQzZ0jOPocVci1DjcmLzv7aaBY=";
 
+  patches = [
+    ./0001-fix-CVE-2026-32146.patch
+    ./0002-fix-tests-for-CVE-2026-32416.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     erlang


### PR DESCRIPTION
Resolves #509292 for stable

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
