### PR TITLE
nixos/sillytavern: respect cfg.package option

### DIFF
--- a/nixos/modules/services/web-apps/sillytavern.nix
+++ b/nixos/modules/services/web-apps/sillytavern.nix
@@ -39,8 +39,8 @@ in
 
       configFile = lib.mkOption {
         type = lib.types.path;
-        default = "${pkgs.sillytavern}/lib/node_modules/sillytavern/config.yaml";
-        defaultText = lib.literalExpression "\${pkgs.sillytavern}/lib/node_modules/sillytavern/config.yaml";
+        default = "${cfg.package}/lib/node_modules/sillytavern/config.yaml";
+        defaultText = lib.literalExpression "\${cfg.package}/lib/node_modules/sillytavern/config.yaml";
         description = ''
           Path to the SillyTavern configuration file.
         '';
@@ -109,7 +109,7 @@ in
           in
           lib.concatStringsSep " " (
             [
-              "${lib.getExe pkgs.sillytavern}"
+              "${lib.getExe cfg.package}"
             ]
             ++ f cfg.port "port"
             ++ f cfg.listen "listen"
@@ -122,7 +122,7 @@ in
         Restart = "always";
         StateDirectory = "SillyTavern";
         BindPaths = [
-          "%S/SillyTavern/extensions:${pkgs.sillytavern}/lib/node_modules/sillytavern/public/scripts/extensions/third-party"
+          "%S/SillyTavern/extensions:${cfg.package}/lib/node_modules/sillytavern/public/scripts/extensions/third-party"
         ];
 
         # Security hardening


### PR DESCRIPTION
## Summary

The `services.sillytavern` NixOS module declares a `package` option via `lib.mkPackageOption`, but the implementation never actually reads `cfg.package`. Every reference to the SillyTavern derivation in the `config` block hard-codes `pkgs.sillytavern`:

- [`nixos/modules/services/web-apps/sillytavern.nix:42`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-apps/sillytavern.nix#L42) — `configFile` default
- [`nixos/modules/services/web-apps/sillytavern.nix:112`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-apps/sillytavern.nix#L112) — `ExecStart`
- [`nixos/modules/services/web-apps/sillytavern.nix:125`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-apps/sillytavern.nix#L125) — `BindPaths`

As a result, `services.sillytavern.package = ...` is silently a no-op. The service always runs whatever `pkgs.sillytavern` resolves to at module-evaluation time, regardless of what the user assigns to the option. This defeats the standard NixOS pattern that `mkPackageOption` is supposed to enable.

This patch replaces the three hard-coded references with `cfg.package` and updates the corresponding `defaultText`. The `path = [ pkgs.gitMinimal ];` line above is intentionally left alone — that's git, not sillytavern.

## How I ran into this

I run sillytavern on my home NAS via this NixOS module. My system was tracking a slightly older `nixos-unstable` revision and shipping `sillytavern 1.15.0`, while a newer `nixos-unstable` revision already had `1.17.0`. To upgrade just sillytavern without bumping every other package on the box, I added a second `nixpkgs` flake input as `pkgs-edge` and set:

```nix
services.sillytavern.package = pkgs-edge.sillytavern;
```

After `nixos-rebuild switch` there was no diff and no warning — the service was still on `1.15.0`. Tracing it down led to this bug: the option exists in the schema but is dead code in the implementation. As a workaround I'm currently using a `nixpkgs.overlays` entry that replaces `pkgs.sillytavern` directly, which is exactly what `mkPackageOption` is supposed to let users avoid.

## Verification

After applying the patch:

- `config.systemd.services.sillytavern.serviceConfig.ExecStart` now resolves to whatever `cfg.package` is set to, instead of always pointing at `pkgs.sillytavern`.
- `config.services.sillytavern.configFile` and the `BindPaths` entry similarly track `cfg.package`.
- For users who don't set the option, behavior is unchanged: `mkPackageOption` defaults to `pkgs.sillytavern`, which is exactly what the module hardcoded before. So this is a strict bug fix with no breakage for existing configs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests (no existing test for this module)
  - [ ] Package tests at `passthru.tests` (n/a — NixOS module change)
  - [ ] Tests in lib/tests or pkgs/test (n/a)
- [ ] Ran `nixpkgs-review` on this PR. (Module-only change, no rebuild fan-out.)
- [x] Tested basic functionality — confirmed `ExecStart`, `BindPaths`, and `configFile` now track `cfg.package`, and that defaults are unchanged when users don't set the option.
- Nixpkgs Release Notes
  - [ ] Not applicable.
- NixOS Release Notes
  - [ ] Bug fix only, no user-visible behavior change for unset configs.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

cc @wrvsrx @A1ca7raz (module maintainers per `meta.maintainers`)