### PR TITLE
ocamlPackages.atd: 4.0.0 → 4.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/atd/jsonlike.nix
+++ b/pkgs/development/ocaml-modules/atd/jsonlike.nix
@@ -1,0 +1,18 @@
+{
+  buildDunePackage,
+  atd,
+  re,
+}:
+
+buildDunePackage {
+  pname = "atd-jsonlike";
+  inherit (atd) src version;
+
+  minimalOCamlVersion = "4.12";
+
+  propagatedBuildInputs = [ re ];
+
+  meta = (removeAttrs atd.meta [ "mainProgram" ]) // {
+    description = "Generic JSON-like AST for use with ATD code generators";
+  };
+}

--- a/pkgs/development/ocaml-modules/atd/yamlx.nix
+++ b/pkgs/development/ocaml-modules/atd/yamlx.nix
@@ -1,0 +1,19 @@
+{
+  buildDunePackage,
+  atd-jsonlike,
+  yamlx,
+}:
+
+buildDunePackage {
+  pname = "atd-yamlx";
+  inherit (atd-jsonlike) version src;
+
+  propagatedBuildInputs = [
+    atd-jsonlike
+    yamlx
+  ];
+
+  meta = atd-jsonlike.meta // {
+    description = "YAML-to-jsonlike bridge for use with ATD code generators";
+  };
+}

--- a/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/codec-runtime.nix
@@ -6,11 +6,11 @@
 
 buildDunePackage (finalAttrs: {
   pname = "atdgen-codec-runtime";
-  version = "4.0.0";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "https://github.com/ahrefs/atd/releases/download/${finalAttrs.version}/atd-${finalAttrs.version}.tbz";
-    hash = "sha256-NRT+TcTniGQLPpqf7DtbEG5vYJtZ0oUicB3hvS6pCfE=";
+    hash = "sha256-c7J+xg77vqYPMRy8oJwQS1U3vocz9HcnqfXth41uBGw=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/atdgen/default.nix
+++ b/pkgs/development/ocaml-modules/atdgen/default.nix
@@ -1,12 +1,17 @@
 {
+  lib,
   buildDunePackage,
+  ocaml,
   alcotest,
   atd,
+  atd-jsonlike,
+  atd-yamlx,
   atdgen-codec-runtime,
   atdgen-runtime,
+  atdml,
   biniou,
   re,
-  python3,
+  yamlx,
 }:
 
 buildDunePackage {
@@ -20,15 +25,18 @@ buildDunePackage {
 
   propagatedBuildInputs = [ atdgen-runtime ];
 
-  doCheck = true;
+  doCheck = lib.versionAtLeast ocaml.version "4.14";
   nativeCheckInputs = [
     atd
+    atdml
     biniou
-    (python3.withPackages (ps: [ ps.jsonschema ]))
   ];
   checkInputs = [
     alcotest
     atdgen-codec-runtime
+    yamlx
+    atd-jsonlike
+    atd-yamlx
   ];
 
   meta = (removeAttrs atd.meta [ "mainProgram" ]) // {

--- a/pkgs/development/ocaml-modules/atdml/default.nix
+++ b/pkgs/development/ocaml-modules/atdml/default.nix
@@ -9,6 +9,8 @@ buildDunePackage {
   pname = "atdml";
   inherit (atd) version src;
 
+  minimalOCamlVersion = "4.10";
+
   buildInputs = [ cmdliner ];
 
   propagatedBuildInputs = [ atd ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -70,6 +70,10 @@ let
 
         atd = callPackage ../development/ocaml-modules/atd { };
 
+        atd-jsonlike = callPackage ../development/ocaml-modules/atd/jsonlike.nix { };
+
+        atd-yamlx = callPackage ../development/ocaml-modules/atd/yamlx.nix { };
+
         atdgen = callPackage ../development/ocaml-modules/atdgen { };
 
         atdgen-codec-runtime = callPackage ../development/ocaml-modules/atdgen/codec-runtime.nix { };


### PR DESCRIPTION
ocamlPackages.atd-jsonlike: init at 4.1.0
ocamlPackages.atd-yamlx: init at 4.1.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
