### PR TITLE
ghdl: 5.1.1 -> 6.0.0, fix gcc build, various fixes

### DIFF
--- a/pkgs/by-name/gh/ghdl/package.nix
+++ b/pkgs/by-name/gh/ghdl/package.nix
@@ -133,6 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       lucus16
       thoughtpolice
+      sempiternal-aurora
     ];
     platforms =
       lib.platforms.linux ++ lib.optionals (backend == "mcode" || backend == "llvm") [ "x86_64-darwin" ];

--- a/pkgs/by-name/gh/ghdl/package.nix
+++ b/pkgs/by-name/gh/ghdl/package.nix
@@ -6,13 +6,12 @@
   zlib,
   llvm,
   lib,
-  gcc-unwrapped,
+  gcc13,
   texinfo,
   gmp,
   mpfr,
   libmpc,
   gnutar,
-  glibc,
   makeWrapper,
   backend ? "mcode",
 }:
@@ -21,13 +20,13 @@ assert backend == "mcode" || backend == "llvm" || backend == "gcc";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ghdl-${backend}";
-  version = "5.1.1";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "ghdl";
     repo = "ghdl";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-vPeODNTptxIjN6qLoIHaKOFf3P3iAK2GloVreHPaAz8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Q5lAWMa1SFjoIJTdWlHSbS4Cg5RYWiej8F05Xrz9ArY=";
   };
 
   env.LIBRARY_PATH = "${stdenv.cc.libc}/lib";
@@ -39,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     texinfo
     makeWrapper
   ];
+
   buildInputs = [
     zlib
   ]
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     mpfr
     libmpc
   ];
