### PR TITLE
kasmweb: 1.15.0 -> 1.18.1

### DIFF
--- a/pkgs/by-name/ka/kasmweb/package.nix
+++ b/pkgs/by-name/ka/kasmweb/package.nix
@@ -6,12 +6,12 @@
 
 stdenv.mkDerivation rec {
   pname = "kasmweb";
-  version = "1.15.0";
-  build = "06fdc8";
+  version = "1.18.1";
+  build = "d09dbc";
 
   src = fetchzip {
     url = "https://kasm-static-content.s3.amazonaws.com/kasm_release_${version}.${build}.tar.gz";
-    sha256 = "sha256-7z5lc4QEpQQdVGMEMc04wXlJTK5VXJ4rufZmDEflJLw=";
+    sha256 = "sha256-/PPc9tdf47DHKdZDcPDy7D6upbLaIKYIYQXqyVDPZkc=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
This updates Kasm Workspaces from 1.15.0 to 1.18.1.

Key changes since 1.15.0 (from upstream release notes):
- Updated Apache Guacamole to v1.5.5 (RDP Gateway update)
- Added SmartCard Passthrough for container sessions and web-native Windows sessions
- Session container logging in the UI
- Draining mode & agent rotation for autoscaled Docker agents
- Workspace labels and bulk import for users and servers
- New workspace images: Debian Trixie, Fedora 41, Obsidian, Cyberbro
- Vulkan support for Chromium-based browsers (GPU acceleration)
- Removed Redis requirements (Share server support deprecated)
- Various bug fixes and security improvements

Upstream release notes:
- https://docs.kasm.com/docs/release_notes/1.18.0
- https://docs.kasm.com/docs/release_notes/1.18.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
