### PR TITLE
lib.modules: import attrsets with `.outPath` as paths

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -420,7 +420,12 @@ let
         args: fallbackFile: fallbackKey: m:
         if isFunction m then
           unifyModuleSyntax fallbackFile fallbackKey (applyModuleArgs fallbackKey m args)
-        else if isAttrs m then
+        # If an attrset has an `outPath` member, it should be processed as a path and
+        # not a set, since that is how the nix language treats it for most purposes
+        # (concatenation, interpolation, toString, import, etc.).
+        # This allows, for example, to use derivations in imports without either
+        # turning them into a string, or explicitely using .outPath on them.
+        else if isAttrs m && !(m ? outPath) then
           if m._type or "module" == "module" then
             unifyModuleSyntax fallbackFile fallbackKey m
           else if m._type == "if" || m._type == "override" then
@@ -447,7 +452,10 @@ let
           throw "Module imports can't be nested lists. Perhaps you meant to remove one level of lists? Definitions: ${showDefs defs}"
         else
           unifyModuleSyntax (toString m) (toString m) (
-            applyModuleArgsIfFunction (toString m) (import m) args
+            # note: we specifically try `m.outPath` first, because if the attrset
+            # also has a __toString member, builtins.import will choose that instead
+            # of outPath, and that'd be pretty surprising (cf PR #509749 for discussion)
+            applyModuleArgsIfFunction (toString m) (import (m.outPath or m)) args
           );
 
       checkModule =

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -489,6 +489,12 @@ checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: 
 # Check that imports can depend on derivations
 checkConfigOutput '^true$' config.enable ./import-from-store.nix
 
+# Check that imports treat attrsets with 'outPath' as paths
+checkConfigOutput '^true$' config.enable ./import-from-drv-like.nix
+checkConfigOutput '^2$' config.foo ./import-from-drv-like.nix
+# ...and that importApply also works correctly with it
+checkConfigOutput '^"bcd"$' config.value ./importApply-from-drv-like.nix
+
 # Check that configs can be conditional on option existence
 checkConfigOutput '^true$' config.enable ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix
 checkConfigOutput '^360$' config.value ./define-option-dependently.nix ./declare-enable.nix ./declare-int-positive-value.nix

--- a/lib/tests/modules/import-from-drv-like.nix
+++ b/lib/tests/modules/import-from-drv-like.nix
@@ -1,0 +1,26 @@
+{ ... }:
+let
+  decFoo = "{ lib, ... }: { options.foo = lib.mkOption { default = 5; }; }";
+  defFoo = "{ config.foo = 2; }";
+in
+{
+  imports = [
+    # works as a path object
+    { outPath = ./declare-enable.nix; }
+    # works as a string with context
+    { outPath = "${builtins.toFile "decFoo" decFoo}"; }
+
+    # __toString doesn't override outPath in the import
+    {
+      __toString = self: ./i-dont-exist.nix;
+      outPath = ./define-enable.nix;
+    }
+
+    # other attributes in the set don't affect the import in any way
+    {
+      name = "definitions";
+      some = "description";
+      outPath = builtins.toFile "defFoo" defFoo;
+    }
+  ];
+}

--- a/lib/tests/modules/importApply-from-drv-like.nix
+++ b/lib/tests/modules/importApply-from-drv-like.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+{
+  options.value = lib.mkOption { default = 1; };
+  imports = [
+    (lib.modules.importApply { outPath = ./importApply-function.nix; } { foo = "bcd"; })
+  ];
+}


### PR DESCRIPTION
The nix language treats sets with an `outPath` member _almost_ completely as if they were actual strings/paths, including:
  - concatenation: `{ outPath = "foo"; } + "/hello"` = `foo/hello`
  - interpolation & toString: `"${{ outPath = "foo"; }}"` = `foo` and `toString { outPath = "foo"; }` = `foo`
  - import: `import { outPath = "./foo"; }` = `import "./foo"`

However, they are not _actually_ a path (according to `isPath`) and are very much attrsets (according to `isAttrs`). Since the module system, when encountering a value in `imports`, only checks for `isAttrs`, anything with `outPath` is treated as a raw module value, which is basically never what was intended.

A practical situation where this might happen is when importing from a derivation, like a pin from npins. Currently, this is not directly possible:
```nix
{ ... }:
let pins = import ./npins {}; in {
  imports = [
    # error: will be treated as a raw config, thus generating complaints
    #        about non-existent options and other misleading stuff
    pins.some-module
  ];
}
```

Instead, a user has to do one of the following:

```nix
  imports = [
    pins.some-module.outPath
    "${pins.some-module}"
    (toString pins.some-module)
    (pins.some-module + "/")
  ];
```

This PR fixes that by treating attrsets with `outPath` as if they were normal paths.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
