### PR TITLE
goshs: 2.0.0-beta.5 -> 2.0.1

### DIFF
--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.0.0-beta.5";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rbmHtVtHG8cdhFpVM5A8XlJbeB3Uh/OyUKqmYMPZeU8=";
+    hash = "sha256-Lh4jUz6dtbAwC9ErQrHe5FtxjHLL2gBRTSqLtj33GTc=";
   };
 
   vendorHash = "sha256-wn+t6xY4zUK6NE5kZSefHYGpMq5whFZ644ij5bDs50I=";


### PR DESCRIPTION
Diff: https://github.com/patrickhener/goshs/compare/v2.0.0-beta.5...v2.0.1

Changelog: https://github.com/patrickhener/goshs/releases/tag/refs/tags/v2.0.1

Addresses:

- https://github.com/patrickhener/goshs/security/advisories/GHSA-jgfx-74g2-9r6g
- https://github.com/patrickhener/goshs/security/advisories/GHSA-6qcc-6q27-whp8
- https://github.com/patrickhener/goshs/security/advisories/GHSA-wvhv-qcqf-f3cx

Closes:

- https://github.com/NixOS/nixpkgs/issues/508896
- https://github.com/NixOS/nixpkgs/issues/508903
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
