### PR TITLE
neve: init at 3.0.0

### DIFF
--- a/pkgs/by-name/ne/neve/package.nix
+++ b/pkgs/by-name/ne/neve/package.nix
@@ -18,8 +18,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-c5SwgLMHEuXoR11QACUHnMy9paQsNFXLcoVQfXdrLQo=";
 
-  cargoBuildFlags = [ "--package" "neve" ];
-  cargoTestFlags = [ "--package" "neve" ];
+  cargoBuildFlags = [
+    "--package"
+    "neve"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "neve"
+  ];
   doCheck = false;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ne/neve/package.nix
+++ b/pkgs/by-name/ne/neve/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "neve";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "MCB-SMART-BOY";
+    repo = "Neve";
+    rev = "v${version}";
+    hash = "sha256-ICqAkj7JbQhnJ8U7kYs4EaA7k8hBVP0ZSqc9rWZrzhY=";
+  };
+
+  cargoHash = "sha256-c5SwgLMHEuXoR11QACUHnMy9paQsNFXLcoVQfXdrLQo=";
+
+  cargoBuildFlags = [ "--package" "neve" ];
+  cargoTestFlags = [ "--package" "neve" ];
+  doCheck = false;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Pure functional language for system configuration and package management";
+    homepage = "https://github.com/MCB-SMART-BOY/Neve";
+    license = licenses.mpl20;
+    mainProgram = "neve";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/ne/neve/package.nix
+++ b/pkgs/by-name/ne/neve/package.nix
@@ -3,20 +3,21 @@
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
+  perl,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "neve";
-  version = "1.0.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "MCB-SMART-BOY";
     repo = "Neve";
     rev = "v${version}";
-    hash = "sha256-ICqAkj7JbQhnJ8U7kYs4EaA7k8hBVP0ZSqc9rWZrzhY=";
+    hash = "sha256-1+9USxixmcH5WCG6PDm2bIcONmNCySBWf0Y/H1eKKK0=";
   };
 
-  cargoHash = "sha256-c5SwgLMHEuXoR11QACUHnMy9paQsNFXLcoVQfXdrLQo=";
+  cargoHash = "sha256-TmJzCaImYJzkbIZAVy/ig4re94mG4X5oDGmBs3Y3xd8=";
 
   cargoBuildFlags = [
     "--package"
@@ -30,6 +31,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
+    perl
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Summary
- update  from 1.0.0 to 3.0.0
- refresh  and 
- add  to  because vendored OpenSSL now requires it during build

## Testing
- nix --extra-experimental-features 'nix-command flakes' build ../nixpkgs#neve --no-link