### PR TITLE
iprange: 1.0.4 -> 2.0.0

### DIFF
--- a/pkgs/applications/networking/firehol/iprange.nix
+++ b/pkgs/applications/networking/firehol/iprange.nix
@@ -1,23 +1,38 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  autoreconfHook,
+  fetchFromGitHub,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iprange";
-  version = "1.0.4";
+  version = "2.0.0";
 
-  src = fetchurl {
-    url = "https://github.com/firehol/iprange/releases/download/v${version}/iprange-${version}.tar.xz";
-    sha256 = "0rymw4ydn09dng34q4g5111706fyppzs2gd5br76frgvfj4x2f71";
+  src = fetchFromGitHub {
+    owner = "firehol";
+    repo = "iprange";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/rNM/5SmqpNX/yM/9EZdRYsXxgbPLp7+SL/RDtKo3+0=";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  configureFlags = [ "--disable-man" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "--version" ];
 
   meta = {
     description = "Manage IP ranges";
-    mainProgram = "iprange";
     homepage = "https://github.com/firehol/iprange";
-    license = lib.licenses.gpl2;
+    changelog = "https://github.com/firehol/iprange/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
     maintainers = [ ];
+    mainProgram = "iprange";
   };
-}
+})


### PR DESCRIPTION
https://github.com/firehol/iprange/releases/tag/v2.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
