### PR TITLE
peergos: 1.22.0 -> 1.24.0

### DIFF
--- a/pkgs/by-name/pe/peergos/package.nix
+++ b/pkgs/by-name/pe/peergos/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   ant,
-  jdk,
+  jdk25,
   openjdk8-bootstrap,
   jre,
   stripJavaArchivesHook,
@@ -14,13 +14,13 @@
 let
   tweetnacl = stdenv.mkDerivation {
     pname = "tweetnacl";
-    version = "0-unstable-2020-02-12";
+    version = "0-unstable-2025-11-06";
 
     src = fetchFromGitHub {
       owner = "ianopolous";
       repo = "tweetnacl-java";
-      rev = "6d1bde81ea63051750cda40422b62e478b85d2b0";
-      hash = "sha256-BDWzDpUBi4UuvxFwA9ton+RtHOzDcWql1ti+cdvhzks=";
+      rev = "0cf99e1921b79eb91bc4c27cc15a27e325dbdb75";
+      hash = "sha256-RyyC3/XhOhL7UxtPd2WODJgG6mPqkF/KDtvoa8PKWEM=";
     };
 
     postPatch = ''
@@ -41,18 +41,19 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "peergos";
-  version = "1.22.0";
+  version = "1.24.0";
+
   src = fetchFromGitHub {
     owner = "Peergos";
     repo = "web-ui";
     rev = "v${version}";
-    hash = "sha256-0/kLWX3IbVH5FnffIER/VK2PJpJXOyBECc1upvEcWHI=";
+    hash = "sha256-qZUYtiqEoYs7gal164Qnum83xgRq/wPXz7cLiuqM278=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
     ant
-    jdk
+    jdk25
     stripJavaArchivesHook
     makeWrapper
   ];


### PR DESCRIPTION
Also switch to JDK 25, which is now required.

Release notes:
- https://github.com/Peergos/web-ui/releases/tag/v1.23.0
- https://github.com/Peergos/web-ui/releases/tag/v1.24.0

Supersedes #510200.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
