### PR TITLE
timetagger.services.default: init

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -23,6 +23,7 @@ let
       "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
       "<imports = [ pkgs.snid.services.default ]>" = fakeSubmodule pkgs.snid.services.default;
+      "<imports = [ pkgs.timetagger.services.default ]>" = fakeSubmodule pkgs.timetagger.services.default;
     };
   };
 in

--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -28,6 +28,7 @@ let
       "<imports = [ pkgs.ktls-utils.services.default ]>" = fakeSubmodule pkgs.ktls-utils.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
       "<imports = [ pkgs.snid.services.default ]>" = fakeSubmodule pkgs.snid.services.default;
+      "<imports = [ pkgs.timetagger.services.default ]>" = fakeSubmodule pkgs.timetagger.services.default;
       "<imports = [ pkgs.trailbase.services.default ]>" = fakeSubmodule pkgs.trailbase.services.default;
     };
   };

--- a/pkgs/by-name/ti/timetagger/package.nix
+++ b/pkgs/by-name/ti/timetagger/package.nix
@@ -24,7 +24,6 @@ python3.pkgs.buildPythonApplication {
     timetagger
   ];
 
-  format = "custom";
   installPhase = ''
     mkdir -p $out/bin
     echo "#!${python3.interpreter}" >> $out/bin/timetagger

--- a/pkgs/by-name/ti/timetagger/package.nix
+++ b/pkgs/by-name/ti/timetagger/package.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   python3,
+  callPackage,
 
   addr ? "127.0.0.1",
   port ? 8082,
@@ -11,7 +13,7 @@
 # timetagger.
 #
 
-python3.pkgs.buildPythonApplication {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   inherit (python3.pkgs.timetagger)
     pname
     version
@@ -30,6 +32,15 @@ python3.pkgs.buildPythonApplication {
     cat timetagger/__main__.py >> $out/bin/timetagger
     chmod +x $out/bin/timetagger
     wrapProgram $out/bin/timetagger \
-      --set TIMETAGGER_BIND "${addr}:${toString port}"
+      --set TIMETAGGER_BIND "${finalAttrs.passthru.addr}:${toString finalAttrs.passthru.port}"
   '';
-}
+
+  passthru = (python3.pkgs.timetagger.passthru or { }) // {
+    services.default = {
+      imports = [ (lib.modules.importApply ./service.nix { timetagger = finalAttrs.finalPackage; }) ];
+    };
+    tests = callPackage ./tests.nix { };
+    # can't use override on finalAttrs.finalPackage?
+    inherit port addr;
+  };
+})

--- a/pkgs/by-name/ti/timetagger/package.nix
+++ b/pkgs/by-name/ti/timetagger/package.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   python3,
+  callPackage,
 
   addr ? "127.0.0.1",
   port ? 8082,
@@ -11,7 +13,7 @@
 # timetagger.
 #
 
-python3.pkgs.buildPythonApplication {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   inherit (python3.pkgs.timetagger)
     pname
     version
@@ -30,6 +32,15 @@ python3.pkgs.buildPythonApplication {
     cat timetagger/__main__.py >> $out/bin/timetagger
     chmod +x $out/bin/timetagger
     wrapProgram $out/bin/timetagger \
-      --set TIMETAGGER_BIND "${addr}:${toString port}"
+      --set TIMETAGGER_BIND "${finalAttrs.passthru.addr}:${toString finalAttrs.passthru.port}"
   '';
-}
+
+  passthru = (python3.pkgs.timetagger.passthru or { }) // {
+    services.default = {
+      # NOTE: can't use `override` on finalAttrs.finalPackage
+      imports = [ (lib.modules.importApply ./service.nix { timetagger = finalAttrs.finalPackage; }) ];
+    };
+    tests = callPackage ./tests.nix { };
+    inherit port addr;
+  };
+})

