### PR TITLE
mas: add updateScript

### DIFF
--- a/pkgs/by-name/ma/mas/package.nix
+++ b/pkgs/by-name/ma/mas/package.nix
@@ -8,31 +8,27 @@
   testers,
   mas,
 }:
+
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mas";
   version = "6.0.1";
 
   src =
     let
-      # nix store prefetch-file https://github.com/mas-cli/mas/releases/download/v$VERSION/mas-$VERSION-$ARCH.pkg
-      sources =
-        {
-          x86_64-darwin = {
-            arch = "x86_64";
-            hash = "sha256-7+iDBr4GG5bdTuAlAmMQkEkIzVgLo2+DEdravClaLtQ=";
-          };
-          aarch64-darwin = {
-            arch = "arm64";
-            hash = "sha256-BZ9UE8H28kjqiMNdLDUUyC9madR4rBV1mLUGyj6ol3Y=";
-          };
-        }
-        .${stdenvNoCC.hostPlatform.system}
-          or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+      sources = {
+        # nix store prefetch-file https://github.com/mas-cli/mas/releases/download/v$VERSION/mas-$VERSION-$ARCH.pkg
+        x86_64-darwin = fetchurl {
+          url = "https://github.com/mas-cli/mas/releases/download/v${finalAttrs.version}/mas-${finalAttrs.version}-x86_64.pkg";
+          hash = "sha256-7+iDBr4GG5bdTuAlAmMQkEkIzVgLo2+DEdravClaLtQ=";
+        };
+        aarch64-darwin = fetchurl {
+          url = "https://github.com/mas-cli/mas/releases/download/v${finalAttrs.version}/mas-${finalAttrs.version}-arm64.pkg";
+          hash = "sha256-BZ9UE8H28kjqiMNdLDUUyC9madR4rBV1mLUGyj6ol3Y=";
+        };
+      };
     in
-    fetchurl {
-      url = "https://github.com/mas-cli/mas/releases/download/v${finalAttrs.version}/mas-${finalAttrs.version}-${sources.arch}.pkg";
-      inherit (sources) hash;
-    };
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
   nativeBuildInputs = [
     installShellFiles
@@ -65,11 +61,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
+  passthru = {
+    tests.version = testers.testVersion {
       package = mas;
       command = "mas version";
     };
+    updateScript = ./update.sh;
   };
 
   meta = {
@@ -79,6 +76,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "mas";
     maintainers = with lib.maintainers; [
       zachcoyle
+      tiferrei
     ];
     platforms = [
       "x86_64-darwin"

--- a/pkgs/by-name/ma/mas/package.nix
+++ b/pkgs/by-name/ma/mas/package.nix
@@ -9,6 +9,7 @@
   versionCheckHook,
   zsh,
 }:
+
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mas";
   version = "7.0.0";
@@ -60,6 +61,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Mac App Store command line interface";
     homepage = "https://github.com/mas-cli/mas";
@@ -67,6 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "mas";
     maintainers = with lib.maintainers; [
       zachcoyle
+      tiferrei
     ];
     platforms = [
       "aarch64-darwin"

--- a/pkgs/by-name/ma/mas/update.sh
+++ b/pkgs/by-name/ma/mas/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nurl gnused
+
+set -eu
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/package.nix"
+
+VERSION="$(curl -s https://api.github.com/repos/mas-cli/mas/releases/latest \
+  | jq -r '.tag_name | ltrimstr("v")')"
+
+fetch_hash() {
+    local arch="$1"
+    nurl --hash --expr \
+        "(import <nixpkgs> { }).fetchurl { url = \"https://github.com/mas-cli/mas/releases/download/v${VERSION}/mas-${VERSION}-${arch}.pkg\"; }"
+}
+
+replace_hash() {
+    sed -i "s|$1.pkg\"; hash = \"sha256-.\{44\}\"|$1.pkg\"; hash = \"$2\"|" "$NIX_DRV"
+}
+
+X86_HASH=$(fetch_hash "x86_64")
+ARM_HASH=$(fetch_hash "arm64")
+
+sed -i "s/version = \".*\"/version = \"$VERSION\"/" "$NIX_DRV"
+replace_hash "x86_64" "$X86_HASH"
+replace_hash "arm64" "$ARM_HASH"

--- a/pkgs/by-name/ma/mas/update.sh
+++ b/pkgs/by-name/ma/mas/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nurl gnused
+
+set -eu
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/package.nix"
+
+VERSION="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/mas-cli/mas/releases/latest \
+  | jq -r '.tag_name | ltrimstr("v")')"
+
+URL="https://github.com/mas-cli/mas/releases/download/v${VERSION}/mas-${VERSION}-arm64.pkg"
+HASH=$(nurl --hash --expr \
+    "(import <nixpkgs> { }).fetchurl { url = \"$URL\"; }")
+
+sed -i "s/version = \".*\"/version = \"$VERSION\"/" "$NIX_DRV"
+sed -i "/arm64.pkg\";/{n; s|hash = \"sha256-.\{44\}\"|hash = \"$HASH\"|}" "$NIX_DRV"


### PR DESCRIPTION
Added an updateScript to the `mas` package in the style of `1password-cli`.

Also added myself as a maintainer to be notified of automatic PRs.

Succeeds locally with:
```
Going to be running update for following packages:
 - mas-6.0.1

Press Enter key to continue...

Running update for:
Enqueuing group of 1 packages
 - mas-6.0.1: UPDATING ...
 - mas-6.0.1: DONE.

Packages updated!
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
