### PR TITLE
postgresqlPackages.apache_datasketches: fix build with gcc15; update

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -1,6 +1,7 @@
 {
   boost186,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   postgresql,
   postgresqlBuildExtension,
@@ -41,10 +42,18 @@ postgresqlBuildExtension (finalAttrs: {
   # fails to build with boost 1.87
   buildInputs = [ boost186 ];
 
-  patchPhase = ''
-    runHook prePatch
-    cp -r ../${cpp_src.name} .
-    runHook postPatch
+  patches = [
+    # https://github.com/apache/datasketches-cpp/pull/500
+    (fetchpatch {
+      url = "https://github.com/apache/datasketches-cpp/commit/639134f6e88483bd1bfca451cf09d243ade9bdd4.patch";
+      hash = "sha256-6SYKy3NycYABnUCuLUXQz+mTx4VaeWMlHnJ6aM+sNt4=";
+      stripLen = 1;
+      extraPrefix = "datasketches-cpp/";
+    })
+  ];
+
+  prePatch = ''
+    cp --no-preserve=mode -r ../${cpp_src.name} .
   '';
 
   enableUpdateScript = false;

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -23,8 +23,8 @@ let
     name = "datasketches-cpp";
     owner = "apache";
     repo = "datasketches-cpp";
-    tag = "5.0.2";
-    hash = "sha256-yGk1OckYipAgLTQK6w6p6EdHMxBIQSjPV/MMND3cDks=";
+    tag = "5.2.0";
+    hash = "sha256-h4+cln01jqLV0EpIqScpCyw8jxZgoVtdfBEjdvyUuVk=";
   };
 in
 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324281471
- https://hydra.nixos.org/build/324281603
- https://hydra.nixos.org/build/324281745
- https://hydra.nixos.org/build/324281877
- https://hydra.nixos.org/build/324282011

Updated the internal `datasketches-cpp` library to latest version. Used an upstream patch to fix the compilation error.
```
In file included from src/frequent_strings_sketch_c_adapter.cpp:26:
In file included from datasketches-cpp/fi/include/frequent_items_sketch.hpp:29:
datasketches-cpp/fi/include/reverse_purge_hash_map.hpp:38:16: error: unknown type name 'uint64_t'
   38 |   typename V = uint64_t,
      |                ^
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
