### PR TITLE
nixos/{kanboard, roundcube, baikal, grocy, icingaweb2, selfoss, tt-rss}: don't hard-code nginx user in service

### DIFF
--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -256,8 +256,8 @@ in
         upload_max_filesize = ${cfg.maxAttachmentSize}
       '';
       settings = lib.mapAttrs (name: lib.mkDefault) {
-        "listen.owner" = "nginx";
-        "listen.group" = "nginx";
+        "listen.owner" = config.services.nginx.user;
+        "listen.group" = config.services.nginx.group;
         "listen.mode" = "0660";
         "pm" = "dynamic";
         "pm.max_children" = 75;

--- a/nixos/modules/services/web-apps/baikal.nix
+++ b/nixos/modules/services/web-apps/baikal.nix
@@ -57,8 +57,8 @@ in
           "BAIKAL_PATH_SPECIFIC" = "/var/lib/baikal/specific/";
         };
         settings = lib.mapAttrs (name: lib.mkDefault) {
-          "listen.owner" = "nginx";
-          "listen.group" = "nginx";
+          "listen.owner" = config.services.nginx.user;
+          "listen.group" = config.services.nginx.group;
           "listen.mode" = "0600";
           "pm" = "dynamic";
           "pm.max_children" = 75;

--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -44,7 +44,7 @@ in
         "pm" = "dynamic";
         "php_admin_value[error_log]" = "stderr";
         "php_admin_flag[log_errors]" = true;
-        "listen.owner" = "nginx";
+        "listen.owner" = config.services.nginx.user;
         "catch_workers_output" = true;
         "pm.max_children" = "32";
         "pm.start_servers" = "2";
@@ -52,6 +52,20 @@ in
         "pm.max_spare_servers" = "4";
         "pm.max_requests" = "500";
       };
+      defaultText = lib.literalExpression ''
+        {
+          "pm" = "dynamic";
+          "php_admin_value[error_log]" = "stderr";
+          "php_admin_flag[log_errors]" = true;
+          "listen.owner" = config.services.nginx.user;
+          "catch_workers_output" = true;
+          "pm.max_children" = "32";
+          "pm.start_servers" = "2";
+          "pm.min_spare_servers" = "2";
+          "pm.max_spare_servers" = "4";
+          "pm.max_requests" = "500";
+        }
+      '';
 
       description = ''
         Options for grocy's PHPFPM pool.

--- a/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
+++ b/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
@@ -200,8 +200,8 @@ in
           date.timezone = "${cfg.timezone}"
         '';
         settings = mapAttrs (name: mkDefault) {
-          "listen.owner" = "nginx";
-          "listen.group" = "nginx";
+          "listen.owner" = config.services.nginx.user;
+          "listen.group" = config.services.nginx.group;
           "listen.mode" = "0600";
           "pm" = "dynamic";
           "pm.max_children" = 75;

--- a/nixos/modules/services/web-apps/kanboard.nix
+++ b/nixos/modules/services/web-apps/kanboard.nix
@@ -123,7 +123,7 @@ in
           "pm" = "dynamic";
           "php_admin_value[error_log]" = "stderr";
           "php_admin_flag[log_errors]" = true;
-          "listen.owner" = "nginx";
+          "listen.owner" = config.services.nginx.user;
           "catch_workers_output" = true;
           "pm.max_children" = "32";
           "pm.start_servers" = "2";

--- a/nixos/modules/services/web-apps/selfoss.nix
+++ b/nixos/modules/services/web-apps/selfoss.nix
@@ -37,7 +37,8 @@ in
 
       user = mkOption {
         type = types.str;
-        default = "nginx";
+        default = config.services.nginx.user;
+        defaultText = lib.literalExpression "config.services.nginx.user";
         description = ''
           User account under which both the service and the web-application run.
         '';
@@ -122,10 +123,10 @@ in
   config = mkIf cfg.enable {
     services.phpfpm.pools = mkIf (cfg.pool == "${poolName}") {
       ${poolName} = {
-        user = "nginx";
+        user = config.services.nginx.user;
         settings = mapAttrs (name: mkDefault) {
-          "listen.owner" = "nginx";
-          "listen.group" = "nginx";
+          "listen.owner" = config.services.nginx.user;
+          "listen.group" = config.services.nginx.group;
           "listen.mode" = "0600";
           "pm" = "dynamic";
           "pm.max_children" = 75;

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -594,8 +594,8 @@ in
         inherit (cfg) user;
         inherit phpPackage;
         settings = mapAttrs (name: mkDefault) {
-          "listen.owner" = "nginx";
-          "listen.group" = "nginx";
+          "listen.owner" = config.services.nginx.user;
+          "listen.group" = config.services.nginx.group;
           "listen.mode" = "0600";
           "pm" = "dynamic";
           "pm.max_children" = 75;


### PR DESCRIPTION
Currently, `services.phpfpm.pools.kanboard.settings."listen.owner"` is hard-coded to `"nginx"`. While this is fine for most people, the user under which nginx runs can be customized with the `services.nginx.user` option, and changing this from the default will cause phpfpm-kanboard.service to fail:

```
[ERROR] [pool kanboard] cannot get uid for user 'nginx': Success (0)
```

This PR sets `"listen.owner"` to `config.services.nginx.user` instead.

<br>

For anyone having this issue before this PR is merged, you can do a quick fix by adding the following to your config:

```NIX
services.phpfpm.pools.kanboard.settings."listen.owner" = lib.mkForce config.services.nginx.user;
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
