### PR TITLE
dealers-choice: init at 0.0.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1822,6 +1822,13 @@
     github = "Andy3153";
     githubId = 53472302;
   };
+  andy5995 = {
+    name = "Andy Alt";
+    github = "andy5995";
+    githubId = 16764864;
+    email = "arch_stanton5995@proton.me";
+    keys = [ { fingerprint = "9CC2 4CAA 69F6 A6DA 3EBC  F9C1 F8E7 8111 BE2B 398B"; } ];
+  };
   andys8 = {
     github = "andys8";
     githubId = 13085980;

--- a/pkgs/by-name/de/dealers-choice/package.nix
+++ b/pkgs/by-name/de/dealers-choice/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  testers,
+  meson,
+  ninja,
+  pkg-config,
+  gettext,
+  canfigger,
+  SDL2,
+  SDL2_ttf,
+  SDL2_image,
+  SDL2_net,
+  protobufc,
+  libsodium,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dealers-choice";
+  version = "0.0.13";
+
+  src = fetchurl {
+    url = "https://github.com/Dealer-s-Choice/${finalAttrs.pname}/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
+    hash = "sha256-rZ+Sfu558CZPs9maJY3A43e6QVB9Z5BmEQ44i+jf2Ng=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    canfigger
+    SDL2
+    SDL2_ttf
+    SDL2_image
+    SDL2_net
+    protobufc
+    libsodium
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin gettext;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Online Multiplayer Stud and Draw Poker, Texas Hold'em and Omaha";
+    homepage = "https://dealer-s-choice.github.io/";
+    changelog = "https://github.com/Dealer-s-Choice/${finalAttrs.pname}/blob/v${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.all;
+    mainProgram = finalAttrs.pname;
+  };
+})

--- a/pkgs/by-name/de/dealers-choice/package.nix
+++ b/pkgs/by-name/de/dealers-choice/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  testers,
+  meson,
+  ninja,
+  pkg-config,
+  gettext,
+  canfigger,
+  pcg_c,
+  SDL2,
+  SDL2_ttf,
+  SDL2_image,
+  protobufc,
+  libsodium,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dealers-choice";
+  version = "0.0.15";
+
+  src = fetchFromGitHub {
+    owner = "Dealer-s-Choice";
+    repo = "dealers-choice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2x/nm6NTnQ6tVbQPJOJs+GIwa4Xh2n/e3Kwu0PaBy/Y=";
+    fetchSubmodules = false;
+  };
+
+  postPatch = ''
+    substituteInPlace src/graphics.h \
+      --replace-fail '#include <SDL_image.h>' '#include <SDL2/SDL_image.h>'
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    canfigger
+    pcg_c
+    SDL2
+    SDL2_ttf
+    SDL2_image
+    protobufc
+    libsodium
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin gettext;
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Online Multiplayer Stud and Draw Poker, Texas Hold'em and Omaha";
+    homepage = "https://dealer-s-choice.github.io/";
+    changelog = "https://github.com/Dealer-s-Choice/dealers-choice/blob/v${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ andy5995 ];
+    platforms = lib.platforms.all;
+    mainProgram = "dealers-choice";
+  };
+})


### PR DESCRIPTION
[Dealer's Choice](https://github.com/Dealer-s-Choice/dealers-choice) is a cross-platform, networked multiplayer poker game supporting draw, stud, and community-card variants, including Texas Hold'em and Omaha, with optional wild cards. The deal rotates around the table, and the dealer chooses the game before each hand.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test