### PR TITLE
duckdb: fix build on darwin

### DIFF
--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -123,8 +123,11 @@ stdenv.mkDerivation (finalAttrs: {
           "test/sql/aggregate/aggregates/histogram_table_function.test"
         ]
         ++ lib.optionals stdenv.hostPlatform.isDarwin [
-          # SIGTRAP during iejoin tests on aarch64-darwin (with and without sandbox)
-          # iejoin implementation rewritten in 1.5.x with new parallel task scheduling
+          # UB in PhysicalRangeJoin (shared by IEJoin and PiecewiseMergeJoin) causes
+          # Apple Clang at -O3 to emit brk trap instructions on aarch64-darwin.
+          # Affects any test routing through PhysicalIEJoin (2+ inequality conditions,
+          # cardinality >= merge_join_threshold) or forcing IEJoin via debug_asof_iejoin.
+          "test/sql/join/iejoin/iejoin_issue_6314.test_slow"
           "test/sql/join/iejoin/iejoin_issue_6861.test"
           "test/sql/join/iejoin/iejoin_issue_7278.test"
           "test/sql/join/iejoin/iejoin_projection_maps.test"
@@ -138,7 +141,13 @@ stdenv.mkDerivation (finalAttrs: {
           "test/sql/join/iejoin/test_iejoin_null_keys.test"
           "test/sql/join/iejoin/test_iejoin_overlaps.test"
           "test/sql/join/iejoin/test_iejoin_predicate.test"
+          "test/sql/join/iejoin/test_iejoin_sort_tasks.test_slow"
           "test/sql/join/iejoin/test_iesemijoin.test"
+          # asof tests that loop debug_asof_iejoin=True, forcing the IEJoin path
+          "test/sql/join/asof/test_asof_join_inequalities.test"
+          "test/sql/join/asof/test_asof_join_missing.test_slow"
+          # 10240-row inequality join routing to IEJoin via plan_comparison_join.cpp
+          "test/sql/join/test_complex_range_join.test"
         ]
       );
       LD_LIBRARY_PATH = lib.optionalString stdenv.hostPlatform.isDarwin "DY" + "LD_LIBRARY_PATH";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
