### PR TITLE
nixos/thanos: test: Replace MinIO with Garage

### DIFF
--- a/nixos/tests/thanos.nix
+++ b/nixos/tests/thanos.nix
@@ -3,21 +3,21 @@
 let
   grpcPort = 19090;
   queryPort = 9090;
-  minioPort = 9000;
+  garagePort = 9000;
   pushgwPort = 9091;
   frontPort = 9092;
 
   s3 = {
-    accessKey = "BKIKJAA5BMMU2RHO6IBB";
-    secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";
+    accessKey = "GKaaaaaaaaaaaaaaaaaaaaaaaa";
+    secretKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   };
 
   objstore.config = {
     type = "S3";
     config = {
       bucket = "thanos-bucket";
-      endpoint = "s3:${toString minioPort}";
-      region = "us-east-1";
+      endpoint = "garage:${toString garagePort}";
+      region = "garage";
       access_key = s3.accessKey;
       secret_key = s3.secretKey;
       insecure = true;
@@ -139,14 +139,14 @@ in
               environment.systemPackages = [ pkgs.yq ];
 
               # This configuration just adds a new prometheus job
-              # to scrape the node_exporter metrics of the s3 machine.
+              # to scrape the node_exporter metrics of the garage machine.
               services.prometheus = {
                 scrapeConfigs = [
                   {
-                    job_name = "s3-node_exporter";
+                    job_name = "garage-node_exporter";
                     static_configs = [
                       {
-                        targets = [ "s3:9100" ];
+                        targets = [ "garage:9100" ];
                       }
                     ];
                   }
@@ -207,21 +207,30 @@ in
         };
       };
 
-    s3 =
+    garage =
       { pkgs, ... }:
       {
-        # Minio requires at least 1GiB of free disk space to run.
+        # Garage requires at least 1GiB of free disk space to run.
         virtualisation = {
           diskSize = 2 * 1024;
         };
-        networking.firewall.allowedTCPPorts = [ minioPort ];
+        networking.firewall.allowedTCPPorts = [ garagePort ];
 
-        services.minio = {
+        services.garage = {
           enable = true;
-          inherit (s3) accessKey secretKey;
-        };
+          package = pkgs.garage_2;
+          settings = {
+            rpc_bind_addr = "127.0.0.1:3901";
+            rpc_public_addr = "127.0.0.1:3901";
+            rpc_secret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+            replication_factor = 1;
 
-        environment.systemPackages = [ pkgs.minio-client ];
+            s3_api = {
+              s3_region = "garage";
+              api_bind_addr = "0.0.0.0:${toString garagePort}";
+            };
+          };
+        };
 
         services.prometheus.exporters.node = {
           enable = true;
@@ -235,17 +244,20 @@ in
     ''
       # Before starting the other machines we first make sure that our S3 service is online
       # and has a bucket added for thanos:
-      s3.start()
-      s3.wait_for_unit("minio.service")
-      s3.wait_for_open_port(${toString minioPort})
-      s3.succeed(
-          "mc alias set minio "
-          + "http://localhost:${toString minioPort} "
-          + "${s3.accessKey} ${s3.secretKey} --api s3v4",
-          "mc mb minio/thanos-bucket",
+      garage.start()
+      garage.wait_for_unit("garage.service")
+      garage.wait_for_open_port(3901)
+      garage_node_id = garage.succeed("garage status | tail -n1 | awk '{ print $1 }'")
+      garage.succeed(
+          f"garage layout assign -c 100MB -z garage {garage_node_id}",
+          "garage layout apply --version 1",
+          "garage key import ${s3.accessKey} ${s3.secretKey} --yes",
+          "garage bucket create thanos-bucket",
+          "garage bucket allow --read --write --owner thanos-bucket --key ${s3.accessKey}",
       )
+      garage.wait_for_open_port(${toString garagePort})
 
-      # Now that s3 has started we can start the other machines:
+      # Now that the S3 service has started we can start the other machines:
       for machine in prometheus, query, store:
           machine.start()
 


### PR DESCRIPTION
For #490996

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
