### PR TITLE
nixos/syncthing: fix user service ExecStart when systemService = false

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -73,6 +73,21 @@ let
 
   jq = "${pkgs.jq}/bin/jq";
   grep = lib.getExe pkgs.gnugrep;
+
+  execStart =
+    let
+      args = lib.escapeShellArgs (
+        (lib.cli.toCommandLineGNU { } {
+          "no-browser" = true;
+          "gui-address" = (if isUnixGui then "unix://" else "") + cfg.guiAddress;
+          "config" = cfg.configDir;
+          "data" = cfg.databaseDir;
+        })
+        ++ cfg.extraFlags
+      );
+    in
+    "${lib.getExe cfg.package} ${args}";
+
   updateConfig = pkgs.writers.writeBash "merge-syncthing-config" (
     ''
       set -efu
@@ -996,19 +1011,7 @@ in
                   install -Dm600 -o ${cfg.user} -g ${cfg.group} ${toString cfg.key} ${cfg.configDir}/key.pem
                 ''}
               ''}";
-          ExecStart =
-            let
-              args = lib.escapeShellArgs (
-                (lib.cli.toCommandLineGNU { } {
-                  "no-browser" = true;
-                  "gui-address" = cfg.guiAddress;
-                  "config" = cfg.configDir;
-                  "data" = cfg.databaseDir;
-                })
-                ++ cfg.extraFlags
-              );
-            in
-            "${lib.getExe cfg.package} ${args}";
+          ExecStart = execStart;
           RuntimeDirectory = "syncthing";
           MemoryDenyWriteExecute = true;
           NoNewPrivileges = true;
@@ -1048,6 +1051,13 @@ in
           ExecStart = updateConfig;
         };
       };
+    };
+
+    # When systemService = false, systemd.packages installs the upstream package
+    # unit into /etc/systemd/user/. That unit has no --config/--data/--gui-address
+    # flags. Override ExecStart here so the NixOS-evaluated paths are used.
+    systemd.user.services.syncthing = mkIf (!cfg.systemService) {
+      serviceConfig.ExecStart = [ "" execStart ];
     };
   };
 }


### PR DESCRIPTION
When systemService = false, systemd.packages installs the upstream Syncthing package unit into /etc/systemd/user/. That unit is a static file with ExecStart=/usr/bin/syncthing which does not exist on NixOS, and has no --config/--data/--gui-address flags, so it ignores all NixOS options and defaults to ~/.config/syncthing.

Fix by extracting ExecStart into a shared let binding and adding a systemd.user.services.syncthing override that clears the upstream ExecStart and sets the correct one using the evaluated NixOS options.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
