### PR TITLE
athens: 0.16.2 -> 0.17.0

### DIFF
--- a/pkgs/by-name/at/athens/package.nix
+++ b/pkgs/by-name/at/athens/package.nix
@@ -1,23 +1,31 @@
 {
   lib,
   fetchFromGitHub,
-  buildGoModule,
+  # Requires Go 1.26, drop when that's the default.
+  buildGo126Module,
   nix-update-script,
   versionCheckHook,
+  applyPatches,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo126Module (finalAttrs: {
   pname = "athens";
-  version = "0.16.2";
+  version = "0.17.0";
 
-  src = fetchFromGitHub {
-    owner = "gomods";
-    repo = "athens";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Mv0fJ5EiU/Nxakr1sLx2rcJnQ9SEjFMn+2Gf4qsnN3w=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "gomods";
+      repo = "athens";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-4KCPYqLtqz46zr5+LB4CyG4ZQrjQaPgMEhCuGOWIJKg=";
+    };
+    # Trim the patch version, not needed anyway.
+    postPatch = ''
+      sed -i 's/go 1.26.2/go 1.26/' go.mod
+    '';
   };
 
-  vendorHash = "sha256-bn3He7ImXxrl+Or2pqzVpM8VxbfqDDupwtZbdSMd4HI=";
+  vendorHash = "sha256-he7GNkCfqLgOXuCTahvqOnwW5TpbYjlCMfMGfKGwYZ4=";
 
   env.CGO_ENABLED = "0";
   ldflags = [


### PR DESCRIPTION
https://github.com/gomods/athens/releases/tag/v0.17.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
