### PR TITLE
Fsl bet2 init

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1615,10 +1615,6 @@ lib.mapAttrs mkLicense (
       spdxId = "ZPL-2.1";
       fullName = "Zope Public License 2.1";
     };
-<<<<<<< HEAD
-
-=======
->>>>>>> 4c0839763 (lib/licenses: add fmribSoftwareLibrary license)
   }
   // {
     # TODO: remove legacy aliases

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -621,6 +621,13 @@ lib.mapAttrs mkLicense (
       free = false;
     };
 
+    fmribSoftwareLibrary = {
+      fullName = "FMRIB Software Library Licence";
+      url = "https://fsl.fmrib.ox.ac.uk/fsl/docs/license.html";
+      free = false;
+      redistributable = false; # only free to redistribute "for non-commercial purposes"
+    };
+
     fontException = {
       spdxId = "Font-exception-2.0";
       fullName = "Font exception 2.0";
@@ -1608,7 +1615,10 @@ lib.mapAttrs mkLicense (
       spdxId = "ZPL-2.1";
       fullName = "Zope Public License 2.1";
     };
+<<<<<<< HEAD
 
+=======
+>>>>>>> 4c0839763 (lib/licenses: add fmribSoftwareLibrary license)
   }
   // {
     # TODO: remove legacy aliases

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6812,6 +6812,12 @@
     github = "DimitarNestorov";
     githubId = 8790386;
   };
+  dinga92 = {
+    name = "Richard Dinga";
+    email = "dinga92@gmail.com";
+    github = "dinga92";
+    githubId = 10049011;
+  };
   diniamo = {
     name = "diniamo";
     email = "diniamo53@gmail.com";

--- a/pkgs/by-name/fs/fsl-armawrap/package.nix
+++ b/pkgs/by-name/fs/fsl-armawrap/package.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-armawrap";
   version = "0.7.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";
@@ -18,7 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-I13c2WtwV4rT63T9iP6VkVQ5uw9i2Sh9sfL797xBw7Y=";
   };
 
-  buildInputs = [ fsl-base armadillo ];
+  buildInputs = [
+    fsl-base
+    armadillo
+  ];
 
   buildPhase = ''
     export FSLDIR=${fsl-base}

