### PR TITLE
nixos/dovecot: define options for config and storage version

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -148,8 +148,8 @@ let
 
   doveConf =
     let
-      configVersion = cfg.settings.dovecot_config_version or null;
-      storageVersion = cfg.settings.dovecot_storage_version or null;
+      configVersion = cfg.settings.dovecot_config_version;
+      storageVersion = cfg.settings.dovecot_storage_version;
       remainingSettings = builtins.removeAttrs cfg.settings [
         "dovecot_config_version"
         "dovecot_storage_version"
@@ -577,6 +577,26 @@ in
               };
 
               # 2.4-only options
+
+              dovecot_config_version = mkOption {
+                default = null;
+                description = ''
+                  Dovecot configuration version. It uses the same versioning as Dovecot in general, e.g. 3.0.5. It specifies the configuration syntax, the used setting names and the expected default values.
+
+                  See <https://doc.dovecot.org/latest/core/summaries/settings.html#dovecot_config_version>.
+                '';
+                type = nullOr str;
+              };
+
+              dovecot_storage_version = mkOption {
+                default = null;
+                description = ''
+                  Dovecot storage file format version. It uses the same versioning as Dovecot in general, e.g. 3.0.5. It specifies the oldest Dovecot version that must be able to read files written by this Dovecot instance.
+
+                  See <https://doc.dovecot.org/latest/core/summaries/settings.html#dovecot_storage_version>.
+                '';
+                type = nullOr str;
+              };
 
               sieve_script_bin_path = mkOption {
                 default = if isPre24 then null else "/tmp/dovecot-%{user|username|lower}";


### PR DESCRIPTION
dovecot_config_version and dovecot_storage_version are accessed by the module, so should at least have a default set so that assertions eval correctly.

Guess this was missed when I transitioned the defaults set in config to declared options. Oops.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
