### PR TITLE
coqPackages_8_20.coq-elpi: 2.6.0 -> 2.2.0

### DIFF
--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -20,7 +20,7 @@ let
         in
         with lib.versions;
         lib.switch coq.coq-version [
-          (case (range "8.20" "8.20") "2.0.7")
+          (case (range "8.20" "8.20") "1.19.2")
           (case (range "8.18" "8.19") "1.18.1")
           (case (range "8.16" "8.17") "1.17.0")
           (case "8.15" "1.15.0")
@@ -29,7 +29,10 @@ let
           (case "8.11" "1.11.4")
         ] coq.ocamlPackages.elpi.version
       );
-  elpi = coq.ocamlPackages.elpi.override { version = default-elpi-version; };
+  elpi = coq.ocamlPackages.elpi.override {
+    version = default-elpi-version;
+    ppx_deriving_0_33 = coq.ocamlPackages.ppx_deriving;
+  };
   propagatedBuildInputs_wo_elpi = [
     coq.ocamlPackages.findlib
   ];
@@ -44,7 +47,7 @@ let
       in
       with lib.versions;
       lib.switch coq.coq-version [
-        (case (range "8.20" "8.20") "2.6.0")
+        (case (range "8.20" "8.20") "2.2.0")
         (case (range "8.20" "8.20") "2.5.2")
         (case "8.19" "2.0.1")
         (case "8.18" "2.0.0")


### PR DESCRIPTION
Pin coqPackages_8_20.coq-elpi to the 2024-07-01 to 2025-05-01 era default (2.2.0 with elpi 1.19.2) to work around a build failure on aarch64.

ocamlPackages.elpi-2.0.7's menhir-generated grammar.ml overflows OCaml 4.14.3's aarch64 conditional-branch range, so the elpi 2.0.7 that coqPackages_8_20.coq-elpi has pulled in since 952c7177e0aef7eb15d2cf196d2c3527d27c44a4 ("coqPackages.hierarchy- builder: 1.8.1 -> 1.9.1", 2025-05-01) is unbuildable from source on aarch64-linux and aarch64-darwin with the current ocamlPackages_4_14. Adjacent elpi versions (1.18.x, 3.6.x) build fine, confirming the issue is specific to the 2.0.7 grammar.

The 2.2.0/1.19.2 pair was the previous master default for Coq 8.20 (introduced in 383e9b5696798029f18360701c6d3fb3e673b918, "coq-elpi: 2.0.1 -> 2.2.0"), so this is a historically validated combination. Other Coq versions are unaffected; 9.0/9.1 still go through the rocqPackages.rocq-elpi shim.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