--- a/pkgs/by-name/fs/fsl-armawrap/package.nix
+++ b/pkgs/by-name/fs/fsl-armawrap/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  armadillo,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-armawrap";
+  version = "0.7.0";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "armawrap";
+    rev = finalAttrs.version;
+    hash = "sha256-I13c2WtwV4rT63T9iP6VkVQ5uw9i2Sh9sfL797xBw7Y=";
+  };
+
+  buildInputs = [ fsl-base armadillo ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/include
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Armadillo wrapper library used by FSL";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/armawrap";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-avwutils/package.nix
+++ b/pkgs/by-name/fs/fsl-avwutils/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  fsl-newimage,
+  nlohmann_json,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-avwutils";
+  version = "2209.6";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "avwutils";
+    rev = finalAttrs.version;
+    hash = "sha256-qtvVuERT+oqiAx1BY/o7jv7hZ+a0ILw+kO52XgYpmlQ=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    fsl-newimage
+    nlohmann_json
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/avwutils $out/bin
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for f in $out/bin/fslval $out/bin/fslinfo $out/bin/fslsize $out/bin/fslchpixdim \
+              $out/bin/fsledithd $out/bin/fslmodhd $out/bin/fslreorient2std $out/bin/fslswapdim; do
+      [ -f "$f" ] && sed -i 's|''${FSLDIR}/bin/||g; s|\$FSLDIR/bin/||g' "$f" || true
+    done
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL image utilities including fslmaths, fslstats and fslhd";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/avwutils";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-avwutils/package.nix
+++ b/pkgs/by-name/fs/fsl-avwutils/package.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-avwutils";
   version = "2209.6";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-base/package.nix
+++ b/pkgs/by-name/fs/fsl-base/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  tcl,
+  tk,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-base";
+  version = "2604.1";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "base";
+    rev = finalAttrs.version;
+    hash = "sha256-fvElyS3udWurzpI3XZkFJUu4GFc6pJLA7h0KZfp9eJI=";
+  };
+
+  buildInputs = [ tcl tk ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/config $out/etc $out/share $out/bin
+    cp -r config/* $out/config/
+    cp -r etc/*    $out/etc/
+    cp -r share/*  $out/share/
+    cp -r bin/*    $out/bin/
+    substituteInPlace $out/config/buildSettings.mk \
+      --replace-fail 'MKDIR   ?= /bin/mkdir' 'MKDIR   ?= mkdir' \
+      --replace-fail 'RM      ?= /bin/rm'    'RM      ?= rm'    \
+      --replace-fail 'CP      ?= /bin/cp'    'CP      ?= cp'    \
+      --replace-fail 'MV      ?= /bin/mv'    'MV      ?= mv'    \
+      --replace-fail 'CHMOD   ?= /bin/chmod' 'CHMOD   ?= chmod'
+    sed -i "s|\''${FSLDIR}/bin/wish|${tk}/bin/wish|g"   $out/bin/fslwish
+    sed -i "s|\''${FSLDIR}/bin/tclsh|${tcl}/bin/tclsh|g" $out/bin/fsltclsh
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL base configuration and Makefile infrastructure";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/base";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-base/package.nix
+++ b/pkgs/by-name/fs/fsl-base/package.nix
@@ -10,6 +10,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-base";
   version = "2604.1";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";
@@ -18,7 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-fvElyS3udWurzpI3XZkFJUu4GFc6pJLA7h0KZfp9eJI=";
   };
 
-  buildInputs = [ tcl tk ];
+  buildInputs = [
+    tcl
+    tk
+  ];
 
   dontBuild = true;
 

--- a/pkgs/by-name/fs/fsl-bet2/package.nix
+++ b/pkgs/by-name/fs/fsl-bet2/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  makeWrapper,
+  bc,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  fsl-newimage,
+  fsl-meshclass,
+  fsl-avwutils,
+  python3Packages,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-bet2";
+  version = "2111.9";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "bet2";
+    rev = finalAttrs.version;
+    hash = "sha256-9KI/gvEzfUER1YvxAu2z6TEIgQlaGNu2OWMi5PzUueI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    fsl-newimage
+    fsl-meshclass
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    rm -f $out/bin/Bet $out/bin/Bet_gui
+    sed -i 's|''${FSLDIR}/bin/||g' $out/bin/bet
+    sed -i 's|\$FSLDIR/bin/||g'    $out/bin/bet
+    sed -i 's|/bin/rm |rm |g'      $out/bin/bet
+    wrapProgram $out/bin/bet \
+      --set-default FSLOUTPUTTYPE NIFTI_GZ \
+      --set-default FSLDIR ${fsl-base} \
+      --prefix PATH : ${lib.makeBinPath [ fsl-avwutils bc python3Packages.fslpy ]} \
+      --prefix PATH : $out/bin
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL Brain Extraction Tool";
+    homepage = "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    mainProgram = "bet";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-bet2/package.nix
+++ b/pkgs/by-name/fs/fsl-bet2/package.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-bet2";
   version = "2111.9";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";
@@ -69,7 +72,13 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/bet \
       --set-default FSLOUTPUTTYPE NIFTI_GZ \
       --set-default FSLDIR ${fsl-base} \
-      --prefix PATH : ${lib.makeBinPath [ fsl-avwutils bc python3Packages.fslpy ]} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fsl-avwutils
+          bc
+          python3Packages.fslpy
+        ]
+      } \
       --prefix PATH : $out/bin
   '';
 

--- a/pkgs/by-name/fs/fsl-cprob/package.nix
+++ b/pkgs/by-name/fs/fsl-cprob/package.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-cprob";
   version = "2111.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-cprob/package.nix
+++ b/pkgs/by-name/fs/fsl-cprob/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-cprob";
+  version = "2111.0";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "cprob";
+    rev = finalAttrs.version;
+    hash = "sha256-wsnYbpmIIWNOHC4Ev30xdPAeKIv4YxWEfWxIE8267NQ=";
+  };
+
+  buildInputs = [
+    fsl-base
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/cprob
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Probability distributions library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/cprob";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-meshclass/package.nix
+++ b/pkgs/by-name/fs/fsl-meshclass/package.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-meshclass";
   version = "2111.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-meshclass/package.nix
+++ b/pkgs/by-name/fs/fsl-meshclass/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  fsl-newimage,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-meshclass";
+  version = "2111.0";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "meshclass";
+    rev = finalAttrs.version;
+    hash = "sha256-ALpAVSHijfiCI8vvAdPgzWSGXyw2zTMBz0SHj5EzAs8=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    fsl-newimage
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/meshclass $out/bin
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL mesh class library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/meshclass";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-miscmaths/package.nix
+++ b/pkgs/by-name/fs/fsl-miscmaths/package.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-miscmaths";
   version = "2412.6";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-miscmaths/package.nix
+++ b/pkgs/by-name/fs/fsl-miscmaths/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-miscmaths";
+  version = "2412.6";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "miscmaths";
+    rev = finalAttrs.version;
+    hash = "sha256-aZLrhyUtYNJIacoj61ekR4pJEzfv6VGpDGDmut5XS/0=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/miscmaths
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Miscellaneous maths library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/miscmaths";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-newimage/package.nix
+++ b/pkgs/by-name/fs/fsl-newimage/package.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-newimage";
   version = "2601.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-newimage/package.nix
+++ b/pkgs/by-name/fs/fsl-newimage/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-newimage";
+  version = "2601.0";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "newimage";
+    rev = finalAttrs.version;
+    hash = "sha256-b+q98F1KsOlAnpV84SZuhy61Q6rO4pjuOmiwSxUYEFs=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/newimage
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL image data structure library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/newimage";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-newnifti/package.nix
+++ b/pkgs/by-name/fs/fsl-newnifti/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-znzlib,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-newnifti";
+  version = "5.0.0";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "newnifti";
+    rev = finalAttrs.version;
+    hash = "sha256-vtboEezMrdg3ZnCWjFYB06X7p6rgTXnz+BbTU4OWE4s=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-znzlib
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/NewNifti
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "NIfTI-2 image I/O library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/newnifti";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-newnifti/package.nix
+++ b/pkgs/by-name/fs/fsl-newnifti/package.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-newnifti";
   version = "5.0.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-utils/package.nix
+++ b/pkgs/by-name/fs/fsl-utils/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-armawrap,
+  armadillo,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-utils";
+  version = "2412.6";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "utils";
+    rev = finalAttrs.version;
+    hash = "sha256-XfLEEzBHjvva3rBTgJSrIxbKnVA0caiYgttCk5EDs5s=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-armawrap
+    armadillo
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/utils
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL utilities library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/utils";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-utils/package.nix
+++ b/pkgs/by-name/fs/fsl-utils/package.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-utils";
   version = "2412.6";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";

--- a/pkgs/by-name/fs/fsl-znzlib/package.nix
+++ b/pkgs/by-name/fs/fsl-znzlib/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  zlib,
+  bzip2,
+  zstd,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-znzlib";
+  version = "2511.3";
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "znzlib";
+    rev = finalAttrs.version;
+    hash = "sha256-DE1j6vg2Emie1pXAWEyAgOQbgbFVmMXzVfO4J23mcLQ=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    zlib
+    bzip2
+    zstd
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/znzlib
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ZNZ compressed file I/O library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/znzlib";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-znzlib/package.nix
+++ b/pkgs/by-name/fs/fsl-znzlib/package.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fsl-znzlib";
   version = "2511.3";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "git.fmrib.ox.ac.uk";
     owner = "fsl";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fsl-base: init at 2604.1
fsl-armawrap: init at 0.7.0
fsl-utils: init at 2412.6
fsl-znzlib: init at 2511.3
fsl-cprob: init at 2111.0
fsl-newnifti: init at 5.0.0
fsl-miscmaths: init at 2412.6
fsl-newimage: init at 2601.0
fsl-meshclass: init at 2111.0
fsl-avwutils: init at 2209.6
fsl-bet2: init at 2111.9

Init fsl-bet2 and its dependencies

BET (Brain Extraction Tool) is part of FSL (FMRIB Software Library), a comprehensive library of analysis tools for FMRI, MRI and diffusion brain imaging data. BET removes non-brain tissue from whole head images.

https://fsl.fmrib.ox.ac.uk/fsl/docs/structural/bet.html

FSL uses a custom non-commercial license (free to use and redistribute for non-commercial purposes): https://fsl.fmrib.ox.ac.uk/fsl/docs/license.html

The library packages (fsl-base through fsl-meshclass and fsl-avwutils) are dependencies of fsl-bet2 and do not provide useful standalone functionality. They are included in this PR as a sanity check per nixpkgs guidelines, and will also serve as the foundation for packaging other FSL tools (flirt, mcflirt, fast, topup, fnirt, etc.).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
