### PR TITLE
satochip-utils: init at 0.4.0-beta, pythonPackages.pycryptotools: init at 0.3.1

### DIFF
--- a/pkgs/by-name/sa/satochip-utils/package.nix
+++ b/pkgs/by-name/sa/satochip-utils/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeBinaryWrapper,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "satochip-utils";
+  version = "0.4.0-beta";
+  format = "other";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Toporin";
+    repo = "Satochip-Utils";
+    tag = "v${version}";
+    hash = "sha256-QOnW06sfSPN7tgsAfJYySpY4/+53x1hmxFJK/9s9Jhc=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeBinaryWrapper
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    cbor2
+    customtkinter
+    mnemonic
+    pillow
+    pycryptotools
+    pyperclip
+    pyqrcode
+    pysatochip
+    pyscard
+    tkinter
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/lib/satochip-utils
+    cp -r . $out/lib/satochip-utils/
+
+    makeBinaryWrapper ${python3.interpreter} $out/bin/satochip-utils \
+      --set PYTHONPATH "$PYTHONPATH:$out/lib/satochip-utils" \
+      --add-flags "$out/lib/satochip-utils/satochip_utils.py"
+
+    install -Dm644 satochip_utils.png $out/share/icons/hicolor/128x128/apps/satochip-utils.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "Satochip Utils";
+      comment = "Configure your Satochip, Satodime or Seedkeeper hardware wallet card";
+      categories = [
+        "Finance"
+        "Security"
+        "Utility"
+      ];
+    })
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "GUI tool to configure Satochip, Satodime and Seedkeeper hardware wallet cards";
+    homepage = "https://satochip.io/satochip-utils/";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ stargate01 ];
+    mainProgram = "satochip-utils";
+  };
+}

--- a/pkgs/development/python-modules/pycryptotools/default.nix
+++ b/pkgs/development/python-modules/pycryptotools/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  base58,
+  cashaddress,
+  pbkdf2,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "pycryptotools";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-oXvBit2Z8o6QXC12ob1jX9A0wsev6Kfbtwz/fBmnRls=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    base58
+    cashaddress
+    pbkdf2
+    requests
+  ];
+
+  pythonImportsCheck = [ "pycryptotools" ];
+
+  meta = {
+    description = "Python crypto coin tools";
+    homepage = "https://github.com/Toporin/pycryptotools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stargate01 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13530,6 +13530,8 @@ self: super: with self; {
 
   pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
 
+  pycryptotools = callPackage ../development/python-modules/pycryptotools { };
+
   pycsdr = callPackage ../development/python-modules/pycsdr { };
 
   pycsspeechtts = callPackage ../development/python-modules/pycsspeechtts { };


### PR DESCRIPTION
This PR adds `Satochip Utils` (https://satochip.io/satochip-utils/), a desktop tool to manage Satochip hardware key cards via PC/SC. In addition, the required Python package pycryptotools (https://pypi.org/project/pycryptotools/), a library by Satochip for "Crypto coins signatures and transactions" is packaged as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
