### PR TITLE
python3Packages.pywebtransport: init at 0.16.1

### DIFF
--- a/pkgs/development/python-modules/pywebtransport/default.nix
+++ b/pkgs/development/python-modules/pywebtransport/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  buildPythonPackage,
+  clang,
+  fetchFromGitHub,
+  libclang,
+  llvmPackages,
+  msgpack,
+  pkg-config,
+  protobuf,
+  psutil,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-mock,
+  pytestCheckHook,
+  rustPlatform,
+  types-psutil,
+  uvloop,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pywebtransport";
+  version = "0.16.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wtransport";
+    repo = "pywebtransport";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DKvWSu2ufoIsBODNfFbM9JUtY81mmUISmD+qMQ6UVDI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    cargoRoot = "crates";
+    hash = "sha256-gplelmBqntws+64DmjOZ5xbo3L/f+3+oasi5qLXT1pg=";
+  };
+
+  build-system = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeBuildInputs = [
+    clang
+    llvmPackages.libclang.lib
+    pkg-config
+  ];
+
+  env.LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  env.LD_LIBRARY_PATH = "${llvmPackages.libclang.lib}/lib:${lib.getLib libclang}/lib";
+
+  prePatch = ''
+    # maturin can't find the file
+    ln -s crates/Cargo.lock Cargo.lock || true
+  '';
+
+  optional-dependencies = {
+    msgpack = [ msgpack ];
+    protobuf = [ protobuf ];
+  };
+
+  nativeCheckInputs = [
+    psutil
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+    types-psutil
+    uvloop
+  ]
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
+
+  disabledTestPaths = [
+    # Tests require network access
+    "tests/e2e"
+  ];
+
+  preCheck = ''
+    cp -v $out/lib/python*/site-packages/pywebtransport/_wtransport*.so src/pywebtransport/
+  '';
+
+  pythonImportsCheck = [ "pywebtransport" ];
+
+  meta = {
+    description = "WebTransport stack for Python";
+    homepage = "https://github.com/wtransport/pywebtransport";
+    changelog = "https://github.com/wtransport/pywebtransport/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16277,6 +16277,8 @@ self: super: with self; {
 
   pywebpush = callPackage ../development/python-modules/pywebpush { };
 
+  pywebtransport = callPackage ../development/python-modules/pywebtransport { };
+
   pywebview = callPackage ../development/python-modules/pywebview { };
 
   pywemo = callPackage ../development/python-modules/pywemo { };


### PR DESCRIPTION
WebTransport stack for Python

https://github.com/wtransport/pywebtransport


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
