### PR TITLE
netwatch: init at 0.11.1

### DIFF
--- a/pkgs/by-name/ne/netwatch/package.nix
+++ b/pkgs/by-name/ne/netwatch/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  libpcap,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "netwatch";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "matthart1983";
+    repo = "netwatch";
+    tag = "v${version}";
+    hash = "sha256-Isv5xtR8NDB6zU45Kfu0JAbe0MHyUYYJStZh0ble0fY=";
+  };
+
+  cargoHash = "sha256-+/GK9now28Ujidp888EQDlturehDv3v2woO9xq5p/3U=";
+
+  buildInputs = [
+    libpcap
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Real-time network diagnostics in your terminal";
+    longDescription = ''
+      Real-time network diagnostics in your terminal.
+      One command, zero config, instant visibility.
+    '';
+    homepage = "https://github.com/matthart1983/netwatch";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ blemouzy ];
+    mainProgram = "netwatch";
+  };
+}


### PR DESCRIPTION
Add the new package netwatch (https://github.com/matthart1983/netwatch).
netwatch is a real-time network diagnostics in terminal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
