### PR TITLE
prometheus-rtorrent-exporter: init at 1.7.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -117,6 +117,7 @@ let
         "redis"
         "restic"
         "rtl_433"
+        "rtorrent"
         "sabnzbd"
         "scaphandre"
         "script"

--- a/nixos/modules/services/monitoring/prometheus/exporters/rtorrent.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rtorrent.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.rtorrent;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    optionalString
+    ;
+in
+{
+  port = 9135;
+  extraOpts = {
+    rtorrentAddr = mkOption {
+      type = types.str;
+      example = "http://localhost:8080";
+      description = ''
+        HTTP(S) URL of the rTorrent XML-RPC endpoint.
+        rTorrent exposes SCGI natively, so this should point to a
+        reverse proxy (e.g. nginx) that translates HTTP to SCGI.
+      '';
+    };
+    trackersEnabled = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable tracker information collection.
+      '';
+    };
+    insecure = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to skip TLS certificate verification when connecting to rTorrent.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-rtorrent-exporter}/bin/rtorrent-exporter \
+          --rtorrent.addr ${cfg.rtorrentAddr} \
+          --telemetry.addr ${cfg.listenAddress}:${toString cfg.port} \
+          ${optionalString cfg.trackersEnabled "--rtorrent.trackers.enabled"} \
+          ${optionalString cfg.insecure "--rtorrent.insecure"} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-rtorrent-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-rtorrent-exporter/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+}:
+
+buildGoModule rec {
+  __structuredAttrs = true;
+
+  pname = "prometheus-rtorrent-exporter";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "aauren";
+    repo = "rtorrent-exporter";
+    rev = "v${version}";
+    hash = "sha256-hlqlRTZGJ3kg4kvgmORGrhvQrUh4kFXl372LsqisE0U=";
+  };
+
+  vendorHash = "sha256-rIXqoGPgaP65yf8r4+n73+Ie0b5uiWCr/fo6YCZ1rGY=";
+
+  ldflags = [
+    "-X github.com/aauren/rtorrent-exporter/cmd.Version=v${version}"
+    "-X github.com/aauren/rtorrent-exporter/cmd.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  passthru.tests = {
+    inherit (nixosTests.prometheus-exporters) rtorrent;
+  };
+
+  meta = {
+    description = "Prometheus exporter for rTorrent";
+    homepage = "https://github.com/aauren/rtorrent-exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ananthb ];
+    mainProgram = "rtorrent-exporter";
+  };
+}


### PR DESCRIPTION
## Summary

- Add `prometheus-rtorrent-exporter` package (v1.7.0) — a Prometheus exporter for rTorrent
- Add NixOS module at `services.prometheus.exporters.rtorrent` with options for the rTorrent XML-RPC address, tracker collection, and TLS verification
- Register the exporter in the prometheus exporters list

## Description

[rtorrent-exporter](https://github.com/aauren/rtorrent-exporter) is a Go-based Prometheus exporter that collects metrics from rTorrent via its XML-RPC interface (exposed through a reverse proxy like nginx that translates HTTP to SCGI).

### Usage example

```nix
services.prometheus.exporters.rtorrent = {
  enable = true;
  rtorrentAddr = "http://localhost:8080";
};
```

## Things done

- [x] Built package successfully with `nix-build -A prometheus-rtorrent-exporter`
- [x] Verified NixOS module evaluates correctly
- [x] Added maintainer (`ananthb`)
- [ ] NixOS test for the exporter