### PR TITLE
migrate-to-uv: 0.11.1 -> 0.12.0

### DIFF
--- a/pkgs/by-name/mi/migrate-to-uv/package.nix
+++ b/pkgs/by-name/mi/migrate-to-uv/package.nix
@@ -11,19 +11,19 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "migrate-to-uv";
-  version = "0.11.1";
+  version = "0.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "mkniewallner";
+    owner = "osprey-oss";
     repo = "migrate-to-uv";
     tag = finalAttrs.version;
-    hash = "sha256-gKiLGuHlUtSFdZCZZIxK7V6apvHMJ7sBZZo0auK4w2s=";
+    hash = "sha256-+UXPgFYgTlLmUYpE2aWsO2OdelP9dCZsB3cWjG4negA=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src pname version;
-    hash = "sha256-CZEZ1zLXAerUPgKRmzkN4Q3v/tNDI438V0yfYYZK+pQ=";
+    hash = "sha256-evsc5uOZnN6+tRXmN1SQD5Iqnm4Y+TjmBzWaGQQj2UQ=";
   };
 
   build-system = [
@@ -39,8 +39,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Migrate a project from Poetry/Pipenv/pip-tools/pip to uv package manager";
-    homepage = "https://mkniewallner.github.io/migrate-to-uv/";
-    changelog = "https://github.com/mkniewallner/migrate-to-uv/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    homepage = "https://osprey-oss.github.io/migrate-to-uv/";
+    changelog = "https://osprey-oss.github.io/migrate-to-uv/CHANGELOG/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ malik ];
     mainProgram = "migrate-to-uv";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Owner of the upstream repo changed. This fixes this

also bumped version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
