### PR TITLE
slint-viewer: 1.14.1 -> 1.16.0

### DIFF
--- a/pkgs/by-name/sl/slint-viewer/package.nix
+++ b/pkgs/by-name/sl/slint-viewer/package.nix
@@ -2,29 +2,37 @@
   lib,
   rustPlatform,
   fetchCrate,
-  qt6,
+
+  fontconfig,
   libGL,
+  pkg-config,
+  qt6,
+
   nix-update-script,
   versionCheckHook,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "slint-viewer";
-  version = "1.14.1";
+  version = "1.16.0";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-7NxpnkMAQTBDfcDhdnneFNjB0oE82dDdpfq4vmMqECg=";
+    hash = "sha256-POkfEU4m54dEgaSSEHLqKozMXqMxqkUoLCevm6SY2IU=";
   };
 
-  cargoHash = "sha256-RNK3dzXdWRpugC7FwenUF/IsKbD3GxFRLqyLzBf2Wuw=";
+  cargoHash = "sha256-zjiII898Zpzdr19UHua3yuhRRHCn5yg/PHYpYODh7Pc=";
 
   buildInputs = [
     qt6.qtbase
     qt6.qtsvg
+    fontconfig
     libGL
   ];
 
-  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
 
   # There are no tests
   doCheck = false;


### PR DESCRIPTION
Made the PR cause r-ryantm fails (for obvious reasons): https://nixpkgs-update-logs.nix-community.org/slint-viewer/2026-04-14.log

Changelogs:
- [1.15.0](https://github.com/slint-ui/slint/blob/059a8e1c6f16cea3dffec06a76b55993b439e279/CHANGELOG.md#1150---2026-02-04)
- [1.15.1](https://github.com/slint-ui/slint/blob/059a8e1c6f16cea3dffec06a76b55993b439e279/CHANGELOG.md#1151---2026-02-12)
- [1.16.0](https://github.com/slint-ui/slint/blob/059a8e1c6f16cea3dffec06a76b55993b439e279/CHANGELOG.md#1160---2026-04-16)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
