### PR TITLE
container: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/by-name/co/container/package.nix
+++ b/pkgs/by-name/co/container/package.nix
@@ -11,11 +11,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "container";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchurl {
-    url = "https://github.com/apple/container/releases/download/${finalAttrs.version}/container-installer-signed.pkg";
-    hash = "sha256-6KQysR85bVzlDkTqFPAvffkP/O9EHJFrL6krY+lfWAE=";
+    url = "https://github.com/apple/container/releases/download/${finalAttrs.version}/container-${finalAttrs.version}-installer-signed.pkg";
+    hash = "sha256-xIHONVUk0DbDzdrH/SgeMXlNQGkL+aIfcy7z12+p/gg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description

  Update [apple/container](https://github.com/apple/container) from 0.9.0 to 0.10.0.

  Fix URL template: starting with 0.10.0, Apple changed the release asset naming
  from `container-installer-signed.pkg` to
  `container-${version}-installer-signed.pkg`. The old unversioned URL 404s for
  0.10.0+.

  [Changelog](https://github.com/apple/container/releases/tag/0.10.0)

  ## Things done

  - Built on platform:
    - [x] aarch64-darwin
  - Tested, as applicable:
    - [ ] NixOS tests in `nixos/tests`
    - [x] Package tests at `passthru.tests`
    - [ ] Tests in `lib/tests` or `pkgs/test` for functions and "core" functionality
  - [ ] Ran `nixpkgs-review` on this PR
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module
    - [ ] Module update: when the change is significant
  - [x] Fits
  [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md),
  `pkgs/README.md`, `maintainers/README.md` and other READMEs