### PR TITLE
easylpac: init at 0.8.0.2

### DIFF
--- a/pkgs/by-name/ea/easylpac/package.nix
+++ b/pkgs/by-name/ea/easylpac/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook3,
+  makeDesktopItem,
+  copyDesktopItems,
+  gtk3,
+  libglvnd,
+  libxxf86vm,
+  libxrandr,
+  libxi,
+  libxinerama,
+  libxcursor,
+  libx11,
+  libxext,
+  lpac,
+}:
+
+buildGoModule rec {
+  pname = "easylpac";
+  version = "0.8.0.2";
+
+  src = fetchFromGitHub {
+    owner = "creamlike1024";
+    repo = "EasyLPAC";
+    tag = version;
+    hash = "sha256-GxcaMyEaPIGf+/wzmmycmFssTkP5Praj4GCYbxbJU28=";
+  };
+
+  vendorHash = "sha256-52I8hlnoHPhygwr0dxDP50X2A7Gsh0v/0SGQFH3FG/8=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    libglvnd
+    libxxf86vm
+    libx11
+    libxrandr
+    libxinerama
+    libxcursor
+    libxi
+    libxext
+  ];
+
+  postInstall = ''
+    install -Dm644 assets/icon64.png "$out/share/icons/hicolor/64x64/apps/EasyLPAC.png"
+    install -Dm644 assets/icon128.png "$out/share/icons/hicolor/128x128/apps/EasyLPAC.png"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ lpac ]}
+    )
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "EasyLPAC";
+      exec = "EasyLPAC";
+      icon = "EasyLPAC";
+      desktopName = "EasyLPAC";
+      comment = "GUI frontend for lpac, a C-based eUICC LPA";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "GUI frontend for lpac, a C-based eUICC LPA";
+    homepage = "https://github.com/creamlike1024/EasyLPAC";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stargate01 ];
+    mainProgram = "EasyLPAC";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds the EasyLPAC (https://github.com/creamlike1024/EasyLPAC) application, a GUI for the already packaged `lpac` tool, to manage profiles in a connected eSIM card.

Successfully tested on a Thinkpad Yoga X1 Gen 8 with a 9esim.com eUICC SIM card, via 
- Internal Mediatek T700 5G Modem using the MBIM protocol
- ACS ACR40U ICC USB Reader with GMMC SIM-2-Smart Card Adapter using the PC/SC protocol

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
