### PR TITLE
agent-browser: 0.25.4 -> 0.27.0

### DIFF
--- a/pkgs/by-name/ag/agent-browser/package.nix
+++ b/pkgs/by-name/ag/agent-browser/package.nix
@@ -14,13 +14,13 @@
 }:
 
 let
-  version = "0.26.0";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "vercel-labs";
     repo = "agent-browser";
     tag = "v${version}";
-    hash = "sha256-q3UcFTB8OMOrfx5xcNPtBBAwOxoscwrjGg+y8tdETm0=";
+    hash = "sha256-c+AJAXMX88t+zzFsEAtFJDjDY5EbhmEyMRGFL4t63nE=";
   };
 
   # The Rust CLI embeds the dashboard UI via RustEmbed at compile time.
@@ -81,7 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/cli";
 
-  cargoHash = "sha256-ENIGFhZ+pXIZvEFUA0No3HpeHtxgJohMgx6F0wNpmO0=";
+  cargoHash = "sha256-2u7yokHCxIVq16370Mg+n5kf03yUDYJmctFxN1fnaAA=";
 
   # Place the pre-built dashboard where RustEmbed expects it
   postUnpack = ''
@@ -102,10 +102,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
-  # skills/ contains SKILL.md for tools like Claude Code
+  # The `skills` subcommand looks for `skills/` and `skill-data/` next to
+  # `bin/`, relative to the canonical exe path. See cli/src/skills.rs.
   postInstall = ''
-    mkdir -p $out/share/agent-browser
-    cp -r ../skills $out/share/agent-browser/
+    cp -r ../skills $out/skills
+    cp -r ../skill-data $out/skill-data
   '';
 
   passthru = {

--- a/pkgs/by-name/ag/agent-browser/package.nix
+++ b/pkgs/by-name/ag/agent-browser/package.nix
@@ -9,17 +9,18 @@
   pnpmConfigHook,
   geist-font,
   nix-update-script,
+  which,
   writableTmpDirAsHomeHook,
 }:
 
 let
-  version = "0.25.4";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "vercel-labs";
     repo = "agent-browser";
     tag = "v${version}";
-    hash = "sha256-2Dv+ZY9cvcz6EIpI+gkV9w5eqQzpAD2N+yf4dJrmdwg=";
+    hash = "sha256-q3UcFTB8OMOrfx5xcNPtBBAwOxoscwrjGg+y8tdETm0=";
   };
 
   # The Rust CLI embeds the dashboard UI via RustEmbed at compile time.
@@ -46,8 +47,8 @@ let
 
     pnpmWorkspaces = [ "dashboard" ];
 
-    # Replace Google Fonts fetch with a local font from nixpkgs since
-    # the nix sandbox has no network access.
+    # Replace Google Fonts fetch with a local font from nixpkgs since the
+    # Nix sandbox has no network access.
     postPatch = ''
       substituteInPlace packages/dashboard/src/app/layout.tsx --replace-fail \
         '{ Geist } from "next/font/google"' \
@@ -80,7 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/cli";
 
-  cargoHash = "sha256-3vzVVHFo13ZLsbbXw7n9BE/YXBJwoxzhvfjuqOQwdfg=";
+  cargoHash = "sha256-ENIGFhZ+pXIZvEFUA0No3HpeHtxgJohMgx6F0wNpmO0=";
 
   # Place the pre-built dashboard where RustEmbed expects it
   postUnpack = ''
@@ -88,7 +89,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cp -r ${dashboard} source/packages/dashboard/out
   '';
 
-  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  # `which_exists` spawns the external `which` binary at runtime to probe
+  # for optional tools; pin it to an absolute store path.
+  postPatch = ''
+    substituteInPlace src/doctor/helpers.rs src/install.rs --replace-fail \
+      '"which"' '"${lib.getExe which}"'
+  '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/vercel-labs/agent-browser/releases/tag/v0.27.0

Fixed skills copying logic to get `agent-browser skills get` command work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
