### PR TITLE
kdePackages.kwin: backport https://invent.kde.org/plasma/kwin/-/merge_requests/8716 from 6.6 to fix https://bugs.kde.org/show_bug.cgi?id=511611

### DIFF
--- a/pkgs/kde/plasma/kwin/0001-Drop-Activate-request-in-LogindSession.patch
+++ b/pkgs/kde/plasma/kwin/0001-Drop-Activate-request-in-LogindSession.patch
@@ -1,0 +1,113 @@
+From 14bb08163b58b4402fc735e1caf484f81870cbb7 Mon Sep 17 00:00:00 2001
+From: Vlad Zahorodnii <vlad.zahorodnii@kde.org>
+Date: Wed, 28 Jan 2026 11:39:36 +0200
+Subject: [PATCH 1/2] core: Drop Activate request in LogindSession
+
+Apparently depending on the system configuration, the Activate request
+may fail even though the session is already active.
+
+In general, we don't support starting kwin in a specific VT, so the
+activate request isn't really necessary. Other compositors don't bother
+making the Activate() request too. So assume that the display manager
+sets things up for us as expected.
+
+(cherry picked from commit bc8bfb19ddc849193694ceda9d18de58b17e4c58)
+---
+ src/core/session_logind.cpp | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/src/core/session_logind.cpp b/src/core/session_logind.cpp
+index 5f6541c289b..dfadf0ec48b 100644
+--- a/src/core/session_logind.cpp
++++ b/src/core/session_logind.cpp
+@@ -95,17 +95,6 @@ static void releaseControl(const QString &sessionPath)
+     QDBusConnection::systemBus().asyncCall(message);
+ }
+ 
+-static bool activate(const QString &sessionPath)
+-{
+-    const QDBusMessage message = QDBusMessage::createMethodCall(s_serviceName, sessionPath,
+-                                                                s_sessionInterface,
+-                                                                QStringLiteral("Activate"));
+-
+-    const QDBusMessage reply = QDBusConnection::systemBus().call(message);
+-
+-    return reply.type() != QDBusMessage::ErrorMessage;
+-}
+-
+ std::unique_ptr<LogindSession> LogindSession::create()
+ {
+     if (!QDBusConnection::systemBus().interface()->isServiceRegistered(s_serviceName)) {
+@@ -118,12 +107,6 @@ std::unique_ptr<LogindSession> LogindSession::create()
+         return nullptr;
+     }
+ 
+-    if (!activate(sessionPath)) {
+-        qCWarning(KWIN_CORE, "Failed to activate %s session. Maybe another compositor is running?",
+-                  qPrintable(sessionPath));
+-        return nullptr;
+-    }
+-
+     if (!takeControl(sessionPath)) {
+         qCWarning(KWIN_CORE, "Failed to take control of %s session. Maybe another compositor is running?",
+                   qPrintable(sessionPath));
+-- 
+GitLab
+
+
+From 8431c80304f581eb2d4d119773bc6b09c9b9c045 Mon Sep 17 00:00:00 2001
+From: Vlad Zahorodnii <vlad.zahorodnii@kde.org>
+Date: Wed, 28 Jan 2026 11:43:56 +0200
+Subject: [PATCH 2/2] core: Drop Activate request in ConsoleKitSession
+
+Apparently depending on the system configuration, the Activate request
+may fail even though the session is already active.
+
+In general, we don't support starting kwin in a specific VT, so the
+activate request isn't really necessary. Other compositors don't bother
+making the Activate() request too. So assume that the display manager
+sets things up for us as expected.
+
+(cherry picked from commit 7fb47baf262f4cb5ea1198f9e8762630cec698f6)
+---
+ src/core/session_consolekit.cpp | 17 -----------------
+ 1 file changed, 17 deletions(-)
+
+diff --git a/src/core/session_consolekit.cpp b/src/core/session_consolekit.cpp
+index c0e8449f8a2..e75ed46ac54 100644
+--- a/src/core/session_consolekit.cpp
++++ b/src/core/session_consolekit.cpp
+@@ -97,17 +97,6 @@ static void releaseControl(const QString &sessionPath)
+     QDBusConnection::systemBus().asyncCall(message);
+ }
+ 
+-static bool activate(const QString &sessionPath)
+-{
+-    const QDBusMessage message = QDBusMessage::createMethodCall(s_serviceName, sessionPath,
+-                                                                s_sessionInterface,
+-                                                                QStringLiteral("Activate"));
+-
+-    const QDBusMessage reply = QDBusConnection::systemBus().call(message);
+-
+-    return reply.type() != QDBusMessage::ErrorMessage;
+-}
+-
+ std::unique_ptr<ConsoleKitSession> ConsoleKitSession::create()
+ {
+     if (!QDBusConnection::systemBus().interface()->isServiceRegistered(s_serviceName)) {
+@@ -120,12 +109,6 @@ std::unique_ptr<ConsoleKitSession> ConsoleKitSession::create()
+         return nullptr;
+     }
+ 
+-    if (!activate(sessionPath)) {
+-        qCWarning(KWIN_CORE, "Failed to activate %s session. Maybe another compositor is running?",
+-                  qPrintable(sessionPath));
+-        return nullptr;
+-    }
+-
+     if (!takeControl(sessionPath)) {
+         qCWarning(KWIN_CORE, "Failed to take control of %s session. Maybe another compositor is running?",
+                   qPrintable(sessionPath));
+-- 
+GitLab
+

--- a/pkgs/kde/plasma/kwin/default.nix
+++ b/pkgs/kde/plasma/kwin/default.nix
@@ -17,7 +17,6 @@
   pipewire,
   krunner,
   python3,
-  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "kwin";
@@ -26,6 +25,7 @@ mkKdeDerivation {
     ./0003-plugins-qpa-allow-using-nixos-wrapper.patch
     ./0001-NixOS-Unwrap-executable-name-for-.desktop-search.patch
     ./0001-Lower-CAP_SYS_NICE-from-the-ambient-set.patch
+    ./0001-Drop-Activate-request-in-LogindSession.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://bugs.kde.org/show_bug.cgi?id=511611
> ### SUMMARY
>
> Occasionally, kwin_wayland failing to request access to input devices from logind, resulting in inaccessible mouse and keyboard in its graphical session. This happens not every login, just at random login attempt, both at the clean boot or re-login. Mouse and keyboard are inaccessible in this case due to permission request failing (btw, mouse pointer is invisible, but it is not the problem with drm and video driver in this situation. so software cursor doesn't help). And when that happens, I can't interact with my PC though keyboard. keystrokes are blocked and the ways to deal with it is wait for screen off and sysrq-ing virtual console and login to it or hit ctrl+alt+del to reboot system. At the time, when error happened, this log line appears in journald:
>
> Failed to activate /org/freedesktop/login1/session/_32 session. Maybe another compositor is running?
>
> There is no another compositor runnging and I using sddm greeter with Wayland backend. This error didn't happen in 6.4.5 or even 6.4.91 and appeared with Plasma 6.5.0 release.
>
> ### STEPS TO REPRODUCE
> 1.  Login from sddm to Plasma Wayland session.
> 2.  Expect no possibility for interaction with interface (only ctrl+alt+del or wait for screen of and sysrq-ing)
>
>
> ### OBSERVED RESULT
>
> No possibility for interaction with interface (only ctrl+alt+del or wait for screen of and sysrq-ing). (happens not every time)
>
> ### EXPECTED RESULT
>
> Normal interraction with interface (which happens not every login)

https://invent.kde.org/plasma/kwin/-/merge_requests/8716 fix this but only merged into `6.6` branch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
