### PR TITLE
libutempter: 1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/by-name/li/libutempter/Makefile-add-STATIC-and-DYNAMIC-build-variables.patch
+++ b/pkgs/by-name/li/libutempter/Makefile-add-STATIC-and-DYNAMIC-build-variables.patch
@@ -1,0 +1,45 @@
+From fe256f79a66e1098707dd1e5b79ed4920d7a13c4 Mon Sep 17 00:00:00 2001
+From: Henri Menke <henri@henrimenke.de>
+Date: Thu, 9 Apr 2026 07:12:04 +0000
+Subject: [PATCH] Makefile: add STATIC and DYNAMIC build variables
+
+---
+ libutempter/Makefile | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/libutempter/Makefile b/libutempter/Makefile
+index 5634d03..7014ca4 100644
+--- a/libutempter/Makefile
++++ b/libutempter/Makefile
+@@ -27,7 +27,15 @@ SONAME = $(SHAREDLIB).$(MAJOR)
+ STATICLIB = lib$(PROJECT).a
+ MAP = lib$(PROJECT).map
+ 
+-TARGETS = $(PROJECT) $(SHAREDLIB)
++STATIC ?= 0
++DYNAMIC ?= 1
++TARGETS = $(PROJECT)
++ifeq ($(DYNAMIC),1)
++TARGETS += $(SHAREDLIB)
++endif
++ifeq ($(STATIC),1)
++TARGETS += $(STATICLIB)
++endif
+ 
+ INSTALL = install
+ libdir = /usr/lib
+@@ -81,9 +89,14 @@ install:
+ 		$(DESTDIR)$(includedir) $(DESTDIR)$(man3dir)
+ 	$(INSTALL) -p -m2711 $(PROJECT) $(DESTDIR)$(libexecdir)/$(PROJECT)/
+ 	$(INSTALL) -p -m644 $(PROJECT).h $(DESTDIR)$(includedir)/
++ifeq ($(DYNAMIC),1)
+ 	$(INSTALL) -p -m755 $(SHAREDLIB) $(DESTDIR)$(libdir)/$(SHAREDLIB).$(VERSION)
+ 	ln -fns $(SHAREDLIB).$(VERSION) $(DESTDIR)$(libdir)/$(SONAME)
+ 	ln -fns $(SONAME) $(DESTDIR)$(libdir)/$(SHAREDLIB)
++endif
++ifeq ($(STATIC),1)
++	$(INSTALL) -p -m644 $(STATICLIB) $(DESTDIR)$(libdir)/
++endif
+ 	$(INSTALL) -p -m644 $(PROJECT).3 $(DESTDIR)$(man3dir)/
+ 	for n in lib$(PROJECT) utempter_add_record utempter_remove_record \
+ 	    utempter_remove_added_record utempter_set_helper; do \

--- a/pkgs/by-name/li/libutempter/package.nix
+++ b/pkgs/by-name/li/libutempter/package.nix
@@ -1,22 +1,35 @@
 {
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  fetchpatch,
   lib,
   glib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libutempter";
-  version = "1.2.1";
+  version = "1.2.3";
 
-  src = fetchurl {
-    url = "https://ftp.altlinux.org/pub/people/ldv/utempter/libutempter-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-ln/vNy85HeUBhDrYdXDGz12r2WUfAPF4MJD7wSsqNMs=";
+  src = fetchFromGitHub {
+    owner = "altlinux";
+    repo = "libutempter";
+    tag = "${finalAttrs.version}-alt1";
+    hash = "sha256-CiRZiEXzfOrtx1XXdMG2QZqzRtvY5mdA4SwTHRxkLUI=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/libutempter";
 
   buildInputs = [ glib ];
 
-  patches = [ ./exec_path.patch ];
+  patches = [
+    ./exec_path.patch
+    (fetchpatch {
+      name = "build-overwrite-already-existing-symlinks-during-ins.patch";
+      url = "https://github.com/altlinux/libutempter/commit/717116b93d496a19f7f8abf8702517de0053f66e.patch";
+      hash = "sha256-4YaxgbORNm+rlp0YzYKj5a7/zJl1dxo72i/Rei9qulg=";
+    })
+    ./Makefile-add-STATIC-and-DYNAMIC-build-variables.patch # https://github.com/altlinux/libutempter/pull/9
+  ];
 
   patchFlags = [ "-p2" ];
 
@@ -24,12 +37,17 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Makefile --replace 2711 0711
   '';
 
-  makeFlags = [
-    "libdir=\${out}/lib"
-    "libexecdir=\${out}/lib"
-    "includedir=\${out}/include"
-    "mandir=\${out}/share/man"
-  ];
+  makeFlags =
+    lib.optionals stdenv.hostPlatform.isStatic [
+      "DYNAMIC=0"
+      "STATIC=1"
+    ]
+    ++ [
+      "libdir=\${out}/lib"
+      "libexecdir=\${out}/lib"
+      "includedir=\${out}/include"
+      "mandir=\${out}/share/man"
+    ];
 
   meta = {
     homepage = "https://github.com/altlinux/libutempter";


### PR DESCRIPTION
Diff: https://github.com/altlinux/libutempter/compare/1.2.1-alt1...1.2.3-alt1

Tested building and running tmux.

Changed source to GitHub, because altlinux FTP is behind upstream.

Also backported two patches to make the static library build work.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
