### PR TITLE
mir: 2.25.2 -> 2.26.0, miracle-wm: 0.8.3 -> 0.9.0

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -25,36 +25,27 @@
   pkg-config,
   python3,
   systemd,
+  wasmedge,
   wayland,
+  wayland-scanner,
   yaml-cpp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "miracle-wm";
-  version = "0.8.3";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "miracle-wm-org";
     repo = "miracle-wm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N8FDoQDEfv0xGjtnKx+jNfRwxvJdb4ETvQnZuBvlccQ=";
+    hash = "sha256-yrshySK7tstNAgb9jApqqx4R+c74G2Ada6fjmCeKsV0=";
   };
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail 'DESTINATION /usr/lib' 'DESTINATION ''${CMAKE_INSTALL_LIBDIR}' \
       --replace-fail '-march=native' '# -march=native'
-  ''
-  # Fix compat with newer Mir
-  # https://github.com/miracle-wm-org/miracle-wm/commit/aaae6e64261d8a00c2a1df47e2eab99400382d69
-  # Remove when version > 0.8.3
-  + ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'pkg_check_modules(MIRRENDERER REQUIRED mirrenderer' 'pkg_check_modules(MIRRENDERER mirrenderer'
-  ''
-  + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'add_subdirectory(tests/)' ""
   '';
 
   strictDeps = true;
@@ -63,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     makeWrapper
     pkg-config
+    wayland-scanner
   ];
 
   buildInputs = [
@@ -85,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
         tenacity
       ]
     ))
+    wasmedge
     wayland
     yaml-cpp
   ];
@@ -93,6 +86,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "ENABLE_LTO" true)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    # https://github.com/miracle-wm-org/miracle-wm/issues/865
+    (lib.cmakeBool "FEATURE_PLUGIN_SYSTEM" false)
     (lib.cmakeBool "SYSTEMD_INTEGRATION" true)
     (lib.cmakeBool "END_TO_END_TESTS" finalAttrs.finalPackage.doCheck)
   ];

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -312,9 +312,14 @@ stdenv.mkDerivation (
       ]
       ++ lib.optionals (lib.strings.versionOlder version "2.17.0") [ "mircookie" ]
       ++ lib.optionals (lib.strings.versionAtLeast version "2.17.0") [
-        "mircommon-internal"
         "mirserver-internal"
       ]
+      ++
+        lib.optionals
+          (lib.strings.versionAtLeast version "2.17.0" && lib.strings.versionOlder version "2.26.0")
+          [
+            "mircommon-internal"
+          ]
       ++ lib.optionals (lib.strings.versionOlder version "2.25.0") [
         "mir-renderer-gl-dev"
         "mirrenderer"

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,18 +5,9 @@ let
 in
 {
   mir = common {
-    version = "2.25.2";
-    hash = "sha256-+nahWuAcGWgxBM6/a2HWwDw5DkQpUt5i/CEGzTLwNQw=";
-    cargoHash = "sha256-fVD+RGU/2UGVihIktKg2+eDWmlWomDOAcrY6k2XwF1c=";
-    patches = [
-      # Fix leftover boost_system references when linking miracle-wm (library no longer exists)
-      # https://github.com/canonical/mir/pull/4721
-      (fetchpatch {
-        name = "mir-tests-mirtest.pc.in-Drop-remaining-references-to-boost_system.patch";
-        url = "https://github.com/canonical/mir/commit/14d396ecef4611e9182d78890a2d908439478799.patch";
-        hash = "sha256-IpX/7lkuYwoITzOz/gF5q7TAFUg4YH0IY2fWkorIEiM=";
-      })
-    ];
+    version = "2.26.0";
+    hash = "sha256-gADqNNkaYj8KQ67wWzUWT4LuTQh1S+w/qLhVDKdBH4Q=";
+    cargoHash = "sha256-bG2p5Gz34yQJLI1Wuejq6o+jXLn6O2eZE1XGddvxkV4=";
   };
 
   mir_2_15 = common {


### PR DESCRIPTION
https://github.com/canonical/mir/releases/tag/v2.26.0
https://github.com/miracle-wm-org/miracle-wm/releases/tag/v0.9.0

`nixosTests.miracle-wm` only shows a black screen when the plugin system is enabled. Happens both before and after the `mir` bump. Reported upstream in https://github.com/miracle-wm-org/miracle-wm/issues/865, plugin system disabled for now. `nixosTests.miriway` works without issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
