### PR TITLE
emissary: include necessary dynamic library guis, and 0.3.1 -> 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4428,6 +4428,12 @@
     github = "caperren";
     githubId = 4566591;
   };
+  cappuccinocosmico = {
+    name = "Nicole Venner";
+    email = "nvenner@protonmail.ch";
+    github = "cappuccinocosmico";
+    githubId = 12666459;
+  };
   CaptainJawZ = {
     email = "CaptainJawZ@outlook.com";
     name = "Danilo Reyes";

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -25,19 +25,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-  ]
-  ++ lib.optionals stdenv.targetPlatform.isLinux [
-    makeWrapper
   ];
-
   buildInputs = [
     openssl
     fontconfig
-  ]
-  ++ lib.optionals stdenv.targetPlatform.isLinux [
-    libx11
-    libxkbcommon
-    wayland
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -57,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/eepnet/emissary/releases/tag/${finalAttrs.version}";
     description = "Rust implementation of the I2P protocol stack";
     homepage = "https://eepnet.github.io/emissary/";
-    license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/altonen/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
+    license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/eepnet/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
     mainProgram = "emissary-cli";
     maintainers = [
       lib.maintainers.N4CH723HR3R

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -42,9 +42,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
-  postInstall = lib.optionalString stdenv.targetPlatform.isLinux ''
-    wrapProgram $out/bin/emissary-cli \
-      --prefix LD_LIBRARY_PATH : ${
+  postFixup = lib.optionalString stdenv.targetPlatform.isLinux ''
+    patchelf $out/bin/${finalAttrs.meta.mainProgram} \
+      --add-rpath ${
         lib.makeLibraryPath [
           wayland
           libxkbcommon

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -59,6 +59,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://eepnet.github.io/emissary/";
     license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/altonen/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
     mainProgram = "emissary-cli";
-    maintainers = [ lib.maintainers.N4CH723HR3R ];
+    maintainers = [
+      lib.maintainers.N4CH723HR3R
+      lib.maintainers.cappuccinocosmico
+    ];
   };
 })

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -8,15 +8,15 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "emissary";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "altonen";
     repo = "emissary";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fLhvMzdxXAuEB99NgIfTLxYezIIZVaC8Z6snK9UUEl0=";
+    hash = "sha256-W4QEN52A6s1qDso73tM50/BcjxoX72LbmTG2kJiTfRs=";
   };
-  cargoHash = "sha256-ZboA5wO3vitts6L/tQc23z7bIFmFdj1freXHBoDl06k=";
+  cargoHash = "sha256-cP1ddtppcSUhl2G2C/Pd4+C/xqlB27/D12t5lFUfChQ=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -2,16 +2,21 @@
   rustPlatform,
   fetchFromGitHub,
   lib,
+  stdenv,
   pkg-config,
   openssl,
   fontconfig,
+  libx11,
+  libxkbcommon,
+  wayland,
+  makeWrapper,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "emissary";
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "altonen";
+    owner = "eepnet";
     repo = "emissary";
     tag = "v${finalAttrs.version}";
     hash = "sha256-W4QEN52A6s1qDso73tM50/BcjxoX72LbmTG2kJiTfRs=";
@@ -20,20 +25,39 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+  ]
+  ++ lib.optionals stdenv.targetPlatform.isLinux [
+    makeWrapper
   ];
 
   buildInputs = [
     openssl
     fontconfig
+  ]
+  ++ lib.optionals stdenv.targetPlatform.isLinux [
+    libx11
+    libxkbcommon
+    wayland
   ];
 
   __darwinAllowLocalNetworking = true;
 
+  postInstall = lib.optionalString stdenv.targetPlatform.isLinux ''
+    wrapProgram $out/bin/emissary-cli \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+          libx11
+        ]
+      }
+  '';
+
   meta = {
-    changelog = "https://github.com/altonen/emissary/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/eepnet/emissary/releases/tag/${finalAttrs.version}";
     description = "Rust implementation of the I2P protocol stack";
-    homepage = "https://altonen.github.io/emissary/";
-    license = lib.licenses.mit; # https://github.com/altonen/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/altonen/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
+    homepage = "https://eepnet.github.io/emissary/";
+    license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/altonen/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
     mainProgram = "emissary-cli";
     maintainers = [ lib.maintainers.N4CH723HR3R ];
   };

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -48,6 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/eepnet/emissary/releases/tag/${finalAttrs.version}";
     description = "Rust implementation of the I2P protocol stack";
     homepage = "https://eepnet.github.io/emissary/";
+    changelog = "https://github.com/eepnet/emissary/releases";
     license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/eepnet/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
     mainProgram = "emissary-cli";
     maintainers = [


### PR DESCRIPTION
This goes ahead and bumps the version from 0.3.1 -> 0.4.0, and adds in some dynamic libraries that were preventing the UI from running on a regular nixos install.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
