### PR TITLE
nixos/switchable-system: improve switch-inhibitor pre-check

### DIFF
--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -71,41 +71,31 @@
 
       preSwitchChecks.switchInhibitors =
         let
-          realpath = lib.getExe' pkgs.coreutils "realpath";
-          mktemp = lib.getExe' pkgs.coreutils "mktemp";
-          rm = lib.getExe' pkgs.coreutils "rm";
-          jq = lib.getExe' pkgs.jq "jq";
+          jq = lib.getExe pkgs.jq;
+          empty = pkgs.writeText "empty-inhibitors" "{}";
         in
         # bash
         ''
           incoming="''${1-}"
           action="''${2-}"
 
-          if [ "$action" == "boot" ]; then
-            echo "Not checking switch inhibitors (action = $action)"
-            exit
-          fi
+          case "$action" in
+            boot|dry-activate)
+              echo "Not checking switch inhibitors (action = $action)"
+              exit
+              ;;
+          esac
 
           echo -n "Checking switch inhibitors..."
 
-          # Create a temporary file that we use in case a generation does not have
-          # the switch-inhibitors file.
-          empty="$(${mktemp} -t switch_inhibit.XXXX)"
-          # shellcheck disable=SC2329
-          clean_up() {
-            ${rm} -f "$empty"
-          }
-          trap clean_up EXIT
-          echo "{}" > "$empty"
-
-          current_inhibitors="$(${realpath} /run/current-system)/switch-inhibitors"
+          current_inhibitors="/run/current-system/switch-inhibitors"
           if [ ! -f "$current_inhibitors" ]; then
-            current_inhibitors="$empty"
+            current_inhibitors="${empty}"
           fi
 
-          new_inhibitors="$(${realpath} "$incoming")/switch-inhibitors"
+          new_inhibitors="$incoming/switch-inhibitors"
           if [ ! -f "$new_inhibitors" ]; then
-            new_inhibitors="$empty"
+            new_inhibitors="${empty}"
           fi
 
           diff="$(
@@ -115,8 +105,8 @@
               --rawfile current "$current_inhibitors" \
               --rawfile newgen "$new_inhibitors" \
             '
-              $current | try fromjson catch {} as $old |
-              $newgen | try fromjson catch {} as $new |
+              ($current | fromjson) as $old |
+              ($newgen | fromjson) as $new |
               $old |
               to_entries |
               map(

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -776,6 +776,9 @@ in
           assert_contains(out, "baz")
           # Confirm that we can set that same generation as the new boot default
           switch_to_specialisation("${machine}", "inhibitors_changed", action="boot")
+          # Confirm that dry-activate is not blocked by inhibitors
+          out = switch_to_specialisation("${machine}", "inhibitors_changed", action="dry-activate")
+          assert_contains(out, "Not checking switch inhibitors")
           # Check that we can switch into a new generation with new inhibitors, but same values for existing ones
           switch_to_specialisation("${machine}", "inhibitors_new", action="switch")
           # Check that we can switch back into a generation without inhibitors


### PR DESCRIPTION
Three small correctness fixes to the switch-inhibitor pre-switch check:

1. `realpath /run/current-system` ran under `errexit`, so a missing `current-system` symlink (first activation, `nixos-enter`, some container bootstraps) aborted the check.
   Dropped the `realpath` calls since `[ -f ]` and `jq` already follow symlinks and replaced the runtime `mktemp`/`trap` fallback file with a static store path.
1. `dry-activate` was being blocked by inhibitor mismatches even though it makes no state changes, it now skips the check like `boot` does.
1. `try fromjson catch {}` silently treated a corrupted `switch-inhibitors` file as empty, disabling all inhibitors.
   jq now fails loudly on parse errors, which surfaces as a pre-switch-check failure.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
