### PR TITLE
qownnotes: 26.4.11 -> 26.4.14, fix UI tests

### DIFF
--- a/nixos/tests/qownnotes.nix
+++ b/nixos/tests/qownnotes.nix
@@ -50,7 +50,7 @@
           machine.wait_for_text("Note folder")
           machine.send_key("ret")
           machine.wait_for_console_text("Note path '/home/alice/Notes' was now created.")
-          machine.wait_for_text("Panel layout")
+          machine.wait_for_text("Layout preset")
           machine.send_key("ret")
           machine.wait_for_text("Nextcloud")
           machine.send_key("ret")

--- a/pkgs/by-name/qo/qownnotes/package.nix
+++ b/pkgs/by-name/qo/qownnotes/package.nix
@@ -19,11 +19,11 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "qownnotes";
   appname = "QOwnNotes";
-  version = "26.4.11";
+  version = "26.4.14";
 
   src = fetchurl {
     url = "https://github.com/pbek/QOwnNotes/releases/download/v${finalAttrs.version}/qownnotes-${finalAttrs.version}.tar.xz";
-    hash = "sha256-5V5fBxDlTjuj0RxxR4QcBlFmiSAWpRUxIZjpRzdDVJo=";
+    hash = "sha256-LiznKJRaXMNQUO/iomWGn8IDlRnWYtZQKDFVL5Vl3ZQ=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
In version [26.4.13](https://github.com/pbek/QOwnNotes/releases/tag/v26.4.13) there was a rename of a dialog which needs a change in the UI test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
