### PR TITLE
jellyfin-mpv-shim: Clean up

### DIFF
--- a/pkgs/applications/video/jellyfin-mpv-shim/default.nix
+++ b/pkgs/applications/video/jellyfin-mpv-shim/default.nix
@@ -13,6 +13,7 @@
   python,
   python-mpv-jsonipc,
   pywebview,
+  setuptools,
   tkinter,
   wrapGAppsHook3,
 }:
@@ -20,7 +21,7 @@
 buildPythonApplication rec {
   pname = "jellyfin-mpv-shim";
   version = "2.9.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -33,7 +34,9 @@ buildPythonApplication rec {
     gobject-introspection
   ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     jellyfin-apiclient-python
     mpv
     pillow
@@ -61,12 +64,12 @@ buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace jellyfin_mpv_shim/conf.py \
-      --replace "check_updates: bool = True" "check_updates: bool = False" \
-      --replace "notify_updates: bool = True" "notify_updates: bool = False"
+      --replace-fail "check_updates: bool = True" "check_updates: bool = False" \
+      --replace-fail "notify_updates: bool = True" "notify_updates: bool = False"
     # python-mpv renamed to mpv with 1.0.4
     substituteInPlace setup.py \
-      --replace "python-mpv" "mpv" \
-      --replace "mpv-jsonipc" "python_mpv_jsonipc"
+      --replace-fail "python-mpv" "mpv" \
+      --replace-fail "mpv-jsonipc" "python_mpv_jsonipc"
   '';
 
   # Install all the icons for the desktop item
@@ -84,8 +87,6 @@ buildPythonApplication rec {
   '';
   dontWrapGApps = true;
 
-  # no tests
-  doCheck = false;
   pythonImportsCheck = [ "jellyfin_mpv_shim" ];
 
   desktopItems = [
@@ -113,6 +114,7 @@ buildPythonApplication rec {
       to prevent needless transcoding of your media files on the server. The player also has
       advanced features, such as bulk subtitle updates and launching commands on events.
     '';
+    changelog = "https://github.com/jellyfin/jellyfin-mpv-shim/releases/tag/v${version}";
     license = with lib.licenses; [
       # jellyfin-mpv-shim
       gpl3Only


### PR DESCRIPTION
Modernizes the nix package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
