### PR TITLE
vscodium: vscodium.vscodeVersion should be set to latestUpstream

### DIFF
--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 
 latestVersion=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL https://api.github.com/repos/VSCodium/vscodium/releases/latest | jq -r ".tag_name")
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; vscodium.version or (lib.getVersion vscodium)" | tr -d '"')
-latestUpstream=$(curl -sL https://raw.githubusercontent.com/VSCodium/vscodium/refs/tags/$latestVersion/upstream/stable.json | jq -r ".tag")
+latestUpstream=$(curl -sL "https://raw.githubusercontent.com/VSCodium/vscodium/refs/tags/$latestVersion/upstream/stable.json" | jq -r ".tag")
 
 echo "latest  version: $latestVersion"
 echo "current version: $currentVersion"

--- a/pkgs/applications/editors/vscode/update-vscodium.sh
+++ b/pkgs/applications/editors/vscode/update-vscodium.sh
@@ -5,9 +5,11 @@ set -eou pipefail
 
 latestVersion=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL https://api.github.com/repos/VSCodium/vscodium/releases/latest | jq -r ".tag_name")
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; vscodium.version or (lib.getVersion vscodium)" | tr -d '"')
+latestUpstream=$(curl -sL https://raw.githubusercontent.com/VSCodium/vscodium/refs/tags/$latestVersion/upstream/stable.json | jq -r ".tag")
 
 echo "latest  version: $latestVersion"
 echo "current version: $currentVersion"
+echo "latest upstream version: $latestUpstream"
 
 if [[ "$latestVersion" == "$currentVersion" ]]; then
     echo "package is up-to-date"
@@ -25,3 +27,5 @@ for i in \
     hash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri $(nix-prefetch-url "https://github.com/VSCodium/vscodium/releases/download/$latestVersion/VSCodium-$2-$latestVersion.$3"))
     update-source-version vscodium $latestVersion $hash --system=$1 --ignore-same-version
 done
+
+update-source-version vscodium $latestUpstream --version-key=vscodeVersion --ignore-same-version --ignore-same-hash

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -44,6 +44,7 @@ buildVscode rec {
   # Please backport all compatible updates to the stable release.
   # This is important for the extension ecosystem.
   version = "1.112.01907";
+  vscodeVersion = "1.112.0";
   pname = "vscodium";
 
   executableName = "codium";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -44,6 +44,7 @@ buildVscode rec {
   # Please backport all compatible updates to the stable release.
   # This is important for the extension ecosystem.
   version = "1.116.02821";
+  vscodeVersion = "1.116.0";
   pname = "vscodium";
 
   executableName = "codium";


### PR DESCRIPTION

## Things done

Closes #505096

VSCodium's `vscodeVersion` was implicitly defaulting to `version` (the VSCodium build number, e.g. `1.112.01907`), which breaks downstream tooling that expects a valid semantic version matching upstream VSCode. The leading zero in the patch component (`1.112.01907`) is not valid semver, and even when parsed, comparisons go wrong (e.g. `1.109.21026` would sort above `1.109.3`).

This PR makes `vscodeVersion` track the actual upstream VSCode tag the VSCodium release is built from (e.g. `1.112.0` for VSCodium `1.112.01907`), keeping `version` as the VSCodium build number for source URL interpolation.

- **`pkgs/applications/editors/vscode/vscodium.nix`**: declare `vscodeVersion` explicitly.
- **`pkgs/applications/editors/vscode/update-vscodium.sh`**:
  - Fetch the upstream VSCode tag via `https://raw.githubusercontent.com/VSCodium/vscodium/refs/tags/<tag>/upstream/stable.json`.
  - Bump `vscodeVersion` independently with `--version-key=vscodeVersion --ignore-same-version --ignore-same-hash`.

## Verification

Tested locally by rolling `vscodium.nix` back to `version = "1.110.11631"` / `vscodeVersion = "1.110.1"`, running the script, and confirming:
- All 6 platform hashes were correctly refreshed for `1.112.01907`.
- `version` bumped to `1.112.01907`.
- `vscodeVersion` bumped to `1.112.0`.
- Resulting `vscodium` builds cleanly and `codium --version` reports `1.112.01907`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
