### PR TITLE
silverbullet-cli: init at 2.6.1

### DIFF
--- a/pkgs/by-name/si/silverbullet-cli/package.nix
+++ b/pkgs/by-name/si/silverbullet-cli/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+}:
+buildGoModule (finalAttrs: {
+  pname = "silverbullet-cli";
+  version = "2.6.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "silverbulletmd";
+    repo = "silverbullet";
+    rev = finalAttrs.version;
+    hash = "sha256-vHRLOYsFsQjpDu3mlbJxWq+P07JnHdO54myFb2Rm18s=";
+  };
+
+  vendorHash = "sha256-SvMPyJbSVrj+lwXrNh2WEYNI41oqlzchFxCtXvIl4/4=";
+  subPackages = [ "cmd/cli" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/silverbullet-cli
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "silverbullet-cli version";
+  };
+
+  meta = {
+    changelog = "https://github.com/silverbulletmd/silverbullet/blob/${finalAttrs.version}/website/CHANGELOG.md";
+    description = "CLI for SilverBullet, an open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application";
+    homepage = "https://silverbullet.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      aorith
+      gleber
+    ];
+    mainProgram = "silverbullet-cli";
+  };
+})


### PR DESCRIPTION
Add `silverbullet-cli` package, built from source using `buildGoModule`.

Per @aorith's suggestion: the CLI is Go-based and can be built from the silverbullet monorepo (`cmd/cli` subpackage). Version injected via ldflags.

> **Note:** `aorith` maintains the main `silverbullet` package. This `silverbullet-cli` is a companion CLI tool; both are co-maintained here.

## Things done

- Built on platform:
  - [x] x86_64-linux *(native build + binary tested: `silverbullet-cli version` → `2.6.1`)*
  - [x] aarch64-linux *(cross-compiled via `pkgsCross.aarch64-multiplatform`)*
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. *(not applicable)*
  - [x] [Package tests] at `passthru.tests`. *(`testers.testVersion` with `silverbullet-cli version` — passes)*
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test