### PR TITLE
nixos/sshd: remove 'moduliFile' option, in favour of settings.ModuliFile

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -230,6 +230,10 @@ in
       "openssh"
       "banner"
     ] "Use services.openssh.settings.Banner instead.")
+    (lib.mkRenamedOptionModule
+      [ "services" "openssh" "moduliFile" ]
+      [ "services" "openssh" "settings" "ModuliFile" ]
+    )
   ];
 
   ###### interface
@@ -727,6 +731,14 @@ in
                 '';
                 example = "/etc/ssh/banner";
               };
+              ModuliFile = lib.mkOption {
+                type = lib.types.path;
+                default = "${config.services.openssh.package}/etc/ssh/moduli";
+                defaultText = lib.literalExpression ''"''${config.services.openssh.package}/etc/ssh/moduli"'';
+                description = ''
+                  Specifies the {manpage}`moduli(5)` file to use for Diffie-Hellman key exchange.
+                '';
+              };
             };
           }
         );
@@ -736,16 +748,6 @@ in
         type = lib.types.lines;
         default = "";
         description = "Verbatim contents of {file}`sshd_config`.";
-      };
-
-      moduliFile = lib.mkOption {
-        example = "/etc/my-local-ssh-moduli;";
-        type = lib.types.path;
-        description = ''
-          Path to `moduli` file to install in
-          `/etc/ssh/moduli`. If this option is unset, then
-          the `moduli` file shipped with OpenSSH will be used.
-        '';
       };
 
     };
@@ -768,14 +770,12 @@ in
       };
       users.groups.sshd = { };
 
-      services.openssh.moduliFile = lib.mkDefault "${cfg.package}/etc/ssh/moduli";
       services.openssh.sftpServerExecutable = lib.mkDefault "${cfg.package}/libexec/sftp-server";
 
       environment.etc =
         authKeysFiles
         // authPrincipalsFiles
         // {
-          "ssh/moduli".source = cfg.moduliFile;
           "ssh/sshd_config".source = sshconf;
         };
 

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -232,6 +232,10 @@ in
       "openssh"
       "banner"
     ] "Use services.openssh.settings.Banner instead.")
+    (lib.mkRenamedOptionModule
+      [ "services" "openssh" "moduliFile" ]
+      [ "services" "openssh" "settings" "ModuliFile" ]
+    )
   ];
 
   ###### interface
@@ -729,6 +733,14 @@ in
                 '';
                 example = "/etc/ssh/banner";
               };
+              ModuliFile = lib.mkOption {
+                type = lib.types.path;
+                default = "${config.services.openssh.package}/etc/ssh/moduli";
+                defaultText = lib.literalExpression ''"''${config.services.openssh.package}/etc/ssh/moduli"'';
+                description = ''
+                  Specifies the {manpage}`moduli(5)` file to use for Diffie-Hellman key exchange.
+                '';
+              };
             };
           }
         );
@@ -738,16 +750,6 @@ in
         type = lib.types.lines;
         default = "";
         description = "Verbatim contents of {file}`sshd_config`.";
-      };
-
-      moduliFile = lib.mkOption {
-        example = "/etc/my-local-ssh-moduli;";
-        type = lib.types.path;
-        description = ''
-          Path to `moduli` file to install in
-          `/etc/ssh/moduli`. If this option is unset, then
-          the `moduli` file shipped with OpenSSH will be used.
-        '';
       };
 
     };
@@ -770,14 +772,12 @@ in
       };
       users.groups.sshd = { };
 
-      services.openssh.moduliFile = lib.mkDefault "${cfg.package}/etc/ssh/moduli";
       services.openssh.sftpServerExecutable = lib.mkDefault "${cfg.package}/libexec/sftp-server";
 
       environment.etc =
         authKeysFiles
         // authPrincipalsFiles
         // {
-          "ssh/moduli".source = cfg.moduliFile;
           "ssh/sshd_config".source = sshconf;
         };
 


### PR DESCRIPTION
Per RFC42.

As a result, `/etc/ssh/moduli` will no longer exist, and sshd_config's ModuliFile will point to /nix/store/...

Man page: https://man.openbsd.org/sshd_config#ModuliFile

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
