### PR TITLE
unbreak semantic-release on aarch64 by adding setuptools

### DIFF
--- a/pkgs/by-name/se/semantic-release/package.nix
+++ b/pkgs/by-name/se/semantic-release/package.nix
@@ -24,7 +24,8 @@ buildNpmPackage rec {
   dontNpmBuild = true;
 
   nativeBuildInputs = [
-    python3, setuptools
+    python3
+    setuptools
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin cctools;
 

--- a/pkgs/by-name/se/semantic-release/package.nix
+++ b/pkgs/by-name/se/semantic-release/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   lib,
   python3,
+  setuptools,
   stdenv,
 }:
 
@@ -40,7 +41,5 @@ buildNpmPackage rec {
     homepage = "https://semantic-release.gitbook.io/semantic-release/";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.sestrella ];
-    # https://hydra.nixos.org/job/nixpkgs/trunk/semantic-release.aarch64-linux
-    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/pkgs/by-name/se/semantic-release/package.nix
+++ b/pkgs/by-name/se/semantic-release/package.nix
@@ -24,7 +24,7 @@ buildNpmPackage rec {
   dontNpmBuild = true;
 
   nativeBuildInputs = [
-    python3
+    python3, setuptools
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin cctools;
 

--- a/pkgs/by-name/se/semantic-release/package.nix
+++ b/pkgs/by-name/se/semantic-release/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   lib,
   python3,
-  setuptools,
   stdenv,
 }:
 
@@ -23,11 +22,12 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
 
-  nativeBuildInputs = [
-    python3
-    setuptools
-  ]
+  nativeBuildInputs = [ python3 ]
   ++ lib.optional stdenv.hostPlatform.isDarwin cctools;
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
 
   # Fixes `semantic-release --version` output
   postPatch = ''


### PR DESCRIPTION
Semantic-release build on aarch64 failed with a distutils related error. Installing setuptools is the easiest fix.
This is my first PR here, I would guess a ci build should show if this resolves the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
