### PR TITLE
calamares-nixos-extensions: quote username in users.users attribute

### DIFF
--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -247,7 +247,7 @@ cfgmisc = """  # Enable CUPS to print documents.
 
 """
 cfgusers = """  # Define a user account. Don't forget to set a password with ‘passwd’.
-  users.users.@@username@@ = {
+  users.users."@@username@@" = {
     isNormalUser = true;
     description = "@@fullname@@";
     extraGroups = [ @@groups@@ ];


### PR DESCRIPTION
The Calamares NixOS module generates a `configuration.nix` snippet of the form:

```
users.users.<username> = { ... };
```

This assumes that `<username>` is a valid unquoted Nix identifier, which isn't always the case.

For example, usernames such as `else` (a reserved keyword) cause a syntax error during installation:
```
error: syntax error, **unexpected ELSE**
```
This results in the installation process aborting.

The solution is to place the username attribute in quotes:
```
users.users."<username>" = { ... };
```
This ensures that all usernames are handled correctly by Nix.

Fixes #509356 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
