### PR TITLE
nixpkgs-plugin-update: only use branch-merged tags

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -1259,7 +1259,7 @@ final: prev: {
 
   auto-save-nvim = buildVimPlugin {
     pname = "auto-save.nvim";
-    version = "1.1.0-unstable-2026-03-30";
+    version = "1.2.0-unstable-2026-03-30";
     src = fetchFromGitHub {
       owner = "okuuva";
       repo = "auto-save.nvim";
@@ -1272,7 +1272,7 @@ final: prev: {
 
   auto-session = buildVimPlugin {
     pname = "auto-session";
-    version = "0-unstable-2026-02-15";
+    version = "2.5.1-unstable-2026-02-15";
     src = fetchFromGitHub {
       owner = "rmagatti";
       repo = "auto-session";
@@ -1415,7 +1415,7 @@ final: prev: {
 
   baleia-nvim = buildVimPlugin {
     pname = "baleia.nvim";
-    version = "1.4.0-unstable-2026-02-03";
+    version = "1.3.0-unstable-2026-02-03";
     src = fetchFromGitHub {
       owner = "m00qek";
       repo = "baleia.nvim";
@@ -3194,7 +3194,7 @@ final: prev: {
 
   coc-svelte = buildVimPlugin {
     pname = "coc-svelte";
-    version = "0.0.1-unstable-2023-10-08";
+    version = "0-unstable-2023-10-08";
     src = fetchFromGitHub {
       owner = "coc-extensions";
       repo = "coc-svelte";
@@ -4809,7 +4809,7 @@ final: prev: {
 
   doki-theme-vim = buildVimPlugin {
     pname = "doki-theme-vim";
-    version = "88.1-1.0.0-unstable-2023-01-07";
+    version = "15.0.0-unstable-2023-01-07";
     src = fetchFromGitHub {
       owner = "doki-theme";
       repo = "doki-theme-vim";
@@ -5891,7 +5891,7 @@ final: prev: {
 
   gentoo-syntax = buildVimPlugin {
     pname = "gentoo-syntax";
-    version = "16-unstable-2025-06-26";
+    version = "20170225-unstable-2025-06-26";
     src = fetchFromGitHub {
       owner = "gentoo";
       repo = "gentoo-syntax";
@@ -6124,7 +6124,7 @@ final: prev: {
 
   gitv = buildVimPlugin {
     pname = "gitv";
-    version = "1.4-rc1-unstable-2019-08-22";
+    version = "1.3.1-unstable-2019-08-22";
     src = fetchFromGitHub {
       owner = "gregsexton";
       repo = "gitv";
@@ -6176,7 +6176,7 @@ final: prev: {
 
   godbolt-nvim = buildVimPlugin {
     pname = "godbolt.nvim";
-    version = "2022-09-11-unstable-2025-12-23";
+    version = "0-unstable-2025-12-23";
     src = fetchFromGitHub {
       owner = "dchinmay2";
       repo = "godbolt.nvim";
@@ -6293,7 +6293,7 @@ final: prev: {
 
   gruvbox = buildVimPlugin {
     pname = "gruvbox";
-    version = "3.0.1-rc.0-unstable-2025-04-20";
+    version = "2.0.0-unstable-2025-04-20";
     src = fetchFromGitHub {
       owner = "morhetz";
       repo = "gruvbox";
@@ -6840,7 +6840,7 @@ final: prev: {
 
   houdini-nvim = buildVimPlugin {
     pname = "houdini.nvim";
-    version = "0.7-unstable-2024-07-05";
+    version = "0-unstable-2024-07-05";
     src = fetchFromGitHub {
       owner = "TheBlob42";
       repo = "houdini.nvim";
@@ -6892,7 +6892,7 @@ final: prev: {
 
   hurl-nvim = buildVimPlugin {
     pname = "hurl.nvim";
-    version = "0-unstable-2025-09-16";
+    version = "2.2.0-unstable-2025-09-16";
     src = fetchFromGitHub {
       owner = "jellydn";
       repo = "hurl.nvim";
@@ -7555,7 +7555,7 @@ final: prev: {
 
   kmonad-vim = buildVimPlugin {
     pname = "kmonad-vim";
-    version = "1.0.0-unstable-2022-03-20";
+    version = "0-unstable-2022-03-20";
     src = fetchFromGitHub {
       owner = "kmonad";
       repo = "kmonad-vim";
@@ -7686,7 +7686,7 @@ final: prev: {
 
   latex-box = buildVimPlugin {
     pname = "latex-box";
-    version = "0.9.5@1-unstable-2015-06-01";
+    version = "0.9.5-unstable-2015-06-01";
     src = fetchFromGitHub {
       owner = "latex-box-team";
       repo = "latex-box";
@@ -8816,7 +8816,7 @@ final: prev: {
 
   melange-nvim = buildVimPlugin {
     pname = "melange-nvim";
-    version = "2025-07-10-unstable-2025-06-16";
+    version = "0.9.0-unstable-2025-06-16";
     src = fetchFromGitHub {
       owner = "savq";
       repo = "melange-nvim";
@@ -9115,7 +9115,7 @@ final: prev: {
 
   mini-files = buildVimPlugin {
     pname = "mini.files";
-    version = "0-unstable-2026-04-09";
+    version = "0.17.0-unstable-2026-04-09";
     src = fetchFromGitHub {
       owner = "nvim-mini";
       repo = "mini.files";
@@ -10756,7 +10756,7 @@ final: prev: {
 
   neuron-vim = buildVimPlugin {
     pname = "neuron.vim";
-    version = "1.0-unstable-2023-07-06";
+    version = "0-unstable-2023-07-06";
     src = fetchFromGitHub {
       owner = "fiatjaf";
       repo = "neuron.vim";
@@ -11972,7 +11972,7 @@ final: prev: {
 
   nvim-metals = buildVimPlugin {
     pname = "nvim-metals";
-    version = "0.10.x-unstable-2026-04-10";
+    version = "0-unstable-2026-04-10";
     src = fetchFromGitHub {
       owner = "scalameta";
       repo = "nvim-metals";
@@ -12297,7 +12297,7 @@ final: prev: {
 
   nvim-snippets = buildVimPlugin {
     pname = "nvim-snippets";
-    version = "1.0.0-unstable-2024-07-10";
+    version = "0-unstable-2024-07-10";
     src = fetchFromGitHub {
       owner = "garymjr";
       repo = "nvim-snippets";
@@ -12440,7 +12440,7 @@ final: prev: {
 
   nvim-treesitter = buildVimPlugin {
     pname = "nvim-treesitter";
-    version = "0.10.0-unstable-2026-04-03";
+    version = "0.9.3-unstable-2026-04-03";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter";
@@ -13038,7 +13038,7 @@ final: prev: {
 
   onedarkpro-nvim = buildVimPlugin {
     pname = "onedarkpro.nvim";
-    version = "0-unstable-2026-04-11";
+    version = "2.28.0-unstable-2026-04-11";
     src = fetchFromGitHub {
       owner = "olimorris";
       repo = "onedarkpro.nvim";
@@ -13077,7 +13077,7 @@ final: prev: {
 
   open-browser-github-vim = buildVimPlugin {
     pname = "open-browser-github.vim";
-    version = "1.0.0-unstable-2021-03-21";
+    version = "0-unstable-2021-03-21";
     src = fetchFromGitHub {
       owner = "tyru";
       repo = "open-browser-github.vim";
@@ -13312,7 +13312,7 @@ final: prev: {
 
   papercolor-theme-slim = buildVimPlugin {
     pname = "papercolor-theme-slim";
-    version = "1.0.0-unstable-2026-01-16";
+    version = "0-unstable-2026-01-16";
     src = fetchFromGitHub {
       owner = "pappasam";
       repo = "papercolor-theme-slim";
@@ -14406,7 +14406,7 @@ final: prev: {
 
   samodostal-image-nvim = buildVimPlugin {
     pname = "samodostal-image-nvim";
-    version = "1.0-unstable-2024-01-07";
+    version = "0-unstable-2024-01-07";
     src = fetchFromGitHub {
       owner = "samodostal";
       repo = "image.nvim";
@@ -15631,7 +15631,7 @@ final: prev: {
 
   tcomment_vim = buildVimPlugin {
     pname = "tcomment_vim";
-    version = "4.00-unstable-2024-03-25";
+    version = "201-unstable-2024-03-25";
     src = fetchFromGitHub {
       owner = "tomtom";
       repo = "tcomment_vim";
@@ -16388,7 +16388,7 @@ final: prev: {
 
   tlib_vim = buildVimPlugin {
     pname = "tlib_vim";
-    version = "1.28-unstable-2022-07-22";
+    version = "040-unstable-2022-07-22";
     src = fetchFromGitHub {
       owner = "tomtom";
       repo = "tlib_vim";
@@ -16938,7 +16938,7 @@ final: prev: {
 
   unicode-vim = buildVimPlugin {
     pname = "unicode.vim";
-    version = "21-unstable-2025-09-22";
+    version = "20-unstable-2025-09-22";
     src = fetchFromGitHub {
       owner = "chrisbra";
       repo = "unicode.vim";
@@ -17029,7 +17029,7 @@ final: prev: {
 
   urlview-nvim = buildVimPlugin {
     pname = "urlview.nvim";
-    version = "0.6-compat-unstable-2025-11-30";
+    version = "0-unstable-2025-11-30";
     src = fetchFromGitHub {
       owner = "axieax";
       repo = "urlview.nvim";
@@ -17536,7 +17536,7 @@ final: prev: {
 
   vim-agda = buildVimPlugin {
     pname = "vim-agda";
-    version = "2022-09-16-unstable-2024-05-17";
+    version = "0-unstable-2024-05-17";
     src = fetchFromGitHub {
       owner = "msuperdock";
       repo = "vim-agda";
@@ -18836,7 +18836,7 @@ final: prev: {
 
   vim-eunuch = buildVimPlugin {
     pname = "vim-eunuch";
-    version = "0-unstable-2024-12-29";
+    version = "1.3-unstable-2024-12-29";
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-eunuch";
@@ -19187,7 +19187,7 @@ final: prev: {
 
   vim-git = buildVimPlugin {
     pname = "vim-git";
-    version = "0-unstable-2024-10-03";
+    version = "6.0-unstable-2024-10-03";
     src = fetchFromGitHub {
       owner = "tpope";
       repo = "vim-git";
@@ -19330,7 +19330,7 @@ final: prev: {
 
   vim-grepper = buildVimPlugin {
     pname = "vim-grepper";
-    version = "0-unstable-2025-02-18";
+    version = "1.3-unstable-2025-02-18";
     src = fetchFromGitHub {
       owner = "mhinz";
       repo = "vim-grepper";
@@ -20918,7 +20918,7 @@ final: prev: {
 
   vim-oscyank = buildVimPlugin {
     pname = "vim-oscyank";
-    version = "2.0.0-unstable-2025-04-11";
+    version = "0-unstable-2025-04-11";
     src = fetchFromGitHub {
       owner = "ojroques";
       repo = "vim-oscyank";
@@ -21165,7 +21165,7 @@ final: prev: {
 
   vim-polyglot = buildVimPlugin {
     pname = "vim-polyglot";
-    version = "4.17.1-unstable-2025-08-27";
+    version = "4.17.0-unstable-2025-08-27";
     src = fetchFromGitHub {
       owner = "sheerun";
       repo = "vim-polyglot";
@@ -21659,7 +21659,7 @@ final: prev: {
 
   vim-sentence-chopper = buildVimPlugin {
     pname = "vim-sentence-chopper";
-    version = "1.5-unstable-2026-01-19";
+    version = "1.4-unstable-2026-01-19";
     src = fetchFromGitHub {
       owner = "Konfekt";
       repo = "vim-sentence-chopper";
@@ -21724,7 +21724,7 @@ final: prev: {
 
   vim-signify = buildVimPlugin {
     pname = "vim-signify";
-    version = "0-unstable-2026-03-12";
+    version = "1.9-unstable-2026-03-12";
     src = fetchFromGitHub {
       owner = "mhinz";
       repo = "vim-signify";
@@ -22737,7 +22737,7 @@ final: prev: {
 
   vim-vue-plugin = buildVimPlugin {
     pname = "vim-vue-plugin";
-    version = "2021_03_29-unstable-2023-10-05";
+    version = "1.0.20200714-unstable-2023-10-05";
     src = fetchFromGitHub {
       owner = "leafOfTree";
       repo = "vim-vue-plugin";
@@ -23036,7 +23036,7 @@ final: prev: {
 
   vimfiler-vim = buildVimPlugin {
     pname = "vimfiler.vim";
-    version = "0-unstable-2024-05-20";
+    version = "1.01-unstable-2024-05-20";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "vimfiler.vim";
@@ -23075,7 +23075,7 @@ final: prev: {
 
   vimproc-vim = buildVimPlugin {
     pname = "vimproc.vim";
-    version = "0-unstable-2024-09-04";
+    version = "2.03-unstable-2024-09-04";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "vimproc.vim";
@@ -23101,7 +23101,7 @@ final: prev: {
 
   vimshell-vim = buildVimPlugin {
     pname = "vimshell.vim";
-    version = "0-unstable-2025-07-09";
+    version = "6.04-unstable-2025-07-09";
     src = fetchFromGitHub {
       owner = "Shougo";
       repo = "vimshell.vim";

--- a/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/nixpkgs-plugin-update/src/nixpkgs_plugin_update/__init__.py
@@ -24,7 +24,7 @@ from datetime import datetime, date
 from functools import wraps
 from multiprocessing.dummy import Pool
 from pathlib import Path
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Callable
 from urllib.parse import urljoin, urlparse
 
@@ -132,48 +132,23 @@ class Repo:
         return loaded["rev"], updated
 
     @retry(urllib.error.URLError, tries=4, delay=3, backoff=2)
+    def resolve_tag(self, tag: str) -> tuple[str, datetime]:
+        return self.resolve_ref(f"{GIT_TAGS_PREFIX}{tag}")
+
+    @retry(urllib.error.URLError, tries=4, delay=3, backoff=2)
+    def resolve_ref(self, ref: str) -> tuple[str, datetime]:
+        loaded = self._prefetch(ref)
+        updated = datetime.strptime(loaded["date"], "%Y-%m-%dT%H:%M:%S%z")
+        return loaded["rev"], updated
+
+    @retry(urllib.error.URLError, tries=4, delay=3, backoff=2)
     def get_latest_tag(self) -> str | None:
         try:
-            # FIXME: This fetches all tags. We need to find a way to check if a tag exists in
-            # an ancestor of the default branch.
-            cmd = ["git", "ls-remote", "--tags", "--refs", self.uri]
-            log.debug("Fetching tags with: %s", cmd)
-            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=10)
-            lines = output.decode("utf-8").strip().split("\n")
-
-            if not lines or lines[0] == "":
-                log.debug("No tags found for %s", self.uri)
+            tags = self._get_branch_merged_tags()
+            latest_tag = select_latest_release_tag(tags)
+            if latest_tag is None:
+                log.debug("No usable branch-merged release tags found for %s", self.uri)
                 return None
-
-            tags = []
-            for line in lines:
-                if "\t" in line:
-                    tag_ref = line.split("\t")[1]
-                    if tag_ref.startswith(GIT_TAGS_PREFIX):
-                        tag_name = tag_ref[len(GIT_TAGS_PREFIX) :]
-                        tags.append(tag_name)
-
-            if not tags:
-                return None
-
-            valid_versions = []
-            invalid_tags = []
-
-            for tag in tags:
-                try:
-                    version = parse_version(tag)
-                    valid_versions.append((tag, version))
-                except InvalidVersion:
-                    invalid_tags.append(tag)
-
-            if valid_versions:
-                latest_tag = max(valid_versions, key=lambda x: x[1])[0]
-            elif invalid_tags:
-                latest_tag = max(invalid_tags)
-            else:
-                log.debug("No tags found for %s", self.uri)
-                return None
-
             log.debug("Found latest tag: %s", latest_tag)
             return latest_tag
         except subprocess.CalledProcessError as e:
@@ -182,6 +157,38 @@ class Repo:
         except Exception as e:
             log.warning("Unexpected error fetching tags for %s: %s", self.uri, e)
             return None
+
+    def _get_branch_merged_tags(self) -> list[str]:
+        with TemporaryDirectory(prefix="nixpkgs-plugin-update-") as git_dir:
+            init_cmd = ["git", "init", "--bare", git_dir]
+            log.debug("Initializing temporary git dir with: %s", init_cmd)
+            subprocess.check_output(init_cmd, stderr=subprocess.STDOUT, timeout=10)
+
+            fetch_cmd = [
+                "git",
+                f"--git-dir={git_dir}",
+                "fetch",
+                "--quiet",
+                "--filter=tree:0",
+                "--tags",
+                self.uri,
+                self.branch,
+            ]
+            log.debug("Fetching branch history and tags with: %s", fetch_cmd)
+            subprocess.check_output(fetch_cmd, stderr=subprocess.STDOUT, timeout=30)
+
+            merged_tags_cmd = [
+                "git",
+                f"--git-dir={git_dir}",
+                "tag",
+                "--merged",
+                "FETCH_HEAD",
+            ]
+            log.debug("Listing merged tags with: %s", merged_tags_cmd)
+            output = subprocess.check_output(
+                merged_tags_cmd, stderr=subprocess.STDOUT, timeout=10
+            )
+            return [line for line in output.decode("utf-8").splitlines() if line]
 
     def _prefetch(self, ref: str | None):
         cmd = ["nix-prefetch-git", "--quiet", "--fetch-submodules", self.uri]
@@ -261,147 +268,19 @@ class RepoGitHub(Repo):
             )
             updated = datetime.strptime(updated_tag.text, "%Y-%m-%dT%H:%M:%SZ")
             return Path(str(url.path)).name, updated
-
-    def _execute_graphql(self, query: str, variables: dict) -> dict:
-        graphql_url = "https://api.github.com/graphql"
-
-        payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
-
-        req = make_request(graphql_url, self.token)
-        req.add_header("Content-Type", "application/json")
-        req.data = payload
-
-        with urllib.request.urlopen(req, timeout=10) as response:
-            return json.load(response)
-
-    def _extract_commit_date(self, target: dict) -> datetime | None:
-        commit_date_str = None
-        if "committedDate" in target:
-            commit_date_str = target["committedDate"]
-        elif "target" in target and "committedDate" in target["target"]:
-            commit_date_str = target["target"]["committedDate"]
-
-        if commit_date_str:
-            return datetime.fromisoformat(commit_date_str.replace("Z", "+00:00"))
-        return None
+    @retry(urllib.error.URLError, tries=4, delay=3, backoff=2)
+    def resolve_ref(self, ref: str) -> tuple[str, datetime]:
+        if ref == self.branch:
+            return self.latest_commit()
+        self._check_ref_redirect(ref)
+        return super().resolve_ref(ref)
 
     @retry(urllib.error.URLError, tries=4, delay=3, backoff=2)
-    def get_latest_tag(self) -> str | None:
-        try:
-            if not self.token or self.token == "":
-                log.info(
-                    "No GitHub token available for %s/%s, using git ls-remote fallback",
-                    self.owner,
-                    self.repo,
-                )
-                return super().get_latest_tag()
-
-            # FIXME: This fetches all tags. We need to find a way to check if a tag exists in
-            # an ancestor of the default branch.
-            query = """
-            query GetLatestVersionInfo($owner: String!, $name: String!) {
-              repository(owner: $owner, name: $name) {
-                refs(refPrefix: "refs/tags/", first: 5, orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
-                  nodes {
-                    name
-                    target {
-                      ... on Commit {
-                        committedDate
-                      }
-                      ... on Tag {
-                        target {
-                          ... on Commit {
-                            committedDate
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            """
-
-            data = self._execute_graphql(
-                query, {"owner": self.owner, "name": self.repo}
-            )
-
-            if "errors" in data:
-                log.warning(
-                    "GraphQL errors for %s/%s: %s",
-                    self.owner,
-                    self.repo,
-                    data["errors"],
-                )
-                return None
-
-            if "data" not in data or not data["data"]:
-                log.warning(
-                    "No data in GraphQL response for %s/%s", self.owner, self.repo
-                )
-                return None
-
-            repo = data["data"]["repository"]
-            if not repo:
-                log.debug(
-                    "Repository %s/%s not found or inaccessible", self.owner, self.repo
-                )
-                return None
-
-            valid_versions = []
-            invalid_tags = []
-            for ref_node in repo["refs"]["nodes"]:
-                tag_name = ref_node["name"]
-                commit_date = self._extract_commit_date(ref_node["target"])
-                if not commit_date:
-                    continue
-
-                try:
-                    version = parse_version(tag_name)
-                    valid_versions.append((tag_name, version, commit_date))
-                except InvalidVersion:
-                    invalid_tags.append((tag_name, None, commit_date))
-
-            def get_version(tag_tuple):
-                _, version, _ = tag_tuple
-                return version
-
-            def get_date(tag_tuple):
-                _, _, date = tag_tuple
-                return date or datetime.min
-
-            def get_max_versions(versions, sort_key):
-                return max(versions, key=sort_key, default=(None, None, None))
-
-            max_valid_tag, _, max_valid_date = get_max_versions(
-                valid_versions, get_version
-            )
-            max_invalid_tag, _, max_invalid_date = get_max_versions(
-                invalid_tags, get_date
-            )
-            if max_valid_tag and max_invalid_tag:
-                return (
-                    max_invalid_tag
-                    if (max_invalid_date or datetime.min)
-                    > (max_valid_date or datetime.min)
-                    else max_valid_tag
-                )
-            elif max_valid_tag:
-                return max_valid_tag
-            elif max_invalid_tag:
-                return max_invalid_tag
-            else:
-                return None
-
-        except Exception as e:
-            log.warning(
-                "Error fetching version info for %s/%s: %s",
-                self.owner,
-                self.repo,
-                e,
-                exc_info=True,
-            )
-            return None
+    def _check_ref_redirect(self, ref: str) -> None:
+        ref_url = self.url(f"tree/{urllib.parse.quote(ref, safe='')}")
+        ref_req = make_request(ref_url, self.token)
+        with urllib.request.urlopen(ref_req, timeout=10) as req:
+            self._check_for_redirect(ref_url, req)
 
     def _check_for_redirect(self, url: str, req: http.client.HTTPResponse):
         response_url = req.geturl()
@@ -543,6 +422,46 @@ class Plugin:
         copy = self.__dict__.copy()
         del copy["date"]
         return copy
+def normalize_release_version(tag: str) -> str | None:
+    version = tag[1:] if tag.startswith(("v", "V")) else tag
+    if version and version[0].isdigit():
+        return version
+    return None
+
+
+def select_latest_release_tag(tags: list[str]) -> str | None:
+    release_tags = []
+    for tag in tags:
+        normalized = normalize_release_version(tag)
+        if normalized is None:
+            continue
+
+        try:
+            version = parse_version(normalized)
+        except InvalidVersion:
+            continue
+
+        release_tags.append((tag, version))
+
+    if not release_tags:
+        return None
+
+    return max(
+        release_tags,
+        key=lambda x: (x[1], x[0].count("."), len(x[0])),
+    )[0]
+
+
+def make_unstable_version(date: datetime, last_tag: str | None) -> str:
+    date_str = date.strftime("%Y-%m-%d")
+
+    tag_part = "0"
+    if last_tag:
+        normalized_tag = normalize_release_version(last_tag)
+        if normalized_tag is not None:
+            tag_part = normalized_tag
+
+    return f"{tag_part}-unstable-{date_str}"
 
 
 def load_plugins_from_csv(


### PR DESCRIPTION
When preferring tagged releases, selecting from all remote tags can pick a tag that is not on the default branch ancestry.

That can roll a plugin back to an unrelated or very old tagged commit simply because it sorts as the latest tag, even if the tracked branch has moved far past it.

Fix this by only considering tags merged into the tracked branch before choosing the latest usable release tag.

Resolves earlier concern from initial implementation about this. 

split from https://github.com/NixOS/nixpkgs/pull/510468

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
