### PR TITLE
python3Packages.speechrecognition: 3.14.3 -> 3.16.0

### DIFF
--- a/pkgs/development/python-modules/speechrecognition/default.nix
+++ b/pkgs/development/python-modules/speechrecognition/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   cacert,
+  cohere,
   faster-whisper,
   flac,
   google-cloud-speech,
@@ -12,6 +13,7 @@
   openai,
   pocketsphinx,
   pyaudio,
+  pytest-httpserver,
   pytestCheckHook,
   requests,
   respx,
@@ -21,16 +23,16 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "speechrecognition";
-  version = "3.14.3";
+  version = "3.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Uberi";
     repo = "speech_recognition";
-    tag = version;
-    hash = "sha256-g//KKxPRe1pWVJo7GsRNIV59r0J7XJEoXvH0tGuV3Jk=";
+    tag = finalAttrs.version;
+    hash = "sha256-EIDhWx1s1B0DX4Vmd/a8hRnTBgdBx9ALOonOWFPgUOg=";
   };
 
   postPatch = ''
@@ -52,6 +54,7 @@ buildPythonPackage rec {
   optional-dependencies = {
     assemblyai = [ requests ];
     audio = [ pyaudio ];
+    cohere = [ cohere ];
     faster-whisper = [ faster-whisper ];
     google-cloud = [ google-cloud-speech ];
     groq = [
@@ -67,15 +70,17 @@ buildPythonPackage rec {
       openai-whisper
       soundfile
     ];
+    # vosk = [ vosk ];
   };
 
   nativeCheckInputs = [
     groq
+    pytest-httpserver
     pytestCheckHook
     pocketsphinx
     respx
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   pythonImportsCheck = [ "speech_recognition" ];
 
@@ -84,14 +89,19 @@ buildPythonPackage rec {
     "test_sphinx_keywords"
   ];
 
+  disabledTestPaths = [
+    # vosk is not available in nixpkgs
+    "tests/recognizers/test_vosk.py"
+  ];
+
   meta = {
     description = "Speech recognition module for Python, supporting several engines and APIs, online and offline";
     homepage = "https://github.com/Uberi/speech_recognition";
-    changelog = "https://github.com/Uberi/speech_recognition/releases/tag/${src.tag}";
+    changelog = "https://github.com/Uberi/speech_recognition/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [
       gpl2Only
       bsd3
     ];
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/Uberi/speech_recognition/releases/tag/3.16.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
