### PR TITLE
meshmc: init at 7.0.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -177,6 +177,11 @@ lib.mapAttrs mkLicense (
       fullName = "Baekmuk License";
     };
 
+    batchLicense = {
+      fullName = "Batch Icons License";
+      url = "https://github.com/rivermont/batch/blob/master/License.txt";
+    };
+
     bitstreamCharter = {
       spdxId = "Bitstream-Charter";
       fullName = "Bitstream Charter Font License";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29999,6 +29999,13 @@
       { fingerprint = "D2A8 A906 ACA7 B6D6 575E 9A2F 3A49 5054 6EA6 9E5C"; }
     ];
   };
+  yongdohyun = {
+    name = "Mehmet Samet Duman";
+    email = "yongdohyun@projecttick.org";
+    github = "YongDo-Hyun";
+    githubId = 97219311;
+    keys = [ { fingerprint = "FB56 5272 D5AE 8B57 463D A965 E49B 53C9 18C3 39A6"; } ];
+  };
   yorickvp = {
     email = "yorickvanpelt@gmail.com";
     matrix = "@yorickvp:matrix.org";

--- a/pkgs/by-name/me/meshmc-unwrapped/package.nix
+++ b/pkgs/by-name/me/meshmc-unwrapped/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cmake,
+  cmark,
+  extra-cmake-modules,
+  jdk17,
+  kdePackages,
+  libarchive,
+  ninja,
+  nix-update-script,
+  stripJavaArchivesHook,
+  vulkan-headers,
+  zlib,
+  msaClientID ? null,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "meshmc-unwrapped";
+  version = "7.0.1";
+  snapshottag = "v202604131638";
+
+  src = fetchurl {
+    url = "https://github.com/Project-Tick/Project-Tick/releases/download/${finalAttrs.snapshottag}/meshmc-${finalAttrs.snapshottag}.tar.gz";
+    hash = "sha256-YSrU0dx0ILMcKKP71pPfCUB0Z8IefIgEX21lb7sH6kw=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    extra-cmake-modules
+    jdk17
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [
+    cmark
+    kdePackages.qtbase
+    kdePackages.qtnetworkauth
+    libarchive
+    vulkan-headers
+    zlib
+  ];
+
+  postInstall = ''
+    rm -f $out/bin/meshmc-updater
+  '';
+
+  cmakeFlags = [
+    # downstream branding
+    (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+  ]
+  ++ lib.optionals (msaClientID != null) [
+    (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # we wrap our binary manually
+    (lib.cmakeFeature "INSTALL_BUNDLE" "nodeps")
+    # disable built-in updater
+    (lib.cmakeFeature "MACOSX_SPARKLE_UPDATE_FEED_URL" "''")
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/Applications/")
+  ];
+
+  doCheck = true;
+
+  dontWrapQtApps = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have multiple, separate instances of Minecraft (each with
+      their own mods, texture packs, saves, etc) and helps you manage them and
+      their associated options with a simple interface. (Fork of MultiMC, not
+      prism or PolyMC)
+    '';
+    homepage = "https://projecttick.org/p/meshmc";
+    changelog = "https://projecttick.org/product/meshmc/news/release-${finalAttrs.version}";
+    license = with lib.licenses; [
+      # MeshMC License
+      gpl3Plus
+      # Original MultiMC license
+      asl20
+      # Some Prism Launcher and MeshMC assets
+      cc-by-sa-40
+      # LibNBT++, Oxygen Icons
+      lgpl3Plus
+      # rainbow
+      lgpl2Plus
+      # qdcss
+      lgpl3Only
+      # Material Design Icons
+      ofl
+      # lionshead
+      mit
+      # LocalPeer
+      bsd3
+      # Batch Icons
+      batchLicense
+      # murmur2
+      publicDomain
+    ];
+    maintainers = with lib.maintainers; [
+      yongdohyun
+    ];
+    mainProgram = "meshmc";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/me/meshmc/package.nix
+++ b/pkgs/by-name/me/meshmc/package.nix
@@ -1,0 +1,132 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  kdePackages,
+  lib,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  openal,
+  pciutils,
+  pipewire,
+  meshmc-unwrapped,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  controllerSupport ? stdenv.hostPlatform.isLinux,
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  controllerSupport -> stdenv.hostPlatform.isLinux
+) "controllerSupport only has an effect on Linux.";
+
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+
+let
+  meshmc' = meshmc-unwrapped.override { inherit msaClientID; };
+in
+
+symlinkJoin {
+  pname = "meshmc";
+  inherit (meshmc') version;
+
+  paths = [ meshmc' ];
+
+  nativeBuildInputs = [ kdePackages.wrapQtAppsHook ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.qtimageformats
+    kdePackages.qtsvg
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux kdePackages.qtwayland;
+
+  postBuild = ''
+    wrapQtAppsHook
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  qtWrapperArgs =
+    let
+      runtimeLibs = [
+        (lib.getLib stdenv.cc.cc)
+        ## native versions
+        glfw3-minecraft
+        openal
+
+        ## openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        ## glfw
+        libGL
+        libx11
+        libxcursor
+        libxext
+        libxrandr
+        libxxf86vm
+
+        udev # oshi
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        pciutils # need lspci
+        xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      ]
+      ++ additionalPrograms;
+
+    in
+    lib.optionals stdenv.hostPlatform.isLinux [
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
+    ];
+
+  meta = {
+    inherit (meshmc'.meta)
+      description
+      longDescription
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      platforms
+      ;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I would be happy to answer the questions in the survey you provided, if you consent:

> * Is the package ready for general use?
>   We don't want to include projects that are too immature or are going to be abandoned immediately.
>   In case of doubt, check with upstream.

It is ready for general use. MeshMC is a launcher that, while not a continuation of ProjT Launcher, is built on the experience gained from ProjT Launcher, is entirely based on MultiMC, and continues the MultiMC tradition.

> * Does the project have a clear license statement?
>    Remember that software is unfree by default (all rights reserved), and merely providing access to the source code does >    not imply its redistribution.
>    In case of doubt, ask upstream.

The project has an explicit license statement. It is licensed under the General Public License Version 3 and later, published by GNU in 2007.

> * How realistic is it that it will be used by other people?
>   It's good that nixpkgs caters to various niches, but if it's a niche of 5 people it's probably too small.
>   A good estimate is checking upstream issues and pull requests, or other software repositories.
>    * Library packages should have at least one dependent.
>      If possible, that dependent should be packaged in the same PR the library is added in, as a sanity check.
>      If it is not possible to package the dependent, a minimal test program should be added to `passthru.tests`.

There is an audience that will use it. My fellow Minecraft players, including myself, want to use this launcher.

> * Is the software actively maintained upstream?
>  Especially packages that are security-critical, rely on fast-moving dependencies, or affect data integrity should see regular maintenance.

> * Are you willing to maintain the package?
>   You should care enough about the package to be willing to keep it up and running for at least one complete Nixpkgs' release life-cycle.

Yes, it is officially being actively driven upstream by me.

>   * In case you are not able to maintain the package you wrote, you can seek someone to fill that role, effectively adopting the package.

I'm a Nix user myself, and I'm both a Minecraft player and developer. I'm willing to keep this package going.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
