### PR TITLE
python3Packages.deep-ep: remove eval-time warning

### DIFF
--- a/pkgs/development/python-modules/deep-ep/default.nix
+++ b/pkgs/development/python-modules/deep-ep/default.nix
@@ -64,13 +64,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     {
       TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep " " cudaCapabilities'}";
 
-      DISABLE_SM90_FEATURES =
-        if disableSm90Features then
-          lib.warn ''
-            python3Packages.deepep: Disabling SM90 features as the provided `cudaCapabilities` list include '${minCudaCapability}'
-          '' "1"
-        else
-          "0";
+      DISABLE_SM90_FEATURES = if disableSm90Features then "1" else "0";
 
       CUDA_HOME = symlinkJoin {
         name = "cuda-redist";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The issue with this warning is that it gets triggered when evaluating `nixpkgs` with the default set of `cudaCapabilities`.
This makes evaluations of the [cuda-packages-unstable](https://hydra.nixos-cuda.org/jobset/nixos-cuda/cuda-packages-unstable) jobset of the NixOS-CUDA hydra fail.

Let's simply remove it.

cc @NixOS/cuda-maintainers

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
