### PR TITLE
amazon-image: add amazonImage.registerImage options

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -15,6 +15,14 @@ let
   inherit (lib.options) literalExpression;
   cfg = config.amazonImage;
   amiBootMode = if config.ec2.efi then "uefi" else "legacy-bios";
+  amiArch =
+    {
+      "aarch64-linux" = "arm64";
+      "x86_64-linux" = "x86_64";
+    }
+    .${pkgs.stdenv.hostPlatform.system}
+      or (throw "Unsupported system for AMI architecture: ${pkgs.stdenv.hostPlatform.system}");
+  registerImageJSON = builtins.toJSON cfg.registerImage;
 in
 {
   imports = [
@@ -69,6 +77,92 @@ in
       default = "vpc";
       description = "The image format to output";
     };
+
+    registerImage = {
+      Architecture = mkOption {
+        type = types.enum [
+          "x86_64"
+          "arm64"
+        ];
+        default = amiArch;
+        description = "The architecture of the AMI.";
+      };
+
+      BootMode = mkOption {
+        type = types.enum [
+          "legacy-bios"
+          "uefi"
+        ];
+        default = amiBootMode;
+        description = "The boot mode for the AMI. Must match the builder's boot mode derived from `ec2.efi`.";
+      };
+
+      RootDeviceName = mkOption {
+        type = types.str;
+        default = "/dev/xvda";
+        description = "The root device name.";
+      };
+
+      VirtualizationType = mkOption {
+        type = types.enum [ "hvm" ];
+        default = "hvm";
+        readOnly = true;
+        description = "The virtualization type. Fixed to HVM; non-HVM support has been dropped.";
+      };
+
+      EnaSupport = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to enable Enhanced Networking (ENA).";
+      };
+
+      ImdsSupport = mkOption {
+        type = types.enum [ "v2.0" ];
+        default = "v2.0";
+        description = "The IMDS version to require.";
+      };
+
+      SriovNetSupport = mkOption {
+        type = types.enum [ "simple" ];
+        default = "simple";
+        description = "The SR-IOV network support setting.";
+      };
+
+      TpmSupport = mkOption {
+        type = types.nullOr (types.enum [ "v2.0" ]);
+        default = null;
+        description = "TPM support version, or `null` to omit.";
+      };
+
+      BlockDeviceMappings = mkOption {
+        type = types.listOf (
+          types.submodule {
+            options = {
+              DeviceName = mkOption {
+                type = types.str;
+                default = "/dev/xvda";
+                description = "The device name for the block device mapping.";
+              };
+              Ebs = mkOption {
+                type = types.submodule {
+                  options = {
+                    VolumeType = mkOption {
+                      type = types.str;
+                      default = "gp3";
+                      description = "The EBS volume type (e.g. `gp3`, `gp2`, `io1`, `io2`, `standard`).";
+                    };
+                  };
+                };
+                default = { };
+                description = "The EBS block device parameters.";
+              };
+            };
+          }
+        );
+        default = [ { } ];
+        description = "Block device mappings for the AMI.";
+      };
+    };
   };
 
   # Use a priority just below mkOptionDefault (1500) instead of lib.mkDefault
@@ -79,6 +173,30 @@ in
   config.system.nixos.tags = [ "amazon" ];
   config.system.build.image = config.system.build.amazonImage;
   config.image.extension = if cfg.format == "vpc" then "vhd" else cfg.format;
+
+  config.assertions = [
+    {
+      assertion =
+        let
+          mappings = cfg.registerImage.BlockDeviceMappings;
+        in
+        builtins.length mappings == 1
+        && (builtins.head mappings).DeviceName == cfg.registerImage.RootDeviceName;
+      message = "amazonImage.registerImage must contain exactly one BlockDeviceMapping and its DeviceName must match RootDeviceName.";
+    }
+    {
+      assertion = cfg.registerImage.TpmSupport == null || cfg.registerImage.BootMode == "uefi";
+      message = "amazonImage.registerImage.TpmSupport requires BootMode to be \"uefi\".";
+    }
+    {
+      assertion = cfg.registerImage.BootMode == amiBootMode;
+      message = "amazonImage.registerImage.BootMode (${cfg.registerImage.BootMode}) does not match the builder's boot mode (${amiBootMode}). Set ec2.efi to change it.";
+    }
+    {
+      assertion = cfg.registerImage.Architecture == amiArch;
+      message = "amazonImage.registerImage.Architecture (${cfg.registerImage.Architecture}) does not match the builder's architecture (${amiArch}).";
+    }
+  ];
 
   config.system.build.amazonImage =
     let
@@ -137,6 +255,7 @@ in
             --arg boot_mode "${amiBootMode}" \
             --arg root "$rootDisk" \
             --arg boot "$bootDisk" \
+            --argjson register_image ${lib.escapeShellArg registerImageJSON} \
            '{}
              | .label = $system_version
              | .boot_mode = $boot_mode
@@ -145,6 +264,7 @@ in
              | .disks.boot.file = $boot
              | .disks.root.logical_bytes = $root_logical_bytes
              | .disks.root.file = $root
+             | .registerImage = $register_image
              ' > $out/nix-support/image-info.json
         '';
       };
@@ -176,6 +296,7 @@ in
             --arg logical_bytes "$(${pkgs.qemu_kvm}/bin/qemu-img info --output json "$diskImage" | ${pkgs.jq}/bin/jq '."virtual-size"')" \
             --arg boot_mode "${amiBootMode}" \
             --arg file "$diskImage" \
+            --argjson register_image ${lib.escapeShellArg registerImageJSON} \
              '{}
              | .label = $system_version
              | .boot_mode = $boot_mode
@@ -184,6 +305,7 @@ in
              | .file = $file
              | .disks.root.logical_bytes = $logical_bytes
              | .disks.root.file = $file
+             | .registerImage = $register_image
              ' > $out/nix-support/image-info.json
         '';
       };


### PR DESCRIPTION
Add a declarative registerImage option surface to the EC2 AMI builder so the full RegisterImage API body is emitted in image-info.json. This moves registration policy out of the upload tooling and into the NixOS module where the image is defined.

Previous defaults are preserved for newly built images. The companion upload-ami change requires this key, so this must land first.

- Architecture and BootMode derived from build platform with assertions
- VirtualizationType fixed to HVM (readOnly)
- TpmSupport requires BootMode == "uefi" (assertion)
- Ebs submodule exposes VolumeType (str, default gp3)
- Both ext and ZFS postVM emitters updated
- JSON passed to jq via lib.escapeShellArg


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
