### PR TITLE
matrix-continuwuity: 0.5.6 -> 0.5.7

### DIFF
--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -33,40 +33,6 @@ let
           };
 
           patches = [ ];
-
-          cmakeFlags =
-            lib.subtractLists [
-              # no real reason to have snappy or zlib, no one uses this
-              (lib.cmakeBool "WITH_SNAPPY" true)
-              (lib.cmakeBool "ZLIB" true)
-              (lib.cmakeBool "WITH_ZLIB" true)
-              # we dont need to use ldb or sst_dump (core_tools)
-              (lib.cmakeBool "WITH_CORE_TOOLS" true)
-              # we dont need to build rocksdb tests
-              (lib.cmakeBool "WITH_TESTS" true)
-              # we use rust-rocksdb via C interface and dont need C++ RTTI
-              (lib.cmakeBool "USE_RTTI" true)
-              # this doesn't exist in RocksDB
-              (lib.cmakeBool "FORCE_SSE43" true)
-            ] old.cmakeFlags
-            ++ [
-              # no real reason to have snappy, no one uses this
-              (lib.cmakeBool "WITH_SNAPPY" false)
-              (lib.cmakeBool "ZLIB" false)
-              (lib.cmakeBool "WITH_ZLIB" false)
-              # we dont need to use ldb or sst_dump (core_tools)
-              (lib.cmakeBool "WITH_CORE_TOOLS" false)
-              # we dont need to build rocksdb tests
-              (lib.cmakeBool "WITH_TESTS" false)
-              # we use rust-rocksdb via C interface and dont need C++ RTTI
-              (lib.cmakeBool "USE_RTTI" false)
-              (lib.cmakeBool "WITH_TRACE_TOOLS" false)
-            ];
-          outputs = [ "out" ];
-
-          # We aren't building tools, the original package uses this to make sure rocksdb
-          # tools work as expected. Hence we override this and make it empty.
-          preInstall = "";
         }
       );
 in

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -122,6 +122,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
+      bartoostveen
       nyabinary
       snaki
     ];

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -23,13 +23,13 @@ let
     }).overrideAttrs
       (
         final: old: {
-          version = "10.5.1";
+          version = "10.10.1";
           src = fetchFromGitea {
             domain = "forgejo.ellis.link";
             owner = "continuwuation";
             repo = "rocksdb";
-            rev = "10.5.fb";
-            hash = "sha256-X4ApGLkHF9ceBtBg77dimEpu720I79ffLoyPa8JMHaU=";
+            rev = "10.10.fb";
+            hash = "sha256-1ef75IDMs5Hba4VWEyXPJb02JyShy5k4gJfzGDhopRk=";
           };
 
           patches = [ ];
@@ -72,17 +72,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-continuwuity";
-  version = "0.5.6";
+  version = "0.5.7";
 
   src = fetchFromGitea {
     domain = "forgejo.ellis.link";
     owner = "continuwuation";
     repo = "continuwuity";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-p6dL1wL9n+1ivUItdlZuLxTneDBjCHEdNr0ukau2rHI=";
+    hash = "sha256-DrW31VesYipZlFpCoCv4Sj4BtKeAF9/UpWhZjBIrXH4=";
   };
 
-  cargoHash = "sha256-lLbnFA2WS96er84G2e9bGrYhhqe2zL3Npn1SXB3De2w=";
+  cargoHash = "sha256-E4eqPTLTilqMdIJ9MHbMbu5zTpqEqNPPo3rMS+sA8uA=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v0.5.7
Bumped rocksdb as well following [this commit](https://forgejo.ellis.link/continuwuation/continuwuity/commit/1bd161a306826bd3b03737c346a9d8ad92fec01b)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
