### PR TITLE
electricsheep: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/el/electricsheep/package.nix
+++ b/pkgs/by-name/el/electricsheep/package.nix
@@ -2,9 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   autoreconfHook,
   wxwidgets_3_2,
-  ffmpeg,
+  ffmpeg_7,
   lua5_1,
   curl,
   libpng,
@@ -34,6 +35,11 @@ stdenv.mkDerivation {
   patches = [
     # <https://github.com/scottdraves/electricsheep/pull/126>
     ./boost-1.85.patch
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/proj/guru.git/plain/app-misc/electricsheep/files/electricsheep-boost-system-r1.patch?id=b9f2c3c92d29ed57491a88e45dc8a99bbc73fc15";
+      hash = "sha256-wCRT0pSC9w+XXAbeCTukvPMu5mVeGdfwnkBieMmBIwA=";
+      extraPrefix = "";
+    })
   ];
 
   nativeBuildInputs = [
@@ -43,7 +49,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     wxwidgets_3_2
-    ffmpeg
+    ffmpeg_7
     lua5_1
     curl
     libpng


### PR DESCRIPTION
- #485826 
- https://hydra.nixos.org/build/325287590

Fixes #465327 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
