### PR TITLE
nixos/test-driver: Replace custom logger with python logging framework

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -6,7 +6,6 @@
   coreutils,
   imagemagick_light,
   ipython,
-  junit-xml,
   mypy,
   ptpython,
   python,
@@ -43,7 +42,6 @@ buildPythonApplication {
   dependencies = [
     colorama
     ipython
-    junit-xml
     ptpython
     remote-pdb
   ]

--- a/nixos/lib/test-driver/src/pyproject.toml
+++ b/nixos/lib/test-driver/src/pyproject.toml
@@ -32,10 +32,6 @@ ignore_missing_imports = true
 module = "ptpython.*"
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = "junit_xml.*"
-ignore_missing_imports = true
-
 [tool.mypy]
 warn_redundant_casts = true
 disallow_untyped_calls = true

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -12,6 +12,7 @@ from test_driver.driver import Driver
 from test_driver.logger import (
     CompositeLogger,
     JunitXMLLogger,
+    LogLevel,
     TerminalLogger,
     XMLLogger,
 )
@@ -151,6 +152,15 @@ def main() -> None:
         help="indicates that the interactive SSH backdoor is active and dumps information about it on start",
         type=int,
     )
+    log_level_map = {level.name.lower(): level for level in LogLevel}
+    arg_parser.add_argument(
+        "--log-level",
+        metavar="LOG_LEVEL",
+        action=EnvDefault,
+        envvar="logLevel",
+        choices=log_level_map,
+        help="Set the log level",
+    )
 
     args = arg_parser.parse_args()
 
@@ -168,6 +178,9 @@ def main() -> None:
 
     if args.junit_xml:
         logger.add_logger(JunitXMLLogger(output_directory / args.junit_xml))
+
+    if args.log_level:
+        logger.set_log_level(log_level_map[args.log_level])
 
     if not args.keep_machine_state:
         logger.info(

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -10,11 +10,8 @@ import ptpython.ipython
 from test_driver.debug import Debug, DebugAbstract, DebugNop
 from test_driver.driver import Driver
 from test_driver.logger import (
-    CompositeLogger,
-    JunitXMLLogger,
     LogLevel,
-    TerminalLogger,
-    XMLLogger,
+    Logger,
 )
 
 
@@ -136,11 +133,6 @@ def main() -> None:
         type=writeable_dir,
     )
     arg_parser.add_argument(
-        "--junit-xml",
-        help="Enable JunitXML report generation to the given path",
-        type=Path,
-    )
-    arg_parser.add_argument(
         "testscript",
         action=EnvDefault,
         envvar="testScript",
@@ -171,13 +163,7 @@ def main() -> None:
         )
 
     output_directory = args.output_directory.resolve()
-    logger = CompositeLogger([TerminalLogger()])
-
-    if "LOGFILE" in os.environ.keys():
-        logger.add_logger(XMLLogger(os.environ["LOGFILE"]))
-
-    if args.junit_xml:
-        logger.add_logger(JunitXMLLogger(output_directory / args.junit_xml))
+    logger = Logger()
 
     if args.log_level:
         logger.set_log_level(log_level_map[args.log_level])
@@ -241,7 +227,7 @@ def generate_driver_symbols() -> None:
         vlans=[],
         tests="",
         out_dir=Path(),
-        logger=CompositeLogger([]),
+        logger=Logger(),
     )
     test_symbols = d.test_symbols()
     with open("driver-symbols", "w") as fp:

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -7,6 +7,7 @@ import unicodedata
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
+from enum import IntEnum
 from pathlib import Path
 from queue import Empty, Queue
 from typing import Any
@@ -15,6 +16,12 @@ from xml.sax.xmlreader import AttributesImpl
 
 from colorama import Fore, Style
 from junit_xml import TestCase, TestSuite
+
+
+class LogLevel(IntEnum):
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
 
 
 class AbstractLogger(ABC):
@@ -56,6 +63,10 @@ class AbstractLogger(ABC):
     def print_serial_logs(self, enable: bool) -> None:
         pass
 
+    @abstractmethod
+    def set_log_level(self, level: LogLevel) -> None:
+        pass
+
 
 class JunitXMLLogger(AbstractLogger):
     class TestCaseState:
@@ -71,6 +82,7 @@ class JunitXMLLogger(AbstractLogger):
         self.currentSubtest = "main"
         self.outfile: Path = outfile
         self._print_serial_logs = True
