### PR TITLE
nixos/autokuma: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14692,6 +14692,14 @@
     github = "krovuxdev";
     githubId = 62192487;
   };
+  kruemmelspalter = {
+    github = "kruemmelspalter";
+    githubId = 54735589;
+    name = "kruemmelspalter";
+    email = "kruemmelspalter@kruemmelspalter.org";
+    matrix = "@kruemmelsplater:kruemmelspalter.org";
+    keys = [ { fingerprint = "28F5 4BD4 73F1 7495 24BF  F4BD 4F4A 2EFA E386 71C8"; } ];
+  };
   krupkat = {
     github = "krupkat";
     githubId = 6817216;

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -156,6 +156,8 @@
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
+- [Autokuma](https://github.com/BigBoot/AutoKuma), automatically setting up uptime-kuma monitors from docker container labels and from files, now also configurable using nix as [services.autokuma](#opt-services.autokuma.enable)
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1005,6 +1005,7 @@
   ./services/monitoring/amazon-cloudwatch-agent.nix
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix
+  ./services/monitoring/autokuma.nix
   ./services/monitoring/below.nix
   ./services/monitoring/beszel-agent.nix
   ./services/monitoring/beszel-hub.nix

--- a/nixos/modules/services/monitoring/autokuma.nix
+++ b/nixos/modules/services/monitoring/autokuma.nix
@@ -1,0 +1,201 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.autokuma;
+  monitorDir = pkgs.callPackage (
+    { runCommand, jq }:
+    runCommand "autokuma-monitors"
+      {
+        nativeBuildInputs = [ jq ];
+        value = builtins.toJSON cfg.staticMonitors;
+        passAsFile = [ "value" ];
+        preferLocalBuild = true;
+      }
+      ''
+        mkdir $out
+        jq -rc "to_entries | .[] | [.key,.value] | .[]" $valuePath | while IFS= read -r filename ; do
+          IFS= read -r content
+          echo "$content" > "$out/$filename.json"
+        done
+      ''
+  ) { };
+in
+{
+  options.services.autokuma = {
+    enable = lib.mkEnableOption "autokuma";
+    docker = {
+      enable = lib.mkEnableOption "reading monitor configuration from docker labels; will add autokuma user to docker / podman group which would allow it to gain root, use services.uptime-kuma.docker.addGroups = false; to disable";
+      addGroups = lib.mkOption {
+        description = "add autokuma user to docker/podman groups if docker/podman is enabled locally";
+        default = true;
+        type = lib.types.bool;
+      };
+      hosts = lib.mkOption {
+        type =
+          with lib.types;
+          oneOf [
+            str
+            (listOf str)
+            (listOf (attrsOf str))
+          ];
+        default = [ ];
+        description = ''
+          docker hosts to watch for container labels, either a semicolon-separated string, a list of strings or a list of attrsets according to https://github.com/BigBoot/AutoKuma
+                  will be set to the docker and/or podman sockets if the respective service is enabled'';
+      };
+    };
+    package = lib.mkPackageOption pkgs "autokuma" { };
+
+    localUptimeKuma = lib.mkOption {
+      description = "use local uptime-kuma.service as After; set automatically if service.uptime-kuma.enable";
+      type = lib.types.bool;
+      default = false;
+    };
+
+    settings = lib.mkOption {
+      description = "settings for autokuma, passed as environment variables. do not set secrets here; use proper secret management using services.autokuma.environmentFile";
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          str
+          int
+          bool
+        ]);
+      default = { };
+    };
+    environmentFile = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "file with environment variables passed to the systemd service, see systemd documentation for format";
+    };
+
+    staticMonitorsDir = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "the directory in which static monitor definitions reside. set per default to static monitor directory generated from services.autokuma.staticMonitors, can be set to a custom directory with files placed manually";
+    };
+
+    staticMonitors = lib.mkOption {
+      description = "every element of this list is a file, containing an array of static monitors, see https://github.com/BigBoot/AutoKuma/blob/master/monitors for examples. for example `{thefile = [{...}]} is written to a file called `thefile.json`, so if one wants to use the first defined item (e. g. group), one needs to use `\"thefile[0]\"`. this is very jank but autokuma doesn't support anything else afaik";
+      type = with lib.types; attrsOf (listOf attrs);
+      default = { };
+    };
+
+    kumaUrl = lib.mkOption {
+      description = "the url of the uptime kuma instance to access";
+      type = lib.types.str;
+      default = "";
+    };
+    kumaUser = lib.mkOption {
+      description = "the username of the uptime kuma instance to access";
+      type = lib.types.str;
+      default = "";
+    };
+    kumaPassword = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "the password of the uptime kuma instance to access; do not use this field to set the password in production because it will be world readable; use proper secret management, this is just for testing";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.autokuma = {
+      docker.hosts =
+        (
+          if config.virtualisation.docker.enable then
+            builtins.map (
+              s: if lib.strings.hasPrefix "/" s then "unix://${s}" else s
+            ) config.virtualisation.docker.listenOptions
+          else
+            [ ]
+        )
+        ++ (lib.optional config.virtualisation.podman.enable "/run/podman/podman.sock");
+      localUptimeKuma = config.services.uptime-kuma.enable;
+      staticMonitorsDir = if cfg.staticMonitors == { } then "" else monitorDir.outPath;
+      settings = {
+        AUTOKUMA__STATIC_MONITORS = cfg.staticMonitorsDir;
+        AUTOKUMA__KUMA__URL = cfg.kumaUrl;
+        AUTOKUMA__KUMA__USERNAME = cfg.kumaUser;
+        AUTOKUMA__KUMA__PASSWORD = cfg.kumaPassword;
+        AUTOKUMA__DOCKER__ENABLED = if cfg.docker.enable then "true" else "false";
+        AUTOKUMA__DOCKER__HOSTS =
+          if lib.isString cfg.docker.hosts then
+            cfg.docker.hosts
+          else if lib.isList cfg.docker.hosts then
+            if cfg.docker.hosts == [ ] then
+              ""
+            else if lib.isString (builtins.elemAt cfg.docker.hosts 0) then
+              lib.join ";" cfg.docker.hosts
+            else
+              builtins.toJSON cfg.docker.hosts
+          else
+            "";
+        AUTOKUMA__FILES__ENABLED = if cfg.staticMonitorsDir == "" then "false" else "true";
+        AUTOKUMA__LOG_DIR = "/var/log/autokuma"; # set for systemd LogsDirectory to work
+        XDG_CONFIG_HOME = "/etc"; # set for systemd ConfigurationDirectory to work
+      };
+    };
+
+    systemd.services.autokuma = {
+      description = "Autokuma";
+      after = [ "network.target" ] ++ lib.optionals cfg.localUptimeKuma [ "uptime-kuma.service" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.settings;
+
+      serviceConfig = {
+        Type = "simple";
+        EnvironmentFile = cfg.environmentFile;
+
+        ExecStart = "${cfg.package.outPath}/bin/autokuma";
+        Restart = "on-failure";
+
+        DynamicUser = true;
+        SupplementaryGroups =
+          lib.optionals (cfg.docker.enable && cfg.docker.addGroups && config.virtualisation.docker.enable) [
+            "docker"
+          ]
+          ++ lib.optionals (
+            cfg.docker.enable && cfg.docker.addGroups && config.virtualisation.podman.enable
+          ) [ "podman" ];
+        LogsDirectory = "autokuma";
+        ConfigurationDirectory = "autokuma";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false;
+        MountAPIVFS = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = 0027;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ kruemmelspalter ];
+}

--- a/nixos/modules/services/monitoring/autokuma.nix
+++ b/nixos/modules/services/monitoring/autokuma.nix
@@ -23,31 +23,11 @@ let
         done
       ''
   ) { };
