### PR TITLE
tux-manager: init at 1.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21306,6 +21306,11 @@
     githubId = 627831;
     name = "Hoang Xuan Phu";
   };
+  phyrophone = {
+    name = "phyrophone";
+    github = "phyrophone";
+    githubId = 255566614;
+  };
   picnoir = {
     email = "felix@alternativebit.fr";
     matrix = "@picnoir:alternativebit.fr";

--- a/pkgs/by-name/tu/tux-manager/package.nix
+++ b/pkgs/by-name/tu/tux-manager/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  kdePackages,
+  makeDesktopItem,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tux-manager";
+  version = "1.0.4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "benapetr";
+    repo = "TuxManager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ko41pTGkWjCgKX65YmWt2KamlltIQkjmFIsl7fuMDK4=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = finalAttrs.pname;
+    desktopName = "Tux Manager";
+    type = "Application";
+    comment = "Linux system monitor inspired by Windows Task Manager";
+    exec = "tux-manager";
+    icon = "tux-manager";
+    categories = [
+      "System"
+      "Monitor"
+    ];
+    terminal = false;
+  };
+
+  nativeBuildInputs = with kdePackages; [
+    qmake
+    wrapQtAppsHook
+  ];
+  buildInputs = with kdePackages; [ qtbase ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    qmake6 $src/src;
+
+    runHook postConfigure
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp tux-manager $out/bin/tux-manager
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps/
+    cp ${finalAttrs.src}/src/tux_manager_icon.svg $out/share/icons/hicolor/scalable/apps/tux-manager.svg
+
+    mkdir -p $out/share/applications
+    ln -s ${finalAttrs.desktopItem}/share/applications/* $out/share/applications/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Linux system monitor inspired by Windows Task Manager";
+    longDescription = "A Linux Task Manager alternative built with Qt6, inspired by the Windows Task Manager but designed to go further - providing deep visibility into system processes, performance metrics, users, and services.";
+    mainProgram = "tuxmanager";
+    homepage = "https://github.com/benapetr/TuxManager";
+    downloadPage = "https://github.com/benapetr/TuxManager/releases/";
+    changelog = "https://github.com/benapetr/TuxManager/blob/master/CHANGELOG.md#${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ phyrophone ];
+  };
+})

--- a/pkgs/by-name/tu/tux-manager/package.nix
+++ b/pkgs/by-name/tu/tux-manager/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  kdePackages,
+  makeDesktopItem,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tux-manager";
+  version = "1.0.7";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "benapetr";
+    repo = "TuxManager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Lnw78zrfuGHURlpxTRP5RN3gj4oVHMa8R5PfHktUmFg=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = finalAttrs.pname;
+    desktopName = "Tux Manager";
+    type = "Application";
+    comment = "Linux system monitor inspired by Windows Task Manager";
+    exec = "tux-manager";
+    icon = "tux-manager";
+    categories = [
+      "System"
+      "Monitor"
+    ];
+    terminal = false;
+  };
+
+  nativeBuildInputs = with kdePackages; [
+    qmake
+    wrapQtAppsHook
+  ];
+  buildInputs = with kdePackages; [ qtbase ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    qmake6 $src/src;
+
+    runHook postConfigure
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp tux-manager $out/bin/tux-manager
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps/
+    cp ${finalAttrs.src}/src/tux_manager_icon.svg $out/share/icons/hicolor/scalable/apps/tux-manager.svg
+
+    mkdir -p $out/share/applications
+    cp ${finalAttrs.src}/packaging/data/io.github.benapetr.TuxManager.desktop $out/share/applications/io.github.benapetr.TuxManager.desktop
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  qtWrapperArgs = [ "--prefix LD_LIBRARY_PATH : /run/opengl-driver/lib" ];
+
+  meta = {
+    description = "Linux system monitor inspired by Windows Task Manager";
+    longDescription = "A Linux Task Manager alternative built with Qt6, inspired by the Windows Task Manager but designed to go further - providing deep visibility into system processes, performance metrics, users, and services.";
+    mainProgram = "tux-manager";
+    homepage = "https://github.com/benapetr/TuxManager";
+    downloadPage = "https://github.com/benapetr/TuxManager/releases/";
+    changelog = "https://github.com/benapetr/TuxManager/blob/master/CHANGELOG.md#${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ phyrophone ];
+  };
+})


### PR DESCRIPTION
Adds [Tux Manager](https://github.com/benapetr/TuxManager), a system monitor for Linux inspired by windows task manager and built with qt6.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
