### PR TITLE
treewide: fix more icon by moving to valid path

### DIFF
--- a/pkgs/by-name/sh/shipwright/package.nix
+++ b/pkgs/by-name/sh/shipwright/package.nix
@@ -239,7 +239,7 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/bin
       ln -s $out/lib/soh.elf $out/bin/soh
-      install -Dm644 ../soh/macosx/sohIcon.png $out/share/icons/hicolor/1024x1024/apps/soh.png
+      install -Dm644 ../soh/macosx/sohIcon.png $out/share/icons/soh.png
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       # Recreate the macOS bundle (without using cpack)

--- a/pkgs/by-name/so/solidtime-desktop/package.nix
+++ b/pkgs/by-name/so/solidtime-desktop/package.nix
@@ -34,8 +34,8 @@ buildNpmPackage (finalAttrs: {
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   postInstall = ''
-    mkdir -p $out/share/icons/hicolor/1024x1024
-    cp -a build/icon.png $out/share/icons/hicolor/1024x1024/solidtime-desktop.png
+    mkdir -p $out/share/icons
+    cp -a build/icon.png $out/share/icons/solidtime-desktop.png
     cp -a . $out/share/solidtime-desktop
 
     makeWrapper ${lib.getExe electron} $out/bin/solidtime-desktop \

--- a/pkgs/by-name/te/termius/package.nix
+++ b/pkgs/by-name/te/termius/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/applications
     cp "${desktopItem}/share/applications/"* "$out/share/applications"
-    install -Dm644 meta/gui/icon.png $out/share/icons/hicolor/1024x1024/termius-app.png
+    install -Dm644 meta/gui/icon.png $out/share/icons/termius-app.png
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See #428824 and #510472
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
