### PR TITLE
pandora-launcher: init at 5.2.2

### DIFF
--- a/pkgs/by-name/pa/pandora-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher-unwrapped/package.nix
@@ -1,0 +1,144 @@
+{
+  addDriverRunpath,
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  imagemagick,
+  patchelf,
+  pkg-config,
+
+  alsa-lib,
+  dbus,
+  fontconfig,
+  libGL,
+  libseccomp,
+  libxcb,
+  libxkbcommon,
+  openssl,
+  vulkan-loader,
+  wayland,
+
+  copyDesktopItems,
+  makeDesktopItem,
+
+  apple-sdk_15,
+
+  msaClientID ? null,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pandora-launcher-unwrapped";
+  version = "5.0.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Moulberry";
+    repo = "PandoraLauncher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AN7q/efnsypwv6w4XP1vcQfncGljjp2DQreR9i3VVR4=";
+  };
+
+  # Currently the client id is hardcoded and must be patched like this.
+  postPatch = lib.optionalString (msaClientID != null) ''
+    substituteInPlace crates/auth/src/constants.rs \
+      --replace-fail \
+      'pub const CLIENT_ID: &str = "e5226706-5096-431d-9516-ae48fe263401";' \
+      'pub const CLIENT_ID: &str = "${msaClientID}";'
+  '';
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    copyDesktopItems
+
+    imagemagick
+    patchelf
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    dbus
+    libseccomp
+    libxcb
+    libxkbcommon
+    wayland
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+  ];
+
+  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
+
+  doCheck = false; # there aren't any tests
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  dontUpdateAutotoolsGnuConfigScripts = true; # will modify vendor dir, which cargo doesn't allow
+  cargoVendorDir = "vendor"; # everything is vendored in-tree
+  dontCargoSetupPostUnpack = true;
+
+  desktopItems = lib.singleton (makeDesktopItem {
+    name = "com.moulberry.pandoralauncher";
+    desktopName = "Pandora Launcher";
+    genericName = "Unofficial Minecraft Launcher";
+    exec = "pandora_launcher";
+    icon = "pandora_launcher";
+  });
+
+  postInstall = ''
+    for size in 16 24 32 48 64 128 256; do
+      geometry="$size"x"$size"
+      mkdir -p "$out/share/icons/hicolor/$geometry/apps"
+      magick package/windows.svg -resize "$geometry" \
+        "$out/share/icons/hicolor/$geometry/apps/pandora_launcher.png"
+    done
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase =
+    let
+      expectedOutput = builtins.toFile "pandora-launcher-help-expected" ''
+        Usage: pandora_launcher [OPTIONS]
+
+        Options:
+              --run-instance <RUN_INSTANCE>  Instance to launch, instead of opening the launcher
+          -h, --help                         Print help
+      '';
+    in
+    ''
+      runHook preInstallCheck
+
+      diff <($out/bin/pandora_launcher --help) ${expectedOutput}
+
+      runHook postInstallCheck
+    '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf --add-rpath "${addDriverRunpath.driverLink}/lib:${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+      ]
+    }" $out/bin/pandora_launcher
+  '';
+
+  meta = {
+    description = "Minecraft launcher that balances ease-of-use with powerful instance management features";
+    homepage = "https://github.com/Moulberry/PandoraLauncher";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      dtomvan
+      eveeifyeve
+    ];
+    mainProgram = "pandora_launcher";
+  };
+})

