### PR TITLE
nixpkgs-plugin-update: use nix-prefetch-github

### DIFF
--- a/pkgs/applications/editors/vim/plugins/utils/updater.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/updater.nix
@@ -3,6 +3,7 @@
   buildPythonApplication,
   makeWrapper,
   nix,
+  nix-prefetch-github,
   nix-prefetch-git,
   nurl,
   python3Packages,
@@ -37,6 +38,7 @@ buildPythonApplication {
     makeWrapperArgs+=( --prefix PATH : "${
       lib.makeBinPath [
         nix
+        nix-prefetch-github
         nix-prefetch-git
         neovim-unwrapped
         nurl

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -16,7 +16,6 @@ import sys
 import time
 import traceback
 import urllib.error
-import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass
@@ -26,7 +25,7 @@ from multiprocessing.dummy import Pool
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlsplit
 
 import git
 from packaging.version import InvalidVersion, parse as parse_version
@@ -407,7 +406,7 @@ class RepoGitHub(Repo):
         response_url = req.geturl()
         if url != response_url:
             new_owner, new_name = (
-                urllib.parse.urlsplit(response_url).path.strip("/").split("/")[:2]
+                urlsplit(response_url).path.strip("/").split("/")[:2]
             )
 
             new_repo = RepoGitHub(owner=new_owner, repo=new_name, branch=self.branch)
@@ -421,7 +420,15 @@ class RepoGitHub(Repo):
         return sha256
 
     def prefetch_github(self, ref: str) -> str:
-        cmd = ["nix-prefetch-url", "--unpack", self.url(f"archive/{ref}.tar.gz")]
+        quoted_ref = quote(ref, safe="")
+        safe_name = re.sub(r"[^A-Za-z0-9._+-]", "-", f"{self.repo}-{ref}.tar.gz")
+        cmd = [
+            "nix-prefetch-url",
+            "--unpack",
+            "--name",
+            safe_name,
+            self.url(f"archive/{quoted_ref}.tar.gz"),
+        ]
         log.debug("Running %s", cmd)
         data = subprocess.check_output(cmd)
         return data.strip().decode("utf-8")

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -420,18 +420,11 @@ class RepoGitHub(Repo):
         return sha256
 
     def prefetch_github(self, ref: str) -> str:
-        quoted_ref = quote(ref, safe="")
-        safe_name = re.sub(r"[^A-Za-z0-9._+-]", "-", f"{self.repo}-{ref}.tar.gz")
-        cmd = [
-            "nix-prefetch-url",
-            "--unpack",
-            "--name",
-            safe_name,
-            self.url(f"archive/{quoted_ref}.tar.gz"),
-        ]
+        cmd = ["nix-prefetch-github", self.owner, self.repo, "--rev", ref, "--json"]
         log.debug("Running %s", cmd)
         data = subprocess.check_output(cmd)
-        return data.strip().decode("utf-8")
+        loaded = json.loads(data)
+        return loaded["hash"]
 
     def as_nix(self, plugin: "Plugin") -> str:
         if plugin.has_submodules:


### PR DESCRIPTION
Previously errored on special chars. Url encode refs and switch to prefetch-github

Pulling out of https://github.com/NixOS/nixpkgs/pull/510468

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
