### PR TITLE
nixos/test-driver: add golden test for junitXml test report

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -73,6 +73,7 @@ buildPythonApplication {
   doCheck = true;
 
   nativeCheckInputs = [
+    python.pkgs.pytest
     ruff
     ty
   ];
@@ -84,5 +85,7 @@ buildPythonApplication {
     ruff check .
     echo -e "\x1b[32m## run ruff format\x1b[0m"
     ruff format --check --diff .
+    echo -e "\x1b[32m## run pytest\x1b[0m"
+    pytest
   '';
 }

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pytestCheckHook,
 
   buildPythonApplication,
   colorama,
@@ -73,19 +74,26 @@ buildPythonApplication {
   doCheck = true;
 
   nativeCheckInputs = [
-    python.pkgs.pytest
     ruff
     ty
+    pytestCheckHook
   ];
 
-  checkPhase = ''
+  pythonImportsCheck = [
+    "test_driver.driver"
+    "test_driver.machine"
+  ];
+
+  pytestFlags = [
+    "-W error"
+  ];
+
+  preCheck = ''
     echo -e "\x1b[32m## run ty\x1b[0m"
     ty check --error-on-warning test_driver extract-docstrings.py
     echo -e "\x1b[32m## run ruff check\x1b[0m"
     ruff check .
     echo -e "\x1b[32m## run ruff format\x1b[0m"
     ruff format --check --diff .
-    echo -e "\x1b[32m## run pytest\x1b[0m"
-    pytest
   '';
 }

--- a/nixos/lib/test-driver/src/tests/golden/junit_xml_output.xml
+++ b/nixos/lib/test-driver/src/tests/golden/junit_xml_output.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="1" tests="3" time="0.0">
+  <testsuite disabled="0" errors="0" failures="1" name="NixOS integration test" skipped="0" tests="3" time="0">
+    <testcase name="main">
+      <system-out>Starting test...
+Log message 1
+</system-out>
+    </testcase>
+    <testcase name="my subtest">
+      <system-out>Subtest log
+</system-out>
+    </testcase>
+    <testcase name="failing subtest">
+      <failure type="failure" message="test case failed"/>
+      <system-out>Some output
+</system-out>
+      <system-err>Error occurred
+</system-err>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/nixos/lib/test-driver/src/tests/test_junit_xml.py
+++ b/nixos/lib/test-driver/src/tests/test_junit_xml.py
@@ -1,0 +1,55 @@
+import atexit
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from test_driver.logger import JunitXMLLogger
+
+GOLDEN_FILE = Path(__file__).parent / "golden" / "junit_xml_output.xml"
+
+
+def elements_equal(e1: ET.Element, e2: ET.Element) -> bool:
+    """Recursively compare two XML elements for equality."""
+    if e1.tag != e2.tag:
+        return False
+    if e1.attrib != e2.attrib:
+        return False
+    if (e1.text or "").strip() != (e2.text or "").strip():
+        return False
+    if (e1.tail or "").strip() != (e2.tail or "").strip():
+        return False
+    if len(e1) != len(e2):
+        return False
+    return all(elements_equal(c1, c2) for c1, c2 in zip(e1, e2, strict=True))
+
+
+def test_junit_xml_output() -> None:
+    """Test that JunitXMLLogger produces expected JUnit XML output."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outfile = Path(tmpdir) / "output.xml"
+
+        logger = JunitXMLLogger(outfile)
+
+        # Log some messages to main test case
+        logger.log("Starting test...")
+        logger.info("Log message 1")
+
+        # Create a subtest
+        with logger.subtest("my subtest"):
+            logger.log("Subtest log")
+
+        # Create a failing subtest
+        with logger.subtest("failing subtest"):
+            logger.log("Some output")
+            logger.error("Error occurred")
+
+        # Manually close to write the file (normally done via atexit)
+        atexit.unregister(logger.close)
+        logger.close()
+
+        actual_tree = ET.parse(outfile)
+        expected_tree = ET.parse(GOLDEN_FILE)
+
+        assert elements_equal(actual_tree.getroot(), expected_tree.getroot()), (
+            f"JUnit XML output differs from golden file:\n{outfile.read_text()}"
+        )


### PR DESCRIPTION
This PR adds a new golden test for the test driver that ensures the format of the JunitXML test report does not change accidentally. This test is important because we are planning to refactor this part of the test driver in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