--- a/pkgs/by-name/ti/timetagger/service.nix
+++ b/pkgs/by-name/ti/timetagger/service.nix
@@ -1,0 +1,47 @@
+# Non-module dependencies (`importApply`)
+{ timetagger }:
+
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.timetagger;
+in
+{
+  _class = "service";
+  options.timetagger = {
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The timetagger package that provided this module.";
+    };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8082;
+      description = "Which port this service should listen on.";
+    };
+    addr = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Which addr this service should run on.";
+    };
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      default = timetagger.overrideAttrs (prev: {
+        passthru = (prev.passthru or { }) // {
+          inherit (cfg) port addr;
+        };
+      });
+      defaultText = "package overriden with port and addr";
+      description = "Final package constructed from `options.timetagger.package`";
+    };
+  };
+  config = {
+    process.argv = [
+      (lib.getExe cfg.package)
+    ];
+    timetagger.package = cfg.finalPackage;
+  };
+  meta.maintainers = (cfg.package.meta.maintainers or [ ]);
+}

--- a/pkgs/by-name/ti/timetagger/service.nix
+++ b/pkgs/by-name/ti/timetagger/service.nix
@@ -1,0 +1,48 @@
+# Non-module dependencies (`importApply`)
+{ timetagger }:
+
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.timetagger;
+in
+{
+  _class = "service";
+  options.timetagger = {
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The timetagger package that provided this module.";
+    };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8082;
+      description = "Which port this service should listen on.";
+    };
+    addr = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Which addr this service should run on.";
+    };
+    # Because of the way timetagger derivation is written this is how to override it
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      default = timetagger.overrideAttrs (prev: {
+        passthru = (prev.passthru or { }) // {
+          inherit (cfg) port addr;
+        };
+      });
+      defaultText = "package overriden with port and addr";
+      description = "Final package constructed from `options.timetagger.package`";
+    };
+  };
+  config = {
+    process.argv = [
+      (lib.getExe cfg.package)
+    ];
+    timetagger.package = lib.mkDefault cfg.finalPackage;
+  };
+  meta.maintainers = (cfg.package.meta.maintainers or [ ]);
+}

