### PR TITLE
usbvfiod: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14996,6 +14996,12 @@
     githubId = 120277625;
     name = "LazilyStableProton";
   };
+  lbeierlieb = {
+    email = "lukasbrlb.lb@gmail.com";
+    github = "lbeierlieb";
+    githubId = 16045805;
+    name = "Lukas Beierlieb";
+  };
   lblasc = {
     email = "lblasc@znode.net";
     github = "lblasc";

--- a/pkgs/by-name/us/usbvfiod/package.nix
+++ b/pkgs/by-name/us/usbvfiod/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "usbvfiod";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "cyberus-technology";
+    repo = "usbvfiod";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SG5S0wRue/G31XuR2D8xFrbAIhWG3rl+aNjEnhZ7dmI=";
+  };
+
+  cargoHash = "sha256-nTNUC7Tiib2wWYC1g7S1W7wgIkqZLTN8aKUKjpgZlqo=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor";
+    description = "A tool for USB device pass-through using the vfio-user protocol.";
+    changelog = "https://github.com/cyberus-technology/usb/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "usbvfiod";
+    maintainers = with lib.maintainers; [
+      lbeierlieb
+    ];
+    platforms = [
+      "aarch64-linux"
+      "riscv64-linux"
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
Add [usbvfiod](https://github.com/cyberus-technology/usbvfiod), an emulated USB controller. VMMs with vfio-user support (such as Cloud Hypervisor and QEMU) can utilize usbvfiod for USB-device passthrough.

I also added myself to the maintainers file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
