### PR TITLE
truehdd: init at 0.4.0

### DIFF
--- a/pkgs/by-name/tr/truehdd/package.nix
+++ b/pkgs/by-name/tr/truehdd/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "truehdd";
+  version = "0.4.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "truehdd";
+    repo = "truehdd";
+    tag = finalAttrs.version;
+    hash = "sha256-PhJWtiYtELNkpnhI9e6tv3zFsSJnIYhu2eSy7RyReUE=";
+  };
+
+  cargoHash = "sha256-UvHdFtdkQPySEpCZ31n25jfvCsf7ETA7SVSR+/WfEM8=";
+
+  env.VERGEN_GIT_DESCRIBE = finalAttrs.version;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tools for inspecting and decoding Dolby TrueHD bitstreams";
+    homepage = "https://github.com/truehdd/truehdd";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      Renna42
+    ];
+    mainProgram = "truehdd";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
A command-line tool for decoding Dolby TrueHD audio streams.

Homepage: <https://github.com/truehdd/truehdd>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
