### PR TITLE
nixosTests.rss2email: fixup for new dovecot module

### DIFF
--- a/nixos/tests/rss2email.nix
+++ b/nixos/tests/rss2email.nix
@@ -3,7 +3,7 @@ import ./make-test-python.nix {
 
   nodes = {
     server =
-      { pkgs, ... }:
+      { config, pkgs, ... }:
       {
         imports = [ common/user-account.nix ];
         services.nginx = {
@@ -33,9 +33,14 @@ import ./make-test-python.nix {
         };
         services.dovecot2 = {
           enable = true;
-          enableImap = true;
-          mailLocation = "maildir:~/mail";
-          protocols = [ "imap" ];
+          enablePAM = true;
+          settings = {
+            dovecot_config_version = "2.4.3";
+            dovecot_storage_version = config.services.dovecot2.package.version;
+            mail_driver = "maildir";
+            mail_path = "~/mail";
+            protocols.imap = true;
+          };
         };
         environment.systemPackages =
           let
@@ -67,7 +72,7 @@ import ./make-test-python.nix {
     server.systemctl("start network-online.target")
     server.wait_for_unit("network-online.target")
     server.wait_for_unit("opensmtpd")
-    server.wait_for_unit("dovecot2")
+    server.wait_for_unit("dovecot")
     server.wait_for_unit("nginx")
     server.wait_for_unit("rss2email")
 


### PR DESCRIPTION
See #509564.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
