### PR TITLE
gcx: init at 0.2.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2430,6 +2430,12 @@
     name = "Mariia Holovata";
     keys = [ { fingerprint = "409D 201E 9450 8732 A49E  D0FC 6BDA F874 0068 08DF"; } ];
   };
+  asimpson = {
+    email = "adam@adamsimpson.net";
+    github = "asimpson";
+    githubId = 1048831;
+    name = "Adam Simpson";
+  };
   asininemonkey = {
     email = "nixpkgs@asininemonkey.com";
     github = "asininemonkey";

--- a/pkgs/by-name/gc/gcx/package.nix
+++ b/pkgs/by-name/gc/gcx/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  testers,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gcx";
+  version = "0.2.7";
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = "gcx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M4qZghOhEq8WgGeJkTB1Ff+RBs2KD8ZLr/zVpX0CB28=";
+  };
+
+  vendorHash = "sha256-fgPyTVN7acPiRls038sINZwiEBs5dZXGXtB+c6CUUVw=";
+
+  subPackages = [ "cmd/gcx" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.commit=${finalAttrs.src.rev}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd gcx \
+      --bash <($out/bin/gcx completion bash) \
+      --fish <($out/bin/gcx completion fish) \
+      --zsh <($out/bin/gcx completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Grafana Cloud CLI";
+    homepage = "https://github.com/grafana/gcx";
+    changelog = "https://github.com/grafana/gcx/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "gcx";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ asimpson ];
+  };
+})

--- a/pkgs/by-name/gc/gcx/package.nix
+++ b/pkgs/by-name/gc/gcx/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gcx";
+  version = "0.2.7";
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = "gcx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M4qZghOhEq8WgGeJkTB1Ff+RBs2KD8ZLr/zVpX0CB28=";
+  };
+
+  vendorHash = "sha256-fgPyTVN7acPiRls038sINZwiEBs5dZXGXtB+c6CUUVw=";
+
+  subPackages = [ "cmd/gcx" ];
+
+  ldflags = [
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.commit=${finalAttrs.src.rev}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd gcx \
+      --bash <($out/bin/gcx completion bash) \
+      --fish <($out/bin/gcx completion fish) \
+      --zsh <($out/bin/gcx completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Grafana Cloud CLI";
+    homepage = "https://github.com/grafana/gcx";
+    changelog = "https://github.com/grafana/gcx/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    mainProgram = "gcx";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ asimpson ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A CLI for managing Grafana Cloud resources. Optimized for agentic usage. 
Repo: https://github.com/grafana/gcx

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
