### PR TITLE
nixos/flood: add `AF_NETLINK` to `RestrictedAddressFamilies`

### DIFF
--- a/nixos/modules/services/torrent/flood.nix
+++ b/nixos/modules/services/torrent/flood.nix
@@ -80,6 +80,7 @@ in
           "AF_UNIX"
           "AF_INET"
           "AF_INET6"
+          "AF_NETLINK"
         ];
         RestrictNamespaces = true;
         RestrictRealtime = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This resolves the following error that is present without `AF_NETLINK` in `RestrictedAddressFamilies`:

```
Apr 14 18:37:16 media systemd[1]: flood.service: Failed with result 'exit-code'.
Apr 14 18:37:16 media systemd[1]: flood.service: Main process exited, code=exited, status=1/FAILURE
Apr 14 18:37:16 media flood[170990]: Node.js v24.14.0
Apr 14 18:37:16 media flood[170990]: }
Apr 14 18:37:16 media flood[170990]:   syscall: [Getter/Setter]
Apr 14 18:37:16 media flood[170990]:   errno: [Getter/Setter],
Apr 14 18:37:16 media flood[170990]:   },
Apr 14 18:37:16 media flood[170990]:     syscall: 'uv_interface_addresses'
Apr 14 18:37:16 media flood[170990]:     message: 'Unknown system error 97',
Apr 14 18:37:16 media flood[170990]:     code: 'Unknown system error 97',
Apr 14 18:37:16 media flood[170990]:     errno: 97,
Apr 14 18:37:16 media flood[170990]:   info: {
Apr 14 18:37:16 media flood[170990]:   code: 'ERR_SYSTEM_ERROR',
Apr 14 18:37:16 media flood[170990]:     at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
Apr 14 18:37:16 media flood[170990]:     at emitListeningNT (node:net:1991:10)
Apr 14 18:37:16 media flood[170990]:     at Server.emit (node:events:520:35)
Apr 14 18:37:16 media flood[170990]:     at Object.onceWrapper (node:events:622:28)
Apr 14 18:37:16 media flood[170990]:     at Server.listeningEventHandler (/nix/store/imvay9sax2z0xxs6h0bsx8433b618cv3-flood-4.13.0/lib/node_modules/flood/dist/index.js:44264:36)
Apr 14 18:37:16 media flood[170990]:     at Object.logServerAddress (/nix/store/imvay9sax2z0xxs6h0bsx8433b618cv3-flood-4.13.0/lib/node_modules/flood/dist/index.js:44322:23)
Apr 14 18:37:16 media flood[170990]:     at getAddresses (/nix/store/imvay9sax2z0xxs6h0bsx8433b618cv3-flood-4.13.0/lib/node_modules/flood/dist/index.js:44307:34)
Apr 14 18:37:16 media flood[170990]:     at Object.networkInterfaces (node:os:218:16)
Apr 14 18:37:16 media flood[170990]: SystemError [ERR_SYSTEM_ERROR]: A system error occurred: uv_interface_addresses returned Unknown system error 97 (Unknown system error 97)
Apr 14 18:37:16 media flood[170990]:       ^
Apr 14 18:37:16 media flood[170990]:       throw error;
Apr 14 18:37:16 media flood[170990]: node:internal/errors:542
```

This failure likely happens because the application is calling Node's `os.networkInterfaces` which calls libuv `uv_interface_addresses()` (I think), followed by a call to glibc's `getifaddrs` and then creates a socket with AF_NETLINK set via `__netlink_open` [Reference](https://sourceware.org/git/?p=glibc.git&a=blob&f=sysdeps/unix/sysv/linux/ifaddrs.c&hb=HEAD) 

## Things  done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
