### PR TITLE
mistral-vibe: init at 2.7.4

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -28,14 +28,14 @@ let
 in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mistral-vibe";
-  version = "2.7.3";
+  version = "2.7.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mistralai";
     repo = "mistral-vibe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XRBrBd7X8HewrUJ7K8wQMcVJz3ITPKzyKpyCi7detsE=";
+    hash = "sha256-SPn6YaGmEt2r9Fm3Eagubqw0Q2U5bSvNUY1qo2XfVlE=";
   };
 
   build-system = with python3Packages; [
@@ -48,11 +48,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "agent-client-protocol"
     "cryptography"
     "gitpython"
+    "mcp"
     "mistralai"
+    "opentelemetry-api"
     "opentelemetry-exporter-otlp-proto-http"
     "opentelemetry-sdk"
     "opentelemetry-semantic-conventions"
+    "pydantic"
     "pydantic-settings"
+    "rich"
+    "textual"
+    "watchfiles"
     "zstandard"
   ];
   dependencies = with python3Packages; [

--- a/pkgs/development/python-modules/mistralai/default.nix
+++ b/pkgs/development/python-modules/mistralai/default.nix
@@ -22,6 +22,7 @@
   mcp,
   google-auth,
   requests,
+  websockets,
 
   # tests
   opentelemetry-sdk,
@@ -72,6 +73,9 @@ buildPythonPackage (finalAttrs: {
       google-auth
       requests
     ];
+    realtime = [
+      websockets
+    ];
   };
 
   pythonImportsCheck = [ "mistralai" ];
@@ -86,6 +90,14 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # AssertionError: <Response [200 OK]> is not an instance of <class 'mistralai.extra.observability.otel.TracedResponse'>
     "TestOtelTracing"
+  ];
+
+  disabledTestPaths = [
+    # Require GCP credentials
+    "tests/test_gcp_integration.py"
+    "tests/test_gcp_v2_parity.py"
+    # Extra tests require additional dependencies (mcp, etc.)
+    "src/mistralai/extra/tests"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -14,7 +14,7 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.34.0";
+    version = "1.39.0";
     pyproject = true;
 
     # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
@@ -22,7 +22,7 @@ let
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       tag = "v${version}";
-      hash = "sha256-fAXcS2VyDMk+UDW3ru5ZvwzXjydsY1uFcT2GvZuiGWw=";
+      hash = "sha256-JimYrjqXRCaFC4ki4Q8tUCQg0S11S/W16JMtXk0sVKU=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "opentelemetry-instrumentation";
-  version = "0.55b0";
+  version = "0.60b1";
   pyproject = true;
 
   # To avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     tag = "v${version}";
-    hash = "sha256-UM9ezCh3TVwyj257O0rvTCIgfrddobWcVIgJmBUj/Vo=";
+    hash = "sha256-/xTv/JovC8IVZz14ygnEL5vg/W8xR4Ie78hTi+gG58M=";
   };
 
   sourceRoot = "${src.name}/opentelemetry-instrumentation";

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -8,23 +8,22 @@
 
   # dependencies
   markdown-it-py,
+  mdit-py-plugins,
   platformdirs,
+  pygments,
   rich,
   typing-extensions,
-  mdit-py-plugins,
 
   # optional-dependencies
   tree-sitter,
-  tree-sitter-c-sharp,
   tree-sitter-html,
   tree-sitter-javascript,
-  tree-sitter-make,
+  tree-sitter-json,
   tree-sitter-markdown,
   tree-sitter-python,
   tree-sitter-rust,
   tree-sitter-sql,
   tree-sitter-yaml,
-  tree-sitter-zeek,
 
   # tests
   jinja2,
@@ -56,6 +55,7 @@ buildPythonPackage rec {
     markdown-it-py
     mdit-py-plugins
     platformdirs
+    pygments
     rich
     typing-extensions
   ]
@@ -65,16 +65,14 @@ buildPythonPackage rec {
   optional-dependencies = {
     syntax = [
       tree-sitter
-      tree-sitter-c-sharp
       tree-sitter-html
       tree-sitter-javascript
-      tree-sitter-make
+      tree-sitter-json
       tree-sitter-markdown
       tree-sitter-python
       tree-sitter-rust
       tree-sitter-sql
       tree-sitter-yaml
-      tree-sitter-zeek
     ];
   };
 


### PR DESCRIPTION
this pr adds mistral-vibe and related dependencies:
- mistralai:  2.3.2
- textual:  8.2.3
- opentelemetry-api:  1.39.0
- opentelemetry-instrumentation:   0.60b1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
