### PR TITLE
kmymoney: add gappsWrapperArgs to qtWrapperArgs

### DIFF
--- a/pkgs/by-name/km/kmymoney/package.nix
+++ b/pkgs/by-name/km/kmymoney/package.nix
@@ -15,6 +15,8 @@
   libical,
   libofx,
   sqlcipher,
+  # TODO: Remove wrapGAppsHook* once PR #507455 or an alternative lands.
+  wrapGAppsHook3,
 
   # Needed for running tests:
   xvfb-run,
@@ -41,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     graphviz
     pkg-config
     python3.pkgs.wrapPython
+    wrapGAppsHook3
   ]
   ++ (with kdePackages; [
     extra-cmake-modules
@@ -91,6 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
     # by patchPythonScript doesn't fail:
     sed -i -e '1i import sys; sys.argv = [""]' \
       "kmymoney/plugins/woob/interface/kmymoneywoob.py"
+  '';
+
+  dontWrapGApps = true; # TODO: Remove this when removing wrapGAppsHook*.
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   # libpython is required by the python interpreter embedded in kmymoney, so we


### PR DESCRIPTION
Add `gappsWrapperArgs` to KMyMoney's `qtWrapperArgs`, so that attempting to export a report (as well as presumably any other action requiring a file chooser dialog) will work again also on GNOME, rather than crashing with
```
(kmymoney:26393): GLib-GIO-ERROR **: 16:18:43.780: Settings schema ‘org.gtk.Settings.FileChooser’ is not installed
```

This change was authored following the example of https://github.com/NixOS/nixpkgs/pull/507382 as of 1e50738ad31484af01cf19167ff713898477312d, though with the addition of TODO comments to remind me to revert this once the underlying problem has been solved globally in nixpkgs, e.g. by #507455 or #271037.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
