### PR TITLE
rocmPackages: 7.2.1 -> 7.2.2

### DIFF
--- a/pkgs/development/rocm-modules/amdsmi/default.nix
+++ b/pkgs/development/rocm-modules/amdsmi/default.nix
@@ -21,7 +21,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "amdsmi";
-  version = "7.2.1";
+  version = "7.2.2";
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rocm-systems";

--- a/pkgs/development/rocm-modules/aqlprofile/default.nix
+++ b/pkgs/development/rocm-modules/aqlprofile/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "aqlprofile";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/clr/default.nix
+++ b/pkgs/development/rocm-modules/clr/default.nix
@@ -70,7 +70,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "clr";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
       "projects/clr"
       "shared"
     ];
-    hash = "sha256-8V2WbyaJZbEcKZpF/xvg0p+3oX9f/zy/45rkKZT9R3o=";
+    hash = "sha256-Xfo6513ERdEoLy+iknQbEgPG7InLcU7E7ssZd4HMvpI=";
   };
   sourceRoot = "${finalAttrs.src.name}/projects/clr";
 

--- a/pkgs/development/rocm-modules/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/base.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   pname = "composable_kernel_base";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/half/default.nix
+++ b/pkgs/development/rocm-modules/half/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "half";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/hip-common/default.nix
+++ b/pkgs/development/rocm-modules/hip-common/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hip-common";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/hipblas-common/default.nix
+++ b/pkgs/development/rocm-modules/hipblas-common/default.nix
@@ -8,7 +8,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblas-common";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/hipblas/default.nix
+++ b/pkgs/development/rocm-modules/hipblas/default.nix
@@ -24,7 +24,7 @@
 # Can also use cuBLAS
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblas";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/hipblaslt/default.nix
+++ b/pkgs/development/rocm-modules/hipblaslt/default.nix
@@ -70,7 +70,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblaslt${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/hipcub/default.nix
+++ b/pkgs/development/rocm-modules/hipcub/default.nix
@@ -17,7 +17,7 @@
 # CUB can also be used as a backend instead of rocPRIM.
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipcub";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/hipfft/default.nix
+++ b/pkgs/development/rocm-modules/hipfft/default.nix
@@ -21,7 +21,7 @@
 # Can also use cuFFT
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipfft";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/hipfort/default.nix
+++ b/pkgs/development/rocm-modules/hipfort/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipfort";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/hipify/default.nix
+++ b/pkgs/development/rocm-modules/hipify/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipify";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/hiprand/default.nix
+++ b/pkgs/development/rocm-modules/hiprand/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hiprand";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/hipsolver/default.nix
+++ b/pkgs/development/rocm-modules/hipsolver/default.nix
@@ -21,7 +21,7 @@
 # Can also use cuSOLVER
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipsolver";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/hipsparse/default.nix
+++ b/pkgs/development/rocm-modules/hipsparse/default.nix
@@ -19,7 +19,7 @@
 # This can also use cuSPARSE as a backend instead of rocSPARSE
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipsparse";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/llvm/default.nix
+++ b/pkgs/development/rocm-modules/llvm/default.nix
@@ -36,7 +36,7 @@
 }:
 
 let
-  version = "7.2.1";
+  version = "7.2.2";
   # major version of this should be the clang version ROCm forked from
   rocmLlvmVersion = "22.0.0-rocm";
   # llvmPackages_base version should match rocmLlvmVersion

--- a/pkgs/development/rocm-modules/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/migraphx/default.nix
@@ -59,7 +59,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "migraphx";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "AMDMIGraphX";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-2jNdbfDLHqifCst8yPiJy7y2/PIaaVS9101p3VZTvnc=";
+    hash = "sha256-jHAdlqRhEiBtU4h76k0NTGUABiOmb3xKADr5sWme4+8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -44,7 +44,7 @@
 let
   # FIXME: cmake files need patched to include this properly
   cFlags = "-Wno-documentation-pedantic --offload-compress -I${hipblas-common}/include -I${hipblas}/include -I${roctracer}/include -I${nlohmann_json}/include -I${sqlite.dev}/include -I${rocrand}/include";
-  version = "7.2.1";
+  version = "7.2.2";
 
   # Targets outside this list will get
   # error: use of undeclared identifier 'CK_BUFFER_RESOURCE_3RD_DWORD'

