### PR TITLE
hickory-dns: 0.25.2 -> 0.26.0, enable features and tests

### DIFF
--- a/pkgs/by-name/hi/hickory-dns/package.nix
+++ b/pkgs/by-name/hi/hickory-dns/package.nix
@@ -38,7 +38,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Rust based DNS client, server, and resolver";
     homepage = "https://hickory-dns.org/";
     changelog = "https://github.com/hickory-dns/hickory-dns/releases/tag/v${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ colinsane ];
+    maintainers = with lib.maintainers; [
+      adamcstephens
+      colinsane
+    ];
     platforms = lib.platforms.linux;
     license = with lib.licenses; [
       asl20

--- a/pkgs/by-name/hi/hickory-dns/package.nix
+++ b/pkgs/by-name/hi/hickory-dns/package.nix
@@ -1,10 +1,9 @@
 {
-  lib,
+  cacert,
   fetchFromGitHub,
-  openssl,
-  pkg-config,
-  rustPlatform,
+  lib,
   nix-update-script,
+  rustPlatform,
   versionCheckHook,
 }:
 
@@ -21,16 +20,65 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-El5NuGevzTpHJP5MVYjyED0UwV7xM9iwv/X7x5Gz/+I=";
 
-  buildInputs = [ openssl ];
-  nativeBuildInputs = [ pkg-config ];
+  buildFeatures = [
+    "blocklist"
+    "dnssec-ring"
+    "h3-ring"
+    "https-ring"
+    "quic-ring"
+    "recursor"
+    "rustls-platform-verifier"
+    "tls-ring"
+  ];
 
-  # tests expect internet connectivity to query real nameservers like 8.8.8.8
-  doCheck = false;
+  # skip tests that need network or public resolvers
+  checkFlags = [
+    "--skip=client::tests::async_client"
+    "--skip=client::tests::readme_example"
+    "--skip=client_future_tests::test_query_https"
+    "--skip=client_future_tests::test_query_tcp_ipv4"
+    "--skip=client_future_tests::test_query_udp_ipv4"
+    "--skip=client_future_tests::test_timeout_query_udp"
+    "--skip=client_tests::test_nsec3_nxdomain"
+    "--skip=client_tests::test_query_udp_edns"
+    "--skip=client_tests::test_secure_query_example_tcp"
+    "--skip=client_tests::test_timeout_query_tcp"
+    "--skip=client_tests::test_timeout_query_udp"
+    "--skip=connection_provider::tests"
+    "--skip=dnssec_client_handle_tests::test_secure_query_example_tcp"
+    "--skip=forwarder::test_lookup"
+    "--skip=h2::tests::test_https_google"
+    "--skip=h2::tests::test_https_google_with_pure_ip_address_server"
+    "--skip=h3::h3_client_stream::tests::test_h3_client_stream_clonable"
+    "--skip=h3::h3_client_stream::tests::test_h3_cloudflare"
+    "--skip=h3::h3_client_stream::tests::test_h3_google"
+    "--skip=h3::h3_client_stream::tests::test_h3_google_with_pure_ip_address_server"
+    "--skip=name_server::tests::test_name_server"
+    "--skip=name_server_pool::tests::test_multi_use_conns"
+    "--skip=named_tests::test_forward"
+    "--skip=resolver::tests::test_domain_search"
+    "--skip=resolver::tests::test_fqdn"
+    "--skip=resolver::tests::test_idna"
+    "--skip=resolver::tests::test_large_ndots"
+    "--skip=resolver::tests::test_lookup_cloudflare"
+    "--skip=resolver::tests::test_lookup_google"
+    "--skip=resolver::tests::test_ndots"
+    "--skip=resolver::tests::test_search_list"
+    "--skip=tests::readme_example"
+  ];
 
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
   doInstallCheck = true;
+
+  preCheck = ''
+    # integration tests spin up the server which needs a cert bundle
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+    # skip some doctests that need network
+    substituteInPlace crates/resolver/src/lib.rs --replace-fail '//! ```rust' '//! ```rust,no_run'
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/hi/hickory-dns/package.nix
+++ b/pkgs/by-name/hi/hickory-dns/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hickory-dns";
-  version = "0.25.2";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "hickory-dns";
     repo = "hickory-dns";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-sPVulok18WAWyCXDNJzjioCO733vHmCcC5SjYrs/T+E=";
+    hash = "sha256-1VryKiE7kri7XQmVpCmZjc98L9iN60UVz5bNgphjDAU=";
   };
 
-  cargoHash = "sha256-q54faGF/eLdCRB0Eljkgl/x78Fnpm0eAEK9gCUwiAgo=";
+  cargoHash = "sha256-El5NuGevzTpHJP5MVYjyED0UwV7xM9iwv/X7x5Gz/+I=";
 
   buildInputs = [ openssl ];
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/hickory-dns/hickory-dns/releases/tag/v0.26.0

I also added a list of features to enable that we weren't previously. Without these, none of these features are available to users and the package is pretty barebones.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
