### PR TITLE
python3Packages.pdf-oxide: init at 0.3.32

### DIFF
--- a/pkgs/by-name/pd/pdf-oxide/package.nix
+++ b/pkgs/by-name/pd/pdf-oxide/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   rustPlatform,
   nix-update-script,
+  python3Packages,
   versionCheckHook,
 }:
 
@@ -28,7 +29,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    python-bindings = python3Packages.pdf-oxide;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Fastest PDF library for text extraction, image extraction, and markdown conversion";

--- a/pkgs/development/python-modules/pdf-oxide/default.nix
+++ b/pkgs/development/python-modules/pdf-oxide/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  pkgs,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # build-system
+  rustPlatform,
+
+  # optional-dependencies
+  onnxruntime,
+
+  # tests
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  inherit (pkgs.pdf-oxide)
+    pname
+    version
+    src
+    cargoDeps
+    ;
+
+  pyproject = true;
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  optional-dependencies = {
+    ocr = [ onnxruntime ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pdf_oxide"
+  ];
+
+  meta = pkgs.pdf-oxide.meta // {
+    description = "Python bindings for the pdf_oxide library";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12245,6 +12245,8 @@ self: super: with self; {
 
   pdbfixer = callPackage ../development/python-modules/pdbfixer { };
 
+  pdf-oxide = callPackage ../development/python-modules/pdf-oxide { };
+
   pdf2docx = callPackage ../development/python-modules/pdf2docx { };
 
   pdf2image = callPackage ../development/python-modules/pdf2image { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

PDF Oxide is a library for Text extraction, image extraction, markdown conversion, PDF creation & editing.
Python bindings: https://github.com/yfedoseev/pdf_oxide/tree/main/python

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
