### PR TITLE
devShell interface

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -397,6 +397,9 @@
   "sec-darwin-libcxx-versions": [
     "index.html#sec-darwin-libcxx-versions"
   ],
+  "sec-devshells": [
+    "index.html#sec-devshells"
+  ],
   "sec-functions-library-treefmt": [
     "index.html#sec-functions-library-treefmt"
   ],

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -445,6 +445,9 @@
   "sec-darwin-libcxx-versions": [
     "index.html#sec-darwin-libcxx-versions"
   ],
+  "sec-devshells": [
+    "index.html#sec-devshells"
+  ],
   "sec-functions-library-treefmt": [
     "index.html#sec-functions-library-treefmt"
   ],

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1727,6 +1727,22 @@ This may cause problems with code that does advanced stack manipulation, and deb
 
 Pre-ARM v8.3 processors will ignore Pointer Authentication instructions, so code built with this flag will continue to work on older processors, though without any of the intended protections. If enabling this flag, it is recommended to ensure the resultant packages are tested against an ARM v8.3+ linux system with known-working Pointer Authentication support so that any breakage caused by this feature is actually detected.
 
+## Development Shells {#sec-devshells}
+
+Any package built with `stdenv` will have a `.devShell` attribute. This is a special attribute used by `nix develop` to enter a development shell for a package. However, you do not need `nix develop` to use a stdenv-produced development shell. It is also possible to `nix run` a package's `.devShell`, or manually run the `bin/setup` program in its default output.
+
+It is possible to change the shell used for a development shell to a different bash-compatible shell. For example, you can use a path to a shell installed locally on your system for the `shell` value. This is useful for debugging broken derivations on which the normal shell value depends. To do this, override `mkStdenvDevShell`. For example:
+
+```nix
+{
+  overlays = [
+    (final: prev: prev.mkStdenvDevShell.override { shell = "/run/current-system/sw/bin/bash"; })
+  ];
+}
+```
+
+To completely customize the development shell of a specific package, you can provide a `mkDevShell` argument to `mkDerivation`. `mkDevShell` should take a single named argument, `drvAttrs`, which will be the value of the final package derivation's `.drvAttrs` attribute. Its primary output should be a directory containing a `./bin/run-shell` executable, which `nix develop` runs to enter the shell, a `./env` file containing text that will be printed by `nix print-dev-env`, and a `./env.json` file containing text that will be printed by `nix print-dev-env --json`. The resulting development shell derivation should have `meta.mainProgram = "run-shell"`.
+
 [^footnote-stdenv-ignored-build-platform]: The build platform is ignored because it is a mere implementation detail of the package satisfying the dependency: As a general programming principle, dependencies are always *specified* as interfaces, not concrete implementation.
 [^footnote-stdenv-native-dependencies-in-path]: Currently, this means for native builds all dependencies are put on the `PATH`. But in the future that may not be the case for sake of matching cross: the platforms would be assumed to be unique for native and cross builds alike, so only the `depsBuild*` and `nativeBuildInputs` would be added to the `PATH`.
 [^footnote-stdenv-propagated-dependencies]: Nix itself already takes a package’s transitive dependencies into account, but this propagation ensures nixpkgs-specific infrastructure like [setup hooks](#ssec-setup-hooks) also are run as if it were a propagated dependency.

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -5,8 +5,20 @@
   hostPlatform,
   fetchurl,
   checkMeta,
+  devShell,
 }:
 
+let
+  addDevShells =
+    pkgs:
+    lib.attrsets.mapAttrs (
+      name: value:
+      if value.type or null != "derivation" then
+        value
+      else
+        value // { devShell = devShell { inherit (value) drvAttrs; }; }
+    ) pkgs;
+in
 lib.makeScope
   # Prevent using top-level attrs to protect against introducing dependency on
   # non-bootstrap packages by mistake. Any top-level inputs must be explicitly
