### PR TITLE
nixos/parsedmarc: fixup for new dovecot module

### DIFF
--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -37,6 +37,7 @@ let
     typeOf
     hashString
     ;
+  inherit (lib) mkDefault;
 in
 {
   options.services.parsedmarc = {
@@ -422,7 +423,37 @@ in
 
     services.dovecot2 = lib.mkIf cfg.provision.localMail.enable {
       enable = true;
-      protocols = [ "imap" ];
+      enablePAM = mkDefault true;
+      settings =
+        let
+          toplevelConfig = config;
+        in
+        { config, ... }:
+        {
+          options = {
+            ssl_server_cert_file = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+            };
+
+            # If STARTTLS is enabled, parsedmarc really wants to use it. However,
+            # if we don't have any certs set, then Dovecot will advertise STARTTLS
+            # but kick the client out if it does try to use it. Therefore, default
+            # this to whether ssl_server_cert_file is set.
+            ssl = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = config.ssl_server_cert_file != null;
+            };
+          };
+
+          config = {
+            dovecot_config_version = mkDefault "2.4.3";
+            dovecot_storage_version = mkDefault "2.4.3";
+            protocols.imap = true;
+            mail_driver = mkDefault "maildir";
+            mail_path = mkDefault "${toplevelConfig.services.postfix.settings.main.mail_spool_directory}/%{user}";
+          };
+        };
     };
 
     services.postfix = lib.mkIf cfg.provision.localMail.enable {
@@ -535,7 +566,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [
           "postfix.service"
-          "dovecot2.service"
+          "dovecot.service"
           "elasticsearch.service"
         ];
         path = with pkgs; [

--- a/nixos/tests/parsedmarc/default.nix
+++ b/nixos/tests/parsedmarc/default.nix
@@ -99,7 +99,7 @@ in
       ''
         parsedmarc.start()
         parsedmarc.wait_for_unit("postfix.service")
-        parsedmarc.wait_for_unit("dovecot2.service")
+        parsedmarc.wait_for_unit("dovecot.service")
         parsedmarc.wait_for_unit("parsedmarc.service")
         parsedmarc.wait_until_succeeds(
             "curl -sS -f http://localhost:${esPort}"
@@ -164,7 +164,7 @@ in
           };
 
         mail =
-          { nodes, ... }:
+          { config, nodes, ... }:
           {
             imports = [ ../common/user-account.nix ];
 
@@ -175,10 +175,17 @@ in
 
             services.dovecot2 = {
               enable = true;
-              protocols = [ "imap" ];
-              sslCACert = "${certs.ca.cert}";
-              sslServerCert = "${certs.${mailDomain}.cert}";
-              sslServerKey = "${certs.${mailDomain}.key}";
+              enablePAM = true;
+              settings = {
+                dovecot_config_version = "2.4.3";
+                dovecot_storage_version = config.services.dovecot2.package.version;
+                protocols.imap = true;
+                mail_driver = "maildir";
+                mail_path = "${config.services.postfix.settings.main.mail_spool_directory}/%{user}";
+                ssl_server_ca_file = "${certs.ca.cert}";
+                ssl_server_cert_file = "${certs.${mailDomain}.cert}";
+                ssl_server_key_file = "${certs.${mailDomain}.key}";
+              };
             };
 
             services.postfix = {
@@ -210,7 +217,7 @@ in
         ''
           mail.start()
           mail.wait_for_unit("postfix.service")
-          mail.wait_for_unit("dovecot2.service")
+          mail.wait_for_unit("dovecot.service")
 
           parsedmarc.start()
           parsedmarc.wait_for_unit("parsedmarc.service")


### PR DESCRIPTION
See #509564.

This dynamically defines new options in services.dovecot2.settings to fix infrec when provision.localMail is true. It works, at least for the test, but not sure whether this should be done another way (such as always defining them in the dovecot module).

cc @dblsaiko

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
