### PR TITLE
python3Packages.fli: init at 0.8.4

### DIFF
--- a/pkgs/by-name/fl/fli/package.nix
+++ b/pkgs/by-name/fl/fli/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication fli

--- a/pkgs/development/python-modules/fli/default.nix
+++ b/pkgs/development/python-modules/fli/default.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  buildPythonPackage,
+  installShellFiles,
+  pytestCheckHook,
+  babel,
+  curl-cffi,
+  hatchling,
+  httpx,
+  plotext,
+  pydantic,
+  python-dotenv,
+  ratelimit,
+  stdenv,
+  tenacity,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "flights";
+  version = "0.8.4";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "punitarani";
+    repo = "fli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-57eAtCUXuFmOizLPliI5YVj9ZHJPL7AzxpFAU6K2lDs=";
+  };
+
+  patches = [
+    # Fix regression in shell completion generation.
+    (fetchpatch {
+      # This commit has been submitted in a PR to the upstream repo: https://github.com/punitarani/fli/pull/130.
+      url = "https://github.com/punitarani/fli/commit/54af7b4f8bcbc85464383d525947e103ad3a7ec7.patch";
+      hash = "sha256-8NNRg/COpm0VURwKQZU87trarrfBgX21+TXexKdPLzM=";
+    })
+  ];
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    babel
+    curl-cffi
+    httpx
+    plotext
+    pydantic
+    python-dotenv
+    ratelimit
+    tenacity
+    typer
+  ];
+
+  pythonImportsCheck = [ "fli" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    lib.optionalString
+      (
+        # Required to avoid breaking cross builds
+        (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+
+        # Shell  not supported.
+        # ERROR: installShellCompletion: installShellCompletion: installed shell completion file `/nix/store/...-python3.14-flights-0.8.4/share/bash-completion/completions/fli.bash' does not exist or has zero size
+        || stdenv.hostPlatform.isDarwin
+      )
+      ''
+        installShellCompletion --cmd fli \
+          --bash <($out/bin/fli --show-completion bash) \
+          --fish <($out/bin/fli --show-completion fish) \
+          --zsh <($out/bin/fli --show-completion zsh)
+      '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Tests under tests/mcp require fastmcp v3, which nixpkgs does not yet have.
+    "tests/mcp"
+    # Tests under tests/search execute real searches and require the network.
+    "tests/search"
+  ];
+
+  meta = {
+    description = "Google Flights MCP and Python Library";
+    homepage = "https://github.com/punitarani/fli";
+    changelog = "https://github.com/punitarani/fli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ squat ];
+    mainProgram = "fli";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5775,6 +5775,8 @@ self: super: with self; {
 
   flexparser = callPackage ../development/python-modules/flexparser { };
 
+  fli = callPackage ../development/python-modules/fli { };
+
   flickrapi = callPackage ../development/python-modules/flickrapi { };
 
   flipr-api = callPackage ../development/python-modules/flipr-api { };


### PR DESCRIPTION
This commit introduces the `fli` package
(https://github.com/punitarani/fli), is a library and CLI to search for flights on Google Flights.

Support for the MCP feature is intentionally left un-implemented because a main dependency, `fastmcp`, is currently unsupported in nixpkgs at the required major version v3. That will ideally come in a follow-up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
