### PR TITLE
mullvad-vpn: 2025.14 -> 2026.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21703,12 +21703,11 @@
     keys = [ { fingerprint = "240B 57DE 4271 2480 7CE3  EAC8 4F74 D536 1C4C A31E"; } ];
   };
   preArcMed821 = {
-    email = "228732420+preArcMed821@users.noreply.github.com";
     github = "preArcMed821";
     githubId = 228732420;
     name = "preArcMed821";
-    keys = [ { fingrerprint = "0FF1 4046 5246 E4FB 6C5D  0302 8454 3F17 ADB9 6273"; }];
-  }
+    keys = [ { fingerprint = "0FF1 4046 5246 E4FB 6C5D  0302 8454 3F17 ADB9 6273"; } ];
+  };
   preisschild = {
     email = "florian@florianstroeger.com";
     github = "Preisschild";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21702,6 +21702,13 @@
     name = "Pradyuman Vig";
     keys = [ { fingerprint = "240B 57DE 4271 2480 7CE3  EAC8 4F74 D536 1C4C A31E"; } ];
   };
+  preArcMed821 = {
+    email = "228732420+preArcMed821@users.noreply.github.com";
+    github = "preArcMed821";
+    githubId = 228732420;
+    name = "preArcMed821";
+    keys = [ { fingrerprint = "0FF1 4046 5246 E4FB 6C5D  0302 8454 3F17 ADB9 6273"; }];
+  }
   preisschild = {
     email = "florian@florianstroeger.com";
     github = "Preisschild";

--- a/pkgs/by-name/mu/mullvad-vpn/package.nix
+++ b/pkgs/by-name/mu/mullvad-vpn/package.nix
@@ -79,7 +79,7 @@ let
     systemd
   ];
 
-  version = "2025.14";
+  version = "2026.1";
 
   selectSystem =
     attrs:
@@ -91,8 +91,8 @@ let
   };
 
   hash = selectSystem {
-    x86_64-linux = "sha256-JHuYHi4uBHzMopa45ipwsdx/3Ox/FxN3lYhBACQOCkE=";
-    aarch64-linux = "sha256-miCh1x6sCcAbg9iX7SJzYcxJ8DIQVNdrg6b39ht8gTw=";
+    x86_64-linux = "sha256-HleajbEbw5Z1ab/E4zSR+GxDOIuvegP4N9yRFZYv7z4=";
+    aarch64-linux = "sha256-Mm2F6PB15pHgRpsw1c1PjmIAcuGaqhfAeZS5HXdoWRQ=";
   };
 in
 

--- a/pkgs/by-name/wl/wlctl/package.nix
+++ b/pkgs/by-name/wl/wlctl/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wlctl";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "aashish-thapa";
+    repo = "wlctl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-omeRIERhax7lmBYcjKm2Vp32yTKvnkOEAgMhRL4/uUY=";
+  };
+
+  cargoHash = "sha256-8LTC5fRdwyXZD8EUz2gR0GTaZuldUTYF/WgAfpMsguM=";
+
+  meta = {
+    description = "TUI for managing WiFi using NetworkManager (fork of Impala)";
+    homepage = "https://github.com/aashish-thapa/wlctl";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      preArcMed821
+    ];
+    mainProgram = "wlctl";
+  };
+})


### PR DESCRIPTION
Updated mullvad-vpn to match that of the daemon when using:

      services.mullvad-vpn = {
        enable = true;
      };

This already uses 2026.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
