### PR TITLE
nixos/ipu6, nixos/v4l2-relayd: fix device visibility, relay stability, and PipeWire integration

### DIFF
--- a/nixos/modules/hardware/video/webcam/ipu6.nix
+++ b/nixos/modules/hardware/video/webcam/ipu6.nix
@@ -9,6 +9,7 @@ let
   inherit (lib)
     mkDefault
     mkEnableOption
+    mkForce
     mkIf
     mkOption
     optional
@@ -38,6 +39,19 @@ in
       '';
     };
 
+    videoDeviceNumber = mkOption {
+      type = types.int;
+      default = 50;
+      description = ''
+        v4l2loopback device number for the relay output (`/dev/videoN`).
+
+        Must be fixed so application camera permission grants, which are keyed to
+        the PipeWire node name (derived from the sysfs device path), survive
+        reboots. Choose a number above the IPU6 raw node range (typically 3-34)
+        and any other v4l2loopback devices on the system.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -51,9 +65,31 @@ in
       ivsc-firmware
     ];
 
+    # Restrict IPU6 raw nodes and media controller to root. DRIVERS== matches the
+    # parent PCI device. TAG-="uaccess" blocks logind ACL grants at login.
     services.udev.extraRules = ''
       SUBSYSTEM=="intel-ipu6-psys", MODE="0660", GROUP="video"
+      SUBSYSTEM=="media", DRIVERS=="intel-ipu6", MODE="0600", GROUP="root", TAG-="uaccess"
+      SUBSYSTEM=="video4linux", DRIVERS=="intel-ipu6", MODE="0600", GROUP="root", TAG-="uaccess"
     '';
+
+    # ipu6-camera-hal writes AIQ tuning data and debug logs here.
+    systemd.tmpfiles.rules = [ "d /run/camera 0755 root video -" ];
+
+    # Disable raw IPU6 nodes in WirePlumber. Matched via udev ID_V4L_PRODUCT=ipu6,
+    # set by the kernel at device registration without requiring a device open.
+    services.pipewire.wireplumber.extraConfig."ipu6-v4l2-rules" = {
+      "monitor.v4l2.rules" = [
+        {
+          matches = [ { "device.product.name" = "ipu6"; } ];
+          actions = {
+            "update-props" = {
+              "device.disabled" = true;
+            };
+          };
+        }
+      ];
+    };
 
     services.v4l2-relayd.instances.ipu6 = {
       enable = mkDefault true;
@@ -72,5 +108,23 @@ in
         format = mkIf (cfg.platform != "ipu6") (mkDefault "NV12");
       };
     };
+
+    # Override preStart/postStop from the v4l2-relayd module:
+    # - Use a fixed device number so PipeWire node names (and application permission
+    #   grants) are stable across reboots. Exit 17 (EEXIST) is success.
+    # - Keep the device alive on stop so apps survive relay restarts via
+    #   VIDIOC_DQBUF blocking rather than receiving errors.
+    systemd.services.v4l2-relayd-ipu6 = {
+      preStart = mkForce ''
+        mkdir -p "$(dirname "$V4L2_DEVICE_FILE")"
+        ${config.boot.kernelPackages.v4l2loopback.bin}/bin/v4l2loopback-ctl \
+          add --name "Intel MIPI Camera" --exclusive-caps=1 ${toString cfg.videoDeviceNumber} || [ $? -eq 17 ]
+        echo /dev/video${toString cfg.videoDeviceNumber} > "$V4L2_DEVICE_FILE"
+      '';
+      postStop = mkForce ''
+        rm -rf "$(dirname "$V4L2_DEVICE_FILE")"
+      '';
+    };
+
   };
 }

--- a/nixos/modules/services/video/v4l2-relayd.nix
+++ b/nixos/modules/services/video/v4l2-relayd.nix
@@ -221,6 +221,11 @@ in
       boot = mkIf ((length enabledInstances) > 0) {
         extraModulePackages = [ kernelPackages.v4l2loopback ];
         kernelModules = [ "v4l2loopback" ];
+        # Prevent v4l2loopback from auto-creating a device at load time. An
+        # unconfigured device has a degenerate framerate range that breaks
+        # GStreamer caps negotiation. All devices are created at runtime via
+        # v4l2loopback-ctl add in each instance's preStart instead.
+        extraModprobeConfig = "options v4l2loopback devices=0";
       };
 
       systemd.services = mkInstanceServices enabledInstances;


### PR DESCRIPTION
This PR fixes several issues with the `hardware.ipu6` and `services.v4l2-relayd` modules that prevent the camera from working correctly out of the box. It builds on the insights of #225743, #481796 and https://discourse.nixos.org/t/how-to-hide-this-dummy-video-device/40985 .

