### PR TITLE
luajit_2_0: 2.0.1741557863 -> 2.0.1774896119; luajit_2_1: 2.1.1741730670 -> 2.1.1774638290

### DIFF
--- a/pkgs/development/interpreters/luajit/2.0.nix
+++ b/pkgs/development/interpreters/luajit/2.0.nix
@@ -9,13 +9,13 @@
 callPackage ./default.nix {
   # The patch version is the timestamp of the git commit,
   # obtain via `cat $(nix-build -A luajit_2_0.src)/.relver`
-  version = "2.0.1741557863";
+  version = "2.0.1774896119";
 
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = "85c3f2fb6f59276ebf07312859a69d6d5a897f62";
-    hash = "sha256-5UIZ650M/0W08iX1ajaHvDbNgjbzZJ1akVwNbiDUeyY=";
+    rev = "e4c7d8b38040518d42599eef8ddb5e67aa967a9c";
+    hash = "sha256-nioJxKo6msQQTP4skMEFDh6xD2cekOEXbMRFus73XuI=";
   };
 
   extraMeta = {

--- a/pkgs/development/interpreters/luajit/2.1.nix
+++ b/pkgs/development/interpreters/luajit/2.1.nix
@@ -8,13 +8,13 @@
 callPackage ./default.nix {
   # The patch version is the timestamp of the git commit,
   # obtain via `cat $(nix-build -A luajit_2_1.src)/.relver`
-  version = "2.1.1741730670";
+  version = "2.1.1774638290";
 
   src = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
-    rev = "538a82133ad6fddfd0ca64de167c4aca3bc1a2da";
-    hash = "sha256-3DhNqVdojsWDo8mKJXIyTqFODIiKzThcAzHPdnoJaVM=";
+    rev = "fbb36bb6bfa88716a47c58bcf9ce9f2ef752abac";
+    hash = "sha256-BqH66q38mJpIYJgPiSPt7I0B3VLBvuDRRTiMJ7ldkBI=";
   };
 
   inherit self passthruFun;


### PR DESCRIPTION
- **luajit_2_0: 2.0.1741557863 -> 2.0.1774896119**
- **luajit_2_1: 2.1.1741730670 -> 2.1.1774638290**

luajit_2_1 is the version used in upstream Nvim 0.12.1.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[contributing.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/readme.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[pkgs/readme.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
