### PR TITLE
lfe: fix install phase, make sure we get the binaries in the right place

### DIFF
--- a/pkgs/development/interpreters/lfe/default.nix
+++ b/pkgs/development/interpreters/lfe/default.nix
@@ -68,17 +68,22 @@ else
 
     beamDeps = [ proper ];
 
-    makeFlags = [
-      "-e"
-      "MANDB=''"
-      "PREFIX=$$out"
-    ];
-
     # override buildRebar3's install to let the builder use make install
-    installPhase = "";
+    installPhase = ''
+      runHook preInstall
+      make -e MANDB= PREFIX=$out install
+      runHook postInstall
+    '';
 
     doCheck = true;
     checkTarget = "travis";
+
+    doInstallCheck = true;
+    installCheckPhase = ''
+      runHook preInstallCheck
+      test -e $out/bin/lfe
+      runHook postInstallCheck
+    '';
 
     postFixup = ''
       # LFE binaries are shell scripts which run erl and lfe.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Closes #509420

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
