### PR TITLE
ocamlPackages.elpi: Add update.sh

### DIFF
--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -109,6 +109,8 @@ buildDunePackage {
       ]
   );
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Embeddable λProlog Interpreter";
     license = lib.licenses.lgpl21Plus;

--- a/pkgs/development/ocaml-modules/elpi/update.sh
+++ b/pkgs/development/ocaml-modules/elpi/update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+
+set -euo pipefail
+
+cd $(dirname ${BASH_SOURCE[0]})
+
+# Detect latest tag
+latestVersion=$(curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    'https://api.github.com/repos/LPCIC/elpi/releases' | jq -r 'map(.tag_name).[0]' | sed 's/^v//')
+
+# Detect current tag
+currentVersion=$(sed -e "/    if lib.versionAtLeast ocaml.version \"4.13\" then/{n;q}" default.nix | tail -n 1 | sed 's/[[:space:]"]//g')
+
+if [ "$latestVersion" == "$currentVersion" ]
+then
+  echo "Already up to date"
+  exit 0
+fi
+
+# Get hash for latest tag
+versionCommit=$(curl --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    'https://api.github.com/repos/LPCIC/elpi/tags' | \
+    jq -r "map(select(.name == \"v$latestVersion\")) | .[0] | .commit.sha")
+
+ELPI_GIT_PREFETCH=$(nix-prefetch-url --unpack https://github.com/LPCIC/elpi/archive/${versionCommit}.tar.gz)
+ELPI_GIT_HASH=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 ${ELPI_GIT_PREFETCH})
+
+# We register the new version
+sed "/fetched = coqPackages.metaFetch {/a\\    release.\"$latestVersion\".sha256 = \"$ELPI_GIT_HASH\";" -i default.nix
+
+# We set it as default
+sed "/    if lib.versionAtLeast ocaml.version \"4.13\" then/{n;d}" -i default.nix
+sed "/    else if lib.versionAtLeast ocaml.version \"4.08\" then/i\\      \"$latestVersion\"" -i default.nix


### PR DESCRIPTION
Added an automatic update script for elpi package

Tested on 3.6.2 -> 3.7.0 update.
This does not update coq-elpi or any other pinned
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
