### PR TITLE
lib/modules: reduce allocations in evalModules and mergeModules

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -589,6 +589,8 @@ let
     in
     modulesPath: initialModules: args: {
       modules = filterModules modulesPath (collectStructuredModules unknownModule "" initialModules args);
+      # Intentionally not shared with `modules` above: this allows `collected`
+      # to be garbage collected after `filterModules` returns.
       graph = toGraph modulesPath (collectStructuredModules unknownModule "" initialModules args);
     };
 
@@ -783,7 +785,7 @@ let
     prefix: modules: configs:
     let
       # an attrset 'name' => list of submodules that declare ‘name’.
-      declsByName = zipAttrsWith (n: v: v) (
+      declsByName = zipAttrs (
         map (
           module:
           let
@@ -838,7 +840,7 @@ let
         ) checkedConfigs
       );
       # extract the definitions for each loc
-      rawDefinitionsByName = zipAttrsWith (n: v: v) (
+      rawDefinitionsByName = zipAttrs (
         map (
           module:
           mapAttrs (n: value: {
@@ -1439,7 +1441,7 @@ let
         def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
     in
     {
-      values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
+      values = map strip (filter (def: getPrio def == highestPrio) defs);
       inherit highestPrio;
     };
 


### PR DESCRIPTION
Two eval performance micro-optimizations in the module system hot paths:

- Replace `zipAttrsWith (n: v: v)` with `zipAttrs` in `mergeModules'`
- Replace `concatMap` with `filter`+`map` in `filterOverrides'`

Removed from earlier revision per reviewer feedback:
- ~`evalModules` `modules ++ []` avoidance~ -- Nix already [returns the non-empty list without copying](https://github.com/NixOS/nix/blob/8bdee4d8dbc1100c0a467312256e1bcca41ffe72/src/libexpr/eval.cc#L2054-L2056), so the optimization was counterproductive (added extra bindings for no gain).
- ~`collectModules` result sharing~ -- the duplicate `collectStructuredModules` call was intentional so that `collected` can be garbage collected after `filterModules` returns; `graph` is for diagnostics only.

## Benchmark

```
Linux desktop 6.18.9 #1-NixOS SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
AMD Ryzen 9 5950X 16-Core Processor, 128 GB RAM
nix (Nix) 2.33.3
```

```bash
# minimal NixOS system eval
NIX_SHOW_STATS=1 nix-instantiate -I nixpkgs=. --eval -E '
  let nixos = import ./nixos/lib/eval-config.nix {
    modules = [ ./nixos/modules/profiles/minimal.nix
      { fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
        boot.loader.grub.devices = ["/dev/sda"]; } ];
  }; in nixos.config.system.build.toplevel.drvPath
' >/dev/null 2>stats.json

# all top-level .drvPaths
NIX_SHOW_STATS=1 nix-instantiate --eval --strict \
  -E 'let pkgs = import ./. {}; in builtins.mapAttrs (n: v: let e = builtins.tryEval (v.drvPath or null); in if e.success then e.value else null) pkgs' \
  >/dev/null 2>stats.json
```

### Minimal NixOS system eval (primary target)

| metric | baseline | optimized | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 4,670,560 | 4,670,560 | +0 | 0.00% |
| nrThunks | 7,060,169 | 7,042,412 | -17,757 | **-0.25%** |
| envs.number | 5,459,106 | 5,459,106 | +0 | 0.00% |
| envs.bytes | 105,475,120 | 105,475,120 | +0 | 0.00% |
| list.bytes | 13,093,576 | 12,960,432 | -133,144 | **-1.02%** |
| list.concats | 189,590 | 189,590 | +0 | 0.00% |
| gc.totalBytes | 556,650,544 | 556,749,600 | +99,056 | +0.02% |

### Full eval (all top-level .drvPaths)

| metric | baseline | optimized | delta | % change |
|---|---|---|---|---|
| nrFunctionCalls | 104,012,255 | 104,012,255 | +0 | 0.00% |
| nrThunks | 178,494,970 | 178,470,977 | -23,993 | -0.01% |
| list.concats | 8,684,416 | 8,684,416 | +0 | 0.00% |

The `zipAttrs` change reduces thunk allocations (each `zipAttrsWith (n: v: v)` wraps values in an extra identity-function thunk). The `filter`+`map` change reduces list.bytes by avoiding intermediate singleton lists from `concatMap`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test