### PR TITLE
terraform-providers/1password_onepassword: 2.2.0 -> 3.3.1

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -108,6 +108,15 @@ let
       propagatedBuildInputs = [ cdrtools ];
     });
     aminueza_minio = automated-providers.aminueza_minio.override { spdx = "AGPL-3.0-only"; };
+    # proxyVendor is necessary because enabling CGO causes `go mod vendor` to include
+    # platform-specific files leading to vendorHash varying across platforms.
+    "1password_onepassword" =
+      (automated-providers."1password_onepassword".override { proxyVendor = true; }).overrideAttrs
+        (finalAttrs: {
+          env = finalAttrs.env // {
+            CGO_ENABLED = "1";
+          };
+        });
   };
 
   # Put all the providers we not longer support in this list.

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -1,12 +1,12 @@
 {
   "1password_onepassword": {
-    "hash": "sha256-4wEKPTBt9F8N9jPk/PUu+ewrCJ8IztU9CblfJxA7h1k=",
+    "hash": "sha256-BK6rKoEva8ChSARBXZNUAAphjG+Y+eeje8Gdi4DAJoc=",
     "homepage": "https://registry.terraform.io/providers/1Password/onepassword",
     "owner": "1Password",
     "repo": "terraform-provider-onepassword",
-    "rev": "v2.2.0",
+    "rev": "v3.3.1",
     "spdx": "MIT",
-    "vendorHash": "sha256-n01cHzyG9FvxCb92sFccKY1h7Pa0zmi+CUxSYHM5Elc="
+    "vendorHash": "sha256-RTfj2Omiqe92Ad0swEY/aGIMvcXb39bdQoObYKiekiw="
   },
   "a10networks_thunder": {
     "hash": "sha256-RX3mP5btzyvuBjoMNiUL6ZeFLEo5SqmwwSK/eE0gWEw=",

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -86,7 +86,7 @@ update_attr() {
 repo_root=$(git rev-parse --show-toplevel)
 
 generate_hash() {
-  nurl --expr "(import ${repo_root} {}).terraform-providers.${provider}.$1"
+  nurl --expr "(import ${repo_root} {}).terraform-providers.\"${provider}\".$1"
 }
 
 echo_provider() {
@@ -167,7 +167,7 @@ fi
 # Check that the provider builds
 if [[ ${build} == 1 ]]; then
   echo_provider "building"
-  nix-build --no-out-link "${repo_root}" -A "terraform-providers.${provider}"
+  nix-build --no-out-link "${repo_root}" -A "terraform-providers.\"${provider}\""
 fi
 
 popd >/dev/null


### PR DESCRIPTION
https://github.com/1Password/terraform-provider-onepassword/compare/v2.2.0...v3.3.1

Looks like it wasn't automatically updating due to the update-provider script missing some quoting which I've fixed now

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