+  settingsFormat = pkgs.formats.json { };
 in
 {
   options.services.autokuma = {
     enable = lib.mkEnableOption "autokuma";
-    docker = {
-      enable = lib.mkEnableOption "reading monitor configuration from docker labels; will add autokuma user to docker / podman group which would allow it to gain root, use services.uptime-kuma.docker.addGroups = false; to disable";
-      addGroups = lib.mkOption {
-        description = "add autokuma user to docker/podman groups if docker/podman is enabled locally";
-        default = true;
-        type = lib.types.bool;
-      };
-      hosts = lib.mkOption {
-        type =
-          with lib.types;
-          oneOf [
-            str
-            (listOf str)
-            (listOf (attrsOf str))
-          ];
-        default = [ ];
-        description = ''
-          docker hosts to watch for container labels, either a semicolon-separated string, a list of strings or a list of attrsets according to https://github.com/BigBoot/AutoKuma
-                  will be set to the docker and/or podman sockets if the respective service is enabled'';
-      };
-    };
     package = lib.mkPackageOption pkgs "autokuma" { };
 
     localUptimeKuma = lib.mkOption {
@@ -55,96 +35,110 @@ in
       type = lib.types.bool;
       default = false;
     };
+    dockerAddToGroups = lib.mkOption {
+      description = "add autokuma user to docker/podman groups if docker/podman is enabled locally";
+      default = true;
+      type = lib.types.bool;
+    };
+    staticMonitors = lib.mkOption {
+      description = "every element of this list is a file, containing an array of static monitors, see https://github.com/BigBoot/AutoKuma/blob/master/monitors for examples. for example `{thefile = [{...}]} is written to a file called `thefile.json`, so if one wants to use the first defined item (e. g. group), one needs to use `\"thefile[0]\"`. this is very jank but autokuma doesn't support anything else afaik";
+      type = lib.types.attrsOf (lib.types.listOf lib.types.attrs);
+      default = { };
+    };
 
     settings = lib.mkOption {
-      description = "settings for autokuma, passed as environment variables. do not set secrets here; use proper secret management using services.autokuma.environmentFile";
-      type =
-        with lib.types;
-        attrsOf (oneOf [
-          str
-          int
-          bool
-        ]);
+      description = "settings for autokuma, passed in a config file. do not set secrets here; use proper secret management using services.autokuma.environmentFile";
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          kuma = {
+            url = lib.mkOption {
+              description = "the url of the uptime kuma instance to access";
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+            };
+            username = lib.mkOption {
+              description = "the username of the uptime kuma instance to access";
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+            };
+            password = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "the password of the uptime kuma instance to access; do not use this field to set the password in production because it will be world readable; use proper secret management, this is just for testing";
+            };
+          };
+
+          static_monitors = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "the directory in which static monitor definitions reside. set per default to static monitor directory generated from services.autokuma.staticMonitors, can be set to a custom directory with files placed manually";
+          };
+
+          docker = {
+            enabled = lib.mkEnableOption "reading monitor configuration from docker labels; will add autokuma user to docker / podman group which would allow it to gain root, use services.uptime-kuma.docker.addGroups = false; to disable";
+            hosts = lib.mkOption {
+              type = lib.types.nullOr (
+                lib.types.oneOf [
+                  lib.types.str
+                  (lib.types.listOf lib.types.str)
+                  (lib.types.listOf (lib.types.attrsOf lib.types.str))
+                ]
+              );
+              default = null;
+              description = ''
+                docker hosts to watch for container labels, either a semicolon-separated string, a list of strings or a list of attrsets according to https://github.com/BigBoot/AutoKuma
+                        will be set to the docker and/or podman sockets if the respective service is enabled'';
+            };
+          };
+        };
+      };
       default = { };
     };
     environmentFile = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.oneOf [
+        lib.types.str
+        (lib.types.listOf lib.types.str)
+      ];
       default = "";
       description = "file with environment variables passed to the systemd service, see systemd documentation for format";
