### PR TITLE
pcmanfm: add support for video file thumbnailing

### DIFF
--- a/pkgs/by-name/pc/pcmanfm/package.nix
+++ b/pkgs/by-name/pc/pcmanfm/package.nix
@@ -11,6 +11,7 @@
   pkg-config,
   wrapGAppsHook3,
   adwaita-icon-theme,
+  ffmpegthumbnailer,
   withGtk3 ? true,
   gtk2,
   gtk3,
@@ -48,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     pango
     adwaita-icon-theme
+    ffmpegthumbnailer
   ];
 
   env.ACLOCAL = "aclocal -I ${gettext}/share/gettext/m4";

--- a/pkgs/by-name/pc/pcmanfm/package.nix
+++ b/pkgs/by-name/pc/pcmanfm/package.nix
@@ -12,6 +12,7 @@
   wrapGAppsHook3,
   adwaita-icon-theme,
   gtk3,
+  ffmpegthumbnailer,
   gettext,
   nix-update-script,
 }:
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     pango
     adwaita-icon-theme
+    ffmpegthumbnailer
   ];
 
   env.ACLOCAL = "aclocal -I ${gettext}/share/gettext/m4";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add ffmpegthumbnailer to buildInputs for video thumbnailing support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
