### PR TITLE
mavproxy: Fix usage

### DIFF
--- a/pkgs/applications/science/robotics/mavproxy/default.nix
+++ b/pkgs/applications/science/robotics/mavproxy/default.nix
@@ -1,24 +1,27 @@
 {
   stdenv,
   lib,
+  billiard,
   buildPythonApplication,
   fetchFromGitHub,
+  fetchpatch,
+  gnureadline,
   lxml,
   matplotlib,
   numpy,
   opencv-python,
   pymavlink,
+  pynmeagps,
   pyserial,
   setuptools,
+  versionCheckHook,
   wxpython,
-  billiard,
-  gnureadline,
 }:
 
 buildPythonApplication rec {
   pname = "MAVProxy";
   version = "1.8.74";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ArduPilot";
@@ -27,14 +30,25 @@ buildPythonApplication rec {
     hash = "sha256-1/bp3vlCXt4Hg36zwMKSzPSxW7xlxpfx2o+2uQixdos=";
   };
 
-  propagatedBuildInputs = [
+  patches = [
+    # Remove python 2 future imports
+    (fetchpatch {
+      url = "https://github.com/ArduPilot/MAVProxy/commit/db52f3f5d1991942026c00b51a3ce1ce85998cbd.patch";
+      hash = "sha256-mNhOfXJMiUihsso3fjzlbeXW/3ENvrdkFSLo23dMCY4=";
+    })
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     lxml
     matplotlib
     numpy
     opencv-python
     pymavlink
+    pynmeagps
     pyserial
-    setuptools
+    setuptools # Imports `pkg_resources` at runtime
     wxpython
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -42,12 +56,16 @@ buildPythonApplication rec {
     gnureadline
   ];
 
-  # No tests
-  doCheck = false;
+  pythonImportsCheck = [ "MAVProxy" ];
+
+  # No tests, but we can check the version
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "MAVLink proxy and command line ground station";
+    mainProgram = "mavproxy.py";
     homepage = "https://github.com/ArduPilot/MAVProxy";
+    changelog = "https://github.com/ArduPilot/MAVProxy/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ lopsided98 ];
   };


### PR DESCRIPTION
It would previously complain about missing future, which isnt needed on modern python versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
