### PR TITLE
stats: refactor build to data-driven Nix functions

### DIFF
--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -67,13 +67,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.12.7";
+  version = "2.12.9";
 
   src = fetchFromGitHub {
     owner = "exelban";
     repo = "Stats";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qx4FI+MnFknIrTOPP+8wyy1wqFMWyaunmags023ay6A=";
+    hash = "sha256-Yp8B2VdOkt8hWp0jR2CActZw2Q/NWLPeTRmEGdvAyhc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -13,19 +13,59 @@
 let
   inherit (swiftPackages) stdenv swift;
 
-  frameworks = [
-    "Kit"
-    "CPU"
-    "GPU"
-    "RAM"
-    "Disk"
-    "Net"
-    "Battery"
-    "Bluetooth"
-    "Sensors"
-    "Clock"
+  moduleConfigs = [
+    {
+      name = "CPU";
+      bridgingHeader = "Modules/CPU/bridge.h";
+      sysFrameworks = [ "IOKit" ];
+    }
+    {
+      name = "GPU";
+      bridgingHeader = "Modules/GPU/bridge.h";
+      sysFrameworks = [
+        "IOKit"
+        "Metal"
+      ];
+    }
+    {
+      name = "RAM";
+      sysFrameworks = [ "IOKit" ];
+    }
+    {
+      name = "Disk";
+      bridgingHeader = "Modules/Disk/header.h";
+      sysFrameworks = [
+        "IOKit"
+        "DiskArbitration"
+      ];
+    }
+    {
+      name = "Net";
+      sysFrameworks = [
+        "IOKit"
+        "CoreWLAN"
+        "SystemConfiguration"
+      ];
+    }
+    {
+      name = "Battery";
+      sysFrameworks = [ "IOKit" ];
+    }
+    {
+      name = "Bluetooth";
+      sysFrameworks = [
+        "IOKit"
+        "IOBluetooth"
+        "CoreBluetooth"
+      ];
+    }
+    { name = "Sensors"; } # custom build (ObjC + Swift)
+    { name = "Clock"; }
   ];
-  modules = lib.tail frameworks;
+
+  genericModules = lib.filter (m: m.name != "Sensors") moduleConfigs;
+  allFrameworkNames = [ "Kit" ] ++ map (m: m.name) moduleConfigs;
+  moduleNames = lib.tail allFrameworkNames;
 
   toPlist = lib.generators.toPlist { escape = true; };
 
@@ -64,6 +104,78 @@ let
       NSUserNotificationAlertStyle = "alert";
       TeamId = "RP2S87B72W";
     };
+
+  # Collect .swift files from directories into a bash array variable
+  findSwiftFiles = varName: dirs: ''
+    ${varName}=()
+    while IFS= read -r -d "" f; do
+      ${varName}+=("$f")
+    done < <(find ${lib.escapeShellArgs dirs} -name '*.swift' -print0 2>/dev/null)
+  '';
+
+  # Full swiftc invocation for a generic module
+  buildModuleShell = mod: ''
+    nixLog "Building framework: ${mod.name}"
+
+    ${findSwiftFiles "swiftFiles" [
+      mod.name
+      "Modules/${mod.name}"
+    ]}
+
+    swiftc \
+      "''${commonSwiftFlags[@]}" \
+      -emit-module -emit-library \
+      -module-name ${mod.name} -module-link-name ${mod.name} \
+      -emit-module-path "$buildDir/${mod.name}.swiftmodule" \
+      ${lib.optionalString (mod ? bridgingHeader) ''-import-objc-header "${mod.bridgingHeader}"''} \
+      -I "$buildDir" -L "$buildDir" \
+      -Xlinker -install_name -Xlinker "@rpath/${mod.name}.framework/${mod.name}" \
+      -lKit ${lib.concatMapStringsSep " " (f: "-framework ${f}") (mod.sysFrameworks or [ ])} \
+      "''${swiftFiles[@]}" \
+      -o "$buildDir/lib${mod.name}.dylib"
+  '';
+
+  # Sensors needs ObjC compilation before Swift
+  buildSensorsShell = ''
+    nixLog "Building framework: Sensors"
+
+    clang -x objective-c \
+      -I "Modules/Sensors" \
+      -fobjc-arc -O2 \
+      -c Modules/Sensors/reader.m \
+      -o "$buildDir/sensors_reader.o"
+
+    ${findSwiftFiles "sensorsSwiftFiles" [ "Modules/Sensors" ]}
+
+    swiftc \
+      "''${commonSwiftFlags[@]}" \
+      -emit-module -emit-library \
+      -module-name Sensors -module-link-name Sensors \
+      -emit-module-path "$buildDir/Sensors.swiftmodule" \
+      -import-objc-header "Modules/Sensors/bridge.h" \
+      -I "$buildDir" -L "$buildDir" \
+      -lKit -framework IOKit \
+      -Xlinker -install_name -Xlinker "@rpath/Sensors.framework/Sensors" \
+      "$buildDir/sensors_reader.o" \
+      "''${sensorsSwiftFiles[@]}" \
+      -o "$buildDir/libSensors.dylib"
+  '';
+
+  # Compile an asset catalog
+  compileAssetCatalog =
+    {
+      destDir,
+      catalog,
+      appIcon ? null,
+    }:
+    ''
+      actool \
+        --compile "${destDir}" \
+        --platform macosx \
+        --minimum-deployment-target 14.0 \
+        ${lib.optionalString (appIcon != null) "--app-icon ${appIcon}"} \
+        "${catalog}"
+    '';
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stats";
@@ -99,7 +211,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # CWPHYMode.mode11be (WiFi 7) requires macOS 15+ SDK; @unknown default covers it
     sed -i '/mode11be/d' Modules/Net/readers.swift
-
   '';
 
   dontConfigure = true;
@@ -122,49 +233,7 @@ stdenv.mkDerivation (finalAttrs: {
       -Xlinker -platform_version -Xlinker macos -Xlinker 14.0 -Xlinker 26.0
     )
 
-    buildFramework() {
-      local name="$1"
-      shift
-      local bridgingHeader="$1"
-      shift
-      local extraFlags=("$@")
-
-      echo "Building framework: $name"
-
-      local swiftFiles=()
-      while IFS= read -r -d "" f; do
-        swiftFiles+=("$f")
-      done < <(find "$name" -name '*.swift' -print0 2>/dev/null)
-
-      # For modules in Modules/ subdirectory
-      if [ ''${#swiftFiles[@]} -eq 0 ]; then
-        while IFS= read -r -d "" f; do
-          swiftFiles+=("$f")
-        done < <(find "Modules/$name" -name '*.swift' -print0 2>/dev/null)
-      fi
-
-      local bridgeFlags=()
-      if [ -n "$bridgingHeader" ]; then
-        bridgeFlags=(-import-objc-header "$bridgingHeader")
-      fi
-
-      swiftc \
-        "''${commonSwiftFlags[@]}" \
-        -emit-module \
-        -emit-library \
-        -module-name "$name" \
-        -module-link-name "$name" \
-        -emit-module-path "$buildDir/$name.swiftmodule" \
-        "''${bridgeFlags[@]}" \
-        -I "$buildDir" \
-        -L "$buildDir" \
-        -Xlinker -install_name -Xlinker "@rpath/$name.framework/$name" \
-        "''${extraFlags[@]}" \
-        "''${swiftFiles[@]}" \
-        -o "$buildDir/lib$name.dylib"
-    }
-
-    echo "=== Building Kit ==="
+    nixLog "Building Kit"
 
     # Compile lldb.m (Objective-C++ with LevelDB)
     clang++ -x objective-c++ \
@@ -176,10 +245,7 @@ stdenv.mkDerivation (finalAttrs: {
       -c Kit/lldb/lldb.m \
       -o "$buildDir/lldb.o"
 
-    kitSwiftFiles=()
-    while IFS= read -r -d "" f; do
-      kitSwiftFiles+=("$f")
-    done < <(find Kit -name '*.swift' -print0)
+    ${findSwiftFiles "kitSwiftFiles" [ "Kit" ]}
     # Kit also compiles shared SMC source files (protocol.swift, smc.swift)
     kitSwiftFiles+=("SMC/Helper/protocol.swift" "SMC/smc.swift")
 
@@ -201,69 +267,13 @@ stdenv.mkDerivation (finalAttrs: {
       "''${kitSwiftFiles[@]}" \
       -o "$buildDir/libKit.dylib"
 
-    buildFramework CPU "Modules/CPU/bridge.h" \
-      -lKit -framework IOKit
+    ${lib.concatMapStrings buildModuleShell genericModules}
 
-    buildFramework GPU "" \
-      -lKit -framework IOKit -framework Metal
+    ${buildSensorsShell}
 
-    buildFramework RAM "" \
-      -lKit -framework IOKit
+    nixLog "Building Stats app"
 
-    buildFramework Disk "Modules/Disk/header.h" \
-      -lKit -framework IOKit -framework DiskArbitration
-
-    buildFramework Net "" \
-      -lKit -framework IOKit -framework CoreWLAN -framework SystemConfiguration
-
-    buildFramework Battery "" \
-      -lKit -framework IOKit
-
-    buildFramework Bluetooth "" \
-      -lKit -framework IOKit -framework IOBluetooth -framework CoreBluetooth
-
-    # Build Sensors - needs ObjC file too
-    echo "Building framework: Sensors"
-
-    # Compile reader.m (ObjC)
-    clang -x objective-c \
-      -I "Modules/Sensors" \
-      -fobjc-arc \
-      -O2 \
-      -c Modules/Sensors/reader.m \
-      -o "$buildDir/sensors_reader.o"
-
-    sensorsSwiftFiles=()
-    while IFS= read -r -d "" f; do
-      sensorsSwiftFiles+=("$f")
-    done < <(find Modules/Sensors -name '*.swift' -print0)
-
-    swiftc \
-      "''${commonSwiftFlags[@]}" \
-      -emit-module \
-      -emit-library \
-      -module-name Sensors \
-      -module-link-name Sensors \
-      -emit-module-path "$buildDir/Sensors.swiftmodule" \
-      -import-objc-header "Modules/Sensors/bridge.h" \
-      -I "$buildDir" \
-      -L "$buildDir" \
-      -lKit \
-      -framework IOKit \
-      -Xlinker -install_name -Xlinker "@rpath/Sensors.framework/Sensors" \
-      "$buildDir/sensors_reader.o" \
-      "''${sensorsSwiftFiles[@]}" \
-      -o "$buildDir/libSensors.dylib"
-
-    buildFramework Clock "" \
-      -lKit
-
-    echo "=== Building Stats app ==="
-
-    statsSwiftFiles=()
-    while IFS= read -r -d "" f; do
-      statsSwiftFiles+=("$f")
-    done < <(find Stats -name '*.swift' -print0)
+    ${findSwiftFiles "statsSwiftFiles" [ "Stats" ]}
 
     swiftc \
       "''${commonSwiftFlags[@]}" \
@@ -271,7 +281,7 @@ stdenv.mkDerivation (finalAttrs: {
       -module-name Stats \
       -I "$buildDir" \
       -L "$buildDir" \
-      ${lib.concatMapStringsSep " " (fw: "-l${fw}") frameworks} \
+      ${lib.concatMapStringsSep " " (name: "-l${name}") allFrameworkNames} \
       -Xlinker -rpath -Xlinker "@executable_path/../Frameworks" \
       "''${statsSwiftFiles[@]}" \
       -o "$buildDir/Stats"
@@ -288,12 +298,12 @@ stdenv.mkDerivation (finalAttrs: {
     cp "$buildDir/Stats" "$app/Contents/MacOS/Stats"
 
     # Install frameworks with generated Info.plists
-    ${lib.concatMapStrings (fw: ''
-      fwDir="$app/Contents/Frameworks/${fw}.framework"
+    ${lib.concatMapStrings (name: ''
+      fwDir="$app/Contents/Frameworks/${name}.framework"
       mkdir -p "$fwDir/Resources"
-      cp "$buildDir/lib${fw}.dylib" "$fwDir/${fw}"
-      printf '%s' ${lib.escapeShellArg (frameworkPlist fw)} > "$fwDir/Resources/Info.plist"
-    '') frameworks}
+      cp "$buildDir/lib${name}.dylib" "$fwDir/${name}"
+      printf '%s' ${lib.escapeShellArg (frameworkPlist name)} > "$fwDir/Resources/Info.plist"
+    '') allFrameworkNames}
 
     printf '%s' ${lib.escapeShellArg (mainInfoPlist finalAttrs.version)} > "$app/Contents/Info.plist"
     # Splice CFBundleVersion from upstream's checked-in Info.plist so it stays
@@ -304,29 +314,26 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i "s|</dict>|<key>CFBundleVersion</key><string>$bundleVersion</string></dict>|" \
       "$app/Contents/Info.plist"
 
-    # Compile asset catalogs
-    actool \
-      --compile "$app/Contents/Resources" \
-      --platform macosx \
-      --minimum-deployment-target 14.0 \
-      --app-icon AppIcon \
-      "Stats/Supporting Files/Assets.xcassets"
+    ${compileAssetCatalog {
+      destDir = "$app/Contents/Resources";
+      catalog = "Stats/Supporting Files/Assets.xcassets";
+      appIcon = "AppIcon";
+    }}
 
-    actool \
-      --compile "$app/Contents/Frameworks/Kit.framework/Resources" \
-      --platform macosx \
-      --minimum-deployment-target 14.0 \
-      "Kit/Supporting Files/Assets.xcassets"
+    ${compileAssetCatalog {
+      destDir = "$app/Contents/Frameworks/Kit.framework/Resources";
+      catalog = "Kit/Supporting Files/Assets.xcassets";
+    }}
 
     # Copy localization files
     find "Stats/Supporting Files" -name '*.lproj' -type d -exec cp -r {} "$app/Contents/Resources/" \;
 
     # Copy module config plists into each framework's Resources
-    for mod in ${lib.concatStringsSep " " modules}; do
-      if [ -f "Modules/$mod/config.plist" ]; then
-        cp "Modules/$mod/config.plist" "$app/Contents/Frameworks/$mod.framework/Resources/config.plist"
+    ${lib.concatMapStrings (name: ''
+      if [ -f "Modules/${name}/config.plist" ]; then
+        cp "Modules/${name}/config.plist" "$app/Contents/Frameworks/${name}.framework/Resources/config.plist"
       fi
-    done
+    '') moduleNames}
 
     makeWrapper "$app/Contents/MacOS/Stats" "$out/bin/stats"
 


### PR DESCRIPTION
Also bumped to 2.12.9

Changelog: https://github.com/exelban/stats/releases/tag/v2.12.9
Diff: https://github.com/exelban/stats/compare/v2.12.7...v2.12.9

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
