### PR TITLE
python3Packages.gepa: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27404,6 +27404,11 @@
     github = "tilpner";
     githubId = 4322055;
   };
+  tim-tx = {
+    name = "Timothy S. Jones";
+    github = "tim-tx";
+    githubId = 13240467;
+  };
   timasoft = {
     name = "Timofey Klester";
     email = "tima.klester@yandex.ru";

--- a/pkgs/development/python-modules/gepa/default.nix
+++ b/pkgs/development/python-modules/gepa/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  cloudpickle,
+  datasets,
+  litellm,
+  mcp,
+  mlflow,
+  tqdm,
+  wandb,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "gepa";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gepa-ai";
+    repo = "gepa";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cmQQWTYNccHdbf+j+0fu1oJOLCL0z3YeBHke1tDjTps=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail 'version="0.1.0"' 'version="${finalAttrs.version}"'
+  '';
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    cloudpickle
+    datasets
+    litellm
+    mcp
+    mlflow
+    tqdm
+    wandb
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_e2e_resume_run"
+    "test_aime_prompt_optimize"
+    "test_callbacks_during_optimization"
+    "test_multiple_callbacks_all_receive_events"
+    "test_partial_callback_implementation"
+    "test_aime_prompt_optimize_with_cache"
+    "test_pareto_frontier_type_with_cache[objective]"
+    "test_pareto_frontier_type_with_cache[hybrid]"
+    "test_pareto_frontier_type_with_cache[instance]"
+    "test_pareto_frontier_type[objective]"
+    "test_pareto_frontier_type[hybrid]"
+    "test_pareto_frontier_type[instance]"
+  ];
+
+  meta = {
+    description = "Framework for optimizing any system with textual parameters against any evaluation metric";
+    homepage = "https://gepa-ai.github.io/gepa/";
+    changelog = "https://github.com/gepa-ai/gepa/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tim-tx ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6192,6 +6192,8 @@ self: super: with self; {
 
   geotorch = callPackage ../development/python-modules/geotorch { };
 
+  gepa = callPackage ../development/python-modules/gepa { };
+
   gepetto-gui = toPythonModule (gepetto-viewer.withPlugins [ gepetto-viewer-corba ]);
 
   gepetto-viewer = toPythonModule (pkgs.gepetto-viewer.override { python3Packages = self; });


### PR DESCRIPTION
Add Python package `gepa`. Widely used for prompt optimization.
https://gepa-ai.github.io/gepa/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
