### PR TITLE
lomiri-qt6.gmenuharness: init at 0.1.5

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -26,6 +26,7 @@ let
       cmake-extras = callPackage ./development/cmake-extras { };
       deviceinfo = callPackage ./development/deviceinfo { };
       geonames = callPackage ./development/geonames { };
+      gmenuharness = callPackage ./development/gmenuharness { };
       gsettings-qt = callPackage ./development/gsettings-qt { };
       lomiri-api = callPackage ./development/lomiri-api { };
       lomiri-app-launch = callPackage ./development/lomiri-app-launch { };
@@ -80,7 +81,6 @@ let
       lomiri-session = callPackage ./data/lomiri-session { };
 
       #### Development tools / libraries
-      gmenuharness = callPackage ./development/gmenuharness { };
       libusermetrics = callPackage ./development/libusermetrics { };
       qtmir = callPackage ./development/qtmir { };
       trust-store = callPackage ./development/trust-store { };

--- a/pkgs/desktops/lomiri/development/gmenuharness/1001-gmenuharness-Fix-order-of-cmake_minimum_required-and-project.patch
+++ b/pkgs/desktops/lomiri/development/gmenuharness/1001-gmenuharness-Fix-order-of-cmake_minimum_required-and-project.patch
@@ -1,0 +1,26 @@
+From 15b5a78289cbc4c0146b7e7561a3539e8cdfaa29 Mon Sep 17 00:00:00 2001
+From: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+Date: Fri, 17 Apr 2026 11:18:51 +0200
+Subject: [PATCH] CMakeLists.txt: Fix order of calling cmake_minimum_required()
+ and project().
+
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c1b3eb3..0d0f66d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,7 @@
+-project(gmenu-harness VERSION 0.1.5 LANGUAGES C CXX)
+ cmake_minimum_required(VERSION 3.10)
+ 
++project(gmenu-harness VERSION 0.1.5 LANGUAGES C CXX)
++
+ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
+ find_package(PkgConfig REQUIRED)
+ include(GNUInstallDirs)
+-- 
+GitLab
+

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -16,6 +16,9 @@
   qtbase,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmenuharness";
   version = "0.1.5";
@@ -43,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     cmake-extras
     glib
     lomiri-api
-    qtbase
   ];
 
   nativeCheckInputs = [
@@ -54,10 +56,14 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [
     gtest
     libqtdbustest
+    qtbase
   ];
 
   cmakeFlags = [
-    "-Denable_tests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
+    (lib.strings.cmakeBool "enable_tests" finalAttrs.finalPackage.doCheck)
+  ]
+  ++ lib.optionals finalAttrs.finalPackage.doCheck [
+    (lib.strings.cmakeBool "ENABLE_QT6" withQt6)
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/desktops/lomiri/development/gmenuharness/default.nix
+++ b/pkgs/desktops/lomiri/development/gmenuharness/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   cmake,
@@ -19,35 +18,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gmenuharness";
-  version = "0.1.4";
+  version = "0.1.5";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/gmenuharness";
     rev = finalAttrs.version;
-    hash = "sha256-MswB8cQvz3JvcJL2zj7szUOBzKRjxzJO7/x+87m7E7c=";
+    hash = "sha256-hPlCetQ+2gmRdOoVQg7dIndiTxPEKgf8JJtZlihyIYA=";
   };
 
   patches = [
-    # Remove when version > 0.1.4
-    (fetchpatch {
-      name = "0001-gmenuharness-Rename-type-attribute-from-x-canonical-type-to-x-lomiri-type.patch";
-      url = "https://gitlab.com/ubports/development/core/gmenuharness/-/commit/70e9ed85792a6ac1950faaf26391ce91e69486ab.patch";
-      hash = "sha256-jeue0qrl2JZCt/Yfj4jT210wsF/E+MlbtNT/yFTcw5I=";
-    })
-    (fetchpatch {
-      name = "0002-gmenuharness-CMakeLists.txt-Bump-cmake_minimum_required-to-version-3.10.patch";
-      url = "https://gitlab.com/ubports/development/core/gmenuharness/-/commit/42d04e0d484b3715e7b9935e3ef3e2fa6c33b409.patch";
-      hash = "sha256-Gyk8TxIfEWsqL9CGymmnVA/Xj4/+J1PRNmWikNEcRJ8=";
-    })
+    # Remove when https://gitlab.com/ubports/development/core/gmenuharness/-/merge_requests/10 merged & in release
+    ./1001-gmenuharness-Fix-order-of-cmake_minimum_required-and-project.patch
   ];
-
-  postPatch = ''
-    # GTest needs C++17
-    # Remove when https://gitlab.com/ubports/development/core/gmenuharness/-/merge_requests/5 merged & in release
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'std=c++14' 'std=c++17'
-  '';
 
   strictDeps = true;
 


### PR DESCRIPTION
Output is effectively the same as `lomiri.gmenuharness`, the only difference is which Qt libraries get used in the tests. But alas, it's still a difference.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
