### PR TITLE
aqtinstall: init at 3.3.0

### DIFF
--- a/pkgs/by-name/aq/aqtinstall/package.nix
+++ b/pkgs/by-name/aq/aqtinstall/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "aqtinstall";
+  version = "3.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "miurahr";
+    repo = "aqtinstall";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CXG8GH1MSS2HhDA/SnqQP7mQG+/OfZ5P6JRG8ZIVlLs=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"bs4"' '"beautifulsoup4"'
+  '';
+
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    defusedxml
+    humanize
+    patch-ng
+    py7zr
+    requests
+    semantic-version
+    texttable
+  ];
+
+  # Tests require network access
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Unofficial Qt installer";
+    homepage = "https://github.com/miurahr/aqtinstall";
+    changelog = "https://github.com/miurahr/aqtinstall/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+    mainProgram = "aqt";
+  };
+})


### PR DESCRIPTION
Adds the unofficial qt installer https://github.com/miurahr/aqtinstall
This is useful in nixpkgs as it can help with installing qt android toolchains used for cross compiling, for example.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