@@ -30,7 +42,7 @@ lib.makeScope
   (
     self:
     with self;
-    (
+    addDevShells (
       {
         supportedSystems = [
           "i686-linux"

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -13,7 +13,11 @@
 let
   # N.B. Keep in sync with default arg for stdenv/generic.
   defaultMkDerivationFromStdenv =
-    stdenv: (import ./generic/make-derivation.nix { inherit lib config; } stdenv).mkDerivation;
+    stdenv:
+    (import ./generic/make-derivation.nix {
+      inherit lib config;
+      inherit (pkgs) mkStdenvDevShell;
+    } stdenv).mkDerivation;
 
   # Low level function to help with overriding `mkDerivationFromStdenv`. One
   # gives it the old stdenv arguments and a "continuation" function, and

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -14,7 +14,7 @@ let
   # N.B. Keep in sync with default arg for stdenv/generic.
   defaultMkDerivationFromStdenv =
     let
-      makeDerivationFile = import ./generic/make-derivation.nix lib config;
+      makeDerivationFile = import ./generic/make-derivation.nix lib config pkgs.mkStdenvDevShell;
     in
     stdenv: (makeDerivationFile stdenv).mkDerivation;
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -5,6 +5,8 @@
   config,
   overlays,
   crossOverlays ? [ ],
+  mkStdenvDevShell,
+  mkBootstrapDevShell,
 }:
 
 let
@@ -17,6 +19,8 @@ let
     # Ignore custom stdenvs when cross compiling for compatibility
     # Use replaceCrossStdenv instead.
     config = removeAttrs config [ "replaceStdenv" ];
+
+    inherit mkStdenvDevShell mkBootstrapDevShell;
   };
 
 in

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -5,6 +5,8 @@
   config,
   overlays,
   crossOverlays,
+  mkStdenvDevShell,
+  mkBootstrapDevShell,
 }:
 
 let
@@ -17,6 +19,8 @@ let
     # Ignore custom stdenvs when cross compiling for compatibility
     # Use replaceCrossStdenv instead.
     config = removeAttrs config [ "replaceStdenv" ];
+
+    inherit mkStdenvDevShell mkBootstrapDevShell;
   };
 
 in

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -14,6 +14,7 @@
   config,
   overlays,
   crossOverlays ? [ ],
+  mkStdenvDevShell,
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
   bootstrapFiles ? (config.replaceBootstrapFiles or lib.id) (
     if localSystem.isAarch64 then
@@ -21,6 +22,7 @@
     else
       import ./bootstrap-files/x86_64-apple-darwin.nix
   ),
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -111,7 +113,7 @@ let
         hostPlatform = localSystem;
         targetPlatform = localSystem;
 
-        inherit config;
+        inherit config mkStdenvDevShell;
 
         extraBuildInputs = [ prevStage.apple-sdk ];
         inherit extraNativeBuildInputs;
@@ -991,7 +993,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         hostPlatform = localSystem;
         targetPlatform = localSystem;
 
-        inherit config;
+        inherit config mkStdenvDevShell;
 
         preHook = ''
           ${commonPreHook}

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -13,6 +13,7 @@
   crossSystem,
   config,
   overlays,
+  mkStdenvDevShell,
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
   bootstrapFiles ? (config.replaceBootstrapFiles or lib.id) (
     if localSystem.isAarch64 then
@@ -20,6 +21,7 @@
     else
       throw "Unsupported platform for the Darwin stdenv"
   ),
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -110,6 +112,8 @@ let
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
+
+        inherit mkStdenvDevShell;
 
         extraBuildInputs = [ prevStage.apple-sdk ];
         inherit extraNativeBuildInputs;
@@ -979,6 +983,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
+
+        inherit mkStdenvDevShell;
 
         preHook = ''
           ${commonPreHook}

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -13,6 +13,8 @@
   config,
   overlays,
   crossOverlays ? [ ],
+  mkStdenvDevShell,
+  mkBootstrapDevShell,
 }@args:
 
 let

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -13,6 +13,8 @@
   config,
   overlays,
   crossOverlays,
+  mkStdenvDevShell,
+  mkBootstrapDevShell,
 }:
 
 let
@@ -23,6 +25,8 @@ let
       crossSystem
       config
       overlays
+      mkStdenvDevShell
+      mkBootstrapDevShell
       ;
   };
   # The native (i.e., impure) build environment.  This one uses the

--- a/pkgs/stdenv/devShell.nix
+++ b/pkgs/stdenv/devShell.nix
@@ -1,0 +1,34 @@
+{ lib, shell }:
+{ drvAttrs, ... }:
+
+assert lib.asserts.assertMsg (
+  (baseNameOf drvAttrs.builder) == "bash"
+) "devShell attribute is only supported on derivations that use 'bash' as their builder";
+
+let
+  sanitize =
+    drvAttrs:
+    removeAttrs drvAttrs [
+      "outputChecks"
+      "allowedReferences"
+      "allowedRequisites"
+      "disallowedReferences"
+      "disallowedRequisites"
+    ];
+in
+derivation (
+  sanitize drvAttrs
+  // {
+    name = "${drvAttrs.name}-env";
+    args = [
+      ./get-env.sh
+      shell
+    ];
+  }
+)
+// {
+  meta = {
+    mainProgram = "run-shell";
+  };
+  __isDevShell = true;
+}

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -7,6 +7,7 @@
   config,
   overlays,
   crossOverlays ? [ ],
