### PR TITLE
lib/systems, gcc, glibc: add HPPA (PA-RISC) cross-compilation target

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -300,6 +300,8 @@ let
             "powerpc"
           else if final.isRiscV then
             "riscv"
+          else if final.isHppa then
+            "parisc"
           else if final.isS390 then
             "s390"
           else if final.isLoongArch64 then

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -336,6 +336,8 @@ let
             "riscv"
           else if final.isSh4 then
             "sh"
+          else if final.isHppa then
+            "parisc"
           else if final.isS390 then
             "s390"
           else if final.isLoongArch64 then

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -39,6 +39,7 @@ let
     "armv7l-linux"
     "i686-linux"
     "loongarch64-linux"
+    "hppa-linux"
     "m68k-linux"
     "microblaze-linux"
     "microblazeel-linux"
@@ -145,6 +146,7 @@ in
   or1k = filterDoubles predicates.isOr1k;
   m68k = filterDoubles predicates.isM68k;
   arc = filterDoubles predicates.isArc;
+  hppa = filterDoubles predicates.isHppa;
   s390 = filterDoubles predicates.isS390;
   s390x = filterDoubles predicates.isS390x;
   loongarch64 = filterDoubles predicates.isLoongArch64;

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -48,6 +48,7 @@ let
     "armv7l-linux"
     "i686-linux"
     "loongarch64-linux"
+    "hppa-linux"
     "m68k-linux"
     "sh4-linux"
     "microblaze-linux"
@@ -163,6 +164,7 @@ in
   m68k = filterDoubles predicates.isM68k;
   arc = filterDoubles predicates.isArc;
   sh4 = filterDoubles predicates.isSh4;
