### PR TITLE
llama-cpp-turboquant-amesianx: init at 1.6.0

### DIFF
--- a/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  llama-cpp,
+  nix-update-script,
+}:
+
+llama-cpp.overrideAttrs (oa: {
+  pname = "llama-cpp-turboquant";
+
+  src = fetchFromGitHub {
+    owner = "AmesianX";
+    repo = "TurboQuant";
+    rev = "v1.6.0";
+    hash = "sha256-K/07z6xePGV2AJD38AHy2XDIeS1hEeng4hrR/nP5UQQ=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C "$out" rev-parse --short HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  npmDepsHash = "sha256-RAFtsbBGBjteCt5yXhrmHL39rIDJMCFBETgzId2eRRk=";
+
+  strictDeps = true;
+
+  __structuredAttrs = false;
+
+  cmakeFlags = oa.cmakeFlags ++ [
+    # Disables automatic use of ccache or sccache — compiler caching tools that speed up rebuilds by caching compilation results
+    (lib.cmakeBool "GGML_CCACHE" false)
+
+    # Disables Microsoft's DirectML backend for GGML — a hardware-accelerated compute API on Windows
+    (lib.cmakeBool "GGML_DML" false)
+
+    # F16C provides a fast hardware instruction for converting between: float (32b) ↔ half (16b) FP
+    (lib.cmakeBool "GGML_F16C" true)
+
+    # FMA (Fused Multiply-Add) CPU instruction set combines a multiplication and addition into a single CPU instruction: a = a*b + c
+    (lib.cmakeBool "GGML_FMA" true)
+  ];
+
+  passthru.updateScript = nix-update-script {
+    attrPath = "llama-cpp-turboquant-amesianx";
+    extraArgs = [
+      "--version-regex"
+      "v(.*)"
+    ];
+  };
+
+  meta = {
+    description = "LLaMA-CPP with TurboQuant KV cache compression";
+    homepage = "https://github.com/AmesianX/TurboQuant";
+    license = lib.licenses.mit;
+    mainProgram = "llama";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
@@ -20,11 +20,9 @@ llama-cpp.overrideAttrs (oa: {
     '';
   };
 
-  npmDepsHash = "sha256-RAFtsbBGBjteCt5yXhrmHL39rIDJMCFBETgzId2eRRk=";
+  npmDepsHash = "sha256-f13UBug5CGvMAge+ArkgRzNYCeOeIbIOVLdjgobMhJM=";
 
   strictDeps = true;
-
-  __structuredAttrs = false;
 
   cmakeFlags = oa.cmakeFlags ++ [
     # Disables automatic use of ccache or sccache — compiler caching tools that speed up rebuilds by caching compilation results
@@ -53,7 +51,7 @@ llama-cpp.overrideAttrs (oa: {
     homepage = "https://github.com/AmesianX/TurboQuant";
     license = lib.licenses.mit;
     mainProgram = "llama";
-    maintainers = with lib.maintainers; [ superherointj ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
@@ -53,7 +53,7 @@ llama-cpp.overrideAttrs (oa: {
     homepage = "https://github.com/AmesianX/TurboQuant";
     license = lib.licenses.mit;
     mainProgram = "llama";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ superherointj ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
+++ b/pkgs/by-name/ll/llama-cpp-turboquant-amesianx/package.nix
@@ -51,7 +51,7 @@ llama-cpp.overrideAttrs (oa: {
     homepage = "https://github.com/AmesianX/TurboQuant";
     license = lib.licenses.mit;
     mainProgram = "llama";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ superherointj ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
- llama-cpp-turboquant-amesianx: init at 1.6.0
- maintainers: add superherointj

On CI:
  - `__structuredAttrs = true` is causing the npm lock file validation to fail.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

CC Llama-cpp maintainers: @booxter @dit7ya @philiptaron @xddxdd @yuannan 

# Pending

- Waiting PR to reach master:
  - https://github.com/NixOS/nixpkgs/pull/487974
  - https://nixpk.gs/pr-tracker.html?pr=487974