### PR TITLE
Nixos test driver tidy up

### DIFF
--- a/nixos/lib/test-driver/src/extract-docstrings.py
+++ b/nixos/lib/test-driver/src/extract-docstrings.py
@@ -66,17 +66,20 @@ def function_docstrings(functions: list[ast.FunctionDef]) -> str | None:
 def machine_methods(
     class_name: str, class_definitions: list[ast.ClassDef]
 ) -> list[ast.FunctionDef]:
-    """Given a class name and a list of class definitions, returns the list of function definitions
-    for the class matching the given name.
+    """
+    Given a class name and a list of class definitions, returns the list of
+    function definitions for the class matching the given name.
     """
     machine_class = next(filter(lambda x: x.name == class_name, class_definitions))
     assert machine_class is not None
 
-    function_definitions = [
-        node for node in machine_class.body if isinstance(node, ast.FunctionDef)
-    ]
-    function_definitions.sort(key=lambda x: x.name)
-    return function_definitions
+    methods = [node for node in machine_class.body if isinstance(node, ast.FunctionDef)]
+    methods.sort(key=lambda x: x.name)
+
+    # Do not document internal functions prefixed with underscore
+    methods = [m for m in methods if not m.name.startswith("_")]
+
+    return methods
 
 
 def main() -> None:

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -27,8 +27,6 @@ from test_driver.machine import (
 from test_driver.polling_condition import PollingCondition
 from test_driver.vlan import VLan
 
-SENTINEL = object()
-
 
 class AssertionTester(TestCase):
     """


### PR DESCRIPTION

- Removed the `SENTINEL` object in the driver.py file
- dropped `_`-prefixed machine methods from being documented.

cc @m1-s 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
