### PR TITLE
plakar: fix build by using buildGo125Module; install manpages

### DIFF
--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -1,11 +1,11 @@
 {
   stdenv,
   lib,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
   fuse,
 }:
-buildGoModule (finalAttrs: {
+buildGo125Module (finalAttrs: {
   pname = "plakar";
   version = "1.0.6";
 

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -36,6 +36,7 @@ buildGo125Module (finalAttrs: {
       ++ lib.optionals stdenv.isDarwin [
         "TestBTreeScanMemory"
         "TestBTreeScanPebble"
+        "TestExecuteCmdServerDefault"
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -3,6 +3,7 @@
   lib,
   buildGo125Module,
   fetchFromGitHub,
+  installShellFiles,
   fuse,
 }:
 buildGo125Module (finalAttrs: {
@@ -22,6 +23,10 @@ buildGo125Module (finalAttrs: {
     fuse
   ];
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
   checkFlags =
     let
       skippedTests = [
@@ -34,6 +39,10 @@ buildGo125Module (finalAttrs: {
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  postInstall = ''
+    installManPage $(find $src -regex '.*\.[0-9]$')
+  '';
 
   meta = {
     mainProgram = "plakar";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Install manpages
* Switch to `buildGo125Module` as the build otherwise fails with:
```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/inikwpl2c7jjbi3d5kb3yfdi3yikikix-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Building subPackage .
# github.com/cockroachdb/swiss
vendor/github.com/cockroachdb/swiss/map.go:286:7: undefined: hashFn
vendor/github.com/cockroachdb/swiss/map.go:337:14: undefined: getRuntimeHasher
vendor/github.com/cockroachdb/swiss/map.go:338:22: undefined: fastrand64
vendor/github.com/cockroachdb/swiss/map.go:600:23: undefined: fastrand64
vendor/github.com/cockroachdb/swiss/map.go:649:19: undefined: fastrand64
vendor/github.com/cockroachdb/swiss/map.go:670:20: undefined: fastrand64
vendor/github.com/cockroachdb/swiss/options.go:30:14: undefined: hashFn
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
