### PR TITLE
various: remove unused optional/optionalString from let bindings

### DIFF
--- a/pkgs/by-name/bl/blitz/package.nix
+++ b/pkgs/by-name/bl/blitz/package.nix
@@ -22,7 +22,7 @@
 }:
 
 let
-  inherit (lib) optional optionals;
+  inherit (lib) optional;
 in
 stdenv.mkDerivation rec {
   pname = "blitz++";

--- a/pkgs/by-name/gs/gsm/package.nix
+++ b/pkgs/by-name/gs/gsm/package.nix
@@ -8,7 +8,7 @@
 
 let
   inherit (stdenv.hostPlatform) isDarwin;
-  inherit (lib) optional optionalString;
+  inherit (lib) optionalString;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/li/libmikmod/package.nix
+++ b/pkgs/by-name/li/libmikmod/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  inherit (lib) optional optionalString;
+  inherit (lib) optional;
 
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/or/oracle-instantclient/package.nix
+++ b/pkgs/by-name/or/oracle-instantclient/package.nix
@@ -15,7 +15,7 @@
 assert odbcSupport -> unixodbc != null;
 
 let
-  inherit (lib) optional optionals optionalString;
+  inherit (lib) optional optionalString;
 
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 

--- a/pkgs/by-name/sq/squeezelite/package.nix
+++ b/pkgs/by-name/sq/squeezelite/package.nix
@@ -28,7 +28,7 @@
 }:
 
 let
-  inherit (lib) optional optionals optionalString;
+  inherit (lib) optional optionalString;
 
   pulseSupport = audioBackend == "pulse";
 

--- a/pkgs/by-name/st/stable-diffusion-cpp/package.nix
+++ b/pkgs/by-name/st/stable-diffusion-cpp/package.nix
@@ -35,7 +35,6 @@ let
     cmakeBool
     cmakeFeature
     optionals
-    optionalString
     ;
 
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;


### PR DESCRIPTION
This pull request simplifies the way Nix package files import functions from the `lib` module by removing unused imports of `optionals` and, in some cases, `optionalString`. The changes help clean up the code and ensure only necessary functions are imported.

**Cleanup of unused imports:**

* Removed unnecessary `optionals` and/or `optionalString` imports from the `lib` module in several package files, including `blitz++`, `gsm`, `libmikmod`, `oracle-instantclient`, and `squeezelite`.

**Refinement of let bindings:**

* Removed the unused `optionalString` binding from the `let` block in `stable-diffusion-cpp/package.nix`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
