### PR TITLE
surrealdb-surrealkv: init at 2.6.1

### DIFF
--- a/pkgs/by-name/su/surrealdb-surrealkv/package.nix
+++ b/pkgs/by-name/su/surrealdb-surrealkv/package.nix
@@ -1,0 +1,7 @@
+{
+  _surrealdbPackage,
+  callPackage,
+}:
+callPackage _surrealdbPackage {
+  backend = "surrealkv";
+}

--- a/pkgs/by-name/su/surrealdb/package.nix
+++ b/pkgs/by-name/su/surrealdb/package.nix
@@ -7,10 +7,20 @@
   rocksdb,
   testers,
   protobuf,
+  backend ? "rocksdb",
 }:
+let
+  hasRocksDB = backend == "rocksdb";
+in
+assert lib.assertMsg (builtins.elem backend [
+  "rocksdb"
+  "surrealkv"
+]) "surrealdb: backend must be one of [ \"rocksdb\" \"surrealkv\" ]";
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "surrealdb";
+  pname = if hasRocksDB then "surrealdb" else "surrealdb-surrealkv";
   version = "2.6.1";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "surrealdb";
@@ -21,19 +31,34 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-lebSQPGnxW+3a7vWw3R7QYtHx04/DsRK/n8c/UT3FZo=";
 
-  # error: linker `aarch64-linux-gnu-gcc` not found
+  # Upstream hard-codes `aarch64-linux-gnu-gcc` in `.cargo/config.toml`.
+  # Remove it so Cargo uses nixpkgs' wrapped C toolchain instead.
   postPatch = ''
     rm .cargo/config.toml
   '';
 
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "allocator"
+    "allocation-tracking"
+    "http"
+    "scripting"
+    "storage-mem"
+    "storage-surrealcs"
+    # Keep this enabled for the default RocksDB build to preserve upstream's
+    # default storage feature set. It can be dropped if `pkgs.surrealdb` is
+    # intentionally slimmed to RocksDB-only in a later change.
+    "storage-surrealkv"
+  ]
+  ++ lib.optional hasRocksDB "storage-rocksdb";
+
   env = {
     PROTOC = "${protobuf}/bin/protoc";
     PROTOC_INCLUDE = "${protobuf}/include";
-
+  }
+  // lib.optionalAttrs hasRocksDB {
     ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
     ROCKSDB_LIB_DIR = "${rocksdb}/lib";
-
-    RUSTFLAGS = "--cfg surrealdb_unstable";
   };
 
   nativeBuildInputs = [
@@ -60,7 +85,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "Scalable, distributed, collaborative, document-graph database, for the realtime web";
+    description =
+      if hasRocksDB then
+        "Scalable, distributed, collaborative, document-graph database, for the realtime web"
+      else
+        "SurrealDB with the SurrealKV storage backend";
     homepage = "https://surrealdb.com/";
     mainProgram = "surreal";
     license = lib.licenses.bsl11;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7948,6 +7948,8 @@ with pkgs;
 
   home-assistant-cli = callPackage ../servers/home-assistant/cli.nix { };
 
+  _surrealdbPackage = ../by-name/su/surrealdb/package.nix;
+
   icingaweb2-ipl = callPackage ../servers/icingaweb2/ipl.nix { };
   icingaweb2-thirdparty = callPackage ../servers/icingaweb2/thirdparty.nix { };
   icingaweb2 = callPackage ../servers/icingaweb2 { };


### PR DESCRIPTION
Adds a separate SurrealKV-backed SurrealDB package as `pkgs.surrealdb-surrealkv`.

`pkgs.surrealdb` and the existing NixOS module defaults stay unchanged so downstream users can opt into the new package name first. Keeping this PR to one new attr also avoids dragging multiple heavy SurrealDB variants through the same review job.

nixpkgs-review-gha: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25203912321

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

