### PR TITLE
giter8: init at 0.18.0

### DIFF
--- a/pkgs/by-name/gi/giter8/package.nix
+++ b/pkgs/by-name/gi/giter8/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  jre,
+  coursier,
+  makeWrapper,
+  setJavaClassPath,
+  testers,
+  giter8,
+}:
+
+let
+  pname = "giter8";
+  version = "0.18.0";
+  deps = stdenv.mkDerivation {
+    name = "${pname}-deps-${version}";
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      ${coursier}/bin/cs fetch org.foundweekends.giter8:giter8_2.13:${version} > deps
+      mkdir -p $out/share/java
+      cp $(< deps) $out/share/java/
+    '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-MrFuyktyXADZ8lh/vzpVNi12IbKjM/Q8P7X8EE4KFNo=";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    setJavaClassPath
+  ];
+  buildInputs = [ deps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    makeWrapper ${jre}/bin/java $out/bin/g8 \
+      --add-flags "-cp $CLASSPATH giter8.Giter8"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/g8 --version | grep -q "${version}"
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  passthru.tests.version = testers.testVersion {
+    package = giter8;
+    command = "g8 --version";
+  };
+
+  meta = {
+    description = "A command line tool to apply templates defined on GitHub";
+    homepage = "https://www.foundweekends.org/giter8/";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.agilesteel ];
+    changelog = "https://github.com/foundweekends/giter8/releases/tag/v${version}";
+    mainProgram = "g8";
+  };
+}

--- a/pkgs/by-name/gi/giter8/update.sh
+++ b/pkgs/by-name/gi/giter8/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq gnused nix
+
+set -euo pipefail
+
+latest_version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    https://api.github.com/repos/foundweekends/giter8/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+
+current_version=$(nix-instantiate --eval -A giter8.version | jq -r)
+
+if [[ "$current_version" == "$latest_version" ]]; then
+    echo "Already up to date, nothing to do."
+    exit 0
+fi
+
+echo "Updating giter8: $current_version -> $latest_version"
+
+package_dir="$(dirname "${BASH_SOURCE[0]}")"
+package_nix="$package_dir/package.nix"
+
+sed -i "s|version = \"$current_version\"|version = \"$latest_version\"|" "$package_nix"
+
+build_output=$(nix-build --no-out-link -A giter8 2>&1) || true
+
+if echo "$build_output" | grep -q "hash mismatch"; then
+    new_deps_hash=$(echo "$build_output" | grep "got:" | sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' | head -1)
+    if [[ -n "$new_deps_hash" ]]; then
+        sed -i "s|outputHash = \"sha256-[A-Za-z0-9+/=]*\"|outputHash = \"$new_deps_hash\"|" "$package_nix"
+    else
+        echo "Could not extract new hash from build output, build output:"
+        echo "$build_output"
+        exit 1
+    fi
+else
+    echo "Unexpected: build succeeded without hash mismatch, build output:"
+    echo "$build_output"
+    exit 1
+fi
+
+echo "Verifying build..."
+nix-build --no-out-link -A giter8


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
