### PR TITLE
nixos/qemu-guest: add virtiofs

### DIFF
--- a/nixos/modules/profiles/qemu-guest.nix
+++ b/nixos/modules/profiles/qemu-guest.nix
@@ -12,6 +12,7 @@
     "virtio_scsi"
     "9p"
     "9pnet_virtio"
+    "virtiofs"
   ];
   boot.initrd.kernelModules = [
     "virtio_balloon"

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -75,10 +75,6 @@ let
   # improvement: move following profile to ../modules/profiles/vmspawn-guest.nix
   profile-guest-vmspawn = {
     imports = [ ../modules/profiles/qemu-guest.nix ];
-    # improvement: move following configuration to qemu-guest.nix
-    boot.initrd.availableKernelModules = [
-      "virtiofs"
-    ];
 
     boot.initrd.systemd.enable = true;
     # root is defined by systemd-vmspawn


### PR DESCRIPTION
Making `virtiofs` available in initrd to enable virtiofs as rootfs, which is needed for `systemd-vmspawn`.

This change is part of a series of improvements (#506751) to `systemd-vmspawn`.

The same PR exists, but stalled: #237701

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
