### PR TITLE
nixos/bird: start bird after network.target

### DIFF
--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -93,6 +93,14 @@ in
     systemd.services.bird = {
       description = "BIRD Internet Routing Daemon";
       wantedBy = [ "multi-user.target" ];
+      after = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
+      wants = [
+        "network-online.target"
+        "nss-lookup.target"
+      ];
       reloadTriggers = lib.optional cfg.autoReload config.environment.etc."bird/bird.conf".source;
       serviceConfig = {
         Type = "forking";

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -93,6 +93,7 @@ in
     systemd.services.bird = {
       description = "BIRD Internet Routing Daemon";
       wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
       reloadTriggers = lib.optional cfg.autoReload config.environment.etc."bird/bird.conf".source;
       serviceConfig = {
         Type = "forking";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

on my deployments with rpki setup (using domain name instead of ip), the protocol will report transport error after reboot due to the name resolver being ordered after bird

```console
$ colmena exec --verbose --on @router -- sudo birdc show proto rpki0
     butte |
   roraima |
    lantau |
      rysy |
     timah |
   toompea |
     baldy |
    cradle |
  highline |
     kongo |
      rysy | BIRD 3.2.1 ready.
      rysy | Name       Proto      Table      State  Since         Info
      rysy | rpki0      RPKI       ---        start  11:30:38.185  Transport-Error
      rysy | Succeeded
     butte | BIRD 3.2.1 ready.
     butte | Name       Proto      Table      State  Since         Info
     butte | rpki0      RPKI       ---        start  11:30:23.650  Transport-Error
     butte | Succeeded
   toompea | BIRD 3.2.1 ready.
   toompea | Name       Proto      Table      State  Since         Info
   toompea | rpki0      RPKI       ---        start  11:30:15.704  Transport-Error
   toompea | Succeeded
  highline | BIRD 3.2.1 ready.
  highline | Name       Proto      Table      State  Since         Info
  highline | rpki0      RPKI       ---        start  11:30:49.280  Transport-Error
  highline | Succeeded
     timah | BIRD 3.2.1 ready.
     timah | Name       Proto      Table      State  Since         Info
     timah | rpki0      RPKI       ---        start  11:30:04.504  Transport-Error
     timah | Succeeded
   roraima | BIRD 3.2.1 ready.
   roraima | Name       Proto      Table      State  Since         Info
   roraima | rpki0      RPKI       ---        start  11:30:49.168  Transport-Error
   roraima | Succeeded
     baldy | BIRD 3.2.1 ready.
     baldy | Name       Proto      Table      State  Since         Info
     baldy | rpki0      RPKI       ---        start  11:30:51.788  Transport-Error
     baldy | Succeeded
     kongo | BIRD 3.2.1 ready.
     kongo | Name       Proto      Table      State  Since         Info
     kongo | rpki0      RPKI       ---        start  11:30:16.922  Transport-Error
     kongo | Succeeded
    lantau | BIRD 3.2.1 ready.
    lantau | Name       Proto      Table      State  Since         Info
    lantau | rpki0      RPKI       ---        start  11:30:58.516  Transport-Error
    lantau | Succeeded
    cradle | BIRD 3.2.1 ready.
    cradle | Name       Proto      Table      State  Since         Info
    cradle | rpki0      RPKI       ---        start  11:30:35.574  Transport-Error
    cradle | Succeeded
           | All done!
```

```
Apr 17 11:30:38 rysy bird[910]: rpki0: Cannot resolve hostname 'rtr.rpki.cloudflare.com': Name or service not known
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
