### PR TITLE
nixos/recyclarr: resync on config change

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -305,6 +305,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- The [recyclarr](#opt-services.recyclarr.enable) module now automatically triggers an immediate sync when the NixOS-level configuration changes during activation instead of waiting for the next scheduled run.
+
 - [hardware.xpadneo](#opt-hardware.xpadneo.enable) now supports configuring kernel module parameters via a freeform [settings](#opt-hardware.xpadneo.settings) option, with convenience options for [rumble attenuation](#opt-hardware.xpadneo.rumbleAttenuation) and [controller quirks](#opt-hardware.xpadneo.quirks).
 
 - Wine has been updated to the 11.0 branch. Please check the [upstream announcement](https://gitlab.winehq.org/wine/wine/-/releases/wine-11.0) for more details.

--- a/nixos/modules/services/misc/recyclarr.nix
+++ b/nixos/modules/services/misc/recyclarr.nix
@@ -151,7 +151,16 @@ in
         OnCalendar = cfg.schedule;
         Persistent = true;
         RandomizedDelaySec = "5m";
+
+        # Trigger recyclarr to apply configuration changes when the
+        # timer is restarted.
+        OnActiveSec = "5s";
       };
+
+      # When the config is changed, the timer should be triggered via
+      # restarting the timer and firing OnActiveSec. This ensures that
+      # a NixOS activation will immediately enforce the new config changes.
+      unitConfig.X-ConfigHash = builtins.hashString "sha256" (builtins.toJSON cfg.configuration);
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

When an activation occurs that includes a recyclarr config change, this should translate to recylcarr actually applying that change. To do that, I used `X-ConfigHash` to hash the config, which trigger restarts, along with setting the `OnActiveSec` to 5s.

I've been running this change on my machine for a while now with no issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
