### PR TITLE
ocamlPackages.yamlx: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/yamlx/default.nix
+++ b/pkgs/development/ocaml-modules/yamlx/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  ppx_deriving,
+  testo,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yamlx";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://github.com/mjambon/yamlx/releases/download/${finalAttrs.version}/yamlx-${finalAttrs.version}.tbz";
+    hash = "sha256-Ihar37R1dUFMXSgNGEJu5z6ysFMcrg1Hd74hNLletwE=";
+  };
+
+  propagatedBuildInputs = [ ppx_deriving ];
+
+  doCheck = true;
+  checkInputs = [ testo ];
+
+  minimalOCamlVersion = "4.14";
+
+  meta = {
+    description = "Pure-OCaml YAML 1.2 parser with a lossless, comment-preserving AST";
+    maintainers = [ lib.maintainers.vbgl ];
+    license = lib.licenses.agpl3Only;
+    homepage = "https://github.com/mjambon/yamlx";
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2285,6 +2285,8 @@ let
 
         yaml-sexp = callPackage ../development/ocaml-modules/yaml/yaml-sexp.nix { };
 
+        yamlx = callPackage ../development/ocaml-modules/yamlx { };
+
         yojson = callPackage ../development/ocaml-modules/yojson { };
 
         yojson_2 = yojson.overrideAttrs (_: {


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
