### PR TITLE
fakecloud: init at 0.9.2

### DIFF
--- a/pkgs/by-name/fa/fakecloud/package.nix
+++ b/pkgs/by-name/fa/fakecloud/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "fakecloud";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "faiscadev";
+    repo = "fakecloud";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0XgamS2ReW1GCxX0s8grhFDWDCyY6GDmPr82Lg42urA=";
+  };
+
+  cargoHash = "sha256-ROd/Us0H0KnD/oeorGScoqR74BtXqC1Xfb+fxXQWhKM=";
+
+  # Conformance tests require a running fakecloud instance
+  doCheck = false;
+
+  meta = {
+    description = "Local AWS cloud emulator for integration testing and local development";
+    longDescription = ''
+      fakecloud is a free, open-source local AWS emulator. It runs as a single
+      binary with no account or auth token required, accepting connections at
+      http://localhost:4566. It supports 22 AWS services with real end-to-end
+      integrations (e.g. EventBridge → Step Functions, S3 → Lambda), stateful
+      services (Lambda in Docker, RDS with real Postgres/MySQL/MariaDB,
+      ElastiCache with real Redis/Valkey), and first-party test SDKs for
+      TypeScript, Python, Go, PHP, Java, and Rust.
+    '';
+    homepage = "https://fakecloud.dev/";
+    changelog = "https://github.com/faiscadev/fakecloud/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ kubukoz ];
+    mainProgram = "fakecloud";
+  };
+})


### PR DESCRIPTION
fakecloud is a free, open-source local AWS emulator for integration testing and local development. Single binary, no account or auth token required, supports 22 AWS services. https://fakecloud.dev/

Tested by running fakecloud and issuing `aws kinesis list-streams` against it successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test