### PR TITLE
gajim: migrate to by-name, preserve override

### DIFF
--- a/pkgs/by-name/ga/gajim/package.nix
+++ b/pkgs/by-name/ga/gajim/package.nix
@@ -20,10 +20,7 @@
   # Optional dependencies
   enableJingle ? true,
   farstream,
-  gstreamer,
-  gst-plugins-base,
-  gst-libav,
-  gst-plugins-good,
+  gst_all_1,
   libnice,
   enableE2E ? true,
   enableSecrets ? true,
@@ -40,7 +37,14 @@
   gsound,
   extraPythonPackages ? ps: [ ],
 }:
-
+let
+  inherit (gst_all_1)
+    gstreamer
+    gst-plugins-base
+    gst-libav
+    gst-plugins-good
+    ;
+in
 python3.pkgs.buildPythonApplication rec {
   pname = "gajim";
   version = "2.4.5";
@@ -66,7 +70,7 @@ python3.pkgs.buildPythonApplication rec {
     gstreamer
     gst-plugins-base
     gst-libav
-    gst-plugins-good
+    (gst-plugins-good.override { gtkSupport = true; })
     libnice
   ]
   ++ lib.optional enableSecrets libsecret

--- a/pkgs/by-name/ga/gajim/package.nix
+++ b/pkgs/by-name/ga/gajim/package.nix
@@ -16,10 +16,7 @@
   # Optional dependencies
   enableJingle ? true,
   farstream,
-  gstreamer,
-  gst-plugins-base,
-  gst-libav,
-  gst-plugins-good,
+  gst_all_1,
   libnice,
   enableSecrets ? true,
   libsecret,
@@ -35,7 +32,14 @@
   gsound,
   extraPythonPackages ? ps: [ ],
 }:
-
+let
+  inherit (gst_all_1)
+    gstreamer
+    gst-plugins-base
+    gst-libav
+    gst-plugins-good
+    ;
+in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "gajim";
   version = "2.5.0";
@@ -61,7 +65,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ++ lib.optionals enableJingle [
     farstream
     gst-libav
-    gst-plugins-good
+    (gst-plugins-good.override { gtkSupport = true; })
     libnice
   ]
   ++ lib.optional enableSecrets libsecret

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11679,11 +11679,6 @@ with pkgs;
 
   faust = faust2;
 
-  gajim = callPackage ../applications/networking/instant-messengers/gajim {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-libav;
-    gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
-  };
-
   helmfile-wrapped = helmfile.override {
     inherit (kubernetes-helm-wrapped.passthru) pluginsDir;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10591,11 +10591,6 @@ with pkgs;
 
   faust = faust2;
 
-  gajim = callPackage ../applications/networking/instant-messengers/gajim {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-libav;
-    gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
-  };
-
   helmfile-wrapped = helmfile.override {
     inherit (kubernetes-helm-wrapped.passthru) pluginsDir;
   };


### PR DESCRIPTION
This PR migrates gajim to the by‑name layout and updates its GStreamer setup. The package is moved to pkgs/by-name/ga/gajim/package.nix, switches to the unified gst_all_1 set, and applies the gtkSupport = true override for gst-plugins-good directly in the package file. The old entry in all-packages.nix is removed as part of the migration.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test