### PR TITLE
vimPlugins.nvim-treesitter-legacy: don't warn on allowAliases == false

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  config,
   # nixpkgs functions
   buildGoModule,
   callPackage,
@@ -2805,7 +2806,10 @@ assertNoAdditions {
         callPackage ./nvim-treesitter-legacy/overrides.nix { } self super
       );
     in
-    lib.warnOnInstantiate "nvim-treesitter-legacy is deprecated, please migrate to the new version. This will become an error in 26.11" drv;
+    if config.allowAliases then
+      lib.warnOnInstantiate "nvim-treesitter-legacy is deprecated, please migrate to the new version. This will become an error in 26.11" drv
+    else
+      drv;
 
   nvim-treesitter-pairs = super.nvim-treesitter-pairs.overrideAttrs {
     dependencies = [ self.nvim-treesitter-legacy ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Unblocks channels as @vcunat said in https://github.com/NixOS/nixpkgs/pull/510623#issuecomment-4265737076

As verification, ran `nix-env -f . --show-trace --argstr system aarch64-linux --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' --option lint-url-literals fatal -qa --drv-path --system-filter '*' --system` and `(import ./. { config.allowAliases = false; }).vimPlugins.nvim-treesitter-legacy` in REPL.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
