### PR TITLE
wcag-lsp: init at 0.5.12

### DIFF
--- a/pkgs/by-name/wc/wcag-lsp/package.nix
+++ b/pkgs/by-name/wc/wcag-lsp/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wcag-lsp";
+  version = "0.5.12";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "maxischmaxi";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-mckcOY4gtfx4sHVTDBTe9aCgtkxQYPIQdwzihAH/Irw=";
+  };
+
+  cargoHash = "sha256-gNTBUUHdJVvbmbBR1M/Gnfxb/2PkNm8AvqF/inzh93c=";
+
+  meta = {
+    description = "A fast Language Server Protocol (LSP) implementation that checks HTML and JSX/TSX code for WCAG 2.1 accessibility violations in real-time.";
+    mainProgram = "wcag-lsp";
+    homepage = "https://github.com/maxischmaxi/wcag-lsp";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+})


### PR DESCRIPTION
[wcag-lsp](https://github.com/maxischmaxi/wcag-lsp/tree/v0.5.12)
A fast Language Server Protocol (LSP) implementation that checks HTML and JSX/TSX code for [WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/) accessibility violations in real-time.


## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.