### PR TITLE
parted: cleanup

### DIFF
--- a/pkgs/by-name/pa/parted/package.nix
+++ b/pkgs/by-name/pa/parted/package.nix
@@ -38,23 +38,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libuuid
-  ]
-  ++ lib.optional (readline != null) readline
-  ++ lib.optional (gettext != null) gettext
-  ++ lib.optional (lvm2 != null) lvm2;
+    readline
+    gettext
+    lvm2
+  ];
 
   nativeBuildInputs = [
     pkg-config
   ];
-  configureFlags =
-    (if (readline != null) then [ "--with-readline" ] else [ "--without-readline" ])
-    ++ lib.optional (lvm2 == null) "--disable-device-mapper"
-    ++ lib.optional enableStatic "--enable-static";
+  configureFlags = lib.optional enableStatic "--enable-static";
 
   enableParallelBuilding = true;
 
-  # Tests were previously failing due to Hydra running builds as uid 0.
-  # That should hopefully be fixed now.
   doCheck = !stdenv.hostPlatform.isMusl; # translation test
   nativeCheckInputs = [
     check


### PR DESCRIPTION
phase out `pkg != null`
`--with-readline` is enabled by [default](https://cgit.git.savannah.gnu.org/cgit/parted.git/tree/configure.ac#n70) so no need to set it explicitly.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
