### PR TITLE
open-webui: Add missing datasets dependency for local "transformers" text-to-speech (TTS)

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -110,6 +110,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       chardet
       chromadb
       cryptography
+      datasets_3
       ddgs
       docx2txt
       einops

--- a/pkgs/development/python-modules/datasets/3.nix
+++ b/pkgs/development/python-modules/datasets/3.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+
+  # dependencies
+  dill,
+  filelock,
+  fsspec,
+  httpx,
+  huggingface-hub,
+  multiprocess,
+  numpy,
+  pandas,
+  pyarrow,
+  pyyaml,
+  requests,
+  tqdm,
+  xxhash,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "datasets";
+  version = "3.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "datasets";
+    tag = finalAttrs.version;
+    hash = "sha256-/xhu0cDKfCEwrp9IzKd0+AeQky1198f9sba/pdutvAk=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    dill
+    filelock
+    fsspec
+    httpx
+    huggingface-hub
+    multiprocess
+    numpy
+    pandas
+    pyarrow
+    pyyaml
+    requests
+    tqdm
+    xxhash
+  ]
+  ++ fsspec.optional-dependencies.http;
+
+  pythonRelaxDeps = [
+    # https://github.com/huggingface/datasets/blob/a256b85cbc67aa3f0e75d32d6586afc507cf535b/setup.py#L117
+    # "pin until dill has official support for determinism"
+    "dill"
+    # https://github.com/huggingface/datasets/blob/4.5.0/setup.py#L127
+    "multiprocess"
+    # https://github.com/huggingface/datasets/blob/4.5.0/setup.py#L130
+    "fsspec"
+  ];
+
+  # Tests require pervasive internet access
+  doCheck = false;
+
+  # Module import will attempt to create a cache directory
+  postFixup = "export HF_MODULES_CACHE=$TMPDIR";
+
+  pythonImportsCheck = [ "datasets" ];
+
+  meta = {
+    description = "Open-access datasets and evaluation metrics for natural language processing";
+    mainProgram = "datasets-cli";
+    homepage = "https://github.com/huggingface/datasets";
+    changelog = "https://github.com/huggingface/datasets/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      osbm
+      malteneuss
+    ];
+  };
+})

--- a/pkgs/development/python-modules/datasets/default.nix
+++ b/pkgs/development/python-modules/datasets/default.nix
@@ -20,7 +20,7 @@
   tqdm,
   xxhash,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "datasets";
   version = "4.5.0";
   pyproject = true;
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "datasets";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-K8JqIbYz3ZfT1t1h5dRGCo9kBQp0E+kElqzaw2InaOI=";
   };
 
@@ -75,8 +75,8 @@ buildPythonPackage rec {
     description = "Open-access datasets and evaluation metrics for natural language processing";
     mainProgram = "datasets-cli";
     homepage = "https://github.com/huggingface/datasets";
-    changelog = "https://github.com/huggingface/datasets/releases/tag/${src.tag}";
+    changelog = "https://github.com/huggingface/datasets/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ osbm ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3624,6 +3624,8 @@ self: super: with self; {
 
   datasets = callPackage ../development/python-modules/datasets { };
 
+  datasets_3 = callPackage ../development/python-modules/datasets/3.nix { };
+
   datasette = callPackage ../development/python-modules/datasette { };
 
   datasette-publish-fly = callPackage ../development/python-modules/datasette-publish-fly { };


### PR DESCRIPTION
Readded an older Python package datasets version from https://github.com/NixOS/nixpkgs/commit/e80cc8d10b4ebb89f83d0943c754bd662f701de2 to download speech models ( SpeechT5 speaker embedding dataset Matthijs/cmu-arctic-xvectors) from Huggingface in open-webui. Otherwise 
we get the following runtime error:

```
File "/nix/store/la8ip2dp3y02kx768rm9x8xbd93d4wrq-open-webui-0.8.12/lib/python3.13/site-packages/open_webui/routers/audio.py", line 530, in speech
open-webui[582836]:     load_speech_pipeline(request)
open-webui[582836]:     ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
open-webui[582836]:   File "/nix/store/la8ip2dp3y02kx768rm9x8xbd93d4wrq-open-webui-0.8.12/lib/python3.13/site-packages/open_webui/routers/audio.py", line 306, in load_speech_pipeline
open-webui[582836]:     from datasets import load_dataset
open-webui[582836]: ModuleNotFoundError: No module named 'datasets'
```

It needs to be an older <4 version, otherwise we get `RuntimeError: Dataset scripts are no longer supported, but found cmu-arctic-xvectors.py`. See https://github.com/open-webui/open-webui/pull/22365

relates to #361550

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
