### PR TITLE
nixos/plasma6-mobile: add module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15239,6 +15239,12 @@
     githubId = 480920;
     name = "Luca Bruno";
   };
+  leuflatworm = {
+    email = "leu@mail.leuf.jp";
+    github = "leuflatworm";
+    githubId = 61083894;
+    name = "Leu";
+  };
   leungbk = {
     email = "leungbk@mailfence.com";
     github = "leungbk";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -54,6 +54,10 @@
 
 - [knot-resolver](https://www.knot-resolver.cz/) in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
 
+- [Plasma Mobile 6](https://plasma-mobile.org/), KDE's mobile shell
+  for smartphones and tablets, built on top of Plasma 6. Available as
+  [services.desktopManager.plasma6.mobile](#opt-services.desktopManager.plasma6.mobile.enable).
+
 - [ImmichFrame](https://immichframe.dev/), display your photos from Immich as a digital photo frame. Available as `services.immichframe`.
 
 - [PdfDing](https://www.pdfding.com/), manage, view and edit your PDFs seamlessly on all your devices wherever you are. Available as [services.pdfding](#opt-services.pdfding.enable).

--- a/nixos/modules/services/desktop-managers/plasma6-mobile.nix
+++ b/nixos/modules/services/desktop-managers/plasma6-mobile.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.desktopManager.plasma6.mobile;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  inherit (pkgs) kdePackages;
+in
+{
+  options.services.desktopManager.plasma6.mobile = {
+    enable = mkEnableOption "Plasma Mobile shell (Plasma 6)";
+  };
+
+  options.environment.plasma6.mobile.excludePackages = mkOption {
+    description = "List of Plasma Mobile packages to exclude from the default installation.";
+    type = types.listOf types.package;
+    default = [ ];
+    example = lib.literalExpression "[ pkgs.kdePackages.kclock ]";
+  };
+
+  config = mkIf cfg.enable {
+    services.desktopManager.plasma6.enable = mkDefault true;
+
+    # plasmashell crashes without a PulseAudio-compatible sound server.
+    warnings =
+      lib.optionals
+        (
+          !(
+            config.services.pulseaudio.enable
+            || (config.services.pipewire.enable && config.services.pipewire.pulse.enable)
+          )
+        )
+        [
+          ''
+            Plasma Mobile requires a PulseAudio-compatible sound server.
+            Without one, plasmashell will crash on startup.
+            Enable services.pipewire with services.pipewire.pulse.enable = true,
+            or enable services.pulseaudio.
+          ''
+        ];
+
+    services.pipewire.enable = mkDefault true;
+    services.pipewire.pulse.enable = mkDefault true;
+
+    environment.systemPackages =
+      let
+        requiredPackages = with kdePackages; [
+          plasma-mobile
+          plasma-keyboard # .desktop file referenced by envmanager's kwinrc InputMethod
+        ];
+        optionalPackages = with kdePackages; [
+          alligator
+          audiotube
+          calindori
+          kalk
+          kasts
+          kclock
+          keysmith
+          koko
+          kongress
+          krecorder
+          ktrip
+          kweather
+          plasma-dialer
+          qmlkonsole
+          spacebar
+        ];
+      in
+      requiredPackages
+      ++ utils.removePackagesByName optionalPackages config.environment.plasma6.mobile.excludePackages;
+
+    services.displayManager = {
+      sessionPackages = [ kdePackages.plasma-mobile ];
+      defaultSession = lib.mkOverride 900 "plasma-mobile";
+    };
+    services.displayManager.sddm.settings.General.InputMethod = mkDefault "qtvirtualkeyboard";
+
+    hardware.bluetooth.enable = mkDefault true;
+    networking.networkmanager.enable = mkDefault true;
+    hardware.sensor.iio.enable = mkDefault true;
+  };
+  meta.maintainers = with lib.maintainers; [ leuflatworm ];
+}

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -27,6 +27,7 @@ in
     ./phosh.nix
     ./xfce.nix
     ../../desktop-managers/plasma6.nix
+    ../../desktop-managers/plasma6-mobile.nix
     ./lumina.nix
     ./lxqt.nix
     ./enlightenment.nix

--- a/pkgs/kde/plasma/plasma-mobile/default.nix
+++ b/pkgs/kde/plasma/plasma-mobile/default.nix
@@ -17,6 +17,17 @@ mkKdeDerivation {
   # FIXME: work around Qt 6.10 cmake API changes
   cmakeFlags = [ "-DQT_FIND_PRIVATE_MODULES=1" ];
 
+  # Upstream hardcodes an FHS path in envmanager/config.h for the default
+  # kwinrc InputMethod. plasma-mobile-envmanager writes this to
+  # ~/.config/plasma-mobile/kwinrc as an immutable ([$i]) entry, so it cannot
+  # be overridden by /etc/xdg. Rewrite the prefix to the NixOS system path so
+  # the on-screen keyboard loads on first boot.
+  postPatch = ''
+    substituteInPlace envmanager/config.h \
+      --replace-fail "/usr/share/applications/org.kde.plasma.keyboard.desktop" \
+      "/run/current-system/sw/share/applications/org.kde.plasma.keyboard.desktop"
+  '';
+
   postFixup = ''
     substituteInPlace "$out/share/wayland-sessions/plasma-mobile.desktop" \
       --replace-fail \


### PR DESCRIPTION
## Motivation

Adds a NixOS module for Plasma Mobile 6. Addresses #432702 and
supersedes the stalled #459790 (which targeted Plasma Mobile 6.5.x
and hit the maliit-keyboard incompatibility; upstream resolved most
of that between 6.5.5 and 6.6.4, leaving only an FHS path prefix to
patch).

## Testing

Tested on a Panasonic TOUGHBOOK FZ-G2 (touchscreen tablet) running
NixOS unstable. Verified: shell starts, on-screen keyboard appears
automatically on first boot, Bluetooth / WiFi / auto-rotate work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.