### PR TITLE
various: migrate to pytest-cov-stub

### DIFF
--- a/pkgs/development/python-modules/bugsnag/default.nix
+++ b/pkgs/development/python-modules/bugsnag/default.nix
@@ -7,6 +7,7 @@
   setuptools,
   webob,
   pytestCheckHook,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
@@ -21,11 +22,6 @@ buildPythonPackage rec {
     hash = "sha256-WXBdlgUoWdptv1weJf82qyH8TTqNCC1rYFEa972TqDY=";
   };
 
-  postPatch = ''
-    substituteInPlace tox.ini --replace-fail \
-      "--cov=bugsnag --cov-report html --cov-append --cov-report term" ""
-  '';
-
   build-system = [ setuptools ];
 
   dependencies = [ webob ];
@@ -39,7 +35,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "bugsnag" ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   disabledTestPaths = [
     # Extra dependencies

--- a/pkgs/development/python-modules/openevsewifi/default.nix
+++ b/pkgs/development/python-modules/openevsewifi/default.nix
@@ -6,6 +6,7 @@
   fetchpatch,
   poetry-core,
   pytestCheckHook,
+  pytest-cov-stub,
   requests,
   requests-mock,
 }:
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     requests-mock
     pytestCheckHook
+    pytest-cov-stub
   ];
 
   patches = [
@@ -42,11 +44,6 @@ buildPythonPackage rec {
       hash = "sha256-XGeyi/PchBju1ICgL/ZCDGCbWwIJmLAcHuKaj+kDsI0=";
     })
   ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'pytest-cov = "^2.8.1"' ""
-  '';
 
   pythonImportsCheck = [ "openevsewifi" ];
 

--- a/pkgs/development/python-modules/pyairtable/default.nix
+++ b/pkgs/development/python-modules/pyairtable/default.nix
@@ -11,7 +11,7 @@
   click,
 
   pytest,
-  pytest-cov,
+  pytest-cov-stub,
   mock,
   requests-mock,
   tox,
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest
-    pytest-cov
+    pytest-cov-stub
     mock
     requests-mock
     tox

--- a/pkgs/development/python-modules/returns/default.nix
+++ b/pkgs/development/python-modules/returns/default.nix
@@ -8,6 +8,7 @@
   mypy,
   poetry-core,
   pytest-aio,
+  pytest-cov-stub,
   pytest-mypy,
   pytest-mypy-plugins,
   pytestCheckHook,
@@ -28,11 +29,6 @@ buildPythonPackage rec {
     hash = "sha256-VQzsa/uNTQVND0kc20d25to/6LELEiS3cqvG7a1kDw4=";
   };
 
-  postPatch = ''
-    sed -i setup.cfg \
-      -e '/--cov.*/d'
-  '';
-
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [ typing-extensions ];
@@ -45,6 +41,7 @@ buildPythonPackage rec {
     mypy
     pytestCheckHook
     pytest-aio
+    pytest-cov-stub
     pytest-mypy
     pytest-mypy-plugins
     setuptools

--- a/pkgs/development/python-modules/static3/default.nix
+++ b/pkgs/development/python-modules/static3/default.nix
@@ -8,6 +8,7 @@
 
   # tests
   pytestCheckHook,
+  pytest-cov-stub,
   webtest,
 }:
 
@@ -23,11 +24,6 @@ buildPythonPackage rec {
     hash = "sha256-uFgv+57/UZs4KoOdkFxbvTEDQrJbb0iYJ5JoWWN4yFY=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace ", 'pytest-cov'" ""
-  '';
-
   optional-dependencies = {
     KidMagic = [
       # TODO: kid
@@ -39,6 +35,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     webtest
   ]
   ++ lib.concatAttrValues optional-dependencies;


### PR DESCRIPTION
Stumbled upon some `unrecognized arguments: --cov=` errors on https://nfd.1l.is, and remembered this is a error I've almost eradicated. This PR migrates some packages I found via grep to pytest-cov-stub.

- **python3Packages.bugsnag: migrate to pytest-cov-stub**
- **python3Packages.openevsewifi: migrate to pytest-cov-stub**
- **python3Packages.pyairtable: migrate to pytest-cov-stub**
- **python3Packages.returns: migrate to pytest-cov-stub**
- **python3Packages.static3: migrate to pytest-cov-stub**

related: https://github.com/NixOS/nixpkgs/pull/510056 https://github.com/NixOS/nixpkgs/pull/510046


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
