### PR TITLE
nixos/systemd-boot: Add rememberLastChoice option.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17615,6 +17615,12 @@
     githubId = 96200;
     name = "Jörg Thalheim";
   };
+  micha4w = {
+    name = "micha4w";
+    github = "micha4w";
+    githubId = 85169193;
+    email = "micha4w@gmail.com";
+  };
   michael-k-williams = {
     name = "Michael Williams";
     email = "michael.williams@brighter-applications.com";

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -34,6 +34,7 @@ GRACEFUL = "@graceful@"
 COPY_EXTRA_FILES = "@copyExtraFiles@"
 CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
+REMEMBER_LAST_CHOICE = "@rememberLastChoice@" == "1" # noqa: PLR0133
 
 @dataclass
 class BootSpec:
@@ -107,7 +108,12 @@ def write_loader_conf(profile: str | None, generation: int, specialisation: str 
     tmp = LOADER_CONF.with_suffix(".tmp")
     with tmp.open('x') as f:
         f.write(f"timeout {TIMEOUT}\n")
-        f.write("default %s\n" % generation_conf_filename(profile, generation, specialisation))
+        if REMEMBER_LAST_CHOICE:
+            default_setting = "@saved"
+        else:
+            default_setting = generation_conf_filename(profile, generation, specialisation)
+        f.write("default %s\n" % default_setting)
+
         if not EDITOR:
             f.write("editor 0\n")
         if REBOOT_FOR_BITLOCKER:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -87,11 +87,13 @@ def system_dir(profile: str | None, generation: int, specialisation: str | None)
 
 BOOT_ENTRY = """title {title}
 sort-key {sort_key}
-version Generation {generation} {description}
+version {version_prefix} {generation} {description}
 linux {kernel}
 initrd {initrd}
 options {kernel_params}
 """
+
+CURRENT_GENERATION_ID = "nixos-current-generation.conf"
 
 def generation_conf_filename(profile: str | None, generation: int, specialisation: str | None) -> str:
     pieces = [
@@ -104,14 +106,14 @@ def generation_conf_filename(profile: str | None, generation: int, specialisatio
     return "-".join(p for p in pieces if p) + ".conf"
 
 
-def write_loader_conf(profile: str | None, generation: int, specialisation: str | None) -> None:
+def write_loader_conf() -> None:
     tmp = LOADER_CONF.with_suffix(".tmp")
     with tmp.open('x') as f:
         f.write(f"timeout {TIMEOUT}\n")
         if REMEMBER_LAST_CHOICE:
             default_setting = "@saved"
         else:
-            default_setting = generation_conf_filename(profile, generation, specialisation)
+            default_setting = CURRENT_GENERATION_ID
         f.write("default %s\n" % default_setting)
 
         if not EDITOR:
@@ -220,6 +222,7 @@ def write_entry(profile: str | None, generation: int, specialisation: str | None
     with tmp_path.open("w") as f:
         f.write(BOOT_ENTRY.format(title=title,
                     sort_key=bootspec.sortKey,
+                    version_prefix="Generation",
                     generation=generation,
                     kernel=f"/{kernel}",
                     initrd=f"/{initrd}",
@@ -232,6 +235,29 @@ def write_entry(profile: str | None, generation: int, specialisation: str | None
         f.flush()
         os.fsync(f.fileno())
     tmp_path.rename(entry_file)
+
+    if current:
+        current_entry_file = BOOT_MOUNT_POINT / "loader/entries" / CURRENT_GENERATION_ID
+
+        with tmp_path.open("w") as f:
+            f.write(BOOT_ENTRY.format(title=title + " - Current Profile",
+                        sort_key=bootspec.sortKey,
+                        # For ordering in list and so that shortcuts pick this generation
+                        version_prefix="z Current Generation",
+                        generation=generation,
+                        kernel=f"/{kernel}",
+                        initrd=f"/{initrd}",
+                        kernel_params=kernel_params,
+                        description=f"{bootspec.label}, built on {build_date}"))
+            if machine_id is not None:
+                f.write("machine-id %s\n" % machine_id)
+            if devicetree is not None:
+                f.write("devicetree %s\n" % devicetree)
+            f.flush()
+            os.fsync(f.fileno())
+
+        tmp_path.rename(current_entry_file)
+
 
 
 def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
@@ -387,16 +413,18 @@ def install_bootloader(args: argparse.Namespace) -> None:
         gens += get_generations(profile)
 
     remove_old_entries(gens)
+    write_loader_conf()
 
     for gen in gens:
         try:
             bootspec = get_bootspec(gen.profile, gen.generation)
             is_default = Path(bootspec.init).parent == Path(args.default_config)
-            write_entry(*gen, machine_id, bootspec, current=is_default)
             for specialisation in bootspec.specialisations.keys():
                 write_entry(gen.profile, gen.generation, specialisation, machine_id, bootspec, current=is_default)
-            if is_default:
-                write_loader_conf(*gen)
+
+            # Run this last so that the current generation file will be this
+            write_entry(*gen, machine_id, bootspec, current=is_default)
+
         except OSError as e:
             # See https://github.com/NixOS/nixpkgs/issues/114552
             if e.errno == errno.EINVAL:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -55,6 +55,8 @@ let
 
       configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
+      rememberLastChoice = cfg.rememberLastChoice;
+
       inherit (cfg)
         consoleMode
         graceful
@@ -514,6 +516,20 @@ in
         )
       );
     };
+
+    rememberLastChoice = mkOption {
+      default = false;
+
+      type = types.bool;
+
+      description = ''
+        Remembers the last chosen systemd-boot entry. For example, given entries A and B. If B is
+        is selected, next boot B will automatically be highlighted instead of the latest generation.
+        This is done by setting `default @saved` within the systemd-boot config.
+
+        This option will not work properly unless `boot.loader.canTouchEfiVariables = true`
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -540,6 +556,10 @@ in
           -> config.hardware.deviceTree.enable
           -> config.hardware.deviceTree.name != null;
         message = "Cannot install devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
+      }
+      {
+        assertion = cfg.rememberLastChoice -> efi.canTouchEfiVariables;
+        message = "'boot.loader.systemd-boot.rememberLastChoice' requires 'boot.loader.efi.canTouchEfiVariables' to be set";
       }
     ]
     ++ concatMap (filename: [

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -654,4 +654,29 @@ in
       '';
     }
   );
+
+  rememberLastChoice = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-boot-remember-last-choice";
+      meta.maintainers = with lib.maintainers; [ noar-t ];
+
+      nodes.machine = {
+        imports = [ common ];
+        boot.loader.systemd-boot.rememberLastChoice = true;
+      };
+
+      testScript = ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+
+        machine.succeed(
+            "test -e /boot/loader/loader.conf"
+        )
+        machine.succeed(
+            "grep -q '@saved' /boot/loader/loader.conf"
+        )
+      '';
+    }
+  );
 }

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -655,11 +655,32 @@ in
     }
   );
 
