### PR TITLE
filezilla: enable strictDeps, fix xdg-utils

### DIFF
--- a/pkgs/by-name/fi/filezilla/package.nix
+++ b/pkgs/by-name/fi/filezilla/package.nix
@@ -33,12 +33,14 @@ stdenv.mkDerivation {
   configureFlags = [
     "--disable-manualupdatecheck"
     "--disable-autoupdatecheck"
+    "--with-wx-prefix=${wxwidgets_3_2}"
   ];
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
     wrapGAppsHook3
+    xdg-utils
   ];
 
   buildInputs = [
@@ -52,12 +54,18 @@ stdenv.mkDerivation {
     pugixml
     sqlite
     tinyxml
-    wxwidgets_3_2
     gtk3
-    xdg-utils
   ];
 
+  strictDeps = true;
+
   enableParallelBuilding = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}"
+    )
+  '';
 
   meta = {
     homepage = "https://filezilla-project.org/";


### PR DESCRIPTION
xdg-utils should be on the PATH at runtime


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
