### PR TITLE
inventree-plugin-creator: init at 1.15.1

### DIFF
--- a/pkgs/by-name/in/inventree-plugin-creator/package.nix
+++ b/pkgs/by-name/in/inventree-plugin-creator/package.nix
@@ -1,0 +1,35 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pyproject = true;
+  pname = "inventree";
+  version = "1.15.1";
+  src = fetchFromGitHub {
+    owner = "inventree";
+    repo = "plugin-creator";
+    tag = "${version}";
+    hash = "sha256-6sQL2ZizlMVrjhQExp8Piry1C0SxFM8hOn3l9ZlUIDA=";
+  };
+
+  dependencies = with python3Packages; [
+    appdirs
+    cookiecutter
+    license
+    questionary
+    twine
+  ];
+
+  build-system = [ python3Packages.setuptools ];
+
+  meta = {
+    description = "Command line tool for scaffolding a new InvenTree plugin";
+    homepage = "https://github.com/inventree/plugin-creator";
+    changelog = "https://github.com/inventree/plugin-creator/releases/tag/${version}";
+    license = lib.licenses.mit;
+    mainProgram = "create-inventree-plugin";
+    maintainers = with lib.maintainers; [ gigahawk ];
+  };
+}

--- a/pkgs/development/python-modules/license/default.nix
+++ b/pkgs/development/python-modules/license/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  jinja2,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "license";
+  version = "0.1a3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hroncok";
+    repo = "license";
+    tag = "v${version}";
+    hash = "sha256-T0J54Xq5cBn+zY9mV/rw9AFv97pnOJa+E5mmlkdhi4Y=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    jinja2
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "license" ];
+
+  meta = {
+    description = "Python library that encapsulates free software licenses";
+    homepage = "https://github.com/hroncok/license";
+    changelog = "https://github.com/hroncok/license/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      gigahawk
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8923,6 +8923,8 @@ self: super: with self; {
 
   liccheck = callPackage ../development/python-modules/liccheck { };
 
+  license = callPackage ../development/python-modules/license { };
+
   license-expression = callPackage ../development/python-modules/license-expression { };
 
   lida = callPackage ../development/python-modules/lida { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
