### PR TITLE
zapper: init at 1.1

### DIFF
--- a/pkgs/by-name/za/zapper/package.nix
+++ b/pkgs/by-name/za/zapper/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  glibc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zapper";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "hackerschoice";
+    repo = "zapper";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k8tkM3/hRSWwsgLiv9+n06INYpk6tz0hMZtOcOlQfLw=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  buildInputs = [ glibc.static ];
+
+  buildFlags = [ "zapper" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 zapper $out/bin/zapper
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Zaps arguments and environment from the process list";
+    homepage = "https://github.com/hackerschoice/zapper";
+    changelog = "https://github.com/hackerschoice/zapper/releases/tag/v${finalAttrs.src.tag}";
+    # https://github.com/hackerschoice/zapper/issues/4
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "zapper";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Zaps arguments and environment from the process list

https://github.com/hackerschoice/zapper

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
