### PR TITLE
python3Packages.nireports: init at 25.3.0

### DIFF
--- a/pkgs/development/python-modules/nireports/default.nix
+++ b/pkgs/development/python-modules/nireports/default.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  nipreps-versions,
+  acres,
+  lxml,
+  matplotlib,
+  nibabel,
+  nilearn,
+  nipype,
+  numpy,
+  pandas,
+  pybids,
+  pyyaml,
+  seaborn,
+  templateflow,
+  texlive,
+  texlivePackages,
+  ghostscript,
+  pytestCheckHook,
+  pytest-env,
+}: let
+  tex = texlive.combine {inherit (texlive) scheme-small type1cm cm-super dvipng;};
+in
+  buildPythonPackage rec {
+    pname = "nireports";
+    version = "25.3.0";
+    pyproject = true;
+    env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+    src = fetchFromGitHub {
+      owner = "nipreps";
+      repo = "nireports";
+      rev = version;
+      hash = "sha256-HHAKc0CC7GB6kqXQ0yVvK79SIe1PQjySSt69nPomc3s=";
+    };
+
+    build-system = [
+      hatch-vcs
+      hatchling
+      nipreps-versions
+    ];
+
+    dependencies = [
+      acres
+      lxml
+      matplotlib
+      nibabel
+      nilearn
+      nipype
+      numpy
+      pandas
+      pybids
+      pyyaml
+      seaborn
+      templateflow
+      tex
+      ghostscript
+    ];
+
+    nativeCheckInputs = [
+      pytestCheckHook
+      pytest-env
+      tex
+      ghostscript
+    ];
+
+    preCheck = ''
+      export MPLCONFIGDIR=$(mktemp -d)
+      export TEMPLATEFLOW_HOME=$(mktemp -d)
+      export HOME=$(mktemp -d)
+    '';
+
+    disabledTests = [
+      # require network access to templateflow S3
+      "test_ROIsPlot"
+      "test_ROIsPlot2"
+      "test_SimpleShowMaskRPT"
+      "test_BrainExtractionRPT"
+      "test_compression"
+      "test_cifti_surfaces_plot"
+      "test_mriqc_plot_mosaic"
+      "test_mriqc_plot_mosaic_1"
+      "test_mriqc_plot_mosaic_2"
+      "test_plot_dist"
+    ];
+
+    # this is needed otherwise pytest expects pytest-cov
+    pytestFlagsArray = [
+      "--override-ini=addopts="
+    ];
+
+    pythonImportsCheck = ["nireports"];
+
+    meta = {
+      description = "NiPreps' Reporting and Visualization system - report templates and reportlets";
+      homepage = "https://github.com/nipreps/nireports";
+      changelog = "https://github.com/nipreps/nireports/blob/${version}/CHANGES.rst";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ dinga92 ];
+    };
+  }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11096,6 +11096,8 @@ self: super: with self; {
 
   nipype = callPackage ../development/python-modules/nipype { inherit (pkgs) which; };
 
+  nireports = callPackage ../development/python-modules/nireports { };
+
   niquests = callPackage ../development/python-modules/niquests { };
 
   nitime = callPackage ../development/python-modules/nitime { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init nireports, the NiPreps reporting and visualization system used by neuroimaging preprocessing pipelines.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
