### PR TITLE
<deprecated> pam-db: init at 0.4.0-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7646,6 +7646,12 @@
     githubId = 1181393;
     name = "Eduard Bachmakov";
   };
+  eduardofuncao = {
+    email = "eduardofuncao@hotmail.com";
+    github = "eduardofuncao";
+    githubId = 45571086;
+    name = "Eduardo Função";
+  };
   edude03 = {
     email = "michael@melenion.com";
     github = "edude03";

--- a/pkgs/by-name/s/squix/package.nix
+++ b/pkgs/by-name/s/squix/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "squix";
+  version = "0.4.0-beta";
+
+  src = fetchFromGitHub {
+    owner = "eduardofuncao";
+    repo = "squix";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-lJOXzBgVgRdUi+btu/eOlYXDLhS2FLEnJQ/UjGk5jF4=";
+  };
+
+  vendorHash = "sha256-JRmNajvCb57dMo8eggOD1m4N01p2RSK8r49pmBB56Z0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Minimal CLI tool for managing SQL queries across multiple databases";
+    homepage = "https://github.com/eduardofuncao/squix";
+    license = lib.licenses.mit;
+    mainProgram = "squix";
+    maintainers = with lib.maintainers; [ eduardofuncao ];
+  };
+})


### PR DESCRIPTION
## Summary

Add pam](https://github.com/eduardofuncao/pam) — a minimal CLI tool for managing and executing SQL queries across multiple databases (PostgreSQL, MySQL, SQLite, Oracle, SQL Server, ClickHouse, Firebird, DuckDB).

Features:
- TUI with keyboard-driven navigation (vim-style keybindings)
- Query library: save, organize, and reuse queries
- In-place cell editing and row deletion from results
- Export to CSV, JSON, SQL, Markdown, HTML
- Shell completions for bash, zsh, fish

## Testing

- [x] `nix-build -A squix` succeeds
- [x] `./result/bin/squix --version` outputs correct version
- [x] Formatted with `nixfmt`

Add a :+1: reaction to [this comment](https://github.com/NixOS/nixpkgs/issues/374361) if you'd like this package in nixpkgs.

---

This package was manually tested on `x86_64-linux` (NixOS).