### PR TITLE
python314Packages.finvizfinance: fix build, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/finvizfinance/default.nix
+++ b/pkgs/development/python-modules/finvizfinance/default.nix
@@ -12,7 +12,7 @@
   requests,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "finvizfinance";
   version = "1.3.0";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "lit26";
     repo = "finvizfinance";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-M/EyQgINdJLLfOFNm/RhqONz3slb4ukugHLdiozDY0s=";
   };
 
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Finviz Finance information downloader";
     homepage = "https://github.com/lit26/finvizfinance";
-    changelog = "https://github.com/lit26/finvizfinance/releases/tag/${src.tag}";
+    changelog = "https://github.com/lit26/finvizfinance/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ icyrockcom ];
   };
-}
+})

--- a/pkgs/development/python-modules/finvizfinance/default.nix
+++ b/pkgs/development/python-modules/finvizfinance/default.nix
@@ -45,13 +45,15 @@ buildPythonPackage rec {
     # Tests require network access
     "test_finvizfinance_calendar"
     "test_finvizfinance_crypto"
-    "test_forex_performance_percentage"
-    "test_group_overview"
+    "test_finvizfinance_finvizfinance"
     "test_finvizfinance_insider"
     "test_finvizfinance_news"
-    "test_finvizfinance_finvizfinance"
-    "test_statements"
+    "test_forex_performance_percentage"
+    "test_group_overview"
     "test_screener_overview"
+    "test_statements"
+    "test_ticker_etf_holders_returns_list"
+    "test_ticker_peer_returns_list"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://nfd.1l.is/?selected=python314Packages.finvizfinance

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
