### PR TITLE
linuxdeploy: init at 0-unstable-2026-04-12; linuxdeploy-plugin-qt: init at 0-unstable-2026-03-07

### DIFF
--- a/pkgs/by-name/li/linuxdeploy-plugin-qt/package.nix
+++ b/pkgs/by-name/li/linuxdeploy-plugin-qt/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  pkg-config,
+  cimg,
+  libjpeg,
+  libpng,
+  nlohmann_json,
+}:
+let
+  excludelist = fetchurl {
+    url = "https://raw.githubusercontent.com/probonopd/AppImages/15a64c20dc23a0154622ba25829364323903b6b5/excludelist";
+    sha256 = "sha256-UNsPiU80sWnEely8DBfbq2Hp7evKW8gmmh5qwb9L2tk=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "linuxdeploy-plugin-qt";
+  version = "0-unstable-2026-03-07";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "linuxdeploy";
+    repo = "linuxdeploy-plugin-qt";
+    rev = "511d51d066f632dfdfbcf0bf7284ec38090812d2";
+    hash = "sha256-q/LL7XVtqCGyMxSFtHK7LinKF/TetYRtAfMpxZzPs6M=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # Deploy wayland-graphics-integration-client alongside wayland platform plugin
+    # Without this, wayland EGL rendering fails
+    # https://github.com/linuxdeploy/linuxdeploy-plugin-qt/issues/160
+    ./wayland-fix.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace lib/linuxdeploy/src/core/generate-excludelist.sh \
+      --replace-fail "wget --quiet \"\$url\" -O - " "cat ${excludelist}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cimg
+    libjpeg
+    libpng
+    nlohmann_json
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=OFF"
+  ];
+
+  meta = {
+    description = "Qt plugin for linuxdeploy to bundle Qt applications into AppImage format";
+    homepage = "https://github.com/linuxdeploy/linuxdeploy-plugin-qt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+    mainProgram = "linuxdeploy-plugin-qt";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/li/linuxdeploy-plugin-qt/wayland-fix.patch
+++ b/pkgs/by-name/li/linuxdeploy-plugin-qt/wayland-fix.patch
@@ -1,0 +1,11 @@
+--- a/src/deployers/PlatformPluginsDeployer.cpp
++++ b/src/deployers/PlatformPluginsDeployer.cpp
+@@ -30,7 +30,7 @@ bool PlatformPluginsDeployer::doDeploy() {
+
+             using namespace linuxdeploy::util::misc;
+             if (stringStartsWith(platformToDeploy, "libqwayland")) {
+-                if (!deployStandardQtPlugins({"wayland-decoration-client", "wayland-shell-integration"})) {
++                if (!deployStandardQtPlugins({"wayland-decoration-client", "wayland-graphics-integration-client", "wayland-shell-integration"})) {
+                     return false;
+                 }
+             }

--- a/pkgs/by-name/li/linuxdeploy/package.nix
+++ b/pkgs/by-name/li/linuxdeploy/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  pkg-config,
+  cimg,
+  libjpeg,
+  libpng,
+}:
+let
+  excludelist = fetchurl {
+    url = "https://raw.githubusercontent.com/probonopd/AppImages/15a64c20dc23a0154622ba25829364323903b6b5/excludelist";
+    sha256 = "sha256-UNsPiU80sWnEely8DBfbq2Hp7evKW8gmmh5qwb9L2tk=";
+  };
+in
+stdenv.mkDerivation {
+  pname = "linuxdeploy";
+  version = "0-unstable-2026-04-12";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "linuxdeploy";
+    repo = "linuxdeploy";
+    rev = "8dccfe12c273bb598937fcea6da46c0d29d84452";
+    hash = "sha256-gP9yZwrgpRZ4BBYvSnC306iWaV+1cOVxdpxlEBE7aHE=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace src/core/generate-excludelist.sh \
+      --replace-fail "wget --quiet \"\$url\" -O - " "cat ${excludelist}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cimg
+    libjpeg
+    libpng
+  ];
+
+  meta = {
+    description = "Tool to bundle Linux applications into AppImage format";
+    homepage = "https://github.com/linuxdeploy/linuxdeploy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+    mainProgram = "linuxdeploy";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds utils for making appimages
https://github.com/linuxdeploy/linuxdeploy
https://github.com/linuxdeploy/linuxdeploy-plugin-qt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
