### PR TITLE
tmux-snaglord: init at 0.1.7

### DIFF
--- a/pkgs/by-name/tm/tmux-snaglord/package.nix
+++ b/pkgs/by-name/tm/tmux-snaglord/package.nix
@@ -1,0 +1,29 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tmux-snaglord";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "tmux-snaglord";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-kWlGvUmYBXbHnVohyWxV9oW5FCXd0HgdD/E9wlHfI4A=";
+  };
+
+  cargoHash = "sha256-QtW83eJ7B63rbgoZAbdmdMLlWm27uT4GfoFo7leFV20=";
+
+  meta = {
+    description = "turn your tmux scrollback into a structured, searchable list of commands and their outputs";
+    homepage = "https://github.com/raine/tmux-snaglord";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      bbigras
+    ];
+    mainProgram = "tmux-snaglord";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
