### PR TITLE
chordsketch: init at 0.2.0

### DIFF
--- a/pkgs/by-name/ch/chordsketch/package.nix
+++ b/pkgs/by-name/ch/chordsketch/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "chordsketch";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "koedame";
+    repo = "chordsketch";
+    tag = "v${version}";
+    hash = "sha256-8i5rDUVmE5MKqXtXY8bgumEHr8jVS6bk9XClZATwC6E=";
+  };
+
+  cargoHash = "sha256-52vnW3E7Fdl2aLOKh+w13Tmf0PaD6FdXqf+YyCV6Yec=";
+
+  cargoBuildFlags = [ "--package" "chordsketch" ];
+  cargoTestFlags = [ "--package" "chordsketch" ];
+
+  meta = {
+    description = "ChordPro file format renderer and CLI (text, HTML, PDF)";
+    homepage = "https://github.com/koedame/chordsketch";
+    changelog = "https://github.com/koedame/chordsketch/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "chordsketch";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
## Description

Add [chordsketch](https://github.com/koedame/chordsketch), a Rust
implementation of the [ChordPro](https://www.chordpro.org/) file format
parser and renderer. It reads `.cho` files and renders them to plain
text, HTML, or PDF output.

- **Homepage**: https://github.com/koedame/chordsketch
- **License**: MIT
- **Platforms**: x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin

## Build verification

Verified locally on x86_64-linux (nixpkgs unstable):

```
$ nix-build -E 'let pkgs = import <nixpkgs> {}; in pkgs.callPackage ./pkgs/by-name/ch/chordsketch/package.nix {}'
/nix/store/k12yqg7dq9r865lzq7njmrik88mr58p6-chordsketch-0.2.0

$ result/bin/chordsketch --version
chordsketch 0.2.0
```

## Things done

- [x] Built on x86_64-linux
- [ ] Built on aarch64-linux (CI will verify)
- [ ] Built on x86_64-darwin (CI will verify)
- [ ] Built on aarch64-darwin (CI will verify)
- [x] `nix-shell -p nix-init -- nix-init` was **not** used (manual derivation)
- [x] Checked that `meta.maintainers` is set (empty for now — I don't have a nixpkgs maintainer handle yet)
- [x] Tested the binary runs correctly
- [x] No nixpkgs review request (first-time contributor)