### PR TITLE
onnxruntime: provide TensorRT support

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -24,6 +24,7 @@
   pythonSupport ? true,
   cudaSupport ? config.cudaSupport,
   ncclSupport ? cudaSupport && cudaPackages.nccl.meta.available,
+  tensorrtSupport ? cudaSupport && cudaPackages.tensorrt.meta.available,
   rocmSupport ? config.rocmSupport,
   withFullProtobuf ? false,
   cudaPackages ? { },
@@ -191,6 +192,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       cuda_cudart
     ]
     ++ lib.optionals ncclSupport [ nccl ]
+    ++ lib.optionals tensorrtSupport [ tensorrt ]
   )
   ++ lib.optionals rocmSupport [
     rocmPackages.clr
@@ -274,6 +276,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "onnxruntime_CUDNN_HOME" "${cudaPackages.cudnn}")
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaArchitecturesString)
     (lib.cmakeFeature "onnxruntime_NVCC_THREADS" "1")
+  ]
+  ++ lib.optionals tensorrtSupport [
+    (lib.cmakeBool "onnxruntime_USE_TENSORRT" true)
+    (lib.cmakeBool "onnxruntime_USE_TENSORRT_BUILTIN_PARSER" true)
+    (lib.cmakeFeature "onnxruntime_TENSORRT_HOME" "${cudaPackages.tensorrt}")
   ]
   ++ lib.optionals rocmSupport [
     (lib.cmakeFeature "CMAKE_HIP_ARCHITECTURES" (


### PR DESCRIPTION
This PR adds the TensorRT Execution provider to the onnxruntime build, by default if cudaSupport is enabled and tensorrt is available on the platform.

I've built and tested this works on a x86_64-linux on a 5090, as well as on aarch64-linux using an Orin AGX devkit.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