+  mkStdenvDevShell,
   bootstrapFiles ?
     let
       table = {
@@ -17,6 +18,7 @@
           or (throw "unsupported platform ${localSystem.system} for the pure FreeBSD stdenv");
     in
     files,
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -394,6 +396,7 @@ let
           initialPath
           shell
           fetchurlBoot
+          mkStdenvDevShell
           ;
         name = "stdenvNoCC-${name}";
         buildPlatform = localSystem;
@@ -412,6 +415,7 @@ let
           initialPath
           shell
           fetchurlBoot
+          mkStdenvDevShell
           ;
         name = "stdenv-${name}";
         buildPlatform = localSystem;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -6,6 +6,7 @@
   crossSystem,
   config,
   overlays,
+  mkStdenvDevShell,
   bootstrapFiles ?
     let
       table = {
@@ -16,6 +17,7 @@
           or (throw "unsupported platform ${localSystem.system} for the pure FreeBSD stdenv");
     in
     files,
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -389,6 +391,7 @@ let
           initialPath
           shell
           fetchurlBoot
+          mkStdenvDevShell
           ;
         name = "stdenvNoCC-${name}";
         buildPlatform = localSystem;
@@ -406,6 +409,7 @@ let
           initialPath
           shell
           fetchurlBoot
+          mkStdenvDevShell
           ;
         name = "stdenv-${name}";
         buildPlatform = localSystem;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -64,7 +64,10 @@ let
       # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
       # This is convenient to have as a parameter so the stdenv "adapters" work better
       mkDerivationFromStdenv ?
-        stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation,
+        stdenv: (import ./make-derivation.nix { inherit lib config mkStdenvDevShell; } stdenv).mkDerivation,
+
+      # See ./make-derivation.nix
+      mkStdenvDevShell ? _: null,
     }:
 
     let

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -98,9 +98,15 @@ let
       mkDerivationFromStdenv ?
         let
           makeDerivationWithConfig' =
-            if argsStdenv ? config then makeDerivationFile config else makeDerivationFileWithConfig;
+            if argsStdenv ? config then
+              makeDerivationFile config mkStdenvDevShell
+            else
+              makeDerivationFileWithConfig mkStdenvDevShell;
         in
         stdenv: (makeDerivationWithConfig' stdenv).mkDerivation,
+
+      # See ./make-derivation.nix
+      mkStdenvDevShell ? _: null,
     }:
 
     let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -6,7 +6,12 @@
 #
 # See https://github.com/NixOS/nixpkgs/pull/430969 for measurements.
 
-{ lib, config }:
+{
+  lib,
+  config,
+  # Function to construct the default devShell attribute; when not set via passthru.
+  mkStdenvDevShell ? _: null,
+}:
 
 stdenv:
 
@@ -180,6 +185,7 @@ let
     "allowedReferences"
     "allowedRequisites"
     "allowedImpureDLLs"
+    "mkDevShell"
   ];
 
   inherit (stdenv)
@@ -923,6 +929,10 @@ let
             ];
           }
         );
+
+        devShell = attrs.mkDevShell or mkStdenvDevShell {
+          drvAttrs = derivationArg // checkedEnv;
+        };
 
         inherit passthru overrideAttrs;
         inherit meta;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -94,6 +94,7 @@ let
     "allowedReferences"
     "allowedRequisites"
     "allowedImpureDLLs"
+    "mkDevShell"
   ];
 
   referenceCheckingAttrsToRemove = [
@@ -193,7 +194,7 @@ let
     inherit lib config;
   };
 in
-stdenv:
+mkStdenvDevShell: stdenv:
 
 let
   inherit (import ../../build-support/lib/cmake.nix { inherit lib stdenv; }) makeCMakeFlags;
@@ -1059,6 +1060,10 @@ let
             ];
           }
         );
+
+        devShell = attrs.mkDevShell or mkStdenvDevShell {
+          drvAttrs = derivationArg // checkedEnv;
+        };
 
         inherit passthru overrideAttrs;
         inherit meta;