+  currentGenerationFile = runTest (
+    { lib, ... }:
+    {
+      name = "systemd-boot-current-generation";
+      meta.maintainers = with lib.maintainers; [ micha4w ];
+
+      nodes.machine = common;
+
+      testScript =
+        { nodes, ... }:
+        ''
+          machine.start()
+          machine.wait_for_unit("multi-user.target")
+
+          machine.succeed(
+              "bootctl list | grep 'title: NixOS' | head -n1 | grep -q 'Current Profile'"
+          )
+        '';
+    }
+  );
+
   rememberLastChoice = runTest (
     { lib, ... }:
     {
       name = "systemd-boot-remember-last-choice";
-      meta.maintainers = with lib.maintainers; [ noar-t ];
+      meta.maintainers = with lib.maintainers; [ micha4w ];
 
       nodes.machine = {
         imports = [ common ];


### PR DESCRIPTION
This PR continue the one of noah-thor (#286672) that was closed.

## Original PR (commit b4e57da6410b8d5978199afc34549a2c11e970fe)

The systemd-boot configuration lacks the ability to remember the last used choice. This feature is included with systemd-boot via the `default @saved` option, which saves the last choice into an EFI variable. Having this option is useful for when users have mutliple OSes installed on a single machine but the boot loader is managed by nix-os.

### Description of changes
This adds the ability to enable the systemd-boot flag to remember last selected entry. The change requires changes to the both the configuration and the python script that generates the /boot/loader/loader.conf file.

## Additional changes (commit 2425f96e292745c1455861e452a0a50d406da7d5)
From https://github.com/NixOS/nixpkgs/pull/286672#issuecomment-2716290927: added a new entry which is shown at the top and is equal to the default generation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test