### PR TITLE
Revert "signal-desktop: deprecate commandLineArgs override"

### DIFF
--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -347,6 +347,7 @@ stdenv.mkDerivation (finalAttrs: {
       iamanaws
       marcin-serwin
       teutat3s
+      ncfavier
     ];
     mainProgram = "signal-desktop";
     platforms = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -23,9 +23,6 @@
 
   withAppleEmojis ? false,
 }:
-assert lib.warnIf (commandLineArgs != "")
-  "`commandLineArgs` has been deprecated and will be removed in the future. Consider creating a wrapper script or a desktop entry with your desired flags."
-  true;
 let
   nodejs = nodejs_24;
   pnpm = pnpm_10_29_2;


### PR DESCRIPTION
This reverts commit 60304c712e2f68a3331cd7af142035262effa218 from https://github.com/NixOS/nixpkgs/pull/506698. See there for why.