### PR TITLE
grooveauthor: 1.1.3 -> 1.1.4

### DIFF
--- a/pkgs/by-name/gr/grooveauthor/package.nix
+++ b/pkgs/by-name/gr/grooveauthor/package.nix
@@ -13,11 +13,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "grooveauthor";
-  version = "1.1.3";
+  version = "1.1.4";
 
   src = fetchzip {
     url = "https://github.com/PerryAsleep/GrooveAuthor/releases/download/v${finalAttrs.version}/GrooveAuthor-v${finalAttrs.version}-linux-x64.tar.gz";
-    hash = "sha256-XuELs7Sj/M32ros5clKxKuVo/CdCja39Lwc+zsFGvFU=";
+    hash = "sha256-LjOOI1cUbYpl4tmY1eAZV3S99yQOb4V6LU9Gu/hTtnY=";
     stripRoot = false;
   };
 
@@ -70,7 +70,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --set DOTNET_ROOT ${dotnetCorePackages.runtime_8_0}/share/dotnet
+      --set DOTNET_ROOT ${dotnetCorePackages.runtime_10_0}/share/dotnet
       --suffix LD_LIBRARY_PATH : "${
         lib.makeLibraryPath [
           alsa-lib


### PR DESCRIPTION
Requires manual update due to the .NET runtime update.

Can be tested using
```
nix run github:ungeskriptet/nixpkgs/grooveauthor#grooveauthor
```
Cc: @rehtlaw

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
