### PR TITLE
Dynamic music pill

### DIFF
--- a/pkgs/desktops/gnome/extensions/dynamic-music-pill/default.nix
+++ b/pkgs/desktops/gnome/extensions/dynamic-music-pill/default.nix
@@ -43,19 +43,19 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = {
-    description = "An elegant, pill-shaped music player for your desktop. Features a smooth audio visualizer, scrolling text, and seamless integration with Dash-to-Dock and the Top Panel.";
-    longDescription = "An elegant, pill-shaped music player for your desktop. Features a smooth audio visualizer, scrolling text, and seamless integration with Dash-to-Dock and the Top Panel.";
-    homepage = "https://github.com/Andbal23/dynamic-music-pill";
-    license = lib.licenses.gpl3;
-    platforms = lib.platforms.linux;
-  };
-
   passthru = {
     extensionPortalSlug = "dynamic-music-pill";
     extensionUuid = "dynamic-music-pill@andbal";
     tests = {
       gnome-extensions = nixosTests.gnome-extensions;
     };
+  };
+
+  meta = {
+    description = "An elegant, pill-shaped music player for your desktop. Features a smooth audio visualizer, scrolling text, and seamless integration with Dash-to-Dock and the Top Panel.";
+    longDescription = "An elegant, pill-shaped music player for your desktop. Features a smooth audio visualizer, scrolling text, and seamless integration with Dash-to-Dock and the Top Panel.";
+    homepage = "https://github.com/Andbal23/dynamic-music-pill";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome/extensions/dynamic-music-pill/default.nix
+++ b/pkgs/desktops/gnome/extensions/dynamic-music-pill/default.nix
@@ -1,0 +1,61 @@
+{
+  pkgs ? import <nixpkgs> { },
+  lib ? pkgs.lib,
+  stdenv ? pkgs.stdenv,
+  fetchFromGitHub ? pkgs.fetchFromGitHub,
+  glib ? pkgs.glib,
+  nixosTests ? pkgs.nixosTests,
+  ...
+}:
+stdenv.mkDerivation {
+  pname = "gnome-shell-extension-dynamic-music-pill";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Andbal23";
+    repo = "dynamic-music-pill";
+    rev = "refs/tags/1.0.0";
+    hash = "sha256-DIO6qVAfcKY5IAyeKrzhGE6qEXHcr4hb7Viu6MlqpJA=";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  buildPhase = ''
+    runHook preBuild
+    if [ -d schemas ]; then
+      glib-compile-schemas --strict schemas
+    fi
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/glib-2.0/schemas/
+    if [ -d schemas ] && [ -f schemas/*.gschema.xml ]; then
+      glib-compile-schemas --strict schemas
+      if [ -f schemas/gschemas.compiled ]; then
+        cp schemas/gschemas.compiled $out/share/glib-2.0/schemas/
+      fi
+      cp schemas/*.gschema.xml $out/share/glib-2.0/schemas/
+    fi
+    mkdir -p $out/share/gnome-shell/extensions/
+    cp -r -T . $out/share/gnome-shell/extensions/dynamic-music-pill@andbal
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "An elegant, pill-shaped music player for your desktop. Features a smooth audio visualizer, scrolling text, and seamless integration with Dash-to-Dock and the Top Panel.";
+    longDescription = "An elegant, pill-shaped music player for your desktop. Features a smooth audio visualizer, scrolling text, and seamless integration with Dash-to-Dock and the Top Panel.";
+    homepage = "https://github.com/Andbal23/dynamic-music-pill";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+  };
+
+  passthru = {
+    extensionPortalSlug = "dynamic-music-pill";
+    extensionUuid = "dynamic-music-pill@andbal";
+    tests = {
+      gnome-extensions = nixosTests.gnome-extensions;
+    };
+  };
+}


### PR DESCRIPTION
<!--
^ Packaging of the gnome extension Dynamic Music Pill ^
## Things done

<!-- Package the extension using the official github repository -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
