### PR TITLE
imapgoose: 0.5.0 -> 0.5.2

### DIFF
--- a/pkgs/by-name/im/imapgoose/package.nix
+++ b/pkgs/by-name/im/imapgoose/package.nix
@@ -6,16 +6,16 @@
 }:
 buildGoModule rec {
   pname = "imapgoose";
-  version = "0.5.0";
+  version = "0.5.2";
 
   src = fetchFromSourcehut {
     owner = "~whynothugo";
     repo = "ImapGoose";
     tag = "v${version}";
-    hash = "sha256-H+6S+jAZT4jj1R8sJeLzFjyNkZqo0WlTLVfu1BH+RM4=";
+    hash = "sha256-OJ6qV3nZD1chLOG/LDn8fbf1R70Xnzo2Gx5/PYSPCAk=";
   };
 
-  vendorHash = "sha256-75dP0iB3Tu1GQfi9w+H1dgWHZh7X9FJOlsLbC3Baqjg=";
+  vendorHash = "sha256-PY6m92/8bzbYjkGvbNtL1W9sMayjPOyWVvJPwKAnLc8=";
 
   subPackages = [
     "cmd/imapgoose"


### PR DESCRIPTION
Bump imapgoose from 0.5.0 to 0.5.2.

https://git.sr.ht/~whynothugo/ImapGoose/refs/v0.5.2