### PR TITLE
Cross-compilation support for SuperH (sh4)

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -300,6 +300,8 @@ let
             "powerpc"
           else if final.isRiscV then
             "riscv"
+          else if final.isSh4 then
+            "sh"
           else if final.isS390 then
             "s390"
           else if final.isLoongArch64 then

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -40,6 +40,7 @@ let
     "i686-linux"
     "loongarch64-linux"
     "m68k-linux"
+    "sh4-linux"
     "microblaze-linux"
     "microblazeel-linux"
     "mips-linux"
@@ -145,6 +146,7 @@ in
   or1k = filterDoubles predicates.isOr1k;
   m68k = filterDoubles predicates.isM68k;
   arc = filterDoubles predicates.isArc;
+  sh4 = filterDoubles predicates.isSh4;
   s390 = filterDoubles predicates.isS390;
   s390x = filterDoubles predicates.isS390x;
   loongarch64 = filterDoubles predicates.isLoongArch64;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -243,6 +243,10 @@ rec {
     config = "arc-unknown-linux-gnu";
   };
 
+  sh4 = {
+    config = "sh4-unknown-linux-gnu";
+  };
+
   s390 = {
     config = "s390-unknown-linux-gnu";
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -234,6 +234,11 @@ rec {
         family = "arc";
       };
     };