+        self._log_level = LogLevel.INFO
         atexit.register(self.close)
 
     def log(self, message: str, attributes: dict[str, str] = {}) -> None:
@@ -92,10 +104,12 @@ class JunitXMLLogger(AbstractLogger):
         yield
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
-        self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+        if self._log_level <= LogLevel.INFO:
+            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def warning(self, *args, **kwargs) -> None:  # type: ignore
-        self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+        if self._log_level <= LogLevel.WARNING:
+            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def error(self, *args, **kwargs) -> None:  # type: ignore
         self.tests[self.currentSubtest].stderr += args[0] + os.linesep
@@ -112,6 +126,9 @@ class JunitXMLLogger(AbstractLogger):
 
     def print_serial_logs(self, enable: bool) -> None:
         self._print_serial_logs = enable
+
+    def set_log_level(self, level: LogLevel) -> None:
+        self._log_level = level
 
     def close(self) -> None:
         with open(self.outfile, "w") as f:
@@ -180,10 +197,15 @@ class CompositeLogger(AbstractLogger):
         for logger in self.logger_list:
             logger.log_serial(message, machine)
 
+    def set_log_level(self, level: LogLevel) -> None:
+        for logger in self.logger_list:
+            logger.set_log_level(level)
+
 
 class TerminalLogger(AbstractLogger):
     def __init__(self) -> None:
         self._print_serial_logs = True
+        self._log_level = LogLevel.INFO
 
     def maybe_prefix(self, message: str, attributes: dict[str, str]) -> str:
         if "machine" in attributes:
