### PR TITLE
nixos/unpackerr: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29068,6 +29068,14 @@
     github = "weitzj";
     githubId = 829277;
   };
+  Wekuz = {
+    name = "Wekuz";
+    github = "Wekuz";
+    githubId = 89638089;
+    email = "wekuz@duck.com";
+    matrix = "@wekuz:matrix.org";
+    keys = [ { fingerprint = "0CCE 1200 AB5E 7B05 9A22  B0D8 2E50 2F2A ABD3 2DF9"; } ];
+  };
   wellmannmathis = {
     email = "wellmannmathis@gmail.com";
     github = "MathisWellmann";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29465,6 +29465,14 @@
     github = "weitzj";
     githubId = 829277;
   };
+  Wekuz = {
+    name = "Wekuz";
+    github = "Wekuz";
+    githubId = 89638089;
+    email = "wekuz@duck.com";
+    matrix = "@wekuz:matrix.org";
+    keys = [ { fingerprint = "0CCE 1200 AB5E 7B05 9A22  B0D8 2E50 2F2A ABD3 2DF9"; } ];
+  };
   wellmannmathis = {
     email = "wellmannmathis@gmail.com";
     github = "MathisWellmann";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,7 +128,7 @@
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
-- Unpackerr, extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as services.unpackerr.
+- [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,6 +128,8 @@
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
+- Unpackerr, extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as services.unpackerr.
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -164,6 +164,8 @@
 
 - [LogiOps](https://github.com/PixlOne/logiops), a unofficial userspace driver for HID++ Logitech devices. Available as [services.logiops](#opt-services.logiops.enable).
 
+- [Unpackerr](https://unpackerr.zip), extracts downloads for Radarr, Sonarr, Lidarr, Readarr, and/or a Watch folder. Available as [services.unpackerr](#opt-services.unpackerr.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -988,6 +988,7 @@
   ./services/misc/tuxclocker.nix
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix
+  ./services/misc/unpackerr.nix
   ./services/misc/wastebin.nix
   ./services/misc/weechat.nix
   ./services/misc/workout-tracker.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -993,6 +993,7 @@
   ./services/misc/tuxclocker.nix
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix
+  ./services/misc/unpackerr.nix
   ./services/misc/wastebin.nix
   ./services/misc/weechat.nix
   ./services/misc/workout-tracker.nix

--- a/nixos/modules/services/misc/unpackerr.nix
+++ b/nixos/modules/services/misc/unpackerr.nix
@@ -1,0 +1,144 @@
+{
+  config,
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.unpackerr;
+  configFormat = pkgs.formats.toml { };
+  configFile = configFormat.generate "unpackerr.conf" cfg.settings;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkIf
+    getExe
+    ;
+  inherit (lib.types) types;
+in
+{
+  options = {
+    services.unpackerr = {
+      enable = mkEnableOption "Unpackerr";
+
+      settings = mkOption {
+        type = configFormat.type;
+        default = {
+          # Config needs to be non-empty, otherwise unpackerr
+          # crashes. debug=false is the default value.
+          debug = false;
+        };
+        example = {
+          radarr = [
+            {
+              url = "http://127.0.0.1:8989";
+              api_key = "0123456789abcdef0123456789abcdef";
+            }
+          ];
+          sonarr = [
+            {
+              url = "http://127.0.0.1:7878";
+              api_key = "0123456789abcdef0123456789abcdef";
+            }
+          ];
+        };
+        description = ''
+          Unpackerr TOML configuration as a Nix attribute set.
+          Refer to [Unpackerr docs](https://unpackerr.zip/docs/install/configuration) for details.
+          For setting secrets refer to this [section](https://unpackerr.zip/docs/install/configuration/#secrets-and-passwords).
+        '';
+      };
+
+      environmentFiles = mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = [ ];
+        example = [ "/run/secrets/unpackerr.env" ];
+        description = ''
+          Environment file to pass secret configuration values.
+          Refer to [Unpackerr docs](https://unpackerr.zip/docs/install/configuration) for details.
+          For setting secrets refer to this [section](https://unpackerr.zip/docs/install/configuration/#secrets-and-passwords).
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "unpackerr";
+        description = "User account under which Unpackerr runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "unpackerr";
+        description = "Group under which Unpackerr runs.";
+      };
+
+      package = mkPackageOption pkgs "unpackerr" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.unpackerr = {
+      description = "Unpackerr - archive extraction daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "unpackerr";
+        LogsDirectory = "unpackerr";
+        ExecStart = utils.escapeSystemdExecArgs [
+          (getExe cfg.package)
+          "-c"
+          configFile
+        ];
+        Restart = "always";
+        RestartSec = 10;
+        UMask = "0002";
+        WorkingDirectory = "/tmp";
+
+        # Hardening
+        LockPersonality = true;
+        PrivateDevices = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RestrictNamespaces = true;
+        RemoveIPC = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        NoNewPrivileges = true;
+        CapabilityBoundingSet = [ "" ];
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        SystemCallArchitectures = "native";
+      };
+    };
+
+    users.users = mkIf (cfg.user == "unpackerr") {
+      unpackerr = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "unpackerr") {
+      unpackerr = { };
+    };
+  };
+
+  meta = with lib; {
+    maintainers = with lib.maintainers; [ Wekuz ];
+  };
+}

--- a/nixos/modules/services/misc/unpackerr.nix
+++ b/nixos/modules/services/misc/unpackerr.nix
@@ -53,7 +53,7 @@ in
       };
 
       environmentFiles = mkOption {
-        type = lib.types.listOf lib.types.path;
+        type = types.listOf types.path;
         default = [ ];
         example = [ "/run/secrets/unpackerr.env" ];
         description = ''
@@ -80,49 +80,33 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.services.unpackerr = {
-      description = "Unpackerr - archive extraction daemon";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
-        StateDirectory = "unpackerr";
-        LogsDirectory = "unpackerr";
-        ExecStart = utils.escapeSystemdExecArgs [
-          (getExe cfg.package)
-          "-c"
-          configFile
-        ];
-        Restart = "always";
-        RestartSec = 10;
-        UMask = "0002";
-        WorkingDirectory = "/tmp";
-
-        # Hardening
-        LockPersonality = true;
-        PrivateDevices = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        RestrictNamespaces = true;
-        RemoveIPC = true;
-        PrivateTmp = true;
-        ProtectHome = true;
-        ProtectClock = true;
-        ProtectHostname = true;
-        ProtectControlGroups = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        NoNewPrivileges = true;
-        CapabilityBoundingSet = [ "" ];
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
-        SystemCallArchitectures = "native";
+    # Upstream service: https://github.com/Unpackerr/unpackerr/blob/main/init/systemd/unpackerr.service
+    systemd = {
+      tmpfiles.settings."10-unpackerr"."/var/lib/unpackerr/unpackerr.conf"."L+" = {
+        argument = "${configFile}";
+      };
+      services.unpackerr = {
+        description = "Unpackerr - archive extraction daemon";
+        wants = [ "network.target" ];
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ configFile ];
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          StateDirectory = "unpackerr";
+          EnvironmentFile = cfg.environmentFiles;
+          ExecStart = utils.escapeSystemdExecArgs [
+            (getExe cfg.package)
+            "-c"
+            "/var/lib/unpackerr/unpackerr.conf"
+          ];
+          Restart = "always";
+          RestartSec = 10;
+          UMask = "0002";
+          WorkingDirectory = "/tmp";
+        };
       };
     };
 
@@ -139,6 +123,6 @@ in
   };
 
   meta = with lib; {
-    maintainers = with lib.maintainers; [ Wekuz ];
+    maintainers = with maintainers; [ Wekuz ];
   };
 }

--- a/nixos/modules/services/misc/unpackerr.nix
+++ b/nixos/modules/services/misc/unpackerr.nix
@@ -1,0 +1,102 @@
+{
+  config,
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.unpackerr;
+  configFormat = pkgs.formats.toml { };
+  configFile = configFormat.generate "unpackerr.conf" cfg.settings;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkIf
+    getExe
+    types
+    ;
+in
+{
+  options = {
+    services.unpackerr = {
+      enable = mkEnableOption "Unpackerr";
+
+      settings = mkOption {
+        type = configFormat.type;
+        default = { };
+        example = {
+          radarr = [
+            {
+              url = "http://127.0.0.1:8989";
+              api_key = "0123456789abcdef0123456789abcdef";
+            }
+          ];
+          sonarr = [
+            {
+              url = "http://127.0.0.1:7878";
+              api_key = "0123456789abcdef0123456789abcdef";
+            }
+          ];
+        };
+        description = ''
+          Unpackerr TOML configuration as a Nix attribute set.
+          Refer to [Unpackerr docs](https://unpackerr.zip/docs/install/configuration) for details.
+          For setting secrets refer to this [section](https://unpackerr.zip/docs/install/configuration/#secrets-and-passwords).
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "unpackerr";
+        description = "User account under which Unpackerr runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "unpackerr";
+        description = "Group under which Unpackerr runs.";
+      };
+
+      package = mkPackageOption pkgs "unpackerr" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Upstream service: https://github.com/Unpackerr/unpackerr/blob/main/init/systemd/unpackerr.service
+    systemd = {
+      services.unpackerr = {
+        description = "Unpackerr - archive extraction daemon";
+        wants = [ "network.target" ];
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "exec";
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStart = utils.escapeSystemdExecArgs [
+            (getExe cfg.package)
+            "--config=${configFile}"
+          ];
+          Restart = "always";
+          RestartSec = 10;
+        };
+      };
+    };
+
+    users.users = mkIf (cfg.user == "unpackerr") {
+      unpackerr = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "unpackerr") {
+      unpackerr = { };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ Wekuz ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1698,6 +1698,7 @@ in
   unifi = runTest ./unifi.nix;
   unit-perl = runTest ./web-servers/unit-perl.nix;
   unit-php = runTest ./web-servers/unit-php.nix;
+  unpackerr = runTest ./unpackerr.nix;
   upnp.iptables = handleTest ./upnp.nix { useNftables = false; };
   upnp.nftables = handleTest ./upnp.nix { useNftables = true; };
   uptermd = runTest ./uptermd.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1737,6 +1737,7 @@ in
   unifi = runTest ./unifi.nix;
   unit-perl = runTest ./web-servers/unit-perl.nix;
   unit-php = runTest ./web-servers/unit-php.nix;
+  unpackerr = runTest ./unpackerr.nix;
   upnp.iptables = handleTest ./upnp.nix { useNftables = false; };
   upnp.nftables = handleTest ./upnp.nix { useNftables = true; };
   uptermd = runTest ./uptermd.nix;

--- a/nixos/tests/unpackerr.nix
+++ b/nixos/tests/unpackerr.nix
@@ -1,0 +1,37 @@
+{ lib, ... }:
+
+{
+  name = "unpackerr";
+  meta.maintainers = with lib.maintainers; [ Wekuz ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [ zip ];
+
+      systemd.tmpfiles.rules = [
+        "d /srv/unpackerr 0775 unpackerr users -"
+      ];
+
+      services.unpackerr = {
+        enable = true;
+        group = "users";
+        settings = {
+          start_delay = "15s";
+          folder = [
+            {
+              path = "/srv/unpackerr";
+            }
+          ];
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("unpackerr.service")
+    machine.wait_until_succeeds("journalctl -u unpackerr.service --grep '\\[Folder\\] Watching \\(fsnotify\\)'", timeout=60)
+    machine.execute("echo unpackerr-test > /tmp/file.txt && cd /tmp && zip /srv/unpackerr/test.zip ./file.txt && rm ./file.txt")
+    machine.wait_until_succeeds("[[ -d /srv/unpackerr/test ]]", timeout=120)
+    machine.succeed("""[[ 'unpackerr-test' == "$(< /srv/unpackerr/test/file.txt)" ]]""")
+  '';
+}

--- a/nixos/tests/unpackerr.nix
+++ b/nixos/tests/unpackerr.nix
@@ -9,9 +9,11 @@
     {
       environment.systemPackages = with pkgs; [ zip ];
 
-      systemd.tmpfiles.rules = [
-        "d /srv/unpackerr 0775 unpackerr users -"
-      ];
+      systemd.tmpfiles.settings."10-unpackerr"."/srv/unpackerr".d = {
+        mode = "0775";
+        user = "unpackerr";
+        group = "users";
+      };
 
       services.unpackerr = {
         enable = true;

--- a/nixos/tests/unpackerr.nix
+++ b/nixos/tests/unpackerr.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+
+{
+  name = "unpackerr";
+  meta.maintainers = with lib.maintainers; [ Wekuz ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [ zip ];
+
+      systemd.tmpfiles.settings."10-unpackerr"."/srv/unpackerr".d = {
+        mode = "0775";
+        user = "unpackerr";
+        group = "users";
+      };
+
+      services.unpackerr = {
+        enable = true;
+        group = "users";
+        settings = {
+          start_delay = "15s";
+          folder = [
+            {
+              path = "/srv/unpackerr";
+            }
+          ];
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("unpackerr.service")
+    machine.wait_until_succeeds("journalctl -u unpackerr.service --grep '\\[Folder\\] Watching \\(fsnotify\\)'", timeout=60)
+    machine.succeed("echo unpackerr-test > /tmp/file.txt && cd /tmp && zip /srv/unpackerr/test.zip ./file.txt && rm ./file.txt")
+    machine.wait_until_succeeds("[[ -d /srv/unpackerr/test ]]", timeout=120)
+    machine.succeed("""[[ 'unpackerr-test' == "$(< /srv/unpackerr/test/file.txt)" ]]""")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Add a NixOS module for the unpackerr package so it can be run as a service. It was requested here #478499. Wrote a simple test for the Watch folder feature, but not for the *arr integrations, as I deemed it too complicated at least for now.
The upstream systemd service for reference is [here](https://github.com/Unpackerr/unpackerr/blob/main/init/systemd/unpackerr.service).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
