### PR TITLE
fsl-avwutils: init at 2209.6

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1615,10 +1615,7 @@ lib.mapAttrs mkLicense (
       spdxId = "ZPL-2.1";
       fullName = "Zope Public License 2.1";
     };
-<<<<<<< HEAD
 
-=======
->>>>>>> 4c0839763 (lib/licenses: add fmribSoftwareLibrary license)
   }
   // {
     # TODO: remove legacy aliases

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -621,6 +621,13 @@ lib.mapAttrs mkLicense (
       free = false;
     };
 
+    fmribSoftwareLibrary = {
+      fullName = "FMRIB Software Library Licence";
+      url = "https://fsl.fmrib.ox.ac.uk/fsl/docs/license.html";
+      free = false;
+      redistributable = false; # only free to redistribute "for non-commercial purposes"
+    };
+
     fontException = {
       spdxId = "Font-exception-2.0";
       fullName = "Font exception 2.0";
@@ -1608,7 +1615,10 @@ lib.mapAttrs mkLicense (
       spdxId = "ZPL-2.1";
       fullName = "Zope Public License 2.1";
     };
+<<<<<<< HEAD
 
+=======
+>>>>>>> 4c0839763 (lib/licenses: add fmribSoftwareLibrary license)
   }
   // {
     # TODO: remove legacy aliases

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6812,6 +6812,12 @@
     github = "DimitarNestorov";
     githubId = 8790386;
   };
