### PR TITLE
unfs3: 0.10.0 -> 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26584,6 +26584,12 @@
     githubId = 156964;
     name = "Thomas Boerger";
   };
+  tbutter = {
+    email = "tbutter@gmail.com";
+    github = "tbutter";
+    githubId = 1336537;
+    name = "Thomas Butter";
+  };
   tc-kaluza = {
     github = "tc-kaluza";
     githubId = 101565936;

--- a/pkgs/by-name/un/unfs3/package.nix
+++ b/pkgs/by-name/un/unfs3/package.nix
@@ -14,22 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "unfs3";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "unfs3";
     repo = "unfs3";
     tag = "unfs3-${version}";
-    hash = "sha256-5iAriIutBhwyZVS7AG2fnkrHOI7pNAKfYv062Cy0WXw=";
+    hash = "sha256-0IHpHW9lCPSltfl+VrS25tB9csISvTwCpD1oqwXpBwU=";
   };
-
-  patches = [
-    # Fix implicit declaration warning with GCC 14
-    (fetchpatch2 {
-      url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/152dc14a65a89f253294cc5b4c96cf0d6658711a/main/unfs3/implicit.patch";
-      hash = "sha256-zrF87fJhc8mDgIs0vsMoqIHYQPtKWn2XMBSePvHOByA=";
-    })
-  ];
 
   nativeBuildInputs = [
     flex
@@ -70,16 +62,12 @@ stdenv.mkDerivation rec {
       server.
     '';
 
-    # The old http://unfs3.sourceforge.net/ has a <meta>
-    # http-equiv="refresh" pointing here, so we can assume that
-    # whoever controls the old URL approves of the "unfs3" github
-    # account.
     homepage = "https://unfs3.github.io/";
     changelog = "https://raw.githubusercontent.com/unfs3/unfs3/unfs3-${version}/NEWS";
     mainProgram = "unfsd";
 
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
   };
 }


### PR DESCRIPTION
Updating unfs3 to 0.11.0
Removing obsolete patch

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
