### PR TITLE
[25.11] activemq: 6.1.8 -> 6.2.4

### DIFF
--- a/pkgs/by-name/ac/activemq/package.nix
+++ b/pkgs/by-name/ac/activemq/package.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "6.1.8";
+  version = "6.2.0";
 in
 stdenvNoCC.mkDerivation {
   pname = "activemq";
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "mirror://apache/activemq/${version}/apache-activemq-${version}-bin.tar.gz";
-    hash = "sha256-BCrdMR698xAsl+8nY8DpwdZZH6LH2C5FBNZ2sRUmtBk=";
+    hash = "sha256-J3u/p5LRQPgJvQKm4/1TgZVUuFetWlItcWoUpn9jxpg=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ac/activemq/package.nix
+++ b/pkgs/by-name/ac/activemq/package.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "6.2.0";
+  version = "6.2.1";
 in
 stdenvNoCC.mkDerivation {
   pname = "activemq";
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "mirror://apache/activemq/${version}/apache-activemq-${version}-bin.tar.gz";
-    hash = "sha256-J3u/p5LRQPgJvQKm4/1TgZVUuFetWlItcWoUpn9jxpg=";
+    hash = "sha256-vBbQMLxTykJAZRxl7BPfonLHN8kPx+NFSa3gwLZwdw0=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ac/activemq/package.nix
+++ b/pkgs/by-name/ac/activemq/package.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "6.2.1";
+  version = "6.2.4";
 in
 stdenvNoCC.mkDerivation {
   pname = "activemq";
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
 
   src = fetchurl {
     url = "mirror://apache/activemq/${version}/apache-activemq-${version}-bin.tar.gz";
-    hash = "sha256-vBbQMLxTykJAZRxl7BPfonLHN8kPx+NFSa3gwLZwdw0=";
+    hash = "sha256-/jvyO8cDQ666i8J53SXPS5WyBmN5GZwK6TVaDxXxJhM=";
   };
 
   installPhase = ''


### PR DESCRIPTION
Fixes CVE-2026-34197, CVE-2026-40046 and CVE-2026-39304.

https://www.openwall.com/lists/oss-security/2026/04/09/18
https://www.openwall.com/lists/oss-security/2026/04/09/17
http://www.openwall.com/lists/oss-security/2026/04/06/3

6.2.0: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12354379
https://github.com/apache/activemq/releases/tag/activemq-6.2.2
https://github.com/apache/activemq/releases/tag/activemq-6.2.3
https://github.com/apache/activemq/releases/tag/activemq-6.2.4


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
