### PR TITLE
nixos/autokuma: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14556,6 +14556,14 @@
     github = "krovuxdev";
     githubId = 62192487;
   };
+  kruemmelspalter = {
+    github = "kruemmelspalter";
+    githubId = 54735589;
+    name = "kruemmelspalter";
+    email = "kruemmelspalter@kruemmelspalter.org";
+    matrix = "@kruemmelsplater:kruemmelspalter.org";
+    keys = [ { fingerprint = "28F5 4BD4 73F1 7495 24BF  F4BD 4F4A 2EFA E386 71C8"; } ];
+  };
   krupkat = {
     github = "krupkat";
     githubId = 6817216;

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -108,6 +108,8 @@
 
 - [tabbyAPI](https://github.com/theroyallab/tabbyAPI), the official OpenAI compatible API server for Exllama. Available as [services.tabbyapi](#opt-services.tabbyapi.enable).
 
+- [Autokuma](https://github.com/BigBoot/AutoKuma), automatically setting up uptime-kuma monitors from docker container labels and from files, now also configurable using nix as [services.autokuma](#opt-services.autokuma.enable)
+
 - [Tdarr](https://tdarr.io), Audio/Video Library Analytics & Transcode/Remux Automation. Available as [services.tdarr](#opt-services.tdarr.enable)
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -999,6 +999,7 @@
   ./services/monitoring/amazon-cloudwatch-agent.nix
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix
+  ./services/monitoring/autokuma.nix
   ./services/monitoring/below.nix
   ./services/monitoring/beszel-agent.nix
   ./services/monitoring/beszel-hub.nix

--- a/nixos/modules/services/monitoring/autokuma.nix
+++ b/nixos/modules/services/monitoring/autokuma.nix
@@ -1,0 +1,181 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.autokuma;
+  monitorDir = pkgs.callPackage (
+    { runCommand, jq }:
+    runCommand "autokuma-monitors"
+      {
+        nativeBuildInputs = [ jq ];
+        value = builtins.toJSON cfg.staticMonitors;
+        passAsFile = [ "value" ];
+        preferLocalBuild = true;
+      }
+      ''
+        mkdir $out
+        jq -r "to_entries | .[] | [.key,.value] | .[]" $valuePath | while read filename ; do
+          read > "$out/$filename.json"
+        done
+      ''
+  ) { };
+in
+{
+  options.services.autokuma = {
+    enable = lib.mkEnableOption "autokuma";
+    docker = {
+      enable = lib.mkEnableOption "reading monitor configuration from docker labels";
+      hosts = lib.mkOption {
+        type =
+          with lib.types;
+          oneOf [
+            str
+            (listOf str)
+            (listOf (attrsOf str))
+          ];
+        default = [ ];
+        description = ''
+          docker hosts to watch for container labels, either a semicolon-separated string, a list of strings or a list of attrsets according to https://github.com/BigBoot/AutoKuma
+                  will be set to the docker and/or podman sockets if the respective service is enabled'';
+      };
+    };
+    package = lib.mkPackageOption pkgs "autokuma" { };
+
+    localUptimeKuma = lib.mkOption {
+      description = "use local uptime-kuma.service as After; set automatically if service.uptime-kuma.enable";
+      type = lib.types.bool;
+      default = false;
+    };
+
+    settings = lib.mkOption {
+      description = "settings for autokuma, passed as environment variables. do not set secrets here; use proper secret management using services.autokuma.environmentFile";
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          str
+          int
+          bool
+        ]);
+      default = { };
+    };
+    environmentFile = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "file with environment variables passed to the systemd service, see systemd documentation for format";
+    };
+
+    staticMonitorsDir = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "the directory in which static monitor definitions reside. set per default to static monitor directory generated from services.autokuma.staticMonitors, can be set to a custom directory with files placed manually";
+    };
+
+    staticMonitors = lib.mkOption {
+      description = "every element of this list is a file, containing an array of static monitors, see https://github.com/BigBoot/AutoKuma/blob/master/monitors for examples. for example `{thefile = [{...}]} is written to a file called `thefile.json`, so if one wants to use the first defined item (e. g. group), one needs to use `\"thefile[0]\"`. this is very jank but autokuma doesn't support anything else afaik";
+      type = with lib.types; attrsOf (listOf attrs);
+      default = [ ];
+    };
+
+    kumaUrl = lib.mkOption {
+      description = "the url of the uptime kuma instance to access";
+      type = lib.types.str;
+      default = "";
+    };
+    kumaUser = lib.mkOption {
+      description = "the username of the uptime kuma instance to access";
+      type = lib.types.str;
+      default = "";
+    };
+    kumaPassword = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "the password of the uptime kuma instance to access; do not use this field to set the password in production because it will be world readable; use proper secret management, this is just for testing";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    services.autokuma = {
+      docker.hosts =
+        (if config.virtualisation.docker.enable then config.virtualisation.docker.listenOptions else [ ])
+        ++ (lib.optional config.virtualisation.podman.enable "/run/podman/podman.sock");
+      localUptimeKuma = config.services.uptime-kuma.enable;
+      staticMonitorsDir = if cfg.staticMonitors == [ ] then "" else monitorDir.outPath;
+      settings = {
+        AUTOKUMA__STATIC_MONITORS = cfg.staticMonitorsDir;
+        AUTOKUMA__KUMA__URL = cfg.kumaUrl;
+        AUTOKUMA__KUMA__USERNAME = cfg.kumaUser;
+        AUTOKUMA__KUMA__PASSWORD = cfg.kumaPassword;
+        AUTOKUMA__DOCKER__ENABLED = if cfg.docker.enable then "true" else "false";
+        AUTOKUMA__DOCKER__HOSTS =
+          if lib.isString cfg.docker.hosts then
+            cfg.docker.hosts
+          else if lib.isList cfg.docker.hosts then
+            if cfg.docker.hosts == [ ] then
+              ""
+            else if lib.isString (builtins.elemAt 0 cfg.docker.hosts) then
+              lib.join ";" cfg.docker.hosts
+            else
+              builtins.toJSON cfg.docker.hosts
+          else
+            "";
+        AUTOKUMA__FILES__ENABLED = if cfg.staticMonitorsDir == "" then "false" else "true";
+        AUTOKUMA__LOG_DIR = "/var/log/autokuma"; # set for systemd LogsDirectory to work
+        XDG_CONFIG_HOME = "/etc"; # set for systemd ConfigurationDirectory to work
+      };
+    };
+
+    systemd.services.autokuma = {
+      description = "Autokuma";
+      after = [ "network.target" ] ++ lib.optionals cfg.localUptimeKuma [ "uptime-kuma.service" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.settings;
+
+      serviceConfig = {
+        Type = "simple";
+        EnvironmentFile = cfg.environmentFile;
+
+        ExecStart = "${cfg.package.outPath}/bin/autokuma";
+        Restart = "on-failure";
+
+        DynamicUser = true;
+        LogsDirectory = "autokuma";
+        ConfigurationDirectory = "autokuma";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false;
+        MountAPIVFS = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = 0027;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ kruemmelspalter ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

enables declarative configuration of uptime kuma monitors using pkgs.autokuma (see  https://github.com/BigBoot/AutoKuma)

@JulienMalka maybe you want to look over this as you're maintaining the uptime-kuma module?

~I don't know what exactly is meant by "NixOS Release Notes / Module addition: when adding a new NixOS module.", please tell me if I should add something somewhere ^^~


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

- [x] module path fits the guidelines
- [x] module tests, if any, succeed on ARCHITECTURE
- [x] module tests, if any, are added to package `passthru.tests`
- [x] options have appropriate types
- [x] options have default
- [x] options have example
- [x] options have descriptions
- [x] No unneeded package is added to `environment.systemPackages`
- [x] `meta.maintainers` is set
- [x] module documentation is declared in `meta.doc`
