### PR TITLE
prek: 0.3.8 -> 0.3.9

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.3.8";
+  version = "0.3.9";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0mddrCEGQHFm4zW5nQ7HHFK826XcYSymr9AfVd5P+eg=";
+    hash = "sha256-gfWaJxcT44+yEkZtDSQwKP1oILMUsF4apYeety+XESM=";
   };
 
-  cargoHash = "sha256-YZqIx6P2nkaKaJUW6IPboiHVDlaDvPCpLMlX0swJYyU=";
+  cargoHash = "sha256-dKSsH4IUWLdlthvAmS+MmuAVicCCKefy1D4YleRO0fI=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested via one or more NixOS test(s) if existing tests cover the changes
- [ ] Tested compilation of all pkgs that depend on this change using `nixpkgs-review` rev-by-commit
- [x] Tested execution of the binary with `nix build .#prek --no-link`
- [ ] Added or updated tests if this change requires them

## Notes

`prek` 0.3.9 was released on 2026-04-13 and includes the upstream fix to honor repo- and worktree-scoped `core.hooksPath`:

- j178/prek#1892
- release notes: https://github.com/j178/prek/releases/tag/v0.3.9

That fix is useful for downstream consumers like `devenv`, which currently need a wrapper around older `prek` behavior until nixpkgs picks up this release.
