### PR TITLE
[25.11] luanti: add knownVulnerabilities affecting versions >= 5.0.0 < 5.15.2

### DIFF
--- a/pkgs/by-name/lu/luanti/package.nix
+++ b/pkgs/by-name/lu/luanti/package.nix
@@ -155,5 +155,9 @@ stdenv.mkDerivation (finalAttrs: {
       jk
     ];
     mainProgram = if buildClient then "luanti" else "luantiserver";
+    knownVulnerabilities = [
+      "GHSA-22c4-238c-m5j4: HTTP API and insecure environment access control bypass"
+      "GHSA-g596-mf82-w8c3: Mod security sandbox escape"
+    ];
   };
 })


### PR DESCRIPTION

https://github.com/luanti-org/luanti/security/advisories/GHSA-22c4-238c-m5j4
https://github.com/luanti-org/luanti/security/advisories/GHSA-g596-mf82-w8c3

Fixed in master with #510495 d44d5d525247db33d2a8cd744f5360913709db46


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
