### PR TITLE
deej: init at 0.9.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26363,6 +26363,13 @@
     githubId = 36695359;
     name = "Vasyl Solovei";
   };
+  swaggeroo = {
+    email = "swaggerooo@pm.me";
+    github = "swaggeroo";
+    githubId = 57057662;
+    name = "Swaggeroo";
+    keys = [ { fingerprint = "D221 99EC 4FFF EF4D F29D  2435 5208 74E7 3291 4E0B"; } ];
+  };
   swarren83 = {
     email = "shawn.w.warren@gmail.com";
     github = "swarren83";

--- a/pkgs/by-name/de/deej/package.nix
+++ b/pkgs/by-name/de/deej/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  gtk3,
+  libappindicator-gtk3,
+  webkitgtk_4_1,
+}:
+
+buildGoModule {
+  pname = "deej";
+  version = "0.9.10";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "omriharel";
+    repo = "deej";
+    rev = "v0.9.10";
+    hash = "sha256-T6S3FQ9vxl4R3D+uiJ83z1ueK+3pfASEjpRI+HjIV0M=";
+  };
+
+  vendorHash = "sha256-1gjFPD7YV2MTp+kyC+hsj+NThmYG3hlt6AlOzXmEKyA=";
+
+  subPackages = [ "cmd" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    gtk3
+    libappindicator-gtk3
+    webkitgtk_4_1
+  ];
+
+  preBuild = ''
+    # getlantern/systray hardcodes webkit2gtk-4.0
+    for file in $(grep -rl "webkit2gtk-4.0" .); do
+      substituteInPlace "$file" --replace-fail "webkit2gtk-4.0" "webkit2gtk-4.1"
+    done
+  '';
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/deej
+  '';
+
+  meta = with lib; {
+    description = "Open-source hardware volume mixer for Windows and Linux";
+    longDescription = ''
+      deej is an open-source hardware volume mixer for Windows and Linux.
+      It lets you use real-world sliders (potentiometers) to control the
+      volume of individual apps (like Discord, Spotify and Games) independently.
+    '';
+    homepage = "https://github.com/omriharel/deej";
+    license = lib.licenses.mit;
+    maintainers = with maintainers; [ swaggeroo ];
+    platforms = platforms.linux;
+    mainProgram = "deej";
+  };
+}


### PR DESCRIPTION
This PR adds `deej`, an open-source hardware volume mixer. 

**Upstream Status:**
The upstream repository has not seen recent activity, but the project has 4.8k stars on GitHub. I use this software personally and will handle the maintenance and any necessary fixes (like the library patch below) within Nixpkgs.

**Technical Notes:**
The derivation includes a `preBuild` patch to update a hardcoded dependency on `webkit2gtk-4.0` to `webkit2gtk-4.1`. This ensures compatibility with current Nixpkgs libraries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
