### PR TITLE
garage_2: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/filesystems/garage/default.nix
+++ b/pkgs/tools/filesystems/garage/default.nix
@@ -2,12 +2,15 @@
   lib,
   rustPlatform,
   fetchFromGitea,
+  fetchpatch2,
+  installShellFiles,
   openssl,
   pkg-config,
   protobuf,
   cacert,
   nix-update-script,
   nixosTests,
+  stdenv,
 }:
 let
   generic =
@@ -34,6 +37,7 @@ let
       inherit cargoHash cargoPatches;
 
       nativeBuildInputs = [
+        installShellFiles
         protobuf
         pkg-config
       ];
@@ -48,7 +52,7 @@ let
 
       env.OPENSSL_NO_VENDOR = true;
 
-      # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v2.2.0/nix/compile.nix#L71-L78
+      # See https://git.deuxfleurs.fr/Deuxfleurs/garage/src/tag/v2.3.0/nix/compile.nix#L71-L78
       # on version changes for checking if changes are required here
       buildFeatures = [
         "bundled-libs"
@@ -63,6 +67,16 @@ let
         "syslog"
         "telemetry-otlp"
       ];
+
+      postInstall =
+        lib.optionalString
+          ((lib.versionAtLeast version "2.3.0") && (stdenv.buildPlatform.canExecute stdenv.hostPlatform))
+          ''
+            installShellCompletion --cmd garage \
+              --bash <($out/bin/garage completions bash) \
+              --fish <($out/bin/garage completions fish) \
+              --zsh <($out/bin/garage completions zsh)
+          '';
 
       passthru = {
         tests = nixosTests."garage_${lib.versions.major version}";
@@ -99,9 +113,16 @@ rec {
   };
 
   garage_2 = generic {
-    version = "2.2.0";
-    hash = "sha256-UaWHZPV0/Jgeiwvvr9V9Gqthn5KXErLx8gL4JdBRDVs=";
-    cargoHash = "sha256-U6Wipvlw3XdKUBNZMznENJ9m+9fzP9Nb6217+Kytu7s=";
+    version = "2.3.0";
+    hash = "sha256-CqHcaVGgXL/jjqq7XN+kzEp6xoNgwBfGpMKYbTd78Ys=";
+    cargoHash = "sha256-ANh97G/2/KtCMN4gldteq6ROduk1AQJkI5zS9n97OJY=";
+    cargoPatches = [
+      (fetchpatch2 {
+        # fix: prevent depending on aws-lc via reqwest
+        url = "https://git.deuxfleurs.fr/Deuxfleurs/garage/commit/7c18abb664d891cdb696b478058b7506e3d53f44.patch";
+        hash = "sha256-f/+vDOC+kcmJVLtx1Y6OepoJBZhX30DULwSLnyQN5aI=";
+      })
+    ];
   };
 
   garage = garage_1;


### PR DESCRIPTION
Changelog: https://git.deuxfleurs.fr/Deuxfleurs/garage/releases/tag/v2.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (only x86_64-linux)
  - [x] [Package tests] at `passthru.tests`. (only x86_64-linux)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
