### PR TITLE
pkgs/by-name/gr/gridix: init at 5.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17077,6 +17077,12 @@
     githubId = 2971615;
     name = "Marius Bergmann";
   };
+  mcbsmartboy = {
+    email = "mcb2720838051@gmail.com";
+    github = "MCB-SMART-BOY";
+    githubId = 177301053;
+    name = "mcb";
+  };
   mccartykim = {
     email = "mccartykim@zoho.com";
     github = "mccartykim";

--- a/pkgs/by-name/gr/gridix/package.nix
+++ b/pkgs/by-name/gr/gridix/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+  openssl,
+  xdotool,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gridix";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "MCB-SMART-BOY";
+    repo = "Gridix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nDWxAujkUpTmQx6OfnpeBlqRYJ2XeWIj8jeU7A+Itik=";
+  };
+
+  cargoHash = "sha256-cm63ebYDAcWlMXVBuN2qm3eXQG0tFlxyKj0sF89Eil4=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    openssl
+    xdotool
+  ];
+
+  preCheck = ''
+    export RUST_TEST_THREADS=1
+  '';
+
+  meta = {
+    description = "Fast, secure database management tool with Helix/Vim keybindings";
+    longDescription = ''
+      Gridix is a keyboard-driven database management tool supporting SQLite,
+      PostgreSQL, and MySQL. Features include SSH tunneling, SSL/TLS encryption,
+      AES-256-GCM encrypted password storage, 19 built-in themes, and Helix/Vim-style
+      keybindings for efficient navigation and editing.
+    '';
+    homepage = "https://github.com/MCB-SMART-BOY/Gridix";
+    changelog = "https://github.com/MCB-SMART-BOY/Gridix/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mcbsmartboy ];
+    mainProgram = "gridix";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gr/gridix/package.nix
+++ b/pkgs/by-name/gr/gridix/package.nix
@@ -10,6 +10,8 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "gridix";
   version = "5.0.0";
 


### PR DESCRIPTION
## Summary
- add Gridix as a new package under pkgs/by-name/gr
- package release v5.0.0 from upstream GitHub tag
- add `mcbsmartboy` to maintainers

## Testing
- nix-instantiate . -A gridix
- nix-build . -A gridix
