### PR TITLE
netpeek: switch to finalAttrs

### DIFF
--- a/pkgs/by-name/ne/netpeek/package.nix
+++ b/pkgs/by-name/ne/netpeek/package.nix
@@ -8,12 +8,10 @@
   desktop-file-utils,
   gobject-introspection,
   wrapGAppsHook4,
-  pkg-config,
   libadwaita,
   libportal-gtk4,
-  gnome,
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "netpeek";
   version = "0.2.6";
   pyproject = false;
@@ -21,7 +19,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "ZingyTomato";
     repo = "NetPeek";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-SFY/bUUS4AOniOGjngH/fUHrYiq+dMWxHYvoSkhfnkA=";
   };
 
@@ -32,7 +30,6 @@ python3Packages.buildPythonApplication rec {
     desktop-file-utils
     gobject-introspection
     wrapGAppsHook4
-    pkg-config
   ];
 
   buildInputs = [
@@ -55,10 +52,10 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "Modern network scanner for GNOME";
     homepage = "https://github.com/ZingyTomato/NetPeek";
-    changelog = "https://github.com/ZingyTomato/NetPeek/releases/tag/${src.tag}";
+    changelog = "https://github.com/ZingyTomato/NetPeek/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ Cameo007 ];
     mainProgram = "netpeek";
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
I just saw that Netpeek doesn’t use finalAttrs, and remove two unnecessary inputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
