### PR TITLE
nixosTests.opensmtpd-rspamd: fixup for new dovecot module

### DIFF
--- a/nixos/tests/opensmtpd-rspamd.nix
+++ b/nixos/tests/opensmtpd-rspamd.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix {
 
   nodes = {
     smtp1 =
-      { pkgs, ... }:
+      { config, pkgs, ... }:
       {
         imports = [ common/user-account.nix ];
         networking = {
@@ -26,7 +26,7 @@ import ./make-test-python.nix {
           serverConfiguration = ''
             listen on 0.0.0.0
             action dovecot_deliver mda \
-              "${pkgs.dovecot}/libexec/dovecot/deliver -d %{user.username}"
+              "${config.services.dovecot2.package}/libexec/dovecot/deliver -d %{user.username}"
             match from any for local action dovecot_deliver
 
             action relay_smtp2 relay host "smtp://192.168.1.2"
@@ -35,14 +35,20 @@ import ./make-test-python.nix {
         };
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
-          mailLocation = "maildir:~/mail";
-          protocols = [ "imap" ];
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = config.services.dovecot2.package.version;
+            mail_driver = "maildir";
+            mail_path = "~/mail";
+            protocols.imap = true;
+            auth_allow_cleartext = true;
+          };
         };
       };
 
     smtp2 =
-      { pkgs, ... }:
+      { config, pkgs, ... }:
       {
         imports = [ common/user-account.nix ];
         networking = {
@@ -72,15 +78,21 @@ import ./make-test-python.nix {
             filter rspamd proc-exec "${pkgs.opensmtpd-filter-rspamd}/bin/filter-rspamd"
             listen on 0.0.0.0 filter rspamd
             action dovecot_deliver mda \
-              "${pkgs.dovecot}/libexec/dovecot/deliver -d %{user.username}"
+              "${config.services.dovecot2.package}/libexec/dovecot/deliver -d %{user.username}"
             match from any for local action dovecot_deliver
           '';
         };
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
-          mailLocation = "maildir:~/mail";
-          protocols = [ "imap" ];
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = config.services.dovecot2.package.version;
+            mail_driver = "maildir";
+            mail_path = "~/mail";
+            protocols.imap = true;
+            auth_allow_cleartext = true;
+          };
         };
       };
 
@@ -146,7 +158,7 @@ import ./make-test-python.nix {
     smtp1.wait_for_unit("opensmtpd")
     smtp2.wait_for_unit("opensmtpd")
     smtp2.wait_for_unit("rspamd")
-    smtp2.wait_for_unit("dovecot2")
+    smtp2.wait_for_unit("dovecot")
 
     # To prevent sporadic failures during daemon startup, make sure
     # services are listening on their ports before sending requests


### PR DESCRIPTION
See #509564.

Like the opensmtpd one, #509568.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