+  hppa = filterDoubles predicates.isHppa;
   s390 = filterDoubles predicates.isS390;
   s390x = filterDoubles predicates.isS390x;
   loongarch64 = filterDoubles predicates.isLoongArch64;

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -241,6 +241,8 @@ rec {
 
   arc = {
     config = "arc-unknown-linux-gnu";
+  hppa = {
+    config = "hppa-unknown-linux-gnu";
   };
 
   s390 = {

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -241,6 +241,8 @@ rec {
 
   arc = {
     config = "arc-unknown-linux-gnu";
+  };
+
   hppa = {
     config = "hppa-unknown-linux-gnu";
   };

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -234,6 +234,8 @@ rec {
 
   arc = {
     config = "arc-unknown-linux-gnu";
+  };
+
   hppa = {
     config = "hppa-unknown-linux-gnu";
   };

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -234,6 +234,8 @@ rec {
 
   arc = {
     config = "arc-unknown-linux-gnu";
+  hppa = {
+    config = "hppa-unknown-linux-gnu";
   };
 
   sh4 = {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -232,6 +232,8 @@ rec {
     isArc = {
       cpu = {
         family = "arc";
+      };
+    };
     isHppa = {
       cpu = {
         family = "pa";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -232,6 +232,9 @@ rec {
     isArc = {
       cpu = {
         family = "arc";
+    isHppa = {
+      cpu = {
+        family = "pa";
       };
     };
     isS390 = {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -265,6 +265,8 @@ rec {
     isArc = {
       cpu = {
         family = "arc";
+      };
+    };
     isHppa = {
       cpu = {
         family = "pa";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -265,6 +265,9 @@ rec {
     isArc = {
       cpu = {
         family = "arc";
+    isHppa = {
+      cpu = {
+        family = "pa";
       };
     };
     isSh4 = {

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -284,6 +284,12 @@ rec {
         family = "m68k";
       };
 
+      hppa = {
+        bits = 32;
+        significantByte = bigEndian;
+        family = "pa";
+      };
+
       powerpc = {
         bits = 32;
         significantByte = bigEndian;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -293,6 +293,12 @@ rec {
         family = "sh";
       };
 
+      hppa = {
+        bits = 32;
+        significantByte = bigEndian;
+        family = "pa";
+      };
+
       powerpc = {
         bits = 32;
         significantByte = bigEndian;

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -170,6 +170,7 @@ lib.runTests (
       "armv7l-linux"
       "i686-linux"
       "loongarch64-linux"
+      "hppa-linux"
       "m68k-linux"
       "microblaze-linux"
       "microblazeel-linux"

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -168,6 +168,7 @@ lib.runTests (
       "armv7l-linux"
       "i686-linux"
       "loongarch64-linux"
+      "hppa-linux"
       "m68k-linux"
       "sh4-linux"
       "microblaze-linux"

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -138,6 +138,8 @@ let
       "${sharedLibraryLoader}/lib/ld-linux*.so.3"
     else if targetPlatform.system == "aarch64-linux" then
       "${sharedLibraryLoader}/lib/ld-linux-aarch64.so.1"
+    else if targetPlatform.system == "hppa-linux" then
+      "${sharedLibraryLoader}/lib/ld.so.1"
     else if targetPlatform.system == "powerpc-linux" then
       "${sharedLibraryLoader}/lib/ld.so.1"
     else if targetPlatform.system == "s390-linux" then

--- a/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc-buildstuff.nix
@@ -49,7 +49,10 @@ in
 # 'parsed.cpu.family' won't be correct for every platform.
 + (lib.optionalString
   (
-    stdenv.targetPlatform.isLoongArch64 || stdenv.targetPlatform.isS390 || stdenv.targetPlatform.isAlpha
+    stdenv.targetPlatform.isLoongArch64
+    || stdenv.targetPlatform.isS390
+    || stdenv.targetPlatform.isAlpha
+    || stdenv.targetPlatform.isHppa
   )
   ''
     touch libgcc/config/${stdenv.targetPlatform.parsed.cpu.family}/crt{i,n}.S

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -63,7 +63,13 @@ lib.pipe drv
 
         # For some reason libgcc_s.so has major-version "2" on m68k but
         # "1" everywhere else.  Might be worth changing this to "*".
-        libgcc_s-version-major = if targetPlatform.isM68k then "2" else "1";
+        libgcc_s-version-major =
+          if targetPlatform.isM68k then
+            "2"
+          else if targetPlatform.isHppa then
+            "4"
+          else
+            "1";
 
       in
       [

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -57,7 +57,13 @@ lib.pipe drv
 
         # For some reason libgcc_s.so has major-version "2" on m68k but
         # "1" everywhere else.  Might be worth changing this to "*".
-        libgcc_s-version-major = if targetPlatform.isM68k then "2" else "1";
+        libgcc_s-version-major =
+          if targetPlatform.isM68k then
+            "2"
+          else if targetPlatform.isHppa then
+            "4"
+          else
+            "1";
 
       in
       [

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -404,6 +404,8 @@ pipe
             !(targetPlatform.isLinux && targetPlatform.isx86_64 && targetPlatform.libc == "glibc")
           ) "shadowstack"
           ++ optional (!(targetPlatform.isLinux && targetPlatform.isAarch64)) "pacret"
+          # HPPA has an upward-growing stack, so -fstack-clash-protection is not supported
+          ++ optional targetPlatform.isHppa "stackclashprotection"
           ++ optionals langFortran [
             "fortify"
             "format"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -408,6 +408,8 @@ pipe
             !(targetPlatform.isLinux && targetPlatform.isx86_64 && targetPlatform.libc == "glibc")
           ) "shadowstack"
           ++ optional (!(targetPlatform.isLinux && targetPlatform.isAarch64)) "pacret"
+          # HPPA has an upward-growing stack, so -fstack-clash-protection is not supported
+          ++ optional targetPlatform.isHppa "stackclashprotection"
           ++ optionals langFortran [
             "fortify"
             "format"

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -305,6 +305,18 @@ stdenv.mkDerivation (
         libc_cv_c_cleanup=yes
         libc_cv_gnu89_inline=yes
         EOF
+      ''
+      # HPPA's function descriptors (plabels) cause a false positive on the
+      # alias attribute check. PIE_UNSUPPORTED was set due to a binutils bug
+      # (https://sourceware.org/bugzilla/show_bug.cgi?id=28672) fixed in 2.38;
+      # we remove it since HPPA requires position-independent code.
+      + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isHppa) ''
+        cat >> config.cache << "EOF"
+        libc_cv_broken_alias_attribute=no
+        EOF
+        sed -i 's/#define PIE_UNSUPPORTED 1//' ../sysdeps/hppa/configure
+      ''
+      + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
 
         # ./configure has logic like
         #

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -319,6 +319,13 @@ stdenv.mkDerivation (
         libc_cv_c_cleanup=yes
         libc_cv_gnu89_inline=yes
         EOF
+      ''
+      # PIE_UNSUPPORTED was set due to a binutils bug
+      # (https://sourceware.org/bugzilla/show_bug.cgi?id=28672) fixed in 2.38.
+      + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isHppa) ''
+        sed -i 's/#define PIE_UNSUPPORTED 1//' ../sysdeps/hppa/configure
+      ''
+      + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
 
         # ./configure has logic like
         #


### PR DESCRIPTION
## Summary

Add cross-compilation support for HPPA ([PA-RISC](https://en.wikipedia.org/wiki/PA-RISC)), a 32-bit big-endian architecture with GCC, glibc, and Linux kernel support. Has an active [Debian port](https://www.debian.org/ports/hppa/) and [Gentoo support](https://wiki.gentoo.org/wiki/Handbook:HPPA).

### HPPA-specific fixes

HPPA has several architectural quirks requiring targeted fixes (all scoped to `isHppa`, zero rebuilds on other platforms):
- `libgcc_s.so.4` (major version 4, not 1)
- No `crti.S`/`crtn.S` (same as LoongArch64/S390/Alpha)
- Upward-growing stack — `-fstack-clash-protection` unsupported
- Function descriptors (plabels) cause false positive on glibc alias attribute check
- Remove stale glibc `PIE_UNSUPPORTED` workaround (binutils <2.38 bug, long fixed)
- Dynamic linker: `/lib/ld.so.1`

### Test results

Cross-compiled with `nix build '.#pkgsCross.hppa.hello'` and verified with `qemu-hppa`.

| Package | Build | Run (QEMU) |
|---|---|---|
| hello | :white_check_mark: | :white_check_mark: |
| coreutils | :white_check_mark: | :white_check_mark: |
| bash | :white_check_mark: | :white_check_mark: |

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test