### PR TITLE
libiconvReal: make default on Darwin

### DIFF
--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -2,6 +2,7 @@
   fetchurl,
   stdenv,
   lib,
+  darwin,
   updateAutotoolsGnuConfigScriptsHook,
   enableStatic ? stdenv.hostPlatform.isStatic,
   enableShared ? !stdenv.hostPlatform.isStatic,
@@ -10,7 +11,12 @@
 
 # assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross
 
-stdenv.mkDerivation rec {
+let
+  # libiconv is propagated by the SDK in the stdenv. Avoid an infinite recursion by using a stdenv
+  # with an SDK that does not try to propagate it.
+  stdenv' = if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
+in
+stdenv'.mkDerivation rec {
   pname = "libiconv";
   version = "1.19";
 
@@ -124,6 +130,6 @@ stdenv.mkDerivation rec {
     mainProgram = "iconv";
 
     # This library is not needed on GNU platforms.
-    hydraPlatforms = with lib.platforms; cygwin ++ darwin ++ freebsd;
+    hydraPlatforms = lib.platforms.cygwin ++ lib.platforms.darwin ++ lib.platforms.freebsd;
   };
 }

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -5,7 +5,7 @@
   updateAutotoolsGnuConfigScriptsHook,
   enableStatic ? stdenv.hostPlatform.isStatic,
   enableShared ? !stdenv.hostPlatform.isStatic,
-  enableDarwinABICompat ? false,
+  enableDarwinABICompat ? stdenv.hostPlatform.isDarwin,
 }:
 
 # assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -28,9 +28,13 @@ stdenv.mkDerivation rec {
   # https://github.com/NixOS/nixpkgs/pull/192630#discussion_r978985593
   hardeningDisable = lib.optional (stdenv.hostPlatform.libc == "bionic") "fortify";
 
-  setupHooks = [
-    ../../../build-support/setup-hooks/role.bash
-    ./setup-hook.sh
+  setupHooks =
+    # Match the default behavior on Darwin, which does not automatically link libiconv.
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      ../../../build-support/setup-hooks/role.bash
+      ./setup-hook.sh
+    ];
+
   patches = [
     # Add support for the UTF-8-MAC encoding. This is needed for correct behavior of applications that interact with
     # the filesystem on Darwin because it uses a variant of NFD to store filenames.

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -31,7 +31,17 @@ stdenv.mkDerivation rec {
   setupHooks = [
     ../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh
+  patches = [
+    # Add support for the UTF-8-MAC encoding. This is needed for correct behavior of applications that interact with
+    # the filesystem on Darwin because it uses a variant of NFD to store filenames.
+    (fetchurl {
+      url = "https://raw.githubusercontent.com/macports/macports-ports/ce1083dbec406fcea0f2678308ae85639798aa6e/textproc/libiconv/files/patch-utf8mac.diff";
+      hash = "sha256-aqoTDIunKnWLHPizdWbU6eCDZXaj2s+GJwtg6Spzfio=";
+    })
   ];
+
+  # The patch for UTF-8-MAC requires -p0. It can’t use `fetchpatch2` because that results in an infinite recursion.
+  patchFlags = [ "-p0" ];
 
   postPatch =
     lib.optionalString
@@ -81,6 +91,12 @@ stdenv.mkDerivation rec {
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114870.
   # remove after gnulib is updated
   ++ lib.optional stdenv.hostPlatform.isCygwin "gl_cv_clean_version_stddef=yes";
+
+  preBuild = ''
+    # The UTF-8-MAC patch requires regenerating `flags.h`
+    make -C lib genflags
+    lib/genflags > lib/flags.h
+  '';
 
   passthru = { inherit setupHooks; };
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -277,6 +277,7 @@ let
   sdkPackages = prevStage: {
     inherit (prevStage)
       bashNonInteractive
+      libiconvReal
       libpng
       libxml2
       libxo
@@ -291,7 +292,6 @@ let
       Csu
       adv_cmds
       copyfile
-      libiconv
       libresolv
       libsbuf
       libutil
@@ -556,9 +556,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
         # Use this stage’s CF to build CMake. It’s required but can’t be included in the stdenv.
         cmake = self.cmakeMinimal;
-
-        # Use libiconvReal with gettext to break an infinite recursion.
-        gettext = super.gettext.override { libiconv = super.libiconvReal; };
 
         # Disable grep’s tests for now due to impure locale updates in
         # macOS 15.4 breaking them in the bootstrap.
@@ -1050,6 +1047,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               ld64.lib
               ld64.out
               libffi.out
+              libiconv.out
               libxml2.out
               ncurses.dev
               ncurses.man
@@ -1076,7 +1074,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             binutils
             binutils.bintools
             libcxx
-            libiconv.out
             libresolv.out
             libsbuf.out
             libSystem
@@ -1192,8 +1189,8 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
     assert isFromNixpkgs prevStage.binutils-unwrapped.src;
     assert isBuiltByNixpkgsCompiler prevStage.curl;
 
-    # libiconv should be an alias for darwin.libiconv
-    assert prevStage.libiconv == prevStage.darwin.libiconv;
+    # libiconv should be an alias for libiconvReal
+    assert prevStage.libiconv == prevStage.libiconvReal;
 
     {
       inherit (prevStage) config overlays stdenv;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6674,8 +6674,6 @@ with pkgs;
       ]
     then
       libcIconv pkgs.libc
-    else if stdenv.hostPlatform.isDarwin then
-      darwin.libiconv
     else
       libiconvReal;
 


### PR DESCRIPTION
The Darwin libiconv tries to be compatible with GNU libiconv, but it’s not. Recent versions of Autoconf and gnulib include checks for issues in Darwin’s libiconv implementation, which has effectively turned `autoreconfHook` into `autoBreakDarwinHook` due to failing to link libiconv. Instead of continuing to work around it, make GNU libiconv the default. With the UTF-8-MAC patch, it should be a drop-in replacement.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
