### PR TITLE
leela-zero: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/le/leela-zero/package.nix
+++ b/pkgs/by-name/le/leela-zero/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchDebianPatch,
   boost,
   cmake,
   libsForQt5,
@@ -10,17 +11,27 @@
   zlib,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "leela-zero";
   version = "0.17-unstable-2023-02-07";
 
   src = fetchFromGitHub {
-    owner = "gcp";
+    owner = "leela-zero";
     repo = "leela-zero";
     rev = "3ee6d20d0b36ae26120331c610926359cc5837de";
     hash = "sha256-JF25y471miw/0b7XXBURzK+4WBwZI5ZUP+36/cZUORo=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = finalAttrs.pname;
+      version = "0.17";
+      debianRevision = "1.3";
+      patch = "boost1.90.patch";
+      hash = "sha256-/vnRuRWlZl+pzJvjP6a/A9TaFNuCSkTZkd4h9zvZJis=";
+    })
+  ];
 
   buildInputs = [
     boost
@@ -47,4 +58,4 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
- #485826 
- https://hydra.nixos.org/build/324517191

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
