### PR TITLE
citrix_workspace: 25.08.111 -> 26.01.0.150

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -149,6 +149,9 @@ stdenv.mkDerivation rec {
   preferLocalBuild = true;
   passthru.icaroot = "${placeholder "out"}/opt/citrix-icaclient";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     autoPatchelfHook
     file
@@ -282,8 +285,15 @@ stdenv.mkDerivation rec {
       export ICAInstDir="$out/opt/citrix-icaclient"
       export HOME=$(mktemp -d)
 
+      # Needed override to make the installer non-interactive. Especially in 26.01 when the installer verifies ubuntu version, there is no /etc/os-release while building.
+      sed -i \
+        -e '2216s/getyesno.*/ANSWER=$INSTALLER_YES/' \
+        -e 's,^ANSWER="",ANSWER="$INSTALLER_YES",g' \
+        -e 's,/bin/true,true,g' -e 's, -C / , -C . ,g' \
+        -e '1615s,"$ubuntu_major_version",99,g' \
+        ./linuxx64/hinst
+
       # Run upstream installer in the store-path.
-      sed -i -e 's,^ANSWER="",ANSWER="$INSTALLER_YES",g' -e 's,/bin/true,true,g' -e 's, -C / , -C . ,g' ./linuxx64/hinst
       source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
       faketime -f "$source_date" ${stdenv.shell} linuxx64/hinst CDROM "$(pwd)"
 
@@ -330,6 +340,10 @@ stdenv.mkDerivation rec {
   # Make sure that `autoPatchelfHook` is executed before
   # running `ctx_rehash`.
   dontAutoPatchelf = true;
+
+  # 26.01 Comes with its own copy of webkitgtk4.0 which is patched to look for libraries in the bundle. Since we don't want to patch it, we need to ignore missing dependencies.
+  autoPatchelfIgnoreMissingDeps = true;
+
   # Null out hardcoded webkit bundle path so it falls back to LD_LIBRARY_PATH
   postFixup = ''
     ${lib.getExe perl} -0777 -pi -e 's{/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/injected-bundle/}{"\0" x length($&)}e' \
@@ -342,8 +356,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     # Older versions need webkitgtk_4_0 which was removed.
-    # 25.08 bundles the same.
-    broken = lib.versionOlder version "25.08";
+    # 26.01 and 25.08 bundles the same.
+    broken = lib.versionOlder version "26.01.0";
     license = lib.licenses.unfree;
     description = "Citrix Workspace";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -21,6 +21,14 @@ let
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
   supportedVersions = lib.mapAttrs mkVersionInfo {
+    "26.01.0" = {
+      major = "26";
+      minor = "01";
+      patch = "0";
+      hash = "0avrf9jpqhijvp6w4jgs7xgp4gg1q2mdzak9h9klkqrbsgrvjr3p";
+      suffix = "150";
+      homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
+    };
     "25.08.10" = {
       major = "25";
       minor = "08";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1980,9 +1980,10 @@ with pkgs;
   };
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
+    citrix_workspace_26_01_0
     citrix_workspace_25_08_10
     ;
-  citrix_workspace = citrix_workspace_25_08_10;
+  citrix_workspace = citrix_workspace_26_01_0;
 
   colord-gtk4 = colord-gtk.override { withGtk4 = true; };
 


### PR DESCRIPTION
Added Citrix Workspace 26.01 support, package still comes bundled with webkitgtk4.0.

Tested with COSMIC DE while setting `GDK_BACKEND` and Gnome.

I also tested that requesting 25.08.10 was still possible and functional.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
