### PR TITLE
vscode: guard preFixup with isLinux to fix darwin evaluation

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -346,13 +346,10 @@ stdenv.mkDerivation (
       runHook postInstall
     '';
 
-    preFixup = ''
+    preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
       gappsWrapperArgs+=(
-          ${
-            # we cannot use runtimeDependencies otherwise libdbusmenu do not work on kde
-            lib.optionalString stdenv.hostPlatform.isLinux
-              "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libdbusmenu ]}"
-          }
+          # we cannot use runtimeDependencies otherwise libdbusmenu do not work on kde
+          --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libdbusmenu ]}
         --prefix PATH : ${
           lib.makeBinPath [
             # for moving files to trash


### PR DESCRIPTION
## Problem

Commit 1cbb45d453 ("buildVcode: disable update checks and add missing tools") added `glibc.bin`, `gawk`, `gnused`, and `which` to the `preFixup` PATH in `pkgs/applications/editors/vscode/generic.nix` without an `isLinux` guard.

On darwin, `dontFixup = true` prevents the script from **running**, but Nix still **evaluates** the attribute at derivation construction time. This triggers glibc's `meta.platforms` assertion:

```
error: Refusing to evaluate package 'glibc-nolibgcc-2.42-51' because it is not available on the requested hostPlatform:
  hostPlatform.system = "aarch64-darwin"
```

This breaks any darwin user who has `vscode` in their package set (e.g. via `programs.vscode.enable = true` in home-manager).

## Fix

Guard the entire `preFixup` block with `lib.optionalString stdenv.hostPlatform.isLinux`. The whole block is Linux-only because:
- `gappsWrapperArgs` is populated by `wrapGAppsHook3`, only added to `nativeBuildInputs` on Linux
- The `LD_LIBRARY_PATH` prefix targets `libdbusmenu` (Linux)
- The `NIXOS_OZONE_WL` / Wayland flags are Linux-specific
- On darwin, `dontFixup = true` already prevents execution

Also removes the now-redundant inner `lib.optionalString stdenv.hostPlatform.isLinux` on the `LD_LIBRARY_PATH` line.

## Testing

- [x] `nix-instantiate --eval -E '(import ./. {}).vscode.preFixup'` returns `""` on aarch64-darwin (no glibc assertion)
- [x] `nix-instantiate --eval -E '(import ./. {}).vscode.name'` returns `"vscode-1.115.0"` on darwin
- [x] No functional change on Linux (preFixup content unchanged)

## Checklist
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [x] Tested on aarch64-darwin