### PR TITLE
puddletag: `aarch64-darwin` support

### DIFF
--- a/pkgs/by-name/pu/puddletag/package.nix
+++ b/pkgs/by-name/pu/puddletag/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   python3,
   libsForQt5,
@@ -7,7 +8,6 @@
 
 let
   qt = libsForQt5;
-
 in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "puddletag";
@@ -33,10 +33,14 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       --replace-fail share/pixmaps share/icons
   '';
 
-  buildInputs = with qt; [
-    qtbase
-    qtwayland
-  ];
+  buildInputs =
+    with qt;
+    [
+      qtbase
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      qtwayland
+    ];
 
   nativeBuildInputs = with qt; [
     wrapQtAppsHook
@@ -75,6 +79,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       peterhoeg
       dschrempf
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/pu/puddletag/package.nix
+++ b/pkgs/by-name/pu/puddletag/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   python3,
   libsForQt5,
@@ -33,14 +32,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       --replace-fail share/pixmaps share/icons
   '';
 
-  buildInputs =
-    with qt;
-    [
-      qtbase
-    ]
-    ++ lib.optionals stdenv.isLinux [
-      qtwayland
-    ];
+  buildInputs = with qt; [
+    qtbase
+  ];
 
   nativeBuildInputs = with qt; [
     wrapQtAppsHook

--- a/pkgs/by-name/pu/puddletag/package.nix
+++ b/pkgs/by-name/pu/puddletag/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   python3,
   libsForQt5,
@@ -7,7 +8,6 @@
 
 let
   qt = libsForQt5;
-
 in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "puddletag";
@@ -33,10 +33,17 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       --replace-fail share/pixmaps share/icons
   '';
 
-  buildInputs = with qt; [
-    qtbase
-    qtwayland
-  ];
+  buildInputs =
+    with qt;
+    [
+      qtbase
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      # Note: after puddletag releases with Qt6,
+      # `qtwayland` can be safely dropped.
+      # Reason: https://github.com/NixOS/nixpkgs/pull/450591
+      qtwayland
+    ];
 
   nativeBuildInputs = with qt; [
     wrapQtAppsHook
@@ -75,6 +82,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       peterhoeg
       dschrempf
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
i wanted to try this tool. surprisingly it runs on `aarch64-darwin` with no apparent issues - the basic functionality just works 🥳 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` 
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
