### PR TITLE
apfel-ai: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2293,6 +2293,12 @@
     githubId = 3965744;
     name = "Arthur Lee";
   };
+  arthur-ficial = {
+    email = "arti.ficial@fullstackoptimization.com";
+    github = "Arthur-Ficial";
+    githubId = 258112064;
+    name = "Arthur Ficial";
+  };
   arthurteisseire = {
     email = "arthurteisseire33@gmail.com";
     github = "arthurteisseire";

--- a/pkgs/by-name/ap/apfel-ai/package.nix
+++ b/pkgs/by-name/ap/apfel-ai/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "apfel-ai";
+  version = "1.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/Arthur-Ficial/apfel/releases/download/v${finalAttrs.version}/apfel-${finalAttrs.version}-arm64-macos.tar.gz";
+    hash = "sha256-xxPTFpaQ9/CQLyMKy30yUaTIvO7A6ml8tZGlV4L+CGg=";
+  };
+
+  sourceRoot = ".";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 apfel $out/bin/apfel
+    runHook postInstall
+  '';
+
+  # The binary is self-contained (static Swift runtime + system frameworks)
+  # so no fixup is needed beyond the default install-name handling.
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "On-device LLM CLI using Apple FoundationModels (distinct from the 'apfel' physics library)";
+    longDescription = ''
+      apfel exposes Apple's on-device FoundationModels LLM as a UNIX tool,
+      an OpenAI-compatible HTTP server (drop-in replacement for
+      http://localhost:11434/v1), and an interactive command-line chat.
+
+      100% on-device - no cloud, no API keys, no network for inference.
+
+      Runtime requirements (Nix cannot enforce these at build time):
+        * macOS 26 "Tahoe" or later
+        * Apple Silicon (aarch64-darwin)
+        * Apple Intelligence enabled in System Settings -> Apple Intelligence & Siri
+        * Siri language matching device language
+
+      This derivation installs the official pre-built release binary from
+      GitHub because apfel links against Apple's FoundationModels system
+      framework, which requires the macOS 26 SDK and Apple Silicon at
+      build time. Building from source in the nixpkgs darwin stdenv is
+      not currently supported.
+    '';
+    homepage = "https://github.com/Arthur-Ficial/apfel";
+    changelog = "https://github.com/Arthur-Ficial/apfel/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ arthur-ficial ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "apfel";
+  };
+})


### PR DESCRIPTION
## Summary

Adds `apfel-ai`, an on-device LLM command-line tool for macOS that exposes Apple's FoundationModels framework as:

1. A UNIX tool (`apfel "prompt"`, streaming via `--stream`, JSON output)
2. An OpenAI-compatible HTTP server (`apfel --serve`) — drop-in replacement for `http://localhost:11434/v1`
3. An interactive command-line chat (`apfel --chat`)

All inference is 100% on-device. No cloud, no API keys, no network.

- Homepage: https://github.com/Arthur-Ficial/apfel
- License: MIT
- Upstream release: https://github.com/Arthur-Ficial/apfel/releases/tag/v1.0.1

## Naming

The attribute `apfel` is already taken in nixpkgs by `scarrazza/apfel`, an unrelated particle-physics PDF Evolution Library. To avoid collision this package is `apfel-ai`. The binary on PATH is still `apfel`.

## Why pre-built binary

`apfel` links against Apple's FoundationModels system framework, which requires the macOS 26 ("Tahoe") SDK and Apple Silicon at build time. The nixpkgs darwin stdenv does not currently ship those prerequisites, so building from source inside a Nix sandbox is infeasible today. This derivation installs the official signed release tarball published by the maintainer, and declares `sourceProvenance = [ binaryNativeCode ]` accordingly.

When nixpkgs' darwin stdenv gains macOS 26 SDK support, this can be switched to a source build in a follow-up PR.

## Runtime requirements (Nix cannot enforce these)

- macOS 26 ("Tahoe") or later
- Apple Silicon (`aarch64-darwin`)
- Apple Intelligence enabled in System Settings → Apple Intelligence & Siri
- Siri language matching device language

These are documented in `meta.longDescription`.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Tested basic functionality of the binary — `apfel --version` reports `v1.0.1` and a real on-device prompt (`apfel "say hello in three words"`) returns a coherent response when run from `result/bin/apfel` on macOS 26 with Apple Intelligence enabled.
- [ ] Ran `nixpkgs-review` on this PR. (`nix-build -A apfel-ai` succeeds locally; full `nixpkgs-review` not run — PR is new-package, only the aarch64-darwin platform is relevant and the derivation is a simple binary install.)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md].

## Maintainer

Adding myself (`arthur-ficial`, GitHub `Arthur-Ficial`) as the maintainer. I'm upstream on `Arthur-Ficial/apfel` and will keep the nixpkgs package in sync with releases via `passthru.updateScript = nix-update-script {}` plus a release-triggered bump workflow on the upstream side.