### PR TITLE
librenms: 26.2.0 -> 26.3.1

### DIFF
--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -735,8 +735,6 @@ in
         '';
     };
 
-    programs.mtr.enable = true;
-
     services.logrotate = {
       enable = true;
       settings."${cfg.logDir}/librenms.log" = {

--- a/pkgs/by-name/li/librenms/package.nix
+++ b/pkgs/by-name/li/librenms/package.nix
@@ -11,13 +11,10 @@
   ipmitool,
   libvirt,
   monitoring-plugins,
-  mtr,
   net-snmp,
   nfdump,
-  nmap,
   rrdtool,
   system-sendmail,
-  whois,
   dataDir ? "/var/lib/librenms",
   logDir ? "/var/log/librenms",
 }:
@@ -27,16 +24,16 @@ let
 in
 phpPackage.buildComposerProject2 rec {
   pname = "librenms";
-  version = "26.2.0";
+  version = "26.3.1";
 
   src = fetchFromGitHub {
     owner = "librenms";
     repo = "librenms";
     tag = version;
-    hash = "sha256-cFFAUgUq+AxOdmHI92WYY6h9jSubXRUL4Jp8q+mDdHg=";
+    hash = "sha256-wLmZHE7W1ulBvUBpwVatdR8etFVhdG/zpggUpNIb65s=";
   };
 
-  vendorHash = "sha256-73E3fH1JUHxjphF6aPrmNJu3P1DZd28blmBxSiyuCTc=";
+  vendorHash = "sha256-uJ7DBJGQ4D1UnZXSUnrO3Fy3xEFz6ZxcMQ12E2jKKSM=";
 
   php = phpPackage;
 
@@ -45,14 +42,11 @@ phpPackage.buildComposerProject2 rec {
     ipmitool
     libvirt
     monitoring-plugins
-    mtr
     net-snmp
     nfdump
-    nmap
     rrdtool
     system-sendmail
     unixtools.whereis
-    whois
     (python3.withPackages (
       ps: with ps; [
         pymysql
@@ -78,22 +72,18 @@ phpPackage.buildComposerProject2 rec {
 
     substituteInPlace \
       $out/resources/definitions/config_definitions.json \
-      --replace-fail '"default": "/bin/ping",' '"default": "/run/wrappers/bin/ping",' \
       --replace-fail '"default": "fping",' '"default": "/run/wrappers/bin/fping",' \
       --replace-fail '"default": "fping6",' '"default": "/run/wrappers/bin/fping6",' \
       --replace-fail '"default": "rrdtool",' '"default": "${rrdtool}/bin/rrdtool",' \
       --replace-fail '"default": "snmpgetnext",' '"default": "${net-snmp}/bin/snmpgetnext",' \
       --replace-fail '"default": "traceroute",' '"default": "/run/wrappers/bin/traceroute",' \
       --replace-fail '"default": "/usr/bin/ipmitool",' '"default": "${ipmitool}/bin/ipmitool",' \
-      --replace-fail '"default": "/usr/bin/mtr",' '"default": "${mtr}/bin/mtr",' \
       --replace-fail '"default": "/usr/bin/nfdump",' '"default": "${nfdump}/bin/nfdump",' \
-      --replace-fail '"default": "/usr/bin/nmap",' '"default": "${nmap}/bin/nmap",' \
       --replace-fail '"default": "/usr/bin/snmpbulkwalk",' '"default": "${net-snmp}/bin/snmpbulkwalk",' \
       --replace-fail '"default": "/usr/bin/snmpget",' '"default": "${net-snmp}/bin/snmpget",' \
       --replace-fail '"default": "/usr/bin/snmptranslate",' '"default": "${net-snmp}/bin/snmptranslate",' \
       --replace-fail '"default": "/usr/bin/snmpwalk",' '"default": "${net-snmp}/bin/snmpwalk",' \
       --replace-fail '"default": "/usr/bin/virsh",' '"default": "${libvirt}/bin/virsh",' \
-      --replace-fail '"default": "/usr/bin/whois",' '"default": "${whois}/bin/whois",' \
       --replace-fail '"default": "/usr/lib/nagios/plugins",' '"default": "${monitoring-plugins}/bin",' \
       --replace-fail '"default": "/usr/sbin/sendmail",' '"default": "${system-sendmail}/bin/sendmail",'
 


### PR DESCRIPTION
Fixes #509914
Fixes #509901

The runtime dependencies ping, whois, nmap and mtr got removed in PR
librenms/librenms#19131 for security reasons.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
