### PR TITLE
writeShellApplication: fix meta.position

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -109,6 +109,7 @@ rec {
       allowSubstitutes ? false,
       preferLocalBuild ? true,
       derivationArgs ? { },
+      pos ? builtins.unsafeGetAttrPos "name" args,
     }@args:
     assert lib.assertMsg (destination != "" -> (lib.hasPrefix "/" destination && destination != "/")) ''
       destination must be an absolute path, relative to the derivation's out path,
@@ -123,8 +124,8 @@ rec {
     runCommand name
       (
         {
-          pos = builtins.unsafeGetAttrPos "name" args;
           inherit
+            pos
             text
             executable
             checkPhase
@@ -261,6 +262,7 @@ rec {
       inheritPath ? true,
     }@args:
     writeTextFile {
+      pos = builtins.unsafeGetAttrPos "name" args;
       inherit
         name
         meta


### PR DESCRIPTION
This avoids getting random pings when the trivial builders are changed.

In my case this is `keen4`, which uses `writeShellApplication`, which then causes pings for example on #510526.

~~Not sure whether this triggers rebuilds, let's try master first.~~

Before:
```
nix-repl> keen4.meta.position
"[...]/pkgs/build-support/trivial-builders/default.nix:266"
```

After:

```
nix-repl> keen4.meta.position
"[...]/pkgs/by-name/ke/keen4/package.nix:16"
```

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
