### PR TITLE
treewide: Don't stabilize fetchpatch GitHub compare URLs, mostly revert #509752

### DIFF
--- a/pkgs/by-name/am/amd-ucodegen/package.nix
+++ b/pkgs/by-name/am/amd-ucodegen/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     # instead of processor ID
     (fetchpatch {
       name = "validate-family-not-id.patch";
-      url = "https://github.com/AndyLavr/amd-ucodegen/compare/0d34b54e396ef300d0364817e763d2c7d1ffff02...dobo90:amd-ucodegen:7a3c51e821df96910ecb05b22f3e4866b4fb85b2.diff?full_index=1";
-      hash = "sha256-kbvpiizfVq+DoX9lr9gyX49I7vrZX460Xs9l5vAPUa4=";
+      url = "https://github.com/AndyLavr/amd-ucodegen/compare/0d34b54e396ef300d0364817e763d2c7d1ffff02...dobo90:amd-ucodegen:7a3c51e821df96910ecb05b22f3e4866b4fb85b2.patch";
+      hash = "sha256-jvsvu9QgXikwsxjPiTaRff+cOg/YQmKg1MYKyBoMRQI=";
     })
   ];
 

--- a/pkgs/by-name/cy/cyrus_sasl/package.nix
+++ b/pkgs/by-name/cy/cyrus_sasl/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     ./cyrus-sasl-ac-try-run-fix.patch
     # make compatible with openssl3. can probably be dropped with any release after 2.1.28
     (fetchpatch {
-      url = "https://github.com/cyrusimap/cyrus-sasl/compare/cb549ef71c5bb646fe583697ebdcaba93267a237...dfaa62392e7caecc6ecf0097b4d73738ec4fc0a8.diff?full_index=1";
+      url = "https://github.com/cyrusimap/cyrus-sasl/compare/cb549ef71c5bb646fe583697ebdcaba93267a237...dfaa62392e7caecc6ecf0097b4d73738ec4fc0a8.patch";
       hash = "sha256-pc0cZqj1QoxDqgd/j/5q3vWONEPrTm4Pr6MzHlfjRCc=";
     })
     # Fix build with gcc15

--- a/pkgs/by-name/mi/microbin/package.nix
+++ b/pkgs/by-name/mi/microbin/package.nix
@@ -27,8 +27,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # MicroBin returns wrong URLs on deployments with non-root URLs.
     (fetchpatch {
       name = "0001-fixup-explicit-urls.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..df062134cbaf3fd0ebcb67af8453a4c66844cd13.diff?full_index=1";
-      hash = "sha256-ssePgbVU5C04u9z+AWUyovccOPUSXqFpohRi5DYYCoE=";
+      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..df062134cbaf3fd0ebcb67af8453a4c66844cd13.patch";
+      hash = "sha256-h13FBuzu2O4AwdhRHF5EX5LaKyPeWJAcaV6SGTaYzTg=";
     })
 
     # Minor fixups by LuK1337
@@ -36,8 +36,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Fixup styling, password protected and private pastas.
     (fetchpatch {
       name = "0002-minor-fixups.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..3b0c025e9b6dc1ca69269541940bdb53032a048a.diff?full_index=1";
-      hash = "sha256-f+pn9dGcdCm+kCBDtxUpdbEEn7stgZMvAhZMOq46Tw8=";
+      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..3b0c025e9b6dc1ca69269541940bdb53032a048a.patch";
+      hash = "sha256-cZB/jx5d6F+C4xOn49TQ1at/Z4ov26efo9PTtWEdCHw=";
     })
 
     # Fix MICROBIN_ETERNAL_PASTA by SouthFox-D
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # MICROBIN_ETERNAL_PASTA config doesn't work without this.
     (fetchpatch {
       name = "0003-fix-microbin-eternal-pasta.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..c7c846c64344b8d51500aa9a4b2e9a92de8d09d8.diff?full_index=1";
+      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..c7c846c64344b8d51500aa9a4b2e9a92de8d09d8.patch";
       hash = "sha256-gCio73Jt0F7YCFtQxtf6pPBDLNcyOAcfSsiyjLFzEzY=";
     })
 
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Existing pastas return code 404 even when they exist.
     (fetchpatch {
       name = "0004-fix-raw-pastas-returning-404.patch";
-      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..e789901520824d4bf610d28923097affe85ead7d.diff?full_index=1";
+      url = "https://github.com/szabodanika/microbin/compare/b8a0c5490d681550d982ad02d67a1aaa0897f503..e789901520824d4bf610d28923097affe85ead7d.patch";
       hash = "sha256-R47ozwu/FD1kCu5nx4Gf1cOFeLVFdS67K8RNDygwoZM=";
     })
   ];