--- a/pkgs/by-name/pa/pandora-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher-unwrapped/package.nix
@@ -1,0 +1,144 @@
+{
+  addDriverRunpath,
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  imagemagick,
+  patchelf,
+  pkg-config,
+
+  alsa-lib,
+  dbus,
+  fontconfig,
+  libGL,
+  libseccomp,
+  libxcb,
+  libxkbcommon,
+  openssl,
+  vulkan-loader,
+  wayland,
+
+  copyDesktopItems,
+  makeDesktopItem,
+
+  apple-sdk_15,
+
+  msaClientID ? null,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pandora-launcher-unwrapped";
+  version = "5.2.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Moulberry";
+    repo = "PandoraLauncher";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jUvCrz8srRRlXcrFWQ5Kx8V6KLc8cozZg+QYrcnMOUE=";
+  };
+
+  # Currently the client id is hardcoded and must be patched like this.
+  postPatch = lib.optionalString (msaClientID != null) ''
+    substituteInPlace crates/auth/src/constants.rs \
+      --replace-fail \
+      'pub const CLIENT_ID: &str = "e5226706-5096-431d-9516-ae48fe263401";' \
+      'pub const CLIENT_ID: &str = "${msaClientID}";'
+  '';
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    copyDesktopItems
+
+    imagemagick
+    patchelf
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    dbus
+    libseccomp
+    libxcb
+    libxkbcommon
+    wayland
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+  ];
+
+  buildFeatures = lib.optionals stdenv.hostPlatform.isDarwin [ "gpui/runtime_shaders" ];
+
+  doCheck = false; # there aren't any tests
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  dontUpdateAutotoolsGnuConfigScripts = true; # will modify vendor dir, which cargo doesn't allow
+  cargoVendorDir = "vendor"; # everything is vendored in-tree
+  dontCargoSetupPostUnpack = true;
+
+  desktopItems = lib.singleton (makeDesktopItem {
+    name = "com.moulberry.pandoralauncher";
+    desktopName = "Pandora Launcher";
+    genericName = "Unofficial Minecraft Launcher";
+    exec = "pandora_launcher";
+    icon = "pandora_launcher";
+  });
+
+  postInstall = ''
+    for size in 16 24 32 48 64 128 256; do
+      geometry="$size"x"$size"
+      mkdir -p "$out/share/icons/hicolor/$geometry/apps"
+      magick package/windows.svg -resize "$geometry" \
+        "$out/share/icons/hicolor/$geometry/apps/pandora_launcher.png"
+    done
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase =
+    let
+      expectedOutput = builtins.toFile "pandora-launcher-help-expected" ''
+        Usage: pandora_launcher [OPTIONS]
+
+        Options:
+              --run-instance <RUN_INSTANCE>  Instance to launch, instead of opening the launcher
+          -h, --help                         Print help
+      '';
+    in
+    ''
+      runHook preInstallCheck
+
+      diff <($out/bin/pandora_launcher --help) ${expectedOutput}
+
+      runHook postInstallCheck
+    '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf --add-rpath "${addDriverRunpath.driverLink}/lib:${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        wayland
+      ]
+    }" $out/bin/pandora_launcher
+  '';
+
+  meta = {
+    description = "Minecraft launcher that balances ease-of-use with powerful instance management features";
+    homepage = "https://github.com/Moulberry/PandoraLauncher";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      dtomvan
+      eveeifyeve
+    ];
+    mainProgram = "pandora_launcher";
+  };
+})

