### PR TITLE
raiderio-client: init at 4.10.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9453,6 +9453,12 @@
     githubId = 33058747;
     name = "Gaetan Lepage";
   };
+  Gako358 = {
+    email = "merrinx@proton.me";
+    github = "Gako358";
+    githubId = 42249650;
+    name = "Knut Oien";
+  };
   gal_bolle = {
     email = "florent.becker@ens-lyon.org";
     github = "FlorentBecker";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9475,6 +9475,12 @@
     githubId = 33058747;
     name = "Gaetan Lepage";
   };
+  Gako358 = {
+    email = "merrinx@proton.me";
+    github = "Gako358";
+    githubId = 42249650;
+    name = "Knut Oien";
+  };
   gal_bolle = {
     email = "florent.becker@ens-lyon.org";
     github = "FlorentBecker";

--- a/pkgs/by-name/ra/raiderio-client/package.nix
+++ b/pkgs/by-name/ra/raiderio-client/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  nix-update-script,
+}:
+
+let
+  version = "4.10.7";
+  pname = "raiderio-client";
+
+  src = fetchurl {
+    url = "https://github.com/RaiderIO/raiderio-client-builds/releases/download/v${version}/RaiderIO_Installer_Linux_x86_64.AppImage";
+    hash = "sha256-6YkX4DUZLK1F0hP36FGmH3lyDITqjTwyfq9Aqinqi7A=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  passthru.updateScript = nix-update-script { };
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/scalable/${pname}.svg \
+      $out/share/icons/hicolor/scalable/apps/${pname}.svg
+  '';
+
+  meta = {
+    description = "RaiderIO Desktop Client for World of Warcraft Mythic+ and Raid tracking";
+    longDescription = ''
+      The RaiderIO Desktop Client keeps your Raider.IO addon up to date and
+      provides Mythic+ and Raid profile data for World of Warcraft players.
+    '';
+    mainProgram = "raiderio-client";
+    homepage = "https://raider.io/addon";
+    downloadPage = "https://github.com/RaiderIO/raiderio-client-builds/releases";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ Gako358 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/ra/raiderio-client/package.nix
+++ b/pkgs/by-name/ra/raiderio-client/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  nix-update-script,
+}:
+
+let
+  version = "4.12.0";
+  pname = "raiderio-client";
+
+  src = fetchurl {
+    url = "https://github.com/RaiderIO/raiderio-client-builds/releases/download/v${version}/RaiderIO_Installer_Linux_x86_64.AppImage";
+    hash = "sha256-iHZ18buYGxP8qEs/Bp10QYS/0wwAUj5rbPprJH/3QLk=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  passthru.updateScript = nix-update-script { };
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/scalable/${pname}.svg \
+      $out/share/icons/hicolor/scalable/apps/${pname}.svg
+  '';
+
+  meta = {
+    description = "RaiderIO Desktop Client for World of Warcraft Mythic+ and Raid tracking";
+    longDescription = ''
+      The RaiderIO Desktop Client keeps your Raider.IO addon up to date and
+      provides Mythic+ and Raid profile data for World of Warcraft players.
+    '';
+    mainProgram = "raiderio-client";
+    homepage = "https://raider.io/addon";
+    downloadPage = "https://github.com/RaiderIO/raiderio-client-builds/releases";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ Gako358 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
RaiderIO Desktop Client for World of Warcraft — keeps the Raider.IO addon up to date and provides Mythic+ and Raid profile data.

Homepage: https://raider.io/addon
Upstream releases: https://github.com/RaiderIO/raiderio-client-builds/releases

Packaged from the upstream AppImage using `appimageTools.wrapType2`.

Build and testet locally, working.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
