### PR TITLE
[Backport release-25.11]: mas: 2.2.2 -> 6.0.1

### DIFF
--- a/pkgs/by-name/ma/mas/package.nix
+++ b/pkgs/by-name/ma/mas/package.nix
@@ -26,7 +26,8 @@ stdenvNoCC.mkDerivation rec {
             hash = "sha256-8zaZOPOCyLHOFmHhviJXIy5SB5trqQM/MFHhB9ygilQ=";
           };
         }
-        .${stdenvNoCC.hostPlatform.system};
+        .${stdenvNoCC.hostPlatform.system}
+          or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
     in
     fetchurl {
       url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas-${version}-${sources.arch}.pkg";

--- a/pkgs/by-name/ma/mas/package.nix
+++ b/pkgs/by-name/ma/mas/package.nix
@@ -10,7 +10,7 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mas";
-  version = "5.1.0";
+  version = "6.0.1";
 
   src =
     let
@@ -19,11 +19,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         {
           x86_64-darwin = {
             arch = "x86_64";
-            hash = "sha256-G7o0nHsf6Ay2k3quMs45KH9h4yEpbvyGPm/u86naWcM=";
+            hash = "sha256-7+iDBr4GG5bdTuAlAmMQkEkIzVgLo2+DEdravClaLtQ=";
           };
           aarch64-darwin = {
             arch = "arm64";
-            hash = "sha256-XZM0YeFLHYhoEqQLaG1Jz3OWcT9DILqFEcgqI3yvDk8=";
+            hash = "sha256-BZ9UE8H28kjqiMNdLDUUyC9madR4rBV1mLUGyj6ol3Y=";
           };
         }
         .${stdenvNoCC.hostPlatform.system}

--- a/pkgs/by-name/ma/mas/package.nix
+++ b/pkgs/by-name/ma/mas/package.nix
@@ -8,29 +8,29 @@
   testers,
   mas,
 }:
-
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mas";
-  version = "4.1.0";
+  version = "5.1.0";
 
   src =
     let
+      # nix store prefetch-file https://github.com/mas-cli/mas/releases/download/v$VERSION/mas-$VERSION-$ARCH.pkg
       sources =
         {
           x86_64-darwin = {
             arch = "x86_64";
-            hash = "sha256-9GkAV2gitqtZ7Ew/QVXDj3tDTbh5uwBxPtYdLSnucZE=";
+            hash = "sha256-G7o0nHsf6Ay2k3quMs45KH9h4yEpbvyGPm/u86naWcM=";
           };
           aarch64-darwin = {
             arch = "arm64";
-            hash = "sha256-8zaZOPOCyLHOFmHhviJXIy5SB5trqQM/MFHhB9ygilQ=";
+            hash = "sha256-XZM0YeFLHYhoEqQLaG1Jz3OWcT9DILqFEcgqI3yvDk8=";
           };
         }
         .${stdenvNoCC.hostPlatform.system}
           or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
     in
     fetchurl {
-      url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas-${version}-${sources.arch}.pkg";
+      url = "https://github.com/mas-cli/mas/releases/download/v${finalAttrs.version}/mas-${finalAttrs.version}-${sources.arch}.pkg";
       inherit (sources) hash;
     };
 
@@ -49,12 +49,14 @@ stdenvNoCC.mkDerivation rec {
     runHook postUnpack
   '';
 
+  dontConfigure = true;
   dontBuild = true;
+  strictDeps = true;
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 usr/local/opt/mas/bin/mas $out/bin/mas
+    installBin usr/local/opt/mas/bin/mas
 
     installManPage usr/local/opt/mas/share/man/man1/mas.1
     installShellCompletion --bash usr/local/opt/mas/etc/bash_completion.d/mas
@@ -84,4 +86,4 @@ stdenvNoCC.mkDerivation rec {
       "aarch64-darwin"
     ];
   };
-}
+})


### PR DESCRIPTION
Backport PR #506669 to release 25.11.

The old `mas` version in `release` is causing [issues in nix-darwin](https://github.com/nix-darwin/nix-darwin/issues/1722).
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