--- a/pkgs/stdenv/get-env.sh
+++ b/pkgs/stdenv/get-env.sh
@@ -1,0 +1,306 @@
+# shellcheck shell=bash
+set -e
+
+exitError() {
+    echo "$1" >&2
+    exit 1
+}
+
+eval "[[ "foo" =~ "foo" ]]" 2>/dev/null || exitError "error: get-env.sh uses pattern matching but the derivation builder does not support this"
+eval "declare -a arr=()" 2>/dev/null || exitError "error: get-env.sh uses arrays but the derivation builder does not support this"
+
+# shellcheck disable=SC1090  # Dynamic sourcing is intentional
+if [ -e "$NIX_ATTRS_SH_FILE" ]; then source "$NIX_ATTRS_SH_FILE"; fi
+
+export IN_NIX_SHELL=impure
+export dontAddDisableDepTrack=1
+
+if [[ -n $stdenv ]]; then
+    # shellcheck disable=SC1091  # setup file is in nix store
+    source "$stdenv"/setup
+fi
+
+# Better to use compgen, but stdenv bash doesn't have it.
+__vars="$(declare -p)"
+__functions="$(declare -F)"
+
+declare -a __saved_vars=("PATH" "XDG_DATA_DIRS")
+
+__shell="$1"
+
+__dumpEnv() {
+    printf "unset shellHook\n\n"
+
+    for var in "${__saved_vars[@]}"; do
+        printf '%s=${%s:-}\n' "$var" "$var"
+        printf 'nix_saved_%s="$%s"\n' "$var" "$var"
+    done
+    printf '\n'
+
+    while read -r __line; do
+        if ! [[ $__line =~ ^declare\ -f\ (.*) ]]; then continue; fi
+        __fun_name="${BASH_REMATCH[1]}"
+        __fun_body="$(type "$__fun_name")"
+        if [[ $__fun_body =~ \{(.*)\} ]]; then
+            __fun_body="${BASH_REMATCH[1]}"
+            printf "%s() {%s}\n\n" "$__fun_name" "$__fun_body"
+        else
+            printf "Cannot parse definition of function '%s'.\n" "$__fun_name" >&2
+            return 1
+        fi
+    done < <(printf "%s\n" "$__functions")
+
+    while read -r __line; do
+        if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*) ]]; then continue; fi
+        local type="${BASH_REMATCH[1]}"
+        local __var_name="${BASH_REMATCH[2]}"
+
+        if [[ $__var_name =~ ^BASH_ || \
+              $__var_name =~ ^COMP_ || \
+              $__var_name = _ || \
+              $__var_name = DIRSTACK || \
+              $__var_name = EUID || \
+              $__var_name = FUNCNAME || \
+              $__var_name = HISTCMD || \
+              $__var_name = HOSTNAME || \
+              $__var_name = GROUPS || \
+              $__var_name = PIPESTATUS || \
+              $__var_name = PWD || \
+              $__var_name = RANDOM || \
+              $__var_name = SHLVL || \
+              $__var_name = SECONDS || \
+              $__var_name = EPOCHREALTIME || \
+              $__var_name = EPOCHSECONDS || \
+              $__var_name = LINENO \
+            ]]; then continue; fi
+
+        if [[ $type == -x ]] || [[ $type == -- ]] || [[ $type == -a ]] || [[ $type == -A ]]; then
+            printf '%s\n' "$__line"
+        fi
+    done < <(printf "%s\n" "$__vars")
+    printf '\n'
+
+    for var in "${__saved_vars[@]}"; do
+        printf '%s="$%s${nix_saved_%s:+:$nix_saved_%s}"\n' "$var" "$var" "$var" "$var"
+    done
+    printf '\n'
+
+    printf '%s\n'   'if [[ -z "${NIX_BUILD_TOP:-}" ]]; then'
+    printf '%s\n'   '    export NIX_BUILD_TOP="$(mktemp -d -t devshell.XXXXXX)"'
+    printf '%s\n\n' 'fi'
+
+    for var in "TMP" "TMPDIR" "TEMP" "TEMPDIR"; do
+        printf 'export %s="$NIX_BUILD_TOP"\n' "$var"
+    done
+    printf '\n'
+
+    printf '%s\n\n' 'eval "${shellHook:-}"'
+}
+
+__dumpRc() {
+    printf '#!%s --rcfile\n\n' "$__shell"
+
+    printf 'if [[ -z "${NIX_DEVSHELL_PHASE:-}" && -z "${NIX_DEVSHELL_COMMAND:-}" ]]; then\n'
+    printf '    [ -n "$PS1" ] && [ -e ~/.bashrc ] && source ~/.bashrc;\n'
+    printf '    shopt -u expand_aliases\n'
+    printf 'fi\n\n'
+
+    __dumpEnv
+
+    printf '%s\n'   'if [[ ! -z "${NIX_DEVSHELL_VERBOSE:-}" ]]; then'
+    printf '%s\n'   '    set -x'
+    printf '%s\n\n' 'fi'
+
+    printf '%s\n'   'if [[ ! -z "${NIX_DEVSHELL_PHASE:-}" ]]; then'
+    printf '%s\n'   '    cd "${NIX_DEVSHELL_PHASE_SRCPATH:-.}"'
+    printf '%s\n'   '    runHook ${NIX_DEVSHELL_PHASE}Phase'
+    printf '%s\n'   '    exit "$?"'
+    printf '%s\n'   'elif [[ ! -z "${NIX_DEVSHELL_COMMAND:-}" ]]; then'
+    printf '%s\n'   '    eval "$NIX_DEVSHELL_COMMAND"'
+    printf '%s\n'   '    exit "$?"'
+    printf '%s\n'   'else'
+    printf '%s\n'   '    shopt -s expand_aliases'
+    printf '%s\n'   '    if [[ ! -z "${NIX_DEVSHELL_PROMPT:-}" ]]; then'
+    printf '%s\n'   '        [ -n "$PS1" ] && PS1="$NIX_DEVSHELL_PROMPT";'
+    printf '%s\n'   '    fi'
+    printf '%s\n'   '    if [[ ! -z "${NIX_DEVSHELL_PROMPT_PREFIX:-}" ]]; then'
+    printf '%s\n'   '        [ -n "$PS1" ] && PS1="$NIX_DEVSHELL_PROMPT_PREFIX$PS1";'
+    printf '%s\n'   '    fi'
+    printf '%s\n'   '    if [[ ! -z "${NIX_DEVSHELL_PROMPT_SUFFIX:-}" ]]; then'
+    printf '%s\n'   '        [ -n "$PS1" ] && PS1+="${NIX_DEVSHELL_PROMPT_SUFFIX}";'
+    printf '%s\n'   '    fi'
+    printf '%s\n\n' 'fi'
+
+    printf 'SHELL="%s"\n' "$__shell"
+    printf '%s\n' 'if [[ $(dirname "$SHELL") != "." ]]; then'
+    printf '%s\n' '    PATH="$(dirname "$SHELL")${PATH:+:$PATH}"'
+    printf '%s\n' 'fi'
+}
+
+__dumpEnvJson() {
+    printf '{\n'
+
+    printf '  "bashFunctions": {\n'
+    local __first=1
+    while read -r __line; do
+        if ! [[ $__line =~ ^declare\ -f\ (.*) ]]; then continue; fi
+        __fun_name="${BASH_REMATCH[1]}"
+        __fun_body="$(type "$__fun_name")"
+        if [[ $__fun_body =~ \{(.*)\} ]]; then
+            if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+            __fun_body="${BASH_REMATCH[1]}"
+            printf "    "
+            __escapeString "$__fun_name"
+            printf ':'
+            __escapeString "$__fun_body"
+        else
+            printf "Cannot parse definition of function '%s'.\n" "$__fun_name" >&2
+            return 1
+        fi
+    done < <(printf "%s\n" "$__functions")
+    printf '\n  },\n'
+
+    printf '  "variables": {\n'
+    local __first=1
+    while read -r __line; do
+        if ! [[ $__line =~ ^declare\ (-[^ ])\ ([^=]*) ]]; then continue; fi
+        local type="${BASH_REMATCH[1]}"
+        local __var_name="${BASH_REMATCH[2]}"
+
+        if [[ $__var_name =~ ^BASH_ || \
+              $__var_name =~ ^COMP_ || \
+              $__var_name = _ || \
+              $__var_name = DIRSTACK || \
+              $__var_name = EUID || \
+              $__var_name = FUNCNAME || \
+              $__var_name = HISTCMD || \
+              $__var_name = HOSTNAME || \
+              $__var_name = GROUPS || \
+              $__var_name = PIPESTATUS || \
+              $__var_name = PWD || \
+              $__var_name = RANDOM || \
+              $__var_name = SHLVL || \
+              $__var_name = SECONDS || \
+              $__var_name = EPOCHREALTIME || \
+              $__var_name = EPOCHSECONDS || \
+              $__var_name = LINENO \
+            ]]; then continue; fi
+
+        if [[ -z $__first ]]; then printf ',\n'; else __first=; fi
+
+        printf "    "
+        __escapeString "$__var_name"
+        printf ': {'
+
+        # FIXME: handle -i, -r, -n.
+        if [[ $type == -x ]]; then
+            printf '"type": "exported", "value": '
+            __escapeString "${!__var_name}"
+        elif [[ $type == -- ]]; then
+            printf '"type": "var", "value": '
+            __escapeString "${!__var_name}"
+        elif [[ $type == -a ]]; then
+            printf '"type": "array", "value": ['
+            local __first2=1
+            # shellcheck disable=SC1087  # Complex array manipulation, syntax is correct
+            __var_name="$__var_name[@]"
+            # shellcheck disable=SC1087  # Complex array manipulation, syntax is correct
+            for __i in "${!__var_name}"; do
+                if [[ -z $__first2 ]]; then printf ', '; else __first2=; fi
+                __escapeString "$__i"
+                printf ' '
+            done
+            printf ']'
+        elif [[ $type == -A ]]; then
+            printf '"type": "associative", "value": {\n'
+            local __first2=1
+            declare -n __var_name2="$__var_name"
+            for __i in "${!__var_name2[@]}"; do
+                if [[ -z $__first2 ]]; then printf ',\n'; else __first2=; fi
+                printf "      "
+                __escapeString "$__i"
+                printf ": "
+                __escapeString "${__var_name2[$__i]}"
+            done
+            printf '\n    }'
+        else
+            printf '"type": "unknown"'
+        fi
+
+        printf "}"
+    done < <(printf "%s\n" "$__vars")
+    printf '\n  }'
+
+    if [ -e "$NIX_ATTRS_SH_FILE" ]; then
+        printf ',\n  "structuredAttrs": {\n    '
+        __escapeString ".attrs.sh"
+        printf ': '
+        __escapeString "$(<"$NIX_ATTRS_SH_FILE")"
+        printf ',\n    '
+        __escapeString ".attrs.json"
+        printf ': '
+        __escapeString "$(<"$NIX_ATTRS_JSON_FILE")"
+        printf '\n  }'
+    fi
+
+    printf '\n}'
+}
+
+__escapeString() {
+    local __s="$1"
+    __s="${__s//\\/\\\\}"
+    __s="${__s//\"/\\\"}"
+    __s="${__s//$'\n'/\\n}"
+    __s="${__s//$'\r'/\\r}"
+    __s="${__s//$'\t'/\\t}"
+    printf '"%s"' "$__s"
+}
+
+__rewriteOutputs() {
+    __in=$(</dev/stdin)
+
+    if [ -e "$NIX_ATTRS_SH_FILE" ]; then
+        for __output in ${!outputs[@]}; do
+            __in="${__in//${outputs[$__output]}/\$PWD/outputs/$__output}"
+        done
+    elif [[ ! -z "$outputs" ]]; then
+        for __outname in $outputs; do
+            __in="${__in//${!__outname}/\$PWD/outputs/$__outname}"
+        done
+    else
+        __in="${__in//$out/\$PWD/outputs/out}"
+    fi
+
+    printf "%s" "${__in}"
+}
+
+__dumpToOutput() {
+    local __output="$1"
+    if [[ -z ${__done-} ]]; then
+        mkdir "$__output"
+        __dumpEnvJson > "${__output}/env.json"
+        __dumpEnv | __rewriteOutputs > "${__output}/env"
+        mkdir "${__output}/bin"
+        __dumpRc  | __rewriteOutputs > "${__output}/bin/run-shell"
+        chmod +x "${__output}/bin/run-shell"
+        __done=1
+    else
+        echo -n >> "$__output"
+    fi
+}
+
+# In case of `__structuredAttrs = true;` the list of outputs is an associative
+# array with a format like `outname => /nix/store/hash-drvname-outname`.
+# Otherwise it is a space-separated list of output variable names.
+if [ -e "$NIX_ATTRS_SH_FILE" ]; then
+    # shellcheck disable=SC2154  # outputs is set by sourced file
+    for __output in "${outputs[@]}"; do
+        __dumpToOutput "$__output"
+    done
+elif [[ ! -z "$outputs" ]]; then
+    for __outname in $outputs; do
+        __dumpToOutput "${!__outname}"
+    done
+else
+    __dumpToOutput "$out"
+fi

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -60,6 +60,8 @@
   config,
   overlays,
   crossOverlays ? [ ],
