### PR TITLE
gitkraken: 11.6.0 -> 12.0.1

### DIFF
--- a/pkgs/by-name/gi/gitkraken/package.nix
+++ b/pkgs/by-name/gi/gitkraken/package.nix
@@ -56,24 +56,24 @@
 
 let
   pname = "gitkraken";
-  version = "12.0.0";
+  version = "12.0.1";
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
   srcs = {
     x86_64-linux = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/linux/x64/${version}/gitkraken-amd64.tar.gz";
-      hash = "sha256-O0w8FbwPzviDeDlN/BeN63ibSOKgJjHoL/r69jg0lGI=";
+      hash = "sha256-Tn4j9zmH8hr5rKaPFgox/LopTvEWghnPGf4JiM8y86k=";
     };
 
     x86_64-darwin = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/darwin/x64/${version}/GitKraken-v${version}.zip";
-      hash = "sha256-nP47MGVIikj/MZk4875lhc1B2Q1ccCAvrssxiyWozos=";
+      hash = "sha256-bKbqu94JPI4VOPcphkw/vAN/ihb5wc5qh/qaw7bweG0=";
     };
 
     aarch64-darwin = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/darwin/arm64/${version}/GitKraken-v${version}.zip";
-      hash = "sha256-asC7VmTb7zCMsSAiccqrzWkpzS6W0ZxErDCLzNGS85Q=";
+      hash = "sha256-h2RSdK75i1NbchGauDSvaYJyz39Bncgf+RQIfRdDQuE=";
     };
   };
 

--- a/pkgs/by-name/gi/gitkraken/package.nix
+++ b/pkgs/by-name/gi/gitkraken/package.nix
@@ -211,9 +211,9 @@ let
       if [ -e nodegit-x64-ubuntu-20.node ]; then
         nodegitBinary=nodegit-x64-ubuntu-20
       fi
-      mv ''${nodegitBinary}.node ''${nodegitBinary}-ssl-1.1.1.node
-      mv ''${nodegitBinary}-ssl-static.node ''${nodegitBinary}.node
-      chmod 755 ''${nodegitBinary}.node
+      mv $nodegitBinary.node $nodegitBinary-ssl-1.1.1.node
+      mv $nodegitBinary-ssl-static.node $nodegitBinary.node
+      chmod 755 $nodegitBinary.node
       popd
 
       # Devendor bundled git

--- a/pkgs/by-name/gi/gitkraken/package.nix
+++ b/pkgs/by-name/gi/gitkraken/package.nix
@@ -56,24 +56,24 @@
 
 let
   pname = "gitkraken";
-  version = "11.6.0";
+  version = "11.10.0";
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
   srcs = {
     x86_64-linux = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/linux/x64/${version}/gitkraken-amd64.tar.gz";
-      hash = "sha256-MU/WB4RsNViEulvE6fB7S4QTjjMI/50enlyCIX+xar4=";
+      hash = "sha256-t7baPue255rpC/7NpO9PNVOorEp/w44sJl98Jl8x7VU=";
     };
 
     x86_64-darwin = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/darwin/x64/${version}/GitKraken-v${version}.zip";
-      hash = "sha256-Ty+eRZJ6bnBsrs1VtGem1+m9WDZZf/PgiOvFIazQF6I=";
+      hash = "sha256-0BZ7tTobB1ut0AQekBNBwVWlMBO8cDXotzOhEoLlONs=";
     };
 
     aarch64-darwin = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/darwin/arm64/${version}/GitKraken-v${version}.zip";
-      hash = "sha256-mpJNhvKIBYt3Yd+RjxSgzRP6AfnfHPRbQ0dzd5kQQIQ=";
+      hash = "sha256-CZitCSL3T8bkwas6/+LJ78/HJd6LlWOimS60WMf5xXU=";
     };
   };
 
@@ -207,9 +207,13 @@ let
 
       # SSL and permissions fix for bundled nodegit
       pushd $out/share/${pname}/resources/app.asar.unpacked/node_modules/@axosoft/nodegit/build/Release
