### PR TITLE
nixos/antigravity: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17821,6 +17821,12 @@
     name = "Marcin Mikuła";
     keys = [ { fingerprint = "5547 2A56 AC30 69C9 15C8  B98D 997F 71FA 1D74 6E37"; } ];
   };
+  milas = {
+    email = "antonbergmark@gmail.com";
+    github = "milas0";
+    githubId = 56896821;
+    name = "Anton Bergmark";
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "MilesBreslin";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18598,6 +18598,12 @@
     name = "Marcin Mikuła";
     keys = [ { fingerprint = "5547 2A56 AC30 69C9 15C8  B98D 997F 71FA 1D74 6E37"; } ];
   };
+  milas = {
+    email = "antonbergmark@gmail.com";
+    github = "milas0";
+    githubId = 56896821;
+    name = "Anton Bergmark";
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "MilesBreslin";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -164,6 +164,7 @@
   ./programs/_1password.nix
   ./programs/alvr.nix
   ./programs/amnezia-vpn.nix
+  ./programs/antigravity.nix
   ./programs/appgate-sdp.nix
   ./programs/appimage.nix
   ./programs/arp-scan.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -165,6 +165,7 @@
   ./programs/_1password.nix
   ./programs/alvr.nix
   ./programs/amnezia-vpn.nix
+  ./programs/antigravity-ide.nix
   ./programs/appgate-sdp.nix
   ./programs/appimage.nix
   ./programs/arp-scan.nix

--- a/nixos/modules/programs/antigravity-ide.nix
+++ b/nixos/modules/programs/antigravity-ide.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.antigravity-ide;
+in
+{
+  options.programs.antigravity-ide = {
+    enable = lib.mkEnableOption "Antigravity IDE";
+
+    defaultEditor = lib.mkEnableOption "" // {
+      description = ''
+        When enabled, configures Antigravity IDE to be the default editor using the EDITOR environment variable.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "antigravity-ide" {
+      extraDescription = "The final package will be customized with extensions from {option}`programs.antigravity-ide.extensions`";
+    };
+
+    extensions = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs.vscode-extensions; [
+          bbenoist.nix
+          golang.go
+        ]
+      '';
+      description = "List of extensions to install.";
+    };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      visible = false;
+      readOnly = true;
+      description = "Resulting customized Antigravity IDE package.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.finalPackage
+    ];
+
+    environment.sessionVariables.EDITOR = lib.mkIf cfg.defaultEditor (
+      lib.mkOverride 900 cfg.finalPackage.meta.mainProgram
+    );
+
+    programs.antigravity-ide.finalPackage = pkgs.vscode-with-extensions.override {
+      vscode = cfg.package;
+      vscodeExtensions = cfg.extensions;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ milas ];
+}

--- a/nixos/modules/programs/antigravity.nix
+++ b/nixos/modules/programs/antigravity.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.antigravity;
+in
+{
+  options.programs.antigravity = {
+    enable = lib.mkEnableOption "Antigravity editor";
+
+    defaultEditor = lib.mkEnableOption "" // {
+      description = ''
+        When enabled, configures Antigravity to be the default editor
+        using the EDITOR environment variable.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "antigravity" {
+      extraDescription = "The final package will be customized with extensions from {option}`programs.antigravity.extensions`";
+    };
+
+    extensions = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression ''
+        with pkgs.vscode-extensions; [
+          bbenoist.nix
+          golang.go
+        ]
+      '';
+      description = "List of extensions to install.";
+    };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      visible = false;
+      readOnly = true;
+      description = "Resulting customized Antigravity package.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.finalPackage
+    ];
+
+    environment.sessionVariables.EDITOR = lib.mkIf cfg.defaultEditor (
+      lib.mkOverride 900 cfg.finalPackage.meta.mainProgram
+    );
+
+    programs.antigravity.finalPackage = pkgs.vscode-with-extensions.override {
+      vscode = cfg.package;
+      vscodeExtensions = cfg.extensions;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ milas ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds a new nixos module for the Antigravity code editor.

The module closely follows the existing `programs.vscode` module and provides the following functionality:
- `programs.antigravity.enable`
- `programs.antigravity.defaultEditor`
- `programs.antigravity.package`
- `programs.antigravity.extensions`
- `programs.antigravity.finalPackage`

It uses `vscode-with-extensions.override` to customize the Antigravity package with extensions, mirroring the behavior of the VS Code module. This allows users to declaratively install extensions and optionally set Antigravity as the default editor.

### Example configuration 
This enables the application, sets it as the default editor and installs the pkgs.vscode-extensions.bbenoist.nix VScode plugin.

```nix
{
  programs.antigravity = {
    enable = true;
    defaultEditor = true;
    extensions = with pkgs.vscode-extensions; [
      bbenoist.nix
    ];
  };
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test