### PR TITLE
[25.11] vaultwarden: 1.35.4 -> 1.35.6; vaultwarden.webvault: 2026.1.1+0 -> 2026.2.0+0

### DIFF
--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -19,13 +19,13 @@ in
 
 rustPackages_1_94.rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.35.6";
+  version = "1.35.7";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
     tag = version;
-    hash = "sha256-Q5D/tDE7rC9/iIaD0WlGr2AaoCdAEJQs++8uOdYgRXo=";
+    hash = "sha256-HJDpGsKLsVbeUPqTAph5luROpz7ioJXs/PV5nwtmAz8=";
   };
 
   cargoHash = "sha256-LSmzR3X04i2dmPwj1ivPm/YeNtxGhfwsEXG93iVvhrI=";

--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   callPackage,
-  rustPlatform,
+  rustPackages_1_94,
   fetchFromGitHub,
   nixosTests,
   pkg-config,
@@ -17,18 +17,18 @@ let
   webvault = callPackage ./webvault.nix { };
 in
 
-rustPlatform.buildRustPackage rec {
+rustPackages_1_94.rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.35.4";
+  version = "1.35.6";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
     tag = version;
-    hash = "sha256-NphgKTlyVsH42TEGU8unhL798jTQMkS5JyNckKhk8YM=";
+    hash = "sha256-Q5D/tDE7rC9/iIaD0WlGr2AaoCdAEJQs++8uOdYgRXo=";
   };
 
-  cargoHash = "sha256-PkFxHhFrdVB/hfSoT6j87K4IEknl+ZO1omGHrXBWEMg=";
+  cargoHash = "sha256-LSmzR3X04i2dmPwj1ivPm/YeNtxGhfwsEXG93iVvhrI=";
 
   # used for "Server Installed" version in admin panel
   env.VW_VERSION = version;

