### PR TITLE
nixos/prometheus-{node,postfix}-exporter: add listenStream option

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -575,6 +575,19 @@ in
               `services.prometheus.exporters.pgbouncer.connectionString` are mutually exclusive!
             '';
           }
+          {
+            assertion =
+              cfg.node.enable
+              ->
+                cfg.node.listenStream == "${cfg.node.listenAddress}:${toString cfg.node.port}"
+                || (cfg.node.listenAddress == "0.0.0.0" && cfg.node.port == 9100);
+            message = ''
+              `services.prometheus.exporters.node.listenAddress` and
+              `services.prometheus.exporters.node.port` have no effect
+              when `services.prometheus.exporters.node.listenStream` is set
+              to a non-default value.
+            '';
+          }
         ]
         ++ (flip map (attrNames exporterOpts) (exporter: {
           assertion = cfg.${exporter}.firewallFilter != null -> cfg.${exporter}.openFirewall;

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -588,6 +588,19 @@ in
               to a non-default value.
             '';
           }
+          {
+            assertion =
+              cfg.postfix.enable
+              ->
+                cfg.postfix.listenStream == "${cfg.postfix.listenAddress}:${toString cfg.postfix.port}"
+                || (cfg.postfix.listenAddress == "0.0.0.0" && cfg.postfix.port == 9154);
+            message = ''
+              `services.prometheus.exporters.postfix.listenAddress` and
+              `services.prometheus.exporters.postfix.port` have no effect
+              when `services.prometheus.exporters.postfix.listenStream` is set
+              to a non-default value.
+            '';
+          }
         ]
         ++ (flip map (attrNames exporterOpts) (exporter: {
           assertion = cfg.${exporter}.firewallFilter != null -> cfg.${exporter}.openFirewall;

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -2,13 +2,13 @@
   config,
   lib,
   pkgs,
-  options,
   ...
 }:
 
 let
   cfg = config.services.prometheus.exporters.node;
   inherit (lib)
+    literalExpression
     mkOption
     types
     concatStringsSep
@@ -22,6 +22,18 @@ in
 {
   port = 9100;
   extraOpts = {
+    listenStream = mkOption {
+      type = types.str;
+      default = "${cfg.listenAddress}:${toString cfg.port}";
+      defaultText = literalExpression ''"''${config.services.prometheus.exporters.node.listenAddress}:''${toString config.services.prometheus.exporters.node.port}"'';
+      example = "/run/prometheus-node-exporter.sock";
+      description = ''
+        The value of `ListenStream=` in the exporter's socket unit.
+        Accepts any value supported by systemd, e.g. an IPv4/IPv6 address
+        with port, a Unix domain socket path (absolute), or an abstract
+        namespace socket prefixed with `@`.
+      '';
+    };
     enabledCollectors = mkOption {
       type = types.listOf types.str;
       default = [ ];

--- a/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
@@ -8,6 +8,7 @@
 let
   cfg = config.services.prometheus.exporters.postfix;
   inherit (lib)
+    literalExpression
     mkOption
     types
     mkIf
@@ -19,6 +20,18 @@ in
 {
   port = 9154;
   extraOpts = {
+    listenStream = mkOption {
+      type = types.str;
+      default = "${cfg.listenAddress}:${toString cfg.port}";
+      defaultText = literalExpression ''"''${config.services.prometheus.exporters.postfix.listenAddress}:''${toString config.services.prometheus.exporters.postfix.port}"'';
+      example = "/run/prometheus-postfix-exporter.sock";
+      description = ''
+        The value of `ListenStream=` in the exporter's socket unit.
+        Accepts any value supported by systemd, e.g. an IPv4/IPv6 address
+        with port, a Unix domain socket path (absolute), or an abstract
+        namespace socket prefixed with `@`.
+      '';
+    };
     package = lib.mkPackageOption pkgs "prometheus-postfix-exporter" { };
     group = mkOption {
       type = types.str;


### PR DESCRIPTION
- **nixos/prometheus-node-exporter: add listenStream option**
- **nixos/prometheus-postfix-exporter: add listenStream option**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
