### PR TITLE
webkitgtk_6_0: 2.52.1 → 2.52.2

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -85,7 +85,7 @@ in
 # https://webkitgtk.org/2024/10/04/webkitgtk-2.46.html recommends building with clang.
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "webkitgtk";
-  version = "2.52.1";
+  version = "2.52.2";
   name = "webkitgtk-${finalAttrs.version}+abi=${abiVersion}";
 
   outputs = [
@@ -100,7 +100,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://webkitgtk.org/releases/webkitgtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-I459UyBbFABK3X7rQpPJTW+/cJez7+987lUZ5cEhqQQ=";
+    hash = "sha256-Bd4rRIdLotraV1X4mM+1N4PDFz+RtGNo+i3MxYSXKrs=";
   };
 
   patches = lib.optionals clangStdenv.hostPlatform.isLinux [
@@ -118,12 +118,11 @@ clangStdenv.mkDerivation (finalAttrs: {
       name = "fix_ftbfs_riscv64.patch";
     })
 
-    # Fix webkitgtk_4_1 build
-    # WebKitDOMDOMWindow.cpp:1085:10: error: variable has incomplete type 'void'
-    # https://bugs.webkit.org/show_bug.cgi?id=310915
+    # Fix FTBFS on platforms that don't use Skia
+    # https://bugs.webkit.org/show_bug.cgi?id=312160
     (fetchpatch {
-      url = "https://github.com/WebKit/WebKit/commit/40c315ca7b3ad6ae5c98d72a6927b3a75b43cb46.patch";
-      hash = "sha256-xGPi5p2XhDxpd4NtZMrd1JbHvV2fey6V3eH0fgy6ifY=";
+      url = "https://github.com/WebKit/WebKit/commit/36df921c686c07f2b20e3eed20afad5471b96897.patch";
+      hash = "sha256-iYOs1V/p02XHtytw+r1+TyW08pk6PgUH76U1fXG8w34=";
     })
   ];
 


### PR DESCRIPTION
https://webkitgtk.org/2026/04/13/webkitgtk2.52.2-released.html
https://github.com/WebKit/WebKit/compare/webkitgtk-2.52.1...webkitgtk-2.52.2

I started a build on build-box.nix-community.org.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
