### PR TITLE
lomiri-qt6.lomiri-thumbnailer: init at 3.1.0

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -48,6 +48,7 @@ let
         withDocumentation = !useQt6;
       };
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
+      lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
       lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
     }
     // lib.optionalAttrs useQt6 {
@@ -97,7 +98,6 @@ let
       lomiri-indicator-datetime = ayatana-indicator-datetime.override { enableLomiriFeatures = true; };
       lomiri-polkit-agent = callPackage ./services/lomiri-polkit-agent { };
       lomiri-telephony-service = callPackage ./services/lomiri-telephony-service { };
-      lomiri-thumbnailer = callPackage ./services/lomiri-thumbnailer { };
       mediascanner2 = callPackage ./services/mediascanner2 { };
     };
 in

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -32,6 +32,9 @@
   xvfb-run,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-thumbnailer";
   version = "3.1.0";
@@ -141,6 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontWrapQtApps = true;
 
   cmakeFlags = [
+    (lib.cmakeBool "ENABLE_QT6" withQt6)
     (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
     # error: use of old-style cast to 'std::remove_reference<_GstElement*>::type' {aka 'struct _GstElement*'}
@@ -176,6 +180,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+        versionCheck = true;
+      };
+    }
+    // lib.optionalAttrs (!withQt6) {
       # gallery app delegates to thumbnailer, tests various formats
       inherit (nixosTests.lomiri-gallery-app)
         format-mp4
@@ -187,11 +197,6 @@ stdenv.mkDerivation (finalAttrs: {
 
       # music app relies on thumbnailer to extract embedded cover art
       music-app = nixosTests.lomiri-music-app;
-
-      pkg-config = testers.hasPkgConfigModules {
-        package = finalAttrs.finalPackage;
-        versionCheck = true;
-      };
     };
     updateScript = gitUpdater { };
   };
@@ -208,7 +213,7 @@ stdenv.mkDerivation (finalAttrs: {
     teams = [ lib.teams.lomiri ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [
-      "liblomiri-thumbnailer-qt"
+      "liblomiri-thumbnailer-qt${lib.optionalString withQt6 "6"}"
     ];
   };
 })


### PR DESCRIPTION
Will be needed by any Lomiri app that wants thumbnails (Gallery App, Music App).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
        (only pkg-config module check)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
