### PR TITLE
crystfel: fix dead source URL

### DIFF
--- a/pkgs/applications/science/physics/crystfel/default.nix
+++ b/pkgs/applications/science/physics/crystfel/default.nix
@@ -86,19 +86,18 @@ let
       src =
         if stdenv.hostPlatform.isDarwin then
           fetchurl {
-            url = "https://www.mrc-lmb.cam.ac.uk/mosflm/mosflm/ver${
+            url = "https://www.mrc-lmb.cam.ac.uk/harry/imosflm/ver${
               builtins.replaceStrings [ "." ] [ "" ] version
-            }/pre-built/mosflm-osx-64-noX11.zip";
-            sha256 = "1da5wimv3kl8bccp49j69vh8gi28cn7axg59lrmb38s68c618h7j";
+            }/downloads/mosflm-${version}-osx-64.zip";
+            hash = "sha256-0sXgA3zSIjhy9+zTiv+K/51yZsIgGorMtKVjdRjW+AM=";
           }
         else
           fetchurl {
-            url = "https://www.mrc-lmb.cam.ac.uk/mosflm/mosflm/ver${
+            url = "https://www.mrc-lmb.cam.ac.uk/harry/imosflm/ver${
               builtins.replaceStrings [ "." ] [ "" ] version
-            }/pre-built/mosflm-linux-64-noX11.zip";
-            hash = "sha256:1f2qins5kaz5v6mkaclncqpirx3mlz177ywm13py9p6s9mk99g32";
+            }/downloads/imosflm-${version}-linux-64.zip";
+            hash = "sha256-2we0K09W31LKgn9SHLGti50EA/zhbX+CWWuQGCSKW18=";
           };
-      mosflmBinary = if stdenv.hostPlatform.isDarwin then "bin/mosflm" else "mosflm-linux-64-noX11";
     in
     stdenv.mkDerivation {
       pname = "mosflm";
@@ -112,13 +111,11 @@ let
         makeWrapper
       ];
 
-      sourceRoot = ".";
-
       # mosflm statically links against its own libccp4, which as the syminfo.lib environment variable problem.
       # Here, we circumvent it by creating a little wrapper script that calls mosflm after setting the SYMINFO variable.
       installPhase = ''
         mkdir -p $out/bin
-        cp ${mosflmBinary} $out/bin/mosflm-raw
+        cp bin/mosflm $out/bin/mosflm-raw
         makeWrapper $out/bin/mosflm-raw $out/bin/mosflm --set SYMINFO ${libccp4}/share/syminfo.lib --add-flags -n
       '';
     };


### PR DESCRIPTION
The website for "mosflm", an analysis tool required by CrystFEL, has gone 404. The author is now using his own personal web site to host his application binary.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
