### PR TITLE
yaziPlugins.sshfs: init at 2.0.0-unstable-2026-04-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11157,6 +11157,12 @@
     githubId = 3948275;
     name = "Harikrishnan R";
   };
+  ilosariph = {
+    email = "simon@simon-wick.ch";
+    github = "Ilosariph";
+    githubId = 71074737;
+    name = "Simon Wick";
+  };
   ilya-epifanov = {
     email = "mail@ilya.network";
     github = "ilya-epifanov";

--- a/pkgs/by-name/ya/yazi/plugins/sshfs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/sshfs/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "sshfs.yazi";
+  version = "2.0.0-unstable-2026-04-15";
+
+  src = fetchFromGitHub {
+    owner = "uhs-robert";
+    repo = "sshfs.yazi";
+    rev = "7ba17a8c8498fca9f0a9c437704e74b56d96ed96";
+    hash = "sha256-TS3/xl8jbbCoF1LzPYvmG9BRqvlzPg4EZRErlL7S2/M=";
+  };
+
+  meta = {
+    description = "Minimal SSHFS integration for the Yazi terminal file‑manager";
+    homepage = "https://github.com/uhs-robert/sshfs.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ilosariph ];
+  };
+}


### PR DESCRIPTION
I added the sshfs plugin for yazi. I also added myself to the maintainers.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

