### PR TITLE
nixos/shadow: use file capabilities for newuidmap/newgidmap

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -319,6 +319,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - Wine has been updated to the 11.0 branch. Please check the [upstream announcement](https://gitlab.winehq.org/wine/wine/-/releases/wine-11.0) for more details.
 
+- The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.
+
 - `security.acme` now defaults to a dynamic renewal duration, if
   [security.acme.defaults.validMinDays](#opt-security.acme.defaults.validMinDays)
   remains unset. This accomodates certificates with different ACME profile:

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -24,4 +24,4 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -267,13 +267,22 @@ in
             group = "root";
             inherit source;
           };
+          mkCapRoot = capabilities: source: {
+            inherit capabilities source;
+            owner = "root";
+            group = "root";
+          };
         in
         {
           su = mkSetuidRoot "${config.security.shadow.su.package}/bin/su";
           sg = mkSetuidRoot "${cfg.package.out}/bin/sg";
           newgrp = mkSetuidRoot "${cfg.package.out}/bin/newgrp";
-          newuidmap = mkSetuidRoot "${cfg.package.out}/bin/newuidmap";
-          newgidmap = mkSetuidRoot "${cfg.package.out}/bin/newgidmap";
+          # File capabilities instead of setuid root, mirroring shadow's
+          # own --with-fcaps install mode and what Arch/Fedora/Debian ship.
+          # The kernel only requires CAP_SETUID/CAP_SETGID over the parent
+          # userns to write a multi-line /proc/<pid>/[ug]id_map.
+          newuidmap = mkCapRoot "cap_setuid+ep" "${cfg.package.out}/bin/newuidmap";
+          newgidmap = mkCapRoot "cap_setgid+ep" "${cfg.package.out}/bin/newgidmap";
         }
         // lib.optionalAttrs config.users.mutableUsers {
           chsh = mkSetuidRoot "${cfg.package.out}/bin/chsh";


### PR DESCRIPTION
Writing a multi-line `/proc/<pid>/[ug]id_map` only requires `CAP_SETUID`/`CAP_SETGID` over the parent user namespace, not full root. shadow's own `--with-fcaps` install mode (shadow-maint/shadow@70971457b761) sets exactly `cap_setuid+ep` / `cap_setgid+ep`, and Arch, Fedora and Debian have shipped these binaries with file capabilities instead of setuid for years.

The setuid variant already drops to the same single capability before the `uid_map` write (see `lib/idmapping.c`), so the privilege at the point attacker-controlled data reaches the kernel is unchanged. The reduction is in the startup window: with file capabilities the process never has euid 0 and never holds the full capability set during NSS lookups, `/etc/subuid` parsing and `/proc/<pid>` opening.

The only functional difference is that mapping host uid 0 into a child namespace additionally needs `CAP_SETFCAP`, which the setuid path got implicitly. NixOS never puts uid 0 into auto-allocated subuid ranges, and granting it manually is a deliberate root-equivalent configuration; the release notes document the override for that case.

`nixosTests.shadow`, `nixosTests.podman` and `nixosTests.docker-rootless` pass on x86_64-linux; the latter two exercise `newuidmap`/`newgidmap` via rootless containers.

Supersedes #461172.

CC: @howtonotwin 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - `nixosTests.shadow`
    - `nixosTests.podman` (exercises rootless containers → `newuidmap`/`newgidmap`)
    - `nixosTests.docker-rootless` (same)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
