### PR TITLE
zap-chip: 2025.07.24 -> 2026.02.26

### DIFF
--- a/pkgs/by-name/za/zap-chip/dont-get-version-from-git.patch
+++ b/pkgs/by-name/za/zap-chip/dont-get-version-from-git.patch
@@ -1,8 +1,8 @@
 diff --git a/src-script/script-util.js b/src-script/script-util.js
-index 1897c2b8..aaf9a08b 100644
+index fb8fe7a8589f..2b2a43f46053 100644
 --- a/src-script/script-util.js
 +++ b/src-script/script-util.js
-@@ -196,23 +194,6 @@ async function rebuildBackendIfNeeded() {
+@@ -237,28 +237,6 @@ async function rebuildBackendIfNeeded() {
   * ads the timestamp and saves it into .version.json
   */
  async function stampVersion() {
@@ -18,7 +18,12 @@ index 1897c2b8..aaf9a08b 100644
 -    version.date = d
 -    version.zapVersion = result.version
 -    let versionFile = path.join(__dirname, '../.version.json')
--    console.log(`🔍 Git commit: ${version.hash} from ${version.date}`)
+-    console.log(
+-      env.formatEmojiMessage(
+-        '🔍',
+-        `Git commit: ${version.hash} from ${version.date}`
+-      )
+-    )
 -    await fsp.writeFile(versionFile, JSON.stringify(version))
 -  } catch (err) {
 -    console.log(`Error retrieving version: ${err}`)

--- a/pkgs/by-name/za/zap-chip/package.nix
+++ b/pkgs/by-name/za/zap-chip/package.nix
@@ -11,21 +11,26 @@
 
 buildNpmPackage rec {
   pname = "zap-chip";
-  version = "2025.07.24";
+  version = "2026.02.26";
 
   src = fetchFromGitHub {
     owner = "project-chip";
     repo = "zap";
     rev = "v${version}";
-    hash = "sha256-MGu4qr+iXqI+GTpThI8yCcjt0KAcEwgJJa7wSnbryco=";
+    hash = "sha256-iAubYY/gFVjqNGnI8PIv3twc5j/8a46ycAiaZ7nw1VY=";
   };
 
-  npmDepsHash = "sha256-2AWqqMm91Ql9JA5oqon7H1YUuzJG+Z9c3LpsbQ9HE90=";
+  npmDepsHash = "sha256-SIworjSX2SLiNA2Oshvem0mOW795WkbHWP8WFD9yp8g=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   env.CYPRESS_INSTALL_BINARY = "0";
 
   patches = [
+    # The release's package-lock.json file is not universal. It misses
+    # architecture-related packages, caused by an NPM bug. Add these to the
+    # lock otherwise `npm ci` complains.
+    # https://github.com/npm/cli/issues/8805
+    ./universal-npm-lock.patch
     # the build system creates a file `.version.json` from a git command
     # as we don't build from a git repo, we create the file manually in postPatch
     # and this patch disables the logic running git

--- a/pkgs/by-name/za/zap-chip/universal-npm-lock.patch
+++ b/pkgs/by-name/za/zap-chip/universal-npm-lock.patch
@@ -1,0 +1,276 @@
+diff --git a/package-lock.json b/package-lock.json
+index 3034c5e47fdd..b6cf9a9995b9 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -81,20 +81,20 @@
+         "eslint-plugin-vue": "^9.27.0",
+         "eslint-webpack-plugin": "^4.2.0",
+         "folder-hash": "^4.0.1",
+-        "husky": "^9.1.7",
++        "husky": "9.1.7",
+         "is-reachable": "^5.2.1",
+         "jest": "^29.2.2",
+         "jest-junit": "^16.0.0",
+         "jest-sonar-reporter": "^2.0.0",
+-        "jsdoc": "^4.0.5",
++        "jsdoc": "4.0.5",
+         "jsdoc-to-markdown": "^8.0.3",
+         "license-checker": "^25.0.1",
+         "node-7z": "^3.0.0",
+         "node-gyp": "^10.2.0",
+         "nodejs-file-downloader": "^4.9.3",
+         "octokit": "^1.7.2",
+-        "prettier": "^3.6.2",
+-        "pretty-quick": "^4.2.2",
++        "prettier": "3.6.2",
++        "pretty-quick": "4.2.2",
+         "sonar-scanner": "^3.1.0",
+         "test-utils": "^1.1.1",
+         "typescript": "4.6",
+@@ -6071,6 +6071,246 @@
+         }
+       }
+     },
++    "node_modules/@rollup/rollup-android-arm-eabi": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.20.0.tgz",
++      "integrity": "sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-android-arm64": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.20.0.tgz",
++      "integrity": "sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-darwin-arm64": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
++      "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-darwin-x64": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.20.0.tgz",
++      "integrity": "sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.20.0.tgz",
++      "integrity": "sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.20.0.tgz",
++      "integrity": "sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-arm64-gnu": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.20.0.tgz",
++      "integrity": "sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-arm64-musl": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.20.0.tgz",
++      "integrity": "sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.20.0.tgz",
++      "integrity": "sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==",
++      "cpu": [
++        "ppc64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.20.0.tgz",
++      "integrity": "sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==",
++      "cpu": [
++        "riscv64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-s390x-gnu": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.20.0.tgz",
++      "integrity": "sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==",
++      "cpu": [
++        "s390x"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-x64-gnu": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.20.0.tgz",
++      "integrity": "sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-linux-x64-musl": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.20.0.tgz",
++      "integrity": "sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-win32-arm64-msvc": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.20.0.tgz",
++      "integrity": "sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-win32-ia32-msvc": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.20.0.tgz",
++      "integrity": "sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==",
++      "cpu": [
++        "ia32"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "peer": true
++    },
++    "node_modules/@rollup/rollup-win32-x64-msvc": {
++      "version": "4.20.0",
++      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.20.0.tgz",
++      "integrity": "sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "peer": true
++    },
+     "node_modules/@sideway/address": {
+       "version": "4.1.5",
+       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",


### PR DESCRIPTION
Diff: https://github.com/project-chip/zap/compare/v2025.07.24...v2026.02.26

Changelog: https://github.com/project-chip/zap/releases/tag/v2026.02.26

This is needed for latest Matter codebase which has increased the minimum zap version beyond what Nixpkgs currently have: https://github.com/project-chip/connectedhomeip/blob/master/scripts/tools/zap/zap_execution.py

The git stamping patch is rebased as the removed code has changed upstreram. I have added a new patch to fix up the package-lock.json due to it missing architecture-dependent packages, which is a NPM bug which has since been fixed. 

The zap-chip-gui shows weird error messages, but I've confirmed that they already exist in the current version, and they seems to be cosmetic only. Also, Matter codebase requires zap-cli only.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
