### PR TITLE
nixos/test-driver: add defaultText to pythonTestDriverPackage

### DIFF
--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkOption types literalMD;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    literalMD
+    ;
 
   # Reifies and correctly wraps the python test driver for
   # the respective qemu version and with or without ocr support
@@ -131,9 +136,10 @@ in
 {
   options = {
     pythonTestDriverPackage = mkOption {
-      description = "Package containing the python NixOS test driver implemetnation";
+      description = "Package containing the python NixOS test driver implementation";
       type = types.package;
       default = hostPkgs.nixos-test-driver;
+      defaultText = literalExpression "hostPkgs.nixos-test-driver";
       readOnly = true;
     };
 

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -5,7 +5,12 @@
   ...
 }:
 let
-  inherit (lib) mkOption types literalMD;
+  inherit (lib)
+    mkOption
+    types
+    literalExpression
+    literalMD
+    ;
 
   inherit (config) sshBackdoor;
 
@@ -117,9 +122,10 @@ in
 {
   options = {
     pythonTestDriverPackage = mkOption {
-      description = "Package containing the python NixOS test driver implemetnation";
+      description = "Package containing the python NixOS test driver implementation";
       type = types.package;
       default = hostPkgs.nixos-test-driver;
+      defaultText = literalExpression "hostPkgs.nixos-test-driver";
       readOnly = true;
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -151,6 +151,7 @@ in
     busybox = runTest ./nixos-test-driver/busybox.nix;
     console-log = runTest ./nixos-test-driver/console-log.nix;
     containers = runTest ./nixos-test-driver/containers.nix;
+    options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };
     driver-timeout =
       pkgs.runCommand "ensure-timeout-induced-failure"
         {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -153,6 +153,7 @@ in
     console-log = runTest ./nixos-test-driver/console-log.nix;
     containers = runTest ./nixos-test-driver/containers.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
+    options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };
     driver-timeout =
       pkgs.runCommand "ensure-timeout-induced-failure"
         {

--- a/nixos/tests/nixos-test-driver/options-doc-regression.nix
+++ b/nixos/tests/nixos-test-driver/options-doc-regression.nix
@@ -1,0 +1,58 @@
+# Regression test for the `pythonTestDriverPackage` option's default value
+# leaking a `hostPkgs` reference into the NixOS manual build.
+#
+# `pythonTestDriverPackage` (added in d95261b435c4, "nixos-test-driver: Make
+# overridable") uses `default = hostPkgs.nixos-test-driver`. Without a
+# `defaultText`, the options-doc renderer force-evaluates that default when
+# building `options.json` for the NixOS manual. `hostPkgs` is only defined in
+# the VM testing framework, so evaluating its default from a regular NixOS
+# system configuration throws:
+#
+#   error: The option `hostPkgs' was accessed but has no value defined.
+#
+# In practice the bug only surfaces when `pkgs` ends up depending on
+# `config` — e.g. when `nixpkgs.config.packageOverrides` is wrapped in
+# `lib.mkIf`. Otherwise `nixos/doc/manual/default.nix`'s fallback
+# `config.hostPkgs = pkgs` rescue holds. With the dependency, that rescue
+# creates a cycle and the original `hostPkgs` error surfaces.
+#
+# The test builds a minimal system whose `pkgs` depends on `config`, and
+# asserts the toplevel (which includes `nixos-manual-html`) evaluates.
+
+{
+  pkgs,
+  ...
+}:
+let
+  evalConfig = import ../../lib/eval-config.nix;
+
+  nixos = evalConfig {
+    system = null;
+    modules = [
+      (
+        { lib, ... }:
+        {
+          system.stateVersion = "25.05";
+          fileSystems."/" = {
+            device = "/dev/null";
+            fsType = "none";
+          };
+          boot.loader.grub.device = "nodev";
+          nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
+
+          # This is the trigger: wrapping `packageOverrides` in `mkIf` makes
+          # the `pkgs` module argument depend on `config`, which defeats the
+          # `config.hostPkgs = pkgs` rescue in `nixos/doc/manual/default.nix`.
+          nixpkgs.config.packageOverrides = lib.mkIf false (_: { });
+        }
+      )
+    ];
+  };
+in
+pkgs.runCommand "nixos-test-driver-options-doc-regression"
+  {
+    toplevel = nixos.config.system.build.toplevel.drvPath;
+  }
+  ''
+    echo "$toplevel" > $out
+  ''


### PR DESCRIPTION
After d95261b435c4, the following flake.nix fails:

```nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
  outputs = { nixpkgs, ... }: {
    nixosConfigurations.demo = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        ({ lib, ... }: {
          boot.loader.grub.enable = false;
          fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
          nixpkgs.config.packageOverrides =
            lib.mkIf false (_: { });
        })
      ];
    };
  };
}
```

This is the error:

```
$ nix build /tmp/tmp.vWEVitTgK9/#nixosConfigurations.demo.config.system.build.toplevel
evaluation warning: system.stateVersion is not set, defaulting to 26.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixos-system-nixos-26.05.20260409.4c1018d'
         whose name attribute is located at /nix/store/anvdcc2arw7kqrvwnidvhw6ypkkvws68-source/pkgs/stdenv/generic/make-derivation.nix:541:11

       … while evaluating attribute 'buildCommand' of derivation 'nixos-system-nixos-26.05.20260409.4c1018d'
         at /nix/store/anvdcc2arw7kqrvwnidvhw6ypkkvws68-source/nixos/modules/system/activation/top-level.nix:64:7:
           63|       passAsFile = [ "extraDependencies" ];
           64|       buildCommand = systemBuilder;
             |       ^
           65|

       … while evaluating the option `environment.etc.dbus-1.source':

       … while evaluating the default value of option `pythonTestDriverPackage`

       … while evaluating the module argument `hostPkgs' in "/nix/store/anvdcc2arw7kqrvwnidvhw6ypkkvws68-source/nixos/lib/testing/driver.nix":

       … noting that argument `hostPkgs` is not externally provided, so querying `_module.args` instead, requiring `config`

       … while evaluating the option `hostPkgs':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: The option `hostPkgs' was accessed but has no value defined. Try setting the option.
```

Setting a `defaultText` fixes the issue.

I've also added a regression test under `nixos/tests/nixos-test-driver/` and fixed a typo in the option description ("implemetnation").


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