+    isSh4 = {
+      cpu = {
+        family = "sh";
+      };
+    };
     isS390 = {
       cpu = {
         family = "s390";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -284,6 +284,12 @@ rec {
         family = "m68k";
       };
 
+      sh4 = {
+        bits = 32;
+        significantByte = littleEndian;
+        family = "sh";
+      };
+
       powerpc = {
         bits = 32;
         significantByte = bigEndian;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -632,6 +632,15 @@ rec {
     else if platform.isPower64 then
       if platform.isLittleEndian then powernv else ppc64
 
+    else if platform.isSh4 then
+      {
+        linux-kernel = {
+          target = "vmlinux";
+          # SH arch doesn't have a 'make install' target.
+          installTarget = "vmlinux";
+        };
+      }
+
     else
       { };
 }

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -171,6 +171,7 @@ lib.runTests (
       "i686-linux"
       "loongarch64-linux"
       "m68k-linux"
+      "sh4-linux"
       "microblaze-linux"
       "microblazeel-linux"
       "mips-linux"

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -278,106 +278,117 @@ originalAttrs:
           makeCompatibilitySymlink lib $targetConfig/lib64
         '';
 
-    postInstall = ''
-      # Clean up our compatibility symlinks (see above)
-      for link in "''${compatibilitySymlinks[@]}"; do
-        echo "Removing compatibility symlink: $link"
-        rm -f "$link"
-      done
-
-      # Move target runtime libraries to lib output.
-      # For non-cross, they're in $out/lib; for cross, they're in $out/$targetConfig/lib.
-      targetLibDir="''${targetConfig+$targetConfig/}lib"
-
-      moveToOutput "$targetLibDir/lib*.so*" "''${!outputLib}"
-      moveToOutput "$targetLibDir/lib*.dylib" "''${!outputLib}"
-      moveToOutput "$targetLibDir/lib*.dll.a" "''${!outputLib}"
-      moveToOutput "$targetLibDir/lib*.dll" "''${!outputLib}"
-      moveToOutput "share/gcc-*/python" "''${!outputLib}"
-
-      if [ -z "$enableShared" ]; then
-          moveToOutput "$targetLibDir/lib*.a" "''${!outputLib}"
-      fi
-
-      for i in "''${!outputLib}"/$targetLibDir/*.py; do
-          substituteInPlace "$i" --replace "$out" "''${!outputLib}"
-      done
-
-      # Multilib and cross can't exist at the same time, so just use lib64 here
-      if [ -n "$enableMultilib" ]; then
-          moveToOutput "lib64/lib*.so*" "''${!outputLib}"
-          moveToOutput "lib64/lib*.dylib" "''${!outputLib}"
-          moveToOutput "lib64/lib*.dll.a" "''${!outputLib}"
-          moveToOutput "lib64/lib*.dll" "''${!outputLib}"
-
-          for i in "''${!outputLib}"/lib64/*.py; do
-              substituteInPlace "$i" --replace "$out" "''${!outputLib}"
-          done
-      fi
-
-      # Remove `fixincl' to prevent a retained dependency on the
-      # previous gcc.
-      rm -rf $out/libexec/gcc/*/*/install-tools
-      rm -rf $out/lib/gcc/*/*/install-tools
-
-      # More dependencies with the previous gcc or some libs (gccbug stores the build command line)
-      rm -rf $out/bin/gccbug
-
-      # Remove .la files, they're not adjusted for the makeCompatibilitySymlink magic,
-      # which confuses libtool and leads to weird linking errors.
-      # Removing the files just makes libtool link .so files directly, which is usually
-      # what we want anyway.
-      find $out -name '*.la' -delete
-
-      if type "install_name_tool"; then
-          for i in "''${!outputLib}"/lib/*.*.dylib "''${!outputLib}"/lib/*.so.[0-9]; do
-              install_name_tool -id "$i" "$i" || true
-              for old_path in $(otool -L "$i" | grep "$out" | awk '{print $1}'); do
-                new_path=`echo "$old_path" | sed "s,$out,''${!outputLib},"`
-                install_name_tool -change "$old_path" "$new_path" "$i" || true
-              done
-          done
-      fi
-
-      # Get rid of some "fixed" header files
-      rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux,sys/mount.h,bits/statx.h,pthread.h}
-
-      # Replace hard links for i686-pc-linux-gnu-gcc etc. with symlinks.
-      for i in $out/bin/*-gcc*; do
-          if cmp -s $out/bin/gcc $i; then
-              ln -sfn gcc $i
+    postInstall =
+      # SH installs libraries into a multilib subdirectory (e.g. lib/!m4/)
+      # even with --disable-multilib; move them to the expected location.
+      lib.optionalString stdenv.targetPlatform.isSh4 ''
+        for _mdir in $out/''${targetConfig+$targetConfig/}lib/!*/; do
+          if [ -d "$_mdir" ]; then
+            mv "$_mdir"/* $out/''${targetConfig+$targetConfig/}lib/
+            rmdir "$_mdir"
           fi
-      done
+        done
+      ''
+      + ''
+        # Clean up our compatibility symlinks (see above)
+        for link in "''${compatibilitySymlinks[@]}"; do
+          echo "Removing compatibility symlink: $link"
+          rm -f "$link"
+        done
 
-      for i in $out/bin/c++ $out/bin/*-c++* $out/bin/*-g++*; do
-          if cmp -s $out/bin/g++ $i; then
-              ln -sfn g++ $i
-          fi
-      done
+        # Move target runtime libraries to lib output.
+        # For non-cross, they're in $out/lib; for cross, they're in $out/$targetConfig/lib.
+        targetLibDir="''${targetConfig+$targetConfig/}lib"
 
-      # Two identical man pages are shipped (moving and compressing is done later)
-      for i in "$out"/share/man/man1/*g++.1; do
-          if test -e "$i"; then
-              man_prefix=`echo "$i" | sed "s,.*/\(.*\)g++.1,\1,"`
-              ln -sf "$man_prefix"gcc.1 "$i"
-          fi
-      done
-    ''
-    + lib.optionalString stdenv.targetPlatform.isCygwin ''
-      targetBinDir="''${targetConfig+$targetConfig/}bin"
-      for i in "''${!outputBin}/$targetLibDir"/cyg*.dll; do
-        mkdir -p "''${!outputLib}/$targetBinDir"
-        mv "$i" "''${!outputLib}/$targetBinDir"/
-      done
-    ''
-    # if cross-compiling, link from $lib/lib to $lib/${targetConfig}.
-    # since native-compiles have $lib/lib as a directory (not a
-    # symlink), this ensures that in every case we can assume that
-    # $lib/lib contains the .so files
-    + lib.optionalString isCross ''
-      if [ -e "$lib/$targetConfig/lib" ]; then
-        ln -s "$lib/$targetConfig/lib" "$lib/lib"
-      fi
-    '';
+        moveToOutput "$targetLibDir/lib*.so*" "''${!outputLib}"
+        moveToOutput "$targetLibDir/lib*.dylib" "''${!outputLib}"
+        moveToOutput "$targetLibDir/lib*.dll.a" "''${!outputLib}"
+        moveToOutput "$targetLibDir/lib*.dll" "''${!outputLib}"
+        moveToOutput "share/gcc-*/python" "''${!outputLib}"
+
+        if [ -z "$enableShared" ]; then
+            moveToOutput "$targetLibDir/lib*.a" "''${!outputLib}"
+        fi
+
+        for i in "''${!outputLib}"/$targetLibDir/*.py; do
+            substituteInPlace "$i" --replace "$out" "''${!outputLib}"
+        done
+
+        # Multilib and cross can't exist at the same time, so just use lib64 here
+        if [ -n "$enableMultilib" ]; then
+            moveToOutput "lib64/lib*.so*" "''${!outputLib}"
+            moveToOutput "lib64/lib*.dylib" "''${!outputLib}"
+            moveToOutput "lib64/lib*.dll.a" "''${!outputLib}"
+            moveToOutput "lib64/lib*.dll" "''${!outputLib}"
+
+            for i in "''${!outputLib}"/lib64/*.py; do
+                substituteInPlace "$i" --replace "$out" "''${!outputLib}"
+            done
+        fi
+
+        # Remove `fixincl' to prevent a retained dependency on the
+        # previous gcc.
+        rm -rf $out/libexec/gcc/*/*/install-tools
+        rm -rf $out/lib/gcc/*/*/install-tools
+
+        # More dependencies with the previous gcc or some libs (gccbug stores the build command line)
+        rm -rf $out/bin/gccbug
+
+        # Remove .la files, they're not adjusted for the makeCompatibilitySymlink magic,
+        # which confuses libtool and leads to weird linking errors.
+        # Removing the files just makes libtool link .so files directly, which is usually
+        # what we want anyway.
+        find $out -name '*.la' -delete
+
+        if type "install_name_tool"; then
+            for i in "''${!outputLib}"/lib/*.*.dylib "''${!outputLib}"/lib/*.so.[0-9]; do
+                install_name_tool -id "$i" "$i" || true
+                for old_path in $(otool -L "$i" | grep "$out" | awk '{print $1}'); do
+                  new_path=`echo "$old_path" | sed "s,$out,''${!outputLib},"`
+                  install_name_tool -change "$old_path" "$new_path" "$i" || true
+                done
+            done
+        fi
+
+        # Get rid of some "fixed" header files
+        rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux,sys/mount.h,bits/statx.h,pthread.h}
+
+        # Replace hard links for i686-pc-linux-gnu-gcc etc. with symlinks.
+        for i in $out/bin/*-gcc*; do
+            if cmp -s $out/bin/gcc $i; then
+                ln -sfn gcc $i
+            fi
+        done
+
+        for i in $out/bin/c++ $out/bin/*-c++* $out/bin/*-g++*; do
+            if cmp -s $out/bin/g++ $i; then
+                ln -sfn g++ $i
+            fi
+        done
+
+        # Two identical man pages are shipped (moving and compressing is done later)
+        for i in "$out"/share/man/man1/*g++.1; do
+            if test -e "$i"; then
+                man_prefix=`echo "$i" | sed "s,.*/\(.*\)g++.1,\1,"`
+                ln -sf "$man_prefix"gcc.1 "$i"
+            fi
+        done
+      ''
+      + lib.optionalString stdenv.targetPlatform.isCygwin ''
+        targetBinDir="''${targetConfig+$targetConfig/}bin"
+        for i in "''${!outputBin}/$targetLibDir"/cyg*.dll; do
+          mkdir -p "''${!outputLib}/$targetBinDir"
+          mv "$i" "''${!outputLib}/$targetBinDir"/
+        done
+      ''
+      # if cross-compiling, link from $lib/lib to $lib/${targetConfig}.
+      # since native-compiles have $lib/lib as a directory (not a
+      # symlink), this ensures that in every case we can assume that
+      # $lib/lib contains the .so files
+      + lib.optionalString isCross ''
+        if [ -e "$lib/$targetConfig/lib" ]; then
+          ln -s "$lib/$targetConfig/lib" "$lib/lib"
+        fi
+      '';
   }
 ))

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -227,6 +227,9 @@ let
         ]
       else
         [ "--disable-multilib" ]
