### PR TITLE
python3Packages.python-pkcs11: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/python-pkcs11/default.nix
+++ b/pkgs/development/python-modules/python-pkcs11/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "python-pkcs11";
-  version = "0.9.3";
+  version = "0.9.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "danni";
     repo = "python-pkcs11";
     tag = "v${version}";
-    sha256 = "sha256-ursQHwyTUz4kCg66+Rnvo8bI3fzA3k9FsmbnUvpq/aY=";
+    sha256 = "sha256-9RVUtUe+Af5nTDaMeipdijLK4Un/SGRAQIztVKQZZzQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/python-pkcs11/default.nix
+++ b/pkgs/development/python-modules/python-pkcs11/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "python-pkcs11";
-  version = "0.9.3";
+  version = "0.9.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "danni";
     repo = "python-pkcs11";
     tag = "v${version}";
-    sha256 = "sha256-ursQHwyTUz4kCg66+Rnvo8bI3fzA3k9FsmbnUvpq/aY=";
+    hash = "sha256-9RVUtUe+Af5nTDaMeipdijLK4Un/SGRAQIztVKQZZzQ=";
   };
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/danni/python-pkcs11/compare/v0.9.3...v0.9.4

Changelog: https://github.com/pyauth/python-pkcs11/releases/tag/v0.9.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
