### PR TITLE
forgejo: backport patch for flaky TestBleveDeleteIssue test from v15

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -12,6 +12,7 @@
   bash,
   brotli,
   buildGoModule,
+  fetchpatch,
   forgejo,
   git,
   gzip,
@@ -82,8 +83,15 @@ buildGoModule rec {
 
   patches = [
     ./static-root-path.patch
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "14") [
+    # Backport fix for flaky TestBleveDeleteIssue test from v15.
+    # https://codeberg.org/forgejo/forgejo/pulls/11686
+    (fetchpatch {
+      url = "https://codeberg.org/forgejo/forgejo/commit/a32b0da87c10bb628a9d2203b700f0683e1ae966.patch";
+      hash = "sha256-mY1b35aKsiLNU56Ut/qiLrYj+IR8M2W8dZQiDqkDNxg=";
+    })
   ];
-
   postPatch = ''
     substituteInPlace modules/setting/server.go --subst-var data
   '';


### PR DESCRIPTION
Should be fixed in v15, so this is to be considered temporary.

Closes #509878

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
