### PR TITLE
nixos/acme: improve webroot handling

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -443,13 +443,16 @@ let
           done
 
           ${lib.optionalString (data.webroot != null) ''
-            # Ensure the webroot exists. Fixing group is required in case configuration was changed between runs.
+            # Ensure the webroot exists.
             # Lego will fail if the webroot does not exist at all.
             (
-              mkdir -p '${data.webroot}/.well-known/acme-challenge' \
-              && chgrp '${data.group}' ${data.webroot}/.well-known/acme-challenge
+              # If creating the webroot dir, make it world-readable so that the
+              # web server can access it regardless of whether the certificate
+              # is actually being generated for this web server.
+              umask 0022 \
+              && mkdir -p '${data.webroot}/.well-known/acme-challenge'
             ) || (
-              echo 'Please ensure ${data.webroot}/.well-known/acme-challenge exists and is writable by acme:${data.group}' \
+              echo 'Please ensure ${data.webroot}/.well-known/acme-challenge exists and is writable by the user ${user}.' \
               && exit 1
             )
           ''}
@@ -1281,6 +1284,21 @@ in
           ) (lib.groupBy (conf: conf.accountHash) (lib.attrValues certConfigs));
         in
         accountTargets;
+
+      systemd.tmpfiles.settings."10-acme" =
+        lib.genAttrs
+          (lib.concatMap (dir: [
+            dir
+            (dir + "/.well-known")
+            (dir + "/.well-known/acme-challenge")
+          ]) webroots)
+          (dir: {
+            "d" = {
+              inherit user;
+              group = "acme";
+              mode = "0755";
+            };
+          });
     })
   ];
 

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -441,21 +441,6 @@ let
               chown -R ${user}:${data.group} "$fixpath"
             fi
           done
-
-          ${lib.optionalString (data.webroot != null) ''
-            # Ensure the webroot exists.
-            # Lego will fail if the webroot does not exist at all.
-            (
-              # If creating the webroot dir, make it world-readable so that the
-              # web server can access it regardless of whether the certificate
-              # is actually being generated for this web server.
-              umask 0022 \
-              && mkdir -p '${data.webroot}/.well-known/acme-challenge'
-            ) || (
-              echo 'Please ensure ${data.webroot}/.well-known/acme-challenge exists and is writable by the user ${user}.' \
-              && exit 1
-            )
-          ''}
         '';
       };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This fixes an issue I had with trying to obtain a cert from a private CA with the webroot mechanism for use in other contexts than nginx (so setting the cert's group to `nginx` would not have been appropriate).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS acme tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
