### PR TITLE
python3Packages.ibind: init at 0.1.22

### DIFF
--- a/pkgs/development/python-modules/ibind/default.nix
+++ b/pkgs/development/python-modules/ibind/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pycryptodome,
+  requests,
+  urllib3,
+  websocket-client,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ibind";
+  version = "0.1.22";
+  pyproject = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Voyz";
+    repo = "ibind";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hFjxkAEbhbcwseI7XwrEBtq5kzGj6XRBw3mqcxar9r0=";
+  };
+
+  # Otherwise, fails with:
+  # __main__.py: error: unrecognized arguments: unpacked/ibind-0.0.2
+  postUnpack = ''
+    rm -r "$sourceRoot/dist"
+  '';
+
+  # ModuleNotFoundError: No module named 'test_utils'
+  # TODO: The fix is already merged upstream: remove when updating to the next release
+  postPatch = ''
+    substituteInPlace "pytest.ini" \
+      --replace-fail '[tool:pytest]' '[pytest]'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "requests"
+    "websocket-client"
+  ];
+  dependencies = [
+    pycryptodome
+    requests
+    urllib3
+    websocket-client
+  ];
+
+  pythonImportsCheck = [ "ibind" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError: 0.2564859390258789 != 0.1 within 0.02 delta (0.1564859390258789 difference)
+    "test_wait_until_timeout"
+  ];
+
+  meta = {
+    description = "REST and WebSocket client library for Interactive Brokers Client Portal Web API";
+    homepage = "https://github.com/Voyz/ibind";
+    changelog = "https://github.com/Voyz/ibind/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7350,6 +7350,8 @@ self: super: with self; {
 
   ibeacon-ble = callPackage ../development/python-modules/ibeacon-ble { };
 
+  ibind = callPackage ../development/python-modules/ibind { };
+
   ibis = callPackage ../development/python-modules/ibis { };
 
   ibis-framework = callPackage ../development/python-modules/ibis-framework { };


### PR DESCRIPTION
## Things done

Add [ibind](https://github.com/Voyz/ibind), a REST and WebSocket client library for Interactive Brokers Client Portal Web API.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
