### PR TITLE
stremio-linux-shell: update `meta`, enable `strictDeps` and `__structuredAttrs`

### DIFF
--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -95,6 +95,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env.CEF_PATH = "${cef}";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   postInstall = ''
     mkdir -p $out/share/applications
     cp data/com.stremio.Stremio.desktop $out/share/applications/com.stremio.Stremio.desktop

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -130,11 +130,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Modern media center that gives you the freedom to watch everything you want";
     homepage = "https://www.stremio.com/";
-    license = with lib.licenses; [
-      gpl3Only
-      # server.js is unfree
-      unfree
-    ];
+    license =
+      with lib.licenses;
+      AND [
+        gpl3Only
+        unfree # server.js
+      ];
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       obfuscatedCode # server.js

--- a/pkgs/by-name/st/stremio-linux-shell/package.nix
+++ b/pkgs/by-name/st/stremio-linux-shell/package.nix
@@ -135,6 +135,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       # server.js is unfree
       unfree
     ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      obfuscatedCode # server.js
+    ];
     maintainers = with lib.maintainers; [ thunze ];
     platforms = lib.platforms.linux;
     mainProgram = "stremio";


### PR DESCRIPTION
- Add `meta.sourceProvenance`
  - I'd say [`server.js`](https://raw.githubusercontent.com/Stremio/stremio-linux-shell/refs/tags/v1.0.0-beta.13/data/server.js) counts as obfuscated :)
- Use a compound license (see https://github.com/NixOS/nixpkgs/pull/468378)
- Enable `strictDeps` and `__structuredAttrs`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
