### PR TITLE
fmt_10: remove version

### DIFF
--- a/pkgs/by-name/dc/dcgm/fmt12.patch
+++ b/pkgs/by-name/dc/dcgm/fmt12.patch
@@ -1,0 +1,225 @@
+diff --git a/common/CudaWorker/FieldWorkers.hpp b/common/CudaWorker/FieldWorkers.hpp
+index 380ab1e..15b176e 100644
+--- a/common/CudaWorker/FieldWorkers.hpp
++++ b/common/CudaWorker/FieldWorkers.hpp
+@@ -474,7 +474,7 @@ public:
+         cuSt = cuMemAllocHost(&m_hostMem, m_bufferSize);
+         if (cuSt)
+         {
+-            using fmt::v10::enums::format_as;
++            using fmt::v12::enums::format_as;
+             std::string s = fmt::format("cuMemAllocHost returned {}", cuSt);
+             throw std::runtime_error(s);
+         }
+diff --git a/common/DcgmLogging.h b/common/DcgmLogging.h
+index 75c07de..5c3b458 100644
+--- a/common/DcgmLogging.h
++++ b/common/DcgmLogging.h
+@@ -401,4 +401,4 @@ void InitLogToHostengine(const DcgmLoggingSeverity_t severity);
+ void LoggingSetHostEngineComponentName(const std::string &componentName);
+ int RouteLogToConsoleLogger(loggerCategory_t category);
+ 
+-using fmt::v10::enums::format_as;
+\ No newline at end of file
++using fmt::v12::enums::format_as;
+diff --git a/common/FingerprintStore.h b/common/FingerprintStore.h
+index b05bb7b..688ecaf 100644
+--- a/common/FingerprintStore.h
++++ b/common/FingerprintStore.h
+@@ -57,7 +57,7 @@ struct fmt::formatter<TaskFingerprint>
+ 
+     // Format the TaskFingerprint
+     template <typename FormatContext>
+-    auto format(const TaskFingerprint &fp, FormatContext &ctx)
++    auto format(const TaskFingerprint &fp, FormatContext &ctx) const
+     {
+         return fmt::format_to(ctx.out(), "{:016x}{:016x}", fp[0], fp[1]);
+     }
+diff --git a/common/MigIdParser.hpp b/common/MigIdParser.hpp
+index b22e40e..5aa54bc 100644
+--- a/common/MigIdParser.hpp
++++ b/common/MigIdParser.hpp
+@@ -309,7 +309,7 @@ template <class T>
+ struct fmt::formatter<DcgmNs::Wildcard<T>> : fmt::formatter<fmt::string_view>
+ {
+     template <typename FormatCtx>
+-    auto format(DcgmNs::Wildcard<T> const &value, FormatCtx &ctx)
++    auto format(DcgmNs::Wildcard<T> const &value, FormatCtx &ctx) const
+     {
+         using namespace DcgmNs;
+         return std::visit(
+@@ -321,4 +321,4 @@ struct fmt::formatter<DcgmNs::Wildcard<T>> : fmt::formatter<fmt::string_view>
+                        }),
+             static_cast<typename DcgmNs::Wildcard<T>::BaseType>(value));
+     }
+-};
+\ No newline at end of file
++};
+diff --git a/dcgmi/CommandLineParser.cpp b/dcgmi/CommandLineParser.cpp
+index 5b5bd2f..a116488 100644
+--- a/dcgmi/CommandLineParser.cpp
++++ b/dcgmi/CommandLineParser.cpp
+@@ -37,6 +37,9 @@
+ #include "Topo.h"
+ #include "Version.h"
+ 
++#include <fmt/core.h>
++#include <fmt/ranges.h>
++
+ #include <DcgmBuildInfo.hpp>
+ #include <DcgmDiagCommon.h>
+ #include <DcgmStringConversions.h>
+diff --git a/dcgmi/DcgmiTest.cpp b/dcgmi/DcgmiTest.cpp
+index 2f82489..a7b4400 100755
+--- a/dcgmi/DcgmiTest.cpp
++++ b/dcgmi/DcgmiTest.cpp
+@@ -18,14 +18,15 @@
+  *
+  */
+ 
+-#include "DcgmiTest.h"
+ #include "CommandOutputController.h"
++#include "DcgmiTest.h"
+ #include "dcgm_agent.h"
+ #include "dcgm_structs.h"
+ #include "dcgm_test_apis.h"
+ #include <DcgmStringHelpers.h>
+ #include <ctime>
+ #include <iostream>
++#include <memory>
+ #include <sstream>
+ #include <string>
+ 
+diff --git a/dcgmi/DeviceMonitor.cpp b/dcgmi/DeviceMonitor.cpp
+index bfff37c..00fcc4d 100644
+--- a/dcgmi/DeviceMonitor.cpp
++++ b/dcgmi/DeviceMonitor.cpp
+@@ -176,7 +176,7 @@ template <>
+ struct fmt::formatter<FixedSizeString> : fmt::formatter<std::string_view>
+ {
+     template <typename FormatContext>
+-    auto format(FixedSizeString const &value, FormatContext &ctx)
++    auto format(FixedSizeString const &value, FormatContext &ctx) const
+     {
+         if (value.origin.length() <= value.maxLength)
+         {
+diff --git a/dcgmi/ProcessStats.cpp b/dcgmi/ProcessStats.cpp
+index 54c7cf6..255c26d 100644
+--- a/dcgmi/ProcessStats.cpp
++++ b/dcgmi/ProcessStats.cpp
+@@ -20,14 +20,15 @@
+  *      Author: chris
+  */
+ 
+-#include "ProcessStats.h"
+ #include "CommandOutputController.h"
+ #include "DcgmLogging.h"
++#include "ProcessStats.h"
+ #include "dcgm_agent.h"
+ #include "dcgm_structs.h"
+ #include "dcgm_test_apis.h"
+ #include <iomanip>
+ #include <iostream>
++#include <memory>
+ #include <sstream>
+ #include <time.h>
+ 
+diff --git a/modules/mndiag/MnDiagProcessUtils.h b/modules/mndiag/MnDiagProcessUtils.h
+index 7d735a0..2050457 100644
+--- a/modules/mndiag/MnDiagProcessUtils.h
++++ b/modules/mndiag/MnDiagProcessUtils.h
+@@ -26,6 +26,7 @@ Common helper functions and classes relating to DCGM Multi Node GPU Diagnostics
+ #include <chrono>
+ #include <dcgm_structs.h>
+ #include <functional>
++#include <memory>
+ #include <string>
+ #include <string_view>
+ #include <vector>
+@@ -111,4 +112,4 @@ public:
+  */
+ std::vector<std::pair<pid_t, std::string>> GetMpiProcessInfo(CommandExecutor *executor = nullptr);
+ 
+-} // namespace DcgmNs::Common::ProcessUtils
+\ No newline at end of file
++} // namespace DcgmNs::Common::ProcessUtils
+diff --git a/common/ChildProcess/tests/ChildProcessBuilderTests.cpp b/common/ChildProcess/tests/ChildProcessBuilderTests.cpp
+index bcaa4e9..bcaa4e9 100644
+--- a/common/ChildProcess/tests/ChildProcessBuilderTests.cpp
++++ b/common/ChildProcess/tests/ChildProcessBuilderTests.cpp
+@@ -19,4 +19,5 @@
+ #include <csignal>
+ #include <fmt/format.h>
++#include <fmt/ranges.h>
+ #include <latch>
+ #include <thread>
+
+diff --git a/modules/mndiag/MnDiagMpiRunner.cpp b/modules/mndiag/MnDiagMpiRunner.cpp
+index 3ad4700..3ad4700 100644
+--- a/modules/mndiag/MnDiagMpiRunner.cpp
++++ b/modules/mndiag/MnDiagMpiRunner.cpp
+@@ -21,6 +21,7 @@
+ #include <chrono>
+ #include <cstdlib>
+ #include <dcgm_errors.h>
+ #include <fmt/format.h>
++#include <fmt/ranges.h>
+ #include <numeric>
+ #include <regex>
+ #include <set>
+diff --git a/nvvs/src/ConfigFileParser_v2.cpp b/nvvs/src/ConfigFileParser_v2.cpp
+index 883eb28..883eb28 100644
+--- a/nvvs/src/ConfigFileParser_v2.cpp
++++ b/nvvs/src/ConfigFileParser_v2.cpp
+@@ -35,6 +35,7 @@
+ #include "NvvsCommon.h"
+ #include "ParsingUtility.h"
+ #include "dcgm_fields.h"
+ #include "dcgm_structs.h"
++#include <fmt/ranges.h>
+ #include <EntityListHelpers.h>
+
+diff --git a/modules/diag/DcgmDiagManager.cpp b/modules/diag/DcgmDiagManager.cpp
+index d0a75dc..d0a75dc 100644
+--- a/modules/diag/DcgmDiagManager.cpp
++++ b/modules/diag/DcgmDiagManager.cpp
+@@ -36,6 +36,7 @@
+ #include <cstdlib>
+ #include <cstring>
+ #include <filesystem>
+ #include <fmt/format.h>
++#include <fmt/ranges.h>
+ #include <iterator>
+ #include <ranges>
+ #include <sstream>
+diff --git a/modules/mndiag/MpiRunner.h b/modules/mndiag/MpiRunner.h
+index ac4c969..b4f4fe9 100644
+--- a/modules/mndiag/MpiRunner.h
++++ b/modules/mndiag/MpiRunner.h
+@@ -18,6 +18,7 @@
+ #define MPI_RUNNER_H
+ 
+ #include <fmt/format.h>
++#include <fmt/ranges.h>
+ #include <fstream>
+ #include <functional>
+ #include <memory>
+@@ -238,4 +239,4 @@ protected:
+     std::thread m_stderrRedirectThread;
+ };
+ 
+-#endif // MPI_RUNNER_H
+\ No newline at end of file
++#endif // MPI_RUNNER_H
+diff --git a/nvvs/src/NvidiaValidationSuite.cpp b/nvvs/src/NvidiaValidationSuite.cpp
+index 9fb8e36..9fb8e36 100644
+--- a/nvvs/src/NvidiaValidationSuite.cpp
++++ b/nvvs/src/NvidiaValidationSuite.cpp
+@@ -30,6 +30,7 @@
+ #include <PluginInterface.h>
+ #include <cstdlib>
+ #include <iostream>
++#include <fmt/ranges.h>
+ #include <memory>
+ #include <setjmp.h>
+ #include <signal.h>

