### PR TITLE
protonup-qt: 2.14.0 -> 2.15.1

### DIFF
--- a/pkgs/by-name/pr/protonup-qt/package.nix
+++ b/pkgs/by-name/pr/protonup-qt/package.nix
@@ -3,25 +3,27 @@
   appimageTools,
   fetchurl,
   makeWrapper,
+  nix-update-script,
 }:
-
-appimageTools.wrapAppImage rec {
+let
   pname = "protonup-qt";
-  version = "2.14.0";
+  version = "2.15.0";
 
-  src = appimageTools.extractType2 {
-    inherit pname version;
-    src = fetchurl {
-      url = "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/v${version}/ProtonUp-Qt-${version}-x86_64.AppImage";
-      hash = "sha256-OdogpqqNZiwKqj2ELfmAw/601iVHMsTqxl5CUjqRQBs=";
-    };
+  src = fetchurl {
+    url = "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/v${version}/ProtonUp-Qt-${version}-x86_64.AppImage";
+    hash = "sha256-FzrgOlEmC+4fvd32Btl18+b6eRWaSeTxCLg7K8VZ0dI=";
   };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
 
   nativeBuildInputs = [ makeWrapper ];
 
   extraInstallCommands = ''
-    install -Dm644 ${src}/net.davidotek.pupgui2.desktop $out/share/applications/protonup-qt.desktop
-    install -Dm644 ${src}/net.davidotek.pupgui2.png $out/share/pixmaps/protonup-qt.png
+    install -Dm644 ${appimageContents}/net.davidotek.pupgui2.desktop $out/share/applications/protonup-qt.desktop
+    install -Dm644 ${appimageContents}/net.davidotek.pupgui2.png $out/share/pixmaps/protonup-qt.png
     substituteInPlace $out/share/applications/protonup-qt.desktop \
       --replace-fail "Exec=net.davidotek.pupgui2" "Exec=protonup-qt" \
       --replace-fail "Icon=net.davidotek.pupgui2" "Icon=protonup-qt"
@@ -31,6 +33,8 @@ appimageTools.wrapAppImage rec {
   '';
 
   extraPkgs = pkgs: with pkgs; [ zstd ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://davidotek.github.io/protonup-qt/";

--- a/pkgs/by-name/pr/protonup-qt/package.nix
+++ b/pkgs/by-name/pr/protonup-qt/package.nix
@@ -3,25 +3,27 @@
   appimageTools,
   fetchurl,
   makeWrapper,
+  nix-update-script,
 }:
-
-appimageTools.wrapAppImage rec {
+let
   pname = "protonup-qt";
-  version = "2.14.0";
+  version = "2.15.1";
 
-  src = appimageTools.extractType2 {
-    inherit pname version;
-    src = fetchurl {
-      url = "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/v${version}/ProtonUp-Qt-${version}-x86_64.AppImage";
-      hash = "sha256-OdogpqqNZiwKqj2ELfmAw/601iVHMsTqxl5CUjqRQBs=";
-    };
+  src = fetchurl {
+    url = "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/v${version}/ProtonUp-Qt-${version}-x86_64.AppImage";
+    hash = "sha256-/Xjvsf+gkHpSV4RGJJS5tCk4+f18AZ8+rqO4+vg36ME=";
   };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
 
   nativeBuildInputs = [ makeWrapper ];
 
   extraInstallCommands = ''
-    install -Dm644 ${src}/net.davidotek.pupgui2.desktop $out/share/applications/protonup-qt.desktop
-    install -Dm644 ${src}/net.davidotek.pupgui2.png $out/share/pixmaps/protonup-qt.png
+    install -Dm644 ${appimageContents}/net.davidotek.pupgui2.desktop $out/share/applications/protonup-qt.desktop
+    install -Dm644 ${appimageContents}/net.davidotek.pupgui2.png $out/share/pixmaps/protonup-qt.png
     substituteInPlace $out/share/applications/protonup-qt.desktop \
       --replace-fail "Exec=net.davidotek.pupgui2" "Exec=protonup-qt" \
       --replace-fail "Icon=net.davidotek.pupgui2" "Icon=protonup-qt"
@@ -31,6 +33,8 @@ appimageTools.wrapAppImage rec {
   '';
 
   extraPkgs = pkgs: with pkgs; [ zstd ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://davidotek.github.io/protonup-qt/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated to the latest version and made a few changes to allow `nix-update` to run properly.

https://github.com/NixOS/nixpkgs/pull/492871

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
