### PR TITLE
parted: 3.6 -> 3.7

### DIFF
--- a/pkgs/by-name/pa/parted/package.nix
+++ b/pkgs/by-name/pa/parted/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
+  pkg-config,
   lvm2,
   libuuid,
   gettext,
@@ -18,21 +18,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "parted";
-  version = "3.6";
+  version = "3.7";
 
   src = fetchurl {
     url = "mirror://gnu/parted/parted-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-O0Pb4zzKD5oYYB66tWt4UrEo7Bo986mzDM3l5zNZ5hI=";
+    sha256 = "sha256-AI3ldWGk88JaBkjmbtEeezC+STiJtkM0ptcPLBlR73s=";
   };
-
-  patches = [
-    # Fix the build against C23 compilers (like gcc-15):
-    (fetchpatch {
-      name = "c23.patch";
-      url = "https://git.savannah.gnu.org/gitweb/?p=parted.git;a=patch;h=16343bda6ce0d41edf43f8dac368db3bbb63d271";
-      hash = "sha256-8FgnwMrzMHPZNU+b/mRHCSu8sn6H7GhVLIhMUel40Hk=";
-    })
-  ];
 
   outputs = [
     "out"
@@ -52,6 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (gettext != null) gettext
   ++ lib.optional (lvm2 != null) lvm2;
 
+  nativeBuildInputs = [
+    pkg-config
+  ];
   configureFlags =
     (if (readline != null) then [ "--with-readline" ] else [ "--without-readline" ])
     ++ lib.optional (lvm2 == null) "--disable-device-mapper"

--- a/pkgs/by-name/pa/parted/package.nix
+++ b/pkgs/by-name/pa/parted/package.nix
@@ -81,8 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.gnu.org/software/parted/";
     license = lib.licenses.gpl3Plus;
 
-    maintainers = [
-      # Add your name here!
+    maintainers = with lib.maintainers; [
+      kybe236
     ];
 
     # GNU Parted requires libuuid, which is part of util-linux-ng.


### PR DESCRIPTION
Changelog: https://savannah.gnu.org/news/?id=10879
Diff: https://cgit.git.savannah.gnu.org/cgit/parted.git/diff/?id=v3.7&id2=v3.6
Closes: #482726 (already in upstream)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
