### PR TITLE
Init of AnkiPA addon for Anki as nixpkg + added self as maintainer.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22393,7 +22393,7 @@
     name = "Ralph El Massih";
     email = "ralphelmassih@gmail.com";
     github = "Ralph367";
-    githubId = "110833744";
+    githubId = 110833744;
   };
   r3n3gad3p3arl = {
     github = "r3n3gad3p3arl";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22389,6 +22389,12 @@
     githubId = 35229674;
     name = "Armin Rothfuss";
   };
+  r3lphi = {
+    name = "Ralph El Massih";
+    email = "ralphelmassih@gmail.com";
+    github = "Ralph367";
+    githubId = "110833744";
+  };
   r3n3gad3p3arl = {
     github = "r3n3gad3p3arl";
     githubId = 20760527;

--- a/pkgs/by-name/an/anki/addons/ankipa/default.nix
+++ b/pkgs/by-name/an/anki/addons/ankipa/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "ankipa";
+  version = "0-unstable-2025-12-14";
+  src = fetchFromGitHub {
+    owner = "warleysr";
+    repo = "ankipa";
+    rev = "ad2bc714715f98b392e642cac42af5e0b83959d3";
+    hash = "sha256-fLIqLlJtX7e3Yx1gZizjAOteaIPnlthfrCjv8qn7jy8=";
+  };
+  patches = [ ./remove-new-languages-check.patch ];
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = ''
+      Lets you record your own pronounciation of a word or phrase and get it rated by Azure Pronounciation Assessment.
+    '';
+    homepage = "https://github.com/warleysr/ankipa";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ r3lphi ];
+  };
+})

--- a/pkgs/by-name/an/anki/addons/ankipa/remove-new-languages-check.patch
+++ b/pkgs/by-name/an/anki/addons/ankipa/remove-new-languages-check.patch
@@ -1,0 +1,26 @@
+--- a/__init__.py
++++ b/__init__.py
+@@ -25,23 +25,6 @@
+ with open(data_file, "r") as fp:
+     data = json.load(fp)
+ 
+-# Update languages
+-new_languages = update_available_languages(data["languages"])
+-if new_languages:
+-    with open(data_file, "w") as fp:
+-        json.dump(data, fp, indent=4)
+-    from . import showInfo
+-
+-    update_message = (
+-        f"<h3>AnkiPA Update</h3><br> These {len(new_languages)} new languages "
+-        "was added to the addon:<br><br>"
+-    )
+-    for lang in new_languages:
+-        update_message += f"&#x2022; {lang}<br>"
+-    showInfo(update_message)
+-
+-fp.close()
+-
+ # Load HTML template
+ with open(os.path.join(addon, "template.html"), "r") as ft:
+     html_template = ft.read()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
