### PR TITLE
nixos/network-interfaces: don't write net.ipv4.conf.all.forwarding=0

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1780,7 +1780,9 @@ in
       optionalString hasBonds "options bonding max_bonds=0";
 
     boot.kernel.sysctl = {
-      "net.ipv4.conf.all.forwarding" = mkDefault (any (i: i.proxyARP) interfaces);
+      # Only set when proxyARP needs it; never write =0 (the kernel default),
+      # which would race with systemd-networkd's IPv4Forwarding= on switch.
+      "net.ipv4.conf.all.forwarding" = mkIf (any (i: i.proxyARP) interfaces) (mkDefault true);
       "net.ipv6.conf.all.disable_ipv6" = mkDefault (!cfg.enableIPv6);
       "net.ipv6.conf.default.disable_ipv6" = mkDefault (!cfg.enableIPv6);
       # allow all users to do ICMP echo requests (ping)


### PR DESCRIPTION
`net.ipv4.conf.all.forwarding` is an alias for `net.ipv4.ip_forward`. The kernel default is already 0, so emitting `=0` from `sysctl.d` is at best a no-op.

It is actively harmful when systemd-networkd manages forwarding via `networkd.conf [Network] IPv4Forwarding=yes` (i.e. `systemd.network.config.networkConfig.IPv4Forwarding = true`): on a cold boot `systemd-sysctl` runs before networkd and networkd's write wins, but on a `nixos-rebuild switch` that restarts both services the ordering is undefined and `systemd-sysctl` can run last, silently flipping a router back to `ip_forward=0`. Any systemd package change triggers exactly this, since `kernel.poweroff_cmd` in `60-nixos.conf` follows the systemd store path and lands `systemd-sysctl` in the restart set alongside networkd.

Only emit the sysctl when at least one interface has `proxyARP = true`, matching every other in-tree setter of this key (`nat`, `docker`, `tailscale`, `netbird`, …) which only ever write `true`. The previous value was already `mkDefault`, so nothing could have been relying on it to force forwarding off.

Eval-tested both branches:

```
# no proxyARP -> key absent
nix-instantiate --eval --strict --json -E '(import ./nixos { configuration = { networking.interfaces.eth0 = {}; }; }).config.boot.kernel.sysctl' | jq 'has("net.ipv4.conf.all.forwarding")'
false

# proxyARP=true -> key = true
nix-instantiate --eval --strict --json -E '(import ./nixos { configuration = { networking.interfaces.eth0.proxyARP = true; }; }).config.boot.kernel.sysctl' | jq '."net.ipv4.conf.all.forwarding"'
true
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