--- a/pkgs/by-name/mo/modern-cpp-kafka/package.nix
+++ b/pkgs/by-name/mo/modern-cpp-kafka/package.nix
@@ -25,8 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchpatch {
       # https://github.com/morganstanley/modern-cpp-kafka/pull/221
       name = "fix-avoid-overwriting-library-paths.patch";
-      url = "https://github.com/morganstanley/modern-cpp-kafka/compare/a146d10bcf166f55299c7a55728abaaea52cb0e5...a0b5ec08315759097ce656813be57b2c38d79091.diff?full_index=1";
-      hash = "sha256-1gYzE9m1Y+lgrgR7eyW5WR6zlqnQYAfEBYYK4BC6Jbo=";
+      url = "https://github.com/morganstanley/modern-cpp-kafka/compare/a146d10bcf166f55299c7a55728abaaea52cb0e5...a0b5ec08315759097ce656813be57b2c38d79091.patch";
+      hash = "sha256-UsQcMvJoRTn5kgXhmXOyqfW3n59kGKO596U2WjtdqAY=";
     })
     (fetchpatch {
       # https://github.com/morganstanley/modern-cpp-kafka/pull/222

--- a/pkgs/by-name/na/navidrome/package.nix
+++ b/pkgs/by-name/na/navidrome/package.nix
@@ -33,8 +33,8 @@ buildGoModule (finalAttrs: {
     # https://github.com/navidrome/navidrome/pull/5276 (waiting on release)
     (fetchpatch {
       name = "regenerate-package-lock-json";
-      url = "https://github.com/navidrome/navidrome/compare/v0.61.1...33a05ef662760fd9feb0a3ae43c7fe149eda610b.diff?full_index=1";
-      hash = "sha256-k/MXjuTXyjfiPM8XWX2S3R/KnhR64WCl7BhrFFYxpTA=";
+      url = "https://github.com/navidrome/navidrome/compare/v0.61.1...33a05ef662760fd9feb0a3ae43c7fe149eda610b.patch";
+      hash = "sha256-IQ0wJ7vsSaLjBZS/fKIApNM8UV8oj6L2taCQIPhHvwg=";
     })
   ];
 

--- a/pkgs/by-name/or/orthorobot/package.nix
+++ b/pkgs/by-name/or/orthorobot/package.nix
@@ -57,8 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/Stabyourself/orthorobot/pull/3
     (fetchpatch {
       name = "Stabyourself-orthorobot-pull-3.patch";
-      url = "https://github.com/Stabyourself/orthorobot/compare/48f07423950b29a94b04aefe268f2f951f55b62e...05856ba7dbf1bb86d0f16a5f511d8ee9f2176015.diff?full_index=1";
-      hash = "sha256-CMYfLV8PEoS6GjPXkZ8UuvLKjXwrHquW08IIwlDPz/w=";
+      url = "https://github.com/Stabyourself/orthorobot/compare/48f07423950b29a94b04aefe268f2f951f55b62e...05856ba7dbf1bb86d0f16a5f511d8ee9f2176015.patch";
+      sha256 = "sha256-WHHP6QM7R5eEkVF+J2pGNnds/OKRIRXyon85wjd3GXI=";
     })
   ];
 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -218,7 +218,7 @@ optionals noSysDirs (
         # aa4cd614456de65ee3417acb83c6cff0640144e9 is the merge base of https://github.com/iains/gcc-14-branch/tree/gcc-14-3-darwin-pre-0 and https://github.com/gcc-mirror/gcc/releases/tag/releases%2Fgcc-14.3.0
         # 3e1d48d240f4aa5223c701b5c231c66f66ab1126 is the newest commit of https://github.com/iains/gcc-14-branch/tree/gcc-14-3-darwin-pre-0
         name = "gcc-14-darwin-aarch64-support.patch";
-        url = "https://github.com/iains/gcc-14-branch/compare/aa4cd614456de65ee3417acb83c6cff0640144e9..3e1d48d240f4aa5223c701b5c231c66f66ab1126.diff?full_index=1";
+        url = "https://github.com/iains/gcc-14-branch/compare/aa4cd614456de65ee3417acb83c6cff0640144e9..3e1d48d240f4aa5223c701b5c231c66f66ab1126.diff";
         hash = "sha256-BSTSYnkBJBEm++mGerVVyaCUC4dUyXq0N1tqbk25bO4=";
       })
     ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1420,8 +1420,8 @@ with haskellLib;
     doJailbreak
     (appendPatch (fetchpatch {
       name = "idris-bumps.patch";
-      url = "https://github.com/idris-lang/Idris-dev/compare/c99bc9e4af4ea32d2172f873152b76122ee4ee14...cf78f0fb337d50f4f0dba235b6bbe67030f1ff47.diff?full_index=1";
-      hash = "sha256-HoNMn4yo7G7T37ry0T19wh9yD9mC9Pend8V9zWmAs50=";
+      url = "https://github.com/idris-lang/Idris-dev/compare/c99bc9e4af4ea32d2172f873152b76122ee4ee14...cf78f0fb337d50f4f0dba235b6bbe67030f1ff47.patch";
+      hash = "sha256-RCMIRHIAK1PCm4B7v+5gXNd2buHXIqyAxei4bU8+eCk=";
     }))
     (self.generateOptparseApplicativeCompletions [ "idris" ])
   ];
