### PR TITLE
python3Packages.prefab-ui: init at 0.19.1

### DIFF
--- a/pkgs/by-name/pr/prefab/package.nix
+++ b/pkgs/by-name/pr/prefab/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication prefab-ui

--- a/pkgs/development/python-modules/prefab-ui/default.nix
+++ b/pkgs/development/python-modules/prefab-ui/default.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+
+  # build-system
+  hatchling,
+  uv-dynamic-versioning,
+
+  # dependencies
+  cyclopts,
+  deno,
+  pydantic,
+  rich,
+
+  # tests
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+  versionCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "prefab-ui";
+  version = "0.19.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "PrefectHQ";
+    repo = "prefab";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-caSsMR6Il4D1l9Y1ScdN5HZ4TPG2YyB6JzctDt+W3WE=";
+  };
+
+  patches = [
+    # Fix packaging of static skills directory.
+    (fetchpatch {
+      # This commit has been submitted in a PR to the upstream repo: https://github.com/PrefectHQ/prefab/pull/433.
+      url = "https://github.com/PrefectHQ/prefab/commit/5860b2f3099117d800ca17c10fd3edcb67e07873.patch";
+      hash = "sha256-Eph0PDucH3J7OUP+YQWH6qYycYdLkG52Y6xYNIQUilQ=";
+    })
+  ];
+
+  # Remove the `dev` command; this command is _not_ user-facing
+  # and fails entirely in nix because it needs several
+  # undocumented dependencies (npx, uv, etc) and tries to
+  # generate files in the repository root, i.e. the Nix store.
+  postPatch = ''
+    substituteInPlace src/prefab_ui/cli/cli.py \
+      --replace-fail "app.command(dev_app)" ""
+
+    substituteInPlace src/prefab_ui/sandbox/_pyodide.py \
+      tests/test_generative.py \
+      tests/test_sandbox.py \
+      --replace-fail 'import shutil' 'import pathlib' \
+      --replace-fail 'shutil.which("deno")' 'pathlib.Path("${lib.getExe deno}")'
+  '';
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    cyclopts
+    pydantic
+    rich
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+    versionCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Tests used to validate dev tooling, which we disable.
+    "tests/test_contract.py"
+    # Tests use Pyodide, which tries to access the network to download Pyodide from npm.
+    "tests/test_generative.py"
+    "tests/test_sandbox.py"
+  ];
+
+  pythonImportsCheck = [ "prefab_ui" ];
+
+  meta = {
+    description = "Generative UI framework that even humans can use";
+    homepage = "https://github.com/PrefectHQ/prefab";
+    changelog = "https://github.com/PrefectHQ/prefab/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ squat ];
+    mainProgram = "prefab";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12859,6 +12859,8 @@ self: super: with self; {
 
   precisely = callPackage ../development/python-modules/precisely { };
 
+  prefab-ui = callPackage ../development/python-modules/prefab-ui { };
+
   prefect = toPythonModule pkgs.prefect;
 
   prefixed = callPackage ../development/python-modules/prefixed { };


### PR DESCRIPTION
This commit introduces prefab (https://github.com/PrefectHQ/prefab). It is a CLI and Python library (prefab-ui) for building reactive UIs in Python. It's maintained by the same group that maintains fastmcp. It is also an optional dependency of fastmcp v3.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
