### PR TITLE
python3Packages.attrs-strict: cleanup, skip failing tests on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/attrs-strict/default.nix
+++ b/pkgs/development/python-modules/attrs-strict/default.nix
@@ -2,13 +2,19 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  attrs,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  attrs,
+
+  # tests
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "attrs-strict";
   version = "1.0.1";
   pyproject = true;
@@ -16,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bloomberg";
     repo = "attrs-strict";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-dDOD4Y57E+i8D0S4q+C6t7zjBTsS8q2UFiS22Dsp0Z8=";
   };
 
@@ -35,11 +41,18 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # AssertionError: Regex pattern did not match
+    "test_real_types"
+    "test_recursive"
+    "test_union_when_type_is_not_specified_raises"
+  ];
+
   meta = {
-    changelog = "https://github.com/bloomberg/attrs-strict/releases/tag/${version}";
     description = "Python package which contains runtime validation for attrs data classes based on the types existing in the typing module";
     homepage = "https://github.com/bloomberg/attrs-strict";
+    changelog = "https://github.com/bloomberg/attrs-strict/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/flask-restx/default.nix
+++ b/pkgs/development/python-modules/flask-restx/default.nix
@@ -3,25 +3,32 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   aniso8601,
-  jsonschema,
   flask,
   importlib-resources,
-  werkzeug,
+  jsonschema,
   pytz,
+  werkzeug,
+
+  # tests
+  blinker,
   faker,
   mock,
-  blinker,
   py,
+  pytest-benchmark,
   pytest-flask,
   pytest-mock,
-  pytest-benchmark,
   pytest-vcr,
   pytestCheckHook,
-  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "flask-restx";
   version = "1.3.2";
   pyproject = true;
@@ -30,7 +37,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "python-restx";
     repo = "flask-restx";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-KSHRfGX6M/w09P35A68u7uzMKaRioytScPh0Sw8JBfw=";
   };
 
@@ -80,6 +87,18 @@ buildPythonPackage rec {
     # we disable the tests in the meanwhile and let upstream decide
     "test_rfc822_value"
     "test_iso8601_value"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # TypeError: Wildcard.__init__() takes 2 positional arguments but 3 were given
+    "test_description"
+    "test_max_length"
+    "test_max_length_as_callable"
+    "test_min_length"
+    "test_min_length_as_callable"
+    "test_pattern"
+    "test_readonly"
+    "test_required"
+    "test_title"
   ];
 
   pythonImportsCheck = [ "flask_restx" ];
@@ -87,8 +106,8 @@ buildPythonPackage rec {
   meta = {
     description = "Fully featured framework for fast, easy and documented API development with Flask";
     homepage = "https://github.com/python-restx/flask-restx";
-    changelog = "https://github.com/python-restx/flask-restx/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/python-restx/flask-restx/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
+++ b/pkgs/development/python-modules/netbox-interface-synchronization/default.nix
@@ -1,16 +1,23 @@
 {
   lib,
   buildPythonPackage,
-  django,
   fetchFromGitHub,
-  netaddr,
-  netbox,
-  numpy,
-  requests,
+
+  # build-system
   setuptools,
+
+  # dependencies
+  django,
+  netaddr,
+  numpy,
+  psycopg,
+  requests,
+
+  # tests
+  netbox,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "netbox-interface-synchronization";
   version = "4.1.7";
   pyproject = true;
@@ -18,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "NetTech2001";
     repo = "netbox-interface-synchronization";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-02fdfE1BwpWsh21M0oP65kMAbFxDxYHsAEWA64rUl18=";
   };
 
@@ -29,6 +36,7 @@ buildPythonPackage rec {
     netaddr
     requests
     numpy
+    psycopg # not specified in pyproject.toml, but required at import time
   ];
 
   # netbox is required for the pythonImportsCheck; plugin does not provide unit tests
@@ -43,9 +51,9 @@ buildPythonPackage rec {
   meta = {
     description = "Netbox plugin to compare and synchronize interfaces between devices and device types";
     homepage = "https://github.com/NetTech2001/netbox-interface-synchronization";
-    changelog = "https://github.com/NetTech2001/netbox-interface-synchronization/releases/tag/${src.tag}";
+    changelog = "https://github.com/NetTech2001/netbox-interface-synchronization/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ felbinger ];
   };
-}
+})

--- a/pkgs/development/python-modules/netbox-plugin-prometheus-sd/default.nix
+++ b/pkgs/development/python-modules/netbox-plugin-prometheus-sd/default.nix
@@ -1,11 +1,16 @@
 {
   lib,
   buildPythonPackage,
-  django,
   fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  django,
   netaddr,
   netbox,
-  poetry-core,
+  psycopg,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -30,6 +35,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     django
     netaddr
+    psycopg # not specified in pyproject.toml, but required at import time
   ];
 
   nativeCheckInputs = [ netbox ];

