### PR TITLE
jfrconv: init at 4.5

### DIFF
--- a/pkgs/by-name/jf/jfr-converter/package.nix
+++ b/pkgs/by-name/jf/jfr-converter/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  jre_headless,
+  makeBinaryWrapper,
+  maven,
+  nix-update-script,
+}:
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "jfr-converter";
+  version = "4.4";
+
+  src = fetchFromGitHub {
+    owner = "async-profiler";
+    repo = "async-profiler";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-quXrlkG1MJNQDMYf9YIH4Kg7D8Rs5oOoCr/JoQtY25E=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  mvnHash = "sha256-Q9anERXKcwOClU16TjY6QxELTZC1P7rRNHdDsEB/v3I=";
+  mvnParameters = lib.escapeShellArgs [
+    "--file=pom-converter.xml"
+  ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/jfr-converter
+    install -Dm644 target/jfr-converter-${finalAttrs.version}.jar $out/share/jfr-converter/jfr-converter.jar
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/jfr-converter \
+      --add-flags "-jar $out/share/jfr-converter/jfr-converter.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility to convert between different JVM profile output formats";
+    homepage = "https://github.com/async-profiler/async-profiler/blob/master/docs/ConverterUsage.md";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    inherit (jre_headless.meta) platforms;
+  };
+})

--- a/pkgs/by-name/jf/jfrconv/package.nix
+++ b/pkgs/by-name/jf/jfrconv/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  jre_headless,
+  makeBinaryWrapper,
+  maven,
+  nix-update-script,
+}:
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "jfrconv";
+  version = "4.5";
+
+  src = fetchFromGitHub {
+    owner = "async-profiler";
+    repo = "async-profiler";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-H3NBWyCjyuQkQ7HZ+B8ycBGIvQWdQDkx2SpQr+0gL08=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  mvnHash = "sha256-Q9anERXKcwOClU16TjY6QxELTZC1P7rRNHdDsEB/v3I=";
+  mvnParameters = lib.escapeShellArgs [
+    "--file=pom-converter.xml"
+  ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/jfrconv
+    install -Dm644 target/jfr-converter-${finalAttrs.version}.jar $out/share/jfrconv/jfr-converter.jar
+
+    makeWrapper ${jre_headless}/bin/java $out/bin/jfrconv \
+      --add-flags "-jar $out/share/jfrconv/jfr-converter.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility to convert between different JVM profile output formats";
+    homepage = "https://github.com/async-profiler/async-profiler/blob/master/docs/ConverterUsage.md";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    inherit (jre_headless.meta) platforms;
+  };
+})


### PR DESCRIPTION
Initialize async-profiler's [jfrconv](https://github.com/async-profiler/async-profiler/blob/master/docs/ConverterUsage.md) (JFR converter) utility at `4.5`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
