### PR TITLE
exhaustive: fix build with go 1.25

### DIFF
--- a/pkgs/by-name/ex/exhaustive/fix-go125.patch
+++ b/pkgs/by-name/ex/exhaustive/fix-go125.patch
@@ -1,0 +1,127 @@
+diff --git a/Makefile b/Makefile
+index 868f7fc..2e4d94d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -24,7 +24,6 @@ cover:
+ 
+ .PHONY: install-vet
+ install-vet:
+-	go install github.com/nishanths/exhaustive/cmd/exhaustive@latest
+ 	go install github.com/gordonklaus/ineffassign@latest
+ 	go install github.com/kisielk/errcheck@latest
+ 	go install honnef.co/go/tools/cmd/staticcheck@latest
+@@ -32,7 +31,6 @@ install-vet:
+ .PHONY: vet
+ vet:
+ 	go vet ./...
+-	exhaustive ./...
+ 	ineffassign ./...
+ 	errcheck ./...
+ 	staticcheck -checks="inherit,-S1034" ./...
+diff --git a/common.go b/common.go
+index 71bc8d5..bf30ff7 100644
+--- a/common.go
++++ b/common.go
+@@ -73,6 +73,9 @@ func fromTypeParam(pass *analysis.Pass, tp *types.TypeParam, typeparam bool) (re
+ 
+ func fromType(pass *analysis.Pass, t types.Type, typeparam bool) (result []enumTypeAndMembers, ok bool) {
+ 	switch t := t.(type) {
++	case *types.Alias:
++		return fromType(pass, types.Unalias(t), typeparam)
++
+ 	case *types.Named:
+ 		return fromNamed(pass, t, typeparam)
+ 
+diff --git a/enum.go b/enum.go
+index e95e78e..1960edd 100644
+--- a/enum.go
++++ b/enum.go
+@@ -144,7 +144,7 @@ func possibleEnumMember(constName *ast.Ident, info *types.Info) (et enumType, na
+ 		return enumType{}, "", "", false
+ 	}
+ 
+-	named := obj.Type().(*types.Named) // guaranteed by validNamedBasic
++	named := types.Unalias(obj.Type()).(*types.Named) // guaranteed by validNamedBasic
+ 	tn := named.Obj()
+ 
+ 	// By definition, enum type's scope and enum member's scope must be the
+@@ -216,8 +216,9 @@ func hasIgnoreDecl(pass *analysis.Pass, doc *ast.CommentGroup) bool {
+ //
+ // The following is guaranteed:
+ //
+-//	validNamedBasic(t) == true => t.(*types.Named)
++//	validNamedBasic(t) == true => types.Unalias(t).(*types.Named)
+ func validNamedBasic(t types.Type) bool {
++	t = types.Unalias(t)
+ 	named, ok := t.(*types.Named)
+ 	if !ok {
+ 		return false
+diff --git a/go.mod b/go.mod
+index 0a3984a..d3caaf5 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,10 +1,10 @@
+ module github.com/nishanths/exhaustive
+
+-go 1.18
++go 1.24.0
+
+-require golang.org/x/tools v0.15.0
++require golang.org/x/tools v0.38.0
+
+ require (
+-	golang.org/x/mod v0.14.0 // indirect
+-	golang.org/x/sys v0.14.0 // indirect
++	golang.org/x/mod v0.29.0 // indirect
++	golang.org/x/sync v0.17.0 // indirect
+ )
+diff --git a/go.sum b/go.sum
+index 3041532..9b34f09 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,7 +1,8 @@
+-golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+-golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+-golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
+-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
+-golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
++github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
++github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
++golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
++golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
++golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
++golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
++golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
++golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+diff --git a/map.go b/map.go
+index aa5e9bd..4243f32 100644
+--- a/map.go
++++ b/map.go
+@@ -34,16 +34,18 @@ func mapChecker(pass *analysis.Pass, cfg mapConfig, generated boolCache, comment
+ 
+ 		lit := n.(*ast.CompositeLit)
+ 
+-		mapType, ok := pass.TypesInfo.Types[lit.Type].Type.(*types.Map)
+-		if !ok {
+-			namedType, ok2 := pass.TypesInfo.Types[lit.Type].Type.(*types.Named)
+-			if !ok2 {
+-				return true, resultNotMapLiteral
+-			}
+-			mapType, ok = namedType.Underlying().(*types.Map)
++		var mapType *types.Map
++		switch tt := types.Unalias(pass.TypesInfo.Types[lit.Type].Type).(type) {
++		case *types.Map:
++			mapType = tt
++		case *types.Named:
++			var ok bool
++			mapType, ok = tt.Underlying().(*types.Map)
+ 			if !ok {
+ 				return true, resultNotMapLiteral
+ 			}
++		default:
++			return true, resultNotMapLiteral
+ 		}
+ 
+ 		if len(lit.Elts) == 0 {

--- a/pkgs/by-name/ex/exhaustive/package.nix
+++ b/pkgs/by-name/ex/exhaustive/package.nix
@@ -16,7 +16,12 @@ buildGoModule (finalAttrs: {
     hash = "sha256-OLIdtKzCqnBkzdUSIl+UlENeMl3zrBE47pLWPg+6qXw=";
   };
 
-  vendorHash = "sha256-DyN2z6+lA/163k6TTQZ+ypm9s2EV93zvSo/yKQZXvCg=";
+  vendorHash = "sha256-jTKzfQnqCN15EOzAWGTHtolWFNj/0g4ay0ckgoa2E34=";
+
+  patches = [
+    # https://github.com/nishanths/exhaustive/pull/85
+    ./fix-go125.patch
+  ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/322286679

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
