### PR TITLE
swiftlint: convert to finalAttrs, add linux support, tests and update script

### DIFF
--- a/pkgs/by-name/sw/swiftlint/package.nix
+++ b/pkgs/by-name/sw/swiftlint/package.nix
@@ -7,13 +7,19 @@
   nix-update-script,
   versionCheckHook,
 }:
-stdenvNoCC.mkDerivation rec {
+let
+  sources = lib.importJSON ./sources.json;
+  platform =
+    sources.platforms.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported platform: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "swiftlint";
-  version = "0.63.2";
+  inherit (sources) version;
 
   src = fetchurl {
-    url = "https://github.com/realm/SwiftLint/releases/download/${version}/portable_swiftlint.zip";
-    hash = "sha256-xZpAXIX5W5LO1nelAIBOCBWWpMrkpqSFr3YGVVfW7Sk=";
+    url = "https://github.com/realm/SwiftLint/releases/download/${finalAttrs.version}/${platform.filename}";
+    inherit (platform) hash;
   };
 
   dontPatch = true;
@@ -54,7 +60,7 @@ stdenvNoCC.mkDerivation rec {
       matteopacini
       DimitarNestorov
     ];
-    platforms = lib.platforms.darwin;
+    platforms = lib.attrNames sources.platforms;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/sw/swiftlint/package.nix
+++ b/pkgs/by-name/sw/swiftlint/package.nix
@@ -33,11 +33,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   sourceRoot = ".";
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 swiftlint $out/bin/swiftlint
-    runHook postInstall
-  '';
+  installPhase =
+    let
+      binary = if stdenvNoCC.hostPlatform.isLinux then "swiftlint-static" else "swiftlint";
+    in
+    ''
+      runHook preInstall
+      install -Dm755 ${binary} $out/bin/swiftlint
+      runHook postInstall
+    '';
 
   postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
     installShellCompletion --cmd swiftlint \

--- a/pkgs/by-name/sw/swiftlint/package.nix
+++ b/pkgs/by-name/sw/swiftlint/package.nix
@@ -4,7 +4,6 @@
   fetchurl,
   unzip,
   installShellFiles,
-  nix-update-script,
   versionCheckHook,
   runCommand,
 }:
@@ -55,7 +54,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = ./update.sh;
     tests = {
       lint =
         runCommand "swiftlint-test-lint"

--- a/pkgs/by-name/sw/swiftlint/package.nix
+++ b/pkgs/by-name/sw/swiftlint/package.nix
@@ -6,6 +6,7 @@
   installShellFiles,
   nix-update-script,
   versionCheckHook,
+  runCommand,
 }:
 let
   sources = lib.importJSON ./sources.json;
@@ -53,7 +54,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      lint =
+        runCommand "swiftlint-test-lint"
+          {
+            nativeBuildInputs = [ finalAttrs.finalPackage ];
+          }
+          ''
+            printf "class test{}\n\nvar a = 1" > test.swift
+            swiftlint lint ${lib.optionalString stdenvNoCC.hostPlatform.isDarwin "--disable-sourcekit"} test.swift > output.txt 2>&1 || true
+            grep -q "identifier_name" output.txt
+            grep -q "opening_brace" output.txt
+            grep -q "trailing_newline" output.txt
+            grep -q "type_name" output.txt
+            touch $out
+          '';
+    };
+  };
 
   meta = {
     description = "Tool to enforce Swift style and conventions";

--- a/pkgs/by-name/sw/swiftlint/sources.json
+++ b/pkgs/by-name/sw/swiftlint/sources.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.63.2",
+  "platforms": {
+    "x86_64-darwin": {
+      "filename": "portable_swiftlint.zip",
+      "hash": "sha256-xZpAXIX5W5LO1nelAIBOCBWWpMrkpqSFr3YGVVfW7Sk="
+    },
+    "aarch64-darwin": {
+      "filename": "portable_swiftlint.zip",
+      "hash": "sha256-xZpAXIX5W5LO1nelAIBOCBWWpMrkpqSFr3YGVVfW7Sk="
+    }
+  }
+}

--- a/pkgs/by-name/sw/swiftlint/sources.json
+++ b/pkgs/by-name/sw/swiftlint/sources.json
@@ -1,6 +1,14 @@
 {
   "version": "0.63.2",
   "platforms": {
+    "x86_64-linux": {
+      "filename": "swiftlint_linux_amd64.zip",
+      "hash": "sha256-3RAXz9IKFFfyZFkLy1h1pu4GzXW5qdT3fNQ6VSSZFDs="
+    },
+    "aarch64-linux": {
+      "filename": "swiftlint_linux_arm64.zip",
+      "hash": "sha256-EE3t/3YhV/XP93UvHMKiibYPPqZ35y1lHG86Mof92Ug="
+    },
     "x86_64-darwin": {
       "filename": "portable_swiftlint.zip",
       "hash": "sha256-xZpAXIX5W5LO1nelAIBOCBWWpMrkpqSFr3YGVVfW7Sk="

--- a/pkgs/by-name/sw/swiftlint/update.sh
+++ b/pkgs/by-name/sw/swiftlint/update.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+old_version=$(jq -r ".version" sources.json)
+version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+  "https://api.github.com/repos/realm/SwiftLint/releases/latest" | jq -r ".tag_name")
+
+if [[ "$old_version" == "$version" ]]; then
+    echo "swiftlint is already up to date at $version"
+    exit 0
+fi
+
+echo "Updating swiftlint from $old_version to $version"
+
+declare -A platforms=(
+    [x86_64-linux]="swiftlint_linux_amd64.zip"
+    [aarch64-linux]="swiftlint_linux_arm64.zip"
+    [x86_64-darwin]="portable_swiftlint.zip"
+    [aarch64-darwin]="portable_swiftlint.zip"
+)
+
+sources_tmp="$(mktemp)"
+jq -n --arg v "$version" '{version: $v, platforms: {}}' > "$sources_tmp"
+
+for platform in "${!platforms[@]}"; do
+    filename="${platforms[$platform]}"
+    url="https://github.com/realm/SwiftLint/releases/download/${version}/${filename}"
+    echo "Fetching hash for $platform ($filename)..."
+    sha256hash="$(nix-prefetch-url --type sha256 "$url")"
+    hash="$(nix hash convert --to sri --hash-algo sha256 "$sha256hash")"
+    jq --arg platform "$platform" \
+       --arg filename "$filename" \
+       --arg hash "$hash" \
+       '.platforms += {($platform): {filename: $filename, hash: $hash}}' \
+       "$sources_tmp" > "${sources_tmp}.tmp" && mv "${sources_tmp}.tmp" "$sources_tmp"
+done
+
+mv "$sources_tmp" sources.json
+
+echo "Updated swiftlint to $version"


### PR DESCRIPTION
- Commit I:  converted to `finalAttrs` as per #315337, and switched to an external JSON file for sources
- Commit II:  added linux support via the static binary, to avoid warnings (like those in #338080) - once Swift 6 toolchain is in, we can have a rethink and have the whole derivation rebuild from source
- Commit III: added the tests you perform during the update @DimitarNestorov  (good stuff!) as a `passthru.test`.
- Commit IV: replaced `nix-update-script` with a custom bash script that updates `sources.json` - given the added support for Linux, we should start seeing update PRs from the update bot.

To test the update script:

```bash
nix-shell maintainers/scripts/update.nix --argstr package swiftlint
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test