@@ -1637,8 +1637,8 @@ with haskellLib;
       })
       # Fix build with vector >= 0.13, mtl >= 2.3 (https://github.com/redelmann/scat/pull/8)
       (fetchpatch {
-        url = "https://github.com/redelmann/scat/compare/e8e064f7e6a152fe25a6ccd743573a16974239d0..c6a3636548d628f32d8edc73a333188ce24141a7.diff?full_index=1";
-        hash = "sha256-BU4MUn/TnZHpZBlX1vDHE7QZva5yhlLTb8zwpx7UScI=";
+        url = "https://github.com/redelmann/scat/compare/e8e064f7e6a152fe25a6ccd743573a16974239d0..c6a3636548d628f32d8edc73a333188ce24141a7.patch";
+        hash = "sha256-BU4MUn/TnZHpZBlX1vDHE7QZva5yhlLTb8zwpx7UScI";
       })
     ];
   }) super.scat;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -164,8 +164,8 @@ in
       (pkgs.fetchpatch {
         # https://github.com/jgoerzen/configfile/pull/12
         name = "ConfigFile-pr-12.patch";
-        url = "https://github.com/jgoerzen/configfile/compare/d0a2e654be0b73eadbf2a50661d00574ad7b6f87...83ee30b43f74d2b6781269072cf5ed0f0e00012f.diff?full_index=1";
-        hash = "sha256-Pt4DqsmFSBbgiLJybDC2/o8g7gdH/c/Iyfsee2e7kC4=";
+        url = "https://github.com/jgoerzen/configfile/compare/d0a2e654be0b73eadbf2a50661d00574ad7b6f87...83ee30b43f74d2b6781269072cf5ed0f0e00012f.patch";
+        sha256 = "sha256-b7u9GiIAd2xpOrM0MfILHNb6Nt7070lNRIadn2l3DfQ=";
       })
     ];
   }) super.ConfigFile;

