### PR TITLE
ocamlPackages.smtml: 0.24.0 -> 0.25.0

### DIFF
--- a/pkgs/by-name/ow/owi/package.nix
+++ b/pkgs/by-name/ow/owi/package.nix
@@ -15,14 +15,14 @@ let
 in
 ocamlPackages.buildDunePackage {
   pname = "owi";
-  version = "0.2-unstable-2026-04-08";
+  version = "0.2-unstable-2026-04-12";
 
   src = fetchFromGitHub {
     owner = "ocamlpro";
     repo = "owi";
-    rev = "8357ccd5a43d1e2f9d5648a96286c6b8e6b59b37";
+    rev = "cd54ee715561dc40c9338a16d37eabaa65cbbeaf";
     fetchSubmodules = true;
-    hash = "sha256-4QOUX8iwn826g2rB2fwsFZhrzViZsKONXa5yxCFPT/8=";
+    hash = "sha256-ET/UHwQ0wwXtP1CzAksPi7BRJXyefE4qvi+2r1vl3OI=";
   };
 
   nativeBuildInputs = with ocamlPackages; [

--- a/pkgs/development/ocaml-modules/smtml/default.nix
+++ b/pkgs/development/ocaml-modules/smtml/default.nix
@@ -5,6 +5,7 @@
   ocaml,
   fetchFromGitHub,
   menhir,
+  darwin,
   bitwuzla-cxx,
   bos,
   cmdliner,
@@ -30,19 +31,22 @@
 
 buildDunePackage (finalAttrs: {
   pname = "smtml";
-  version = "0.24.0";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "formalsec";
     repo = "smtml";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9499a8ngL8rTeyhWumn08ZjymD8zOMyyG0ZgjVITSPQ=";
+    hash = "sha256-dWZrN0hTxxqGC2queit91GDuw/x5fyRPwHbmKxkvc/w=";
   };
 
   minimalOCamlVersion = "4.14";
 
   nativeBuildInputs = [
     menhir
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.sigtool
   ];
 
   buildInputs = [


### PR DESCRIPTION
Supersedes and closes https://github.com/NixOS/nixpkgs/pull/508817

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test