### PR TITLE
awesome: migrate to by-name

### DIFF
--- a/pkgs/by-name/aw/awesome/package.nix
+++ b/pkgs/by-name/aw/awesome/package.nix
@@ -38,7 +38,7 @@
   xcbutilxrm,
   hicolor-icon-theme,
   asciidoctor,
-  fontsConf,
+  texFunctions,
   gtk3Support ? false,
   gtk3 ? null,
 }:
@@ -51,6 +51,8 @@ let
     ps.lgi
     ps.ldoc
   ]);
+
+  inherit (texFunctions) fontsConf;
 in
 
 stdenv.mkDerivation rec {
@@ -116,7 +118,7 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ hicolor-icon-theme ];
   buildInputs = [
-    cairo
+    (cairo.override { xcbSupport = true; })
     librsvg
     dbus
     gdk-pixbuf

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9180,11 +9180,6 @@ with pkgs;
 
   bambootracker-qt6 = bambootracker.override { withQt6 = true; };
 
-  awesome = callPackage ../applications/window-managers/awesome {
-    cairo = cairo.override { xcbSupport = true; };
-    inherit (texFunctions) fontsConf;
-  };
-
   awesomebump = libsForQt5.callPackage ../applications/graphics/awesomebump { };
 
   backintime = backintime-qt;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8940,11 +8940,6 @@ with pkgs;
 
   bambootracker-qt6 = bambootracker.override { withQt6 = true; };
 
-  awesome = callPackage ../applications/window-managers/awesome {
-    cairo = cairo.override { xcbSupport = true; };
-    inherit (texFunctions) fontsConf;
-  };
-
   backintime = backintime-qt;
 
   bespokesynth-with-vst2 = bespokesynth.override {


### PR DESCRIPTION
This pull request primarily refactors the packaging of the `awesome` window manager by moving its package definition and updating how some dependencies are handled. The most significant changes involve migrating the package to a new directory, updating dependency injection, and simplifying its inclusion in the top-level package set.

**Package refactoring and dependency management:**

* The `awesome` package definition was moved from `pkgs/applications/window-managers/awesome/default.nix` to `pkgs/by-name/aw/awesome/package.nix`, aligning with the new directory structure.
* The `fontsConf` dependency is now inherited from `texFunctions` instead of being passed directly, streamlining dependency management.

* The `cairo` dependency is now overridden with `{ xcbSupport = true; }` directly in the `buildInputs`, ensuring proper XCB support for the build.

**Top-level package set simplification:**

* The custom `awesome` package override in `pkgs/top-level/all-packages.nix` was removed, as dependency overrides are now handled within the package definition itself.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
