### PR TITLE
canaille: 0.2.3 -> 0.2.4

### DIFF
--- a/pkgs/by-name/ca/canaille/package.nix
+++ b/pkgs/by-name/ca/canaille/package.nix
@@ -12,14 +12,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "canaille";
-  version = "0.2.3";
+  version = "0.2.4";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "yaal";
     repo = "canaille";
     tag = version;
-    hash = "sha256-kBbkqoXyGO238EArwYyjO46Kk5SkfP31Dc51qglLmqQ=";
+    hash = "sha256-iCiQvB+wYpm/Cns63kjo2wVGnSbcQHWo3UJvi0xJf50=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/development/python-modules/scim2-client/default.nix
+++ b/pkgs/development/python-modules/scim2-client/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "scim2-client";
-  version = "0.7.3";
+  version = "0.7.5";
 
   pyproject = true;
 
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "python-scim";
     repo = "scim2-client";
     tag = version;
-    hash = "sha256-jw8Dp/PekM0JrgxRkN+A896O2twkSDxQpsGsljJFdB0=";
+    hash = "sha256-vySSYdCd7O7wDB3NDzGizhREwBJQdLfaXk6edJ1HqGE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/scim2-models/default.nix
+++ b/pkgs/development/python-modules/scim2-models/default.nix
@@ -5,11 +5,15 @@
   uv-build,
   pydantic,
   pytestCheckHook,
+  django,
+  fastapi,
+  flask,
+  httpx,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "scim2-models";
-  version = "0.6.6";
+  version = "0.6.11";
 
   pyproject = true;
 
@@ -17,7 +21,7 @@ buildPythonPackage (finalAttrs: {
     owner = "python-scim";
     repo = "scim2-models";
     tag = finalAttrs.version;
-    hash = "sha256-pYINB8avoYt1VUgvyDTXw3ejSBoZDFEQK0F4flTeyaY=";
+    hash = "sha256-sqXygOutxdLBRJYC3nn78JFsngF2Tq6E0g91VKXQhZE=";
   };
 
   postPatch = ''
@@ -29,7 +33,13 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ pydantic ] ++ pydantic.optional-dependencies.email;
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    django
+    fastapi
+    flask
+    httpx
+  ];
 
   pythonImportsCheck = [ "scim2_models" ];
 

--- a/pkgs/development/python-modules/scim2-tester/default.nix
+++ b/pkgs/development/python-modules/scim2-tester/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "scim2-tester";
-  version = "0.2.6";
+  version = "0.2.8";
 
   pyproject = true;
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "python-scim";
     repo = "scim2-tester";
     tag = version;
-    hash = "sha256-PoaY3gPSm+J/C1ad81Dmn7zrbf00pies8CLmLdV+gus=";
+    hash = "sha256-mWlIZC7080YABBWT2oNDVyrV5YrRzkzCUSZZBK7NNVM=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://gitlab.com/yaal/canaille/-/compare/0.2.3...0.2.4

Changelog: https://gitlab.com/yaal/canaille/-/blob/0.2.4/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
