### PR TITLE
nixos/test-driver: use log levels

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -2207,6 +2207,9 @@
   "test-opt-interactive": [
     "index.html#test-opt-interactive"
   ],
+  "test-opt-logLevel": [
+    "index.html#test-opt-logLevel"
+  ],
   "test-opt-meta": [
     "index.html#test-opt-meta"
   ],

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -12,6 +12,7 @@ from test_driver.driver import Driver
 from test_driver.logger import (
     CompositeLogger,
     JunitXMLLogger,
+    LogLevel,
     TerminalLogger,
     XMLLogger,
 )
@@ -151,6 +152,15 @@ def main() -> None:
         help="indicates that the interactive SSH backdoor is active and dumps information about it on start",
         type=int,
     )
+    log_level_map = {level.name.lower(): level for level in LogLevel}
+    arg_parser.add_argument(
+        "--log-level",
+        metavar="LOG_LEVEL",
+        action=EnvDefault,
+        envvar="logLevel",
+        choices=log_level_map,
+        help="Set the log level",
+    )
 
     args = arg_parser.parse_args()
 
@@ -168,6 +178,9 @@ def main() -> None:
 
     if args.junit_xml:
         logger.add_logger(JunitXMLLogger(output_directory / args.junit_xml))
+
+    if args.log_level:
+        logger.set_log_level(log_level_map[args.log_level])
 
     if not args.keep_machine_state:
         logger.info(

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -7,6 +7,7 @@ import unicodedata
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
+from enum import IntEnum
 from pathlib import Path
 from queue import Empty, Queue
 from typing import Any
@@ -15,6 +16,12 @@ from xml.sax.xmlreader import AttributesImpl
 
 from colorama import Fore, Style
 from junit_xml import TestCase, TestSuite
+
+
+class LogLevel(IntEnum):
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
 
 
 class AbstractLogger(ABC):
@@ -56,6 +63,10 @@ class AbstractLogger(ABC):
     def print_serial_logs(self, enable: bool) -> None:
         pass
 
+    @abstractmethod
+    def set_log_level(self, level: LogLevel) -> None:
+        pass
+
 
 class JunitXMLLogger(AbstractLogger):
     class TestCaseState:
@@ -71,6 +82,7 @@ class JunitXMLLogger(AbstractLogger):
         self.currentSubtest = "main"
         self.outfile: Path = outfile
         self._print_serial_logs = True
+        self._log_level = LogLevel.INFO
         atexit.register(self.close)
 
     def log(self, message: str, attributes: dict[str, str] = {}) -> None:
@@ -92,10 +104,12 @@ class JunitXMLLogger(AbstractLogger):
         yield
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
-        self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+        if self._log_level <= LogLevel.INFO:
+            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def warning(self, *args, **kwargs) -> None:  # type: ignore
-        self.tests[self.currentSubtest].stdout += args[0] + os.linesep
+        if self._log_level <= LogLevel.WARNING:
+            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
 
     def error(self, *args, **kwargs) -> None:  # type: ignore
         self.tests[self.currentSubtest].stderr += args[0] + os.linesep
@@ -112,6 +126,9 @@ class JunitXMLLogger(AbstractLogger):
 
     def print_serial_logs(self, enable: bool) -> None:
         self._print_serial_logs = enable
+
+    def set_log_level(self, level: LogLevel) -> None:
+        self._log_level = level
 
     def close(self) -> None:
         with open(self.outfile, "w") as f:
@@ -180,10 +197,15 @@ class CompositeLogger(AbstractLogger):
         for logger in self.logger_list:
             logger.log_serial(message, machine)
 
+    def set_log_level(self, level: LogLevel) -> None:
+        for logger in self.logger_list:
+            logger.set_log_level(level)
+
 
 class TerminalLogger(AbstractLogger):
     def __init__(self) -> None:
         self._print_serial_logs = True
+        self._log_level = LogLevel.INFO
 
     def maybe_prefix(self, message: str, attributes: dict[str, str]) -> str:
         if "machine" in attributes:
@@ -216,16 +238,21 @@ class TerminalLogger(AbstractLogger):
         self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)", attributes)
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.INFO:
+            self.log(*args, **kwargs)
 
     def warning(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.WARNING:
+            self.log(*args, **kwargs)
 
     def error(self, *args, **kwargs) -> None:  # type: ignore
         self.log(*args, **kwargs)
 
     def print_serial_logs(self, enable: bool) -> None:
         self._print_serial_logs = enable
+
+    def set_log_level(self, level: LogLevel) -> None:
+        self._log_level = level
 
     def log_serial(self, message: str, machine: str) -> None:
         if not self._print_serial_logs:
@@ -246,6 +273,7 @@ class XMLLogger(AbstractLogger):
         self.queue: Queue[dict[str, str]] = Queue()
 
         self._print_serial_logs = True
+        self._log_level = LogLevel.INFO
 
         self.xml.startDocument()
         self.xml.startElement("logfile", attrs=AttributesImpl({}))
@@ -269,10 +297,12 @@ class XMLLogger(AbstractLogger):
         self.xml.endElement("line")
 
     def info(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.INFO:
+            self.log(*args, **kwargs)
 
     def warning(self, *args, **kwargs) -> None:  # type: ignore
-        self.log(*args, **kwargs)
+        if self._log_level <= LogLevel.WARNING:
+            self.log(*args, **kwargs)
 
     def error(self, *args, **kwargs) -> None:  # type: ignore
         self.log(*args, **kwargs)
@@ -286,6 +316,9 @@ class XMLLogger(AbstractLogger):
 
     def print_serial_logs(self, enable: bool) -> None:
         self._print_serial_logs = enable
+
+    def set_log_level(self, level: LogLevel) -> None:
+        self._log_level = level
 
     def log_serial(self, message: str, machine: str) -> None:
         if not self._print_serial_logs:

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -119,6 +119,7 @@ let
           --set testScript "$out/test-script" \
           --set globalTimeout "${toString config.globalTimeout}" \
           --set vlans '${toString vlans}' \
+          --set logLevel "${config.logLevel}" \
           ${lib.escapeShellArgs (
             lib.concatMap (arg: [
               "--add-flags"
@@ -218,6 +219,17 @@ in
 
         This may speed up your iteration cycle, unless you're working on the [{option}`testScript`](#test-opt-testScript).
       '';
+    };
+
+    logLevel = mkOption {
+      description = "Log level for the test driver.";
+      type = types.enum [
+        "info"
+        "warning"
+        "error"
+      ];
+      default = "info";
+      example = "warning";
     };
   };
 


### PR DESCRIPTION
Retrying https://github.com/NixOS/nixpkgs/pull/491742. This time with a fix to the manual.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
