### PR TITLE
lib/systems: add ARC cross-compilation target

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -32,6 +32,7 @@ let
 
     # Linux
     "aarch64-linux"
+    "arc-linux"
     "armv5tel-linux"
     "armv6l-linux"
     "armv7a-linux"
@@ -143,6 +144,7 @@ in
   vc4 = filterDoubles predicates.isVc4;
   or1k = filterDoubles predicates.isOr1k;
   m68k = filterDoubles predicates.isM68k;
+  arc = filterDoubles predicates.isArc;
   s390 = filterDoubles predicates.isS390;
   s390x = filterDoubles predicates.isS390x;
   loongarch64 = filterDoubles predicates.isLoongArch64;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -239,6 +239,10 @@ rec {
     config = "m68k-unknown-linux-gnu";
   };
 
+  arc = {
+    config = "arc-unknown-linux-gnu";
+  };
+
   s390 = {
     config = "s390-unknown-linux-gnu";
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -229,6 +229,11 @@ rec {
         family = "m68k";
       };
     };
+    isArc = {
+      cpu = {
+        family = "arc";
+      };
+    };
     isS390 = {
       cpu = {
         family = "s390";

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -382,6 +382,12 @@ rec {
         family = "or1k";
       };
 
+      arc = {
+        bits = 32;
+        significantByte = littleEndian;
+        family = "arc";
+      };
+
       loongarch64 = {
         bits = 64;
         significantByte = littleEndian;

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -163,6 +163,7 @@ lib.runTests (
     testillumos = mseteq illumos [ "x86_64-solaris" ];
     testlinux = mseteq linux [
       "aarch64-linux"
+      "arc-linux"
       "armv5tel-linux"
       "armv6l-linux"
       "armv7a-linux"

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -250,6 +250,7 @@ in
   loongarch64-linux = mapTestOnCross systems.examples.loongarch64-linux linuxCommon;
 
   m68k = mapTestOnCross systems.examples.m68k linuxCommon;
+  arc = mapTestOnCross systems.examples.arc linuxCommon;
   s390x = mapTestOnCross systems.examples.s390x linuxCommon;
 
   # (Cross-compiled) Linux on x86


### PR DESCRIPTION
## Summary

Add cross-compilation support for [ARC](https://en.wikipedia.org/wiki/ARC_(processor)) (Synopsys DesignWare ARC), a 32-bit little-endian embedded processor with GCC, glibc, and Linux kernel support.

### Test results

Cross-compiled with `nix build '.#pkgsCross.arc.hello'` on x86_64-linux.

| Package | Build |
|---|---|
| hello | :white_check_mark: |
| coreutils | :white_check_mark: |
| bash | :white_check_mark: |

QEMU user-mode testing not possible — mainline QEMU does not include `qemu-arc` user-mode emulation (only `qemu-system-arc` exists in out-of-tree forks).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test