### PR TITLE
nixosTests.alps: fixup for new dovecot module

### DIFF
--- a/nixos/tests/alps.nix
+++ b/nixos/tests/alps.nix
@@ -10,40 +10,49 @@ in
   };
 
   nodes = {
-    server = {
-      imports = [ ./common/user-account.nix ];
-      security.pki.certificateFiles = [
-        certs.ca.cert
-      ];
-      networking.extraHosts = ''
-        127.0.0.1 ${domain}
-      '';
-      networking.firewall.allowedTCPPorts = [
-        25
-        465
-        993
-      ];
-      services.postfix = {
-        enable = true;
-        enableSubmission = true;
-        enableSubmissions = true;
+    server =
+      { config, ... }:
+      {
+        imports = [ ./common/user-account.nix ];
+        security.pki.certificateFiles = [
+          certs.ca.cert
+        ];
+        networking.extraHosts = ''
+          127.0.0.1 ${domain}
+        '';
+        networking.firewall.allowedTCPPorts = [
+          25
+          465
+          993
+        ];
+        services.postfix = {
+          enable = true;
+          enableSubmission = true;
+          enableSubmissions = true;
 
-        settings.main = {
-          smtp_tls_CAfile = "${certs.ca.cert}";
-          smtpd_tls_chain_files = [
-            "${certs.${domain}.key}"
-            "${certs.${domain}.cert}"
-          ];
+          settings.main = {
+            smtp_tls_CAfile = "${certs.ca.cert}";
+            smtpd_tls_chain_files = [
+              "${certs.${domain}.key}"
+              "${certs.${domain}.cert}"
+            ];
+          };
+        };
+        services.dovecot2 = {
+          enable = true;
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = config.services.dovecot2.package.version;
+            mail_driver = "maildir";
+            mail_path = "~/mail";
+            protocols.imap = true;
+            ssl_server_ca_file = "${certs.ca.cert}";
+            ssl_server_cert_file = "${certs.${domain}.cert}";
+            ssl_server_key_file = "${certs.${domain}.key}";
+          };
         };
       };
-      services.dovecot2 = {
-        enable = true;
-        enableImap = true;
-        sslCACert = "${certs.ca.cert}";
-        sslServerCert = "${certs.${domain}.cert}";
-        sslServerKey = "${certs.${domain}.key}";
-      };
-    };
 
     client =
       { nodes, config, ... }:
@@ -110,7 +119,7 @@ in
     ''
       server.start()
       server.wait_for_unit("postfix.service")
-      server.wait_for_unit("dovecot2.service")
+      server.wait_for_unit("dovecot.service")
       server.wait_for_open_port(465)
       server.wait_for_open_port(993)
 


### PR DESCRIPTION
See #509564.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
