### PR TITLE
avfs: 1.2.0 -> 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26584,6 +26584,12 @@
     githubId = 156964;
     name = "Thomas Boerger";
   };
+  tbutter = {
+    email = "tbutter@gmail.com";
+    github = "tbutter";
+    githubId = 1336537;
+    name = "Thomas Butter";
+  };
   tc-kaluza = {
     github = "tc-kaluza";
     githubId = 101565936;

--- a/pkgs/by-name/av/avfs/package.nix
+++ b/pkgs/by-name/av/avfs/package.nix
@@ -5,14 +5,15 @@
   pkg-config,
   fuse,
   xz,
+  zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "avfs";
-  version = "1.2.0";
+  version = "1.3.0";
   src = fetchurl {
     url = "mirror://sourceforge/avf/${finalAttrs.version}/avfs-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-olqOxDwe4XJiThpMec5mobkwhBzbVFtyXx7GS8q+iJw=";
+    sha256 = "sha256-B81p1MDH7QgOgP8EDZgChkBa04pEP9xS3Dle/vEcRLE=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -20,19 +21,20 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     fuse
     xz
+    zlib
   ];
 
   configureFlags = [
     "--enable-library"
     "--enable-fuse"
-  ];
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin "--with-system-zlib";
 
   meta = {
     homepage = "https://avf.sourceforge.net/";
     description = "Virtual filesystem that allows browsing of compressed files";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Only;
-    # The last successful Darwin Hydra build was in 2024
-    broken = stdenv.hostPlatform.isDarwin;
+    maintainers = with lib.maintainers; [ tbutter ];
   };
 })


### PR DESCRIPTION
Fixes darwin build and updates version to 1.3.0

Changes from 1.2.0 to 1.3.0 (2026-03-01)
  - implemented fast random access when using the system zlib instead
    of the internal zlib version. The system zlib will now be used
    by default if available.
  - fixed a possible deadlock with zlib in zlib archive access.
  - added support for fuse version 3.
  - updated autotools files.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
