### PR TITLE
[25.11] xorg-server: 21.1.21 -> 21.1.22

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3051,11 +3051,11 @@ self: with self; {
     }:
     stdenv.mkDerivation (finalAttrs: {
       pname = "xorg-server";
-      version = "21.1.21";
+      version = "21.1.22";
       builder = ./builder.sh;
       src = fetchurl {
-        url = "mirror://xorg/individual/xserver/xorg-server-21.1.21.tar.xz";
-        sha256 = "sha256-wMvlVFs/ZFuuYCS4MNHRFUqVY1BoOk5Ssv/1sPoatRk=";
+        url = "mirror://xorg/individual/xserver/xorg-server-21.1.22.tar.xz";
+        sha256 = "sha256-GiQsiRfEm6KczB9gIWE9iiuYBd0NJxpmrp0J9LC7BrM=";
       };
       hardeningDisable = [
         "bindnow"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -652,6 +652,13 @@ self: super:
   # xvfb is used by a bunch of things to run tests
   # so try to reduce its reverse closure
   xvfb = super.xorgserver.overrideAttrs (old: {
+    #FIXME: go back to xorg-server version on nixpkgs staging-25.11
+    version = "21.1.21";
+    src = fetchurl {
+      url = "mirror://xorg/individual/xserver/xorg-server-21.1.21.tar.xz";
+      hash = "sha256-wMvlVFs/ZFuuYCS4MNHRFUqVY1BoOk5Ssv/1sPoatRk=";
+    };
+
     configureFlags = [
       "--enable-xvfb"
       "--disable-xorg"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -69,4 +69,4 @@ mirror://xorg/individual/driver/xf86-video-vmware-13.4.0.tar.xz
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.6.tar.xz
 mirror://xorg/individual/driver/xf86-video-wsfb-0.4.0.tar.bz2
 mirror://xorg/individual/lib/libXTrap-1.0.1.tar.bz2
-mirror://xorg/individual/xserver/xorg-server-21.1.20.tar.xz
+mirror://xorg/individual/xserver/xorg-server-21.1.22.tar.xz


### PR DESCRIPTION
Announcement: https://lists.x.org/archives/xorg-announce/2026-April/003678.html
Advisories: https://lists.x.org/archives/xorg-announce/2026-April/003677.html

Backported from PR https://github.com/NixOS/nixpkgs/pull/510184

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
