### PR TITLE
areofyl-fetch: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22762,6 +22762,11 @@
     githubId = 77415970;
     name = "Redhawk";
   };
+  redhood = {
+     name = "Alice Liddell"
+     github = "red-hood-woods"
+     githubId = "258934709"
+  };
   redianthus = {
     github = "redianthus";
     githubId = 16472988;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22763,9 +22763,9 @@
     name = "Redhawk";
   };
   redhood = {
-     name = "Alice Liddell"
-     github = "red-hood-woods"
-     githubId = "258934709"
+     name = "Alice Liddell";
+     github = "red-hood-woods";
+     githubId = "258934709";
   };
   redianthus = {
     github = "redianthus";

--- a/pkgs/by-name/fe/fetch-3d/package.nix
+++ b/pkgs/by-name/fe/fetch-3d/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, fastfetch
+}:
+
+stdenv.mkDerivation rec {
+  pname = "fetch-3d";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "areofyl";
+    repo = "fetch";
+    rev = "master";
+    hash = "sha256-ybqmVtCAtP0Pg8ZmrW/boVUMnTfe4o+D9eAy/unqZ1w=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ fastfetch ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    make install PREFIX=$out
+    
+    wrapProgram $out/bin/fetch \
+      --prefix PATH : ${lib.makeBinPath [ fastfetch ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "An animated 3D fetch tool for your terminal";
+    homepage = "https://github.com/areofyl/fetch";
+    license = licenses.isc;
+    platforms = platforms.linux;
+    mainProgram = "fetch";
+    maintainers = with maintainers; [ red-hood-woods ]; 
+  };
+}

--- a/pkgs/by-name/fe/fetch-3d/package.nix
+++ b/pkgs/by-name/fe/fetch-3d/package.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchFromGitHub
 , makeWrapper
-, fastfetch
 }:
 
 stdenv.mkDerivation rec {
@@ -13,20 +12,16 @@ stdenv.mkDerivation rec {
     owner = "areofyl";
     repo = "fetch";
     rev = "master";
-    hash = "sha256-ybqmVtCAtP0Pg8ZmrW/boVUMnTfe4o+D9eAy/unqZ1w=";
+    sha256 = "08ky9k6l6pd5di0caj3a3naz2bafpjf4rqyvh0bnl6czww6632p4";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-
-  buildInputs = [ fastfetch ];
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
     make install PREFIX=$out
-    
-    wrapProgram $out/bin/fetch \
-      --prefix PATH : ${lib.makeBinPath [ fastfetch ]}
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
Fastfetch with 3d rotating assci
-->
Fastfetch with 3d rotating assci
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
