### PR TITLE
netexec: refactored code

### DIFF
--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -2,31 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python312,
+  python3,
   writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
-let
-  python = python312.override {
-    self = python;
-    packageOverrides = self: super: {
-      impacket = super.impacket.overridePythonAttrs {
-        version = "0.14.0-unstable-2025-12-03";
-        src = fetchFromGitHub {
-          owner = "fortra";
-          repo = "impacket";
-          rev = "caba5facdd3a01b5d0decc6daf5871839f22f792";
-          hash = "sha256-jyn5qSSAipGYhHm2EROwDHa227mnmW+d+0H0/++i1OY=";
-        };
-        # Fix version to be compliant with Python packaging rules
-        postPatch = ''
-          substituteInPlace setup.py \
-            --replace 'version="{}.{}.{}.{}{}"' 'version="{}.{}.{}"'
-        '';
-      };
-    };
-  };
-in
-python.pkgs.buildPythonApplication (finalAttrs: {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "netexec";
   version = "1.5.1";
   pyproject = true;
@@ -45,26 +25,25 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     "neo4j"
     # No python package in nixpkgs; use bloodhound-py instead.
     "bloodhound-ce"
+    # Set as git depenencies
+    "oscrypto"
+    "certipy-ad"
+    "impacket"
+    "pynfsclient"
   ];
 
   postPatch = ''
     substituteInPlace nxc/first_run.py \
       --replace-fail "from os import mkdir" "from os import mkdir, chmod" \
       --replace-fail "shutil.copy(default_path, NXC_PATH)" $'shutil.copy(default_path, CONFIG_PATH)\n        chmod(CONFIG_PATH, 0o600)'
-
-    substituteInPlace pyproject.toml \
-      --replace-fail " @ git+https://github.com/Pennyw0rth/Certipy" "" \
-      --replace-fail " @ git+https://github.com/fortra/impacket" "" \
-      --replace-fail " @ git+https://github.com/wbond/oscrypto" "" \
-      --replace-fail " @ git+https://github.com/Pennyw0rth/NfsClient" ""
   '';
 
-  build-system = with python.pkgs; [
+  build-system = with python3.pkgs; [
     poetry-core
     poetry-dynamic-versioning
   ];
 
-  dependencies = with python.pkgs; [
+  dependencies = with python3.pkgs; [
     jwt
     aardwolf
     aioconsole
@@ -73,6 +52,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     asyauth
     beautifulsoup4
     bloodhound-py
+    certihound
     certipy-ad
     dploot
     dsinternals
@@ -81,8 +61,8 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     masky
     minikerberos
     msgpack
-    msldap
     neo4j
+    oscrypto
     paramiko
     pefile
     pyasn1-modules
@@ -101,14 +81,25 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     xmltodict
   ];
 
-  nativeCheckInputs = with python.pkgs; [ pytestCheckHook ] ++ [ writableTmpDirAsHomeHook ];
+  nativeCheckInputs =
+    with python3.pkgs;
+    [ pytestCheckHook ]
+    ++ [
+      writableTmpDirAsHomeHook
+      versionCheckHook
+    ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Network service exploitation tool (maintained fork of CrackMapExec)";
     homepage = "https://github.com/Pennyw0rth/NetExec";
     changelog = "https://github.com/Pennyw0rth/NetExec/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ vncsb ];
+    maintainers = with lib.maintainers; [
+      vncsb
+      letgamer
+    ];
     mainProgram = "nxc";
     # FIXME: failing fixupPhase:
     # $ Rewriting #!/nix/store/<hash>-python3-3.11.7/bin/python3.11 to #!/nix/store/<hash>-python3-3.11.7

--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -2,31 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python312,
+  python3,
   writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
-let
-  python = python312.override {
-    self = python;
-    packageOverrides = self: super: {
-      impacket = super.impacket.overridePythonAttrs {
-        version = "0.14.0-unstable-2025-12-03";
-        src = fetchFromGitHub {
-          owner = "fortra";
-          repo = "impacket";
-          rev = "caba5facdd3a01b5d0decc6daf5871839f22f792";
-          hash = "sha256-jyn5qSSAipGYhHm2EROwDHa227mnmW+d+0H0/++i1OY=";
-        };
-        # Fix version to be compliant with Python packaging rules
-        postPatch = ''
-          substituteInPlace setup.py \
-            --replace 'version="{}.{}.{}.{}{}"' 'version="{}.{}.{}"'
-        '';
-      };
-    };
-  };
-in
-python.pkgs.buildPythonApplication (finalAttrs: {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "netexec";
   version = "1.5.1";
   pyproject = true;
@@ -45,26 +25,25 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     "neo4j"
     # No python package in nixpkgs; use bloodhound instead.
     "bloodhound-ce"
+    # Set as git depenencies
+    "oscrypto"
+    "certipy-ad"
+    "impacket"
+    "pynfsclient"
   ];
 
   postPatch = ''
     substituteInPlace nxc/first_run.py \
       --replace-fail "from os import mkdir" "from os import mkdir, chmod" \
       --replace-fail "shutil.copy(default_path, NXC_PATH)" $'shutil.copy(default_path, CONFIG_PATH)\n        chmod(CONFIG_PATH, 0o600)'
-
-    substituteInPlace pyproject.toml \
-      --replace-fail " @ git+https://github.com/Pennyw0rth/Certipy" "" \
-      --replace-fail " @ git+https://github.com/fortra/impacket" "" \
-      --replace-fail " @ git+https://github.com/wbond/oscrypto" "" \
-      --replace-fail " @ git+https://github.com/Pennyw0rth/NfsClient" ""
   '';
 
-  build-system = with python.pkgs; [
+  build-system = with python3.pkgs; [
     poetry-core
     poetry-dynamic-versioning
   ];
 
-  dependencies = with python.pkgs; [
+  dependencies = with python3.pkgs; [
     jwt
     aardwolf
     aioconsole
@@ -73,6 +52,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     asyauth
     beautifulsoup4
     bloodhound
+    certihound
     certipy-ad
     dploot
     dsinternals
@@ -81,8 +61,8 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     masky
     minikerberos
     msgpack
-    msldap
     neo4j
+    oscrypto
     paramiko
     pefile
     pyasn1-modules
@@ -101,14 +81,25 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     xmltodict
   ];
 
-  nativeCheckInputs = with python.pkgs; [ pytestCheckHook ] ++ [ writableTmpDirAsHomeHook ];
+  nativeCheckInputs =
+    with python3.pkgs;
+    [ pytestCheckHook ]
+    ++ [
+      writableTmpDirAsHomeHook
+      versionCheckHook
+    ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Network service exploitation tool (maintained fork of CrackMapExec)";
     homepage = "https://github.com/Pennyw0rth/NetExec";
     changelog = "https://github.com/Pennyw0rth/NetExec/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ vncsb ];
+    maintainers = with lib.maintainers; [
+      vncsb
+      letgamer
+    ];
     mainProgram = "nxc";
     # FIXME: failing fixupPhase:
     # $ Rewriting #!/nix/store/<hash>-python3-3.11.7/bin/python3.11 to #!/nix/store/<hash>-python3-3.11.7


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Refactored Netexec by changing the following:
- removed impacket pin
- added oscrypto dependency
- added certihound dependency
- removed msldap from deps (upstream)
- added a simple version test
- switched from python312 to python314
- moved Patch to pythonRemoveDeps
- added myself as a maintainer


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
