### PR TITLE
govulncheck: 1.1.4 -> 1.2.0

### DIFF
--- a/pkgs/by-name/go/govulncheck/package.nix
+++ b/pkgs/by-name/go/govulncheck/package.nix
@@ -5,21 +5,21 @@
   replaceVars,
 }:
 
-buildGoLatestModule rec {
+buildGoLatestModule (finalAttrs: {
   pname = "govulncheck";
   version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "vuln";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-15DTxzlK7mkUt7KCwsV5+E5dPopCwFylI0fmVB0LDEo=";
   };
 
   patches = [
     # patch in version information
     (replaceVars ./version.patch {
-      inherit version;
+      inherit (finalAttrs) version;
     })
   ];
 
@@ -40,7 +40,7 @@ buildGoLatestModule rec {
   meta = {
     homepage = "https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck";
     downloadPage = "https://github.com/golang/vuln";
-    changelog = "https://github.com/golang/vuln/releases/tag/v${version}";
+    changelog = "https://github.com/golang/vuln/releases/tag/${finalAttrs.src.tag}";
     description = "Database client and tools for the Go vulnerability database, also known as vuln";
     mainProgram = "govulncheck";
     longDescription = ''
@@ -64,10 +64,10 @@ buildGoLatestModule rec {
       example, a dependency with a Windows-specific vulnerability will not be
       reported for a Linux build.
     '';
-    license = with lib.licenses; [ bsd3 ];
+    license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       jk
       SuperSandro2000
     ];
   };
-}
+})

--- a/pkgs/by-name/go/govulncheck/package.nix
+++ b/pkgs/by-name/go/govulncheck/package.nix
@@ -3,6 +3,7 @@
   buildGoLatestModule,
   fetchFromGitHub,
   replaceVars,
+  versionCheckHook,
 }:
 
 buildGoLatestModule (finalAttrs: {
@@ -36,6 +37,12 @@ buildGoLatestModule (finalAttrs: {
     "-s"
     "-w"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "--version" ];
 
   meta = {
     homepage = "https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck";

--- a/pkgs/by-name/go/govulncheck/package.nix
+++ b/pkgs/by-name/go/govulncheck/package.nix
@@ -7,13 +7,13 @@
 
 buildGoLatestModule rec {
   pname = "govulncheck";
-  version = "1.1.4";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "golang";
     repo = "vuln";
     tag = "v${version}";
-    hash = "sha256-d1JWh/K+65p0TP5vAQbSyoatjN4L5nm3VEA+qBSrkAA=";
+    hash = "sha256-15DTxzlK7mkUt7KCwsV5+E5dPopCwFylI0fmVB0LDEo=";
   };
 
   patches = [
@@ -23,7 +23,7 @@ buildGoLatestModule rec {
     })
   ];
 
-  vendorHash = "sha256-MSTKDeWVxD2Fa6fNoku4EwFwC90XZ5acnM67crcgXDg=";
+  vendorHash = "sha256-+hJtGG9GGDb3D9Cgm7hreySjOlXXsc7HxHcoS2Cxfbs=";
 
   subPackages = [
     "cmd/govulncheck"


### PR DESCRIPTION
Diff: https://github.com/golang/vuln/compare/v1.1.4...v1.2.0

Changelog: https://github.com/golang/vuln/releases/tag/v1.2.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