--- a/pkgs/development/rocm-modules/mivisionx/default.nix
+++ b/pkgs/development/rocm-modules/mivisionx/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
         "cpu"
     );
 
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rccl/default.nix
+++ b/pkgs/development/rocm-modules/rccl/default.nix
@@ -40,7 +40,7 @@ in
 # infiniband ib_peer_mem support isn't in the mainline kernel but is carried by some distros
 stdenv.mkDerivation (finalAttrs: {
   pname = "rccl${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rdc/default.nix
+++ b/pkgs/development/rocm-modules/rdc/default.nix
@@ -49,7 +49,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rdc";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocalution/default.nix
+++ b/pkgs/development/rocm-modules/rocalution/default.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocalution";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/rocblas/default.nix
@@ -40,7 +40,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocblas${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocdbgapi/default.nix
+++ b/pkgs/development/rocm-modules/rocdbgapi/default.nix
@@ -47,7 +47,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocdbgapi";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocfft/default.nix
+++ b/pkgs/development/rocm-modules/rocfft/default.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocfft${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocgdb/default.nix
+++ b/pkgs/development/rocm-modules/rocgdb/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocgdb";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocm-cmake/default.nix
+++ b/pkgs/development/rocm-modules/rocm-cmake/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-cmake";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocm-core/default.nix
+++ b/pkgs/development/rocm-modules/rocm-core/default.nix
@@ -17,7 +17,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-core";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/rocm-runtime/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-runtime";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocm-smi/default.nix
+++ b/pkgs/development/rocm-modules/rocm-smi/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-smi";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/rocminfo/default.nix
@@ -12,7 +12,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "7.2.1";
+  version = "7.2.2";
   pname = "rocminfo";
 
   src = fetchFromGitHub {

--- a/pkgs/development/rocm-modules/rocmlir/default.nix
+++ b/pkgs/development/rocm-modules/rocmlir/default.nix
@@ -42,7 +42,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocmlir${suffix}";
-  version = "7.2.0";
+  version = "7.2.2";
 
   outputs = [
     "out"
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "rocMLIR";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-gg37odxZETpH7HqY+44KQta6f0vxfcxhzMAqxU6vicY=";
+    hash = "sha256-0OvQT8pX6GbEqUwuauKGI66IHw8dsnt5mIijnzYyiRc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/rocm-modules/rocprim/default.nix
+++ b/pkgs/development/rocm-modules/rocprim/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprim";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprofiler-register";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/default.nix
@@ -46,7 +46,7 @@
 # rocprofiler-sdk is the home of rocprofv3
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprofiler-sdk";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-P8c1/HtkdLlZRTMaOFhFF7a/0SlsOabnUwci1w1Svfc=";
+    hash = "sha256-SQjV1FnAgnK1LS5SiApgfvDSjB3AKpucja+PBZSmLvQ=";
     fetchSubmodules = true;
     sparseCheckout = [
       "projects/rocprofiler-sdk"

--- a/pkgs/development/rocm-modules/rocprofiler-sdk/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-sdk/default.nix
@@ -12,6 +12,7 @@
   rocprof-trace-decoder,
   aqlprofile,
   rocm-comgr,
+  rocmUpdateScript,
   rccl,
   python3,
   python3Packages,
@@ -200,6 +201,8 @@ stdenv.mkDerivation (finalAttrs: {
     mv $out/lib/cmake $dev/lib/
     mv $out/share/rocprofiler-sdk/{samples,tests} $dev/share/rocprofiler-sdk/
   '';
+
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm GPU performance analysis SDK";

--- a/pkgs/development/rocm-modules/rocprofiler/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler/default.nix
@@ -44,7 +44,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprofiler";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocr-debug-agent/default.nix
+++ b/pkgs/development/rocm-modules/rocr-debug-agent/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocr-debug-agent";
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/rocrand/default.nix
+++ b/pkgs/development/rocm-modules/rocrand/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocrand${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocsolver/default.nix
+++ b/pkgs/development/rocm-modules/rocsolver/default.nix
@@ -37,7 +37,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsolver${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocsparse/default.nix
+++ b/pkgs/development/rocm-modules/rocsparse/default.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsparse${clr.gpuArchSuffix}";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rocthrust/default.nix
+++ b/pkgs/development/rocm-modules/rocthrust/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocthrust";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/roctracer/default.nix
+++ b/pkgs/development/rocm-modules/roctracer/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "roctracer";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       "projects/roctracer"
       "shared"
     ];
-    hash = "sha256-KUNLX5ZonE0bW/xOacD3k3hCcg7M3Vk1dM3WQSDYMvM=";
+    hash = "sha256-Ps9b/MMdxXthGV96ZDg0kZGPdmn7Sy5if1a/Fjx2fEE=";
   };
   sourceRoot = "${finalAttrs.src.name}/projects/roctracer";
 

--- a/pkgs/development/rocm-modules/rocwmma/default.nix
+++ b/pkgs/development/rocm-modules/rocwmma/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocwmma";
-  version = "7.2.1";
+  version = "7.2.2";
 
   outputs = [
     "out"

--- a/pkgs/development/rocm-modules/rpp/default.nix
+++ b/pkgs/development/rocm-modules/rpp/default.nix
@@ -19,7 +19,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "rpp-${if useCPU then "cpu" else "hip"}";
 
-  version = "7.2.1";
+  version = "7.2.2";
 
   src = fetchFromGitHub {
     owner = "ROCm";

--- a/pkgs/development/rocm-modules/tensile/default.nix
+++ b/pkgs/development/rocm-modules/tensile/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "tensile";
-  version = "7.2.1";
+  version = "7.2.2";
   pyproject = true;
 
   src = fetchFromGitHub {


### PR DESCRIPTION
https://rocm.docs.amd.com/en/docs-7.2.2/about/release-notes.html

There were very few hash changes for this bump, most packages had no diff.

7e6ebca4ba6c (+0    -0    ~0   ) rocmPackages.rocprofiler-sdk: set updateScript
388127f06ebc (+0    -0    ~92  ) rocmPackages: 7.2.1 -> 7.2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
