### PR TITLE
m8c: 1.7.10 -> 2.2.3

### DIFF
--- a/pkgs/by-name/m8/m8c/package.nix
+++ b/pkgs/by-name/m8/m8c/package.nix
@@ -3,31 +3,40 @@
   fetchFromGitHub,
   lib,
   pkg-config,
-  SDL2,
+  sdl3,
   libserialport,
+  cmake,
+  copyDesktopItems,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "m8c";
-  version = "1.7.10";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "laamaa";
     repo = "m8c";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-8QkvvTtFxQmDIqpyhZi/ORcB7YwENu+YafYtCZw0faE=";
+    hash = "sha256-cr5tat7JOFJ7y7AEinphgV/5T138gV6jidb87GooZ8U=";
   };
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    copyDesktopItems
+  ];
 
   buildInputs = [
-    SDL2
+    sdl3
     libserialport
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Cross-platform M8 tracker headless client";


### PR DESCRIPTION
Saw the build failure on [nfd.1l.is](https://nfd.1l.is/?selected=m8c)

Updated m8c to `2.2.3`. 
Changelog: https://github.com/laamaa/m8c/compare/v1.7.10...v2.2.3 

I added `passthru.updateScript = nix-update-script { };` because the update script `maintainers/scripts/update.nix` wasn't picking up otherwise.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
