### PR TITLE
lib/systems: fix incorrect CPU compatibility claims in isCompatible

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -449,19 +449,17 @@ rec {
       (b == armv5tel && isCompatible a armv6l)
 
       # ARMv6
-      (b == armv6l && isCompatible a armv6m)
-      (b == armv6m && isCompatible a armv7l)
+      (b == armv6m && isCompatible a armv6l)
+      (b == armv6l && isCompatible a armv7l)
 
       # ARMv7
       (b == armv7l && isCompatible a armv7a)
       (b == armv7l && isCompatible a armv7r)
-      (b == armv7l && isCompatible a armv7m)
+      (b == armv7m && isCompatible a armv7a)
+      (b == armv7m && isCompatible a armv7r)
 
       # ARMv8
-      (b == aarch64 && a == armv8a)
       (b == armv8a && isCompatible a aarch64)
-      (b == armv8r && isCompatible a armv8a)
-      (b == armv8m && isCompatible a armv8a)
 
       # PowerPC
       (b == powerpc && isCompatible a powerpc64)
@@ -471,14 +469,8 @@ rec {
       (b == mips && isCompatible a mips64)
       (b == mipsel && isCompatible a mips64el)
 
-      # RISCV
-      (b == riscv32 && isCompatible a riscv64)
-
       # SPARC
       (b == sparc && isCompatible a sparc64)
-
-      # WASM
-      (b == wasm32 && isCompatible a wasm64)
 
       # identity
       (b == a)


### PR DESCRIPTION
Fix six incorrect backward-compatibility claims in the isCompatible relation that do not reflect actual hardware/spec capabilities.

- armv6m: Reverse direction. ARMv6-M (Cortex-M0) is Thumb-only and cannot run full ARMv6 ARM-state code; armv6m code runs on armv6l. https://developer.arm.com/documentation/ddi0432/latest/programmers-model/instruction-set-summary

- armv7m: ARMv7-M (Cortex-M3/M4) is Thumb-2 only, cannot run ARM-state armv7l code. armv7a/armv7r (which have ARM-state) can run armv7m code. https://developer.arm.com/documentation/ddi0403/d/Application-Level-Architecture/The-ARMv7-M-Instruction-Set/About-the-instruction-set

- armv8m: Remove armv8m->armv8a. ARMv8-M is Thumb-only M-profile with incompatible system registers and exception model.

- aarch64<->armv8a: Remove bidirectional equivalence. AArch32 cannot execute A64 instructions. Keep one-directional aarch64->armv8a only. https://developer.arm.com/documentation/dui0801/b/BABBDFIH

- armv8r: Change armv8r->armv8a to armv8r->aarch64. The old rule let 32-bit armv8a run armv8r code, but A-profile and R-profile differ at system level (MMU vs MPU, different exception models).

- riscv32->riscv64: Remove. RV64 has no standard RV32 compat mode; identical encodings behave differently at XLEN=32 vs XLEN=64. https://docs.riscv.org/reference/isa/unpriv/rv64.html

- wasm32->wasm64: Remove. Separate spec targets with different address types (i32 vs i64); a wasm64 runtime does not accept wasm32 modules. https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/memory64/Overview.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
