### PR TITLE
openthread-border-router: fix pname, use install for otbr-firewall

### DIFF
--- a/pkgs/by-name/op/openthread-border-router/package.nix
+++ b/pkgs/by-name/op/openthread-border-router/package.nix
@@ -17,7 +17,7 @@
   buildNpmPackage,
 }:
 let
-  pname = "ot-br-posix";
+  pname = "openthread-border-router";
   version = "0-unstable-2025-06-12";
 
   src = fetchFromGitHub {
@@ -74,9 +74,7 @@ stdenv.mkDerivation {
   ];
 
   postInstall = ''
-    mkdir -p $out/bin
-    cp ../script/otbr-firewall $out/bin/
-    chmod +x $out/bin/otbr-firewall
+    install -Dm555 -t $out/bin ../script/otbr-firewall
   '';
 
   cmakeFlags = [


### PR DESCRIPTION
Addresses @dotlambda's post-merge review on #502388:
  
  - `pname` now matches the by-name attribute (`openthread-border-router` instead of `ot-br-posix`)
  - `postInstall` uses `install -Dm555` instead of separate `mkdir`/`cp`/`chmod`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
