### PR TITLE
nixos/test-driver: use junitparser to generate junit reports

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -6,7 +6,7 @@
   coreutils,
   imagemagick_light,
   ipython,
-  junit-xml,
+  junitparser,
   ptpython,
   python,
   remote-pdb,
@@ -44,7 +44,7 @@ buildPythonApplication {
   dependencies = [
     colorama
     ipython
-    junit-xml
+    junitparser
     ptpython
     remote-pdb
   ]

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -74,6 +74,7 @@ buildPythonApplication {
   doCheck = true;
 
   nativeCheckInputs = [
+    python.pkgs.pytest
     ruff
     ty
   ];
@@ -85,5 +86,7 @@ buildPythonApplication {
     ruff check .
     echo -e "\x1b[32m## run ruff format\x1b[0m"
     ruff format --check --diff .
+    echo -e "\x1b[32m## run pytest\x1b[0m"
+    pytest
   '';
 }

--- a/nixos/lib/test-driver/src/pyproject.toml
+++ b/nixos/lib/test-driver/src/pyproject.toml
@@ -22,3 +22,6 @@ line-length = 88
 
 lint.select = ["E", "F", "I", "U", "N"]
 lint.ignore = ["E501", "N818"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -11,11 +11,11 @@ from test_driver.debug import Debug, DebugAbstract, DebugNop
 from test_driver.driver import Driver
 from test_driver.logger import (
     CompositeLogger,
-    JunitXMLLogger,
     LogLevel,
     TerminalLogger,
     XMLLogger,
 )
+from test_driver.test_reporter import TestReporter
 
 
 class EnvDefault(argparse.Action):
@@ -176,8 +176,9 @@ def main() -> None:
     if "LOGFILE" in os.environ.keys():
         logger.add_logger(XMLLogger(os.environ["LOGFILE"]))
 
-    if args.junit_xml:
-        logger.add_logger(JunitXMLLogger(output_directory / args.junit_xml))
+    reporter = (
+        TestReporter(output_directory / args.junit_xml) if args.junit_xml else None
+    )
 
     if args.log_level:
         logger.set_log_level(log_level_map[args.log_level])
@@ -211,6 +212,7 @@ def main() -> None:
         global_timeout=args.global_timeout,
         debug=debugger,
         enable_ssh_backdoor=args.enable_ssh_backdoor,
+        reporter=reporter,
     ) as driver:
         if args.enable_ssh_backdoor:
             driver.dump_machine_ssh()

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -17,7 +17,7 @@ from colorama import Style
 
 from test_driver.debug import DebugAbstract, DebugNop
 from test_driver.errors import MachineError, RequestedAssertionFailed
-from test_driver.logger import AbstractLogger
+from test_driver.logger import AbstractLogger, BufferLogger, CompositeLogger
 from test_driver.machine import (
     BaseMachine,
     NspawnMachine,
@@ -295,17 +295,36 @@ class Driver:
         """Group logs under a given test name"""
         reporter = self.reporter
         tc = reporter.start(name) if reporter else None
+
+        # Capture logs if we have a reporter and a composite logger
+        capture: BufferLogger | None = None
+        if reporter and isinstance(self.logger, CompositeLogger):
+            capture = BufferLogger()
+            self.logger.add_logger(capture)
+
         with self.logger.subtest(name):
             try:
                 yield
             except Exception as e:
                 if reporter and tc:
-                    reporter.finish(tc, str(e))
+                    reporter.finish(
+                        tc,
+                        failure_message=str(e),
+                        stdout=capture.buffer if capture else None,
+                        stderr=capture.errors if capture else None,
+                    )
                 self.logger.log_test_error(f'Test "{name}" failed with error: "{e}"')
                 raise e
             else:
                 if reporter and tc:
-                    reporter.finish(tc)
+                    reporter.finish(
+                        tc,
+                        stdout=capture.buffer if capture else None,
+                        stderr=capture.errors if capture else None,
+                    )
+            finally:
+                if capture and isinstance(self.logger, CompositeLogger):
+                    self.logger.remove_logger(capture)
 
     def test_symbols(self) -> dict[str, Any]:
         @contextmanager

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -25,6 +25,7 @@ from test_driver.machine import (
     retry,
 )
 from test_driver.polling_condition import PollingCondition
+from test_driver.test_reporter import TestReporter
 from test_driver.vlan import VLan
 
 SENTINEL = object()
@@ -119,6 +120,7 @@ class Driver:
     vlan_ids: list[int]
     keep_machine_state: bool
     logger: AbstractLogger
+    reporter: TestReporter | None
     debug: DebugAbstract
     vhost_vsock: VHostDeviceVsock | None = None
     enable_ssh_backdoor: bool
@@ -137,11 +139,13 @@ class Driver:
         global_timeout: int = 24 * 60 * 60 * 7,
         debug: DebugAbstract = DebugNop(),
         enable_ssh_backdoor: bool = False,
+        reporter: TestReporter | None = None,
     ):
         self.tests = tests
         self.out_dir = out_dir
         self.global_timeout = global_timeout
         self.logger = logger
+        self.reporter = reporter
         self.debug = debug
         self.vlan_ids = list(set(vlans))
         self.polling_conditions = []
@@ -289,12 +293,19 @@ class Driver:
 
     def subtest(self, name: str) -> Iterator[None]:
         """Group logs under a given test name"""
+        reporter = self.reporter
+        tc = reporter.start(name) if reporter else None
         with self.logger.subtest(name):
             try:
                 yield
             except Exception as e:
+                if reporter and tc:
+                    reporter.finish(tc, str(e))
                 self.logger.log_test_error(f'Test "{name}" failed with error: "{e}"')
                 raise e
+            else:
+                if reporter and tc:
+                    reporter.finish(tc)
 
     def test_symbols(self) -> dict[str, Any]:
         @contextmanager

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -1,5 +1,4 @@
-import atexit
-import os
+import codecs
 import sys
 import time
 import unicodedata
@@ -7,14 +6,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from enum import IntEnum
-from pathlib import Path
 from queue import Empty, Queue
 from typing import Any
 from xml.sax.saxutils import XMLGenerator
 from xml.sax.xmlreader import AttributesImpl
 
 from colorama import Fore, Style
-from junit_xml import TestCase, TestSuite
 
 
 class LogLevel(IntEnum):
@@ -70,89 +67,6 @@ class AbstractLogger(ABC):
     @abstractmethod
     def set_log_level(self, level: LogLevel) -> None:
         pass
-
-
-class JunitXMLLogger(AbstractLogger):
-    class TestCaseState:
-        def __init__(self) -> None:
-            self.stdout = ""
-            self.stderr = ""
-            self.failure = False
-
-    def __init__(self, outfile: Path) -> None:
-        self.tests: dict[str, JunitXMLLogger.TestCaseState] = {
-            "main": self.TestCaseState()
-        }
-        self.currentSubtest = "main"
-        self.outfile: Path = outfile
-        self._print_serial_logs = True
-        self._log_level = LogLevel.INFO
-        atexit.register(self.close)
-
-    def log(self, message: str, attributes: dict[str, str] = {}) -> None:
-        self.tests[self.currentSubtest].stdout += message + os.linesep
-
-    @contextmanager
-    def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        old_test = self.currentSubtest
-        self.tests.setdefault(name, self.TestCaseState())
-        self.currentSubtest = name
-
-        yield
-
-        self.currentSubtest = old_test
-
-    @contextmanager
-    def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
-        self.log(message)
-        yield
-
-    def debug(self, *args, **kwargs) -> None:
-        if self._log_level <= LogLevel.DEBUG:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
-
-    def info(self, *args, **kwargs) -> None:
-        if self._log_level <= LogLevel.INFO:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
-
-    def warning(self, *args, **kwargs) -> None:
-        if self._log_level <= LogLevel.WARNING:
-            self.tests[self.currentSubtest].stdout += args[0] + os.linesep
-
-    def error(self, *args, **kwargs) -> None:
-        self.tests[self.currentSubtest].stderr += args[0] + os.linesep
-        self.tests[self.currentSubtest].failure = True
-
-    def log_test_error(self, *args, **kwargs) -> None:
-        self.error(*args, **kwargs)
-
-    def log_serial(self, message: str, machine: str) -> None:
-        if not self._print_serial_logs:
-            return
-
-        self.log(f"{machine} # {message}")
-
-    def print_serial_logs(self, enable: bool) -> None:
-        self._print_serial_logs = enable
-
-    def set_log_level(self, level: LogLevel) -> None:
-        self._log_level = level
-
-    def close(self) -> None:
-        with open(self.outfile, "w") as f:
-            test_cases = []
-            for name, test_case_state in self.tests.items():
-                tc = TestCase(
-                    name,
-                    stdout=test_case_state.stdout,
-                    stderr=test_case_state.stderr,
-                )
-                if test_case_state.failure:
-                    tc.add_failure_info("test case failed")
-
-                test_cases.append(tc)
-            ts = TestSuite("NixOS integration test", test_cases)
-            f.write(TestSuite.to_xml_string([ts]))
 
 
 class CompositeLogger(AbstractLogger):

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -1,4 +1,3 @@
-import codecs
 import sys
 import time
 import unicodedata
@@ -69,12 +68,60 @@ class AbstractLogger(ABC):
         pass
 
 
+class BufferLogger(AbstractLogger):
+    """A logger that captures output to a string buffer."""
+
+    def __init__(self) -> None:
+        self.buffer = ""
+        self.errors = ""
+
+    def log(self, message: str, attributes: dict[str, str] = {}) -> None:
+        self.buffer += message + "\n"
+
+    @contextmanager
+    def subtest(self, name: str, attributes: dict[str, str] = {}) -> Iterator[None]:
+        self.buffer += f"subtest: {name}\n"
+        yield
+
+    @contextmanager
+    def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
+        self.buffer += message + "\n"
+        yield
+
+    def debug(self, *args, **kwargs) -> None:
+        self.buffer += args[0] + "\n"
+
+    def info(self, *args, **kwargs) -> None:
+        self.buffer += args[0] + "\n"
+
+    def warning(self, *args, **kwargs) -> None:
+        self.buffer += args[0] + "\n"
+
+    def error(self, *args, **kwargs) -> None:
+        self.errors += args[0] + "\n"
+
+    def log_test_error(self, *args, **kwargs) -> None:
+        self.errors += args[0] + "\n"
+
+    def log_serial(self, message: str, machine: str) -> None:
+        self.buffer += f"{machine} # {message}\n"
+
+    def print_serial_logs(self, enable: bool) -> None:
+        pass
+
+    def set_log_level(self, level: LogLevel) -> None:
+        pass
+
+
 class CompositeLogger(AbstractLogger):
     def __init__(self, logger_list: list[AbstractLogger]) -> None:
         self.logger_list = logger_list
 
     def add_logger(self, logger: AbstractLogger) -> None:
         self.logger_list.append(logger)
+
+    def remove_logger(self, logger: AbstractLogger) -> None:
+        self.logger_list.remove(logger)
 
     def log(self, message: str, attributes: dict[str, str] = {}) -> None:
         for logger in self.logger_list:
@@ -154,7 +201,10 @@ class TerminalLogger(AbstractLogger):
     def nested(self, message: str, attributes: dict[str, str] = {}) -> Iterator[None]:
         self._eprint(
             self.maybe_prefix(
-                Style.BRIGHT + Fore.GREEN + message + Style.RESET_ALL,  # ty: ignore[unsupported-operator]
+                Style.BRIGHT
+                + Fore.GREEN
+                + message
+                + Style.RESET_ALL,  # ty: ignore[unsupported-operator]
                 attributes,
             )
         )
@@ -167,7 +217,9 @@ class TerminalLogger(AbstractLogger):
     def debug(self, *args, **kwargs) -> None:
         if self._log_level <= LogLevel.DEBUG:
             self._eprint(
-                Style.DIM + self.maybe_prefix(args[0], kwargs) + Style.RESET_ALL  # ty: ignore[unsupported-operator]
+                Style.DIM
+                + self.maybe_prefix(args[0], kwargs)
+                + Style.RESET_ALL  # ty: ignore[unsupported-operator]
             )
 
     def info(self, *args, **kwargs) -> None:
@@ -191,7 +243,9 @@ class TerminalLogger(AbstractLogger):
         if not self._print_serial_logs:
             return
 
-        self._eprint(Style.DIM + f"{machine} # {message}" + Style.RESET_ALL)  # ty: ignore[unsupported-operator]
+        self._eprint(
+            Style.DIM + f"{machine} # {message}" + Style.RESET_ALL
+        )  # ty: ignore[unsupported-operator]
 
     def log_test_error(self, *args, **kwargs) -> None:
         prefix = Fore.RED + "!!! " + Style.RESET_ALL  # ty: ignore[unsupported-operator]

--- a/nixos/lib/test-driver/src/test_driver/test_reporter.py
+++ b/nixos/lib/test-driver/src/test_driver/test_reporter.py
@@ -21,10 +21,20 @@ class TestReporter:
         self._suite.add_testcase(tc)
         return tc
 
-    def finish(self, tc: TestCase, failure_message: str | None = None) -> None:
+    def finish(
+        self,
+        tc: TestCase,
+        failure_message: str | None = None,
+        stdout: str | None = None,
+        stderr: str | None = None,
+    ) -> None:
         tc.time = time.time() - tc.time
         if failure_message:
             tc.result = [Failure(failure_message)]
+        if stdout:
+            tc.system_out = stdout
+        if stderr:
+            tc.system_err = stderr
 
     def close(self) -> None:
         self._main.time = time.time() - self._main_start
@@ -32,5 +42,6 @@ class TestReporter:
 
         xml = JUnitXml()
         xml.add_testsuite(self._suite)
+        xml.update_statistics()
         self.outfile.parent.mkdir(parents=True, exist_ok=True)
-        xml.write(str(self.outfile))
+        xml.write(str(self.outfile), pretty=True)

--- a/nixos/lib/test-driver/src/test_driver/test_reporter.py
+++ b/nixos/lib/test-driver/src/test_driver/test_reporter.py
@@ -1,0 +1,36 @@
+import atexit
+import time
+from pathlib import Path
+
+from junitparser import Failure, JUnitXml, TestCase, TestSuite
+
+
+class TestReporter:
+    """Records test results and writes JUnit XML on close."""
+
+    def __init__(self, outfile: Path) -> None:
+        self.outfile = outfile
+        self._suite = TestSuite("NixOS integration test")
+        self._main = TestCase("main")
+        self._main_start = time.time()
+        atexit.register(self.close)
+
+    def start(self, name: str) -> TestCase:
+        tc = TestCase(name)
+        tc.time = time.time()  # store start time, replaced with duration on finish
+        self._suite.add_testcase(tc)
+        return tc
+
+    def finish(self, tc: TestCase, failure_message: str | None = None) -> None:
+        tc.time = time.time() - tc.time
+        if failure_message:
+            tc.result = [Failure(failure_message)]
+
+    def close(self) -> None:
+        self._main.time = time.time() - self._main_start
+        self._suite.add_testcase(self._main)
+
+        xml = JUnitXml()
+        xml.add_testsuite(self._suite)
+        self.outfile.parent.mkdir(parents=True, exist_ok=True)
+        xml.write(str(self.outfile))

--- a/nixos/lib/test-driver/src/tests/golden/junit_xml_output.xml
+++ b/nixos/lib/test-driver/src/tests/golden/junit_xml_output.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="1" tests="3" time="0.0">
+	<testsuite disabled="0" errors="0" failures="1" name="NixOS integration test" skipped="0" tests="3" time="0">
+		<testcase name="main">
+			<system-out>Starting test...
+Log message 1
+</system-out>
+		</testcase>
+		<testcase name="my subtest">
+			<system-out>Subtest log
+</system-out>
+		</testcase>
+		<testcase name="failing subtest">
+			<failure type="failure" message="test case failed"/>
+			<system-out>Some output
+</system-out>
+			<system-err>Error occurred
+</system-err>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/nixos/lib/test-driver/src/tests/golden/junit_xml_output.xml
+++ b/nixos/lib/test-driver/src/tests/golden/junit_xml_output.xml
@@ -1,21 +1,17 @@
-<?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="1" tests="3" time="0.0">
-	<testsuite disabled="0" errors="0" failures="1" name="NixOS integration test" skipped="0" tests="3" time="0">
-		<testcase name="main">
-			<system-out>Starting test...
-Log message 1
-</system-out>
-		</testcase>
-		<testcase name="my subtest">
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites tests="3" failures="1" errors="0" skipped="0" time="0">
+	<testsuite name="NixOS integration test" tests="3" errors="0" failures="1" skipped="0" time="0">
+		<testcase name="my subtest" time="0">
 			<system-out>Subtest log
 </system-out>
 		</testcase>
-		<testcase name="failing subtest">
-			<failure type="failure" message="test case failed"/>
+		<testcase name="failing subtest" time="0">
+			<failure message="test case failed"/>
 			<system-out>Some output
 </system-out>
 			<system-err>Error occurred
 </system-err>
 		</testcase>
+		<testcase name="main" time="0"/>
 	</testsuite>
 </testsuites>

--- a/nixos/lib/test-driver/src/tests/test_junit_xml.py
+++ b/nixos/lib/test-driver/src/tests/test_junit_xml.py
@@ -1,0 +1,49 @@
+import tempfile
+from pathlib import Path
+
+from test_driver.logger import JunitXMLLogger
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+
+
+def test_junit_xml_output() -> None:
+    """Test that JunitXMLLogger produces expected JUnit XML output."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        outfile = Path(f.name)
+
+    logger = JunitXMLLogger(outfile)
+
+    # Log some messages to main test case
+    logger.log("Starting test...")
+    logger.info("Log message 1")
+
+    # Create a subtest
+    with logger.subtest("my subtest"):
+        logger.log("Subtest log")
+
+    # Create a failing subtest
+    with logger.subtest("failing subtest"):
+        logger.log("Some output")
+        logger.error("Error occurred")
+
+    # Manually close to write the file (normally done via atexit)
+    import atexit
+
+    atexit.unregister(logger.close)
+    logger.close()
+
+    actual = outfile.read_text()
+    golden_file = GOLDEN_DIR / "junit_xml_output.xml"
+
+    if not golden_file.exists():
+        golden_file.parent.mkdir(parents=True, exist_ok=True)
+        golden_file.write_text(actual)
+        raise AssertionError(
+            f"Golden file did not exist, created it at {golden_file}. "
+            "Please verify the output and re-run the test."
+        )
+
+    expected = golden_file.read_text()
+    assert actual == expected, f"JUnit XML output differs from golden file:\n{actual}"
+
+    outfile.unlink()

--- a/nixos/lib/test-driver/src/tests/test_junit_xml.py
+++ b/nixos/lib/test-driver/src/tests/test_junit_xml.py
@@ -1,38 +1,43 @@
+import atexit
+import re
 import tempfile
 from pathlib import Path
 
-from test_driver.logger import JunitXMLLogger
+from test_driver.test_reporter import TestReporter
 
 GOLDEN_DIR = Path(__file__).parent / "golden"
 
 
+def normalize_xml(xml: str) -> str:
+    """Remove time attributes since they vary between runs."""
+    return re.sub(r'\btime="[^"]*"', 'time="0"', xml)
+
+
 def test_junit_xml_output() -> None:
-    """Test that JunitXMLLogger produces expected JUnit XML output."""
+    """Test that TestReporter produces expected JUnit XML output."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
         outfile = Path(f.name)
 
-    logger = JunitXMLLogger(outfile)
+    reporter = TestReporter(outfile)
 
-    # Log some messages to main test case
-    logger.log("Starting test...")
-    logger.info("Log message 1")
+    # Create a passing subtest with stdout
+    tc1 = reporter.start("my subtest")
+    reporter.finish(tc1, stdout="Subtest log\n")
 
-    # Create a subtest
-    with logger.subtest("my subtest"):
-        logger.log("Subtest log")
-
-    # Create a failing subtest
-    with logger.subtest("failing subtest"):
-        logger.log("Some output")
-        logger.error("Error occurred")
+    # Create a failing subtest with stdout and stderr
+    tc2 = reporter.start("failing subtest")
+    reporter.finish(
+        tc2,
+        failure_message="test case failed",
+        stdout="Some output\n",
+        stderr="Error occurred\n",
+    )
 
     # Manually close to write the file (normally done via atexit)
-    import atexit
+    atexit.unregister(reporter.close)
+    reporter.close()
 
-    atexit.unregister(logger.close)
-    logger.close()
-
-    actual = outfile.read_text()
+    actual = normalize_xml(outfile.read_text())
     golden_file = GOLDEN_DIR / "junit_xml_output.xml"
 
     if not golden_file.exists():
@@ -43,7 +48,7 @@ def test_junit_xml_output() -> None:
             "Please verify the output and re-run the test."
         )
 
-    expected = golden_file.read_text()
+    expected = normalize_xml(golden_file.read_text())
     assert actual == expected, f"JUnit XML output differs from golden file:\n{actual}"
 
     outfile.unlink()

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -98,6 +98,11 @@ in
       {
         name = "vm-test-run-${config.name}";
 
+        outputs = [
+          "out"
+          "junitXmlReport"
+        ];
+
         requiredSystemFeatures = [
           "nixos-test"
         ]
@@ -126,7 +131,11 @@ in
 
           ${config.driver}/bin/nixos-test-driver \
             -o $out \
-            ${lib.optionalString config.enableDebugHook "--debug-hook=${hostPkgs.breakpointHook.attach}"}
+            ${lib.optionalString config.enableDebugHook "--debug-hook=${hostPkgs.breakpointHook.attach}"} \
+            --junit-xml results.xml
+
+          mkdir -p $junitXmlReport
+          cp $out/results.xml $junitXmlReport/
         '';
 
         passthru = config.passthru;
@@ -137,6 +146,10 @@ in
       # lazyDerivation improves performance when only passthru items and/or meta are used.
       derivation = lib.asserts.checkAssertWarn config.assertions config.warnings config.rawTestDerivation;
       inherit (config) passthru meta;
+      outputs = [
+        "out"
+        "junitXmlReport"
+      ];
     };
 
     # useful for inspection (debugging / exploration)


### PR DESCRIPTION
This PR does several improvements to the junit XML reporting feature of the nixos test driver. 

1. The logic to create reports has been outsourced into a dedicated module `test_reporter.py`. This separates concerns between logging test output (in Logger.py) and reporting the status of the subtests.
1. The test report is now a nix output of the test and always provided. It can be accessed via 
 
    ```
    nix build .#nixosTests.simple.junitXmlReport
    cat result-junitXmlReport/results.xml
    ```

    The previous way to create the report by specifying `--junit-xml` when running the test driver executable is still supported but could be removed in the future since accessing the report from the output of the test derivation is more convenient.
1. The test report is now created with the `junitparser` library which is actively maintained. The `junit_xml` library which we were using before has not seen any maintenance activity since Feb 2020.

This PR enables us to remove the self grown logger in the future as attempted in https://github.com/NixOS/nixpkgs/pull/509687.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
