### PR TITLE
jq: patch CVE-2026-32316, CVE-2026-33947, CVE-2026-33948, CVE-2026-39979 & CVE-2026-40164 

### DIFF
--- a/pkgs/by-name/jq/jq/CVE-2026-33947.patch
+++ b/pkgs/by-name/jq/jq/CVE-2026-33947.patch
@@ -1,0 +1,66 @@
+From fb59f1491058d58bdc3e8dd28f1773d1ac690a1f Mon Sep 17 00:00:00 2001
+From: itchyny <itchyny@cybozu.co.jp>
+Date: Mon, 13 Apr 2026 11:23:40 +0900
+Subject: [PATCH] Limit path depth to prevent stack overflow
+
+Deeply nested path arrays can cause unbounded recursion in
+`jv_setpath`, `jv_getpath`, and `jv_delpaths`, leading to
+stack overflow. Add a depth limit of 10000 to match the
+existing `tojson` depth limit. This fixes CVE-2026-33947.
+---
+ src/jv_aux.c  | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/src/jv_aux.c b/src/jv_aux.c
+index 018f380b10..fd5ff96684 100644
+--- a/src/jv_aux.c
++++ b/src/jv_aux.c
+@@ -365,6 +365,10 @@ static jv jv_dels(jv t, jv keys) {
+   return t;
+ }
+ 
++#ifndef MAX_PATH_DEPTH
++#define MAX_PATH_DEPTH (10000)
++#endif
++
+ jv jv_setpath(jv root, jv path, jv value) {
+   if (jv_get_kind(path) != JV_KIND_ARRAY) {
+     jv_free(value);
+@@ -372,6 +376,12 @@ jv jv_setpath(jv root, jv path, jv value) {
+     jv_free(path);
+     return jv_invalid_with_msg(jv_string("Path must be specified as an array"));
+   }
++  if (jv_array_length(jv_copy(path)) > MAX_PATH_DEPTH) {
++    jv_free(value);
++    jv_free(root);
++    jv_free(path);
++    return jv_invalid_with_msg(jv_string("Path too deep"));
++  }
+   if (!jv_is_valid(root)){
+     jv_free(value);
+     jv_free(path);
+@@ -424,6 +434,11 @@ jv jv_getpath(jv root, jv path) {
+     jv_free(path);
+     return jv_invalid_with_msg(jv_string("Path must be specified as an array"));
+   }
++  if (jv_array_length(jv_copy(path)) > MAX_PATH_DEPTH) {
++    jv_free(root);
++    jv_free(path);
++    return jv_invalid_with_msg(jv_string("Path too deep"));
++  }
+   if (!jv_is_valid(root)) {
+     jv_free(path);
+     return root;
+@@ -502,6 +517,12 @@ jv jv_delpaths(jv object, jv paths) {
+       jv_free(elem);
+       return err;
+     }
++    if (jv_array_length(jv_copy(elem)) > MAX_PATH_DEPTH) {
++      jv_free(object);
++      jv_free(paths);
++      jv_free(elem);
++      return jv_invalid_with_msg(jv_string("Path too deep"));
++    }
+     jv_free(elem);
+   }
+   if (jv_array_length(jv_copy(paths)) == 0) {

--- a/pkgs/by-name/jq/jq/package.nix
+++ b/pkgs/by-name/jq/jq/package.nix
@@ -32,6 +32,29 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./musl.patch
+    # CVE-2026-32316: integer overflow in jvp_string_append allows heap buffer overflow
+    (fetchurl {
+      url = "https://github.com/jqlang/jq/commit/e47e56d226519635768e6aab2f38f0ab037c09e5.patch";
+      hash = "sha256-33WZJ3Klw7wwHz68yh/4qPWV8V4MFfqzBR332phtiY4=";
+    })
+    # CVE-2026-33948: NUL truncation in CLI JSON input path
+    (fetchurl {
+      url = "https://github.com/jqlang/jq/commit/6374ae0bcdfe33a18eb0ae6db28493b1f34a0a5b.patch";
+      hash = "sha256-jXilw3tjsju1KlMyBrlo5CaKrRz38ONHgITDsbTjtEw=";
+    })
+    # CVE-2026-39979: out-of-bounds read in jv_parse_sized() error formatting
+    (fetchurl {
+      url = "https://github.com/jqlang/jq/commit/2f09060afab23fe9390cce7cb860b10416e1bf5f.patch";
+      hash = "sha256-jB7fbllnvf++zRiiYk2jxuDkG9fnZO7acT+GMaQk/Mg=";
+    })
+    # CVE-2026-40164: hash collision DoS via hardcoded MurmurHash3 seed
+    (fetchurl {
+      url = "https://github.com/jqlang/jq/commit/0c7d133c3c7e37c00b6d46b658a02244fdd3c784.patch";
+      hash = "sha256-Sgrtm/090o+eBrzE1vj3VIkP+W+5VwJnYsMCM/rn0E8=";
+    })
+    # CVE-2026-33947: unbounded recursion in jv_setpath/jv_getpath/delpaths_sorted
+    # Test hunk removed: depends on tests added after 1.8.1 (upstream commit fdf8ef0f)
+    ./CVE-2026-33947.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.is32bit [
     # needed because epoch conversion test here is right at the end of 32 bit integer space


### PR DESCRIPTION
Fixes #509905 #509906 #509907  #509911 #509929.

Upstream has not released a new version yet - I'd expect that when they do a few (or all) of the patches could be dropped.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
