### PR TITLE
nixos/cupsd: hide desktop entry if webInterface is disabled

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -40,6 +40,18 @@ let
         fi
       '';
 
+  hiddenDesktopEntry =
+    pkgs.runCommand "cups-hidden-desktop-entry"
+      {
+        preferLocalBuild = true;
+      }
+      ''
+        install -D -m 644 \
+          ${cups.out}/share/applications/cups.desktop \
+          $out/share/applications/cups.desktop
+        echo 'Hidden=true' >> $out/share/applications/cups.desktop
+      '';
+
   # Here we can enable additional backends, filters, etc. that are not
   # part of CUPS itself, e.g. the SMB backend is part of Samba.  Since
   # we can't update ${cups.out}/lib/cups itself, we create a symlink tree
@@ -373,13 +385,20 @@ in
       groups.lpadmin = { };
     };
 
-    # We need xdg-open (part of xdg-utils) for the desktop-file to proper open the users default-browser when opening "Manage Printing"
-    # https://github.com/NixOS/nixpkgs/pull/237994#issuecomment-1597510969
-    environment.systemPackages = [
-      cups.out
-      xdg-utils
-    ]
-    ++ optional polkitEnabled cups-pk-helper;
+    environment.systemPackages =
+      (
+        if cfg.webInterface then
+          [
+            # We need xdg-open (part of xdg-utils) for the desktop-file to proper open the users default-browser when opening "Manage Printing"
+            xdg-utils
+          ]
+        else
+          [
+            hiddenDesktopEntry
+          ]
+      )
+      ++ [ cups.out ]
+      ++ optional polkitEnabled cups-pk-helper;
     environment.etc.cups.source = "/var/lib/cups";
 
     services.dbus.packages = [ cups.out ] ++ optional polkitEnabled cups-pk-helper;


### PR DESCRIPTION
This pull requests makes it so that the cups.desktop "Manage Printing" entry gets hidden when `services.printing.webInterface` is false (not the default). When the web interface is disabled, the desktop entry points only to an informative web page about CUPS itself, cluttering the list of user applications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
