### PR TITLE
s5cmd: inject version

### DIFF
--- a/pkgs/by-name/s5/s5cmd/package.nix
+++ b/pkgs/by-name/s5/s5cmd/package.nix
@@ -17,6 +17,8 @@ buildGoModule (finalAttrs: {
 
   vendorHash = null;
 
+  ldflags = [ "-X github.com/peak/s5cmd/v2/version.Version=v${finalAttrs.version}" ];
+
   # Skip e2e tests requiring network access
   excludedPackages = [ "./e2e" ];
 

--- a/pkgs/by-name/s5/s5cmd/package.nix
+++ b/pkgs/by-name/s5/s5cmd/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -24,6 +25,10 @@ buildGoModule (finalAttrs: {
 
   # Fix tests creating network sockets on macOS
   __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = [ "version" ];
 
   meta = {
     homepage = "https://github.com/peak/s5cmd";

--- a/pkgs/by-name/s5/s5cmd/package.nix
+++ b/pkgs/by-name/s5/s5cmd/package.nix
@@ -22,6 +22,9 @@ buildGoModule (finalAttrs: {
   # Skip e2e tests requiring network access
   excludedPackages = [ "./e2e" ];
 
+  # Fix tests creating network sockets on macOS
+  __darwinAllowLocalNetworking = true;
+
   meta = {
     homepage = "https://github.com/peak/s5cmd";
     description = "Parallel S3 and local filesystem execution tool";


### PR DESCRIPTION
Make sure that `s5cmd version` shows the right version, and not just `v0.0.0-dev`. Unfortunately, they also expect you to hardcode the Git commit, which we do not readily have, so we get `v2.3.0-dev` instead of the expected `v2.3.0-991c9fb` as in the upstream.

While we are here, I've also added a check that `s5cmd version` does return the right version (so if the required `ldflags` argument will change — we will catch that), and also fixed Darwin build with sandbox enabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
