### PR TITLE
cozempic: init at 1.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13537,6 +13537,12 @@
     githubId = 39434424;
     name = "Felix Springer";
   };
+  junaidtitan = {
+    email = "j@junaidq.com";
+    github = "junaidtitan";
+    githubId = 23725493;
+    name = "Junaid Q";
+  };
   junestepp = {
     email = "git@junestepp.me";
     github = "junestepp";

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.2";
+  version = "1.8.3";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7/dZMOmod6gJHXJFwtPsUf4JsySTlq6sMX0BckoWFR0=";
+    hash = "sha256-kOnkKCgnEJnqGYPCKM8M1Wshg5tFDjXHw67KrrQ/yVI=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,19 +6,18 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.0";
+  version = "1.8.2";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-EEBnR3isXLTTeVeihk/UEj4BIGa4lCMYUR0LdWue3Qo=";
+    hash = "sha256-7/dZMOmod6gJHXJFwtPsUf4JsySTlq6sMX0BckoWFR0=";
   };
 
   build-system = [ python3Packages.setuptools ];
 
-  # Zero runtime dependencies — Python stdlib only.
   pythonImportsCheck = [ "cozempic" ];
 
   meta = {

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.3";
+  version = "1.8.6";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kOnkKCgnEJnqGYPCKM8M1Wshg5tFDjXHw67KrrQ/yVI=";
+    hash = "sha256-bnLqHlRNrCtKqJ9myPCaZUMw72xUfuO8gi9Ta1RYlxw=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -9,6 +9,8 @@ python3Packages.buildPythonApplication rec {
   version = "1.7.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-mHjKHg3d5ptHjWbwzgtNWrtJ7MEF9JPlH/+gpzhDaog=";

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.7.1";
+  version = "1.8.0";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-mHjKHg3d5ptHjWbwzgtNWrtJ7MEF9JPlH/+gpzhDaog=";
+    hash = "sha256-EEBnR3isXLTTeVeihk/UEj4BIGa4lCMYUR0LdWue3Qo=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "cozempic";
+  version = "1.7.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mHjKHg3d5ptHjWbwzgtNWrtJ7MEF9JPlH/+gpzhDaog=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  # Zero runtime dependencies — Python stdlib only.
+  pythonImportsCheck = [ "cozempic" ];
+
+  meta = {
+    description = "Context cleaning CLI for Claude Code — prune bloat, protect agent teams from compaction";
+    homepage = "https://github.com/Ruya-AI/cozempic";
+    changelog = "https://github.com/Ruya-AI/cozempic/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "cozempic";
+    maintainers = with lib.maintainers; [ junaidtitan ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.13";
+  version = "1.8.14";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-VzqYkuNJY65GCI9EXQaFmsxyc1Uhp8goOMnac7FY9lg=";
+    hash = "sha256-nJg6+szDefUFpMDXASUBtaWhD5LA+deFzq0Fg2ANPf4=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.16";
+  version = "1.8.17";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-zx/4XZLWYFIdtWehHt5mra4mGcr76raivopBk3G0NL8=";
+    hash = "sha256-ndCbf0FuHs57ksBKf2HSVexLkB7hX1S+0bLY3sMHsqQ=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.14";
+  version = "1.8.16";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nJg6+szDefUFpMDXASUBtaWhD5LA+deFzq0Fg2ANPf4=";
+    hash = "sha256-zx/4XZLWYFIdtWehHt5mra4mGcr76raivopBk3G0NL8=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.6";
+  version = "1.8.12";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-bnLqHlRNrCtKqJ9myPCaZUMw72xUfuO8gi9Ta1RYlxw=";
+    hash = "sha256-lEOWmjcVJiCMlCbCHkt0wMHqp8OTaApYv4GujnBFmhM=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.12";
+  version = "1.8.13";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-lEOWmjcVJiCMlCbCHkt0wMHqp8OTaApYv4GujnBFmhM=";
+    hash = "sha256-VzqYkuNJY65GCI9EXQaFmsxyc1Uhp8goOMnac7FY9lg=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.17";
+  version = "1.8.18";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ndCbf0FuHs57ksBKf2HSVexLkB7hX1S+0bLY3sMHsqQ=";
+    hash = "sha256-2iw3y4XBZSsWryfzWT/EiQsejYeMLfB4jaJ90ZXaHLE=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.33";
+  version = "1.8.34";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-K0vX2Q1rJw78+4isTOLPTrlzaLnUMTTp6/1rTQLMbfI=";
+    hash = "sha256-WhzGI5ye71M/qwtlttqeL4j2O6Py8GxNfSxs/e2Vqc8=";
   };
 
   build-system = [ python3Packages.setuptools ];

--- a/pkgs/by-name/co/cozempic/package.nix
+++ b/pkgs/by-name/co/cozempic/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cozempic";
-  version = "1.8.18";
+  version = "1.8.33";
   pyproject = true;
 
   __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-2iw3y4XBZSsWryfzWT/EiQsejYeMLfB4jaJ90ZXaHLE=";
+    hash = "sha256-K0vX2Q1rJw78+4isTOLPTrlzaLnUMTTp6/1rTQLMbfI=";
   };
 
   build-system = [ python3Packages.setuptools ];


### PR DESCRIPTION
## Description of changes

Initial packaging of [cozempic](https://github.com/Ruya-AI/cozempic) at version 1.7.1.

Cozempic is a CLI tool that prunes bloated Claude Code session JSONL files, protects multi-agent teams from context compaction, and monitors token usage via MCP tools. Widely used by Claude Code power users (~35k+ installs on PyPI + npm).

**Zero runtime dependencies** — Python stdlib only.

Also available via:
- PyPI: \`pip install cozempic\`
- npm: \`npm i -g cozempic\`
- Homebrew tap: \`brew install Ruya-AI/cozempic/cozempic\`

## Things done

- [x] For new packages, used \`pkgs/by-name\` directory structure (\`pkgs/by-name/co/cozempic/package.nix\`)
- [x] Added maintainer entry (\`junaidtitan\`) to \`maintainers/maintainer-list.nix\`
- [x] \`meta.license\` matches upstream (MIT), \`meta.mainProgram\` set, \`meta.platforms = all\`
- [x] \`pythonImportsCheck\` smoke-tests the module import
- [x] Same sdist is in production use via PyPI + Homebrew tap (verified working)

Package is pure Python with no platform-specific code, so ofborg should build cleanly on all platforms. Happy to iterate on feedback.