### PR TITLE
claude-code: fix permissions on seccomp helper

### DIFF
--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -32,6 +32,11 @@ buildNpmPackage (finalAttrs: {
     # https://github.com/anthropics/claude-code/issues/15195
     substituteInPlace cli.js \
           --replace-fail '#!/bin/sh' '#!/usr/bin/env sh'
+
+    # The npm tarball ships apply-seccomp as mode 0644, causing
+    # sandbox failures when bash tries to exec it
+    # https://github.com/anthropics/claude-code/issues/43367
+    chmod +x vendor/seccomp/*/apply-seccomp
   '';
 
   dontNpmBuild = true;


### PR DESCRIPTION
The npm tarball ships `vendor/seccomp/*/apply-seccomp` without the execute bit (mode `0644`), so bash refuses to exec it and all sandbox bash commands fail with exit 126. The binary was introduced in 2.1.96 and has shipped with incorrect permissions in every version since. Known upstream bug (anthropics/claude-code#43367) but no upstream fix yet. I set the exec bit in `postPatch` as a workaround.

`claude-code-bin` is not affected (single Bun binary, seccomp embedded).

Fixes #510938

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test