### PR TITLE
symlinkJoin: support `__structuredAttrs`

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -559,7 +559,10 @@ rec {
         paths = mapPaths (path: "${path}${stripPrefix}") paths;
         buildCommand = ''
           mkdir -p $out
-          for i in $(cat $pathsPath); do
+          if [ -n "''${pathsPath:-}" ] && [ -f "$pathsPath" ]; then
+            mapfile -d " " -t paths < "$pathsPath"
+          fi
+          for i in "''${paths[@]}"; do
             ${optionalString (!failOnMissing) "if test -d $i; then "}${lndir}/bin/lndir -silent $i $out${
               optionalString (!failOnMissing) "; fi"
             }

--- a/pkgs/build-support/trivial-builders/test/symlink-join.nix
+++ b/pkgs/build-support/trivial-builders/test/symlink-join.nix
@@ -55,6 +55,24 @@ in
     '';
   };
 
+  symlinkJoin-structured-attrs = testEqualContents {
+    assertion = "symlinkJoin-structured-attrs";
+    actual = symlinkJoin {
+      __structuredAttrs = true;
+      name = "symlinkJoin-structured-attrs";
+      paths = [
+        foo
+        bar
+        baz
+      ];
+    };
+    expected = runCommand "symlinkJoin-foo-bar-baz" { } ''
+      mkdir -p $out/{var/lib/arbitrary,etc/test.d}
+      ln -s {${foo},${bar}}/etc/test.d/* $out/etc/test.d
+      ln -s ${baz}/var/lib/arbitrary/baz $out/var/lib/arbitrary/
+    '';
+  };
+
   symlinkJoin-strip-paths = testEqualContents {
     assertion = "symlinkJoin-strip-paths";
     actual = symlinkJoin {


### PR DESCRIPTION
When `__structuredAttrs` is enabled, `passAsFiles` is ignored and `fooPath` variables are not defined.
For `symlinkJoin`, that means the paths-loop iterates over nothing.
Use the `$paths` bash array from `__structuredAttrs` when it's available, or create it from the `$pathsPath` file if not.

We could avoid the mass rebuild by interpolating an `if then else` nix expression, but I think long-term it's better to normalize to the `$paths` array. Plus, using `mapfile` is more robust than glob-splitting `$(cat $pathsPath)` ([SC2207](https://www.shellcheck.net/wiki/SC2207)).

Fixes #510434, thanks @dtomvan for identifying the issue and solution.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    - `nix-build -A tests.trivial-builders.symlinkJoin`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
