### PR TITLE
nixos/ec2: switch to UEFI + systemd-boot, drop BIOS support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -141,6 +141,8 @@
 
 - `linux-rt` kernel has been removed due to a lack of maintenance.
 
+- EC2 images now use UEFI with systemd-boot. Legacy BIOS boot with GRUB is no longer supported and the `ec2.efi` option has been removed. Existing instances booted from BIOS-based AMIs cannot be switched in-place and must be re-deployed from a new UEFI AMI. Existing UEFI instances upgrading from GRUB need to run `nixos-rebuild switch --install-bootloader` once to install systemd-boot. When registering new AMIs, pass `--boot-mode uefi` to `aws ec2 register-image`. A small number of older instance types (e.g. `t1.micro`, `m1.*`) do not support UEFI and are no longer compatible with NixOS AMIs. If you need legacy BIOS boot, set `boot.loader.grub.device` and `boot.loader.grub.efiInstallAsRemovable` yourself.
+
 - `rustic` was upgraded to `0.11.x`, which contains breaking [changes to command-line parameters and configuration file](https://rustic.cli.rs/docs/breaking_changes.html#0110).
 
 - The packages `iw` and `wirelesstools` (`iwconfig`, `iwlist`, etc.) are no longer installed implicitly if wireless networking has been enabled.

--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -14,7 +14,7 @@ let
     ;
   inherit (lib.options) literalExpression;
   cfg = config.amazonImage;
-  amiBootMode = if config.ec2.efi then "uefi" else "legacy-bios";
+  amiBootMode = "uefi";
 in
 {
   imports = [
@@ -85,9 +85,6 @@ in
       configFile = pkgs.writeText "configuration.nix" ''
         { modulesPath, ... }: {
           imports = [ "''${modulesPath}/virtualisation/amazon-image.nix" ];
-          ${optionalString config.ec2.efi ''
-            ec2.efi = true;
-          ''}
           ${optionalString config.ec2.zfs.enable ''
             ec2.zfs.enable = true;
             networking.hostId = "${config.networking.hostId}";
@@ -162,7 +159,7 @@ in
         name = config.image.baseName;
 
         fsType = "ext4";
-        partitionTableType = if config.ec2.efi then "efi" else "legacy+gpt";
+        partitionTableType = "efi";
 
         inherit (config.virtualisation) diskSize;
 

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -41,14 +41,10 @@ in
       }
     );
 
-    fileSystems."/boot" = mkIf (cfg.efi || cfg.zfs.enable) (
-      lib.mkDefault {
-        # The ZFS image uses a partition labeled ESP whether or not we're
-        # booting with EFI.
-        device = "/dev/disk/by-label/ESP";
-        fsType = "vfat";
-      }
-    );
+    fileSystems."/boot" = lib.mkDefault {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
+    };
 
     services.zfs.expandOnBoot = mkIf cfg.zfs.enable "all";
 
@@ -81,15 +77,8 @@ in
       "xen_fbfront"
     ];
 
-    boot.loader.grub.device = if cfg.efi then "nodev" else "/dev/xvda";
-    boot.loader.grub.efiSupport = cfg.efi;
-    boot.loader.grub.efiInstallAsRemovable = cfg.efi;
+    boot.loader.systemd-boot.enable = true;
     boot.loader.timeout = 1;
-    boot.loader.grub.extraConfig = ''
-      serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
-      terminal_output console serial
-      terminal_input console serial
-    '';
 
     systemd.services.fetch-ec2-metadata = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -1,13 +1,20 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 let
-  inherit (lib) literalExpression types;
+  inherit (lib) types;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "ec2" "efi" ] ''
+      EC2 images now always use UEFI with systemd-boot.
+      If you need legacy BIOS boot, set boot.loader.grub.device and
+      boot.loader.grub.efiInstallAsRemovable yourself.
+    '')
+  ];
+
   options = {
     ec2 = {
       zfs = {
@@ -48,14 +55,6 @@ in
             }
           );
         };
-      };
-      efi = lib.mkOption {
-        default = pkgs.stdenv.hostPlatform.isAarch64;
-        defaultText = literalExpression "pkgs.stdenv.hostPlatform.isAarch64";
-        internal = true;
-        description = ''
-          Whether the EC2 instance is using EFI.
-        '';
       };
       hvm = lib.mkOption {
         description = "Unused legacy option. While support for non-hvm has been dropped, we keep this option around so that NixOps remains compatible with a somewhat recent `nixpkgs` and machines with an old `stateVersion`.";

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -13,6 +13,10 @@ let
   inherit (lib) mkAfter mkForce;
   pkgs = config.node.pkgs;
 
+  qemuCommon = import ../lib/qemu-common.nix {
+    inherit lib;
+    inherit (pkgs) stdenv;
+  };
   imdsServer = import ./common/imds-server.nix { inherit pkgs; };
 
   # Build an EC2 image configuration
@@ -31,10 +35,12 @@ let
           # the configuration in virtualisation/amazon-image.nix.
           systemd.services."serial-getty@ttyS0".enable = mkForce false;
 
-          # Make /dev/console point to serial console for proper capture
-          # test-instrumentation.nix adds console=tty0, so we need to add console=ttyS0 AFTER it
-          # The last console= parameter takes precedence for /dev/console
-          boot.kernelParams = mkAfter [ "console=ttyS0" ];
+          # Make /dev/console point to the correct serial device for capture.
+          # test-instrumentation.nix adds console=tty0, so we append the
+          # architecture-appropriate serial device AFTER it (last console=
+          # parameter takes precedence for /dev/console). On x86_64 this is
+          # ttyS0 (16550A), on aarch64 it is ttyAMA0 (PL011).
+          boot.kernelParams = mkAfter [ "console=${qemuCommon.qemuSerialDevice}" ];
 
           # Configure VLAN networking to match test framework setup
           networking.interfaces.eth0 = {
@@ -180,8 +186,17 @@ in
             + f" -netdev 'user,id=ec2meta,net=169.0.0.0/8,guestfwd=tcp:169.254.169.254:80-cmd:${lib.getExe imdsServer} {metadata_dir}'"
         )
 
+        # UEFI firmware: writable copy of vars (OVMF needs to write NVRAM)
+        import shutil
+        efi_vars = os.path.join(image_dir, "efivars.fd")
+        shutil.copy2("${pkgs.OVMF.variables}", efi_vars)
+        os.chmod(efi_vars, 0o644)
+
         start_command = (
             "qemu-kvm -m 1024"
+            + "${if pkgs.stdenv.hostPlatform.isAarch64 then " -machine virt -cpu cortex-a72" else ""}"
+            + " -drive if=pflash,format=raw,unit=0,readonly=on,file=${pkgs.OVMF.firmware}"
+            + f" -drive if=pflash,format=raw,unit=1,file={efi_vars}"
             + f" -drive file={disk_image},if=virtio,werror=report"
             + vlan_net
             + metadata_net


### PR DESCRIPTION
Fixes NixOS/amis#353

EC2 images now always use UEFI with systemd-boot. Legacy BIOS boot with GRUB is removed.

Changes:
- `amazon-options.nix`: remove `ec2.efi` option (`mkRemovedOptionModule`)
- `amazon-image.nix`: replace GRUB config with systemd-boot
- `ec2/amazon-image.nix`: hardcode `amiBootMode = "uefi"` and `partitionTableType = "efi"`
- `ec2-image.nix`: boot test VM with OVMF firmware
- Release notes: document breaking change and migration path

Tested on x86_64-linux and aarch64-linux (all 11 subtests in `nixosTests.ec2-image` pass).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