+        # SH targets need m4 and m4-nofpu variants (the kernel uses -m4-nofpu).
+        # An empty list disables -m4-nofpu entirely.
+        ++ lib.optional targetPlatform.isSh4 "--with-multilib-list=m4,m4-nofpu"
     )
     ++ lib.optional (!enableShared) "--disable-shared"
     ++ lib.singleton (lib.enableFeature enablePlugin "plugin")

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
         options.h \
         insn-constants.h \
   ''
-  + lib.optionalString stdenv.targetPlatform.isM68k ''
+  + lib.optionalString (stdenv.targetPlatform.isM68k || stdenv.targetPlatform.isSh4) ''
     sysroot-suffix.h \
   ''
   + lib.optionalString stdenv.targetPlatform.isAarch32 ''


### PR DESCRIPTION
## Summary

Add cross-compilation support for the SH4 (SuperH) architecture, following the same pattern as m68k (#131310) and s390 (#131317).

SH4 is a 32-bit little-endian RISC architecture by Renesas/Hitachi with mature GCC, glibc, and Linux kernel support. It is used in embedded/industrial systems and has an active community around [J-Core](https://j-core.org/) (open-source SuperH implementation).

### Changes

Commit 1 (`lib/systems, release-cross: add SH4 cross-compilation target`): Add `sh4` CPU type, `isSh4` predicate, `"sh4-linux"` system double, cross-compilation example, `linuxArch` mapping to `"sh"`, and entries in tests and release-cross.

Commit 2 (`gcc, libgcc: fix cross-compilation for SH4`):
- Pass `--with-multilib-list=` (empty) for SH4 targets when multilib is disabled. SH's GCC backend creates multilib subdirectories (e.g. `!m4`) even with `--disable-multilib`, causing `libgcc_s.so` to be installed in the wrong location. Scoped to SH4 only to avoid rebuilds on other platforms. Ref: [GCC install docs](https://gcc.gnu.org/install/configure.html) (`--with-multilib-list`), [GCC bug #121998](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121998).
- Generate `sysroot-suffix.h` for SH4 in the standalone libgcc builder. SH targets include `sysroot-suffix.h` from `tm.h`, generated from `MULTILIB_OSDIRNAMES` by `t-sysroot-suffix`. The builder already handled this for m68k; this extends it to SH4.

### Test results

Cross-compiled with `nix build '.#pkgsCross.sh4.hello'` and verified with `qemu-sh4`. Tested 36 packages total:

| Package | Build | Run (QEMU) |
|---|---|---|
| hello | :white_check_mark: | :white_check_mark: |
| coreutils | :white_check_mark: | :white_check_mark: |
| busybox | :white_check_mark: | :white_check_mark: |
| bash | :white_check_mark: | :white_check_mark: |
| zlib | :white_check_mark: | — |
| file | :white_check_mark: | :white_check_mark: |
| lua | :white_check_mark: | :white_check_mark: |
| perl | :white_check_mark: | :white_check_mark: |
| gawk | :white_check_mark: | :white_check_mark: |
| tcl | :white_check_mark: | :white_check_mark: |
| nasm | :white_check_mark: | :white_check_mark: |
| gnumake | :white_check_mark: | :white_check_mark: |
| binutils | :white_check_mark: | :white_check_mark: |
| grep | :white_check_mark: | :white_check_mark: |
| findutils | :white_check_mark: | :white_check_mark: |
| diffutils | :white_check_mark: | :white_check_mark: |
| patch | :white_check_mark: | :white_check_mark: |
| xz | :white_check_mark: | :white_check_mark: |
| bzip2 | :white_check_mark: | :white_check_mark: |
| tar | :white_check_mark: | :white_check_mark: |
| nano | :white_check_mark: | :white_check_mark: |
| less | :white_check_mark: | :white_check_mark: |
| which | :white_check_mark: | :white_check_mark: |
| gnused | :white_check_mark: | :white_check_mark: |
| sqlite | :white_check_mark: | :white_check_mark: |
| jq | :white_check_mark: | :white_check_mark: |
| screen | :white_check_mark: | :white_check_mark: |
| gzip | :white_check_mark: | :x: (QEMU syscall issue) |
| openssl | :x: (missing `-latomic`) | — |
| curl | :x: (openssl dep) | — |
| git | :x: (openssl dep) | — |
| openssh | :x: (openssl dep) | — |
| tmux | :x: (openssl dep chain) | — |
| tinycc | :x: (missing `dynamic-linker`) | — |
| python3 | :x: (GCC ICE / openssl) | — |
| strace | :x: (libunwind platforms) | — |

27/36 packages built, 26 ran successfully under QEMU. Known remaining issues (pre-existing, not introduced by this PR):
1. openssl needs `-latomic` for 64-bit atomics on 32-bit SH4 (same issue on other 32-bit targets)
2. tinycc needs `dynamic-linker` configured in bintools-wrapper for SH4
3. python3Minimal hits a GCC ICE in the SH4 `soft_gusa` atomic backend
4. strace needs libunwind to add SH4 to `meta.platforms`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test