-    };
-
-    staticMonitorsDir = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = "the directory in which static monitor definitions reside. set per default to static monitor directory generated from services.autokuma.staticMonitors, can be set to a custom directory with files placed manually";
-    };
-
-    staticMonitors = lib.mkOption {
-      description = "every element of this list is a file, containing an array of static monitors, see https://github.com/BigBoot/AutoKuma/blob/master/monitors for examples. for example `{thefile = [{...}]} is written to a file called `thefile.json`, so if one wants to use the first defined item (e. g. group), one needs to use `\"thefile[0]\"`. this is very jank but autokuma doesn't support anything else afaik";
-      type = with lib.types; attrsOf (listOf attrs);
-      default = { };
-    };
-
-    kumaUrl = lib.mkOption {
-      description = "the url of the uptime kuma instance to access";
-      type = lib.types.str;
-      default = "";
-    };
-    kumaUser = lib.mkOption {
-      description = "the username of the uptime kuma instance to access";
-      type = lib.types.str;
-      default = "";
-    };
-    kumaPassword = lib.mkOption {
-      type = lib.types.str;
-      default = "";
-      description = "the password of the uptime kuma instance to access; do not use this field to set the password in production because it will be world readable; use proper secret management, this is just for testing";
     };
   };
 
   config = lib.mkIf cfg.enable {
     services.autokuma = {
-      docker.hosts =
-        (
-          if config.virtualisation.docker.enable then
-            builtins.map (
-              s: if lib.strings.hasPrefix "/" s then "unix://${s}" else s
-            ) config.virtualisation.docker.listenOptions
-          else
-            [ ]
-        )
-        ++ (lib.optional config.virtualisation.podman.enable "/run/podman/podman.sock");
-      localUptimeKuma = config.services.uptime-kuma.enable;
-      staticMonitorsDir = if cfg.staticMonitors == { } then "" else monitorDir.outPath;
+      localUptimeKuma = lib.mkDefault config.services.uptime-kuma.enable;
       settings = {
-        AUTOKUMA__STATIC_MONITORS = cfg.staticMonitorsDir;
-        AUTOKUMA__KUMA__URL = cfg.kumaUrl;
-        AUTOKUMA__KUMA__USERNAME = cfg.kumaUser;
-        AUTOKUMA__KUMA__PASSWORD = cfg.kumaPassword;
-        AUTOKUMA__DOCKER__ENABLED = if cfg.docker.enable then "true" else "false";
-        AUTOKUMA__DOCKER__HOSTS =
-          if lib.isString cfg.docker.hosts then
-            cfg.docker.hosts
-          else if lib.isList cfg.docker.hosts then
-            if cfg.docker.hosts == [ ] then
-              ""
-            else if lib.isString (builtins.elemAt cfg.docker.hosts 0) then
-              lib.join ";" cfg.docker.hosts
+        # set for systemd LogsDirectory to work
+        log_dir = "/var/log/autokuma";
+        # set for systemd StateDirectory to work
+        data_path = "/var/lib/autokuma";
+        docker.hosts = lib.mkDefault (
+          (
+            if config.virtualisation.docker.enable then
+              builtins.map (
+                s: if lib.strings.hasPrefix "/" s then "unix://${s}" else s
+              ) config.virtualisation.docker.listenOptions
             else
-              builtins.toJSON cfg.docker.hosts
-          else
-            "";
-        AUTOKUMA__FILES__ENABLED = if cfg.staticMonitorsDir == "" then "false" else "true";
-        AUTOKUMA__LOG_DIR = "/var/log/autokuma"; # set for systemd LogsDirectory to work
-        XDG_CONFIG_HOME = "/etc"; # set for systemd ConfigurationDirectory to work
+              [ ]
+          )
+          ++ (lib.optional config.virtualisation.podman.enable "unix:///run/podman/podman.sock")
+        );
+        static_monitors = lib.mkDefault (if cfg.staticMonitors == { } then null else monitorDir.outPath);
+        files.enabled = lib.mkDefault (toString cfg.settings.static_monitors != "");
       };
+    };
+
+    environment.etc."autokuma/config.json" = {
+      source = settingsFormat.generate "config.json" cfg.settings;
+      mode = "444";
     };
 
     systemd.services.autokuma = {
       description = "Autokuma";
       after = [ "network.target" ] ++ lib.optionals cfg.localUptimeKuma [ "uptime-kuma.service" ];
       wantedBy = [ "multi-user.target" ];
-      environment = cfg.settings;
+      environment.XDG_CONFIG_HOME = "/etc"; # set for systemd ConfigurationDirectory to work
 
       serviceConfig = {
         Type = "simple";
@@ -153,16 +147,19 @@ in
         ExecStart = "${cfg.package.outPath}/bin/autokuma";
         Restart = "on-failure";
 
-        DynamicUser = true;
         SupplementaryGroups =
-          lib.optionals (cfg.docker.enable && cfg.docker.addGroups && config.virtualisation.docker.enable) [
-            "docker"
-          ]
+          lib.optionals
+            (cfg.settings.docker.enabled && cfg.dockerAddToGroups && config.virtualisation.docker.enable)
+            [
+              "docker"
+            ]
           ++ lib.optionals (
-            cfg.docker.enable && cfg.docker.addGroups && config.virtualisation.podman.enable
+            cfg.settings.docker.enabled && cfg.dockerAddToGroups && config.virtualisation.podman.enable
           ) [ "podman" ];
+        DynamicUser = true;
         LogsDirectory = "autokuma";
         ConfigurationDirectory = "autokuma";
+        StateDirectory = "autokuma";
         AmbientCapabilities = "";
         CapabilityBoundingSet = "";
         LockPersonality = true;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -244,6 +244,7 @@ in
   authelia = runTest ./authelia.nix;
   auto-cpufreq = runTest ./auto-cpufreq.nix;
   autobrr = runTest ./autobrr.nix;
+  autokuma = runTest ./autokuma.nix;
   autosuspend = runTest ./autosuspend.nix;
   avahi = runTest {
     imports = [ ./avahi.nix ];

--- a/nixos/tests/autokuma.nix
+++ b/nixos/tests/autokuma.nix
@@ -1,0 +1,92 @@
+{ lib, ... }:
+let
+  kumaHost = "127.0.0.1";
+  kumaPort = "3001";
+  kumaUrl = "http://${kumaHost}:${kumaPort}/";
+  kumaUser = "admin";
+  kumaPassword = "pa55word";
+in
+{
+  name = "autokuma";
+  meta.maintainers = with lib.maintainers; [ kruemmelspalter ];
+
+  containers.machine =
+    { pkgs, lib, ... }:
+    {
+      # only for testing
+      environment.systemPackages = [
+        pkgs.sqlite
+        pkgs.autokuma
+      ];
+
+      services = {
+        uptime-kuma = {
+          enable = true;
+          settings = {
+            HOST = kumaHost;
+            PORT = kumaPort;
+          };
+        };
+
+        autokuma = {
+          enable = true;
+          inherit kumaUrl kumaUser kumaPassword;
+          staticMonitors.config = [
+            {
+              name = "uptime-kuma itself";
+              url = kumaUrl;
+              type = "http";
+            }
+          ];
+          docker.enable = true;
+        };
+      };
+
+      # do not autostart autokuma, start only when done with setup in test
+      systemd.services.autokuma.wantedBy = lib.mkForce [ ];
+
+      virtualisation.docker.enable = true;
+    };
+
+  extraPythonPackages = p: [ p.bcrypt ];
+
+  testScript = ''
+    import json
+    import bcrypt
+
+    # wait for uptime kuma to open the http port; by then, the db is initialized
+    machine.start()
+    machine.wait_for_unit("uptime-kuma.service")
+    machine.wait_for_open_port(${kumaPort})
+
+    # provision user
+    pwhash = bcrypt.hashpw("${kumaPassword}".encode("utf-8"), bcrypt.gensalt()).decode().replace("$", "\\$")
+    machine.succeed(f"echo \"insert into user (username, password) values ('${kumaUser}', '{pwhash}');\" | sqlite3 /var/lib/uptime-kuma/kuma.db");
+
+    machine.wait_for_unit("docker.service")
+    machine.wait_for_unit("docker.socket")
+    machine.succeed("tar cv --files-from /dev/null | docker import - scratchimg")
+    machine.succeed(
+        "docker run -d --name=sleeping -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin --label 'kuma.docker-whoami.http.name=dockertest' --label 'kuma.docker-whoami.http.url=http://example.com/' scratchimg /bin/sleep 20"
+    )
+    machine.wait_until_succeeds("docker ps | grep sleeping")
+
+    machine.systemctl("start autokuma")
+    machine.wait_for_unit("autokuma.service")
+
+    # give autokuma time to register everything
+    machine.succeed("sleep 5")
+
+    # get all monitors from uptime kuma (using the kuma cli provided by autokuma)
+    monitors = machine.succeed("kuma monitor list --url '${kumaUrl}' --username '${kumaUser}' --password '${kumaPassword}'")
+    monitors = json.loads(monitors).values()
+
+    def check_static_monitor(e):
+      return e["type"] == "http" and e["name"] == "uptime-kuma itself" and e["url"] == "${kumaUrl}"
+    assert bool(list(filter(check_static_monitor, monitors))), "static monitor isn't added in uptime-kuma"
+
+    def check_docker_monitor(e):
+      return e["type"] == "http" and e["name"] == "dockertest" and e["url"] == "http://example.com/"
+    assert bool(list(filter(check_docker_monitor, monitors))), "docker monitor isn't added in uptime-kuma"
+  '';
+}

--- a/nixos/tests/autokuma.nix
+++ b/nixos/tests/autokuma.nix
@@ -30,7 +30,14 @@ in
 
         autokuma = {
           enable = true;
-          inherit kumaUrl kumaUser kumaPassword;
+          settings = {
+            kuma = {
+              url = kumaUrl;
+              username = kumaUser;
+              password = kumaPassword;
+            };
+            docker.enabled = true;
+          };
           staticMonitors.config = [
             {
               name = "uptime-kuma itself";
@@ -38,7 +45,6 @@ in
               type = "http";
             }
           ];
-          docker.enable = true;
         };
       };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

this was #509556, I've recreated it to have a clean PR without ten force pushs

enables declarative configuration of uptime kuma monitors using pkgs.autokuma (see  https://github.com/BigBoot/AutoKuma)

@JulienMalka maybe you want to look over this as you're maintaining the uptime-kuma module? if you want, I'll add you as a maintainer


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

- [x] module path fits the guidelines
- [x] module tests, if any, succeed on ARCHITECTURE
- [x] module tests, if any, are added to package `passthru.tests`
- [x] options have appropriate types
- [x] options have default
- [x] options have example
- [x] options have descriptions
- [x] No unneeded package is added to `environment.systemPackages`
- [x] `meta.maintainers` is set
- [x] module documentation is declared in `meta.doc`
