### PR TITLE
lib/systems: add C-SKY (csky) cross-compilation support

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -36,6 +36,7 @@ let
     "armv6l-linux"
     "armv7a-linux"
     "armv7l-linux"
+    "csky-linux"
     "i686-linux"
     "loongarch64-linux"
     "m68k-linux"
@@ -132,6 +133,7 @@ in
   x86 = filterDoubles predicates.isx86;
   i686 = filterDoubles predicates.isi686;
   x86_64 = filterDoubles predicates.isx86_64;
+  csky = filterDoubles predicates.isCsky;
   microblaze = filterDoubles predicates.isMicroBlaze;
   mips = filterDoubles predicates.isMips;
   mmix = filterDoubles predicates.isMmix;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -46,6 +46,7 @@ let
     "armv6l-linux"
     "armv7a-linux"
     "armv7l-linux"
+    "csky-linux"
     "i686-linux"
     "loongarch64-linux"
     "m68k-linux"
@@ -150,6 +151,7 @@ in
   x86 = filterDoubles predicates.isx86;
   i686 = filterDoubles predicates.isi686;
   x86_64 = filterDoubles predicates.isx86_64;
+  csky = filterDoubles predicates.isCsky;
   microblaze = filterDoubles predicates.isMicroBlaze;
   mips = filterDoubles predicates.isMips;
   mmix = filterDoubles predicates.isMmix;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -235,6 +235,10 @@ rec {
     libc = "newlib";
   };
 
+  csky = {
+    config = "csky-unknown-linux-gnuabiv2";
+  };
+
   m68k = {
     config = "m68k-unknown-linux-gnu";
   };

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -228,6 +228,10 @@ rec {
     libc = "newlib";
   };
 
+  csky = {
+    config = "csky-unknown-linux-gnuabiv2";
+  };
+
   m68k = {
     config = "m68k-unknown-linux-gnu";
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -116,6 +116,11 @@ rec {
         family = "arm";
       };
     };
+    isCsky = {
+      cpu = {
+        family = "csky";
+      };
+    };
     isMicroBlaze = {
       cpu = {
         family = "microblaze";
@@ -377,6 +382,7 @@ rec {
         gnueabihf
         gnuabielfv1
         gnuabielfv2
+        gnuabiv2
       ];
     isMusl =
       with abis;

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -149,6 +149,11 @@ rec {
         family = "arm";
       };
     };
+    isCsky = {
+      cpu = {
+        family = "csky";
+      };
+    };
     isMicroBlaze = {
       cpu = {
         family = "microblaze";
@@ -420,6 +425,7 @@ rec {
         gnueabihf
         gnuabielfv1
         gnuabielfv2
+        gnuabiv2
       ];
     isMusl =
       with abis;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -209,6 +209,12 @@ rec {
         arch = "armv8-a";
       };
 
+      csky = {
+        bits = 32;
+        significantByte = littleEndian;
+        family = "csky";
+      };
+
       i386 = {
         bits = 32;
         significantByte = littleEndian;
@@ -733,6 +739,9 @@ rec {
     gnuabielfv1 = {
       abi = "elfv1";
     };
+    gnuabiv2 = {
+      abi = "v2";
+    };
 
     musleabi = {
       float = "soft";
@@ -1000,6 +1009,7 @@ rec {
               gnuabi64 = abis.muslabi64;
               gnuabielfv2 = abis.musl;
               gnuabielfv1 = abis.musl;
+              gnuabiv2 = abis.musl;
               # The following entries ensure that this function is idempotent.
               musleabi = abis.musleabi;
               musleabihf = abis.musleabihf;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -212,6 +212,12 @@ rec {
         arch = "armv8-a";
       };
 
+      csky = {
+        bits = 32;
+        significantByte = littleEndian;
+        family = "csky";
+      };
+
       i386 = {
         bits = 32;
         significantByte = littleEndian;
@@ -731,6 +737,9 @@ rec {
     gnuabielfv1 = {
       abi = "elfv1";
     };
+    gnuabiv2 = {
+      abi = "v2";
+    };
 
     musleabi = {
       float = "soft";
@@ -1023,6 +1032,7 @@ rec {
               gnuabi64 = abis.muslabi64;
               gnuabielfv2 = abis.musl;
               gnuabielfv1 = abis.musl;
+              gnuabiv2 = abis.musl;
               # The following entries ensure that this function is idempotent.
               musleabi = abis.musleabi;
               musleabihf = abis.musleabihf;

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -167,6 +167,7 @@ lib.runTests (
       "armv6l-linux"
       "armv7a-linux"
       "armv7l-linux"
+      "csky-linux"
       "i686-linux"
       "loongarch64-linux"
       "m68k-linux"

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -166,6 +166,7 @@ lib.runTests (
       "armv6l-linux"
       "armv7a-linux"
       "armv7l-linux"
+      "csky-linux"
       "i686-linux"
       "loongarch64-linux"
       "m68k-linux"

--- a/pkgs/development/compilers/gcc/common/platform-flags.nix
+++ b/pkgs/development/compilers/gcc/common/platform-flags.nix
@@ -13,7 +13,7 @@ lib.concatLists [
   (lib.optional (
     with targetPlatform; !isLoongArch64 && !isMips && !isRiscV && !isS390 && !isAarch64Darwin && p ? cpu
   ) "--with-cpu=${p.cpu}")
-  (lib.optional (p ? abi) "--with-abi=${p.abi}")
+  (lib.optional (!targetPlatform.isCsky && p ? abi) "--with-abi=${p.abi}")
   (lib.optional (p ? fpu) "--with-fpu=${p.fpu}")
   (lib.optional (p ? float) "--with-float=${p.float}")
   (lib.optional (p ? mode) "--with-mode=${p.mode}")


### PR DESCRIPTION
## Summary

Add cross-compilation support for [C-SKY](https://en.wikipedia.org/wiki/C-SKY), a 32-bit little-endian embedded processor by T-Head/Alibaba with GCC (since 9), glibc (since 2.29), and Linux kernel (since 4.20) support.

Requires a new `gnuabiv2` ABI type (distinct from PowerPC's `gnuabielfv2`) and a `--with-abi` skip in GCC platform flags since C-SKY uses `--with-cpu`/`--with-endian`/`--with-float` instead.

### Test results

Cross-compiled with `nix build '.#pkgsCross.csky.hello'` on x86_64-linux.

| Package | Build |
|---|---|
| hello | :white_check_mark: |
| coreutils | :white_check_mark: |
| bash | :white_check_mark: |

QEMU user-mode testing not possible — mainline QEMU does not include `qemu-cskyv2` user-mode emulation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test