### PR TITLE
ci/eval/compare: Expose attrdiff by kernel and platform

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -312,6 +312,12 @@ jobs:
           script: |
             const { readFile } = require('node:fs/promises')
             const changed = JSON.parse(await readFile('comparison/changed-paths.json', 'utf-8'))
+            const removedByKernel = Object.fromEntries(
+              Object.entries(changed.attrdiffByKernel ?? {}).map(([kernel, diff]) => [
+                kernel,
+                diff.removed.length,
+              ]),
+            )
             const description =
               'Package: ' + [
                 `added ${changed.attrdiff.added.length}`,
@@ -321,7 +327,15 @@ jobs:
               ' — Rebuild: ' + [
                 `linux ${changed.rebuildCountByKernel.linux}`,
                 `darwin ${changed.rebuildCountByKernel.darwin}`
-              ].join(', ')
+              ].join(', ') +
+              (
+                Object.values(removedByKernel).some((count) => count > 0)
+                  ? ' — Removed: ' + [
+                      `linux ${removedByKernel.linux ?? 0}`,
+                      `darwin ${removedByKernel.darwin ?? 0}`
+                    ].join(', ')
+                  : ''
+              )
 
             const { serverUrl, repo, runId, payload } = context
             const target_url =

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -74,8 +74,37 @@ let
         {
           attrdiff: {
             added: ["package1"],
-            changed: ["package2", "package3"],
+            changed: ["package2", "package3", "package4"],
             removed: ["package4"],
+          },
+          attrdiffByKernel: {
+            darwin: {
+              added: [],
+              changed: ["package2", "package4"],
+              removed: ["package4"],
+            },
+            linux: {
+              added: ["package1"],
+              changed: ["package3", "package4"],
+              removed: [],
+            },
+          },
+          attrdiffByPlatform: {
+            aarch64-darwin: {
+              added: [],
+              changed: ["package2"],
+              removed: ["package4"],
+            },
+            aarch64-linux: {
+              added: ["package1"],
+              changed: ["package3"],
+              removed: [],
+            },
+            x86_64-linux: {
+              added: [],
+              changed: ["package4"],
+              removed: [],
+            },
           },
           labels: {
             "10.rebuild-darwin: 1-10": true,
@@ -113,6 +142,8 @@ let
   inherit (import ./utils.nix { inherit lib; })
     groupByKernel
     convertToPackagePlatformAttrs
+    groupAttrdiffByKernel
+    groupAttrdiffByPlatform
     groupByPlatform
     extractPackageNames
     getLabels
@@ -127,6 +158,15 @@ let
 
   changed-paths =
     let
+      attrdiff = lib.mapAttrs (_: extractPackageNames) {
+        inherit (diffAttrs) added changed removed;
+      };
+      attrdiffByPlatform = groupAttrdiffByPlatform {
+        inherit (diffAttrs) added changed removed;
+      };
+      attrdiffByKernel = groupAttrdiffByKernel {
+        inherit (diffAttrs) added changed removed;
+      };
       rebuildsByPlatform = groupByPlatform rebuildsPackagePlatformAttrs;
       rebuildsByKernel = groupByKernel rebuildsPackagePlatformAttrs;
       rebuildCountByKernel = lib.mapAttrs (
@@ -135,7 +175,7 @@ let
     in
     writeText "changed-paths.json" (
       builtins.toJSON {
-        attrdiff = lib.mapAttrs (_: extractPackageNames) { inherit (diffAttrs) added changed removed; };
+        inherit attrdiff attrdiffByKernel attrdiffByPlatform;
         inherit
           rebuildsByPlatform
           rebuildsByKernel

--- a/ci/eval/compare/test.nix
+++ b/ci/eval/compare/test.nix
@@ -7,6 +7,7 @@
 }:
 let
   fun = import ./maintainers.nix { inherit lib; };
+  utils = import ./utils.nix { inherit lib; };
 
   mockPkgs =
     {
@@ -224,6 +225,83 @@ let
         users."0" = [
           { file = "a"; }
         ];
+      };
+    };
+    testGroupAttrdiffByPlatform = {
+      expr = utils.groupAttrdiffByPlatform {
+        added = [
+          "new-tool.aarch64-linux"
+          "new-tool.x86_64-darwin"
+        ];
+        changed = [
+          "updated-tool.x86_64-darwin"
+          "shared-tool.x86_64-darwin"
+        ];
+        removed = [
+          "removed-tool.aarch64-darwin"
+          "shared-tool.aarch64-darwin"
+        ];
+      };
+      expected = {
+        aarch64-darwin = {
+          added = [ ];
+          changed = [ ];
+          removed = [
+            "removed-tool"
+            "shared-tool"
+          ];
+        };
+        aarch64-linux = {
+          added = [ "new-tool" ];
+          changed = [ ];
+          removed = [ ];
+        };
+        x86_64-darwin = {
+          added = [ "new-tool" ];
+          changed = [
+            "shared-tool"
+            "updated-tool"
+          ];
+          removed = [ ];
+        };
+      };
+    };
+    testGroupAttrdiffByKernel = {
+      expr =
+        let
+          grouped = utils.groupAttrdiffByKernel {
+            added = [
+              "new-tool.aarch64-linux"
+              "new-tool.x86_64-darwin"
+            ];
+            changed = [
+              "updated-tool.x86_64-darwin"
+              "shared-tool.x86_64-darwin"
+            ];
+            removed = [
+              "removed-tool.aarch64-darwin"
+              "shared-tool.aarch64-darwin"
+            ];
+          };
+        in
+        lib.mapAttrs (_: diff: lib.mapAttrs (_: lib.sort lib.lessThan) diff) grouped;
+      expected = {
+        darwin = {
+          added = [ "new-tool" ];
+          changed = [
+            "shared-tool"
+            "updated-tool"
+          ];
+          removed = [
+            "removed-tool"
+            "shared-tool"
+          ];
+        };
+        linux = {
+          added = [ "new-tool" ];
+          changed = [ ];
+          removed = [ ];
+        };
       };
     };
   };

--- a/ci/eval/compare/utils.nix
+++ b/ci/eval/compare/utils.nix
@@ -151,6 +151,50 @@ rec {
     lib.genAttrs [ "linux" "darwin" ] filterKernel;
 
   /*
+    Group an attrdiff-style mapping by a derived key such as platform or kernel.
+
+    Turns
+      {
+        added = [ "new-tool.aarch64-linux" "new-tool.x86_64-darwin" ];
+        changed = [ "updated-tool.x86_64-darwin" "shared-tool.x86_64-darwin" ];
+        removed = [ "removed-tool.aarch64-darwin" "shared-tool.aarch64-darwin" ];
+      }
+    into
+      {
+        aarch64-darwin = {
+          added = [ ];
+          changed = [ ];
+          removed = [ "removed-tool" "shared-tool" ];
+        };
+        aarch64-linux = {
+          added = [ "new-tool" ];
+          changed = [ ];
+          removed = [ ];
+        };
+        x86_64-darwin = {
+          added = [ "new-tool" ];
+          changed = [ "shared-tool" "updated-tool" ];
+          removed = [ ];
+        };
+      }
+    when used with `groupByPlatform`.
+  */
+  groupAttrdiffBy =
+    grouper: attrdiff:
+    let
+      groupedByKind = lib.mapAttrs (
+        _: packagePlatformPaths:
+        grouper (convertToPackagePlatformAttrs (uniqueStrings packagePlatformPaths))
+      ) attrdiff;
+      groups = uniqueStrings (lib.flatten (map builtins.attrNames (lib.attrValues groupedByKind)));
+    in
+    lib.genAttrs groups (group: lib.mapAttrs (_: byGroup: byGroup.${group} or [ ]) groupedByKind);
+
+  groupAttrdiffByPlatform = groupAttrdiffBy groupByPlatform;
+
+  groupAttrdiffByKernel = groupAttrdiffBy groupByKernel;
+
+  /*
     Maps an attrs of `kernel - rebuild counts` mappings to an attrs of labels
 
     Turns

--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -25,6 +25,16 @@ async function checkTargetBranch({ github, context, core, dry }) {
    *   changed: string[],
    *   removed: string[],
    *  },
+   *  attrdiffByKernel: Record<string, {
+   *   added: string[],
+   *   changed: string[],
+   *   removed: string[],
+   *  }>,
+   *  attrdiffByPlatform: Record<string, {
+   *   added: string[],
+   *   changed: string[],
+   *   removed: string[],
+   *  }>,
    *  labels: Record<string, boolean>,
    *  rebuildCountByKernel: Record<string, number>,
    *  rebuildsByKernel: Record<string, string[]>,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add attrdiffByKernel and attrdiffByPlatform to the compare artifact schema so downstream consumers can distinguish platform-specific regressions from plain rebuild counts.

Specifically, in https://github.com/NixOS/nixpkgs/pull/507400 the "Refused to evaluate" darwin errors were missed because nixpkgs-review reported all as "✅ No rebuilds". Resulting in https://github.com/NixOS/nixpkgs/issues/509096. By exposing the attrdiffByPlatform, it will be easy to integrate removed packages as part of the standard nixpkgs-review procedure without local evaluation. Exposing such detailed information in CI that is digestible downstream seems like the best fix to avoid such issues in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
