### PR TITLE
tulip: migrate to by-name

### DIFF
--- a/pkgs/by-name/tu/tulip/package.nix
+++ b/pkgs/by-name/tu/tulip/package.nix
@@ -7,14 +7,16 @@
   libGLU,
   libGL,
   glew,
-  qtbase,
-  wrapQtAppsHook,
+  libsForQt5,
   autoPatchelfHook,
-  python3,
+  python312,
   cmake,
   libjpeg,
   llvmPackages,
 }:
+let
+  python3 = python312; # fails to build otherwise
+in
 
 stdenv.mkDerivation rec {
   pname = "tulip";
@@ -27,7 +29,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    libsForQt5.wrapQtAppsHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
@@ -36,7 +38,7 @@ stdenv.mkDerivation rec {
     freetype
     glew
     libjpeg
-    qtbase
+    libsForQt5.qtbase
     python3
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ]

--- a/pkgs/by-name/tu/tulip/package.nix
+++ b/pkgs/by-name/tu/tulip/package.nix
@@ -7,14 +7,16 @@
   libGLU,
   libGL,
   glew,
-  qtbase,
-  wrapQtAppsHook,
+  qt5,
   autoPatchelfHook,
-  python3,
+  python312,
   cmake,
   libjpeg,
   llvmPackages,
 }:
+let
+  python3 = python312; # fails to build otherwise
+in
 
 stdenv.mkDerivation rec {
   pname = "tulip";
@@ -27,7 +29,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
@@ -36,7 +38,7 @@ stdenv.mkDerivation rec {
     freetype
     glew
     libjpeg
-    qtbase
+    qt5.qtbase
     python3
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11792,10 +11792,6 @@ with pkgs;
 
   spyder = with python3.pkgs; toPythonApplication spyder;
 
-  tulip = libsForQt5.callPackage ../applications/science/misc/tulip {
-    python3 = python312; # fails to build otherwise
-  };
-
   vite = libsForQt5.callPackage ../applications/science/misc/vite { };
 
   ### SCIENCE / PHYSICS

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11251,10 +11251,6 @@ with pkgs;
 
   spyder = with python3.pkgs; toPythonApplication spyder;
 
-  tulip = libsForQt5.callPackage ../applications/science/misc/tulip {
-    python3 = python312; # fails to build otherwise
-  };
-
   ### SCIENCE / PHYSICS
 
   hepmc3 = callPackage ../development/libraries/physics/hepmc3 {


### PR DESCRIPTION
This pull request refactors the packaging of the `tulip` application by moving its package definition to the `by-name` directory, updating its dependencies to use the `libsForQt5` set, and cleaning up its usage in the top-level package list. These changes help standardize how Qt5 applications are packaged and make the dependency management more robust.

**Refactoring and dependency updates:**

* Moved the `tulip` package definition from `pkgs/applications/science/misc/tulip/default.nix` to `pkgs/by-name/tu/tulip/package.nix`, aligning it with the by-name packaging convention.
* Updated dependencies in `package.nix` to use `libsForQt5` for `qtbase` and `wrapQtAppsHook`, improving compatibility and consistency for Qt5 applications.

* Switched from `python3` to `python312` explicitly to fix build issues, and set `python3 = python312` in a local binding.
* Removed the manual addition of `tulip` to `all-packages.nix`, as it is now managed through the new location and conventions.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
