### PR TITLE
Logitune: Init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9512,6 +9512,12 @@
     github = "luna-spirito";
     githubId = 29687558;
   };
+  garrettgr = {
+    name = "Garrett Gonzalez-Rivas";
+    email = "ggonzalez-rivas@acm.org";
+    github = "garrettgr";
+    githubId = 46307948;
+  };
   garrison = {
     email = "jim@garrison.cc";
     github = "garrison";

--- a/pkgs/by-name/lo/logitune/package.nix
+++ b/pkgs/by-name/lo/logitune/package.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBUILD_TESTING=OFF"
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "Configure Logitech devices on Linux (Options+ clone)";
     homepage = "https://github.com/mmaher88/logitune";

--- a/pkgs/by-name/lo/logitune/package.nix
+++ b/pkgs/by-name/lo/logitune/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  qt6,
+  systemd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "logitune";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "mmaher88";
+    repo = "logitune";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zyALn1mOdQoUPj5j045pvCQjffQB6Rl/+QyKziCqixw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    systemd
+  ];
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_TESTING=OFF"
+  ];
+
+  meta = {
+    description = "Configure Logitech devices on Linux (Options+ clone)";
+    homepage = "https://github.com/mmaher88/logitune";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.garrettgr ];
+    platforms = with lib.platforms; linux;
+    mainProgram = "logitune";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This package is a clone of  Logitech's Options+ written in Qt6 and allows for  easy configuration of logitech peripherals (especially mice) including per-application profiles. 

This offers additional features over tools like solaar or logiops and doesn't require a daemon running in the background (connects directly to hid++ 2.0).

More information can be found on the [homepage of the upstream repo](https://github.com/mmaher88/logitune).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
