### PR TITLE
glib: remove util-linuxMinimal assertion when building for Linux

### DIFF
--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -43,8 +43,6 @@
     && stdenv.hostPlatform.isLittleEndian == stdenv.buildPlatform.isLittleEndian,
 }:
 
-assert stdenv.hostPlatform.isLinux -> util-linuxMinimal != null;
-
 let
   glib-untested = glib.overrideAttrs { doCheck = false; };
   # break dependency cycles

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -23,7 +23,7 @@
   docutils,
   gi-docgen,
   # use util-linuxMinimal to avoid circular dependency (util-linux, systemd, glib)
-  util-linuxMinimal ? null,
+  util-linuxMinimal,
   buildPackages,
 
   # this is just for tests (not in the closure of any regular package)
@@ -42,8 +42,6 @@
     && lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.isLittleEndian == stdenv.buildPlatform.isLittleEndian,
 }:
-
-assert stdenv.hostPlatform.isLinux -> util-linuxMinimal != null;
 
 let
   glib-untested = glib.overrideAttrs { doCheck = false; };


### PR DESCRIPTION
According to 868eb8301916d, this assertion was introduced when glib
started requiring this dependency by default due to libmount. However,
it still supports building without libmount and without this dependency
on Linux and this assertion prohibits doing this using overrides.

This changes fixes that and does not affect the builds output.

```
% nix-build -A glib
this path will be fetched (0.17 MiB download, 0.57 MiB unpacked):
    /nix/store/hak3031i8bpmvdqfla85q6q3bgwqppb0-glib-2.86.3-bin
copying path '/nix/store/hak3031i8bpmvdqfla85q6q3bgwqppb0-glib-2.86.3-bin' from 'https://cache.nixos.org'...
/nix/store/hak3031i8bpmvdqfla85q6q3bgwqppb0-glib-2.86.3-bin
% git checkout HEAD^
[...]
HEAD is now at 9b275f8667d8 nixVersions.nix_2_34: 2.34.5 -> 2.34.6 (#509233)
% nix-build -A glib
/nix/store/hak3031i8bpmvdqfla85q6q3bgwqppb0-glib-2.86.3-binn
%
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
