### PR TITLE
perl5Packages.libapreq2: fix build

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18634,9 +18634,12 @@ with self;
     preConfigure = ''
       # override broken prereq check
       substituteInPlace configure --replace "prereq_check=\"\$PERL \$PERL_OPTS build/version_check.pl\"" "prereq_check=\"echo\""
+      # Fix linker detection broken by exported LD (see nixpkgs#9f2a89f)
+      sed -i '1i export LD=${lib.getExe' stdenv.cc.bintools "${stdenv.cc.bintools.targetPrefix}ld"}' configure
     '';
     preBuild = ''
-      substituteInPlace apreq2-config --replace "dirname" "${pkgs.coreutils}/bin/dirname"
+      substituteInPlace apreq2-config --replace "dirname" "${pkgs.coreutils}/bin/dirname" \
+        --replace 'grep' '${pkgs.gnugrep}/bin/grep'
     '';
     installPhase = ''
       mkdir $out


### PR DESCRIPTION
- #459759
- https://hydra.nixos.org/build/322385202

Fixes #492914

This one is related to https://github.com/NixOS/nixpkgs/commit/6e1ce1a647bbda8e174970a3811ad121bc79f6e7 and https://github.com/NixOS/nixpkgs/commit/9f2a89f948f19c473c23d8ec358087a9e51f67d8.

In perl package builder, we forcibly set both `$CC` and `$LD` to `$CC`.

The config script in this package detects gnu ld by checking whether `$LD -v` contains the string "GNU", which you can guess that only genuine GNU ld contains that, not gcc. The detection failure will cause the shared library not to be linked, resulting in later compile failures.

There is a similar issue in perlPackages.AlienLibGumbo (#411028) but this fix is more hacky because the problem happens in `configurePhase`. I hope there is a way to disable overriding `$LD` in the builder but there is none. So I resorted to patching the configure script instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
