### PR TITLE
CI: add new workflow for test driver tests

### DIFF
--- a/.github/workflows/nixos-test-driver.yml
+++ b/.github/workflows/nixos-test-driver.yml
@@ -1,0 +1,39 @@
+name: NixOS test driver
+
+on:
+  pull_request:
+    paths:
+      - 'nixos/lib/test-driver/**'
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31.10.4
+        with:
+          extra_nix_config: |
+            sandbox = true
+            auto-allocate-uids = true
+            extra-system-features = uid-range
+            experimental-features = nix-command auto-allocate-uids cgroups
+            extra-sandbox-paths = /dev/net
+
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
+        continue-on-error: true
+        with:
+          name: ${{ vars.CACHIX_NAME || 'nixpkgs-gha' }}
+          extraPullNames: nixpkgs-gha
+
+      - name: Run nixos-test-driver tests
+        run: nix-build -A nixosTests.nixos-test-driver


### PR DESCRIPTION
Currently, the test suite for the nixos test driver needs to be triggered manually on PRs. 
This PR adds a new github CI workflow that runs the test suite automatically whenever a file under `nixos/lib/test-driver/**` changed. This mechanism does not catch all changes to the test driver but it should cover the majority of breaking changes.

I adopted the 1h timeout and action versions from the existing build.yml.

Since KVM is not available in the github runners, the tests will be very slow but hopefully still finish within 1h.

Open questions:
1. Should we cache the test runs in cachix or not?
2. Do we actually need the limiting trigger on `nixos/lib/test-driver/**` or could we run this on every PR? We could also trigger the workflow based on target branch. Changes to the test driver require a mass rebuild of tests and therefore need to go to the `staging-nixos` branch. We could trigger the workflow only on PRs going to `staging-nixos`.
3. Currently, the `passthru.tests` of the test driver package only declare a single test. We could be adding all the other test driver tests there so ofborg runs them. Then we would not need this workflow at all.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
