### PR TITLE
elephant: enable all providers by default

### DIFF
--- a/pkgs/by-name/el/elephant/package.nix
+++ b/pkgs/by-name/el/elephant/package.nix
@@ -1,25 +1,7 @@
 {
-  enableArchLinuxPkgs ? false,
-  enableDnfPackages ? false,
-  enable1password ? false,
-  enableBitwarden ? true,
-  enableBluetooth ? true,
-  enableBookmarks ? true,
-  enableCalc ? true,
-  enableClipboard ? true,
-  enableDesktopApplications ? true,
-  enableFiles ? true,
-  enableMenus ? true,
-  enableNiriActions ? true,
-  enableNiriSessions ? true,
-  enableProviderList ? true,
-  enableRunner ? true,
-  enableSnippets ? true,
-  enableSymbols ? true,
-  enableTodo ? true,
-  enableUnicode ? true,
-  enableWebsearch ? true,
-  enableWindows ? true,
+  # list of providers to enable, all are enabled by default
+  # e.g. enabledProviders = ["files"] will only install the files provider
+  enabledProviders ? null,
 
   bluez,
   buildGoModule,
@@ -35,38 +17,13 @@
   wl-clipboard,
 }:
 let
-  providerMap = {
-    "1password" = enable1password;
-    "archlinuxpkgs" = enableArchLinuxPkgs;
-    "bitwarden" = enableBitwarden;
-    "bluetooth" = enableBluetooth;
-    "bookmarks" = enableBookmarks;
-    "calc" = enableCalc;
-    "clipboard" = enableClipboard;
-    "desktopapplications" = enableDesktopApplications;
-    "dnfpackages" = enableDnfPackages;
-    "files" = enableFiles;
-    "menus" = enableMenus;
-    "niriactions" = enableNiriActions;
-    "nirisessions" = enableNiriSessions;
-    "providerlist" = enableProviderList;
-    "runner" = enableRunner;
-    "snippets" = enableSnippets;
-    "symbols" = enableSymbols;
-    "todo" = enableTodo;
-    "unicode" = enableUnicode;
-    "websearch" = enableWebsearch;
-    "windows" = enableWindows;
-  };
-
-  enabledProviders = lib.filterAttrs (_: enabled: enabled) providerMap;
-  enabledProvidersList = lib.concatStringsSep " " (lib.attrNames enabledProviders);
+  providerEnabled = provider: (enabledProviders == null) || lib.elem provider enabledProviders;
 
   runtimeDeps =
-    lib.optionals enableFiles [ fd ]
-    ++ lib.optionals enableBluetooth [ bluez ]
-    ++ lib.optionals enableCalc [ libqalculate ]
-    ++ lib.optionals enableClipboard [
+    lib.optionals (providerEnabled "files") [ fd ]
+    ++ lib.optionals (providerEnabled "bluetooth") [ bluez ]
+    ++ lib.optionals (providerEnabled "calc") [ libqalculate ]
+    ++ lib.optionals (providerEnabled "clipboard") [
       wl-clipboard
       imagemagick
     ];
@@ -93,18 +50,31 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/elephant" ];
 
-  postBuild = ''
-    echo "Building providers: ${enabledProvidersList}"
-
-    mkdir -p $out/lib/elephant/providers
-    for provider in ${enabledProvidersList}; do
-      [ -z "$provider" ] && continue
-      if [ -d "internal/providers/$provider" ]; then
-        echo "Building provider: $provider"
-        go build -buildmode=plugin -o "$out/lib/elephant/providers/$provider.so" ./internal/providers/"$provider" || exit 1
-      fi
-    done
-  '';
+  postBuild =
+    (
+      if enabledProviders == null then
+        ''
+          PROVIDERS=()
+          for x in internal/providers/*/; do
+            PROVIDERS+=("$(basename "$x")")
+          done
+        ''
+      else
+        ''
+          PROVIDERS=(${lib.escapeShellArgs enabledProviders})
+        ''
+    )
+    + ''
+      echo "Installing providers"
+      mkdir -p $out/lib/elephant/providers
+      for provider in "''${PROVIDERS[@]}"; do
+        [ -z "$provider" ] && continue
+        if [ -d "internal/providers/$provider" ]; then
+          echo "Building provider: $provider"
+          go build -buildmode=plugin -o "$out/lib/elephant/providers/$provider.so" ./internal/providers/"$provider" || exit 1
+        fi
+      done
+    '';
 
   postInstall = ''
     wrapProgram $out/bin/elephant \


### PR DESCRIPTION
We're already missing providers from not adding them to the package. Switch the logic here, include all by default, and give users a way to be explicit if they don't want all.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
