### PR TITLE
oauth2-proxy: 7.15.1 -> 7.15.2

### DIFF
--- a/pkgs/by-name/oa/oauth2-proxy/package.nix
+++ b/pkgs/by-name/oa/oauth2-proxy/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "oauth2-proxy";
-  version = "7.15.1";
+  version = "7.15.2";
 
   src = fetchFromGitHub {
     repo = "oauth2-proxy";
     owner = "oauth2-proxy";
-    sha256 = "sha256-4PuyX+BbaL1q66LVtLADkOFj1oq49sERmz0igtyOKB8=";
+    sha256 = "sha256-qhWU6i57WS8TWJ5ggzwmeoIv0osQjA9wdwqnvxMddrc=";
     rev = "v${version}";
   };
 
-  vendorHash = "sha256-PB0x4tRBx6U5ZulFYD16AdH2kHCfse8BEJXuiQCFq3I=";
+  vendorHash = "sha256-Iu1dm0f3eYJpr9eR8RL7wAV8UGwpOway0aP8r5wci0M=";
 
   # Taken from https://github.com/oauth2-proxy/oauth2-proxy/blob/master/Makefile
   ldflags = [ "-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v${version}" ];


### PR DESCRIPTION
Diff: https://github.com/oauth2-proxy/oauth2-proxy/compare/v7.15.1...v7.15.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
