### PR TITLE
paperless-asn-qr-codes: 0.2.0 -> 0.5.3

### DIFF
--- a/pkgs/by-name/pa/paperless-asn-qr-codes/package.nix
+++ b/pkgs/by-name/pa/paperless-asn-qr-codes/package.nix
@@ -6,27 +6,26 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "paperless-asn-qr-codes";
-  version = "0.2.0";
+  version = "0.5.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "entropia";
     repo = "paperless-asn-qr-codes";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-/xCU6xDrmhkua4Iw/BCzhOuqO5GT/0rTJ+Y59wuMz6E=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mCymgzKjLMrwb1AjkfFf1EHTkW1G0y+R3ZbG/6Xd978=";
   };
 
-  prePatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "\"argparse\"," ""
-  '';
-
-  nativeBuildInputs = [
+  build-system = [
     python3.pkgs.hatch-vcs
     python3.pkgs.hatchling
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  pythonRelaxDeps = [
+    "reportlab"
+  ];
+
+  dependencies = with python3.pkgs; [
     reportlab
     reportlab-qrcode
   ];
@@ -34,6 +33,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pythonImportsCheck = [ "paperless_asn_qr_codes" ];
 
   meta = {
+    changelog = "https://codeberg.org/entropia/paperless-asn-qr-codes/releases/tag/${finalAttrs.src.tag}";
     description = "Command line utility for generating ASN labels for paperless with both a human-readable representation, as well as a QR code for machine consumption";
     homepage = "https://github.com/entropia/paperless-asn-qr-codes";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Diff: https://github.com/entropia/paperless-asn-qr-codes/compare/v0.2.0...v0.5.3

Changelog: https://codeberg.org/entropia/paperless-asn-qr-codes/releases/tag/v0.5.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
