### PR TITLE
pijul: 1.0.0-beta.9 -> 1.0.0-beta.11

### DIFF
--- a/pkgs/by-name/pi/pijul/fix-rand-0.9-sanakirja-imports.patch
+++ b/pkgs/by-name/pi/pijul/fix-rand-0.9-sanakirja-imports.patch
@@ -1,0 +1,19 @@
+--- a/src/commands/git.rs
++++ b/src/commands/git.rs
+@@ -1,6 +1,7 @@
+ use anyhow::bail;
+ use clap::{Parser, ValueHint};
+ use libpijul::pristine::*;
++use ::sanakirja::RootPageMut as _;
+ use libpijul::*;
+ use log::{debug, error, info, trace};
+ use std::collections::{BTreeMap, BTreeSet, HashSet};
+@@ -564,7 +565,7 @@
+                                     tmp_path.pop();
+                                     use rand::Rng;
+                                     let s: String = rand::thread_rng()
+-                                        .sample_iter(&rand::distributions::Alphanumeric)
++                                        .sample_iter(&rand::distr::Alphanumeric)
+                                         .take(30)
+                                         .map(|x| x as char)
+                                         .collect();

--- a/pkgs/by-name/pi/pijul/package.nix
+++ b/pkgs/by-name/pi/pijul/package.nix
@@ -5,6 +5,7 @@
   rustPlatform,
   installShellFiles,
   pkg-config,
+  dbus,
   libsodium,
   openssl,
   xxHash,
@@ -14,14 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pijul";
-  version = "1.0.0-beta.9";
+  version = "1.0.0-beta.11";
 
   src = fetchCrate {
     inherit (finalAttrs) version pname;
-    hash = "sha256-jy0mzgLw9iWuoWe2ictMTL3cHnjJ5kzs6TAK+pdm28g=";
+    hash = "sha256-+rMMqo2LBYlCFQJv8WFCSEJgDUbMi8DnVDKXIWm3tIk=";
   };
 
-  cargoHash = "sha256-d2IlBtR3j6SF8AAagUQftCOqTqN70rDMlHkA9byxXyk=";
+  cargoHash = "sha256-IhArTiReUdj49bA+XseQpOiszK801xX5LdLj8vXD8rs=";
+
+  patches = [ ./fix-rand-0.9-sanakirja-imports.patch ];
 
   doCheck = false;
   nativeBuildInputs = [
@@ -29,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
   ];
   buildInputs = [
+    dbus
     openssl
     libsodium
     xxHash


### PR DESCRIPTION
Release: https://crates.io/crates/pijul/1.0.0-beta.11
Diff: https://nest.pijul.com/pijul/pijul/log/1.0.0-beta.9..1.0.0-beta.11

Resolves #505539 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
