### PR TITLE
swiftlint: 0.62.1 -> 0.63.2

### DIFF
--- a/pkgs/by-name/sw/swiftlint/package.nix
+++ b/pkgs/by-name/sw/swiftlint/package.nix
@@ -9,11 +9,11 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "swiftlint";
-  version = "0.62.1";
+  version = "0.63.2";
 
   src = fetchurl {
     url = "https://github.com/realm/SwiftLint/releases/download/${version}/portable_swiftlint.zip";
-    hash = "sha256-VB20vZT4z4+6q3YvWX5/DkkBan+MpccNhrQ3CnzSNkE=";
+    hash = "sha256-xZpAXIX5W5LO1nelAIBOCBWWpMrkpqSFr3YGVVfW7Sk=";
   };
 
   dontPatch = true;


### PR DESCRIPTION

## Things done

Update https://github.com/realm/SwiftLint/releases/tag/0.63.2

Works fine on `aarch64-darwin`:

```console
$ nix-build -A swiftlint
/nix/store/f7ak0fvj7z92k8syzkzvwvispa22dcpb-swiftlint-0.63.2
$ printf "class test{}\n\nvar a = 1" > test.swift
$ ./result/bin/swiftlint test.swift
Linting Swift files at paths test.swift
Linting 'test.swift' (1/1)
/Users/dimitar/Projects/nixpkgs/test.swift:3:5: error: Identifier Name Violation: Variable name 'a' should be between 3 and 40 characters long (identifier_name)
/Users/dimitar/Projects/nixpkgs/test.swift:1:11: warning: Opening Brace Spacing Violation: Opening braces should be preceded by a single space and on the same line as the declaration (opening_brace)
/Users/dimitar/Projects/nixpkgs/test.swift:3:1: warning: Trailing Newline Violation: Files should have a single trailing newline (trailing_newline)
/Users/dimitar/Projects/nixpkgs/test.swift:1:7: error: Type Name Violation: Type name 'test' should start with an uppercase character (type_name)
Done linting! Found 4 violations, 2 serious in 1 file.
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
