### PR TITLE
wrtag: 0.20.0 -> 0.31.0

### DIFF
--- a/pkgs/by-name/wr/wrtag/package.nix
+++ b/pkgs/by-name/wr/wrtag/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -8,16 +9,20 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "wrtag";
-  version = "0.20.0";
+  version = "0.30.0";
 
   src = fetchFromGitHub {
     owner = "sentriz";
     repo = "wrtag";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LSYrkXDbl0W7V+wDixIKGlOlSE/t10m/7cdgUYUNcr0=";
+    hash = "sha256-ba3HrAUaI9onuRFns9q2fkJxZWhadqJjd8rAmlIVvg4=";
   };
 
-  vendorHash = "sha256-u2HM1J535SgB7RrDfVjKFa7QpcK06gqr5+DZaNTxcmA=";
+  vendorHash = "sha256-S0emGAQJi9MLvyU3lL/Vrc4SZ10w6MOqND0LsBI7lg8=";
+
+  # Tests check that cover.PNG does not exist after lowercasing to cover.png,
+  # which fails on case-insensitive filesystems (macOS HFS+/APFS default).
+  doCheck = stdenv.hostPlatform.isLinux;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/wr/wrtag/package.nix
+++ b/pkgs/by-name/wr/wrtag/package.nix
@@ -8,16 +8,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "wrtag";
-  version = "0.20.0";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "sentriz";
     repo = "wrtag";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LSYrkXDbl0W7V+wDixIKGlOlSE/t10m/7cdgUYUNcr0=";
+    hash = "sha256-KTACpt1cfxsnwkSqQRng//+VH3FsSpSVGaQqnvduLDc=";
   };
 
-  vendorHash = "sha256-u2HM1J535SgB7RrDfVjKFa7QpcK06gqr5+DZaNTxcmA=";
+  vendorHash = "sha256-hL8T9mC5re1v17grFXdVF6TidI9P41HKq0hQyG0Yl8c=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[0.31.0](https://github.com/sentriz/wrtag/compare/v0.30.0...v0.31.0) (2026-05-15)
Features

