### PR TITLE
unnix: init at 0.1.1

### DIFF
--- a/pkgs/by-name/un/unnix/package.nix
+++ b/pkgs/by-name/un/unnix/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  withBubblewrap ? stdenv.isLinux,
+  makeBinaryWrapper,
+  xz,
+  zstd,
+  writableTmpDirAsHomeHook,
+  bubblewrap,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "unnix";
+  version = "0.1.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "figsoda";
+    repo = "unnix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZmCagknLEJlAtoVfHrQZeb3CbxpT37J6Mvyxn/qQRmQ=";
+  };
+
+  cargoHash = "sha256-NXyB1Ic2EnLJPpFDn1idb5WYfS8gXzgvIRbQoJ3bsS8=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ]
+  ++ lib.optionals withBubblewrap [
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    xz
+    zstd
+  ];
+
+  # tests try to access ~/.cache/unnix
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  env = {
+    GENERATE_ARTIFACTS = "artifacts";
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  postInstall = ''
+    installManPage artifacts/*.1
+    installShellCompletion artifacts/unnix.{bash,fish} --zsh artifacts/_unnix
+  ''
+  + lib.optionalString withBubblewrap ''
+    wrapProgram $out/bin/unnix \
+      --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
+  '';
+
+  meta = {
+    description = "Reproducible Nix environments without installing Nix";
+    homepage = "https://github.com/figsoda/unnix";
+    changelog = "https://github.com/figsoda/unnix/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ figsoda ];
+    mainProgram = "unnix";
+  };
+})


### PR DESCRIPTION
https://github.com/figsoda/unnix


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
