### PR TITLE
television: add shell init scripts

### DIFF
--- a/pkgs/by-name/te/television/package.nix
+++ b/pkgs/by-name/te/television/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
+  installShellFiles,
   testers,
   television,
   nix-update-script,
@@ -19,6 +21,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-n417hrDLpBD7LhtHfqHPgr9N+gkdC9nw+iDnNRcTqQQ=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    HOME=$TMPDIR
+    installShellCompletion --cmd tv \
+      --bash <($out/bin/tv init bash) \
+      --fish <($out/bin/tv init fish) \
+      --zsh <($out/bin/tv init zsh)
+  '';
 
   passthru = {
     tests.version = testers.testVersion {


### PR DESCRIPTION
## Summary
- Add shell init scripts (bash, fish, zsh) to the television package via `installShellCompletion`
- These scripts provide keybindings (`Ctrl+T` for smart autocomplete, `Ctrl+R` for shell history) and helper functions
- Uses `HOME=$TMPDIR` during postInstall to avoid read-only filesystem errors (same pattern as `_1password-cli`)

## Test plan
- [x] Built locally on aarch64-darwin
- [x] Verified `share/fish/vendor_completions.d/tv.fish`, `share/bash-completion/completions/tv.bash`, and `share/zsh/site-functions/_tv` are present and non-empty
- [x] End-to-end tested via home-manager with fish shell — completions loaded successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>