### PR TITLE
python3Packages.pydantic-monty: init at 0.0.13

### DIFF
--- a/pkgs/development/python-modules/pydantic-monty/default.nix
+++ b/pkgs/development/python-modules/pydantic-monty/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  rustPlatform,
+
+  anyio,
+  dirty-equals,
+  inline-snapshot,
+  pytest-examples,
+  pytest-pretty,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pydantic-monty";
+  version = "0.0.13";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pydantic";
+    repo = "monty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0g0/NuwTuUfHVHE8YcVjUeZpSa+ANPWIXllu+qRXjZE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname src version;
+    hash = "sha256-LkTEMhz0MG6RfqejOQMdB2BZU6oxT3ZAo/N0oVlswsQ=";
+  };
+
+  dependencies = [ typing-extensions ];
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  maturinBuildFlags = [
+    "-m"
+    "crates/monty-python/Cargo.toml"
+  ];
+
+  pytestFlags = [
+    "--config-file"
+    "crates/monty-python/pyproject.toml"
+  ];
+
+  disabledTests = [
+    # These tests fails because they expect to have multiple cores
+    # to produce a predicted speedup measurement, which we cannot
+    # achieve in the sandbox.
+    "test_parallel_exec"
+  ];
+
+  nativeCheckInputs = [
+    anyio
+    dirty-equals
+    inline-snapshot
+    pytest-examples
+    pytest-pretty
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pydantic_monty" ];
+
+  meta = {
+    description = "Minimal, secure Python interpreter written in Rust for use by AI";
+    homepage = "https://github.com/pydantic/monty";
+    changelog = "https://github.com/pydantic/monty/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ squat ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13580,6 +13580,8 @@ self: super: with self; {
 
   pydantic-graph = callPackage ../development/python-modules/pydantic-graph { };
 
+  pydantic-monty = callPackage ../development/python-modules/pydantic-monty { };
+
   pydantic-scim = callPackage ../development/python-modules/pydantic-scim { };
 
   pydantic-settings = callPackage ../development/python-modules/pydantic-settings { };


### PR DESCRIPTION
This commit introduces a new Python package:
[pydantic-monty](https://github.com/pydantic/monty), "a minimal, secure Python interpreter written in Rust for use by AI."

It's an optional dependency of
[fastmcp](https://github.com/PrefectHQ/fastmcp), which I'd like to add to the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
