### PR TITLE
nixos/sshd: remove 'banner' option, in favour of settings.Banner

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -344,6 +344,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.openssh.enableRecommendedAlgorithms` has been added to allow users to opt out of NixOS's curated set of recommended algorithms. This set to true by default, and thus is not a breaking change. Users may want to set this to false if they prefer upstream's default algorithms. See <https://github.com/NixOS/nixpkgs/pull/471330>.
 
+- `services.openssh.banner` has been removed. Use `services.openssh.settings.Banner` instead.
+
 - IPVLAN interfaces can now be configured through the `networking.ipvlans` option in the networking module.
 
 - `services.caddy` now supports setting `httpPort` and `httpsPort` and opening them in the firewall via `openFirewall`.

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -225,6 +225,11 @@ in
       [ "services" "openssh" "forwardX11" ]
       [ "services" "openssh" "settings" "X11Forwarding" ]
     )
+    (lib.mkRemovedOptionModule [
+      "services"
+      "openssh"
+      "banner"
+    ] "Use services.openssh.settings.Banner instead.")
   ];
 
   ###### interface
@@ -402,14 +407,6 @@ in
           don't want to enable the SSH daemon.
         '';
         example = true;
-      };
-
-      banner = lib.mkOption {
-        type = lib.types.nullOr lib.types.lines;
-        default = null;
-        description = ''
-          Message to display to the remote user before authentication is allowed.
-        '';
       };
 
       enableRecommendedAlgorithms = lib.mkOption {
@@ -722,6 +719,14 @@ in
               PrintMotd = lib.mkEnableOption "printing /etc/motd when a user logs in interactively" // {
                 type = lib.types.nullOr lib.types.bool;
               };
+              Banner = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+                description = ''
+                  The file whose contents are sent to the remote user before authentication.
+                '';
+                example = "/etc/ssh/banner";
+              };
             };
           }
         );
@@ -886,7 +891,6 @@ in
       services.openssh.extraConfig = lib.mkOrder 0 (
         lib.concatStringsSep "\n" (
           [
-            "Banner ${if cfg.banner == null then "none" else pkgs.writeText "ssh_banner" cfg.banner}"
             "AddressFamily ${if config.networking.enableIPv6 then "any" else "inet"}"
           ]
           ++ lib.map (port: "Port ${toString port}") cfg.ports


### PR DESCRIPTION
Remove `services.openssh.banner`, in favour of `services.openssh.settings.Banner`, per RFC42.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
