### PR TITLE
nixos/tests/: fix various tests after #500271's dovecot changes

### DIFF
--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -38,10 +38,15 @@ in
       };
       services.dovecot2 = {
         enable = true;
-        enableImap = true;
-        sslCACert = "${certs.ca.cert}";
-        sslServerCert = "${certs.${domain}.cert}";
-        sslServerKey = "${certs.${domain}.key}";
+        enablePAM = true;
+        settings = {
+          dovecot_config_version = "2.4.3";
+          dovecot_storage_version = "2.4.3";
+          protocols = [ "imap" ];
+          ssl_server_ca_file = "${certs.ca.cert}";
+          ssl_server_cert_file = "${certs.${domain}.cert}";
+          ssl_server_key_file = "${certs.${domain}.key}";
+        };
       };
     };
 

--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -100,7 +100,12 @@ in
 
       services.dovecot2 = {
         enable = true;
-        protocols = [ "imap" ];
+        enablePAM = true;
+        settings = {
+          dovecot_config_version = "2.4.3";
+          dovecot_storage_version = "2.4.3";
+          protocols = [ "imap" ];
+        };
       };
 
       services.postfix = {

--- a/nixos/tests/gitlab/gitlab.nix
+++ b/nixos/tests/gitlab/gitlab.nix
@@ -75,7 +75,12 @@ in
 
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = "2.4.3";
+            protocols.imap = true;
+          };
         };
 
         systemd.services.gitlab-backup.environment.BACKUP = "dump";

--- a/nixos/tests/opensmtpd-rspamd.nix
+++ b/nixos/tests/opensmtpd-rspamd.nix
@@ -35,9 +35,13 @@ import ./make-test-python.nix {
         };
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
-          mailLocation = "maildir:~/mail";
-          protocols = [ "imap" ];
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = "2.4.3";
+            mail_path = "~/mail";
+            protocols = [ "imap" ];
+          };
         };
       };
 

--- a/nixos/tests/opensmtpd.nix
+++ b/nixos/tests/opensmtpd.nix
@@ -77,9 +77,13 @@ import ./make-test-python.nix {
         };
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
-          mailLocation = "maildir:~/mail";
-          protocols = [ "imap" ];
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = "2.4.3";
+            mail_path = "~/mail";
+            protocols = [ "imap" ];
+          };
         };
       };
 

--- a/nixos/tests/parsedmarc/default.nix
+++ b/nixos/tests/parsedmarc/default.nix
@@ -175,10 +175,15 @@ in
 
             services.dovecot2 = {
               enable = true;
-              protocols = [ "imap" ];
-              sslCACert = "${certs.ca.cert}";
-              sslServerCert = "${certs.${mailDomain}.cert}";
-              sslServerKey = "${certs.${mailDomain}.key}";
+              enablePAM = true;
+              settings = {
+                dovecot_config_version = "2.4.3";
+                dovecot_storage_version = "2.4.3";
+                protocols = [ "imap" ];
+                ssl_server_ca_file = "${certs.ca.cert}";
+                ssl_server_cert_file = "${certs.${mailDomain}.cert}";
+                ssl_server_key_file = "${certs.${mailDomain}.key}";
+              };
             };
 
             services.postfix = {

--- a/nixos/tests/rss2email.nix
+++ b/nixos/tests/rss2email.nix
@@ -33,9 +33,13 @@ import ./make-test-python.nix {
         };
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
-          mailLocation = "maildir:~/mail";
-          protocols = [ "imap" ];
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = "2.4.3";
+            mail_path = "~/mail";
+            protocols = [ "imap" ];
+          };
         };
         environment.systemPackages =
           let


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/NixOS/nixpkgs/pull/500271#issuecomment-4235023744

cc @vcunat 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
