### PR TITLE
[Release 25.11] dolibarr: mark as insecure

### DIFF
--- a/pkgs/by-name/do/dolibarr/package.nix
+++ b/pkgs/by-name/do/dolibarr/package.nix
@@ -46,5 +46,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://dolibarr.org/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ GaetanLepage ];
+    knownVulnerabilities = [
+      # https://github.com/NixOS/nixpkgs/issues/505605
+      "CVE-2026-34036"
+    ];
   };
 })


### PR DESCRIPTION
## Things done

The version of Dolibarr on `25.11` (`22.04`) is affected by [CVE-2026-34036](https://github.com/NixOS/nixpkgs/issues/505605).
Upstream hasn't released a minor update for `22.x`, so we cannot update to a more recent version.

The version on `master` / `nixos-unstable` is not affected anymore.

Fixes #505605

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
