### PR TITLE
pkgs-lib/formats: use yj instead of remarshal for toml.generate

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -461,16 +461,16 @@ optionalAttrs allowAliases aliases
       generate =
         name: value:
         pkgs.callPackage (
-          { runCommand, remarshal }:
+          { runCommand, yj }:
           runCommand name
             {
-              nativeBuildInputs = [ remarshal ];
+              nativeBuildInputs = [ yj ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
               preferLocalBuild = true;
             }
             ''
-              json2toml "$valuePath" "$out"
+              yj -jt < "$valuePath" > "$out"
             ''
         ) { };
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -701,6 +701,8 @@ runBuildTests {
       [attrs]
       foo = "foo"
 
+      [level1]
+      [level1.level2]
       [level1.level2.level3]
       level4 = "deep"
     '';


### PR DESCRIPTION
**This PR was produced with the help of LLMs**

Human speaking:

I was debugging why `treefmt-nix` is slow to eval. There is a deeper issue with pythonPackages is adding a ton of function calls (something related to doCheck = true) that also needs to be addressed at some point. For now, I'd like to propose this as an easy fix.

----
LLM:

`remarshal` is a Python application; evaluating its derivation forces a large slice of `python3Packages` (rich, ruamel-yaml, cbor2, tomlkit and their transitive build/check inputs — ~150 distinct python-modules, ~2700 derivations). 95 NixOS modules use `formats.toml`, so any system enabling one of those services pays this on every `nixos-rebuild`.

`yj` is a small Go binary that does the same JSON→TOML conversion. For all values accepted by `(formats.toml{}).type` the output is semantically identical (verified via `tomllib`).

Reproducer (best of 3, `NIX_SHOW_STATS=1 nix-instantiate -E '(pkgs.formats.toml{}).generate "x" {a.b=1;}'`):

                        cpuTime  nrFunctionCalls   nrThunks  drv-closure
    before (remarshal)    0.69s          634,117  1,184,499   2722 paths
    after  (yj)           0.36s          271,308    566,981   1481 paths
                           -49%             -57%       -52%         -46%

Runtime closure of the converter: remarshal 202.3 MiB → yj 5.2 MiB.

Differences in output:
- yj emits intermediate table headers for deeply-nested keys (`[a]` `[a.b]` `[a.b.c]` rather than just `[a.b.c]`). Valid TOML, parses identically.
- yj renders very small/large floats as decimals rather than scientific notation (`1e-300` → 300-digit literal). Valid TOML, parses identically.
- Direct callers of `generate` that pass `null` (which the format type already rejects) get key-dropped instead of a build-time error. NixOS modules are unaffected since the option type filters this at eval time; several modules already `filterAttrs (v: v != null)` for exactly this reason.

Tested:
- `nix-build pkgs/pkgs-lib/tests -A formats` passes
- arrays of tables, nested tables, string escaping, int64, unicode keys/values, mixed scalar+table siblings round-trip through `tomllib` identically to remarshal output


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
