### PR TITLE
matrix-tuwunel: 1.5.1 -> 1.6.0

### DIFF
--- a/nixos/modules/services/matrix/tuwunel.nix
+++ b/nixos/modules/services/matrix/tuwunel.nix
@@ -81,7 +81,6 @@ in
             description = ''
               Addresses (IPv4 or IPv6) to listen on for connections by the reverse proxy/tls terminator.
               If set to `null`, tuwunel will listen on IPv4 and IPv6 localhost.
-              Must be `null` if `unix_socket_path` is set.
             '';
           };
           global.port = lib.mkOption {
@@ -167,14 +166,6 @@ in
 
   config = lib.mkIf cfg.enable {
     assertions = [
-      {
-        assertion = !(cfg.settings ? global.unix_socket_path) || !(cfg.settings ? global.address);
-        message = ''
-          In `services.matrix-tuwunel.settings.global`, `unix_socket_path` and `address` cannot be set at the
-          same time.
-          Leave one of the two options unset or explicitly set them to `null`.
-        '';
-      }
       {
         assertion = cfg.user != defaultUser -> config ? users.users.${cfg.user};
         message = "If `services.matrix-tuwunel.user` is changed, the configured user must already exist.";

--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -89,16 +89,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-tuwunel";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "matrix-construct";
     repo = "tuwunel";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VdG8tSbRPTG915l0Y7eYsGprPSerYF2dpo64D4er5io=";
+    hash = "sha256-7w2+hltPj0mP3xcmHfjFvIqxwFkcf71bzm4TFiz745g=";
   };
 
-  cargoHash = "sha256-97DM+khPcwze3iH4DJODyI8WEjqcl3ftg26odcRdrKc=";
+  cargoHash = "sha256-DuHV4/a3B/Khq9/RgxFg5RfQ2svdKPv+QyuUqKGAveo=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Since https://github.com/matrix-construct/tuwunel/commit/bd5203b406488b6e34c770ba0ed743209a845401 setting both `address` and `unix_socket_path` is allowed

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
