### PR TITLE
spire-tpm-plugin: init at 1.11.1

### DIFF
--- a/pkgs/by-name/sp/spire-tpm-plugin/package.nix
+++ b/pkgs/by-name/sp/spire-tpm-plugin/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  openssl,
+  tpm2-tools,
+  xxd,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "spire-tpm-plugin";
+  version = "1.11.1";
+
+  src = fetchFromGitHub {
+    owner = "spiffe";
+    repo = "spire-tpm-plugin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6hy1aQg0tS2wxOZRbZLv82HQEufVmW/a5L6Da+bNeHU=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-cENDkx/iz6H/AhAO1lKypHhOFz+F3gC3bMg8Jw7eeo0=";
+
+  ldflags = [ "-s" ];
+
+  buildInputs = [ openssl ];
+
+  nativeCheckInputs = [
+    openssl.bin
+    tpm2-tools
+    xxd
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Provides agent and server plugins for SPIRE to allow TPM 2-based node attestation";
+    homepage = "https://github.com/spiffe/spire-tpm-plugin";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ arianvp ];
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
