### PR TITLE
build2-bootstrap: fix building with new clang/libcpp

### DIFF
--- a/pkgs/by-name/bu/build2-bootstrap/package.nix
+++ b/pkgs/by-name/bu/build2-bootstrap/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   buildPackages,
   fixDarwinDylibNames,
+  fetchpatch,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "build2-bootstrap";
@@ -15,6 +16,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Pick up sysdirs from NIX_LDFLAGS
     ./nix-ldflags-sysdirs.patch
+    # Fix build on newer clang/libcpp
+    (fetchpatch {
+      name = "new-libcpp-fix.patch";
+      url = "https://github.com/build2/build2/commit/7cf9cece1d88cd1be283ab309f9a851bd02b43d0.patch";
+      hash = "sha256-PTo1C6Aa1L9fvjiJ08KtGgVqHMw2ZlW5LSKoripL22g=";
+    })
   ];
 
   sourceRoot = "build2-toolchain-${finalAttrs.version}/build2";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