--- a/pkgs/by-name/ti/timetagger/tests.nix
+++ b/pkgs/by-name/ti/timetagger/tests.nix
@@ -1,0 +1,35 @@
+{
+  pkgs,
+}:
+{
+  timetagger = pkgs.testers.runNixOSTest {
+    # hostPkgs ??
+    _class = "nixosTest";
+
+    name = "timetagger";
+
+    nodes.machine =
+      { pkgs, lib, ... }:
+      {
+        system.services.timetagger-plain = pkgs.timetagger.services.default;
+        system.services.timetagger-custom = {
+          imports = [ pkgs.timetagger.services.default ];
+          timetagger.package = pkgs.timetagger.override { port = 8083; };
+        };
+        system.services.timetagger-port = {
+          imports = [ pkgs.timetagger.services.default ];
+          timetagger.port = 8084;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("default.target")
+      machine.wait_for_unit("timetagger-plain.service")
+      machine.wait_for_unit("timetagger-custom.service")
+      machine.wait_for_unit("timetagger-port.service")
+      machine.wait_for_open_port(8082)
+      machine.wait_for_open_port(8083)
+      machine.wait_for_open_port(8084)
+    '';
+  };
+}

--- a/pkgs/by-name/ti/timetagger/tests.nix
+++ b/pkgs/by-name/ti/timetagger/tests.nix
@@ -1,0 +1,35 @@
+{
+  pkgs,
+}:
+{
+  timetagger = pkgs.testers.runNixOSTest {
+    _class = "nixosTest";
+    name = "timetagger-modular";
+    nodes.machine =
+      { pkgs, lib, ... }:
+      {
+        system.services.timetagger-plain = pkgs.timetagger.services.default;
+        system.services.timetagger-custom = {
+          imports = [ pkgs.timetagger.services.default ];
+          timetagger.package = pkgs.timetagger.override { port = 8083; };
+        };
+        system.services.timetagger-port = {
+          imports = [ pkgs.timetagger.services.default ];
+          timetagger.port = 8084;
+        };
+        environment.systemPackages = [ pkgs.curl ];
+      };
+    testScript = ''
+      machine.wait_for_unit("default.target")
+      machine.wait_for_unit("timetagger-plain.service")
+      machine.wait_for_unit("timetagger-custom.service")
+      machine.wait_for_unit("timetagger-port.service")
+      machine.wait_for_open_port(8082)
+      machine.wait_for_open_port(8083)
+      machine.wait_for_open_port(8084)
+      machine.succeed("curl -fsL http://localhost:8082 | grep -q 'TimeTagger'")
+      machine.succeed("curl -fsL http://localhost:8083 | grep -q 'TimeTagger'")
+      machine.succeed("curl -fsL http://localhost:8084 | grep -q 'TimeTagger'")
+    '';
+  };
+}

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -4,11 +4,13 @@
   bcrypt,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   iptools,
   itemdb,
   jinja2,
   markdown,
   nodejs,
+  platformdirs,
   pscript,
   pyjwt,
   pytestCheckHook,
@@ -31,6 +33,19 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-X82Ai6E844deRGs6KcJATEid3X6IlDq4+LCEU4lc4hM=";
   };
 
+  patches = [
+    # PR https://github.com/almarklein/timetagger/pull/605
+    (fetchpatch2 {
+      url = "https://github.com/almarklein/timetagger/commit/9d4cb5937c52a6cc72e786e5411515737ad3f242.patch?full_index=1";
+      hash = "sha256-n0KluJ3wNA4SDISwJ6KC5PoguJLOMDFt/o2cPBb91Wc=";
+    })
+  ];
+
+  # NOTE: fetchpatch2 doesn't handle new empty files in the patches properly
+  postPatch = ''
+    touch timetagger/migrations/__init__.py
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -40,6 +55,7 @@ buildPythonPackage (finalAttrs: {
     itemdb
     jinja2
     markdown
+    platformdirs
     pscript
     pyjwt
     uvicorn

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -80,7 +80,10 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/almarklein/timetagger";
     changelog = "https://github.com/almarklein/timetagger/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ matthiasbeyer ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      phanirithvij
+    ];
     mainProgram = "timetagger";
   };
 })

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -75,7 +75,10 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/almarklein/timetagger";
     changelog = "https://github.com/almarklein/timetagger/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ matthiasbeyer ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      phanirithvij
+    ];
     mainProgram = "timetagger";
   };
 })

--- a/pkgs/development/python-modules/timetagger/default.nix
+++ b/pkgs/development/python-modules/timetagger/default.nix
@@ -4,11 +4,13 @@
   bcrypt,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   iptools,
   itemdb,
   jinja2,
   markdown,
   nodejs,
+  platformdirs,
   pscript,
   pyjwt,
   pytestCheckHook,
@@ -31,6 +33,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-X82Ai6E844deRGs6KcJATEid3X6IlDq4+LCEU4lc4hM=";
   };
 
+  patches = [
+    # PR https://github.com/almarklein/timetagger/pull/605
+    (fetchpatch {
+      url = "https://github.com/almarklein/timetagger/commit/8221a2a84e83c927c439379c256c53cc74efddb2.patch?full_index=1";
+      hash = "sha256-raeiGJCCE+0q6Pu4srYs8HRgDYwzkFGsf62sow7YMeM=";
+    })
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [
@@ -40,6 +50,7 @@ buildPythonPackage (finalAttrs: {
     itemdb
     jinja2
     markdown
+    platformdirs
     pscript
     pyjwt
     uvicorn


### PR DESCRIPTION
Adds https://github.com/almarklein/timetagger as a modular service.

I've been using this modular service for ~ 5 months now without issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
