### PR TITLE
python3Packages.exllamav3: 0.0.26 -> 0.0.38; python3Packages.exllamav2: fix build after g++ bump; tabbyapi: 0-unstable-2026-01-20 -> 0-unstable-2026-05-29

### DIFF
--- a/pkgs/by-name/ta/tabbyapi/package.nix
+++ b/pkgs/by-name/ta/tabbyapi/package.nix
@@ -7,14 +7,14 @@
 }:
 python3Packages.buildPythonApplication {
   pname = "tabbyapi";
-  version = "0-unstable-2026-01-20";
+  version = "0-unstable-2026-05-29";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "theroyallab";
     repo = "tabbyAPI";
-    rev = "54e3ea1fb30c48217f82dcb4ab1359f4784da4c8";
-    hash = "sha256-cwxpW4s8LKxS+2A2Grfhx8XaxbfT8U1LG59yhbu1lD8=";
+    rev = "95c1101bd2a18abec818a1bc2eb013438d1b55d0";
+    hash = "sha256-VOHoPD8tb1ewOQL4LOhAYxsMBrahLAIEppYA8BXHOfc=";
   };
 
   build-system = with python3Packages; [
@@ -53,6 +53,7 @@ python3Packages.buildPythonApplication {
       psutil
       httptools
       pillow
+      requests
       numpy
       setuptools
 

--- a/pkgs/development/python-modules/exllamav2/default.nix
+++ b/pkgs/development/python-modules/exllamav2/default.nix
@@ -25,7 +25,7 @@
   torch,
   websockets,
 }:
-buildPythonPackage (finalAttrs: {
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "exllamav2";
   version = "0.3.2";
   pyproject = true;

--- a/pkgs/development/python-modules/exllamav3/default.nix
+++ b/pkgs/development/python-modules/exllamav3/default.nix
@@ -21,20 +21,21 @@
   tokenizers,
   torch,
   typing-extensions,
+  xformers,
 }:
 let
   newerThanTuring = lib.filter (version: lib.versionOlder "7.9" version) torch.cudaCapabilities;
 in
 buildPythonPackage (finalAttrs: {
   pname = "exllamav3";
-  version = "0.0.25";
+  version = "0.0.29";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "turboderp-org";
     repo = "exllamav3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CltM0bQ3mvQwUYulsVByS7mcIIy6O/P1+nq4h5UAO6E=";
+    hash = "sha256-dUTVG8hpK7O51C1a9pxUMpzTsO/pGaQfo7HUa6YkVOE=";
   };
 
   pythonRelaxDeps = [
@@ -71,6 +72,7 @@ buildPythonPackage (finalAttrs: {
     tokenizers
     torch
     typing-extensions
+    xformers
   ];
 
   env = lib.optionalAttrs torch.cudaSupport {

--- a/pkgs/development/python-modules/exllamav3/default.nix
+++ b/pkgs/development/python-modules/exllamav3/default.nix
@@ -21,20 +21,21 @@
   tokenizers,
   torch,
   typing-extensions,
+  xformers,
 }:
 let
   newerThanTuring = lib.filter (version: lib.versionOlder "7.9" version) torch.cudaCapabilities;
 in
-buildPythonPackage (finalAttrs: {
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "exllamav3";
-  version = "0.0.25";
+  version = "0.0.38";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "turboderp-org";
     repo = "exllamav3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CltM0bQ3mvQwUYulsVByS7mcIIy6O/P1+nq4h5UAO6E=";
+    hash = "sha256-WlHIbnQX1Jd7y5yQzlqXVgBLQ92rnDSWy4z9bEm3WLA=";
   };
 
   pythonRelaxDeps = [
@@ -71,6 +72,7 @@ buildPythonPackage (finalAttrs: {
     tokenizers
     torch
     typing-extensions
+    xformers
   ];
 
   env = lib.optionalAttrs torch.cudaSupport {


### PR DESCRIPTION
- Bumps exllamav3 to latest version. 
- Exllamav2 needs a slight fix to account for the compiler version bump in nixpkgs.
- Bumped tabbyapi to latest version that targets this exllamav3 version.

Tested inference on tabbyapi works nicely 👍 

https://github.com/turboderp-org/exllamav3/releases
https://github.com/turboderp-org/exllamav3/compare/v0.0.26...v0.0.38

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