+  mkStdenvDevShell,
+  mkBootstrapDevShell,
 
   bootstrapFiles ?
     let
@@ -116,6 +118,7 @@
         );
     in
     (config.replaceBootstrapFiles or lib.id) files,
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -159,6 +162,7 @@ let
       config
       localSystem
       bootstrapFiles
+      mkBootstrapDevShell
       ;
   };
 
@@ -706,7 +710,7 @@ in
         buildPlatform = localSystem;
         hostPlatform = localSystem;
         targetPlatform = localSystem;
-        inherit config;
+        inherit config mkStdenvDevShell;
 
         preHook = commonPreHook;
 
@@ -878,6 +882,8 @@ in
             gcc = cc;
           };
       };
+
+      inherit mkStdenvDevShell;
     }
   )
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -59,6 +59,9 @@
   crossSystem,
   config,
   overlays,
+  mkStdenvDevShell,
+  mkBootstrapDevShell,
+
   bootstrapFiles ?
     let
       table = {
@@ -114,6 +117,7 @@
         );
     in
     (config.replaceBootstrapFiles or lib.id) files,
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -159,6 +163,7 @@ let
       config
       localSystem
       bootstrapFiles
+      mkBootstrapDevShell
       ;
   };
 
@@ -697,6 +702,8 @@ in
         hostPlatform = localSystem;
         targetPlatform = localSystem;
 
