### PR TITLE
coqPackages.jasmin: 2025.06.1 → 2026.03.1

### DIFF
--- a/pkgs/development/coq-modules/jasmin/default.nix
+++ b/pkgs/development/coq-modules/jasmin/default.nix
@@ -16,29 +16,24 @@
   inherit version;
   defaultVersion =
     let
-      case = coq: mc: out: {
-        cases = [
-          coq
-          mc
-        ];
-        inherit out;
-      };
+      case = case: out: { inherit case out; };
     in
     with lib.versions;
-    lib.switch
-      [ coq.coq-version mathcomp.version ]
-      [
-        (case (range "8.20" "9.1") (range "2.2" "2.4") "2025.06.1")
-        (case (range "8.19" "9.1") (range "2.2" "2.4") "2025.02.1")
-        (case (isEq "8.18") (isEq "2.2") "2024.07.2")
-      ]
-      null;
+    lib.switch coq.coq-version [
+      (case (range "8.20" "9.1") "2026.03.1")
+      (case (isEq "8.19") "2025.02.2")
+      (case (isEq "8.18") "2024.07.4")
+    ] null;
   releaseRev = v: "v${v}";
 
+  release."2026.03.1".hash = "sha256-CE+WbcG0lgKvaV/OSMlTp3fG+v82X41z/w7ynsM/LLg=";
+  release."2026.03.0".hash = "sha256-MzdVbZhXlb9JFLsf+23yJNFiGJDBJZGbX6Ox3/U1EzA=";
   release."2025.06.1".sha256 = "sha256-wEL1tN0HUa1Eb7FiQOBA6sAkuonrAMdkqq8gu9/CED0=";
   release."2025.06.0".sha256 = "sha256-XfTg7ofamzMWqmRIU1/MO+S/ieNjvNEhlgIqFrchdAQ=";
+  release."2025.02.2".hash = "sha256-ks0eWqKv7bqgHgMowqTFjKzuT9kMYl2Ozj2s1DaSdEo=";
   release."2025.02.1".sha256 = "sha256-8P2GdplB12Q0e0XdL77w3nQL1/6Xl/gQNhGTB0WX/8I=";
   release."2025.02.0".sha256 = "sha256-Jlf0+VPuYWXdWyKHKHSp7h/HuCCp4VkcrgDAmh7pi5s=";
+  release."2024.07.4".hash = "sha256-eA9xX8jhmt8HJAetBj1lrIOYn5edOjO8iHr8uvm9+lE=";
   release."2024.07.3".sha256 = "sha256-n/X8d7ILuZ07l24Ij8TxbQzAG7E8kldWFcUI65W4r+c=";
   release."2024.07.2".sha256 = "sha256-aF8SYY5jRxQ6iEr7t6mRN3BEmIDhJ53PGhuZiJGB+i8=";
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
