### PR TITLE
gridix: init at 7.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17212,6 +17212,12 @@
     githubId = 2971615;
     name = "Marius Bergmann";
   };
+  mcbsmartboy = {
+    email = "mcb2720838051@gmail.com";
+    github = "MCB-SMART-BOY";
+    githubId = 177301053;
+    name = "mcb";
+  };
   mccartykim = {
     email = "mccartykim@zoho.com";
     github = "mccartykim";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18085,6 +18085,12 @@
     githubId = 2971615;
     name = "Marius Bergmann";
   };
+  mcbsmartboy = {
+    email = "mcb2720838051@gmail.com";
+    github = "MCB-SMART-BOY";
+    githubId = 177301053;
+    name = "mcb";
+  };
   mccartykim = {
     email = "mccartykim@zoho.com";
     github = "mccartykim";

--- a/pkgs/by-name/gr/gridix/package.nix
+++ b/pkgs/by-name/gr/gridix/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+  openssl,
+  xdotool,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "gridix";
+  version = "6.1.0";
+
+  src = fetchFromGitHub {
+    owner = "MCB-SMART-BOY";
+    repo = "Gridix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IsnKK+drjOfO2eg2Nlir73n9t68FDU2Csz4cAyjMtOI=";
+  };
+
+  cargoHash = "sha256-w/zboD6N7zSX7McBCmDoyntJQ6cKjw2bNstxWXKQrAw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    openssl
+    xdotool
+  ];
+
+  preCheck = ''
+    export RUST_TEST_THREADS=1
+  '';
+
+  meta = {
+    description = "Fast, secure database management tool with Helix/Vim keybindings";
+    longDescription = ''
+      Gridix is a keyboard-driven database management tool supporting SQLite,
+      PostgreSQL, and MySQL. Features include SSH tunneling, SSL/TLS encryption,
+      AES-256-GCM encrypted password storage, 19 built-in themes, and Helix/Vim-style
+      keybindings for efficient navigation and editing.
+    '';
+    homepage = "https://github.com/MCB-SMART-BOY/Gridix";
+    changelog = "https://github.com/MCB-SMART-BOY/Gridix/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mcbsmartboy ];
+    mainProgram = "gridix";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gr/gridix/package.nix
+++ b/pkgs/by-name/gr/gridix/package.nix
@@ -13,16 +13,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "gridix";
-  version = "6.0.0";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "MCB-SMART-BOY";
     repo = "Gridix";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7tiuDtHsc294XyuFrLzJ+uQN2SGxcPs4V7QeXx4yXKc=";
+    hash = "sha256-IsnKK+drjOfO2eg2Nlir73n9t68FDU2Csz4cAyjMtOI=";
   };
 
-  cargoHash = "sha256-/COHhHKETcw+hjpYEjexIhNB5cqFb+OJoTELAC5Z2w4=";
+  cargoHash = "sha256-w/zboD6N7zSX7McBCmDoyntJQ6cKjw2bNstxWXKQrAw=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/gr/gridix/package.nix
+++ b/pkgs/by-name/gr/gridix/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+  openssl,
+  xdotool,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "gridix";
+  version = "6.0.0";
+
+  src = fetchFromGitHub {
+    owner = "MCB-SMART-BOY";
+    repo = "Gridix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7tiuDtHsc294XyuFrLzJ+uQN2SGxcPs4V7QeXx4yXKc=";
+  };
+
+  cargoHash = "sha256-/COHhHKETcw+hjpYEjexIhNB5cqFb+OJoTELAC5Z2w4=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    openssl
+    xdotool
+  ];
+
+  preCheck = ''
+    export RUST_TEST_THREADS=1
+  '';
+
+  meta = {
+    description = "Fast, secure database management tool with Helix/Vim keybindings";
+    longDescription = ''
+      Gridix is a keyboard-driven database management tool supporting SQLite,
+      PostgreSQL, and MySQL. Features include SSH tunneling, SSL/TLS encryption,
+      AES-256-GCM encrypted password storage, 19 built-in themes, and Helix/Vim-style
+      keybindings for efficient navigation and editing.
+    '';
+    homepage = "https://github.com/MCB-SMART-BOY/Gridix";
+    changelog = "https://github.com/MCB-SMART-BOY/Gridix/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mcbsmartboy ];
+    mainProgram = "gridix";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Summary
- add Gridix 7.2.0 under pkgs/by-name/gr/gridix
- add maintainer entry for mcbsmartboy
- package the egui/eframe desktop app for Linux

## Testing
- `NIX_BUILD_CORES=1 nix-build --max-jobs 1 --no-out-link -E 'with import <nixpkgs> {}; callPackage ./pkgs/by-name/gr/gridix/package.nix {}'`
- 756 tests passed during the Nix build
