### PR TITLE
where-is-my-sddm-theme: fix Qt6 deps and Qt5 build error

### DIFF
--- a/pkgs/by-name/wh/where-is-my-sddm-theme/package.nix
+++ b/pkgs/by-name/wh/where-is-my-sddm-theme/package.nix
@@ -43,10 +43,11 @@ lib.checkListOfEnum "where-is-my-sddm-theme: variant" validVariants variants
       hash = "sha256-+R0PX84SL2qH8rZMfk3tqkhGWPR6DpY1LgX9bifNYCg=";
     };
 
+    dontWrapQtApps = true;
+
     propagatedBuildInputs =
-      [ ]
-      ++ lib.optionals (lib.elem "qt5" variants) [ libsForQt5.qtgraphicaleffects ]
       # avoid .dev outputs propagation
+      lib.optionals (lib.elem "qt5" variants) [ libsForQt5.qtgraphicaleffects.out ]
       ++ lib.optionals (lib.elem "qt6" variants) [
         qt6.qt5compat.out
         qt6.qtsvg.out


### PR DESCRIPTION
Fix where-is-my-sddm-theme to build and run correctly with both Qt5 and Qt6. Previously there were 3 more fixes, but all other sddm themes work if you add them to sddm.extraPackages

Fixes https://github.com/NixOS/nixpkgs/issues/510489

Tested with `sddm-greeter-qt6 --test-mode`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test