### PR TITLE
duat: 0.7.7 -> 0.10.0

### DIFF
--- a/pkgs/by-name/du/duat/package.nix
+++ b/pkgs/by-name/du/duat/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "duat";
-  version = "0.7.7";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "AhoyISki";
     repo = "duat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Q8HeUN6JeT0OktOrmX3/ohUxCUvbEnlYKukFmtuuA44=";
+    hash = "sha256-SjSJc1pHUNl4G0ROZPyc7ux+Nx7RxMd6vG7jcd6INto=";
   };
 
-  cargoHash = "sha256-Wv2EdOGGsDqdXLvqyZ1sExqTlF+hHYEJu+RON7Ge398=";
+  cargoHash = "sha256-gZPr/I9/Ug+PmS1mUtwQ7JVkJ4gTYctvbtpvuOY8QUc=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/du/duat/package.nix
+++ b/pkgs/by-name/du/duat/package.nix
@@ -2,6 +2,11 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  cargo,
+  cc ? targetPackages.stdenv.cc,
+  rustc,
+  targetPackages,
+  makeBinaryWrapper,
   versionCheckHook,
   nix-update-script,
 }:
@@ -18,6 +23,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-gZPr/I9/Ug+PmS1mUtwQ7JVkJ4gTYctvbtpvuOY8QUc=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/duat \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          cargo
+          cc
+          rustc
+        ]
+      }
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/du/duat/package.nix
+++ b/pkgs/by-name/du/duat/package.nix
@@ -1,14 +1,14 @@
 {
-  lib,
-  rustPlatform,
-  fetchFromGitHub,
   cargo,
   cc ? targetPackages.stdenv.cc,
+  fetchFromGitHub,
+  lib,
+  makeBinaryWrapper,
+  nix-update-script,
+  rustPlatform,
   rustc,
   targetPackages,
-  makeBinaryWrapper,
   versionCheckHook,
-  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {


### PR DESCRIPTION
Also resolves https://github.com/NixOS/nixpkgs/pull/465828#issuecomment-3605557219
cc @Aleksanaa

Successor of #465828

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
