### PR TITLE
nixos: maximise mmap ASLR entropy

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
 
   sysctlOption = lib.mkOptionType {
@@ -87,6 +92,28 @@ in
       # the value below is used by default on several other distros.
       "fs.inotify.max_user_instances" = lib.mkDefault 524288;
       "fs.inotify.max_user_watches" = lib.mkDefault 524288;
+
+      # Maximise address space randomisation.
+      "vm.mmap_rnd_bits" = lib.mkMerge [
+        (lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (
+          let
+            kernel = config.boot.kernelPackages.kernel;
+            isYes = kernel.config.isYes or (_: false);
+          in
+          lib.mkDefault (
+            if isYes "ARM64_64K_PAGES" then
+              29
+            else if isYes "ARM64_16K_PAGES" then
+              31
+            else
+              33
+          )
+        ))
+        (lib.mkIf pkgs.stdenv.hostPlatform.isx86_64 (lib.mkDefault 32))
+      ];
+      "vm.mmap_rnd_compat_bits" = lib.mkIf (
+        pkgs.stdenv.hostPlatform.isx86_64 || pkgs.stdenv.hostPlatform.isAarch64
+      ) (lib.mkDefault 16);
     };
   };
 }


### PR DESCRIPTION
The Linux default of 28 bits on x86_64 and 18 bits (!) on AArch64 is a legacy holdover; Ubuntu 22.04 LTS and newer use a much more defensible 32 bits here on x86_64, and 33 bits on AArch64.

On 32-bit (and in 32-bit compatibility mode), we're limited to 16 bits of entropy by the size of the address space.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
