### PR TITLE
lean-lsp-mcp: init at 0.26.1; python3Packages.leanclient: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22861,6 +22861,12 @@
     githubId = 4196789;
     name = "Nathan Ringo";
   };
+  remix7531 = {
+    email = "remix7531@mailbox.org";
+    github = "remix7531";
+    githubId = 131352678;
+    name = "remix7531";
+  };
   remko = {
     github = "remko";
     githubId = 12300;

--- a/pkgs/by-name/le/lean-lsp-mcp/package.nix
+++ b/pkgs/by-name/le/lean-lsp-mcp/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "lean-lsp-mcp";
+  version = "0.26.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "oOo0oOo";
+    repo = "lean-lsp-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OHbD6HujkXsqe8XpNr1bn+Pel2tbkX7tBapCcUe234o=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    leanclient
+    mcp
+    orjson
+    certifi
+  ];
+
+  pythonRelaxDeps = [
+    "mcp"
+    "leanclient"
+  ];
+
+  # Tests require a real Lean toolchain
+  doCheck = false;
+
+  pythonImportsCheck = [ "lean_lsp_mcp" ];
+
+  meta = {
+    description = "MCP server for the Lean theorem prover via the Lean LSP";
+    homepage = "https://github.com/oOo0oOo/lean-lsp-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ remix7531 ];
+    mainProgram = "lean-lsp-mcp";
+  };
+})

--- a/pkgs/development/python-modules/leanclient/default.nix
+++ b/pkgs/development/python-modules/leanclient/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  orjson,
+  psutil,
+  tqdm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "leanclient";
+  version = "0.9.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "oOo0oOo";
+    repo = "leanclient";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BmIvjFhhlXnyDZWNUZAq41TA+Q5v9UW63rljoeYl44Q=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    orjson
+    psutil
+    tqdm
+  ];
+
+  # Tests require a real Lean toolchain
+  doCheck = false;
+
+  pythonImportsCheck = [ "leanclient" ];
+
+  meta = {
+    description = "Python client for the Lean theorem prover LSP";
+    homepage = "https://github.com/oOo0oOo/leanclient";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ remix7531 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8585,6 +8585,8 @@ self: super: with self; {
 
   leanblueprint = callPackage ../development/python-modules/leanblueprint { };
 
+  leanclient = callPackage ../development/python-modules/leanclient { };
+
   leaone-ble = callPackage ../development/python-modules/leaone-ble { };
 
   leather = callPackage ../development/python-modules/leather { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