--- a/pkgs/by-name/dc/dcgm/package.nix
+++ b/pkgs/by-name/dc/dcgm/package.nix
@@ -12,7 +12,7 @@
   ninja,
   cudaPackages_12,
   boost186,
-  fmt_10,
+  fmt,
   git,
   jsoncpp,
   libevent,
@@ -87,6 +87,7 @@ stdenv.mkDerivation {
     ./remove-cuda-11.patch
     ./dynamic-libs.patch
     ./fix-gcc15.patch
+    ./fmt12.patch
     (replaceVars ./fix-paths.patch {
       inherit coreutils;
       inherit util-linux;
@@ -120,7 +121,7 @@ stdenv.mkDerivation {
     plog.dev
     tclap_1_4
 
-    fmt_10
+    fmt
     yaml-cpp
     jsoncpp
     libevent
@@ -148,7 +149,7 @@ stdenv.mkDerivation {
     "Sysmon: initialize module"
     # Test assumes plugins are installed relative to the binary with a
     # populated `cudaless/` directory
-    "GetPluginCudalessDir returns cudaless directory in plugin directory"
+    "Scenario: GetPluginCudalessDir returns cudaless directory in plugin directory"
   ];
 
   # Add our paths to the CMake flags so FindCuda.cmake can find them.

--- a/pkgs/by-name/ol/olive-editor/olive-editor-openimageio-3.x-compat.patch
+++ b/pkgs/by-name/ol/olive-editor/olive-editor-openimageio-3.x-compat.patch
@@ -1,0 +1,42 @@
+Fix build with OpenImageIO 3.x and Qt 6.10.
+
+In OIIO 3.x, read_image() now requires explicit subimage, miplevel,
+chbegin, and chend parameters before the pixel format argument.
+
+In Qt 6.10, QString::arg() no longer accepts scoped enum values
+implicitly; an explicit cast to int is required.
+
+diff --git a/app/codec/oiio/oiiodecoder.cpp b/app/codec/oiio/oiiodecoder.cpp
+--- a/app/codec/oiio/oiiodecoder.cpp
++++ b/app/codec/oiio/oiiodecoder.cpp
+@@ -134,10 +134,14 @@ TexturePtr OIIODecoder::RetrieveVideoInternal(const RetrieveVideoParams &p)
+
+     if (p.divider == 1) {
+       // Just upload straight to the buffer
+-      image_->read_image(oiio_pix_fmt_, buffer_.data(), OIIO::AutoStride, buffer_.linesize_bytes());
++      image_->read_image(image_->current_subimage(), image_->current_miplevel(),
++                         0, image_->spec().nchannels, oiio_pix_fmt_,
++                         buffer_.data(), OIIO::AutoStride, buffer_.linesize_bytes(), OIIO::AutoStride);
+     } else {
+       OIIO::ImageBuf buf(image_->spec());
+-      image_->read_image(image_->spec().format, buf.localpixels(), buf.pixel_stride(), buf.scanline_stride(), buf.z_stride());
++      image_->read_image(image_->current_subimage(), image_->current_miplevel(),
++                         0, image_->spec().nchannels, image_->spec().format,
++                         buf.localpixels(), buf.pixel_stride(), buf.scanline_stride(), buf.z_stride());
+
+       // Roughly downsample image for divider (for some reason OIIO::ImageBufAlgo::resample failed here)
+       int px_sz = vp.GetBytesPerPixel();
+diff --git a/app/render/videoparams.cpp b/app/render/videoparams.cpp
+--- a/app/render/videoparams.cpp
++++ b/app/render/videoparams.cpp
+@@ -229,2 +229,2 @@
+-  return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(format, 0, 16);
++  return QCoreApplication::translate("VideoParams", "Unknown (0x%1)").arg(static_cast<int>(format), 0, 16);
+ }
+diff --git a/app/ui/humanstrings.cpp b/app/ui/humanstrings.cpp
+--- a/app/ui/humanstrings.cpp
++++ b/app/ui/humanstrings.cpp
+@@ -63,2 +63,2 @@
+-  return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(f, 1, 16);
++  return QCoreApplication::translate("AudioParams", "Unknown (0x%1)").arg(static_cast<int>(f), 1, 16);
+ }

--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -14,25 +14,7 @@
   portaudio,
   imath,
   qt6,
-  fmt_10,
 }:
-
-let
-  # https://github.com/olive-editor/olive/issues/2284
-  # we patch support for 2.3+, but 2.5 fails
-  openimageio' = (openimageio.override { fmt = fmt_10; }).overrideAttrs (old: rec {
-    version = "2.4.15.0";
-    src = (
-      old.src.override {
-        tag = "v${version}";
-        hash = "sha256-I2/JPmUBDb0bw7qbSZcAkYHB2q2Uo7En7ZurMwWhg/M=";
-      }
-    );
-
-    # robin-map headers require c++17
-    cmakeFlags = (old.cmakeFlags or [ ]) ++ [ (lib.cmakeFeature "CMAKE_CXX_STANDARD" "17") ];
-  });
-in
 
 stdenv.mkDerivation {
   pname = "olive-editor";
@@ -62,6 +44,10 @@ stdenv.mkDerivation {
     # https://github.com/KDAB/KDDockWidgets/pull/615
     # https://github.com/KDAB/KDDockWidgets/commit/f2b50fff29bd4b49acdfed3ed8fc42eb0a502032
     ./olive-editor-kddockwidgets-fix-build-with-qt-6_10.patch
+
+    # Fix build with OpenImageIO 3.x: read_image() now requires explicit
+    # subimage, miplevel, chbegin, and chend arguments.
+    ./olive-editor-openimageio-3.x-compat.patch
   ];
 
   # https://github.com/olive-editor/olive/issues/2200

--- a/pkgs/by-name/ol/olive-editor/package.nix
+++ b/pkgs/by-name/ol/olive-editor/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
     ffmpeg_6
     frei0r
     opencolorio
-    openimageio'
+    openimageio
     imath
     openexr
     portaudio

--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -81,11 +81,6 @@ in
     ];
   };
 
-  fmt_10 = generic {
-    version = "10.2.1";
-    hash = "sha256-pEltGLAHLZ3xypD/Ur4dWPWJ9BGVXwqQyKcDWVmC3co=";
-  };
-
   fmt_11 = generic {
     version = "11.2.0";
     hash = "sha256-sAlU5L/olxQUYcv8euVYWTTB8TrVeQgXLHtXy8IMEnU=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6261,7 +6261,6 @@ with pkgs;
 
   inherit (callPackages ../development/libraries/fmt { })
     fmt_9
-    fmt_10
     fmt_11
     fmt_12
     ;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a follow-up to #444918 in an effort to consolidate the fmt version in nixpkgs.

- [x] dcgm: we can't easily update (to a fmt_12 compatible versions) that yet, since it doesn't have a proper release and dependent projects have not been released. So we just fix the issues upstream will have fixed with 4.5.0.
- [x] olive-editor: we pinned an old dependency which needed fmt_10. Getting rid of the dependency and patching the API change for openimageio instead.

Obviously it must be rebased once #444918 is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
