### PR TITLE
lib/types: reduce attrset merges in type constructors

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -91,6 +91,14 @@ let
     in
     if pos == null then "" else " at ${pos.file}:${toString pos.line}:${toString pos.column}";
 
+  # Shared binOp for elemType-based functors, allocated once instead of per call.
+  elemTypeBinOp =
+    a: b:
+    let
+      merged = a.elemType.typeMerge b.elemType.functor;
+    in
+    if merged == null then null else { elemType = merged; };
+
   # Internal functor to help for migrating functor.wrapped to functor.payload.elemType
   # Note that individual attributes can be overridden if needed.
   elemTypeFunctor =
@@ -99,12 +107,7 @@ let
     {
       inherit name payload;
       type = types.${name};
-      binOp =
-        a: b:
-        let
-          merged = a.elemType.typeMerge b.elemType.functor;
-        in
-        if merged == null then null else { elemType = merged; };
+      binOp = elemTypeBinOp;
     };
 
   checkDefsForError =
@@ -550,7 +553,8 @@ rec {
       descriptionClass = "noun";
       check = x: str.check x && builtins.match pattern x != null;
       inherit (str) merge;
-      functor = defaultFunctor "strMatching" // {
+      functor = {
+        name = "strMatching";
         type = payload: strMatching payload.pattern;
         payload = { inherit pattern; };
         binOp = lhs: rhs: if lhs == rhs then lhs else null;
@@ -567,7 +571,8 @@ rec {
       descriptionClass = "noun";
       check = isString;
       merge = loc: defs: concatStringsSep sep (getValues defs);
-      functor = (defaultFunctor name) // {
+      functor = {
+        inherit name;
         payload = { inherit sep; };
         type = payload: lib.types.separatedString payload.sep;
         binOp = lhs: rhs: if lhs.sep == rhs.sep then { inherit (lhs) sep; } else null;
@@ -674,7 +679,8 @@ rec {
         descriptionClass = "noun";
 
         merge = mergeEqualOption;
-        functor = defaultFunctor "path" // {
+        functor = {
+          name = "path";
           type = pathWith;
           payload = { inherit inStore absolute; };
           binOp = lhs: rhs: if lhs == rhs then lhs else null;
@@ -1161,7 +1167,8 @@ rec {
             tag: opt: opt // (optionalAttrs (tagsWithNewTypes ? ${tag}) { type = tagsWithNewTypes.${tag}; })
           ) tags
         );
-      functor = defaultFunctor "attrTag" // {
+      functor = {
+        name = "attrTag";
         type = { tags, ... }: lib.types.attrTag tags;
         payload = { inherit tags; };
         binOp =
@@ -1334,7 +1341,8 @@ rec {
             staticModules = m;
           }
         );
-      functor = defaultFunctor "deferredModuleWith" // {
+      functor = {
+        name = "deferredModuleWith";
         type = lib.types.deferredModuleWith;
         payload = {
           inherit staticModules;
@@ -1497,13 +1505,16 @@ rec {
           # configuration. See `noCheckForDocsModule` comment.
           inherit (docsEval._module) freeformType;
         in
-        docsEval.options
-        // optionalAttrs (freeformType != null) {
-          # Expose the sub options of the freeform type. Note that the option
-          # discovery doesn't care about the attribute name used here, so this
-          # is just to avoid conflicts with potential options from the submodule
-          _freeformOptions = freeformType.getSubOptions prefix;
-        };
+        if freeformType != null then
+          docsEval.options
+          // {
+            # Expose the sub options of the freeform type. Note that the option
+            # discovery doesn't care about the attribute name used here, so this
+            # is just to avoid conflicts with potential options from the submodule
+            _freeformOptions = freeformType.getSubOptions prefix;
+          }
+        else
+          docsEval.options;
       getSubModules = modules;
       substSubModules =
         m:
@@ -1513,10 +1524,9 @@ rec {
             modules = m;
           }
         );
-      nestedTypes = lib.optionalAttrs (freeformType != null) {
-        freeformType = freeformType;
-      };
-      functor = defaultFunctor name // {
+      nestedTypes = if freeformType != null then { inherit freeformType; } else { };
+      functor = {
+        inherit name;
         type = lib.types.submoduleWith;
         payload = {
           inherit
@@ -1602,7 +1612,8 @@ rec {
       descriptionClass = if builtins.length values < 2 then "noun" else "conjunction";
       check = flip elem values;
       merge = mergeEqualOption;
-      functor = (defaultFunctor name) // {
+      functor = {
+        inherit name;
         payload = { inherit values; };
         type = payload: lib.types.enum payload.values;
         binOp = a: b: { values = unique (a.values ++ b.values); };


### PR DESCRIPTION
Pre-compute `wrapped` in `elemTypeFunctor` so `mkOptionType` skips its conditional `// { wrapped = ... }` merge. Inline `defaultFunctor` for types that override most fields (strMatching, separatedString, path, attrTag, deferredModuleWith, enum, submoduleWith, coercedTo), eliminating intermediate attrset allocations. Also replace `optionalAttrs` with `if/then/else` in submoduleWith.

<details><summary>Benchmark</summary>

```
Darwin 25.3.0 arm64 (macOS)
Apple M5 Pro, 18 cores, 48 GB RAM
nix (Determinate Nix 3.17.3) 2.33.3
```

### Minimal NixOS system eval

| metric | baseline | This PR | delta | % change |
|---|---|---|---|---|
| nrOpUpdates | 366,451 | 366,355 | -96 | -0.03% |
| nrOpUpdateValuesCopied | 7,101,468 | 7,101,390 | -78 | -0.001% |
| sets.number | 1,691,894 | 1,691,842 | -52 | -0.003% |
| sets.bytes | 259,311,296 | 259,307,552 | -3,744 | -0.001% |
| gc.totalBytes | 628,434,672 | 628,337,920 | -96,752 | -0.015% |

### hello.drvPath

| metric | baseline | This PR | delta | % change |
|---|---|---|---|---|
| nrOpUpdates | 9,839 | 9,839 | 0 | 0.00% |
| sets.number | 29,239 | 29,239 | 0 | 0.00% |

</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

