### PR TITLE
sc68: unstable-2022-11-24 -> 2.2.1-unstable-2024-09-09

### DIFF
--- a/pkgs/by-name/sc/sc68/package.nix
+++ b/pkgs/by-name/sc/sc68/package.nix
@@ -15,15 +15,22 @@
 
 stdenv.mkDerivation {
   pname = "sc68";
-  version = "unstable-2022-11-24";
+  version = "2.2.1-unstable-2024-09-09";
 
   src = fetchsvn {
     url = "svn://svn.code.sf.net/p/sc68/code/";
-    rev = "695";
-    sha256 = "sha256-RO3Yhjalu49BUM0fYOZtI2l6KbuUuw03whRxlKneabo=";
+    rev = "713";
+    sha256 = "sha256-kiOHUixsf/2mFMzi6P7oC7ujyydLO7K3w7Vwr/GMOvY=";
   };
 
-  preConfigure = "tools/svn-bootstrap.sh";
+  postPatch = ''
+    substituteInPlace vcversion.sh \
+      --replace-fail 'date -u "+%Y%m%d"' 'date -u --date=@$SOURCE_DATE_EPOCH "+%Y%m%d"'
+  '';
+
+  preConfigure = ''
+    tools/svn-bootstrap.sh
+  '';
 
   enableParallelBuilding = true;
 
@@ -41,6 +48,9 @@ stdenv.mkDerivation {
     libao
     zlib
   ];
+
+  # Doesn't specify any standard target, but it's >20yo code
+  env.CFLAGS = "-std=c99";
 
   meta = {
     description = "Atari ST and Amiga music player";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
