### PR TITLE
blender: reenable darwin build

### DIFF
--- a/pkgs/by-name/bl/blender/darwin.patch
+++ b/pkgs/by-name/bl/blender/darwin.patch
@@ -1,8 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0611614fe18..a6dcb2f04b6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -2567,7 +2567,7 @@ if(WITH_COMPILER_SHORT_FILE_MACRO)
+@@ -2651,7 +2651,7 @@
    )
    if(C_MACRO_PREFIX_MAP AND CXX_MACRO_PREFIX_MAP)
      if(APPLE)
@@ -12,10 +11,9 @@ index 0611614fe18..a6dcb2f04b6 100644
          # with Xcode-11 (the Clang of which doesn't support the flag).
          message(
 diff --git a/build_files/cmake/platform/platform_apple.cmake b/build_files/cmake/platform/platform_apple.cmake
-index b2db64bbd2e..aac4b552655 100644
 --- a/build_files/cmake/platform/platform_apple.cmake
 +++ b/build_files/cmake/platform/platform_apple.cmake
-@@ -55,7 +55,6 @@ if(NOT DEFINED LIBDIR)
+@@ -55,7 +55,6 @@
    endif()
  endif()
  if(NOT EXISTS "${LIBDIR}/.git")
@@ -23,7 +21,7 @@ index b2db64bbd2e..aac4b552655 100644
  endif()
  if(FIRST_RUN)
    message(STATUS "Using pre-compiled LIBDIR: ${LIBDIR}")
-@@ -121,10 +120,6 @@ if(WITH_CODEC_SNDFILE)
+@@ -115,10 +114,6 @@
    find_library(_sndfile_VORBIS_LIBRARY NAMES vorbis HINTS ${LIBDIR}/ffmpeg/lib)
    find_library(_sndfile_VORBISENC_LIBRARY NAMES vorbisenc HINTS ${LIBDIR}/ffmpeg/lib)
    list(APPEND LIBSNDFILE_LIBRARIES
@@ -34,48 +32,44 @@ index b2db64bbd2e..aac4b552655 100644
    )
  
    print_found_status("SndFile libraries" "${LIBSNDFILE_LIBRARIES}")
-@@ -168,9 +163,7 @@ if(WITH_CODEC_FFMPEG)
+@@ -169,9 +164,7 @@
    set(FFMPEG_ROOT_DIR ${LIBDIR}/ffmpeg)
    set(FFMPEG_FIND_COMPONENTS
-     avcodec avdevice avformat avutil
+     avcodec avdevice avfilter avformat avutil
 -    mp3lame ogg opus swresample swscale
 -    theora theoradec theoraenc vorbis vorbisenc
 -    vorbisfile vpx x264)
 +    swresample swscale)
+   # Frameworks required by libavfilter, using legacy macOS CGL
+   string(APPEND PLATFORM_LINKFLAGS " -framework CoreImage -framework OpenGL")
    if(EXISTS ${LIBDIR}/ffmpeg/lib/libaom.a)
-     list(APPEND FFMPEG_FIND_COMPONENTS aom)
-   endif()
-@@ -285,7 +278,6 @@ endif()
- add_bundled_libraries(boost/lib)
+@@ -250,7 +243,6 @@
+ endif()
  
  if(WITH_CODEC_FFMPEG)
 -  string(APPEND PLATFORM_LINKFLAGS " -liconv") # ffmpeg needs it !
  endif()
  
  if(WITH_PUGIXML)
-@@ -361,7 +353,7 @@ endif()
- # CMake FindOpenMP doesn't know about AppleClang before 3.12, so provide custom flags.
- if(WITH_OPENMP)
-   if(CMAKE_C_COMPILER_ID MATCHES "Clang")
--    if(${CMAKE_C_COMPILER_VERSION} VERSION_GREATER_EQUAL 17.0)
-+    if(FALSE) # clang in nix was compatible with openmp
-       if(WITH_STRICT_BUILD_OPTIONS)
-         message(SEND_ERROR "OpenMP library is not compatible with the current Clang version")
-       else()
-@@ -446,7 +438,7 @@ string(APPEND PLATFORM_LINKFLAGS
+@@ -411,12 +403,12 @@
    " -Wl,-unexported_symbols_list,'${PLATFORM_SYMBOLS_MAP}'"
  )
  
--if(${XCODE_VERSION} VERSION_GREATER_EQUAL 15.0)
+-if(${XCODE_VERSION} VERSION_EQUAL 15.0)
 +if(FALSE)
-   if("${CMAKE_OSX_ARCHITECTURES}" STREQUAL "x86_64")
+   # V4.5 specific workaround: Enforce the legacy Xcode linker to avoid incorrect
+   # assembly generation caused by known bugs in the modern linker shipped with
+   # Xcode 15.0. See issue #148792 for details.
+   string(APPEND PLATFORM_LINKFLAGS " -Wl,-ld_classic")
+-elseif(${XCODE_VERSION} VERSION_GREATER_EQUAL 15.0)
++elseif(FALSE)
+   if("${CMAKE_OSX_ARCHITECTURES}" STREQUAL "x86_64" AND WITH_LEGACY_MACOS_X64_LINKER)
      # Silence "no platform load command found in <static library>, assuming: macOS".
-     string(APPEND PLATFORM_LINKFLAGS " -Wl,-ld_classic")
+     #
 diff --git a/source/blender/blendthumb/CMakeLists.txt b/source/blender/blendthumb/CMakeLists.txt
-index 935b3f94ee1..f3d73637f71 100644
 --- a/source/blender/blendthumb/CMakeLists.txt
 +++ b/source/blender/blendthumb/CMakeLists.txt
-@@ -65,15 +65,6 @@ elseif(APPLE)
+@@ -81,16 +81,6 @@
      # Prevent Xcode from overwriting the signature.
      XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
    )
@@ -85,8 +79,9 @@ index 935b3f94ee1..f3d73637f71 100644
 -  # Command taken from XCode build process.
 -  add_custom_command(
 -    TARGET blender-thumbnailer POST_BUILD
--    COMMAND codesign --deep --force --sign - --entitlements "${CMAKE_SOURCE_DIR}/release/darwin/thumbnailer_entitlements.plist"
--    --timestamp=none $<TARGET_BUNDLE_DIR:blender-thumbnailer>
+-    COMMAND codesign --deep --force --sign -
+-      --entitlements "${CMAKE_SOURCE_DIR}/release/darwin/thumbnailer_entitlements.plist"
+-      --timestamp=none $<TARGET_BUNDLE_DIR:blender-thumbnailer>
 -  )
  elseif(UNIX)
    # -----------------------------------------------------------------------------

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -138,6 +138,9 @@ stdenv'.mkDerivation (finalAttrs: {
   # Minimal backport of hiprt 3.x support from https://projects.blender.org/blender/blender/pulls/144889
   ++ lib.optionals rocmSupport [
     ./hiprt-3-compat.patch
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    ./darwin.patch
   ];
 
   postPatch =
@@ -312,6 +315,7 @@ stdenv'.mkDerivation (finalAttrs: {
         apple-sdk_15
         brotli
         llvmPackages.openmp
+        openxr-loader
       ]
   )
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [ sse2neon ]
@@ -446,7 +450,6 @@ stdenv'.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "3D Creation/Animation/Publishing System";
     homepage = "https://www.blender.org";
     # They comment two licenses: GPLv2 and Blender License, but they


### PR DESCRIPTION
- update darwin.patch
- add openxr-loader to darwin buildInputs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
