### PR TITLE
radare2: 6.1.2 -> 6.1.4 , add updateScript, versionCheckHook

### DIFF
--- a/pkgs/by-name/ia/iaito/package.nix
+++ b/pkgs/by-name/ia/iaito/package.nix
@@ -7,18 +7,19 @@
   python3,
   qt6Packages,
   radare2,
+  versionCheckHook,
   stdenv,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "iaito";
-  version = "6.1.0";
+  version = "6.1.4";
 
   srcs = [
     (fetchFromGitHub {
       owner = "radareorg";
       repo = "iaito";
       tag = finalAttrs.version;
-      hash = "sha256-nvMx0zbfsphfBgxdQnk+EhRpQnJ2Qv05rF7w+zQUUQg=";
+      hash = "sha256-HKh5D96Dwo6YttWcOMlFy4H9OS3FbQvQ5RK+aOY4V5s=";
       name = "main";
     })
     (fetchFromGitHub {
@@ -78,6 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
 
   meta = {
     description = "Official radare2 GUI";

--- a/pkgs/by-name/ia/iaito/package.nix
+++ b/pkgs/by-name/ia/iaito/package.nix
@@ -7,7 +7,9 @@
   python3,
   qt6Packages,
   radare2,
-  versionCheckHook,
+  xvfb-run,
+  breakpointHook,
+  writableTmpDirAsHomeHook,
   stdenv,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -48,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     qt6Packages.qttools
     qt6Packages.wrapQtAppsHook
+    breakpointHook
   ];
 
   buildInputs = [
@@ -80,9 +83,21 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "-v";
+  nativeInstallCheckInputs = [
+    xvfb-run
+    writableTmpDirAsHomeHook
+  ];
+
+  # `iaito -v` does only work with GUI access
+  installCheckPhase = ''
+    runHook preCheck
+    xvfb-run -a ${placeholder "out"}/bin/iaito -v | grep "${finalAttrs.version}"
+    runHook postCheck
+  '';
+
   doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Official radare2 GUI";

--- a/pkgs/by-name/ia/iaito/update.sh
+++ b/pkgs/by-name/ia/iaito/update.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i sh -p curl jq nix-prefetch-github coreutils gnused gnugrep
+# shellcheck shell=sh
+set -eu
+
+# Directory of this script / the iaito package
+SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
+NIXFILE="$SCRIPT_DIR/package.nix"
+
+# Determine latest release version: use $1 if provided, otherwise auto-detect
+if [ -n "${1:-}" ]; then
+    LATEST_VERSION="$1"
+    echo "Using provided iaito version: $LATEST_VERSION"
+else
+    LATEST_VERSION=$(curl -s https://api.github.com/repos/radareorg/iaito/releases/latest | jq -r '.tag_name')
+    echo "Latest iaito version: $LATEST_VERSION"
+fi
+
+CURRENT_VERSION=$(grep 'version = ' "$NIXFILE" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+echo "Current iaito version: $CURRENT_VERSION"
+
+if [ "$LATEST_VERSION" = "$CURRENT_VERSION" ]; then
+    echo "iaito is already up to date"
+    exit 0
+fi
+
+# Update main source version and hash
+echo "Updating main source to $LATEST_VERSION..."
+MAIN_HASH=$(nix-prefetch-github radareorg iaito --rev "$LATEST_VERSION" --json | jq -r '.hash')
+echo "  New main hash: $MAIN_HASH"
+
+sed -i "s|version = \"$CURRENT_VERSION\"|version = \"$LATEST_VERSION\"|" "$NIXFILE"
+sed -i "/repo = \"iaito\";$/,/})/{s|hash = \".*\"|hash = \"$MAIN_HASH\"|}" "$NIXFILE"
+
+# Update translations to latest master revision
+echo "Updating iaito-translations to latest master..."
+LATEST_TRANS_REV=$(curl -s https://api.github.com/repos/radareorg/iaito-translations/commits/master | jq -r '.sha')
+echo "  Latest translations rev: $LATEST_TRANS_REV"
+
+CURRENT_TRANS_REV=$(grep -A3 'repo = "iaito-translations"' "$NIXFILE" | grep 'rev = ' | sed 's/.*"\(.*\)".*/\1/')
+echo "  Current translations rev: $CURRENT_TRANS_REV"
+
+if [ "$LATEST_TRANS_REV" = "$CURRENT_TRANS_REV" ]; then
+    echo "  Translations unchanged"
+else
+    echo "  Updating translations: $CURRENT_TRANS_REV -> $LATEST_TRANS_REV"
+    TRANS_HASH=$(nix-prefetch-github radareorg iaito-translations --rev "$LATEST_TRANS_REV" --json | jq -r '.hash')
+    echo "  New translations hash: $TRANS_HASH"
+
+    sed -i "/repo = \"iaito-translations\"/,/})/{s|rev = \"$CURRENT_TRANS_REV\"|rev = \"$LATEST_TRANS_REV\"|}" "$NIXFILE"
+    sed -i "/repo = \"iaito-translations\"/,/})/{s|hash = \".*\"|hash = \"$TRANS_HASH\"|}" "$NIXFILE"
+fi
+
+echo "Update complete. Please verify with: nix build .#iaito"

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -21,6 +21,7 @@
   python3,
   readline,
   ruby,
+  versionCheckHook,
   vte,
   xxHash,
   zlib,
@@ -133,6 +134,10 @@ stdenv.mkDerivation (finalAttrs: {
     install_name_tool -add_rpath $out/lib $out/lib/libr_io.${finalAttrs.version}.dylib
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-v";
+  doInstallCheck = true;
+
   passthru.updateScript = ./update.sh;
 
   meta = {
@@ -165,7 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
       mic92
       raskin
     ];
-    mainProgram = "radare2";
+    mainProgram = "r2";
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -133,6 +133,8 @@ stdenv.mkDerivation (finalAttrs: {
     install_name_tool -add_rpath $out/lib $out/lib/libr_io.${finalAttrs.version}.dylib
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "UNIX-like reverse engineering framework and command-line toolset";
     longDescription = ''

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -47,19 +47,19 @@ let
   qjs = fetchFromGitHub {
     owner = "quickjs-ng";
     repo = "quickjs";
-    rev = "e2b100e8c5fa7131e9fb22b8a0e9ca0f16eb9892"; # https://github.com/radareorg/radare2/blob/master/subprojects/qjs.wrap
-    hash = "sha256-vq+K93MuvFC+JKw4623gKs53ngw1097l5Kf/RBGU+mA=";
+    rev = "3087a2ce5bcb66cc1fcd9f34d3e5ce3bd43a67d9"; # https://github.com/radareorg/radare2/blob/master/subprojects/qjs.wrap
+    hash = "sha256-Z6DUe/W1+3SYPRPCiL3oNL5ovXCsW3dsFuGkA9WF3W4=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "radare2";
-  version = "6.1.2";
+  version = "6.1.4";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     tag = finalAttrs.version;
-    hash = "sha256-YiKbXKKwbeAUkeq4LcUwOxTHU1Hua4YhcwDULiHVmrQ=";
+    hash = "sha256-3MwBtjR3XQMhbJHnD30OVedUEKcje5jDPszNynkGCT8=";
   };
 
   mesonFlags = [

--- a/pkgs/development/tools/analysis/radare2/update.sh
+++ b/pkgs/development/tools/analysis/radare2/update.sh
@@ -65,4 +65,14 @@ update_subproject binaryninja Vector35 binaryninja-api binaryninja.wrap rev
 update_subproject sdb radareorg sdb sdb.wrap tag
 update_subproject qjs quickjs-ng quickjs qjs.wrap rev
 
-echo "Update complete. Please verify with: nix build .#radare2"
+echo "Update iaito to follow new radare2 version '$LATEST_VERSION'"
+IAITO_UPDATE_SCRIPT="$(readlink -f "$(dirname "$SCRIPT_DIR")/../../../by-name/ia/iaito/update.sh")"
+if "$IAITO_UPDATE_SCRIPT" "$LATEST_VERSION";then
+    echo "iaito updated to $LATEST_VERSION"
+else
+    # iaito release may not have been published yet, release dates are not in sync
+    # sometimes, iaito is released earlier than radare2
+    echo "failed to update iaito to $LATEST_VERSION, continuing"
+fi
+
+echo "Update complete. Please verify with: nix build .#radare2 .#iaito"

--- a/pkgs/development/tools/analysis/radare2/update.sh
+++ b/pkgs/development/tools/analysis/radare2/update.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i sh -p curl jq nix-prefetch-github nix coreutils gnused gnugrep
+# shellcheck shell=sh
+set -eu
+
+# Directory of this script / the radare2 package
+SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
+NIXFILE="$SCRIPT_DIR/default.nix"
+
+# Determine latest release version
+LATEST_VERSION=$(curl -s https://api.github.com/repos/radareorg/radare2/releases/latest | jq -r '.tag_name')
+echo "Latest radare2 version: $LATEST_VERSION"
+
+CURRENT_VERSION=$(grep 'version = ' "$NIXFILE" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+echo "Current radare2 version: $CURRENT_VERSION"
+
+if [ "$LATEST_VERSION" = "$CURRENT_VERSION" ]; then
+    echo "radare2 is already up to date"
+    exit 0
+fi
+
+# Update main package version and hash
+echo "Updating main source to $LATEST_VERSION..."
+MAIN_HASH=$(nix-prefetch-github radare radare2 --rev "$LATEST_VERSION" --json | jq -r '.hash')
+echo "  New main hash: $MAIN_HASH"
+
+sed -i "s|version = \"$CURRENT_VERSION\"|version = \"$LATEST_VERSION\"|" "$NIXFILE"
+sed -i "/src = fetchFromGitHub/,/};/{s|hash = \".*\"|hash = \"$MAIN_HASH\"|}" "$NIXFILE"
+
+# Update a single subproject
+# Arguments: name owner repo wrap_file ref_type
+update_subproject() {
+    name=$1
+    owner=$2
+    repo=$3
+    wrap_file=$4
+    ref_type=$5
+
+    echo "Checking subproject $name..."
+
+    # Fetch the wrap file from the new version
+    wrap_content=$(curl -sL "https://raw.githubusercontent.com/radareorg/radare2/$LATEST_VERSION/subprojects/$wrap_file")
+    new_rev=$(echo "$wrap_content" | grep '^revision' | sed 's/revision = //')
+
+    # Get the current revision from the nix file
+    current_rev=$(grep -A3 "repo = \"$repo\"" "$NIXFILE" | grep "$ref_type = " | sed 's/.*"\(.*\)".*/\1/')
+
+    if [ "$new_rev" = "$current_rev" ]; then
+        echo "  $name is unchanged at $current_rev"
+        return
+    fi
+
+    echo "  Updating $name: $current_rev -> $new_rev"
+
+    # Prefetch new hash
+    new_hash=$(nix-prefetch-github "$owner" "$repo" --rev "$new_rev" --json | jq -r '.hash')
+    echo "  New hash: $new_hash"
+
+    # Update revision and hash in the nix file
+    sed -i "/repo = \"$repo\"/,/};/{s|$ref_type = \"$current_rev\"|$ref_type = \"$new_rev\"|}" "$NIXFILE"
+    sed -i "/repo = \"$repo\"/,/};/{s|hash = \".*\"|hash = \"$new_hash\"|}" "$NIXFILE"
+}
+
+update_subproject binaryninja Vector35 binaryninja-api binaryninja.wrap rev
+update_subproject sdb radareorg sdb sdb.wrap tag
+update_subproject qjs quickjs-ng quickjs qjs.wrap rev
+
+echo "Update complete. Please verify with: nix build .#radare2"


### PR DESCRIPTION
PR updates radare2 to latest version, fixing #510500 . additionally add an updateScript and test with versionCheckHook
also updates iaito to 6.1.4 because of build errors, adds updateScript as well as versionCheckHook

Question:
How to handle updates for iaito and radare2 in the future? Both packages should ideally always be updated together (see build error of iaito 6.1.0 with radare2 6.1.4), what is the general way forward? should update.sh for radare2 also call update.sh for iaito ?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test