### PR TITLE
lua51Packages.libluv: fix build

### DIFF
--- a/pkgs/development/lua-modules/luv/default.nix
+++ b/pkgs/development/lua-modules/luv/default.nix
@@ -43,30 +43,18 @@ buildLuarocksPackage rec {
   buildInputs = [ libuv ];
   nativeBuildInputs = [ cmake ];
 
-  # Need to specify WITH_SHARED_LIBUV=ON cmake flag, but
-  # Luarocks doesn't take cmake variables from luarocks config.
-  # Need to specify it in rockspec. See https://github.com/luarocks/luarocks/issues/1160.
-  knownRockspec = runCommand "luv-${version}.rockspec" { } ''
-    patch ${src}/luv-scm-0.rockspec -o - > $out <<'EOF'
-    --- a/luv-scm-0.rockspec
-    +++ b/luv-scm-0.rockspec
-    @@ -1,5 +1,5 @@
-     package = "luv"
-    -version = "scm-0"
-    +version = "${version}"
-     source = {
-       url = 'git://github.com/luvit/luv.git'
-     }
-    @@ -24,6 +24,7 @@
-     build =
-       type = 'cmake',
-       variables = {
-    +     WITH_SHARED_LIBUV="ON",
-          CMAKE_C_FLAGS="$(CFLAGS)",
-          CMAKE_MODULE_LINKER_FLAGS="$(LIBFLAG)",
-          LUA_LIBDIR="$(LUA_LIBDIR)",
-    EOF
+  rockspecFilename = "luv-scm-0.rockspec";
+
+  postConfigure = ''
+    mv "$rockspecFilename" "$generatedRockspecFilename"
+    rockspecFilename="$generatedRockspecFilename"
+    substituteInPlace "$rockspecFilename" \
+      --replace-fail 'version = "scm-0"' "version = \"$version\""
   '';
+
+  luarocksConfig.variables = {
+    WITH_SHARED_LIBUV = "ON";
+  };
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Upstream rockspec file now supports `WITH_SHARED_LIBUV` variable since luvit/luv@b77e0d4113c85b67731f281dbf88d74e3544448f. This
commit uses it. Before this change, upstream value of `WITH_SHARED_LIBUV`
overrode the one from the inline patch, which caused a build failure (see https://github.com/NixOS/nixpkgs/pull/500404#issuecomment-4262928851).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[contributing.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/readme.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[pkgs/readme.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
