### PR TITLE
algol68g: 3.5.14 -> 3.11.3

### DIFF
--- a/pkgs/by-name/al/algol68g/package.nix
+++ b/pkgs/by-name/al/algol68g/package.nix
@@ -15,11 +15,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "algol68g";
-  version = "3.5.14";
+  version = "3.11.3";
 
   src = fetchurl {
-    url = "https://jmvdveer.home.xs4all.nl/algol68g-${finalAttrs.version}.tar.gz";
-    hash = "sha256-uIy8rIhUjohiQJ/K5EprsIISXMAx1w27I3cGo/9H9Wk=";
+    # Uses archive.org because the original site removes older versions.
+    url = "https://web.archive.org/web/20260419212716/https://jmvdveer.home.xs4all.nl/algol68g-3.11.3.tar.gz";
+    hash = "sha256-P8hKm5lFG3P8+OigX2mFPzL1bN30bblAvijajJzTcxA=";
   };
 
   outputs = [
@@ -69,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl3Plus;
     mainProgram = "a68g";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
update to 3.11.1 / add myself as maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
