### PR TITLE
bitrise: 2.39.2 -> 2.39.3

### DIFF
--- a/pkgs/by-name/bi/bitrise/package.nix
+++ b/pkgs/by-name/bi/bitrise/package.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "bitrise";
-  version = "2.39.2";
+  version = "2.39.3";
 
   src = fetchFromGitHub {
     owner = "bitrise-io";
     repo = "bitrise";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-yduH5UkBwcp41pCeFyoOYtaTwvINrbMaQQlvmeRAXCY=";
+    hash = "sha256-rL/m5hV1PdNdE51h5xRsGy9Cuj3X/jnoyNnquJPnYfc=";
   };
 
   # many tests rely on writable $HOME/.bitrise and require network access
@@ -25,8 +25,9 @@ buildGoModule (finalAttrs: {
 
   vendorHash = null;
   ldflags = [
-    "-X github.com/bitrise-io/bitrise/version.Commit=${finalAttrs.src.rev}"
-    "-X github.com/bitrise-io/bitrise/version.BuildNumber=0"
+    "-X github.com/bitrise-io/bitrise/v2/version.Commit=${finalAttrs.src.rev}"
+    "-X github.com/bitrise-io/bitrise/v2/version.VERSION=${finalAttrs.version}"
+    "-X github.com/bitrise-io/bitrise/v2/version.BuildNumber=0"
   ];
   env.CGO_ENABLED = 0;
 


### PR DESCRIPTION
Version string handling slightly changed in https://github.com/bitrise-io/bitrise/pull/1239, hence the `ldflags` adjustments 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