-      mv nodegit-ubuntu-20.node nodegit-ubuntu-20-ssl-1.1.1.node
-      mv nodegit-ubuntu-20-ssl-static.node nodegit-ubuntu-20.node
-      chmod 755 nodegit-ubuntu-20.node
+      nodegitBinary=nodegit-ubuntu-20
+      if [ -e nodegit-x64-ubuntu-20.node ]; then
+        nodegitBinary=nodegit-x64-ubuntu-20
+      fi
+      mv ''${nodegitBinary}.node ''${nodegitBinary}-ssl-1.1.1.node
+      mv ''${nodegitBinary}-ssl-static.node ''${nodegitBinary}.node
+      chmod 755 ''${nodegitBinary}.node
       popd
 
       # Devendor bundled git

--- a/pkgs/by-name/gi/gitkraken/package.nix
+++ b/pkgs/by-name/gi/gitkraken/package.nix
@@ -207,13 +207,9 @@ let
 
       # SSL and permissions fix for bundled nodegit
       pushd $out/share/${pname}/resources/app.asar.unpacked/node_modules/@axosoft/nodegit/build/Release
-      nodegitBinary=nodegit-ubuntu-20
-      if [ -e nodegit-x64-ubuntu-20.node ]; then
-        nodegitBinary=nodegit-x64-ubuntu-20
-      fi
-      mv $nodegitBinary.node $nodegitBinary-ssl-1.1.1.node
-      mv $nodegitBinary-ssl-static.node $nodegitBinary.node
-      chmod 755 $nodegitBinary.node
+      mv nodegit-x64-ubuntu-20.node nodegit-x64-ubuntu-20-ssl-1.1.1.node
+      mv nodegit-x64-ubuntu-20-ssl-static.node nodegit-x64-ubuntu-20.node
+      chmod 755 nodegit-ubuntu-20.node
       popd
 
       # Devendor bundled git

--- a/pkgs/by-name/gi/gitkraken/package.nix
+++ b/pkgs/by-name/gi/gitkraken/package.nix
@@ -209,7 +209,7 @@ let
       pushd $out/share/${pname}/resources/app.asar.unpacked/node_modules/@axosoft/nodegit/build/Release
       mv nodegit-x64-ubuntu-20.node nodegit-x64-ubuntu-20-ssl-1.1.1.node
       mv nodegit-x64-ubuntu-20-ssl-static.node nodegit-x64-ubuntu-20.node
-      chmod 755 nodegit-ubuntu-20.node
+      chmod 755 nodegit-x64-ubuntu-20.node
       popd
 
       # Devendor bundled git

--- a/pkgs/by-name/gi/gitkraken/package.nix
+++ b/pkgs/by-name/gi/gitkraken/package.nix
@@ -56,24 +56,24 @@
 
 let
   pname = "gitkraken";
-  version = "11.10.0";
+  version = "12.0.0";
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
   srcs = {
     x86_64-linux = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/linux/x64/${version}/gitkraken-amd64.tar.gz";
-      hash = "sha256-t7baPue255rpC/7NpO9PNVOorEp/w44sJl98Jl8x7VU=";
+      hash = "sha256-O0w8FbwPzviDeDlN/BeN63ibSOKgJjHoL/r69jg0lGI=";
     };
 
     x86_64-darwin = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/darwin/x64/${version}/GitKraken-v${version}.zip";
-      hash = "sha256-0BZ7tTobB1ut0AQekBNBwVWlMBO8cDXotzOhEoLlONs=";
+      hash = "sha256-nP47MGVIikj/MZk4875lhc1B2Q1ccCAvrssxiyWozos=";
     };
 
     aarch64-darwin = fetchzip {
       url = "https://api.gitkraken.dev/releases/production/darwin/arm64/${version}/GitKraken-v${version}.zip";
-      hash = "sha256-CZitCSL3T8bkwas6/+LJ78/HJd6LlWOimS60WMf5xXU=";
+      hash = "sha256-asC7VmTb7zCMsSAiccqrzWkpzS6W0ZxErDCLzNGS85Q=";
     };
   };
 


### PR DESCRIPTION
Bumped GitKraken to the latest version & my IDE copilot noticed that the nodegit binary has different names on different versions, so added a check for that. 

I'm new here, no idea if I did it right or wrong, but am willing to learn :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
