### PR TITLE
python3Packages.apache-beam: 2.71.0 -> 2.72.0

### DIFF
--- a/pkgs/development/python-modules/apache-beam/default.nix
+++ b/pkgs/development/python-modules/apache-beam/default.nix
@@ -29,6 +29,7 @@
   numpy,
   objsize,
   orjson,
+  pillow,
   proto-plus,
   protobuf,
   pyarrow,
@@ -65,14 +66,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "apache-beam";
-  version = "2.71.0";
+  version = "2.72.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "beam";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pIuRaBN1lmC3EMuUnBovl/pBmNwsDZ/vh/OM/sD9SrI=";
+    hash = "sha256-HlpaKDX/w6g6q8nOB8G83q4/ffgymk/XyTpwYVpbd2U=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/sdks/python";
@@ -120,6 +121,7 @@ buildPythonPackage (finalAttrs: {
     numpy
     objsize
     orjson
+    pillow
     proto-plus
     protobuf
     pyarrow
@@ -241,6 +243,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
+    # importlib.metadata.PackageNotFoundError: No package metadata was found for pip
+    "test_populate_requirements_cache_uses_find_links"
+
     # AssertionError: Lists differ:
     # ['pickled_main_session', 'submission_environment_dependencies.txt'] != ['pickled_main_session']
     "test_main_session_staged_when_using_cloudpickle"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/apache/beam/compare/v2.71.0...v2.72.0
Changelog: https://github.com/apache/beam/blob/v2.72.0/CHANGES.md

cc @ndl

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test