--- a/pkgs/development/python-modules/netbox-qrcode/default.nix
+++ b/pkgs/development/python-modules/netbox-qrcode/default.nix
@@ -9,6 +9,7 @@
   # dependencies
   pillow,
   qrcode,
+  psycopg,
 
   # nativeCheckInputs
   django,
@@ -39,6 +40,7 @@ buildPythonPackage (finalAttrs: {
     django
     netaddr
     netbox
+    psycopg # not specified in pyproject.toml, but required at import time
   ];
 
   preFixup = ''

--- a/pkgs/development/python-modules/netbox-qrcode/default.nix
+++ b/pkgs/development/python-modules/netbox-qrcode/default.nix
@@ -1,16 +1,22 @@
 {
   lib,
   buildPythonPackage,
-  django,
   fetchFromGitHub,
-  netaddr,
-  netbox,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   pillow,
   qrcode,
-  setuptools,
+
+  # nativeCheckInputs
+  django,
+  netaddr,
+  netbox,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "netbox-qrcode";
   version = "0.0.20";
   pyproject = true;
@@ -18,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "netbox-community";
     repo = "netbox-qrcode";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7dPMpuJ2nuj9rRmVrfthD+xrEHoUaLFqDJWC6cGGCwY=";
   };
 
@@ -44,9 +50,9 @@ buildPythonPackage rec {
   meta = {
     description = "Netbox plugin for generate QR codes for objects: Rack, Device, Cable";
     homepage = "https://github.com/netbox-community/netbox-qrcode";
-    changelog = "https://github.com/netbox-community/netbox-qrcode/releases/tag/${src.tag}";
+    changelog = "https://github.com/netbox-community/netbox-qrcode/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ felbinger ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-flask/default.nix
+++ b/pkgs/development/python-modules/pytest-flask/default.nix
@@ -1,47 +1,71 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
-  fetchPypi,
-  flask,
-  pytest,
-  pytestCheckHook,
+  fetchFromGitHub,
+
+  # build-system
   setuptools-scm,
+
+  # buildInputs
+  pytest,
+
+  # dependencies
+  flask,
   werkzeug,
+
+  # tests
+  pytestCheckHook,
+  pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-flask";
   version = "1.3.0";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-WL4cl7Ibo8TUfgp2ketBAHdIUGw2v1EAT3jfEGkfqV4=";
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "pytest-flask";
+    tag = finalAttrs.version;
+    hash = "sha256-mcBHpP6A+ehqowDccfcn+wv6WXRrF0cY9ez7kqkb3Hc=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ setuptools-scm ];
 
   buildInputs = [ pytest ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     flask
     werkzeug
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
   pythonImportsCheck = [ "pytest_flask" ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    "tests/test_live_server.py"
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # Failed: nomatch: '*PASSED*'
+    "test_add_endpoint_to_live_server"
+    "test_clean_stop_live_server"
+    "test_live_server_fixed_host"
+    "test_live_server_fixed_port"
+    "test_rewrite_application_server_name"
+    "test_start_live_server"
+
+    # _pickle.PicklingError: Can't pickle local object
+    "test_init"
+    "test_server_is_alive"
+    "test_server_listening"
+    "test_set_application_server_name"
+    "test_stop_cleanly_join_exception"
+    "test_url_for"
   ];
 
   meta = {
     description = "Set of pytest fixtures to test Flask applications";
     homepage = "https://pytest-flask.readthedocs.io/";
-    changelog = "https://github.com/pytest-dev/pytest-flask/blob/${version}/docs/changelog.rst";
+    changelog = "https://github.com/pytest-dev/pytest-flask/blob/${finalAttrs.src.tag}/docs/changelog.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ vanschelven ];
   };
-}
+})

--- a/pkgs/development/python-modules/swh-core/default.nix
+++ b/pkgs/development/python-modules/swh-core/default.nix
@@ -3,6 +3,13 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitLab,
+  pythonAtLeast,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
   backports-entry-points-selectable,
   click,
   deprecated,
@@ -11,8 +18,8 @@
   requests,
   sentry-sdk,
   tenacity,
-  setuptools,
-  setuptools-scm,
+
+  # tests
   aiohttp-utils,
   flask,
   hypothesis,
@@ -112,6 +119,13 @@ buildPythonPackage (finalAttrs: {
     types-requests
     unzip
     pkgs.zstd
+  ];
+
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.14") [
+    # shutil.RegistryError: .tar.zst is already registered for "zstdtar"
+    "swh/core/tests/test_cli_nar.py"
+    "swh/core/tests/test_nar.py"
+    "swh/core/tests/test_tarball.py"
   ];
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/swh-objstorage/default.nix
+++ b/pkgs/development/python-modules/swh-objstorage/default.nix
@@ -3,8 +3,14 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitLab,
+  pythonAtLeast,
+  util-linux,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
   backports-entry-points-selectable,
   cassandra-driver,
   click,
@@ -15,10 +21,12 @@
   mypy-extensions,
   psycopg,
   redis,
-  tenacity,
   swh-core,
   swh-model,
   swh-shard,
+  tenacity,
+
+  # tests
   aiohttp,
   azure-core,
   azure-storage-blob,
@@ -26,16 +34,15 @@
   libcloud,
   postgresql,
   postgresqlTestHook,
-  pytestCheckHook,
   pytest-mock,
   pytest-postgresql,
+  pytestCheckHook,
   requests-mock,
   requests-toolbelt,
   systemd-python,
   types-python-dateutil,
   types-pyyaml,
   types-requests,
-  util-linux,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -51,6 +58,13 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-NnNT9Lt/LGDIJpUmfkfPn6JnF3k8Usf2UVa88zHPKlg=";
   };