normtag: add more artist credits ([fec4b6e](https://github.com/sentriz/wrtag/commit/fec4b6e433cb860ca27dd367d84278f90c7bda21))
wrtag: trim very long filenames ([6b34ac7](https://github.com/sentriz/wrtag/commit/6b34ac7109150372997de535961f40260450e24b)), closes https://github.com/sentriz/wrtag/issues/224

Bug Fixes

coverparse: filter more spectrograms ([4a6b4fd](https://github.com/sentriz/wrtag/commit/4a6b4fde187095d0de91adb0732cc05cd62b5e3b))
test: skip case sensitivity check on darwin (https://github.com/sentriz/wrtag/issues/219) ([1152eb6](https://github.com/sentriz/wrtag/commit/1152eb65fa9e6922037d3c7e853d6038b274d51b))

**0.30.0**
<h3>⚠ BREAKING CHANGES</h3>
<ul>
<li><strong>wrtag:</strong> revise path-format template data for media-aware tracks</li>
</ul>

v0.2x | v0.30.0 | notes
-- | -- | --
.TrackNum | .Track.Position | now uses MusicBrainz's real position (per-disc)
len .Tracks | .Media.TrackCount | track count is now per-medium, not total
.Tracks |   | (removed)
  | .Media | (new) access to the current medium (disc)
  | .Media.Position | (new) disc number


<p><strong>Common find-and-replace in your config:</strong></p>
<ul>
<li><code>.TrackNum</code> -&gt; <code>.Track.Position</code></li>
<li><code>len .Tracks</code> -&gt; <code>.Media.TrackCount</code></li>
<li><code>{{ pad0 2 .TrackNum }}</code> -&gt; <code>{{ pad0 2 .Track.Position }}</code></li>
<li><code>{{ len .Tracks | pad0 2 }}</code> -&gt; <code>{{ .Media.TrackCount | pad0 2 }}</code></li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>pathformat:</strong> add validations for multi disc releases (<a href="https://github.com/sentriz/wrtag/commit/9ea5bec4de9c13e5f9dabffecc26073d326f988f">9ea5bec</a>)</li>
<li><strong>pathformat:</strong> validate that there is always a safepath (<a href="https://github.com/sentriz/wrtag/commit/3eaa31b64e5df7a96b8f669c20b752c20759b440">3eaa31b</a>)</li>
<li>separate rate limiting from timeouts (<a href="https://github.com/sentriz/wrtag/commit/b9e9a7055c81dfc642d49a71fb11889977406fb7">b9e9a70</a>)</li>
<li><strong>wrtag:</strong> add file-mode option to chmod files with respect to umask (<a href="https://github.com/sentriz/wrtag/commit/05f31c94726d948586e668ff839729b5c0c2bde6">05f31c9</a>), closes <a href="https://github.com/sentriz/wrtag/issues/204" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/204/hovercard" aria-keyshortcuts="Alt+ArrowUp">#204</a></li>
<li><strong>wrtag:</strong> filter out data tracks (<a href="https://github.com/sentriz/wrtag/commit/ce435d12e3c57c37ee8a05412a255af242370179">ce435d1</a>), closes <a href="https://github.com/sentriz/wrtag/issues/202" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/202/hovercard" aria-keyshortcuts="Alt+ArrowUp">#202</a></li>
<li><strong>wrtagflag:</strong> add hint for v0.30.0 migration (<a href="https://github.com/sentriz/wrtag/commit/ba07e0c51f6660cf7c48b3dda1310accd85070e6">ba07e0c</a>)</li>
<li><strong>wrtag:</strong> revise path-format template data for media-aware tracks (<a href="https://github.com/sentriz/wrtag/commit/c48707b6061df4473d2457c4d1f41d638ef4a132">c48707b</a>), closes <a href="https://github.com/sentriz/wrtag/issues/165" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/165/hovercard" aria-keyshortcuts="Alt+ArrowUp">#165</a> <a href="https://github.com/sentriz/wrtag/issues/177" data-hovercard-type="pull_request" data-hovercard-url="/sentriz/wrtag/pull/177/hovercard" aria-keyshortcuts="Alt+ArrowUp">#177</a> <a href="https://github.com/sentriz/wrtag/issues/199" data-hovercard-type="pull_request" data-hovercard-url="/sentriz/wrtag/pull/199/hovercard" aria-keyshortcuts="Alt+ArrowUp">#199</a></li>
<li><strong>wrtag:</strong> write disc information (<a href="https://github.com/sentriz/wrtag/commit/b9934f96fd822f1900e56c22bddaced15c54aa87">b9934f9</a>)</li>
<li><strong>wrtag:</strong> write track and disc total (<a href="https://github.com/sentriz/wrtag/commit/3d7fa9536d46e8b393c561f8e970fc9a21e3f3a4">3d7fa95</a>)</li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li><strong>docker:</strong> tolerate existing user on container restart (<a href="https://github.com/sentriz/wrtag/commit/1e6eba7a37c054b798932d62cc29caa05118e2ed">1e6eba7</a>), closes <a href="https://github.com/sentriz/wrtag/issues/216" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/216/hovercard" aria-keyshortcuts="Alt+ArrowUp">#216</a></li>
<li><strong>pathformat:</strong> populate example IDs during validation (<a href="https://github.com/sentriz/wrtag/commit/fd6f2f49a87644c1d8c33e7cc7f5585c8d434661">fd6f2f4</a>), closes <a href="https://github.com/sentriz/wrtag/issues/215" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/215/hovercard" aria-keyshortcuts="Alt+ArrowUp">#215</a></li>
<li><strong>wrtag:</strong> resolve symlinks in dest paths to prevent trim deleting tracks (<a href="https://github.com/sentriz/wrtag/commit/705460663db2292b6f53422f61178b1ffae4fd12">7054606</a>), closes <a href="https://github.com/sentriz/wrtag/issues/214" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/214/hovercard" aria-keyshortcuts="Alt+ArrowUp">#214</a></li>
<li><strong>wrtag:</strong> run HTTP timeouts after rate limiter (<a href="https://github.com/sentriz/wrtag/commit/cebbf0aa526649b4bb55a9296a7c0ddd20d48640">cebbf0a</a>), closes <a href="https://github.com/sentriz/wrtag/issues/201" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/201/hovercard" aria-keyshortcuts="Alt+ArrowUp">#201</a></li>
<li><strong>wrtagweb:</strong> recover enqueued jobs on startup (<a href="https://github.com/sentriz/wrtag/commit/09b6f0e54f9288c851ad3ed2304fa1353e163212">09b6f0e</a>), closes <a href="https://github.com/sentriz/wrtag/issues/217" data-hovercard-type="issue" data-hovercard-url="/sentriz/wrtag/issues/217/hovercard" aria-keyshortcuts="Alt+ArrowUp">#217</a></li>
</ul>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X]  [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