@@ -216,16 +238,21 @@ class TerminalLogger(AbstractLogger):
         self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)", attributes)
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.INFO:
+            self.log(*args, **kwargs)
 
     def warning(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.WARNING:
+            self.log(*args, **kwargs)
 
     def error(self, *args, **kwargs) -> None:  # type: ignore
         self.log(*args, **kwargs)
 
     def print_serial_logs(self, enable: bool) -> None:
         self._print_serial_logs = enable
+
+    def set_log_level(self, level: LogLevel) -> None:
+        self._log_level = level
 
     def log_serial(self, message: str, machine: str) -> None:
         if not self._print_serial_logs:
@@ -246,6 +273,7 @@ class XMLLogger(AbstractLogger):
         self.queue: Queue[dict[str, str]] = Queue()
 
         self._print_serial_logs = True
+        self._log_level = LogLevel.INFO
 
         self.xml.startDocument()
         self.xml.startElement("logfile", attrs=AttributesImpl({}))
@@ -269,10 +297,12 @@ class XMLLogger(AbstractLogger):
         self.xml.endElement("line")
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.INFO:
+            self.log(*args, **kwargs)
 
     def warning(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.WARNING:
+            self.log(*args, **kwargs)
 
     def error(self, *args, **kwargs) -> None:  # type: ignore
         self.log(*args, **kwargs)
@@ -286,6 +316,9 @@ class XMLLogger(AbstractLogger):
 
     def print_serial_logs(self, enable: bool) -> None:
         self._print_serial_logs = enable
+
+    def set_log_level(self, level: LogLevel) -> None:
+        self._log_level = level
 
     def log_serial(self, message: str, machine: str) -> None:
         if not self._print_serial_logs:

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -1,21 +1,19 @@
-import atexit
-import codecs
-import os
+import logging
 import sys
 import time
-import unicodedata
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from enum import IntEnum
-from pathlib import Path
-from queue import Empty, Queue
 from typing import Any
-from xml.sax.saxutils import XMLGenerator
-from xml.sax.xmlreader import AttributesImpl
 
 from colorama import Fore, Style
-from junit_xml import TestCase, TestSuite
+
+LOG_LEVEL_MAP = {
+    1: logging.INFO,
+    2: logging.WARNING,
+    3: logging.ERROR,
+}
 
 
 class LogLevel(IntEnum):
@@ -68,156 +66,28 @@ class AbstractLogger(ABC):
         pass
 
 
-class JunitXMLLogger(AbstractLogger):
-    class TestCaseState:
-        def __init__(self) -> None:
-            self.stdout = ""
-            self.stderr = ""
-            self.failure = False
-
-    def __init__(self, outfile: Path) -> None:
-        self.tests: dict[str, JunitXMLLogger.TestCaseState] = {
-            "main": self.TestCaseState()
-        }
-        self.currentSubtest = "main"
-        self.outfile: Path = outfile
-        self._print_serial_logs = True
-        self._log_level = LogLevel.INFO
-        atexit.register(self.close)
-
-    def log(self, message: str, attributes: dict[str, str] = {}) -> None:
-        self.tests[self.currentSubtest].stdout += message + os.linesep
-
-    @contextmanager
-    def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        old_test = self.currentSubtest
-        self.tests.setdefault(name, self.TestCaseState())
-        self.currentSubtest = name
-
-        yield
-
-        self.currentSubtest = old_test
-
-    @contextmanager
-    def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        self.log(message)
-        yield
-
-    def info(self, *args, **kwargs) -> None:  # type: ignore
-        if self._log_level <= LogLevel.INFO:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
-
-    def warning(self, *args, **kwargs) -> None:  # type: ignore
-        if self._log_level <= LogLevel.WARNING:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
-
-    def error(self, *args, **kwargs) -> None:  # type: ignore
-        self.tests[self.currentSubtest].stderr += args[0] + os.linesep
-        self.tests[self.currentSubtest].failure = True
-
-    def log_test_error(self, *args, **kwargs) -> None:  # type: ignore
-        self.error(*args, **kwargs)
-
-    def log_serial(self, message: str, machine: str) -> None:
-        if not self._print_serial_logs:
-            return
-
-        self.log(f"{machine} # {message}")
-
-    def print_serial_logs(self, enable: bool) -> None:
-        self._print_serial_logs = enable
-
-    def set_log_level(self, level: LogLevel) -> None:
-        self._log_level = level
-
-    def close(self) -> None:
-        with open(self.outfile, "w") as f:
-            test_cases = []
-            for name, test_case_state in self.tests.items():
-                tc = TestCase(
-                    name,
-                    stdout=test_case_state.stdout,
-                    stderr=test_case_state.stderr,
-                )
-                if test_case_state.failure:
-                    tc.add_failure_info("test case failed")
-
-                test_cases.append(tc)
-            ts = TestSuite("NixOS integration test", test_cases)
-            f.write(TestSuite.to_xml_string([ts]))
-
-
-class CompositeLogger(AbstractLogger):
-    def __init__(self, logger_list: list[AbstractLogger]) -> None:
-        self.logger_list = logger_list
-
-    def add_logger(self, logger: AbstractLogger) -> None:
-        self.logger_list.append(logger)
-
-    def log(self, message: str, attributes: dict[str, str] = {}) -> None:
-        for logger in self.logger_list:
-            logger.log(message, attributes)
-
-    @contextmanager
-    def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        with ExitStack() as stack:
-            for logger in self.logger_list:
-                stack.enter_context(logger.subtest(name, attributes))
-            yield
-
-    @contextmanager
-    def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        with ExitStack() as stack:
-            for logger in self.logger_list:
-                stack.enter_context(logger.nested(message, attributes))
-            yield
-
-    def info(self, *args, **kwargs) -> None:  # type: ignore
-        for logger in self.logger_list:
-            logger.info(*args, **kwargs)
-
-    def warning(self, *args, **kwargs) -> None:  # type: ignore
-        for logger in self.logger_list:
-            logger.warning(*args, **kwargs)
-
-    def log_test_error(self, *args, **kwargs) -> None:  # type: ignore
-        for logger in self.logger_list:
-            logger.log_test_error(*args, **kwargs)
-
-    def error(self, *args, **kwargs) -> None:  # type: ignore
-        for logger in self.logger_list:
-            logger.error(*args, **kwargs)
-        sys.exit(1)
-
-    def print_serial_logs(self, enable: bool) -> None:
-        for logger in self.logger_list:
-            logger.print_serial_logs(enable)
-
-    def log_serial(self, message: str, machine: str) -> None:
-        for logger in self.logger_list:
-            logger.log_serial(message, machine)
-
-    def set_log_level(self, level: LogLevel) -> None:
-        for logger in self.logger_list:
-            logger.set_log_level(level)
-
-
-class TerminalLogger(AbstractLogger):
+class Logger(AbstractLogger):
     def __init__(self) -> None:
-        self._print_serial_logs = True
-        self._log_level = LogLevel.INFO
+        self._logger = logging.getLogger("test_driver")
+        self._logger.setLevel(logging.INFO)
+        self._logger.propagate = False
 
-    def maybe_prefix(self, message: str, attributes: dict[str, str]) -> str:
+        if not self._logger.handlers:
+            handler = logging.StreamHandler(sys.stderr)
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            self._logger.addHandler(handler)
+
+        self._print_serial_logs = True
+
+    @staticmethod
+    def _maybe_prefix(message: str, attributes: dict[str, str]) -> str:
         if "machine" in attributes:
             return f"{attributes['machine']}: {message}"
         return message
 
-    @staticmethod
-    def _eprint(*args: object, **kwargs: Any) -> None:
-        print(*args, file=sys.stderr, **kwargs)
-
     def log(self, message: str, attributes: dict[str, str] = {}) -> None:
-        self._eprint(self.maybe_prefix(message, attributes))
+        # log() always prints regardless of log level
+        print(self._maybe_prefix(message, attributes), file=sys.stderr)
 
     @contextmanager
     def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
@@ -226,10 +96,11 @@ class TerminalLogger(AbstractLogger):
 
     @contextmanager
     def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        self._eprint(
-            self.maybe_prefix(
+        print(
+            self._maybe_prefix(
                 Style.BRIGHT + Fore.GREEN + message + Style.RESET_ALL, attributes
-            )
+            ),
+            file=sys.stderr,
         )
 
         tic = time.time()
@@ -237,125 +108,35 @@ class TerminalLogger(AbstractLogger):
         toc = time.time()
         self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)", attributes)
 
-    def info(self, *args, **kwargs) -> None:  # type: ignore
-        if self._log_level <= LogLevel.INFO:
-            self.log(*args, **kwargs)
+    def info(self, *args: Any, **kwargs: Any) -> None:
+        message = args[0] if args else ""
+        attributes = args[1] if len(args) > 1 else {}
+        self._logger.info(self._maybe_prefix(message, attributes))
 
-    def warning(self, *args, **kwargs) -> None:  # type: ignore
-        if self._log_level <= LogLevel.WARNING:
-            self.log(*args, **kwargs)
+    def warning(self, *args: Any, **kwargs: Any) -> None:
+        message = args[0] if args else ""
+        attributes = args[1] if len(args) > 1 else {}
+        self._logger.warning(self._maybe_prefix(message, attributes))
 
-    def error(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+    def error(self, *args: Any, **kwargs: Any) -> None:
+        message = args[0] if args else ""
+        attributes = args[1] if len(args) > 1 else {}
+        self._logger.error(self._maybe_prefix(message, attributes))
+        sys.exit(1)
 
-    def print_serial_logs(self, enable: bool) -> None:
-        self._print_serial_logs = enable
-
-    def set_log_level(self, level: LogLevel) -> None:
-        self._log_level = level
-
-    def log_serial(self, message: str, machine: str) -> None:
-        if not self._print_serial_logs:
-            return
-
-        self._eprint(Style.DIM + f"{machine} # {message}" + Style.RESET_ALL)
-
-    def log_test_error(self, *args, **kwargs) -> None:  # type: ignore
+    def log_test_error(self, *args: Any, **kwargs: Any) -> None:
         prefix = Fore.RED + "!!! " + Style.RESET_ALL
-        # NOTE: using `warning` instead of `error` to ensure it does not exit after printing the first log
-        self.warning(f"{prefix}{args[0]}", *args[1:], **kwargs)
-
-
-class XMLLogger(AbstractLogger):
-    def __init__(self, outfile: str) -> None:
-        self.logfile_handle = codecs.open(outfile, "wb")
-        self.xml = XMLGenerator(self.logfile_handle, encoding="utf-8")
-        self.queue: Queue[dict[str, str]] = Queue()
-
-        self._print_serial_logs = True
-        self._log_level = LogLevel.INFO
-
-        self.xml.startDocument()
-        self.xml.startElement("logfile", attrs=AttributesImpl({}))
-
-    def close(self) -> None:
-        self.xml.endElement("logfile")
-        self.xml.endDocument()
-        self.logfile_handle.close()
-
-    def sanitise(self, message: str) -> str:
-        return "".join(ch for ch in message if unicodedata.category(ch)[0] != "C")
-
-    def maybe_prefix(self, message: str, attributes: dict[str, str]) -> str:
-        if "machine" in attributes:
-            return f"{attributes['machine']}: {message}"
-        return message
-
-    def log_line(self, message: str, attributes: dict[str, str]) -> None:
-        self.xml.startElement("line", attrs=AttributesImpl(attributes))
-        self.xml.characters(message)
-        self.xml.endElement("line")
-
-    def info(self, *args, **kwargs) -> None:  # type: ignore
-        if self._log_level <= LogLevel.INFO:
-            self.log(*args, **kwargs)
-
-    def warning(self, *args, **kwargs) -> None:  # type: ignore
-        if self._log_level <= LogLevel.WARNING:
-            self.log(*args, **kwargs)
-
-    def error(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
-
-    def log_test_error(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
-
-    def log(self, message: str, attributes: dict[str, str] = {}) -> None:
-        self.drain_log_queue()
-        self.log_line(message, attributes)
-
-    def print_serial_logs(self, enable: bool) -> None:
-        self._print_serial_logs = enable
-
-    def set_log_level(self, level: LogLevel) -> None:
-        self._log_level = level
+        # NOTE: using _logger.error directly instead of self.error() to avoid sys.exit(1)
+        self._logger.error(f"{prefix}{args[0]}")
 
     def log_serial(self, message: str, machine: str) -> None:
         if not self._print_serial_logs:
             return
 
-        self.enqueue({"msg": message, "machine": machine, "type": "serial"})
+        print(Style.DIM + f"{machine} # {message}" + Style.RESET_ALL, file=sys.stderr)
 
-    def enqueue(self, item: dict[str, str]) -> None:
-        self.queue.put(item)
+    def print_serial_logs(self, enable: bool) -> None:
+        self._print_serial_logs = enable
 
-    def drain_log_queue(self) -> None:
-        try:
-            while True:
-                item = self.queue.get_nowait()
-                msg = self.sanitise(item["msg"])
-                del item["msg"]
-                self.log_line(msg, item)
-        except Empty:
-            pass
-
-    @contextmanager
-    def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        with self.nested("subtest: " + name, attributes):
-            yield
-
-    @contextmanager
-    def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        self.xml.startElement("nest", attrs=AttributesImpl({}))
-        self.xml.startElement("head", attrs=AttributesImpl(attributes))
-        self.xml.characters(message)
-        self.xml.endElement("head")
-
-        tic = time.time()
-        self.drain_log_queue()
-        yield
-        self.drain_log_queue()
-        toc = time.time()
-        self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)")
-
-        self.xml.endElement("nest")
+    def set_log_level(self, level: LogLevel) -> None:
+        self._logger.setLevel(LOG_LEVEL_MAP[level])

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -119,6 +119,7 @@ let
           --set testScript "$out/test-script" \
           --set globalTimeout "${toString config.globalTimeout}" \
           --set vlans '${toString vlans}' \
+          --set logLevel "${config.logLevel}" \
           ${lib.escapeShellArgs (
             lib.concatMap (arg: [
               "--add-flags"
@@ -218,6 +219,17 @@ in
 
         This may speed up your iteration cycle, unless you're working on the [{option}`testScript`](#test-opt-testScript).
       '';
+    };
+
+    logLevel = mkOption {
+      description = "Log level for the test driver.";
+      type = types.enum [
+        "info"
+        "warning"
+        "error"
+      ];
+      default = "info";
+      example = "warning";
     };
   };
 

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -111,9 +111,6 @@ in
         buildCommand = ''
           mkdir -p $out
 
-          # effectively mute the XMLLogger
-          export LOGFILE=/dev/null
-
           ${lib.optionalString config.enableDebugHook ''
             ln -sf \
               ${hostPkgs.systemd}/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf \


### PR DESCRIPTION
based on #491742 

This PR removes the old selfgrown logging framework of the test driver and replaces it with the commonly used [python logging lib](https://docs.python.org/3/library/logging.html). This means we are removing the previous `XMLLogging` feature (originally introduced by @hertrste). This output format was overly specific and the additional complexity and maintenance overhead that it introduces does not justify its existence.

Instead, custom loggers of any desired format can now be specified directly inside the test script like this:

```py
  import logging

  handler = logging.FileHandler("/tmp/test.xml")
  logging.getLogger("test_driver").addHandler(handler)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
