### PR TITLE
openbgpd: 6.8p0 -> 9.0 (+ refactorings)

### DIFF
--- a/pkgs/by-name/op/openbgpd/package.nix
+++ b/pkgs/by-name/op/openbgpd/package.nix
@@ -1,60 +1,24 @@
 {
   lib,
-  stdenv,
-  fetchFromGitHub,
-  autoconf,
-  automake,
-  libtool,
-  m4,
-  bison,
+  clangStdenv,
+  fetchurl,
+  libevent,
 }:
+# Use clang instead of gcc because that issues way less warnings.
+# Besides, OpenBSD devs generally prefer clang over gcc, so it is more likely
+# that the entire compilation is more tested using clang from an upstream POV.
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "openbgpd";
+  version = "9.0";
 
-let
-  openbsd_version = "OPENBSD_6_8"; # This has to be equal to ${src}/OPENBSD_BRANCH
-  openbsd = fetchFromGitHub {
-    name = "portable";
-    owner = "openbgpd-portable";
-    repo = "openbgpd-openbsd";
-    rev = openbsd_version;
-    sha256 = "sha256-vCVK5k4g6aW2z2fg7Kv0uvkX7f34aRc8K2myb3jjl6w=";
-  };
-in
-stdenv.mkDerivation rec {
-  pname = "opengpd";
-  version = "6.8p0";
-
-  src = fetchFromGitHub {
-    owner = "openbgpd-portable";
-    repo = "openbgpd-portable";
-    rev = version;
-    sha256 = "sha256-TKs6tt/SCWes6kYAGIrSShZgOLf7xKh26xG3Zk7wCCw=";
+  src = fetchurl {
+    url = "https://cdn.openbsd.org/pub/OpenBSD/OpenBGPD/openbgpd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-4JfE81Gibx3lM5IS2eENTPWrxLgQXk8cSI7wZakD9hU=";
   };
 
-  nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
-    m4
-    bison
+  buildInputs = [
+    libevent
   ];
-
-  preConfigure = ''
-    mkdir ./openbsd
-    cp -r ${openbsd}/* ./openbsd/
-    chmod -R +w ./openbsd
-    openbsd_version=$(cat ./OPENBSD_BRANCH)
-    if [ "$openbsd_version" != "${openbsd_version}" ]; then
-      echo "OPENBSD VERSION does not match"
-      exit 1
-    fi
-    ./autogen.sh
-  '';
-
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: bgpd-rde_peer.o:/build/source/src/bgpd/bgpd.h:133: multiple definition of `bgpd_process';
-  #     bgpd-bgpd.o:/build/source/src/bgpd/bgpd.h:133: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
 
   meta = {
     description = "Free implementation of the Border Gateway Protocol, Version 4. It allows ordinary machines to be used as routers exchanging routes with other systems speaking the BGP protocol";
@@ -63,4 +27,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ cvengler ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
This pull request performs the following changes to the OpenBGPD package:
1. Fix typo in `pname`
2. Use the version from the OpenBSD CDN instead of GitHub because it contains a configure script
3. Remove the manual generation of a configure script because it is included in the CDN version
4. Update to 9.0
5. Fix dependencies for 9.0
6. Remove compiler workaround for 6.9p0 because it is no longer required in 9.0
7. Compile with clang because upstream OpenBSD devs prefer that one

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
