### PR TITLE
pyhon314Packages.cert-chain-resolver: fix build, modernize

### DIFF
--- a/pkgs/development/python-modules/cert-chain-resolver/default.nix
+++ b/pkgs/development/python-modules/cert-chain-resolver/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  cacert,
   cryptography,
   fetchFromGitHub,
   pytestCheckHook,
@@ -28,10 +29,13 @@ buildPythonPackage rec {
     six
   ];
 
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
   disabledTests = [
     # Tests require network access
     "test_cert_returns_completed_chain"
     "test_display_flag_is_properly_formatted"
+    "test_display_flag_includes_warning_when_root_was_requested_but_not_found"
   ];
 
   pythonImportsCheck = [ "cert_chain_resolver" ];

--- a/pkgs/development/python-modules/cert-chain-resolver/default.nix
+++ b/pkgs/development/python-modules/cert-chain-resolver/default.nix
@@ -4,24 +4,27 @@
   cacert,
   cryptography,
   fetchFromGitHub,
+  setuptools,
   pytestCheckHook,
   pytest-mock,
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cert-chain-resolver";
   version = "1.4.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rkoopmans";
     repo = "python-certificate-chain-resolver";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-DWE+mR7EO5ohuRAR0WC40GBY7HpwXIpU0hhVUnWNRno=";
   };
 
-  propagatedBuildInputs = [ cryptography ];
+  build-system = [ setuptools ];
+
+  dependencies = [ cryptography ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -44,8 +47,8 @@ buildPythonPackage rec {
     description = "Resolve / obtain the certificate intermediates of a x509 certificate";
     mainProgram = "cert-chain-resolver";
     homepage = "https://github.com/rkoopmans/python-certificate-chain-resolver";
-    changelog = "https://github.com/rkoopmans/python-certificate-chain-resolver/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/rkoopmans/python-certificate-chain-resolver/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ veehaitch ];
   };
-}
+})


### PR DESCRIPTION
- https://nfd.1l.is/?selected=python314Packages.cert-chain-resolver

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
