### PR TITLE
wtcat: init at 0.1.3

### DIFF
--- a/pkgs/by-name/wt/wtcat/package.nix
+++ b/pkgs/by-name/wt/wtcat/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchpatch2,
+  openssl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wtcat";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "pervrosen";
+    repo = "wtcat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jmI5XA8DfsLOKbxsfCE3jSYXP9e2m5Ax4pUYCBDprKw=";
+  };
+
+  cargoPatches = [
+    # https://github.com/pervrosen/wtcat/pull/1
+    (fetchpatch2 {
+      url = "https://github.com/pervrosen/wtcat/commit/b7e2d319147842dfe7246a512a7a2a6aade6d192.patch";
+      hash = "sha256-5XFKgL7+xSs3entwEJMpaa3EgQefPAmkHs5zGDBFasM=";
+    })
+  ];
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  cargoHash = "sha256-DNy1Hz0g0HKDdnXjiLSmDGKaI6sONaxkNXy/zoXErlk=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "WebTransport CLI";
+    homepage = "https://github.com/pervrosen/wtcat";
+    changelog = "https://github.com/pervrosen/wtcat/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "wtcat";
+  };
+})


### PR DESCRIPTION
WebTransport CLI

https://github.com/pervrosen/wtcat


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
