### PR TITLE
postgresql: simplify postgresqlWithPackages function

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -159,6 +159,61 @@ let
 
       dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
 
+      postgresqlWithPackages =
+        postgresql: f:
+        let
+          installedExtensions = f postgresql.pkgs;
+          recurse = postgresqlWithPackages postgresql;
+          finalPackage = buildEnv {
+            pname = "${postgresql.pname}-and-plugins";
+            inherit (postgresql) version;
+            paths = installedExtensions ++ [
+              # consider keeping in-sync with `postBuild` below
+              postgresql
+              postgresql.man # in case user installs this into environment
+            ];
+
+            pathsToLink = [
+              "/"
+              "/bin"
+              "/share/postgresql/extension"
+              # Unbreaks Omnigres' build system
+              "/share/postgresql/timezonesets"
+              "/share/postgresql/tsearch_data"
+            ];
+
+            nativeBuildInputs = [ makeBinaryWrapper ];
+            postBuild =
+              let
+                args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+              in
+              ''
+                wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+              '';
+
+            passthru = {
+              inherit installedExtensions;
+              inherit (postgresql)
+                pkgs
+                psqlSchema
+                ;
+
+              pg_config = postgresql.pg_config.override {
+                outputs = {
+                  out = finalPackage;
+                  man = finalPackage;
+                };
+              };
+
+              withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
+              withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
+
+              withPackages = f': recurse (ps: installedExtensions ++ f' ps);
+            };
+          };
+        in
+        finalPackage;
+
       stdenv' =
         if !stdenv.cc.isClang then
           overrideCC llvmPackages.stdenv (
@@ -585,10 +640,7 @@ let
             in
             import ./ext.nix newSelf newSuper;
 
-          withPackages = postgresqlWithPackages {
-            inherit buildEnv lib makeBinaryWrapper;
-            postgresql = this;
-          };
+          withPackages = postgresqlWithPackages this;
 
           pg_config = buildPackages.callPackage ./pg_config.nix {
             inherit (finalAttrs) finalPackage;
@@ -640,74 +692,6 @@ let
         broken = jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform;
       };
     });
-
-  postgresqlWithPackages =
-    {
-      postgresql,
-      buildEnv,
-      lib,
-      makeBinaryWrapper,
-    }:
-    f:
-    let
-      installedExtensions = f postgresql.pkgs;
-      recurse = postgresqlWithPackages {
-        inherit
-          buildEnv
-          lib
-          makeBinaryWrapper
-          postgresql
-          ;
-      };
-      finalPackage = buildEnv {
-        pname = "${postgresql.pname}-and-plugins";
-        inherit (postgresql) version;
-        paths = installedExtensions ++ [
-          # consider keeping in-sync with `postBuild` below
-          postgresql
-          postgresql.man # in case user installs this into environment
-        ];
-
-        pathsToLink = [
-          "/"
-          "/bin"
-          "/share/postgresql/extension"
-          # Unbreaks Omnigres' build system
-          "/share/postgresql/timezonesets"
-          "/share/postgresql/tsearch_data"
-        ];
-
-        nativeBuildInputs = [ makeBinaryWrapper ];
-        postBuild =
-          let
-            args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-          in
-          ''
-            wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
-          '';
-
-        passthru = {
-          inherit installedExtensions;
-          inherit (postgresql)
-            pkgs
-            psqlSchema
-            ;
-
-          pg_config = postgresql.pg_config.override {
-            outputs = {
-              out = finalPackage;
-              man = finalPackage;
-            };
-          };
-
-          withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
-          withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
-
-          withPackages = f': recurse (ps: installedExtensions ++ f' ps);
-        };
-      };
-    in
-    finalPackage;
 
 in
 # passed by <major>.nix


### PR DESCRIPTION
This PR simplifies `postgresqlWithPackages`. 

Previously:
```nix
  postgresqlWithPackages =
    {
      postgresql,
      buildEnv,
      lib,
      makeBinaryWrapper,
    }:
    f:
```

New:

```nix
      postgresqlWithPackages =
        postgresql:
        f:
```

This is achieved just by moving the declaration of `postgresqlWithPackages` into `generic` where all the other former inputs of the function are already declared.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
