### PR TITLE
nixos/prometheus-exporters: add socketOpts and use for node-exporter & postfix-exporter

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -313,6 +313,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - [hardware.xpadneo](#opt-hardware.xpadneo.enable) now supports configuring kernel module parameters via a freeform [settings](#opt-hardware.xpadneo.settings) option, with convenience options for [rumble attenuation](#opt-hardware.xpadneo.rumbleAttenuation) and [controller quirks](#opt-hardware.xpadneo.quirks).
 
+- The `services.prometheus.exporters` module interface now accepts an optional `socketOpts` attribute, allowing individual exporter modules to describe an accompanying `systemd.sockets.prometheus-${name}-exporter` unit alongside their service, enabling socket activation support.
+
 - Wine has been updated to the 11.0 branch. Please check the [upstream announcement](https://gitlab.winehq.org/wine/wine/-/releases/wine-11.0) for more details.
 
 - `security.acme` now defaults to a dynamic renewal duration, if

--- a/nixos/modules/services/monitoring/prometheus/exporters.md
+++ b/nixos/modules/services/monitoring/prometheus/exporters.md
@@ -138,11 +138,22 @@ example:
           DynamicUser = false;
           ExecStart = ''
             ${pkgs.prometheus-postfix-exporter}/bin/postfix_exporter \
-              --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+              --web.systemd-socket \
               --web.telemetry-path ${cfg.telemetryPath} \
               ${lib.concatStringsSep " \\\n  " cfg.extraFlags}
           '';
         };
+      };
+
+      # `socketOpts` is an optional attribute set describing a
+      # `systemd.sockets.prometheus-${name}-exporter` unit that
+      # accompanies the exporter's service. When set, it is merged
+      # with a default definition that includes
+      # `wantedBy = [ "sockets.target" ]`, enabling socket activation
+      # for exporters that support it.
+      # Note that this attribute is optional.
+      socketOpts = {
+        socketConfig.ListenStream = "${cfg.listenAddress}:${toString cfg.port}";
       };
     }
     ```

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -36,10 +36,15 @@ let
   #   - extraOpts   (types.attrs): extra configuration options to
   #                                configure the exporter with, which
   #                                are appended to the default options
+  #   - socketOpts  (types.attrs): optional config that is merged with
+  #                                the default definition of the
+  #                                exporter's systemd socket unit. When
+  #                                set, a `prometheus-${name}-exporter.socket`
+  #                                unit is created, enabling socket activation.
   #
-  #  Note that `extraOpts` is optional, but a script for the exporter's
-  #  systemd service must be provided by specifying either
-  #  `serviceOpts.script` or `serviceOpts.serviceConfig.ExecStart`
+  #  Note that `extraOpts` and `socketOpts` are optional, but a script
+  #  for the exporter's systemd service must be provided by specifying
+  #  either `serviceOpts.script` or `serviceOpts.serviceConfig.ExecStart`
 
   exporterOpts =
     (genAttrs
@@ -311,6 +316,7 @@ let
       name,
       conf,
       serviceOpts,
+      socketOpts,
     }:
     let
       enableDynamicUser = serviceOpts.serviceConfig.DynamicUser or true;
@@ -368,6 +374,12 @@ let
         "-m comment --comment ${name}-exporter -j nixos-fw-accept"
       ]);
       networking.firewall.extraInputRules = mkIf (conf.openFirewall && nftables) conf.firewallRules;
+      systemd.sockets."prometheus-${name}-exporter" = mkIf (socketOpts != null) (mkMerge [
+        {
+          wantedBy = [ "sockets.target" ];
+        }
+        socketOpts
+      ]);
       systemd.services."prometheus-${name}-exporter" = mkMerge [
         {
           wantedBy = [ "multi-user.target" ];
@@ -603,6 +615,7 @@ in
       mkExporterConf {
         inherit name;
         inherit (conf) serviceOpts;
+        socketOpts = conf.socketOpts or null;
         conf = cfg.${name};
       }
     ) exporterOpts)

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -39,6 +39,7 @@ in
       '';
     };
   };
+
   serviceOpts = {
     serviceConfig = {
       DynamicUser = false;
@@ -47,7 +48,7 @@ in
         ${pkgs.prometheus-node-exporter}/bin/node_exporter \
           ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
           ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}
+          --web.systemd-socket ${concatStringsSep " " cfg.extraFlags}
       '';
       RestrictAddressFamilies =
         optionals (collectorIsEnabled "logind" || collectorIsEnabled "systemd") [
@@ -66,5 +67,9 @@ in
       # Allow space monitoring under /home
       ProtectHome = true;
     };
+  };
+
+  socketOpts = {
+    socketConfig.ListenStream = "${cfg.listenAddress}:${toString cfg.port}";
   };
 }

--- a/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
@@ -85,6 +85,7 @@ in
       };
     };
   };
+
   serviceOpts = {
     after = mkIf cfg.systemd.enable [ cfg.systemd.unit ];
     serviceConfig = {
@@ -95,7 +96,7 @@ in
       SupplementaryGroups = mkIf cfg.systemd.enable [ "systemd-journal" ];
       ExecStart = ''
         ${lib.getExe cfg.package} \
-          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          --web.systemd-socket \
           --web.telemetry-path ${cfg.telemetryPath} \
           --postfix.showq_path ${escapeShellArg cfg.showqPath} \
           ${concatStringsSep " \\\n  " (
@@ -114,5 +115,9 @@ in
           )}
       '';
     };
+  };
+
+  socketOpts = {
+    socketConfig.ListenStream = "${cfg.listenAddress}:${toString cfg.port}";
   };
 }


### PR DESCRIPTION
- **nixos/prometheus-exporters: add socketOpts to the exporter interface**
- **nixos/prometheus-node-exporter: use socket activation**
- **nixos/prometheus-postfix-exporter: use socket activation**

Closes: https://github.com/NixOS/nixpkgs/issues/510379
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
