### PR TITLE
mbedtls_4: init at 4.1.0

### DIFF
--- a/pkgs/development/libraries/mbedtls/0001-fix-gcc14-build.patch
+++ b/pkgs/development/libraries/mbedtls/0001-fix-gcc14-build.patch
@@ -1,0 +1,25 @@
+From 4e49b690260e40bb16ae74a951ef3562a047cfe3 Mon Sep 17 00:00:00 2001
+From: azban <me@azban.net>
+Date: Mon, 13 Apr 2026 18:37:00 -0600
+Subject: [PATCH] fix gcc14 build
+
+---
+ core/tf_psa_crypto_common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tf-psa-crypto/core/tf_psa_crypto_common.h b/tf-psa-crypto/core/tf_psa_crypto_common.h
+index 3aaf5c983..3e485d3d4 100644
+--- a/tf-psa-crypto/core/tf_psa_crypto_common.h
++++ b/tf-psa-crypto/core/tf_psa_crypto_common.h
+@@ -242,7 +242,7 @@ static inline void mbedtls_xor(unsigned char *r,
+         uint8x16_t x = veorq_u8(v1, v2);
+         vst1q_u8(r + i, x);
+     }
+-#if defined(__IAR_SYSTEMS_ICC__)
++#if defined(__IAR_SYSTEMS_ICC__) || (defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 140100)
+     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
+      * where n is a constant multiple of 16.
+      * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
+-- 
+2.51.2
+

--- a/pkgs/development/libraries/mbedtls/4.nix
+++ b/pkgs/development/libraries/mbedtls/4.nix
@@ -1,0 +1,15 @@
+{ callPackage, fetchurl }:
+
+callPackage ./generic.nix {
+  version = "4.1.0";
+  hash = "sha256-TA1uka13So8URttw+JJVdKIL+IonkhIQSc0IfraXpIM=";
+
+  patches = [
+    # Fixes the build with GCC 14 on aarch64.
+    #
+    # See:
+    # * <https://github.com/openwrt/openwrt/pull/15479>
+    # * <https://github.com/Mbed-TLS/mbedtls/issues/9003>
+    ./0001-fix-gcc14-build.patch
+  ];
+}

--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -10,6 +10,7 @@
   ninja,
   perl, # Project uses Perl for scripting and testing
   python3,
+  python3Packages,
 
   enableThreading ? true, # Threading can be disabled to increase security https://tls.mbed.org/kb/development/thread-safety-and-multi-threading
 }:
@@ -34,6 +35,10 @@ stdenv.mkDerivation rec {
     ninja
     perl
     python3
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "4.0") [
+    python3Packages.jinja2
+    python3Packages.jsonschema
   ];
 
   strictDeps = true;
@@ -41,18 +46,27 @@ stdenv.mkDerivation rec {
   # trivialautovarinit on clang causes test failures
   hardeningDisable = lib.optional stdenv.cc.isClang "trivialautovarinit";
 
-  postConfigure = lib.optionalString enableThreading ''
-    perl scripts/config.pl set MBEDTLS_THREADING_C    # Threading abstraction layer
-    perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
-  '';
+  postConfigure =
+    lib.optionalString (enableThreading && lib.versionOlder version "4.0") ''
+      perl scripts/config.pl set MBEDTLS_THREADING_C    # Threading abstraction layer
+      perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
+    ''
+    + lib.optionalString (enableThreading && lib.versionAtLeast version "4.0") ''
+      python scripts/config.py set MBEDTLS_THREADING_C    # Threading abstraction layer
+      python scripts/config.py set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
+    '';
 
   cmakeFlags = [
     "-DUSE_SHARED_MBEDTLS_LIBRARY=${if stdenv.hostPlatform.isStatic then "off" else "on"}"
-
+  ]
+  ++ lib.optionals (lib.versionOlder version "4.0") [
     # Avoid a dependency on jsonschema and jinja2 by not generating source code
     # using python. In releases, these generated files are already present in
     # the repository and do not need to be regenerated. See:
     # https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.3.0 below "Requirement changes".
+
+    # This does not work out of the box on 4.1.0 and creates a significant amount of complexity to reproduce.
+    # Possible related issue: https://github.com/Mbed-TLS/mbedtls/issues/10678
     "-DGEN_FILES=off"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6898,6 +6898,7 @@ with pkgs;
 
   mbedtls_2 = callPackage ../development/libraries/mbedtls/2.nix { };
   mbedtls = callPackage ../development/libraries/mbedtls/3.nix { };
+  mbedtls_4 = callPackage ../development/libraries/mbedtls/4.nix { };
 
   simple-dftd3 = callPackage ../development/libraries/science/chemistry/simple-dftd3 { };
 


### PR DESCRIPTION
Resolves #458508 

I was having a hard time getting Cmake to work with `GEN_FILES=off`. I had to call a lot of manual scripts, and after 5 or 6 scripts, I gave up because it seemed like something was wrong. It seems like their release generation may not include all of the files to match the significant changes in their build process in 4.0. I gated the jinja and jsonschema deps on the version, in case that was preferred, but I also think just generating files for all versions could work as well.

I noticed that you mentioned wanting to build `tf-psa-crypto` as a separate package. This gets included as a submodule and is integrated into the Cmake process, so I don't know if that is necessary.

I also don't know if you think we should change `mbedtls` to point to 4.x or keep `mbedtls` at 3.x for now. nix-vet also is saying this should be moved to by-name, which I guess should happen as a separate cleanup before this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
