### PR TITLE
nixos/test-driver: add option to filter log output for specific systemd units

### DIFF
--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -98,6 +98,21 @@ in
       enables commands to be sent to test and debug stage 1. Use
       machine.switch_root() to leave stage 1 and proceed to stage 2
     '';
+
+    focusUnits = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "nginx.service"
+        "postgresql.service"
+      ];
+      description = ''
+        List of systemd units to focus serial console output on. When set,
+        the default journal forwarding and kernel messages on the serial
+        console are suppressed and only journal output from the specified
+        units is shown.
+      '';
+    };
   };
 
   config = {
@@ -135,12 +150,19 @@ in
 
     boot.initrd.systemd = lib.mkMerge [
       {
-        contents."/etc/systemd/journald.conf".text = ''
-          [Journal]
-          ForwardToConsole=yes
-          TTYPath=/dev/${qemu-common.qemuSerialDevice}
-          MaxLevelConsole=debug
-        '';
+        contents."/etc/systemd/journald.conf".text =
+          if cfg.focusUnits == [ ] then
+            ''
+              [Journal]
+              ForwardToConsole=yes
+              TTYPath=/dev/${qemu-common.qemuSerialDevice}
+              MaxLevelConsole=debug
+            ''
+          else
+            ''
+              [Journal]
+              ForwardToConsole=no
+            '';
 
         settings.Manager = managerSettings;
       }
@@ -225,17 +247,29 @@ in
       # determinism (e.g. if the VM runs at lower speed, then
       # timeouts in the VM should also be delayed).
       "clocksource=acpi_pm"
+    ]
+    ++ lib.optionals (cfg.focusUnits != [ ]) [
+      "systemd.show_status=false"
+      "rd.systemd.show_status=false"
+      "udev.log_level=0"
+      "loglevel=0"
     ];
 
     # `xwininfo' is used by the test driver to query open windows.
     environment.systemPackages = [ pkgs.xwininfo ];
 
-    # Log everything to the serial console.
-    services.journald.extraConfig = ''
-      ForwardToConsole=yes
-      TTYPath=/dev/${qemu-common.qemuSerialDevice}
-      MaxLevelConsole=debug
-    '';
+    # Log everything to the serial console (unless focusUnits is set).
+    services.journald.extraConfig =
+      if cfg.focusUnits == [ ] then
+        ''
+          ForwardToConsole=yes
+          TTYPath=/dev/${qemu-common.qemuSerialDevice}
+          MaxLevelConsole=debug
+        ''
+      else
+        ''
+          ForwardToConsole=no
+        '';
 
     systemd.settings.Manager = managerSettings;
     systemd.user.extraConfig = ''
@@ -244,7 +278,23 @@ in
       DefaultDeviceTimeoutSec=300
     '';
 
-    boot.consoleLogLevel = 7;
+    boot.consoleLogLevel = if cfg.focusUnits == [ ] then 7 else 0;
+
+    systemd.services.focus-units-journal = lib.mkIf (cfg.focusUnits != [ ]) (
+      let
+        unitFlags = lib.concatMapStringsSep " " (u: "-u ${lib.escapeShellArg u}") cfg.focusUnits;
+      in
+      {
+        description = "Stream focused journal units to serial console";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "systemd-journald.service" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.systemd}/bin/journalctl --follow --lines=all --no-pager ${unitFlags}";
+          StandardOutput = "file:/dev/${qemu-common.qemuSerialDevice}";
+          Restart = "on-failure";
+        };
+      }
+    );
 
     # Prevent tests from accessing the Internet.
     networking.defaultGateway = mkOverride 150 null;


### PR DESCRIPTION
This PR adds the option to filter the log output of a nixos test to include only selected systemd units.

```nix
  nodes.machine = {
    testing.focusUnits = [ "hello.service" ];
  };
```

This results in significantly lower log output and makes it easier to debug issues related to the services under test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
