### PR TITLE
ocamlPackages.mariadb: 1.1.6 → 1.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/mariadb/default.nix
+++ b/pkgs/development/ocaml-modules/mariadb/default.nix
@@ -1,74 +1,34 @@
 {
   lib,
   fetchurl,
-  stdenv,
-  fetchpatch,
-  ocaml,
-  findlib,
-  ocamlbuild,
-  camlp-streams,
+  buildDunePackage,
   ctypes,
   mariadb,
   libmysqlclient,
+  dune-configurator,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-mariadb";
-  version = "1.1.6";
+buildDunePackage (finalAttrs: {
+  pname = "mariadb";
+  version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/andrenth/ocaml-mariadb/releases/download/${version}/ocaml-mariadb-${version}.tar.gz";
-    sha256 = "sha256-3/C1Gz6luUzS7oaudLlDHMT6JB2v5OdbLVzJhtayHGM=";
+    url = "https://github.com/ocaml-community/ocaml-mariadb/releases/download/${finalAttrs.version}/mariadb-${finalAttrs.version}.tbz";
+    hash = "sha256-mYktFTUDaA///SzTMgQDNXtYiXxnkMrf4EujijpmjMY=";
   };
 
-  patches =
-    lib.lists.map
-      (
-        x:
-        fetchpatch {
-          url = "https://github.com/andrenth/ocaml-mariadb/commit/${x.path}.patch";
-          inherit (x) hash;
-        }
-      )
-      [
-        {
-          path = "9db2e4d8dec7c584213d0e0f03d079a36a35d9d5";
-          hash = "sha256-heROtU02cYBJ5edIHMdYP1xNXcLv8h79GYGBuudJhgE=";
-        }
-        {
-          path = "40cd3102bc7cce4ed826ed609464daeb1bbb4581";
-          hash = "sha256-YVsAMJiOgWRk9xPaRz2sDihBYLlXv+rhWtQIMOVLtSg=";
-        }
-      ];
-
-  postPatch = ''
-    substituteInPlace setup.ml --replace '#use "topfind"' \
-      '#directory "${findlib}/lib/ocaml/${ocaml.version}/site-lib/";; #use "topfind"'
-  '';
-
-  nativeBuildInputs = [
-    ocaml
-    findlib
-    ocamlbuild
-  ];
   buildInputs = [
     mariadb
     libmysqlclient
-    camlp-streams
-    ocamlbuild
+    dune-configurator
   ];
+
   propagatedBuildInputs = [ ctypes ];
-
-  strictDeps = true;
-
-  preInstall = "mkdir -p $OCAMLFIND_DESTDIR/stublibs";
 
   meta = {
     description = "OCaml bindings for MariaDB";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bcc32 ];
-    homepage = "https://github.com/andrenth/ocaml-mariadb";
-    inherit (ocaml.meta) platforms;
-    broken = !(lib.versionAtLeast ocaml.version "4.07");
+    homepage = "https://github.com/ocaml-community/ocaml-mariadb";
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
