### PR TITLE
revive: 1.11.0 -> 1.15.0

### DIFF
--- a/pkgs/by-name/re/revive/package.nix
+++ b/pkgs/by-name/re/revive/package.nix
@@ -1,58 +1,44 @@
 {
   buildGoModule,
-  fetchFromGitHub,
-  go,
   lib,
-  makeWrapper,
+  fetchFromGitHub,
+  stdenv,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "revive";
-  version = "1.11.0";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "mgechev";
     repo = "revive";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-89BlSc2tgxAJUGZM951fF+0H+SOsl0+xz/G18neRZxI=";
-    # populate values that require us to use git. By doing this in postFetch we
-    # can delete .git afterwards and maintain better reproducibility of the src.
-    leaveDotGit = true;
-    postFetch = ''
-      date -u -d "@$(git -C $out log -1 --pretty=%ct)" "+%Y-%m-%d %H:%M UTC" > $out/DATE
-      git -C $out rev-parse HEAD > $out/COMMIT
-      rm -rf $out/.git
-    '';
+    hash =
+      if stdenv.hostPlatform.isDarwin then
+        "sha256-SfMI9qLk/L4Zh5kgqEO0QoqonBQTl5JCuickpe1Q3lU=" # For some reason there is a hash mismatch on darwin.
+      else
+        "sha256-38NFrKNkVp3hvv5/4bT2JR6mi5Pb7Atx/1xbx5HmOX4=";
   };
-  vendorHash = "sha256-ZxTBGcGSRWlYFBz0+5wR/9d8p7lvjJjyId5VNIVW9rQ=";
+
+  vendorHash = "sha256-KxDWd+fd30eOttNEB6kQDxc2Lnf5Rj2zTCohjyfjMnU=";
+
+  # Only build the revive package at the root.
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"
-    "-w"
-    "-X github.com/mgechev/revive/cli.version=${finalAttrs.version}"
+    "-w" # Best practice for removing debugging information in a production environment.
+    "-X github.com/mgechev/revive/cli.version=${finalAttrs.version}" # Necessary for the executable to be aware of its own version.
     "-X github.com/mgechev/revive/cli.builtBy=nix"
   ];
 
-  # ldflags based on metadata from git and source
-  preBuild = ''
-    ldflags+=" -X github.com/mgechev/revive/cli.commit=$(cat COMMIT)"
-    ldflags+=" -X 'github.com/mgechev/revive/cli.date=$(cat DATE)'"
-  '';
-
-  allowGoReference = true;
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  postFixup = ''
-    wrapProgram $out/bin/revive \
-      --prefix PATH : ${lib.makeBinPath [ go ]}
-  '';
-
   meta = {
     description = "Fast, configurable, extensible, flexible, and beautiful linter for Go";
-    mainProgram = "revive";
+    longDescription = "Drop-in replacement for golint. Revive provides a framework for development of custom rules, and lets you define a strict preset for enhancing your development & code review processes";
     homepage = "https://revive.run";
+    downloadPage = "https://github.com/mgechev/revive";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ andrewfield ];
+    mainProgram = "revive";
   };
 })

--- a/pkgs/by-name/re/revive/package.nix
+++ b/pkgs/by-name/re/revive/package.nix
@@ -1,30 +1,33 @@
 {
   buildGoModule,
   fetchFromGitHub,
-  go,
   lib,
-  makeWrapper,
+  stdenv,
+  testers,
+  revive,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "revive";
-  version = "1.11.0";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "mgechev";
     repo = "revive";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-89BlSc2tgxAJUGZM951fF+0H+SOsl0+xz/G18neRZxI=";
-    # populate values that require us to use git. By doing this in postFetch we
-    # can delete .git afterwards and maintain better reproducibility of the src.
-    leaveDotGit = true;
+    hash = "sha256-FA3IP8TNY911CasYI+m+qpNCvFgMcJ0jUeT1Gk8frAw=";
+
     postFetch = ''
-      date -u -d "@$(git -C $out log -1 --pretty=%ct)" "+%Y-%m-%d %H:%M UTC" > $out/DATE
-      git -C $out rev-parse HEAD > $out/COMMIT
-      rm -rf $out/.git
+      # The repository currently has a 'v1' and 'V1' directory.
+      # On Darwin these are treated as the same. To prevent a hash mismatch, remove the directory.
+      rm -r $out/testdata/package_directory_mismatch/api
     '';
   };
-  vendorHash = "sha256-ZxTBGcGSRWlYFBz0+5wR/9d8p7lvjJjyId5VNIVW9rQ=";
+
+  vendorHash = "sha256-KxDWd+fd30eOttNEB6kQDxc2Lnf5Rj2zTCohjyfjMnU=";
+
+  # Only build the revive package at the root.
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"
@@ -33,26 +36,40 @@ buildGoModule (finalAttrs: {
     "-X github.com/mgechev/revive/cli.builtBy=nix"
   ];
 
-  # ldflags based on metadata from git and source
-  preBuild = ''
-    ldflags+=" -X github.com/mgechev/revive/cli.commit=$(cat COMMIT)"
-    ldflags+=" -X 'github.com/mgechev/revive/cli.date=$(cat DATE)'"
-  '';
+  passthru.tests = {
+    version = testers.testVersion { package = revive; };
+    simple-execution = testers.runCommand {
+      name = "Executes the linter";
+      nativeBuildInputs = [ finalAttrs.finalPackage ];
+      script = ''
+        # Write a simple go program.
+        cat > main.go << EOF
+        // The main package
+        package main
 
-  allowGoReference = true;
+        import "fmt"
 
-  nativeBuildInputs = [ makeWrapper ];
+        func main() {
+          fmt.Println("Hello World")
+        }
+        EOF
 
-  postFixup = ''
-    wrapProgram $out/bin/revive \
-      --prefix PATH : ${lib.makeBinPath [ go ]}
-  '';
+        # This will return an exit status of 1 if there are errors and the test will fail.
+        revive -set_exit_status main.go
+
+        # Test successful.
+        touch $out
+      '';
+    };
+  };
 
   meta = {
     description = "Fast, configurable, extensible, flexible, and beautiful linter for Go";
     mainProgram = "revive";
+    longDescription = "Drop-in replacement for golint. Revive provides a framework for development of custom rules, and lets you define a strict preset for enhancing your development & code review processes";
     homepage = "https://revive.run";
+    downloadPage = "https://github.com/mgechev/revive";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ andrewfield ];
   };
 })


### PR DESCRIPTION
I have made the following changes.
- Updated the version.
- Added myself as a maintainer.
- Removed some of the over complications and non-reproducible parts, like altering the date.
- Added package tests.

Home page: https://revive.run
Source code:  https://github.com/mgechev/revive

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
