### PR TITLE
kdePackages.sierra-breeze-enhanced: fix build for QT 6.10

### DIFF
--- a/pkgs/data/themes/kwin-decorations/sierra-breeze-enhanced/default.nix
+++ b/pkgs/data/themes/kwin-decorations/sierra-breeze-enhanced/default.nix
@@ -6,6 +6,7 @@
   wrapQtAppsHook,
   kwin,
   lib,
+  fetchpatch2,
 }:
 stdenv.mkDerivation rec {
   pname = "sierra-breeze-enhanced";
@@ -17,6 +18,13 @@ stdenv.mkDerivation rec {
     rev = if version == "2.1.1" then "V.2.1.1" else "V${version}";
     hash = "sha256-7mQnJCQr/zm9zEdg2JPr7jQn8uajyCXvyYRQZWxG+Q8=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/kupiqu/SierraBreezeEnhanced/pull/155.patch";
+      hash = "sha256-taj7AqiewiUU4wOTKPgfvua0rDuQ8ssH+/maxz/A3G8=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix #510506
https://github.com/kupiqu/SierraBreezeEnhanced/pull/155

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