--- a/pkgs/development/libraries/qmltermwidget/default.nix
+++ b/pkgs/development/libraries/qmltermwidget/default.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation {
     # Remove when https://github.com/Swordfish90/qmltermwidget/pull/39 merged
     (fetchpatch {
       name = "0001-qmltermwidget-lomiri-submissions.patch";
-      url = "https://github.com/Swordfish90/qmltermwidget/compare/63228027e1f97c24abb907550b22ee91836929c5..ffc6b2b2a20ca785f93300eca93c25c4b74ece17.diff?full_index=1";
-      hash = "sha256-GAx7eyE46H6DzeeoC/tQDmJSQXowZSEhNYtfsq108DU=";
+      url = "https://github.com/Swordfish90/qmltermwidget/compare/63228027e1f97c24abb907550b22ee91836929c5..ffc6b2b2a20ca785f93300eca93c25c4b74ece17.patch";
+      hash = "sha256-1GjC2mdfP3NpePDWZaT8zvIq3vwWIZs+iQ9o01iQtD4=";
     })
 
     # A fix to the above series of patches, to fix a crash in lomiri-terminal-app

--- a/pkgs/development/lisp-modules/asdf/3.3.nix
+++ b/pkgs/development/lisp-modules/asdf/3.3.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Clasp bytecode support
     (fetchpatch {
-      url = "https://github.com/clasp-developers/asdf/compare/fe6e3ab741c71ecebc8503e20637d4c940326421..615771b3d0ee6ebb158134769e88ba421c2ea7d1.diff?full_index=1";
+      url = "https://github.com/clasp-developers/asdf/compare/fe6e3ab741c71ecebc8503e20637d4c940326421..615771b3d0ee6ebb158134769e88ba421c2ea7d1.diff";
       hash = "sha256-jrv/vH4uxLVvaCK4UicNzIePQ12lscA0auwgTMb4QwI=";
     })
   ];

--- a/pkgs/development/python-modules/cypari/default.nix
+++ b/pkgs/development/python-modules/cypari/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   patches = [
     (fetchpatch {
       name = "fix-build-with-cython-3_1.patch";
-      url = "https://github.com/3-manifolds/CyPari/compare/17bf39dc4508f2e46de75b95c65982c627652b60...d6cb914d2bdc74a51cc2a9136204ebf47b3e7369.diff?full_index=1";
+      url = "https://github.com/3-manifolds/CyPari/compare/17bf39dc4508f2e46de75b95c65982c627652b60...d6cb914d2bdc74a51cc2a9136204ebf47b3e7369.diff";
       hash = "sha256-c8sq80mYSMMvgFh7RXYwKcqwI7iVRQsm/8yaIL0+PHQ=";
     })
   ];

--- a/pkgs/development/python-modules/py-slvs/default.nix
+++ b/pkgs/development/python-modules/py-slvs/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     # https://github.com/realthunder/slvs_py/pull/11
     (fetchpatch {
       name = "cmake-4.patch";
-      url = "https://github.com/realthunder/slvs_py/compare/ab95814397c67d02bb751bd7b7055f51a0bf846e...ad0e1f7a37025721312bfbd63dc8c2bec049d8a0.diff?full_index=1";
+      url = "https://github.com/realthunder/slvs_py/compare/ab95814...ad0e1f7.patch";
       hash = "sha256-LqDDx7uWq5VOkbE/aRu1JAau/DVfr40KK+L8PbBeGoU=";
     })
   ];