--- a/pkgs/by-name/pa/pandora-launcher/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher/package.nix
@@ -1,0 +1,144 @@
+# adapted from prismlauncher's wrapper, since they both include libs for
+# launching minecraft. I can't do `prismlauncher.override
+# { prismlauncher-unwrapped = pandora-launcher-unwrapped; }` though, since
+# pandora isn't a QT app (and most likely future subtle differences).
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  lib,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  makeWrapper,
+  openal,
+  pandora-launcher-unwrapped,
+  pciutils,
+  pipewire,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  controllerSupport ? stdenv.hostPlatform.isLinux,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  controllerSupport -> stdenv.hostPlatform.isLinux
+) "controllerSupport only has an effect on Linux.";
+
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+
+let
+  pandora-launcher' = pandora-launcher-unwrapped.override { inherit msaClientID; };
+in
+
+symlinkJoin {
+  pname = "pandora-launcher";
+  inherit (pandora-launcher') version;
+
+  strictDeps = true;
+  # breaks symlinkJoin
+  # tracked in https://github.com/NixOS/nixpkgs/issues/510434
+  # __structuredAttrs = true;
+
+  paths = [ pandora-launcher' ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  makeWrapperArgs =
+    let
+      runtimeLibs = [
+
+        (lib.getLib stdenv.cc.cc)
+        ## native versions
+        glfw3-minecraft
+        openal
+
+        ## openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        ## glfw
+        libGL
+        libx11
+        libxcursor
+        libxext
+        libxrandr
+        libxxf86vm
+
+        udev # oshi
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        pciutils # need lspci
+        xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      ]
+      ++ additionalPrograms;
+
+    in
+    [
+      "--prefix"
+      "FORCE_EXTERNAL_JAVA"
+      ":"
+      (lib.concatStringsSep ":" (map (jdk: jdk.home) jdks))
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--set"
+      "LD_LIBRARY_PATH"
+      "${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath runtimePrograms)
+    ];
+
+  postBuild = ''
+    wrapProgram $out/bin/pandora_launcher $makeWrapperArgs
+  '';
+
+  meta = {
+    inherit (pandora-launcher'.meta)
+      description
+      homepage
+      license
+      maintainers
+      mainProgram
+      ;
+  };
+}

--- a/pkgs/by-name/pa/pandora-launcher/package.nix
+++ b/pkgs/by-name/pa/pandora-launcher/package.nix
@@ -1,0 +1,142 @@
+# adapted from prismlauncher's wrapper, since they both include libs for
+# launching minecraft. I can't do `prismlauncher.override
+# { prismlauncher-unwrapped = pandora-launcher-unwrapped; }` though, since
+# pandora isn't a QT app (and most likely future subtle differences).
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk25,
+  jdk8,
+  lib,
+  libGL,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  libx11,
+  libxcursor,
+  libxext,
+  libxrandr,
+  libxxf86vm,
+  makeWrapper,
+  openal,
+  pandora-launcher-unwrapped,
+  pciutils,
+  pipewire,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  xrandr,
+
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  controllerSupport ? stdenv.hostPlatform.isLinux,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+assert lib.assertMsg (
+  controllerSupport -> stdenv.hostPlatform.isLinux
+) "controllerSupport only has an effect on Linux.";
+
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.hostPlatform.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+
+let
+  pandora-launcher' = pandora-launcher-unwrapped.override { inherit msaClientID; };
+in
+
+symlinkJoin {
+  pname = "pandora-launcher";
+  inherit (pandora-launcher') version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  paths = [ pandora-launcher' ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  makeWrapperArgs =
+    let
+      runtimeLibs = [
+
+        (lib.getLib stdenv.cc.cc)
+        ## native versions
+        glfw3-minecraft
+        openal
+
+        ## openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        ## glfw
+        libGL
+        libx11
+        libxcursor
+        libxext
+        libxrandr
+        libxxf86vm
+
+        udev # oshi
+
+        vulkan-loader # VulkanMod's lwjgl
+      ]
+      ++ lib.optional textToSpeechSupport flite
+      ++ lib.optional gamemodeSupport gamemode.lib
+      ++ lib.optional controllerSupport libusb1
+      ++ additionalLibs;
+
+      runtimePrograms = [
+        pciutils # need lspci
+        xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+      ]
+      ++ additionalPrograms;
+
+    in
+    [
+      "--prefix"
+      "FORCE_EXTERNAL_JAVA"
+      ":"
+      (lib.concatStringsSep ":" (map (jdk: jdk.home) jdks))
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "--set"
+      "LD_LIBRARY_PATH"
+      "${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath runtimePrograms)
+    ];
+
+  postBuild = ''
+    wrapProgram $out/bin/pandora_launcher "''${makeWrapperArgs[@]}"
+  '';
+
+  meta = {
+    inherit (pandora-launcher'.meta)
+      description
+      homepage
+      license
+      maintainers
+      mainProgram
+      ;
+  };
+}


### PR DESCRIPTION
Was able to launch an instance of vanilla minecraft with it (on intel so that doesn't verify that `addDriverRunpath` is doing its work but I see no reason it wouldn't), so I think the wrapper is fine (until we inevitably stumble on some edge case, that is...).

Revival of #479811 

https://pandora.moulberry.com

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