For a more extensive analysis of the underlying issues, see https://gist.github.com/StarGate01/9015c396430ece98df907a2670d26d5c .

## Changes

### Udev rules: hide raw IPU6 nodes from userspace

Two udev rules are added to restrict the 32 raw ISYS capture nodes and the media controller to root.

Without these, browsers and V4L2 tools discover the raw nodes and either show them as selectable cameras or produce spurious permission errors. Any process that successfully opens a raw node will also contend with `ipu6-camera-hal` for the sensor hardware, triggering CSI-2 errors.

`DRIVERS==` matches the parent PCI device (not the nodes themselves, which have no direct driver), making the rule portable across machines regardless of PCI slot assignment. `TAG-="uaccess"` is required because `systemd-logind` would otherwise grant the logged-in user ACL access to all seat-tagged video devices at login time, overriding `MODE="0600"`.

### WirePlumber rule: suppress raw nodes from PipeWire

Without an explicit rule, WirePlumber's V4L2 monitor enumerates the 32 raw IPU6 capture nodes and attempts to present them as PipeWire camera devices, causing them to appear in application camera pickers even though they are inaccessible.

A `monitor.v4l2.rules` entry disables any device whose `device.product.name` is `"ipu6"` - the value set by the `intel_ipu6_isys` kernel driver via the udev `ID_V4L_PRODUCT` attribute at device registration (no device open required). This is precise: only the 32 raw IPU6 nodes carry this product name; USB cameras, v4l2loopback devices, and PCIe capture cards are unaffected.

### v4l2-relayd service: fixed device number and persistent loopback

The upstream module auto-allocates a v4l2loopback device number and deletes the device on service stop. This causes two problems:

1. **Browser permission grants break across reboots.** Browsers key camera permission grants to the PipeWire node name, which includes the sysfs device path. An auto-allocated number can change between reboots, causing the browser to treat the camera as a new device and discard stored grants.

2. **Apps lose the camera on relay restart.** When the device is deleted on stop, applications holding it open receive errors rather than blocking.

The fix overrides `preStart` and `postStop` with `mkForce`:

- `preStart` creates the device at a fixed number (`videoDeviceNumber`, default 50) via `v4l2loopback-ctl add`. Exit 17 (EEXIST) is treated as success so relay restarts reuse the existing device.
- `postStop` removes only the state file, leaving the loopback device alive. Applications survive relay crashes: `VIDIOC_DQBUF` blocks until the relay restarts and streaming resumes without the app needing to re-open the device.

A new `videoDeviceNumber` option (default: 50) allows users to avoid conflicts with other v4l2loopback devices on the system.

### v4l2-relayd module: suppress default dummy loopback device

`v4l2loopback` defaults to `devices=1`, creating a dummy device at module load time. Before any writer sets caps, this device advertises a framerate range where `min == max`, producing a degenerate GStreamer `FractionRange`. When PipeWire enumerates the device, any application that opens a camera triggers a flood of `gst_value_collect_fraction_range` assertion failures, caps negotiation fails with "no more input formats", and the relay enters a crash-restart loop.

`services/video/v4l2-relayd.nix` now sets `options v4l2loopback devices=0` in `boot.extraModprobeConfig`. All loopback devices are created at runtime by each instance's `preStart` via `v4l2loopback-ctl add`, which sets well-formed discrete caps before any reader can enumerate the device.

### tmpfiles: create `/run/camera`

`ipu6-camera-hal` writes AIQ (Active Image Quality) tuning data and debug logs to `/run/camera/` at runtime. Without this directory the HAL fails to start properly.

## Note on libcamera

libcamera has an IPU6 pipeline handler, but it operates directly on the raw ISYS nodes (`/dev/media1` + raw capture nodes) using software image processing in place of Intel's proprietary PSYS ISP. This path is mutually exclusive with the `ipu6-camera-hal` path used by this module — both require exclusive access to the ISYS hardware and cannot run simultaneously. The libcamera path also produces lower image quality and higher CPU/battery usage.

The udev rules in this module intentionally keep the raw nodes and media controller root-only, which blocks the libcamera path. Users who prefer the libcamera path should not enable this module.

## Testing

Tested on kernel 6.19 with `ipu6ep` platform:

- Camera accessible via direct V4L2 (`/dev/video50`), native browsers, and
  Flatpak apps via the XDG camera portal (verified with GNOME Snapshot)
- Raw IPU6 nodes no longer appear in browser camera pickers or `wpctl status`
- Browser camera permission grants persist across reboots
- Relay service restarts do not interrupt applications holding the device open

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
