### PR TITLE
gitlab-runner: 18.9.0 -> 18.10.1

### DIFF
--- a/pkgs/by-name/gi/gitlab-runner/package.nix
+++ b/pkgs/by-name/gi/gitlab-runner/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-runner";
-  version = "18.9.0";
+  version = "18.10.1";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-U13SouwEfCVy5M8fv6rkCX0F+ecVYdsocvAdt3yxPJA=";
+    hash = "sha256-qwEzcZuyPqjuGDxNKCHc6AfBgS+Pp/PV1tK/qfofwtA=";
   };
 
-  vendorHash = "sha256-Ak1Q8FnTD8LKcN9xRc1gpcnUiambGC3CJP84cwQqTtM=";
+  vendorHash = "sha256-iO5xZAdQPmUpgUGe5CjMHOfzWVXT+eukJ/zLw5BE0NE=";
 
   # For patchShebangs
   buildInputs = [ bash ];

--- a/pkgs/by-name/gi/gitlab-runner/remove-bash-test.patch
+++ b/pkgs/by-name/gi/gitlab-runner/remove-bash-test.patch
@@ -1,8 +1,8 @@
 diff --git a/shells/bash_test.go b/shells/bash_test.go
-index bbbe949f4..955992d3f 100644
+index ff4734ede..dd68bb7f0 100644
 --- a/shells/bash_test.go
 +++ b/shells/bash_test.go
-@@ -4,11 +4,9 @@ package shells
+@@ -4,7 +4,6 @@ package shells
  
  import (
  	"path"
@@ -10,11 +10,7 @@ index bbbe949f4..955992d3f 100644
  	"testing"
  
  	"github.com/stretchr/testify/assert"
--	"github.com/stretchr/testify/require"
- 
- 	"gitlab.com/gitlab-org/gitlab-runner/common"
- 	"gitlab.com/gitlab-org/gitlab-runner/common/spec"
-@@ -78,65 +76,6 @@ func TestBash_CheckForErrors(t *testing.T) {
+@@ -78,65 +77,6 @@ func TestBash_CheckForErrors(t *testing.T) {
  	}
  }
  


### PR DESCRIPTION
Changelog: https://gitlab.com/gitlab-org/gitlab-runner/blob/v18.10.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
