### PR TITLE
pihole-ftl: 6.4.1 -> 6.6

### DIFF
--- a/pkgs/by-name/pi/pihole-ftl/package.nix
+++ b/pkgs/by-name/pi/pihole-ftl/package.nix
@@ -5,7 +5,7 @@
   lib,
   libidn2,
   libunistring,
-  mbedtls,
+  mbedtls_4,
   ncurses,
   nettle,
   nix-update-script,
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pihole-ftl";
-  version = "6.4.1";
+  version = "6.6";
 
   src = fetchFromGitHub {
     owner = "pi-hole";
     repo = "FTL";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OpbBd+HS/gwcWNe/6VB3glout1sifJ8o5EnKuXfyZ/o=";
+    hash = "sha256-ZaGiGhROgX9Rwwbqx6sRwTnqNA4yXs+Y4QN2VF/9IsI=";
   };
 
   nativeBuildInputs = [
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     gmp
     libidn2
     libunistring
-    mbedtls
+    mbedtls_4
     ncurses
     nettle
     readline


### PR DESCRIPTION
Requires https://github.com/NixOS/nixpkgs/pull/509801

Resolves https://github.com/NixOS/nixpkgs/issues/507935
Resolves https://github.com/NixOS/nixpkgs/issues/507920
Resolves https://github.com/NixOS/nixpkgs/issues/507915
Resolves https://github.com/NixOS/nixpkgs/issues/507912
Resolves https://github.com/NixOS/nixpkgs/issues/507905
Resolves https://github.com/NixOS/nixpkgs/issues/507898


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