--- a/pkgs/by-name/va/vaultwarden/webvault.nix
+++ b/pkgs/by-name/va/vaultwarden/webvault.nix
@@ -10,16 +10,16 @@
 
 buildNpmPackage rec {
   pname = "vaultwarden-webvault";
-  version = "2026.1.1+0";
+  version = "2026.2.0+0";
 
   src = fetchFromGitHub {
     owner = "vaultwarden";
     repo = "vw_web_builds";
     tag = "v${version}";
-    hash = "sha256-ehL3DDjCav20XJgUR+ED2x0lax4fm1jMZ0rRiqR78a4=";
+    hash = "sha256-rXBDv8ecImA6qdM5JVYy5QJHRj0jP7zinj/8gWRREtQ=";
   };
 
-  npmDepsHash = "sha256-/S0itw2m2k7GiiwBEzeqFQ8oUYD4yIO4knTTn37qkfA=";
+  npmDepsHash = "sha256-PATpmxIHYSgmuOj8dOoa7ynzkGw5l7z62DiulJmufJY=";
 
   nativeBuildInputs = [
     python3
@@ -64,8 +64,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Integrates the web vault into vaultwarden";
-    homepage = "https://github.com/dani-garcia/bw_web_builds";
-    changelog = "https://github.com/dani-garcia/bw_web_builds/releases/tag/v${lib.concatStringsSep "." (lib.take 3 (lib.versions.splitVersion version))}";
+    homepage = "https://github.com/vaultwarden/vw_web_builds";
     platforms = lib.platforms.all;
     license = lib.licenses.gpl3Plus;
     inherit (vaultwarden.meta) maintainers;

--- a/pkgs/development/compilers/rust/1_94.nix
+++ b/pkgs/development/compilers/rust/1_94.nix
@@ -1,0 +1,105 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+
+# Note: The way this is structured is:
+# 1. Import default.nix, and apply arguments as needed for the file-defined function
+# 2. Implicitly, all arguments to this file are applied to the function that is imported.
+#    if you want to add an argument to default.nix's top-level function, but not the function
+#    it instantiates, add it to the `removeAttrs` call below.
+{
+  stdenv,
+  lib,
+  newScope,
+  callPackage,
+  pkgsBuildTarget,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+  makeRustPlatform,
+  wrapRustcWith,
+  llvmPackages,
+  llvm,
+  cargo-auditable,
+  wrapCCWith,
+  overrideCC,
+  fetchpatch,
+}@args:
+let
+  llvmSharedFor =
+    pkgSet:
+    pkgSet.llvmPackages.libllvm.override (
+      {
+        enableSharedLibraries = true;
+      }
+      // lib.optionalAttrs (stdenv.targetPlatform.useLLVM or false) {
+        # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
+        stdenv = pkgSet.stdenv.override {
+          allowedRequisites = null;
+          cc = pkgSet.pkgsBuildHost.llvmPackages.clangUseLLVM;
+        };
+      }
+    );
+in
+import ./default.nix
+  {
+    rustcVersion = "1.94.0";
+    rustcSha256 = "sha256-uD+SHNPzIf9hT5wGqLhw2JKZ/AKIi0ilVJaDo2gjR0w=";
+    rustcPatches = [ ./ignore-missing-docs.patch ];
+
+    llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
+    llvmSharedForHost = llvmSharedFor pkgsBuildHost;
+    llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
+
+    inherit llvmPackages;
+
+    # For use at runtime
+    llvmShared = llvmSharedFor pkgsHostTarget;
+
+    # Note: the version MUST be the same version that we are building. Upstream
+    # ensures that each released compiler can compile itself:
+    # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
+    bootstrapVersion = "1.94.0";
+
+    # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+    bootstrapHashes = {
+      i686-unknown-linux-gnu = "4c309c178f96770968ce79226af935996b1715389abf4bc08bdd4f596660201d";
+      x86_64-unknown-linux-gnu = "3bb1925a0a5ad2c17be731ee6e977e4a68490ab2182086db897bd28be21e965f";
+      x86_64-unknown-linux-musl = "57a78e193b11573da839c7177b8d29552aeb2c4751973179a384d472210f9c89";
+      arm-unknown-linux-gnueabihf = "2abf1ca017b0762f0750bcebff1c4814805a28c66935c09139d2adf3565105c6";
+      armv7-unknown-linux-gnueabihf = "338514f8c7adccb67c851ce220baceef0cec53b26291ae805094dbdbb5ceaad1";
+      aarch64-unknown-linux-gnu = "a0dc5a65ab337421347533e5be11d3fab11f119683a0dbd257ef3fe968bd2d72";
+      aarch64-unknown-linux-musl = "8ff50ffcf1da9aaea29767864abcdc4cce2eb840d3200e9a3ff585ad17f002b8";
+      x86_64-apple-darwin = "97724032da92646194a802a7991f1166c4dc9f0a63f3bb01a53860e98f31d08c";
+      aarch64-apple-darwin = "94903e93a4334d42bb6d92377a39903349c07f3709c792864bcdf7959f3c8c7d";
+      powerpc64-unknown-linux-gnu = "34dcc95d487f5a7da33ec05abf394515f80559d030e45b1c1744e2005690d720";
+      powerpc64le-unknown-linux-gnu = "fc6fa22878c5d12cb60e0ebaffdad70161965719bcc5d0b6793b132a0de8f759";
+      powerpc64le-unknown-linux-musl = "52472bac4cdecb95e7a091ad9bb328747a09b8cfe7082a90511d5250a330cdbc";
+      riscv64gc-unknown-linux-gnu = "ee71279fee2755d7f613597b24c8b168cc4e404d17e4e966c6b92aaf4d3c21ef";
+      s390x-unknown-linux-gnu = "a27d205e95d9e1ec3f14d94c2cc28b1b6d3b64dda50c1f25a787a30989782a18";
+      loongarch64-unknown-linux-gnu = "12361da66b693b848f6908d2321d03bb53ee9037bcc3d406876e6fc7b945e23d";
+      loongarch64-unknown-linux-musl = "42278996624153a2b872905be08796515e49079dfcdee5f28d4c389f18c2f0e5";
+      x86_64-unknown-freebsd = "6fba7bf41553e67b6d0f2014f7e128818b92f215b1e96a100ac5eaed06a41a04";
+    };
+
+    selectRustPackage = pkgs: pkgs.rust_1_94;
+  }
+
+  (
+    removeAttrs args [
+      "llvmPackages"
+      "llvm"
+      "wrapCCWith"
+      "overrideCC"
+      "pkgsHostTarget"
+      "fetchpatch"
+      "cargo-auditable"
+    ]
+  )

--- a/pkgs/development/compilers/rust/ignore-missing-docs.patch
+++ b/pkgs/development/compilers/rust/ignore-missing-docs.patch
@@ -1,0 +1,11 @@
+index 897f59f530..c94a4a804f 100644
+--- a/library/core/src/os/mod.rs
++++ b/library/core/src/os/mod.rs
+@@ -1,6 +1,7 @@
+ //! OS-specific functionality.
+
+ #![unstable(feature = "darwin_objc", issue = "145496")]
++#[allow(missing_docs)]
+
+ #[cfg(all(
+     doc,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5241,6 +5241,7 @@ with pkgs;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
   rust_1_91 = callPackage ../development/compilers/rust/1_91.nix { };
+  rust_1_94 = callPackage ../development/compilers/rust/1_94.nix { };
   rust = rust_1_91;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -5248,6 +5249,7 @@ with pkgs;
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
   rustPackages_1_91 = rust_1_91.packages.stable;
+  rustPackages_1_94 = rust_1_94.packages.stable;
   rustPackages = rustPackages_1_91;
 
   inherit (rustPackages)


### PR DESCRIPTION
At least rust 1.92 is required but I thought why not backport the current one from unstable to avoid having to backport another version in another ~3 weeks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