--- a/pkgs/development/python-modules/rocket-errbot/default.nix
+++ b/pkgs/development/python-modules/rocket-errbot/default.nix
@@ -20,8 +20,8 @@ buildPythonPackage rec {
     (fetchpatch {
       # https://github.com/errbotio/rocket/pull/1
       name = "errbotio-rocket-pull-1.patch";
-      url = "https://github.com/errbotio/rocket/compare/f1a52fe17164f83bccce5e6a1935fc5071c2265f...d69adcd49de5d78bd80f952a2ee31e6a0bac4e3d.diff?full_index=1";
-      hash = "sha256-m/lrxfL2flslrdK/CEQPXoR11GwbCcZFIyFECWMWG8U=";
+      url = "https://github.com/errbotio/rocket/compare/f1a52fe17164f83bccce5e6a1935fc5071c2265f...d69adcd49de5d78bd80f952a2ee31e6a0bac4e3d.patch";
+      sha256 = "1s668yv5b86b78vbqwhcl44k2l16c9bhk3199yy9hayf0vkxnwif";
     })
   ];
 

--- a/pkgs/development/python-modules/wacz/default.nix
+++ b/pkgs/development/python-modules/wacz/default.nix
@@ -29,8 +29,8 @@ buildPythonPackage rec {
     # <https://github.com/webrecorder/py-wacz/pull/47>
     (fetchpatch {
       name = "clean-up-deps.patch";
-      url = "https://github.com/webrecorder/py-wacz/compare/1e8f724a527f28855eedeb0d969ee39b00b2a80a...9d3ad60f125247b8a4354511d9123b85ce6a23c5.diff?full_index=1";
-      hash = "sha256-6sKOJVGPKepT94fMJ+Xy3aH21K1a1USgqBlO1aZDh4o=";
+      url = "https://github.com/webrecorder/py-wacz/compare/1e8f724a527f28855eedeb0d969ee39b00b2a80a...9d3ad60f125247b8a4354511d9123b85ce6a23c5.patch";
+      hash = "sha256-zH6BKhsq9ybjzaWcNbVkk1sWh8vVCkv7Qxuwl0MQhNM=";
     })
   ];
 

--- a/pkgs/development/python-modules/youtube-dl/default.nix
+++ b/pkgs/development/python-modules/youtube-dl/default.nix
@@ -46,8 +46,8 @@ buildPythonPackage rec {
     # plus follow-up (1e677567) from https://github.com/ytdl-org/youtube-dl/pull/30582
     (fetchpatch {
       name = "fix-youtube-dl-speed.patch";
-      url = "https://github.com/ytdl-org/youtube-dl/compare/57044eacebc6f2f3cd83c345e1b6e659a22e4773...1e677567cd083d43f55daef0cc74e5fa24575ae3.diff?full_index=1";
-      hash = "sha256-+RKN6UgNl4WiFqeAnNLffjTC/JCigwtE7+VkYPiQQIc=";
+      url = "https://github.com/ytdl-org/youtube-dl/compare/57044eacebc6f2f3cd83c345e1b6e659a22e4773...1e677567cd083d43f55daef0cc74e5fa24575ae3.diff";
+      sha256 = "11s0j3w60r75xx20p0x2j3yc4d3yvz99r0572si8b5qd93lqs4pr";
     })
     # The above patch may fail to decode the n-parameter (if, say, YouTube is updated). Failure to decode
     # it blocks the download instead of falling back to the throttled version. The patch below implements


### PR DESCRIPTION
The index hash length problem only happens with fetchpatch2, not fetchpatch. Don't cargo cult fixing this when it's not a problem.

This reverts most of commit 6388411ec2959f754029160cca7b88c30f935e52, except:

- Conflicts:
  - pkgs/development/ocaml-modules/mysql/default.nix was deleted
- fetchpatch2 changes were not reverted:
  - pkgs/by-name/gi/gixy/package.nix
  - pkgs/development/python-modules/mohawk/default.nix
  - pkgs/development/python-modules/pyexcel-ods/default.nix

---

See #257446 for the actual problem being tracked.

cc @Mic92 from #509752, which this PR is a partial revert of

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
