### PR TITLE
firefoxpwa-unwrapped: 2.18.0 -> 2.18.2; nixos/tests/firefoxpwa: ensure Jellyfin readiness and increase disk size

### DIFF
--- a/nixos/tests/firefoxpwa.nix
+++ b/nixos/tests/firefoxpwa.nix
@@ -19,6 +19,8 @@
       };
 
       services.jellyfin.enable = true;
+      # Jellyfin requires at least 2 GB of disk space
+      virtualisation.diskSize = 3 * 1024; # 3 GB
     };
 
   enableOCR = true;
@@ -26,9 +28,12 @@
   testScript = ''
     machine.start()
 
-    with subtest("Install a progressive web app"):
+    with subtest("Wait for Jellyfin to be ready"):
         machine.wait_for_unit("jellyfin.service")
         machine.wait_for_open_port(8096)
+        machine.wait_until_succeeds("curl -fs http://localhost:8096/web/manifest.json")
+
+    with subtest("Install a progressive web app"):
         machine.succeed("firefoxpwa site install http://localhost:8096/web/manifest.json >&2")
 
     with subtest("Launch the progressive web app"):

--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -16,19 +16,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "firefoxpwa-unwrapped";
-  version = "2.18.0";
+  version = "2.18.2";
 
   src = fetchFromGitHub {
     owner = "filips123";
     repo = "PWAsForFirefox";
     rev = "v${version}";
-    hash = "sha256-F/Sj72er6aNxoV/dR7wCafgAHOKkQ7267/E+vfXdfdw=";
+    hash = "sha256-eNJKR6dmG4dDKwvWjC0Nbzk5ixNJtnRXjWJgxc9W5i8=";
   };
 
   sourceRoot = "${src.name}/native";
   buildFeatures = [ "immutable-runtime" ];
 
-  cargoHash = "sha256-PnqfYZO454t9XCzc9dwNCe4Qcp0FrG82sQcHUNdEnoo=";
+  cargoHash = "sha256-w3poeQsJf6s8uqqZtigJNHqnO0fpD7T4zyY3WzdE6Bo=";
 
   preConfigure = ''
     sed -i 's;version = "0.0.0";version = "${version}";' Cargo.toml


### PR DESCRIPTION
Diff: https://github.com/filips123/PWAsForFirefox/compare/v2.18.0...v2.18.2

Changelogs:
> https://github.com/filips123/PWAsForFirefox/releases/tag/v2.18.1
> https://github.com/filips123/PWAsForFirefox/releases/tag/v2.18.2

Add required VM disk space for Jellyfin (2 GiB) and wait for web manifest endpoint before installing PWA.
```System.InvalidOperationException: The path `/var/lib/jellyfin/data` has insufficient free space. Available: 885.5MiB, Required: 2GiB.```

Closes: #510920
Supersedes/Closes: #501763

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
