### PR TITLE
nixos-test-driver: don't prepare sandbox environemnt outside of sandbox.

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -64,6 +64,14 @@ def pythonize_name(name: str) -> str:
     return re.sub(r"^[^A-Za-z_]|[^A-Za-z0-9_]", "_", name)
 
 
+def in_nix_sandbox() -> bool:
+    # There seems to be no better method at the time
+    typical_nix_env_vars = "NIX_BUILD_TOP" in os.environ
+    nix_shell_marker = "IN_NIX_SHELL" in os.environ
+
+    return typical_nix_env_vars and not nix_shell_marker
+
+
 @dataclass
 class VsockPair:
     guest: Path
@@ -191,7 +199,7 @@ class Driver:
             for name, vm_start_script in self.vm_start_scripts.items()
         ]
 
-        if len(self.container_start_scripts) > 0:
+        if len(self.container_start_scripts) > 0 and in_nix_sandbox():
             self._init_nspawn_environment()
 
         self.machines_nspawn = [


### PR DESCRIPTION
We should not run the sandbox preparation stuff when we are not in the sandbox.

This fixes running container tests in interactive mode and non-interactive mode outside the nix sandbox. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
