### PR TITLE
bruno: 3.2.0 -> 3.2.2

### DIFF
--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -21,7 +21,7 @@
 
 buildNpmPackage rec {
   pname = "bruno";
-  version = "3.2.0";
+  version = "3.2.2";
 
   src = fetchFromGitHub {
     owner = "usebruno";


### PR DESCRIPTION
Bump version of package "bruno" from 3.2.0 to 3.2.2 (minor version bump).

Changelog: https://github.com/usebruno/bruno/releases/tag/v3.2.2 (there is no 3.2.1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
