### PR TITLE
nixpkgs/release-checks: fix url-literal warns after Nix upgrade

### DIFF
--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -57,7 +57,7 @@ pkgs.runCommand "nixpkgs-release-checks"
           nix-env -f $src \
               --show-trace --argstr system "$platform" \
               --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
-              --option experimental-features 'no-url-literals' \
+              --option lint-url-literals fatal \
               -qa --drv-path --system-filter \* --system \
               "''${opts[@]}" 2> eval-warnings.log > packages1
         )
@@ -73,7 +73,7 @@ pkgs.runCommand "nixpkgs-release-checks"
         nix-env -f $src2 \
             --show-trace --argstr system "$platform" \
             --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
-            --option experimental-features 'no-url-literals' \
+            --option lint-url-literals fatal \
             -qa --drv-path --system-filter \* --system \
             "''${opts[@]}" > packages2
 
@@ -96,7 +96,7 @@ pkgs.runCommand "nixpkgs-release-checks"
         nix-env -f $src \
             --show-trace --argstr system "$platform" \
             --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
-            --option experimental-features 'no-url-literals' \
+            --option lint-url-literals fatal \
             -qa --drv-path --system-filter \* --system --meta --xml \
             "''${opts[@]}" > /dev/null
     done


### PR DESCRIPTION
https://hydra.nixos.org/build/326503233/nixlog/2/tail


## Things done

- [x] Tested `nixpkgs.release-checks`
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