+
+  postPatch = ''
+    substituteInPlace swh/objstorage/backends/winery/roshard.py \
+      --replace-fail \
+        "/usr/bin/fallocate" \
+        "${lib.getExe' util-linux "fallocate"}"
+  '';
 
   build-system = [
     setuptools
@@ -68,16 +82,11 @@ buildPythonPackage (finalAttrs: {
     mypy-extensions
     psycopg
     redis
-    tenacity
     swh-core
     swh-model
     swh-shard
+    tenacity
   ];
-
-  preCheck = ''
-    substituteInPlace swh/objstorage/backends/winery/roshard.py \
-      --replace-fail "/usr/bin/fallocate" "fallocate"
-  '';
 
   pythonImportsCheck = [ "swh.objstorage" ];
 
@@ -94,9 +103,9 @@ buildPythonPackage (finalAttrs: {
     libcloud
     postgresql
     postgresqlTestHook
-    pytestCheckHook
     pytest-mock
     pytest-postgresql
+    pytestCheckHook
     requests-mock
     requests-toolbelt
     systemd-python
@@ -107,10 +116,19 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ psycopg.optional-dependencies.pool;
 
-  disabledTests = lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
-    # FAILED swh/objstorage/tests/test_objstorage_winery.py::test_winery_leaky_bucket_tick - assert 1 == 0
-    "test_winery_leaky_bucket_tick"
+  disabledTestPaths = lib.optionals (pythonAtLeast "3.14") [
+    # _pickle.PicklingError: Can't pickle local object
+    "swh/objstorage/tests/test_objstorage_api.py"
   ];
+
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.14") [
+      "test_winery_add_and_pack"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+      # FAILED swh/objstorage/tests/test_objstorage_winery.py::test_winery_leaky_bucket_tick - assert 1 == 0
+      "test_winery_leaky_bucket_tick"
+    ];
 
   meta = {
     changelog = "https://gitlab.softwareheritage.org/swh/devel/swh-objstorage/-/tags/${finalAttrs.src.tag}";

--- a/pkgs/development/python-modules/swh-scanner/default.nix
+++ b/pkgs/development/python-modules/swh-scanner/default.nix
@@ -3,20 +3,27 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitLab,
+  pythonAtLeast,
+
+  # build-system
   setuptools,
   setuptools-scm,
-  requests,
-  ndjson,
+
+  # dependencies
   flask,
   importlib-metadata,
+  ndjson,
+  requests,
+  swh-auth,
   swh-core,
   swh-model,
-  swh-auth,
   swh-web-client,
+
+  # tests
   beautifulsoup4,
-  pytestCheckHook,
   pytest-flask,
   pytest-mock,
+  pytestCheckHook,
   types-beautifulsoup4,
   types-pyyaml,
   types-requests,
@@ -42,13 +49,13 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    requests
-    ndjson
     flask
     importlib-metadata
+    ndjson
+    requests
+    swh-auth
     swh-core
     swh-model
-    swh-auth
     swh-web-client
   ];
 
@@ -56,9 +63,9 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     beautifulsoup4
-    pytestCheckHook
     pytest-flask
     pytest-mock
+    pytestCheckHook
     swh-core
     swh-model
     types-beautifulsoup4
@@ -66,12 +73,19 @@ buildPythonPackage (finalAttrs: {
     types-requests
   ];
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Failed: Failed to start the server after 5 seconds.
-    "test_add_provenance_with_release"
-    "test_add_provenance_with_revision"
-    "test_scanner_result"
-  ];
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.14") [
+      # _pickle.PicklingError: Can't pickle local object
+      "test_add_provenance_with_release"
+      "test_add_provenance_with_revision"
+      "test_scanner_result"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Failed: Failed to start the server after 5 seconds.
+      "test_add_provenance_with_release"
+      "test_add_provenance_with_revision"
+      "test_scanner_result"
+    ];
 
   disabledTestPaths = [
     # pytestRemoveBytecodePhase fails with: "error (ignored): error: opening directory "/tmp/nix-build-python3.12-swh-scanner-0.8.3.drv-5/build/pytest-of-nixbld/pytest-0/test_randomdir_policy_info_cal0/big-directory/dir/dir/dir/ ......"


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