+
   propagatedBuildInputs = [
   ]
   ++ lib.optionals (backend == "llvm" || backend == "gcc") [
@@ -61,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i 's/check_version  7.0/check_version  7/g' configure
   ''
   + lib.optionalString (backend == "gcc") ''
-    ${gnutar}/bin/tar -xf ${gcc-unwrapped.src}
+    ${gnutar}/bin/tar -xf ${gcc13.cc.src}
   '';
 
   configureFlags = [
@@ -73,16 +74,16 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-llvm-config=${llvm.dev}/bin/llvm-config"
   ]
   ++ lib.optionals (backend == "gcc") [
-    "--with-gcc=gcc-${gcc-unwrapped.version}"
+    "--with-gcc=gcc-${gcc13.cc.version}"
   ];
 
   buildPhase = lib.optionalString (backend == "gcc") ''
     make copy-sources
     mkdir gcc-objs
     cd gcc-objs
-    ../gcc-${gcc-unwrapped.version}/configure \
-      --with-native-system-header-dir=/include \
-      --with-build-sysroot=${lib.getDev glibc} \
+    ../gcc-${gcc13.cc.version}/configure \
+      --with-native-system-header-dir=${lib.getDev stdenv.cc.libc}/include \
+      --with-build-sysroot=/ \
       --prefix=$out \
       --enable-languages=c,vhdl \
       --disable-bootstrap \
@@ -90,7 +91,12 @@ stdenv.mkDerivation (finalAttrs: {
       --disable-multilib \
       --disable-libssp \
       --disable-libgomp \
-      --disable-libquadmath
+      --disable-libquadmath \
+      --with-gmp-include=${gmp.dev}/include \
+      --with-gmp-lib=${gmp.out}/lib \
+      --with-mpfr-include=${mpfr.dev}/include \
+      --with-mpfr-lib=${mpfr.out}/lib \
+      --with-mpc=${libmpc}
     make -j $NIX_BUILD_CORES
     make install
     cd ../
@@ -101,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/ghdl \
       --set LIBRARY_PATH ${
         lib.makeLibraryPath [
-          glibc
+          stdenv.cc.libc
         ]
       }
   '';

--- a/pkgs/by-name/gh/ghdl/package.nix
+++ b/pkgs/by-name/gh/ghdl/package.nix
@@ -37,27 +37,20 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     gnat
   ]
+  ++ lib.optionals (backend == "llvm" || backend == "gcc") [
+    makeWrapper
+  ]
   ++ lib.optionals (backend == "gcc") [
     texinfo
-    makeWrapper
   ];
 
   buildInputs = [
     zlib
   ]
-  ++ lib.optionals (backend == "llvm") [
-    llvm
-  ]
   ++ lib.optionals (backend == "gcc") [
     gmp
     mpfr
     libmpc
-  ];
-
-  propagatedBuildInputs = [
-  ]
-  ++ lib.optionals (backend == "llvm" || backend == "gcc") [
-    zlib
   ];
 
   preConfigure = ''
@@ -99,20 +92,18 @@ stdenv.mkDerivation (finalAttrs: {
       --with-gmp-lib=${gmp.out}/lib \
       --with-mpfr-include=${mpfr.dev}/include \
       --with-mpfr-lib=${mpfr.out}/lib \
-      --with-mpc=${libmpc}
+      --with-mpc=${libmpc} \
+      --enable-default-pie=${if stdenv.targetPlatform.hasSharedLibraries then "yes" else "no"}
     make -j $NIX_BUILD_CORES
     make install
     cd ../
     make -j $NIX_BUILD_CORES ghdllib
   '';
 
-  postFixup = lib.optionalString (backend == "gcc") ''
+  postFixup = lib.optionalString (backend == "llvm" || backend == "gcc") ''
     wrapProgram $out/bin/ghdl \
-      --set LIBRARY_PATH ${
-        lib.makeLibraryPath [
-          stdenv.cc.libc
-        ]
-      }
+      --set LIBRARY_PATH ${lib.makeLibraryPath [ zlib ]} \
+      --prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}
   '';
 
   hardeningDisable = [

--- a/pkgs/by-name/gh/ghdl/package.nix
+++ b/pkgs/by-name/gh/ghdl/package.nix
@@ -29,6 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Q5lAWMa1SFjoIJTdWlHSbS4Cg5RYWiej8F05Xrz9ArY=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   env.LIBRARY_PATH = "${stdenv.cc.libc}/lib";
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4101,10 +4101,7 @@ with pkgs;
 
   ghdl-gcc = ghdl.override { backend = "gcc"; };
 
-  ghdl-llvm = ghdl.override {
-    backend = "llvm";
-    inherit (llvmPackages_20) llvm;
-  };
+  ghdl-llvm = ghdl.override { backend = "llvm"; };
 
   gcc-arm-embedded = gcc-arm-embedded-15;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4097,11 +4097,11 @@ with pkgs;
     }
   );
 
-  ghdl-mcode = callPackage ../by-name/gh/ghdl/package.nix { backend = "mcode"; };
+  ghdl-mcode = ghdl.override { backend = "mcode"; };
 
-  ghdl-gcc = callPackage ../by-name/gh/ghdl/package.nix { backend = "gcc"; };
+  ghdl-gcc = ghdl.override { backend = "gcc"; };
 
-  ghdl-llvm = callPackage ../by-name/gh/ghdl/package.nix {
+  ghdl-llvm = ghdl.override {
     backend = "llvm";
     inherit (llvmPackages_20) llvm;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
release notes: https://github.com/ghdl/ghdl/releases/tag/v6.0.0
upstream changes: [ghdl/ghdl@v5.1.1..v6.0.0](https://github.com/ghdl/ghdl/compare/v5.1.1...v6.0.0)

Version bump and fixes the build for gcc. Also adding myself as a maintainer because I've dealt with ghdl before so am happy to help maintain. Finally, enable `__structuredAttrs` and unpin the llvm version now that ghdl supports up to 22.

Also, finally redo the buildInputs and wrappers so that runtime codegen in the llvm and gcc backends works!

Fixes: #447662 #113401
Supersedes: #497710

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
