### PR TITLE
portkey-gateway: init at 1.15.2

### DIFF
--- a/pkgs/by-name/po/portkey-gateway/package.nix
+++ b/pkgs/by-name/po/portkey-gateway/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  jq,
+  nodejs_20,
+  nix-update-script,
+  patch-package,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "portkey-gateway";
+  version = "1.15.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Portkey-AI";
+    repo = "gateway";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uHIUS9qfFLB1iL/NTtAL/11lizxAGCpiT648/0aHSm8=";
+  };
+
+  npmDepsHash = "sha256-ooViuZzr2lKk1waVd51+pLO597mCr94tZbvhfpLlMYc=";
+
+  # Upstream targets Node 20.x
+  nodejs = nodejs_20;
+
+  nativeBuildInputs = [
+    jq
+    patch-package
+  ];
+
+  # Required for patch-package to modify node_modules
+  makeCacheWritable = true;
+
+  # Rewrite bin field so buildNpmPackage auto-generates the wrapper correctly
+  # (upstream uses string form which doesn't work well with scoped package names)
+  postPatch = ''
+    # With __structuredAttrs, npmDeps is a bash variable but not exported,
+    # so the prefetch-npm-deps Rust binary can't find it via env::var_os.
+    export npmDeps
+    ${lib.getExe jq} '.bin = {"portkey-gateway": "build/start-server.js"}' package.json > package.json.tmp
+    mv package.json.tmp package.json
+  '';
+
+  # Apply upstream's patch-package patches to node_modules
+  postConfigure = ''
+    patch-package
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast AI gateway for routing to 200+ LLMs with one fast and friendly API";
+    homepage = "https://github.com/Portkey-AI/gateway";
+    changelog = "https://github.com/Portkey-AI/gateway/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "portkey-gateway";
+    maintainers = with lib.maintainers; [ trishtzy ];
+  };
+})


### PR DESCRIPTION
[Portkey Gateway](https://github.com/Portkey-AI/gateway) is a fast AI gateway for routing to 200+ LLMs with one fast and friendly API. It provides a unified
  interface, load balancing, fallbacks, retries, caching, and a web UI for managing requests.

  ## Things done

  - Built on platform:
    - [ ] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [x] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test