+        inherit mkStdenvDevShell;
+
         preHook = commonPreHook;
 
         initialPath = ((import ../generic/common-path.nix) { pkgs = prevStage; });
@@ -864,6 +871,8 @@ in
             gcc = cc;
           };
       };
+
+      inherit mkStdenvDevShell;
     }
   )
 

--- a/pkgs/stdenv/linux/stage0.nix
+++ b/pkgs/stdenv/linux/stage0.nix
@@ -3,6 +3,7 @@
   config,
   lib,
   bootstrapFiles,
+  mkBootstrapDevShell,
 }:
 let
   minbootSupportedSystems = [
@@ -24,6 +25,7 @@ if minbootSupported then
           inherit (config) rewriteURL;
         };
         checkMeta = callPackage ../generic/check-meta.nix { hostPlatform = localSystem; };
+        devShell = mkBootstrapDevShell;
       }
     );
     compilerPackage =

--- a/pkgs/stdenv/linux/stage0.nix
+++ b/pkgs/stdenv/linux/stage0.nix
@@ -3,6 +3,7 @@
   config,
   lib,
   bootstrapFiles,
+  mkBootstrapDevShell,
 }:
 let
   minbootSupportedSystems = [
@@ -24,6 +25,7 @@ if minbootSupported then
           inherit (config) rewriteURL;
         };
         checkMeta = callPackage ../generic/check-meta.nix { };
