### PR TITLE
orbit: init at 1.6

### DIFF
--- a/pkgs/by-name/or/orbit/package.nix
+++ b/pkgs/by-name/or/orbit/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "orbit";
+  version = "1.5";
+
+  src = fetchurl {
+    url = "https://github.com/yuzeguitarist/Orbit/releases/download/v${finalAttrs.version}/Orbit.dmg";
+    hash = "sha256-SNwJGUbV6BPmObmMsAui9qXwOPkGheVJ4Ezy6C0Ozpg=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  dontBuild = true;
+  dontFixup = true;
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A radial, gesture-first app switcher and file hub for macOS.";
+    homepage = "https://github.com/yuzeguitarist/Orbit";
+    changelog = "https://github.com/yuzeguitarist/Orbit/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ myzel394 ];
+  };
+})

--- a/pkgs/by-name/or/orbit/package.nix
+++ b/pkgs/by-name/or/orbit/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "orbit";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchurl {
     url = "https://github.com/yuzeguitarist/Orbit/releases/download/v${finalAttrs.version}/Orbit.dmg";
-    hash = "sha256-SNwJGUbV6BPmObmMsAui9qXwOPkGheVJ4Ezy6C0Ozpg=";
+    hash = "sha256-5SHMfufwQgR5u008Ws4qNT5x5Owb4qCO+bKijnfu0YA=";
   };
 
   nativeBuildInputs = [ undmg ];


### PR DESCRIPTION
https://github.com/yuzeguitarist/Orbit

The app is not open-source, as per README:

> This project is source-available and All Rights Reserved

The releases do not seem to be using semantic versioning

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
