### PR TITLE
claude-code: 2.1.107 -> 2.1.111

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "claude-code";
     publisher = "anthropic";
-    version = "2.1.107";
-    hash = "sha256-3RhHJzkY2Lkp5zI8NWXueUfiqd+RuKLfSqcLF4fxvSA=";
+    version = "2.1.111";
+    hash = "sha256-NfmPJl/+PyJTImKsN+cES6XxJryEQW0+dUoOyZsYq4k=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/cl/claude-code-bin/manifest.json
+++ b/pkgs/by-name/cl/claude-code-bin/manifest.json
@@ -1,46 +1,46 @@
 {
-  "version": "2.1.107",
-  "buildDate": "2026-04-14T04:25:18Z",
+  "version": "2.1.111",
+  "buildDate": "2026-04-16T14:30:47Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "af95a2929cea1ac50feb32ac76bcaa9bf4791fdd25c3186ad7b514da0788deaf",
-      "size": 202518512
+      "checksum": "2620cc83dbee72c24858b3519ce5de050fef91f0d3d17b309176d61e679f95ee",
+      "size": 203956832
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "cdfae1d314063e17f7a6fbc153bd9f4f6727e565517b5b9453635acf87f028bb",
-      "size": 204016640
+      "checksum": "16d897d570c93b83d100a16a7a33ca3adbd43b1b0f818ab66bef1a364b2460a6",
+      "size": 205442640
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "b3f1d3acde0a247c67a93638208911dd2f676743d16cb3f9bd3987ffb3498a00",
-      "size": 234883648
+      "checksum": "99376866bf7ec367142d3be548c17184a79f30a97318441ee9a00f78e51246e7",
+      "size": 236128832
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "8abe3909c55b3afafa8939d28c2cc2fcf73ba9424a46b4f435bbadda7e0eb00d",
-      "size": 234576512
+      "checksum": "5d4df970040b0f83aac434ae540b409126a4778a379e8c9b4c793560e3bfa060",
+      "size": 235842176
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "2827a84aa631859be0d3a100f97b9549879bb5098bf311caff4f8ed72c282035",
-      "size": 227936704
+      "checksum": "39f1d4b9c328ced97dae1de8ca000769e935e15aaa89f54f4c6663016c834ff5",
+      "size": 228854208
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "2a47436fae6444bedbbf2f34ba3cae11244761bd61c10bcf568078bec4c2caa0",
-      "size": 228891072
+      "checksum": "cb789bbf32c90aa7b658f0cf1cedd7116b45afc5e0438f6fda4af0bac5996c9f",
+      "size": 230107584
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "d8cddb8c37da11a5a68e1cbde922b472974e93b459d1e4270be6d5856592685f",
-      "size": 244154016
+      "checksum": "51024dbcd60382b6fb881b5cda6754a0fe445a90d3ad02eb5f13a2733ac3262e",
+      "size": 245423264
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "ffa590ddd68e10803c6ea708a1a28ecd24dbe2e24c6a245d286f2d266589ae79",
-      "size": 240854688
+      "checksum": "8381c9964a39cb231e4243d5ec7bf0158719fc292de1130f7c0f07e8b3137327",
+      "size": 242154656
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code-bin/package.nix
+++ b/pkgs/by-name/cl/claude-code-bin/package.nix
@@ -95,8 +95,9 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux"
     ];
     maintainers = with lib.maintainers; [
-      xiaoxiangmoe
       mirkolenz
+      oskarwires
+      xiaoxiangmoe
     ];
     mainProgram = "claude";
   };

--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.107",
+  "version": "2.1.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.107",
+      "version": "2.1.111",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -81,6 +81,7 @@ buildNpmPackage (finalAttrs: {
       malo
       markus1189
       omarjatoi
+      oskarwires
       xiaoxiangmoe
     ];
     mainProgram = "claude";

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -15,14 +15,14 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.107";
+  version = "2.1.111";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-FpJ7grsXbBJxzbqSZTN6uICd1sGxizMEpHbs1n9yW3s=";
+    hash = "sha256-K3qhZXVJ2DIKv7YL9f/CHkuUYnK0lkIR1wjEa+xeSCk=";
   };
 
-  npmDepsHash = "sha256-OVmbHfANAqNe6QLzQaSH1oZP50InstIW6RmN2crvQJw=";
+  npmDepsHash = "sha256-6f68qUMnDk6tn+qypVi8bPtNrxbtcf15tHrgtlhEaK4=";
 
   strictDeps = true;
 


### PR DESCRIPTION
Bumps all three claude-code packages to 2.1.111.

Changelog: https://docs.claude.com/en/release-notes/claude-code

Also adding myself as a maintainer for `claude-code` and `claude-code-bin`, and sorting the `claude-code-bin` maintainer list alphabetically.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test