### PR TITLE
orca-slicer: force GDK_BACKEND=x11 to fix unresponsive UI on Wayland

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -219,6 +219,7 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       }"
       --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+      --set GDK_BACKEND x11
       ${lib.optionalString withNvidiaGLWorkaround ''
         --set __GLX_VENDOR_LIBRARY_NAME mesa
         --set __EGL_VENDOR_LIBRARY_FILENAMES /run/opengl-driver/share/glvnd/egl_vendor.d/50_mesa.json

--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -227,6 +227,7 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       }"
       --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+      --set-default GDK_BACKEND x11
       --set FONTCONFIG_FILE "${fontsConf}"
       ${lib.optionalString withNvidiaGLWorkaround ''
         --set __GLX_VENDOR_LIBRARY_NAME mesa


### PR DESCRIPTION
OrcaSlicer and its startup wizard are completely unresponsive when launched under a Wayland session. The application opens but does not respond to any mouse or keyboard input without this workaround.

Setting `GDK_BACKEND=x11` forces the application to use XWayland, which resolves the issue.

Tested on: x86_64-linux, NixOS with GNOME/Wayland