### PR TITLE
zotero: 8.0.5 -> 9.0.0

### DIFF
--- a/pkgs/by-name/zo/zotero/js-build-fixes.patch
+++ b/pkgs/by-name/zo/zotero/js-build-fixes.patch
@@ -27,16 +27,18 @@ index b820304f3a..aafb6b1ef5 100644
  		}
  		signatures['pdf-worker'] = { hash };
 diff --git a/js-build/reader.js b/js-build/reader.js
-index 67a02a3ad2..5de2f3ada8 100644
+index 12b5df6a92..20c3f20a57 100644
 --- a/js-build/reader.js
 +++ b/js-build/reader.js
-@@ -36,9 +36,6 @@ async function getReader(signatures) {
+@@ -36,11 +36,6 @@ async function getReader(signatures) {
  			await fs.remove(path.join(targetDir, 'zotero'));
  		}
  		catch (e) {
--			console.error(e);
+-			if (!e.message?.includes('The requested URL returned error: 403')) {
+-				console.error(e);
+-			}
 -			await exec('npm ci', { cwd: modulePath });
--			await exec('npm run build', { cwd: modulePath });
- 			await fs.copy(path.join(modulePath, 'build', 'zotero'), targetDir);
- 		}
- 		signatures['reader'] = { hash };
+-			await exec('npm run build:zotero', { cwd: modulePath });
+ 			if (!fs.pathExists(path.join(modulePath, 'build', 'zotero', 'pdf', 'build', 'pdf.mjs'))) {
+ 				throw new Error('pdf.js build failed to produce output');
+ 			}

--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -16,6 +16,7 @@
   copyDesktopItems,
   libGL,
   pciutils,
+  speechd-minimal,
   wrapGAppsHook3,
   nix-update-script,
   xvfb-run,
@@ -27,14 +28,14 @@ let
   nodejs = nodejs_22;
 
   pname = "zotero";
-  version = "8.0.5";
+  version = "9.0.0";
 
   src = fetchFromGitHub {
     owner = "zotero";
     repo = "zotero";
     tag = version;
-    hash = "sha256-Amk2ehdzrQjFhx1eEHcnq+Z+un+2bT/u4kpbWqD5Sbc=";
     fetchSubmodules = true;
+    hash = "sha256-70kVFnypdF3YDXfrA+BFSoGkBfQAjDVa2pWOmaoetBI=";
   };
 
   pdf-js = buildNpmPackage {
@@ -88,8 +89,11 @@ let
     pname = "zotero-pdf-reader";
     inherit version nodejs;
     src = "${src}/reader";
-    npmDepsHash = "sha256-p8O2gIF0S7QO0AR9TPPQsWUtRnKnf58zSl3JZN0lnuc=";
-    patches = [ ./pdf-reader-locales.patch ];
+    npmDepsHash = "sha256-8marAeBAW5cKDaJT3xbVsXyVfGa5ehZYUYijDzFng38=";
+    patches = [
+      ./pdf-reader-locales.patch
+      ./pdf-reader-build-fix.patch
+    ];
     postPatch = ''
       rm -rf pdfjs/pdf.js
       cp -r ${pdf-js} pdfjs/pdf.js
@@ -102,6 +106,7 @@ let
       mkdir -p locales/en-US/
       cp -r ${src}/chrome/locale/en-US/zotero/* locales/en-US/
     '';
+    npmBuildScript = "build:zotero";
     installPhase = ''
       runHook preInstall
 
@@ -208,12 +213,11 @@ buildNpmPackage (finalAttrs: {
     # Skip some flaky/failing tests
     rm test/tests/retractionsTest.js
     for test in \
-      "should throw error on broken symlink" \
       "should use BrowserDownload for 403 when enforcing file type" \
       "should use BrowserDownload for a JS redirect page" \
-      "should keep attachments pane status after changing selection" \
-      "should render preview robustly after making dense calls to render and discard" \
-      "should discard attachment pane preview after becoming invisible" \
+      "should throw error on broken symlink" \
+      "should switch dialog from add note to add/edit citation" \
+      "should vacuum the database with force option" \
     ; do
       sed -i "s|it(\"$test|it.skip(\"$test|" test/tests/*.js
     done
@@ -312,6 +316,7 @@ buildNpmPackage (finalAttrs: {
       lib.makeLibraryPath [
         libGL
         pciutils
+        speechd-minimal
       ]
     })
   '';

--- a/pkgs/by-name/zo/zotero/pdf-reader-build-fix.patch
+++ b/pkgs/by-name/zo/zotero/pdf-reader-build-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/pdfjs/build b/pdfjs/build
+index abd34be..509932f 100755
+--- a/pdfjs/build
++++ b/pdfjs/build
+@@ -14,7 +14,6 @@ BUILD_BASE=./build
+ 
+ # Move into the PDF.js directory, install dependencies, and build
+ pushd pdfjs/pdf.js
+-npm ci
+ if [[ $PDFJS_CONFIG != "web" ]]; then
+ 	npx gulp generic
+ fi


### PR DESCRIPTION
Announcement upstream: https://www.zotero.org/blog/zotero-9/
For the new "read aloud" feature, speechd is required. And besides some build changes, the checks were adapted.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
