### PR TITLE
sable-unwrapped: init at 1.19.4

### DIFF
--- a/pkgs/by-name/ci/cinny/package.nix
+++ b/pkgs/by-name/ci/cinny/package.nix
@@ -4,15 +4,16 @@
   stdenvNoCC,
   writeText,
   conf ? { },
+  pname ? "cinny",
 }:
 let
-  configOverrides = writeText "cinny-config-overrides.json" (builtins.toJSON conf);
+  configOverrides = writeText "${pname}-config-overrides.json" (builtins.toJSON conf);
 in
 if (conf == { }) then
   cinny-unwrapped
 else
   stdenvNoCC.mkDerivation {
-    pname = "cinny";
+    inherit pname;
     inherit (cinny-unwrapped) version meta;
 
     dontUnpack = true;

--- a/pkgs/by-name/sa/sable-unwrapped/package.nix
+++ b/pkgs/by-name/sa/sable-unwrapped/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs-slim_24,
+  nix-update-script,
+}:
+
+let
+  nodejs-slim = nodejs-slim_24;
+  pnpm = pnpm_10.override { inherit nodejs-slim; };
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  __darwinAllowLocalNetworking = true;
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "sable-unwrapped";
+  version = "1.19.4";
+
+  src = fetchFromGitHub {
+    owner = "SableClient";
+    repo = "Sable";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GI4ZXmqPTWt3WlTQDkjVfRWhiJnd3mdq5paA3/TGMEA=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-iBvtMeYUHWhsz1DnKjTzydAt3cGPaisUhaagoaZRg1M=";
+  };
+
+  nativeBuildInputs = [
+    nodejs-slim
+    pnpmConfigHook
+    pnpm
+  ];
+
+  # Controls how the application displays its version, e.g. "v1.14.0 (nix)".
+  # Also prevents some attempts to execute git during build.
+  env = {
+    VITE_IS_RELEASE_TAG = "true";
+    VITE_BUILD_HASH = "nix";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An almost stable Matrix client";
+    homepage = "https://github.com/SableClient/Sable";
+    changelog = "https://github.com/SableClient/Sable/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      fugi
+    ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9359,6 +9359,11 @@ with pkgs;
 
   rusty-psn-gui = rusty-psn.override { withGui = true; };
 
+  sable = callPackage ../by-name/ci/cinny/package.nix {
+    pname = "sable";
+    cinny-unwrapped = sable-unwrapped;
+  };
+
   sweethome3d = recurseIntoAttrs (
     (callPackage ../applications/misc/sweethome3d { })
     // (callPackage ../applications/misc/sweethome3d/editors.nix {


### PR DESCRIPTION
Adds [Sable](https://github.com/SableClient/Sable), a feature rich Matrix client forked from Cinny.

Cinny's config wrapper mechanism is re-used as it works the same.

pnpm and nodejs versions are pinned, as recommended in the nixpkgs manual.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
