### PR TITLE
servo: 0.0.6 -> 0.1.0

### DIFF
--- a/nixos/tests/servo.nix
+++ b/nixos/tests/servo.nix
@@ -20,7 +20,7 @@
     machine.wait_for_x()
 
     with subtest("Wait until Servo has finished loading the Valgrind docs page"):
-      machine.execute("xterm -e 'servo file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html' >&2 &");
+      machine.execute("xterm -e '${lib.getExe pkgs.servo} file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html' >&2 &");
       machine.wait_for_window("Valgrind")
       machine.wait_for_text("Quick Start Guide")
   '';

--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -69,13 +69,13 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "servo";
-  version = "0.0.6";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "servo";
     repo = "servo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eKog8kcZJXBMJz/Lr0+ZwU95HYZRljGWByJ84vPfiEY=";
+    hash = "sha256-DnjtKizYwadBYDqafFDuE/DRIjCqnK/L95zV0Fv0Xhc=";
     # Breaks reproducibility depending on whether the picked commit
     # has other ref-names or not, which may change over time, i.e. with
     # "ref-names: HEAD -> main" as long this commit is the branch HEAD
@@ -85,7 +85,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   };
 
-  cargoHash = "sha256-VP+hAQDfUVbOa2+Uq6hqG5YgQYRNI01+gDaR2MyYUTM=";
+  cargoHash = "sha256-TJXWscTnsXxaWTfn7BugVMPamXOsyHXQhJskX04X7Zw=";
 
   # set `HOME` to a temp dir for write access
   # Fix invalid option errors during linking (https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328)
@@ -159,7 +159,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p $out/resources
     cp -r ./resources $out/
 
-    wrapProgram $out/bin/servo \
+    wrapProgram $out/bin/servoshell \
       --prefix LD_LIBRARY_PATH : ${runtimePaths}
   '';
 
@@ -178,7 +178,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       hexa
     ];
     teams = with lib.teams; [ ngi ];
-    mainProgram = "servo";
+    mainProgram = "servoshell";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
https://servo.org/blog/2026/04/13/servo-0.1.0-release/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
