### PR TITLE
gnuplot_qt: fix overrides

### DIFF
--- a/pkgs/by-name/gn/gnuplot_qt/package.nix
+++ b/pkgs/by-name/gn/gnuplot_qt/package.nix
@@ -1,7 +1,12 @@
 {
   gnuplot,
-}:
+  ...
+}@args:
 
-gnuplot.override {
-  withQt = true;
-}
+gnuplot.override (
+  {
+    withQt = true;
+    withWxGTK = false; # Explicitly prevent dual-GUI bloat
+  }
+  // removeAttrs args [ "gnuplot" ]
+)


### PR DESCRIPTION
This pull request makes a minor update to the `gnuplot_qt` package definition to improve flexibility and prevent unnecessary GUI bloat.

- Refactored the argument handling in `package.nix` to accept arbitrary arguments, allowing for more flexible package overrides.
- Explicitly disabled `withWxGTK` to avoid dual-GUI bloat, ensuring only the Qt interface is enabled.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