+        devShell = mkBootstrapDevShell;
       }
     );
     compilerPackage =

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -5,6 +5,8 @@
   config,
   overlays,
   crossOverlays ? [ ],
+  mkStdenvDevShell,
+  ...
 }:
 
 assert crossSystem == localSystem;
@@ -146,6 +148,7 @@ let
         cc
         overrides
         config
+        mkStdenvDevShell
         ;
     };
 

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -4,6 +4,7 @@
   crossSystem,
   config,
   overlays,
+  mkStdenvDevShell,
 }:
 
 assert crossSystem == localSystem;
@@ -146,6 +147,7 @@ let
         shell
         cc
         overrides
+        mkStdenvDevShell
         ;
     };
 

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -667,3 +667,39 @@ in
       };
   };
 }
+// (
+  let
+    testBuild =
+      hello:
+      runCommand "test-devshell-build-hello" { } ''
+        runShell() {
+            NIX_DEVSHELL_PHASE="$1" bash ${hello.devShell}/bin/run-shell
+        }
+        runShell unpack
+        export NIX_DEVSHELL_PHASE_SRCPATH=${hello.name}
+        runShell configure
+        runShell build
+        runShell install
+        ./outputs/out/bin/hello | grep "Hello, world!"
+        touch $out
+      '';
+  in
+  {
+    test-devshell-build-hello = testBuild pkgs.hello;
+
+    test-devshell-build-hello-unstructured = testBuild (
+      pkgs.hello.overrideAttrs (prev: {
+        __structuredAttrs = false;
+      })
+    );
+
+    test-devshell-command = runCommand "test-devshell-command" { } ''
+      runShell() {
+          NIX_DEVSHELL_COMMAND="$1" bash ${pkgs.hello.devShell}/bin/run-shell
+      }
+      runShell "'echo' 'foo  bar'" | grep "foo  bar"
+      ! runShell "'false'" || exit 1
+      touch $out
+    '';
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -169,6 +169,16 @@ with pkgs;
     # We don't want nix-env -q to enter this, because all of these are aliases.
     dontRecurseIntoAttrs (import ./pkg-config/defaultPkgConfigPackages.nix pkgs);
 
+  mkStdenvDevShell = callPackage ../stdenv/devShell.nix { shell = lib.getExe pkgs.bashInteractive; };
+
+  # get-env.sh uses features not supported by bash_2_05.
+  # People trying to debug a build failure with the devshell for
+  # minimal-bootstrap.bash should override mkBootstrapDevShell's shell argument
+  # with a path to their own system shell.
+  mkBootstrapDevShell = callPackage ../stdenv/devShell.nix {
+    shell = lib.getExe pkgs.minimal-bootstrap.bash;
+  };
+
   ### Nixpkgs maintainer tools
 
   nix-generate-from-cpan = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };
