### PR TITLE
atf: fix cross build on Darwin

### DIFF
--- a/pkgs/by-name/at/atf/package.nix
+++ b/pkgs/by-name/at/atf/package.nix
@@ -45,6 +45,18 @@ stdenv'.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  configureFlags =
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      "ATF_SHELL=${darwin.bootstrapStdenv.shell}"
+    ]
+    # When cross-compiling, autoconf cannot run test programs on the build host.
+    # Pre-set cache variables so configure skips those AC_RUN_IFELSE checks.
+    ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "kyua_cv_getopt_plus=yes"
+      "kyua_cv_attribute_noreturn=yes"
+      "kyua_cv_getcwd_works=yes"
+    ];
+
   enableParallelBuilding = true;
 
   makeFlags = [


### PR DESCRIPTION


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
this is a continuation of https://github.com/NixOS/nixpkgs/pull/414036. without this change some musl linux builds fail on darwin.
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

this is a continuation of https://github.com/NixOS/nixpkgs/pull/414036. without this change some musl cross compile builds fail on darwin. I verified by compiling ATF and cross-compiling `mls_validation_service` in xmtp/libxmtp against musl and this nixpkgs set, i.e `nix build github:xmtp/libxmtp/main#validation-service-image`. without this change the cross compile fails on darwin.

resolves https://github.com/NixOS/nixpkgs/issues/413910
resolves https://github.com/NixOS/nixpkgs/issues/420029

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
