### PR TITLE
nixos/image/repart-verity-store: mount nix-store in the module

### DIFF
--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -89,6 +89,12 @@ in
       };
     };
 
+    fileSystems."/nix/store" = lib.mkDefault {
+      device = "/usr/nix/store";
+      fsType = "none";
+      options = [ "bind" ];
+    };
+
     image.repart.partitions = {
       # dm-verity hash partition
       ${cfg.partitionIds.store-verity}.repartConfig = {

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -18,17 +18,11 @@
     {
       imports = [ ../modules/image/repart.nix ];
 
-      virtualisation.fileSystems = lib.mkVMOverride {
+      virtualisation.fileSystems = lib.mkVMOverride { };
+      fileSystems = {
         "/" = {
           fsType = "tmpfs";
           options = [ "mode=0755" ];
-        };
-
-        # bind-mount the store
-        "/nix/store" = {
-          device = "/usr/nix/store";
-          fsType = "none";
-          options = [ "bind" ];
         };
       };
 


### PR DESCRIPTION
You always need this for the image to be bootable so lets do it in the image and not in the test


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
