### PR TITLE
lib/modules: skip optional + ++ in evalOptionValue when no default

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1121,11 +1121,16 @@ let
     let
       # Add in the default value for this option, if any.
       defs' =
-        (optional (opt ? default) {
-          file = head opt.declarations;
-          value = mkOptionDefault opt.default;
-        })
-        ++ defs;
+        if opt ? default then
+          [
+            {
+              file = head opt.declarations;
+              value = mkOptionDefault opt.default;
+            }
+          ]
+          ++ defs
+        else
+          defs;
 
       # Handle properties, check types, and merge everything together.
       res =


### PR DESCRIPTION
Replace `(optional (opt ? default) { ... }) ++ defs` with a direct `if/then/else` in `evalOptionValue`. When the option has no default, this skips both the `optional` function call (closure + env allocation) and the `++` list concat entirely.

This function runs for every NixOS option evaluation, so even small per-call savings add up.

<details><summary>Benchmark</summary>

```
Linux desktop 6.18.9 #1-NixOS SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
AMD Ryzen 9 5950X 16-Core Processor, 128 GB RAM
nix (Nix) 2.33.3
```

```bash
# hello.drvPath
NIX_SHOW_STATS=1 nix-instantiate --eval -E '(import ./. {}).hello.drvPath' 2>stats.json >/dev/null

# minimal NixOS system eval
NIX_SHOW_STATS=1 nix-instantiate -I nixpkgs=. --eval -E '
  let nixos = import ./nixos/lib/eval-config.nix {
    modules = [ ./nixos/modules/profiles/minimal.nix
      { fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
        boot.loader.grub.devices = ["/dev/sda"]; } ];
  }; in nixos.config.system.build.toplevel.drvPath
' >/dev/null 2>stats.json

# all top-level .drvPaths
NIX_SHOW_STATS=1 nix-instantiate --eval --strict \
  -E 'let pkgs = import ./. {}; in builtins.mapAttrs (n: v: let e = builtins.tryEval (v.drvPath or null); in if e.success then e.value else null) pkgs' \
  2>stats.json >/dev/null
```

### Minimal NixOS system eval (primary target)

Wall-clock cpuTime (5 runs each): baseline mean 5.42s, optimized mean 5.45s — within noise.

| metric | baseline | optimized | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 4,823,689 | 4,778,901 | -44,788 | **-0.93%** |
| envs.number | 5,612,746 | 5,567,964 | -44,782 | **-0.80%** |
| envs.bytes | 107,958,512 | 107,242,064 | -716,448 | **-0.66%** |
| nrThunks | 7,127,313 | 7,101,242 | -26,071 | -0.37% |
| list.concats | 191,587 | 187,892 | -3,695 | **-1.93%** |
| gc.totalBytes | 560,420,864 | 559,292,160 | -1,128,704 | -0.20% |

### Full eval (all top-level .drvPaths)

| metric | baseline | optimized | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 106,853,787 | 106,807,051 | -46,736 | -0.04% |
| envs.number | 120,331,562 | 120,284,838 | -46,724 | -0.04% |
| envs.bytes | 2,494,330,064 | 2,493,582,696 | -747,368 | -0.03% |
| gc.totalBytes | 15,416,949,136 | 15,415,834,944 | -1,114,192 | -0.01% |

`nrOpUpdates`, `nrOpUpdateValuesCopied`, `sets.number`, and `sets.bytes` are unchanged (0.00%) across all workloads — this targets the module merge pipeline, not attrset merges.

</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test