### PR TITLE
python3Packages.linear-operator: 0.6 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/ax-platform/default.nix
+++ b/pkgs/development/python-modules/ax-platform/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "ax-platform";
-  version = "1.2.3";
+  version = "1.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "ax";
     tag = finalAttrs.version;
-    hash = "sha256-zIK3D7QSkfzAxySumdxsA3tiPWYbP9E6SS21837H4ZY=";
+    hash = "sha256-ZeYoLOPF2D1bk89V5/WO/v0UCtDisbAOOL/Su9sB2Fg=";
   };
 
   env.ALLOW_BOTORCH_LATEST = "1";
@@ -120,8 +120,8 @@ buildPythonPackage (finalAttrs: {
     # broken with sqlalchemy 2
     "test_sql_storage"
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # flaky on x86
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    # flaky
     "test_gen_with_expanded_parameter_space"
   ];
 

--- a/pkgs/development/python-modules/botorch/default.nix
+++ b/pkgs/development/python-modules/botorch/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "botorch";
-  version = "0.17.0";
+  version = "0.17.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "botorch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NDdXsmVdrTEXMXXVf89EkGXVOYnEcXwtzarB5niTNaw=";
+    hash = "sha256-KWkRdgOAhWoVRoBn0XvKhTQX3KPHJrzqWoiaKrYzi7o=";
   };
 
   build-system = [
@@ -82,9 +82,18 @@ buildPythonPackage (finalAttrs: {
     # RuntimeError: Boolean value of Tensor with more than one value is ambiguous
     "test_optimize_acqf_mixed_binary_only"
   ]
-  ++ lib.optionals (stdenv.buildPlatform.system == "x86_64-linux") [
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
     # stuck tests on hydra
     "test_moo_predictive_entropy_search"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_append_features"
+    "test_delattr_ctx"
+    "test_input_perturbation"
+    "test_module_rollback_ctx"
+    "test_parameter_rollback_ctx"
+    "test_zero_grad_ctx"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
     # RuntimeError: required keyword attribute 'value' has the wrong type

--- a/pkgs/development/python-modules/gpytorch/default.nix
+++ b/pkgs/development/python-modules/gpytorch/default.nix
@@ -9,7 +9,6 @@
   setuptools-scm,
 
   # dependencies
-  jaxtyping,
   linear-operator,
   mpmath,
   scikit-learn,
@@ -22,23 +21,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gpytorch";
-  version = "1.15.1";
+  version = "1.15.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cornellius-gp";
     repo = "gpytorch";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ftiAY02K0EwVQZufk8xR+/21A+2ONWchuWPF3a5lRW0=";
+    hash = "sha256-1CavS+qrV8YqnsT87GjmJV2LOtvExFYQE5YpYZEw9ts=";
   };
-
-  # AttributeError: module 'numpy' has no attribute 'trapz'
-  postPatch = ''
-    substituteInPlace gpytorch/kernels/spectral_mixture_kernel.py \
-      --replace-fail \
-        "np.trapz(emp_spect, freq)" \
-        "np.trapezoid(emp_spect, freq)"
-  '';
 
   build-system = [
     setuptools
@@ -46,7 +37,6 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    jaxtyping
     linear-operator
     mpmath
     scikit-learn
@@ -67,6 +57,11 @@ buildPythonPackage (finalAttrs: {
     "test_optimization_optimal_error"
     # https://github.com/cornellius-gp/gpytorch/issues/2396
     "test_t_matmul_matrix"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_dtype_value_context"
+    "test_half"
   ];
 
   disabledTestPaths = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [

--- a/pkgs/development/python-modules/linear-operator/default.nix
+++ b/pkgs/development/python-modules/linear-operator/default.nix
@@ -1,26 +1,31 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  jaxtyping,
-  pytestCheckHook,
-  scipy,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  scipy,
   torch,
-  typeguard,
+
+  # tests
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "linear-operator";
-  version = "0.6";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cornellius-gp";
     repo = "linear_operator";
-    tag = "v${version}";
-    hash = "sha256-qBC7wrpcZ8ViFqIOSd2F8heeBRQxrac/l33srHhNaIM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ghe4a3zMSvTv3J6ROd1RLELK+k24/rO8p+XUPVsl090=";
   };
 
   build-system = [
@@ -29,15 +34,8 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    jaxtyping
     scipy
     torch
-    typeguard
-  ];
-
-  pythonRelaxDeps = [
-    "jaxtyping"
-    "typeguard"
   ];
 
   pythonImportsCheck = [ "linear_operator" ];
@@ -49,12 +47,17 @@ buildPythonPackage rec {
     "test_matmul_matrix_broadcast"
     "test_solve_matrix_broadcast"
     "test_svd"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_half"
   ];
 
   meta = {
     description = "LinearOperator implementation to wrap the numerical nuts and bolts of GPyTorch";
-    homepage = "https://github.com/cornellius-gp/linear_operator/";
+    homepage = "https://github.com/cornellius-gp/linear_operator";
+    changelog = "https://github.com/cornellius-gp/linear_operator/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- `python3Packages.linear-operator: 0.6 -> 0.6.1`
  - Diff: https://github.com/cornellius-gp/linear_operator/compare/v0.6...v0.6.1
- `python3Packages.gpytorch: 1.15.1 -> 1.15.2`
  - Diff: https://github.com/cornellius-gp/gpytorch/compare/v1.15.1...v1.15.2
  - Changelog: https://github.com/cornellius-gp/gpytorch/releases/tag/v1.15.2
- `python3Packages.botorch: 0.17.0 -> 0.17.2`
  - Diff: https://github.com/meta-pytorch/botorch/compare/v0.17.0...v0.17.2
  - Changelog: https://github.com/meta-pytorch/botorch/blob/v0.17.2/CHANGELOG.md
- `python3Packages.ax-platform: 1.2.3 -> 1.2.4`
  - Diff: https://github.com/facebook/ax/compare/1.2.3...1.2.4
  - Changelog: https://github.com/facebook/Ax/releases/tag/1.2.4

cc @veprbl

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test