### PR TITLE
vimPlugins.nvim-treesitter: build per-language queries locally

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -7,6 +7,7 @@
   neovim,
   neovimUtils,
   runCommand,
+  runCommandLocal,
   vimPlugins,
   writableTmpDirAsHomeHook,
 }:
@@ -22,7 +23,11 @@ let
       requires ? [ ],
     }:
     vimUtils.toVimPlugin (
-      runCommand "nvim-treesitter-queries-${language}"
+      # Just mkdir + ln -s; cheaper to build than to substitute (and not
+      # on cache.nixos.org anyway since release.nix doesn't recurse into
+      # passthru.queries). With ~300 languages under withAllGrammars,
+      # round-tripping each to a remote builder is very slow.
+      runCommandLocal "nvim-treesitter-queries-${language}"
         {
           passthru = {
             inherit language requires;


### PR DESCRIPTION
`buildQueries` produces ~300 trivial `mkdir + ln -s` derivations (one per language) under `passthru.queries`, all pulled in by `nvim-treesitter.withAllGrammars`.
They're not on cache.nixos.org because `release.nix` doesn't recurse into `passthru.queries`, and the only Hydra job that does build them (`passthru.tests.check-queries`) doesn't reference them in its runtime closure so they're never uploaded.

With remote builders configured, each of the ~300 round-trips over the network for a build that's faster than the SSH handshake. Switch to `runCommandLocal` so they build on the local machine and skip the guaranteed-miss cache queries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
