### PR TITLE
htmd-cli: init at 0.5.1

### DIFF
--- a/pkgs/by-name/ht/htmd-cli/package.nix
+++ b/pkgs/by-name/ht/htmd-cli/package.nix
@@ -1,0 +1,37 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "htmd-cli";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "letmutex";
+    repo = "htmd-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-csc/uAbxFWYohTspWxAEuPDD9RXbknSa0P4PlM6ioX0=";
+  };
+
+  cargoHash = "sha256-Qt6OIorUwXttHajI5pjGjoAl0sENNCR8B2YHpcgxssE=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "The command line tool for htmd, an HTML to Markdown converter";
+    homepage = "https://github.com/letmutex/htmd-cli";
+    changelog = "https://github.com/letmutex/htmd-cli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ drawbu ];
+    mainProgram = "htmd";
+  };
+})


### PR DESCRIPTION
Added htmd-cli to nixpkgs, pinned to the version `0.5.1`.

This is the cli for [htmd](https://github.com/letmutex/htmd), an HTML to Markdown converter.

#

It is *not* the very last version, but `0.5.2` only changes the readme, and fails to update correctly the version which makes the `versionCheckHook` fail.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
