### PR TITLE
maintainers/haskell/eval-pkg-sets.sh: add script for checking eval

### DIFF
--- a/maintainers/scripts/haskell/eval-pkg-sets.sh
+++ b/maintainers/scripts/haskell/eval-pkg-sets.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash
+#!nix-shell -p jq git
+# shellcheck shell=bash
+#
+# Usage: eval-pkg-sets.sh [extra flags for nix-* commands ...]
+#
+# Must be executed in a git checkout of Nixpkgs.
+
+set -euo pipefail
+
+NIXPKGS="$(git rev-parse --show-toplevel)"
+PKGSETS="$(nix-env --readonly-mode --json --drv-path -f "$NIXPKGS" -qaP -A haskell.compiler "$@" \
+  | jq -r 'to_entries | unique_by(.value.drvPath) .[] .key | sub("^haskell.compiler";"haskell.packages")')"
+
+trap 'exit 1' SIGINT SIGTERM
+
+set +e
+
+badsets=""
+for set in $PKGSETS; do
+  # Confirm an equivalent package set to haskell.compiler.$entry exists and is usable
+  if ! nix-instantiate --readonly-mode -A "$set.ghc" "$@" > /dev/null 2>&1; then
+    echo "Skipping $set... ($set.ghc does not evaluate)"
+  else
+    echo "Evaluating $set..."
+
+    if ! nix-env --readonly-mode -f "$NIXPKGS" -qaP --drv-path -A "$set" "$@" > /dev/null; then
+      badsets+="$set "
+    fi
+  fi
+done
+
+if [ -n "$badsets" ]; then
+  echo "Found potential eval issues in the following sets:" >&2
+  # shellcheck disable=SC2086
+  printf '%s\n' $badsets
+  exit 1
+fi


### PR DESCRIPTION
This checks the eval of all package sets, even those neither CI nor Hydra will evaluate (completely).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
