### PR TITLE
blender: 5.1.0 -> 5.1.1

### DIFF
--- a/pkgs/by-name/bl/blender/fix-quite-clog-warning.patch
+++ b/pkgs/by-name/bl/blender/fix-quite-clog-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/source/blender/gpu/vulkan/vk_texture_pool.cc b/source/blender/gpu/vulkan/vk_texture_pool.cc
+index 850e7808ae7..3478d4907f2 100644
+--- a/source/blender/gpu/vulkan/vk_texture_pool.cc
++++ b/source/blender/gpu/vulkan/vk_texture_pool.cc
+@@ -554,7 +554,7 @@ void VKTexturePool::log_usage_data()
+     log_message += std::format(" ({} cached VkImages)", current_usage_data_.image_cache_size);
+   }
+ 
+-  CLOG_TRACE(&LOG, log_message.c_str());
++  CLOG_TRACE(&LOG, "%s", log_message.c_str());
+ }
+ 
+ }  // namespace gpu

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -118,12 +118,12 @@ in
 
 stdenv'.mkDerivation (finalAttrs: {
   pname = "blender";
-  version = "5.1.0";
+  version = "5.1.1";
 
   src = fetchzip {
     name = "source";
     url = "https://download.blender.org/source/blender-${finalAttrs.version}.tar.xz";
-    hash = "sha256-knXAK3mW0tDz5ukuYkAZMv/zF9NLR8pofc3ujabcsys=";
+    hash = "sha256-iJolR8iS2go0doO96ibyseCeMunFL+XPoQ25NbX6oOA=";
   };
 
   patches = [
@@ -131,6 +131,9 @@ stdenv'.mkDerivation (finalAttrs: {
     # ceres-solver dependency propagates eigen 3 and appears to be incompatible
     # with more recent versions.
     ./eigen-3-compat.patch
+    # Required due to `-Werror=format-security` in nixpkgs
+    # https://projects.blender.org/blender/blender/commit/470127ede2448de50a6936b8484b3c382c76d596
+    ./fix-quite-clog-warning.patch
   ]
   # Minimal backport of hiprt 3.x support from https://projects.blender.org/blender/blender/pulls/144889
   ++ lib.optionals rocmSupport [


### PR DESCRIPTION
Changelog: https://developer.blender.org/docs/release_notes/5.1/corrective_releases/#blender-511

Note that we probably can't use `fetchpatch` due to cloudflare protection on blender's git hosting service so I added patch as file, as usual.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