+  dinga92 = {
+    name = "Richard Dinga";
+    email = "dinga92@gmail.com";
+    github = "dinga92";
+    githubId = 10049011;
+  };
   diniamo = {
     name = "diniamo";
     email = "diniamo53@gmail.com";

--- a/pkgs/by-name/fs/fsl-armawrap/package.nix
+++ b/pkgs/by-name/fs/fsl-armawrap/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  armadillo,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-armawrap";
+  version = "0.7.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "armawrap";
+    rev = finalAttrs.version;
+    hash = "sha256-I13c2WtwV4rT63T9iP6VkVQ5uw9i2Sh9sfL797xBw7Y=";
+  };
+
+  buildInputs = [
+    fsl-base
+    armadillo
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/include
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Armadillo wrapper library used by FSL";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/armawrap";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-avwutils/package.nix
+++ b/pkgs/by-name/fs/fsl-avwutils/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  makeWrapper,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  fsl-newimage,
+  nlohmann_json,
+  blas,
+  lapack,
+  nix-update-script,
+  python3Packages,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-avwutils";
+  version = "2209.6";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "avwutils";
+    rev = finalAttrs.version;
+    hash = "sha256-qtvVuERT+oqiAx1BY/o7jv7hZ+a0ILw+kO52XgYpmlQ=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    fsl-newimage
+    nlohmann_json
+    blas
+    lapack
+  ];
+
+  phases = [
+    "unpackPhase"
+    "patchPhase"
+    "configurePhase"
+    "buildPhase"
+    "installPhase"
+    "fixupPhase"
+    "checkPhase"
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/avwutils $out/bin
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for f in $out/bin/fslval $out/bin/fslinfo $out/bin/fslsize $out/bin/fslchpixdim \
+              $out/bin/fsledithd $out/bin/fslmodhd $out/bin/fslreorient2std $out/bin/fslswapdim \
+              $out/bin/avw2fsl $out/bin/fsladd; do
+      [ -f "$f" ] || continue
+      sed -i 's|''${FSLDIR}/bin/||g; s|\$FSLDIR/bin/||g' "$f"
+      wrapProgram "$f" \
+        --set-default FSLOUTPUTTYPE NIFTI_GZ \
+        --prefix PATH : $out/bin
+      sed -i "1s|.*|#!${stdenv.shell}|" "$(dirname $f)/.$(basename $f)-wrapped"
+    done
+
+    for f in $out/bin/*; do
+      [[ "$f" == *-wrapped ]] && continue
+      head -1 "$f" 2>/dev/null | grep -q '^#!' && continue  # already handled above
+      wrapProgram "$f" --set-default FSLOUTPUTTYPE NIFTI_GZ
+    done
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    python3Packages.nibabel
+    python3Packages.numpy
+    python3Packages.fslpy
+  ];
+
+  checkPhase = ''
+    export FSLOUTPUTTYPE=NIFTI_GZ
+    export FSLDIR=${fsl-base}
+    export PATH=$out/bin:$PATH
+    tmpdir=$(mktemp -d)
+    for test in fslmaths fslchpixdim fslcomplex fslcreatehd fix_orient; do
+      echo "running $test tests..."
+      python3 ${finalAttrs.src}/tests/$test/feedsRun $tmpdir
+    done
+  '';
+
+  meta = {
+    description = "FSL image utilities including fslmaths, fslstats and fslhd";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/avwutils";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-base/package.nix
+++ b/pkgs/by-name/fs/fsl-base/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  tcl,
+  tk,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-base";
+  version = "2604.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "base";
+    rev = finalAttrs.version;
+    hash = "sha256-fvElyS3udWurzpI3XZkFJUu4GFc6pJLA7h0KZfp9eJI=";
+  };
+
+  buildInputs = [
+    tcl
+    tk
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/config $out/etc $out/share $out/bin
+    cp -r config/* $out/config/
+    cp -r etc/*    $out/etc/
+    cp -r share/*  $out/share/
+    cp -r bin/*    $out/bin/
+    substituteInPlace $out/config/buildSettings.mk \
+      --replace-fail 'MKDIR   ?= /bin/mkdir' 'MKDIR   ?= mkdir' \
+      --replace-fail 'RM      ?= /bin/rm'    'RM      ?= rm'    \
+      --replace-fail 'CP      ?= /bin/cp'    'CP      ?= cp'    \
+      --replace-fail 'MV      ?= /bin/mv'    'MV      ?= mv'    \
+      --replace-fail 'CHMOD   ?= /bin/chmod' 'CHMOD   ?= chmod'
+    sed -i "s|\''${FSLDIR}/bin/wish|${tk}/bin/wish|g"   $out/bin/fslwish
+    sed -i "s|\''${FSLDIR}/bin/tclsh|${tcl}/bin/tclsh|g" $out/bin/fsltclsh
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL base configuration and Makefile infrastructure";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/base";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-bet2/package.nix
+++ b/pkgs/by-name/fs/fsl-bet2/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  makeWrapper,
+  bc,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  fsl-newimage,
+  fsl-meshclass,
+  fsl-avwutils,
+  python3Packages,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-bet2";
+  version = "2111.9";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "bet2";
+    rev = finalAttrs.version;
+    hash = "sha256-9KI/gvEzfUER1YvxAu2z6TEIgQlaGNu2OWMi5PzUueI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    fsl-newimage
+    fsl-meshclass
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    rm -f $out/bin/Bet $out/bin/Bet_gui
+    sed -i 's|''${FSLDIR}/bin/||g' $out/bin/bet
+    sed -i 's|\$FSLDIR/bin/||g'    $out/bin/bet
+    sed -i 's|/bin/rm |rm |g'      $out/bin/bet
+    wrapProgram $out/bin/bet \
+      --set-default FSLOUTPUTTYPE NIFTI_GZ \
+      --set-default FSLDIR ${fsl-base} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fsl-avwutils
+          bc
+          python3Packages.fslpy
+        ]
+      } \
+      --prefix PATH : $out/bin
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL Brain Extraction Tool";
+    homepage = "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BET";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    mainProgram = "bet";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-cprob/package.nix
+++ b/pkgs/by-name/fs/fsl-cprob/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-cprob";
+  version = "2111.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "cprob";
+    rev = finalAttrs.version;
+    hash = "sha256-wsnYbpmIIWNOHC4Ev30xdPAeKIv4YxWEfWxIE8267NQ=";
+  };
+
+  buildInputs = [
+    fsl-base
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/cprob
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Probability distributions library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/cprob";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-meshclass/package.nix
+++ b/pkgs/by-name/fs/fsl-meshclass/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  fsl-newimage,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-meshclass";
+  version = "2111.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "meshclass";
+    rev = finalAttrs.version;
+    hash = "sha256-ALpAVSHijfiCI8vvAdPgzWSGXyw2zTMBz0SHj5EzAs8=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    fsl-newimage
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/meshclass $out/bin
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL mesh class library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/meshclass";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-miscmaths/package.nix
+++ b/pkgs/by-name/fs/fsl-miscmaths/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-miscmaths";
+  version = "2412.6";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "miscmaths";
+    rev = finalAttrs.version;
+    hash = "sha256-aZLrhyUtYNJIacoj61ekR4pJEzfv6VGpDGDmut5XS/0=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/miscmaths
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Miscellaneous maths library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/miscmaths";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-newimage/package.nix
+++ b/pkgs/by-name/fs/fsl-newimage/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-armawrap,
+  fsl-cprob,
+  fsl-newnifti,
+  fsl-znzlib,
+  fsl-miscmaths,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-newimage";
+  version = "2601.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "newimage";
+    rev = finalAttrs.version;
+    hash = "sha256-b+q98F1KsOlAnpV84SZuhy61Q6rO4pjuOmiwSxUYEFs=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-armawrap
+    fsl-cprob
+    fsl-newnifti
+    fsl-znzlib
+    fsl-miscmaths
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/newimage
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL image data structure library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/newimage";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-newnifti/package.nix
+++ b/pkgs/by-name/fs/fsl-newnifti/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  fsl-znzlib,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-newnifti";
+  version = "5.0.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "newnifti";
+    rev = finalAttrs.version;
+    hash = "sha256-vtboEezMrdg3ZnCWjFYB06X7p6rgTXnz+BbTU4OWE4s=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    fsl-znzlib
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/NewNifti
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "NIfTI-2 image I/O library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/newnifti";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-utils/package.nix
+++ b/pkgs/by-name/fs/fsl-utils/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-armawrap,
+  armadillo,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-utils";
+  version = "2412.6";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "utils";
+    rev = finalAttrs.version;
+    hash = "sha256-XfLEEzBHjvva3rBTgJSrIxbKnVA0caiYgttCk5EDs5s=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-armawrap
+    armadillo
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/utils
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "FSL utilities library";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/utils";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fs/fsl-znzlib/package.nix
+++ b/pkgs/by-name/fs/fsl-znzlib/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  fsl-base,
+  fsl-utils,
+  zlib,
+  bzip2,
+  zstd,
+  blas,
+  lapack,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fsl-znzlib";
+  version = "2511.3";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    domain = "git.fmrib.ox.ac.uk";
+    owner = "fsl";
+    repo = "znzlib";
+    rev = finalAttrs.version;
+    hash = "sha256-DE1j6vg2Emie1pXAWEyAgOQbgbFVmMXzVfO4J23mcLQ=";
+  };
+
+  buildInputs = [
+    fsl-base
+    fsl-utils
+    zlib
+    bzip2
+    zstd
+    blas
+    lapack
+  ];
+
+  buildPhase = ''
+    export FSLDIR=${fsl-base}
+    export FSLCONFDIR=${fsl-base}/config
+    export FSLDEVDIR=$out
+    make
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib $out/include/znzlib
+    make FSLDEVDIR=$out install
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ZNZ compressed file I/O library (part of FSL)";
+    homepage = "https://git.fmrib.ox.ac.uk/fsl/znzlib";
+    license = lib.licenses.fmribSoftwareLibrary;
+    maintainers = with lib.maintainers; [ dinga92 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

fsl-base: init at 2604.1
fsl-armawrap: init at 0.7.0
fsl-utils: init at 2412.6
fsl-znzlib: init at 2511.3
fsl-cprob: init at 2111.0
fsl-newnifti: init at 5.0.0
fsl-miscmaths: init at 2412.6
fsl-newimage: init at 2601.0
fsl-avwutils: init at 2209.6

Add FSL image analysis tools: fsl-avwutils and dependencies. Those are core FSL image utilities used to manipulate clinical imaging data, either by users directly or as a part of other FSL tools. All other packages are non-user facing libraries that avwutils depends on. 

FSL uses a custom non-free license (free to use and redistribute for non-commercial purposes): https://fsl.fmrib.ox.ac.uk/fsl/docs/license.html

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
