### PR TITLE
[Backport release-25.11] opam: 2.4.1 -> 2.5.1

### DIFF
--- a/pkgs/by-name/op/opam-publish/package.nix
+++ b/pkgs/by-name/op/opam-publish/package.nix
@@ -17,15 +17,15 @@ let
     ;
 in
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "opam-publish";
-  version = "2.7.0";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "ocaml-opam";
     repo = "opam-publish";
-    rev = version;
-    hash = "sha256-Li7Js8mrxOrRNNuu8z4X+VXbuECfk7Gsgpy4d6R3RwU=";
+    tag = finalAttrs.version;
+    hash = "sha256-yaFkR+MxkN6/skXx9euKVjTGXk9DraxDj+/2XQuHK4I=";
   };
 
   buildInputs = [
@@ -48,4 +48,4 @@ buildDunePackage rec {
     ];
     maintainers = with lib.maintainers; [ niols ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/oui/default.nix
+++ b/pkgs/development/ocaml-modules/oui/default.nix
@@ -15,15 +15,15 @@
 
 buildDunePackage (finalAttrs: {
   pname = "oui";
-  version = "0-unstable-2025-10-08";
+  version = "0-unstable-2025-12-02";
 
-  minimalOCamlVersion = "4.10";
+  minimalOCamlVersion = "4.13";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";
     repo = "ocaml-universal-installer";
-    rev = "2fe2e33c3f8e1744fdd4dab04458043451bf9f62";
-    hash = "sha256-ALQIQ3Ab1Gs2xST9OwsO5IxixzgKlUg7uHZvfHMbv7Q=";
+    rev = "202dae889c4850674f7b40ca8d541f98afa2ba0f";
+    hash = "sha256-pwvp6bJF18NzKh/JSet05VHoJNZ7FKr0Hsi/RJ/TK4U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -15,11 +15,11 @@ assert lib.versionAtLeast ocaml.version "4.08.0";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opam";
-  version = "2.4.1";
+  version = "2.5.0";
 
   src = fetchurl {
     url = "https://github.com/ocaml/opam/releases/download/${finalAttrs.version}/opam-full-${finalAttrs.version}.tar.gz";
-    hash = "sha256-xNBTApeTxxTk5zQLEVdCjA+QeDWF+xfzUVgkemQEZ9k=";
+    hash = "sha256-JfuY+WLEInwSYeFCr8aKQWd45ugZYAvV7j7EoYrh4jg=";
   };
 
   strictDeps = true;

--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -15,11 +15,11 @@ assert lib.versionAtLeast ocaml.version "4.08.0";
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opam";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchurl {
     url = "https://github.com/ocaml/opam/releases/download/${finalAttrs.version}/opam-full-${finalAttrs.version}.tar.gz";
-    hash = "sha256-JfuY+WLEInwSYeFCr8aKQWd45ugZYAvV7j7EoYrh4jg=";
+    hash = "sha256-SMW/r19cQEjMX0ACXec4X1utOoJpdWIWzW3S8hUAM+0=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/510436 to 25.11
Fixes OSEC-2026-3