### PR TITLE
lua51Packages.libluv: cross-test with lua51Packages.luv

### DIFF
--- a/pkgs/development/lua-modules/luv/default.nix
+++ b/pkgs/development/lua-modules/luv/default.nix
@@ -68,18 +68,23 @@ buildLuarocksPackage rec {
   disabled = luaOlder "5.1";
 
   passthru = {
-    tests.test =
-      runCommand "luv-${version}-test"
-        {
-          nativeBuildInputs = [ (lua.withPackages (ps: [ ps.luv ])) ];
-        }
-        ''
-          lua <<EOF
-          local uv = require("luv")
-          assert(uv.fs_mkdir(assert(uv.os_getenv("out")), 493))
-          print(uv.version_string())
-          EOF
-        '';
+    tests = {
+      test =
+        runCommand "luv-${version}-test"
+          {
+            nativeBuildInputs = [ (lua.withPackages (ps: [ ps.luv ])) ];
+          }
+          ''
+            lua <<EOF
+            local uv = require("luv")
+            assert(uv.fs_mkdir(assert(uv.os_getenv("out")), 493))
+            print(uv.version_string())
+            EOF
+          '';
+
+      # Test libluv too
+      inherit (lua.pkgs) libluv;
+    };
 
     updateScript = nix-update-script { };
   };

--- a/pkgs/development/lua-modules/luv/lib.nix
+++ b/pkgs/development/lua-modules/luv/lib.nix
@@ -34,4 +34,9 @@ stdenv.mkDerivation {
     cmake
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
+
+  passthru.tests = {
+    # Test luv too
+    luv = lua.pkgs.luv.passthru.tests.test;
+  };
 }


### PR DESCRIPTION
Update bot creates PRs for `lua51Packages.libluv` even though the main
package is luv. This PR adds luv to libluv's tests to ensure that
both are tested during automatic updates.
See: https://github.com/NixOS/nixpkgs/pull/510964#issuecomment-4273110779

Base branch is set to `staging-next` because for the tests to pass #510964 is required.
When `staging-next` is merged to `staging` in a couple of hours I can change to `staging` if needed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[contributing.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/readme.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[pkgs/readme.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
