### PR TITLE
motivewave: init at 7.0.22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11913,6 +11913,11 @@
     githubId = 7005773;
     keys = [ { fingerprint = "B982 0250 1720 D540 6A18  2DA8 188E 4945 E85B 2D21"; } ];
   };
+  jakehpark = {
+    name = "Jake Park";
+    github = "JakeHPark";
+    githubId = 268660459;
+  };
   jakeisnt = {
     name = "Jacob Chvatal";
     email = "jake@isnt.online";

--- a/pkgs/by-name/mo/motivewave/package.nix
+++ b/pkgs/by-name/mo/motivewave/package.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeDesktopItem,
+  copyDesktopItems,
+  makeWrapper,
+  alsa-lib,
+  atk,
+  bc,
+  cairo,
+  ffmpeg,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  harfbuzz,
+  libGL,
+  libx11,
+  libxext,
+  libxi,
+  libxrender,
+  libxtst,
+  libxxf86vm,
+  libz,
+  pango,
+  xrandr,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "motivewave";
+  version = "7.0.22";
+
+  buildNumber = "636";
+
+  src = fetchurl {
+    url = "https://downloads.motivewave.com/builds/${finalAttrs.buildNumber}/motivewave_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-PZ94CSKn99LiIntt5hyPfxRNVUMVE8GHfuEml2oAr2M=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    copyDesktopItems
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc
+    alsa-lib
+    atk
+    cairo
+    ffmpeg
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    harfbuzz
+    libGL
+    libx11
+    libxext
+    libxi
+    libxrender
+    libxtst
+    libxxf86vm
+    libz
+    pango
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libavcodec*.so.*"
+    "libavformat*.so.*"
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "motivewave";
+      desktopName = "MotiveWave";
+      exec = "motivewave";
+      icon = "motivewave";
+      type = "Application";
+      genericName = "Trading/Charting Software";
+      comment = "Advanced trading and charting application";
+      categories = [
+        "Office"
+        "Finance"
+      ];
+      keywords = [
+        "Trading"
+        "Charting"
+      ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mv usr/share/motivewave/icons usr/share/icons
+    mkdir -p usr/share/icons/hicolor/256x256/apps
+    mv usr/share/icons/mwave_256x256.png usr/share/icons/hicolor/256x256/apps/motivewave.png
+    rm usr/share/applications/motivewave.desktop
+
+    substituteInPlace usr/share/motivewave/run.sh \
+      --replace-fail /usr/share/motivewave $out/share/motivewave
+
+    mkdir -p $out/bin
+    mv usr/share $out
+
+    # Setting GDK_CORE_DEVICE_EVENTS is necessary to fix the scroll wheel in JavaFX.
+    # See: https://stackoverflow.com/a/77535959
+    makeWrapper $out/share/motivewave/run.sh $out/bin/motivewave \
+      --set GDK_CORE_DEVICE_EVENTS 1 \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bc
+          xrandr
+        ]
+      } \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Advanced trading and charting application";
+    homepage = "https://www.motivewave.com/";
+    license = with lib.licenses; [ unfree ];
+    maintainers = with lib.maintainers; [ jakehpark ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "motivewave";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/mo/motivewave/update.sh
+++ b/pkgs/by-name/mo/motivewave/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I bash -p curl common-updater-scripts
+
+set -euo pipefail
+
+file="$(dirname "${BASH_SOURCE[0]}")/package.nix"
+
+# Should return a URL in this format:
+# https://downloads.motivewave.com/builds/buildNumber/motivewave_version_amd64.deb
+redirected="$(
+  curl -fsSLI -o /dev/null -w '%{url_effective}' "https://www.motivewave.com/update/download.do?file_type=LINUX"
+)"
+build_number="$(sed -nE 's#^.*/builds/([0-9]+)/.*#\1#p' <<<"$redirected")"
+version="$(sed -nE 's#^.*/motivewave_([0-9.]+)_amd64\.deb#\1#p' <<<"$redirected")"
+
+if [[ -z "$build_number" || -z "$version" ]]; then
+  echo "Failed to parse URL: $redirected" >&2
+  exit 1
+fi
+
+tmp="$(mktemp)"
+sed -E \
+  -e "s/buildNumber = \".*\";/buildNumber = \"$build_number\";/" \
+  "$file" > "$tmp"
+mv "$tmp" "$file"
+update-source-version motivewave "$version"


### PR DESCRIPTION
[MotiveWave](https://www.motivewave.com/)'s trading software is broker-neutral and equips active and professional traders with a leading edge trading platform for analysis of stocks, equities, futures and forex and many other financial instruments.

<img width="2063" height="1175" alt="image" src="https://github.com/user-attachments/assets/7614b847-dc27-46bd-ac0c-80e3c80a9fc2" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