@@ -8514,6 +8524,7 @@ with pkgs;
         inherit (config) rewriteURL;
       };
       checkMeta = callPackage ../stdenv/generic/check-meta.nix { inherit (stdenv) hostPlatform; };
+      devShell = mkBootstrapDevShell;
     }
   );
   minimal-bootstrap-sources =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -169,6 +169,16 @@ with pkgs;
     # We don't want nix-env -q to enter this, because all of these are aliases.
     dontRecurseIntoAttrs (import ./pkg-config/defaultPkgConfigPackages.nix pkgs);
 
+  mkStdenvDevShell = callPackage ../stdenv/devShell.nix { shell = lib.getExe pkgs.bashInteractive; };
+
+  # get-env.sh uses features not supported by bash_2_05.
+  # People trying to debug a build failure with the devshell for
+  # minimal-bootstrap.bash should override mkBootstrapDevShell's shell argument
+  # with a path to their own system shell.
+  mkBootstrapDevShell = callPackage ../stdenv/devShell.nix {
+    shell = lib.getExe pkgs.minimal-bootstrap.bash;
+  };
+
   ### Nixpkgs maintainer tools
 
   nix-generate-from-cpan = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };
@@ -7927,6 +7937,7 @@ with pkgs;
         inherit (config) rewriteURL;
       };
       checkMeta = callPackage ../stdenv/generic/check-meta.nix { };
+      devShell = mkBootstrapDevShell;
     }
   );
   minimal-bootstrap-sources =

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -212,6 +212,7 @@ let
       overlays
       crossOverlays
       ;
+    inherit (pkgs) mkStdenvDevShell mkBootstrapDevShell;
   };
 
   pkgs = boot stages;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -216,6 +216,7 @@ let
       overlays
       crossOverlays
       ;
+    inherit (pkgs) mkStdenvDevShell mkBootstrapDevShell;
   };
 
   fixedPoint = boot stages;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -82,6 +82,8 @@ in
   # A list of overlays (Additional `self: super: { .. }` customization
   # functions) to be fixed together in the produced package set
   overlays,
+
+  mkStdenvDevShell ? _: null,
 }@args:
 
 let

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -81,6 +81,8 @@ in
   # A list of overlays (Additional `self: super: { .. }` customization
   # functions) to be fixed together in the produced package set
   overlays,
+
+  mkStdenvDevShell ? _: null,
 }@args:
 
 let


### PR DESCRIPTION
(cribbed from Robert's original POC commit message)

Adds a new devShell interface to stdenv and minimal-bootstrap packages.

The idea here is that future Nix first tries to "`nix run`" the `pkg.devShell` package, and only if that fails, fall back to the legacy `nix develop` (or `nix-shell`) behavior.

This allows the development shell to evolve with stdenv, and it allows packages to individually customize the `devShell` attribute, by setting `passthru.devShell`.

Furthermore, these shell behaviors will be pinned to the expressions, allowing changes to be made in a more agile manner, unlike Nix, which has to be very careful not to break old expressions, as users can not revert Nix.

To give it a try:

    nix run github:lisanna-dettwyler/nix/devshells develop .#hello
    nix run github:lisanna-dettwyler/nix/devshells develop .#minimal-bootstrap.binutils

Or:

    nix run .#hello.devShell
    nix run .#minimal-bootstrap.binutils.devShell

#### Isn't this the responsibility of Nix?

It is not. `nix-shell` and `nix develop` are a great user interface, that everyone loves, but their implementation is a pile of hacks on top of stdenv.
Instead of coercing stdenv to do what `nix-shell` needs it to, we can ask stdenv politely to provide a shell.
Now that Nix doesn't have to assume a package comes from stdenv, there's a possibility for experimental builders to provide shells too.

#### What does this break?

Only packages that define a `devShell` attribute (for some reason?) have to adapt to the suggested new Nix behavior. Note that a `devShell` value for the builder can be overridden by `passthru` without affecting the build or shell.
Packages and shells pinned to older versions can still be loaded because Nix keeps the legacy behavior as a fallback.

#### Does this solve the need for `.env` for Haskell package shells?

Not in this commit, but Haskell packages will be able to produce their own `devShell` attribute, which is derived from the .env derivation rather than the regular derivation.

#### Refs
 - https://github.com/NixOS/nix/issues/7468 and a bunch of other issues where Robert has preached about this idea.
 - https://github.com/NixOS/nix/pull/15738 corresponding change in nix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
