### PR TITLE
regreet: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/re/regreet/package.nix
+++ b/pkgs/by-name/re/regreet/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   pkg-config,
   wrapGAppsHook4,
+  accountsservice,
+  dbus,
   glib,
   gtk4,
   pango,
@@ -13,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "regreet";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "rharish101";
     repo = "ReGreet";
     rev = finalAttrs.version;
-    hash = "sha256-f8Xvno5QqmWz4SUiFYDvs8lFU1ZaqQ8gpTaVzWxW4T8=";
+    hash = "sha256-2yA+LJmF99PJZbOVib3XCjsU95ZwKlXC2PofODFxbf8=";
   };
 
-  cargoHash = "sha256-abCQ3RsnZ/a1DbjQFOiA7Xs7bbqSJxwNps8yV6Q4FIw=";
+  cargoHash = "sha256-BlN63s09uSqYtQdV10VVTngqybfUEdgvsPlplM9PlD0=";
 
   buildFeatures = [ "gtk4_8" ];
 
@@ -31,6 +33,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapGAppsHook4
   ];
   buildInputs = [
+    accountsservice
+    dbus
     glib
     gtk4
     pango


### PR DESCRIPTION
Supersedes #509828, as new dependencies were added.

[ReGreet 0.3.0](https://github.com/rharish101/ReGreet/releases/tag/0.3.0)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
