### PR TITLE
less-unstable: init at 696

### DIFF
--- a/pkgs/by-name/le/less-unstable/package.nix
+++ b/pkgs/by-name/le/less-unstable/package.nix
@@ -1,0 +1,37 @@
+{
+  autoreconfHook,
+  fetchFromGitHub,
+  less,
+  perl,
+}:
+
+less.overrideAttrs (finalAttrs: {
+  pname = "${less.pname}-unstable";
+  version = "696";
+
+  src = fetchFromGitHub {
+    owner = "gwsw";
+    repo = "less";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-//et0thRbNtzlIcZEKx0if33MKIZ+jEjdUHxpaJkTWo=";
+  };
+
+  sourceRoot = "source";
+
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+  ];
+
+  preBuild = ''
+    gcc --output buildgen buildgen.c
+    cat *.c | ./buildgen funcs >funcs.h
+    perl mkhelp.pl less.hlp >help.c
+    perl mkhelp.pl less.hlp >less.nro
+    substituteInPlace less{key,echo}.nro.VER \
+      --replace-fail '@@VERSION@@' "${finalAttrs.version}" \
+      --replace-fail '@@DATE@@' "$(date +%Y-%m-%d)"
+    cp lesskey.nro.VER lesskey.nro
+    cp lessecho.nro.VER lessecho.nro
+  '';
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
