### PR TITLE
piskel: init at 0.15.2-SNAPSHOT-unstable-2026-04-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23647,6 +23647,12 @@
     githubId = 20300874;
     name = "Mohammad Rafiq";
   };
+  rsahwe = {
+    email = "rsahwe@gmx.net";
+    github = "rsahwe";
+    githubId = 201613730;
+    name = "rsahwe";
+  };
   rseichter = {
     email = "nixos.org@seichter.de";
     github = "rseichter";

--- a/pkgs/by-name/pi/piskel/package.nix
+++ b/pkgs/by-name/pi/piskel/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  makeDesktopItem,
+  makeWrapper,
+
+  nwjs,
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    desktopName = "Piskel";
+    comment = "Easy-to-use sprite editor";
+    name = "piskel";
+    exec = "piskel";
+    icon = "piskel";
+    terminal = false;
+    categories = [ "Graphics" ];
+  };
+in
+buildNpmPackage rec {
+  pname = "piskel";
+  # Newest version is 0.15.0 and is years old already (also doesn't build correctly)
+  version = "0.15.2-SNAPSHOT-unstable-2026-04-09";
+
+  src = fetchFromGitHub {
+    owner = "piskelapp";
+    repo = "piskel";
+    rev = "a6b9c02daefceb10093f71e92d52d16920ccb16e";
+    hash = "sha256-AorkV1mqZJ9coRMRCCdYIdAwhedrBRG8GR7Y0/zPPHo=";
+  };
+  npmDepsHash = "sha256-tu0A5Xcz2V12pRF0LxHA48czkPR/0SslA3SEGdhdqMQ=";
+
+  env = {
+    "PUPPETEER_SKIP_DOWNLOAD" = "1";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/site/dest/
+
+    cp -r dest/prod $out/site/dest/
+    cp package.json $out/site/
+
+    install -Dm644 ${desktopItem}/share/applications/piskel.desktop -t $out/share/applications
+    install -Dm644 src/logo.png $out/share/icons/hicolor/64x64/apps/piskel.png
+
+    makeWrapper ${nwjs}/bin/nw $out/bin/${pname} \
+      --add-flags $out/site
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Easy-to-use sprite editor";
+    homepage = "https://github.com/piskelapp/piskel";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      rsahwe
+    ];
+    mainProgram = "piskel";
+    platforms = nwjs.meta.platforms;
+  };
+
+  __structuredAttrs = true;
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/piskelapp/piskel

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
