### PR TITLE
offlineimap: 8.0.1 -> 8.0.2

### DIFF
--- a/pkgs/by-name/of/offlineimap/package.nix
+++ b/pkgs/by-name/of/offlineimap/package.nix
@@ -10,29 +10,19 @@
   libxslt,
   testers,
   offlineimap,
-  fetchpatch,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "offlineimap";
-  version = "8.0.1";
+  version = "8.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OfflineIMAP";
     repo = "offlineimap3";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Aigh2B4MTAOeUprtcK9kOx+aG4yCmGZoWTLmYYhrfXA=";
+    hash = "sha256-mysvqltO4x2dD8V+FAGOnDw5lQ8bgDwXFK9n15fbUdI=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/OfflineIMAP/offlineimap3/pull/225
-      name = "duplicate-bin.patch";
-      url = "https://github.com/OfflineIMAP/offlineimap3/commit/64557d2251f0d911c215eb743f6bfe8de8dfc042.patch";
-      hash = "sha256-Agy38fLt2k9AwPmGBoQxUD7+FD3qJzj89A13SQr0/nU=";
-    })
-  ];
 
   postPatch = ''
     # Skip xmllint to stop failures due to no network access
@@ -62,11 +52,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pysocks
     rfc6555
     urllib3
-  ];
-
-  # https://github.com/OfflineIMAP/offlineimap3/pull/232
-  pythonRelaxDeps = [
-    "urllib3"
   ];
 
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

[Changelog](https://github.com/OfflineIMAP/offlineimap3/releases/tag/v8.0.2). Since https://github.com/NixOS/nixpkgs/pull/484822 the PRs have been merged and https://github.com/OfflineIMAP/offlineimap3/commit/461ea973f651a7c8b3ba9409a3852cf6bcd601ce fixes the duplicate bin issue (https://github.com/OfflineIMAP/offlineimap3/pull/225).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
