### PR TITLE
flutter: avoid deprecated hostPlatform default

### DIFF
--- a/pkgs/development/compilers/flutter/host-artifacts.nix
+++ b/pkgs/development/compilers/flutter/host-artifacts.nix
@@ -7,11 +7,11 @@
   useNixpkgsEngine,
   engines,
   fetchurl,
-  hostPlatform ? stdenv.hostPlatform,
   supportedTargetFlutterPlatforms,
 }:
 
 let
+  hostPlatform = stdenv.hostPlatform;
   hostConstants = constants.makeConstants hostPlatform;
 
   engineBaseUrl = "https://storage.googleapis.com/flutter_infra_release/flutter/${engineVersion}/";


### PR DESCRIPTION
## Summary
- remove the deprecated `hostPlatform ? stdenv.hostPlatform` default from `pkgs/development/compilers/flutter/host-artifacts.nix`
- bind `hostPlatform` from `stdenv.hostPlatform` locally instead, preserving behavior while avoiding the warning during evaluation
- this was reproduced through `pkgs.localsend`

## Original warning
```text
evaluation warning: 'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'
```

## Verification
```text
NIX_ABORT_ON_WARN=1 nix-instantiate --eval --strict --expr 'let pkgs = import /home/bob.vanderlinden/projects/nixpkgs-hostplatform-fix {}; in pkgs.localsend.drvPath'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test