### PR TITLE
python3Packages.python-obfuscator: 0.0.2 -> 0.1.0

### DIFF
--- a/pkgs/development/python-modules/python-obfuscator/default.nix
+++ b/pkgs/development/python-modules/python-obfuscator/default.nix
@@ -4,24 +4,30 @@
   fetchFromGitHub,
   pytestCheckHook,
   regex,
-  setuptools,
+  typer,
+  poetry-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-obfuscator";
-  version = "0.0.2";
+  version = "0.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "davidteather";
     repo = "python-obfuscator";
-    tag = "V${version}";
-    hash = "sha256-LUD+9vNd1sdigbKG2tm5hE3zLtmor/2LqsIarUWS2Ek=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ddFmlNBtITMPJszLjD2FNjSFF8TrawOv0q7iB3EIdAY=";
   };
 
-  build-system = [ setuptools ];
+  pythonRelaxDeps = [ "typer" ];
 
-  dependencies = [ regex ];
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    regex
+    typer
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -30,8 +36,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to obfuscate code";
     homepage = "https://github.com/davidteather/python-obfuscator";
-    changelog = "https://github.com/davidteather/python-obfuscator/releases/tag/${src.tag}";
+    changelog = "https://github.com/davidteather/python-obfuscator/releases/tag/v${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/davidteather/python-obfuscator/releases/tag/vv0.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
