### PR TITLE
xorg-server: 21.1.21 -> 21.1.22

### DIFF
--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -57,6 +57,9 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xorg-server";
+  # `xvfb` inherits `version` and `src` from here, leading to many rebuilds. If
+  # necessary, these can be moved out of lockstep in order to merge updates
+  # quickly.
   version = "21.1.22";
 
   outputs = [

--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -57,7 +57,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xorg-server";
-  version = "21.1.21";
+  version = "21.1.22";
 
   outputs = [
     "out"
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://xorg/individual/xserver/xorg-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-wMvlVFs/ZFuuYCS4MNHRFUqVY1BoOk5Ssv/1sPoatRk=";
+    hash = "sha256-GiQsiRfEm6KczB9gIWE9iiuYBd0NJxpmrp0J9LC7BrM=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/xv/xvfb/package.nix
+++ b/pkgs/by-name/xv/xvfb/package.nix
@@ -7,6 +7,7 @@
   ninja,
   pkg-config,
   xorg-server,
+  fetchurl,
   dri-pkgconfig-stub,
   libdrm,
   libGL,
@@ -37,7 +38,13 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "xvfb";
 
-  inherit (xorg-server) src version;
+  #FIXME: go back to xorg-server version on nixpkgs staging
+  #inherit (xorg-server) src version;
+  version = "21.1.21";
+  src = fetchurl {
+    url = "mirror://xorg/individual/xserver/xorg-server-${finalAttrs.version}.tar.xz";
+    hash = "sha256-wMvlVFs/ZFuuYCS4MNHRFUqVY1BoOk5Ssv/1sPoatRk=";
+  };
 
   strictDeps = true;
 


### PR DESCRIPTION
Announcement: https://lists.x.org/archives/xorg-announce/2026-April/003678.html
Advisories: https://lists.x.org/archives/xorg-announce/2026-April/003677.html

... but we don't update `xvfb` yet to reduce the rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
