### PR TITLE
cargo: remove runtime references to cargo-bootstrap

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -80,9 +80,9 @@ rustPlatform.buildRustPackage.override
       if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
         ''
           installShellCompletion --cmd cargo \
-            --bash <(CARGO_COMPLETE=bash cargo) \
-            --fish <(CARGO_COMPLETE=fish cargo) \
-            --zsh <(CARGO_COMPLETE=zsh cargo)
+            --bash <(CARGO_COMPLETE=bash $out/bin/cargo) \
+            --fish <(CARGO_COMPLETE=fish $out/bin/cargo) \
+            --zsh <(CARGO_COMPLETE=zsh $out/bin/cargo)
         ''
       else
         ''

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -109,6 +109,13 @@ rustPlatform.buildRustPackage.override
       runHook postInstallCheck
     '';
 
+    # Make sure our build rustc/cargo never make it into our runtime closure
+    disallowedReferences = [
+      rustPlatform.rust.cargo
+      rustPlatform.rust.rustc
+      rustPlatform.rust.rustc.unwrapped
+    ];
+
     meta = {
       homepage = "https://crates.io";
       description = "Downloads your Rust project's dependencies and builds your project";

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -72,14 +72,16 @@
         maturinBuildHook
         bindgenHook
         ;
+
+      # Let packages reference the build derivations, e.g. for disallowedReferences.
+      # Get rid of the splicing though, so `nativeBuildInputs = [ rustPlatform.rust.rustc ]` works.
+      rust = {
+        rustc = rustc.__spliced.hostTarget or rustc;
+        cargo = cargo.__spliced.hostTarget or cargo;
+      };
     };
 })
 // lib.optionalAttrs config.allowAliases {
-  rust = {
-    rustc = lib.warn "rustPlatform.rust.rustc is deprecated. Use rustc instead." rustc;
-    cargo = lib.warn "rustPlatform.rust.cargo is deprecated. Use cargo instead." cargo;
-  };
-
   # Added in 25.05.
   fetchCargoTarball = throw "`rustPlatform.fetchCargoTarball` has been removed in 25.05, use `rustPlatform.fetchCargoVendor` instead";
 }

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -443,6 +443,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   requiredSystemFeatures = [ "big-parallel" ];
 
+  # Make sure our bootstrap packages don't end up in our runtime closure
+  disallowedReferences = [
+    cargo
+    rustc
+  ];
+
   passthru = {
     llvm = llvmShared;
     inherit llvmPackages;


### PR DESCRIPTION
The shell completions were being generated by cargo-bootstrap instead of by the just-built cargo, which meant they were embedding the cargo-bootstrap path and causing it to be part of the runtime closure. This unwanted dependency was introduced by #469996.

I didn't do any testing beyond inspecting the resulting Fish shell completion and checking that it embedded the correct path, and making sure the resulting package no longer had cargo-bootstrap in its closure.

Also undeprecate `rustPlatform.rust.{rustc,cargo}`, which were deprecated two years ago (in #230951) for not working correctly with splicing, e.g. `nativeBuildInputs = [ rustPlatform.rust.rustc ];` would produce the wrong results. We can fix that by unsplicing the packages instead of deprecating them. And we need to do this because otherwise Rust packages have no way to reference their build rustc/cargo, which we need so we can use `disallowedReferences` to ensure that the build rustc/cargo don't end up in cargo's runtime closure again.

While we're at it, add `disallowedReferences = [ cargo rustc ]` to `rustc-unwrapped` as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
