### PR TITLE
whisperfish: init at 0-unstable-2027-07-17

### DIFF
--- a/pkgs/by-name/wh/whisperfish/fix-darwin-build.patch
+++ b/pkgs/by-name/wh/whisperfish/fix-darwin-build.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ff134c53877d5aa2e00e3c344eb5c6783cccb2f..164553d34152639c6a2c5319c2a03d7a25c33ba3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -974,16 +974,11 @@ endif()
+ 
+ # potential workaround for macdeployqt issues
+ if(APPLE)
++    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
+     install(TARGETS nheko
+         BUNDLE  DESTINATION .
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     )
+-    qt_generate_deploy_qml_app_script(
+-        TARGET nheko
+-        OUTPUT_SCRIPT deploy_script
+-        NO_UNSUPPORTED_PLATFORM_ERROR
+-    )
+-    install(SCRIPT ${deploy_script})
+ endif()
+ 
+ if(UNIX AND NOT APPLE)

--- a/pkgs/by-name/wh/whisperfish/package.nix
+++ b/pkgs/by-name/wh/whisperfish/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  asciidoc,
+  pkg-config,
+  cmark,
+  coeurl,
+  curl,
+  kdsingleapplication,
+  libevent,
+  libsecret,
+  lmdb,
+  lmdbxx,
+  mtxclient,
+  nlohmann_json,
+  re2,
+  spdlog,
+  gst_all_1,
+  libnice,
+  qt5,
+  withVoipSupport ? stdenv.hostPlatform.isLinux,
+  rustPlatform,
+  protobuf,
+  buildPackages,
+  sqlcipher
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "whisperfish";
+  version = "0-unstable-2026-04-18";
+
+  src = fetchFromGitLab {
+    owner = "whisperfish";
+    repo = "whisperfish";
+    rev = "beba6a88e2ec7db1cfca4845365c478430e64e50";
+    hash = "sha256-RWhTqT4uFNQddFWMpUjiBKwH9MA7mSyz9bTwUy5MkV8=";
+  };
+
+  cargoHash = "sha256-/wYMSxjry2f6UqBqfKKufFuaCV6/fxLrUigHYUEVXs0=";
+
+  env.CXXFLAGS = "-std=c++17";
+
+  preBuild = ''
+    export PROTOC=${buildPackages.protobuf}/bin/protoc
+  '';
+
+  nativeBuildInputs = [
+    asciidoc
+    cmake
+    lmdbxx
+    pkg-config
+    qt5.wrapQtAppsHook
+
+    protobuf
+  ];
+
+  buildInputs = [
+    cmark
+    coeurl
+    curl
+    kdsingleapplication
+    libevent
+    libsecret
+    lmdb
+    mtxclient
+    nlohmann_json
+    qt5.qtbase
+    qt5.qtdeclarative
+    qt5.qtimageformats
+    # qt5.qtkeychain
+    qt5.qtmultimedia
+    qt5.qtsvg
+    qt5.qttools
+    # qt5.qt-jdenticon
+    re2
+    spdlog
+
+    protobuf
+    sqlcipher
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    qt5.qtwayland
+  ]
+  ++ lib.optionals withVoipSupport [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    (gst_all_1.gst-plugins-good.override { qt5Support = true; })
+    gst_all_1.gst-plugins-bad
+    libnice
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "VOIP" withVoipSupport)
+  ];
+
+  preFixup = ''
+    # unset QT_STYLE_OVERRIDE to avoid showing a blank window when started
+    # https://github.com/NixOS/nixpkgs/issues/333009
+    qtWrapperArgs+=(--unset QT_STYLE_OVERRIDE)
+  ''
+  + lib.optionalString withVoipSupport ''
+    # add gstreamer plugins path to the wrapper
+    qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")
+  '';
+
+  meta = {
+    description = "Signal client originally for SailfishOS";
+    homepage = "https://gitlab.com/whisperfish/whisperfish";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.onny ];
+    platforms = lib.platforms.all;
+    mainProgram = "whisperfish";
+  };
+})

--- a/pkgs/by-name/wh/whisperfish/package.nix
+++ b/pkgs/by-name/wh/whisperfish/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  pkg-config,
+  qt5,
+  rustPlatform,
+  protobuf,
+  buildPackages,
+  sqlcipher,
+  cmake,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "whisperfish";
+  version = "0-unstable-2026-07-16";
+
+  src = fetchFromGitLab {
+    owner = "whisperfish";
+    repo = "whisperfish";
+    rev = "99b5228701a0ad1f4140ca618af4b12bc7318be3";
+    hash = "sha256-VDiFFGRL2bYWeSL2jjr/lukWchqwnvYbN19KYyZs2mE=";
+  };
+
+  cargoHash = "sha256-esKiJomSgpzrZLuOcWi4/eg9/o5+2HtFTmQObQoYn3Q=";
+
+  env.QMAKE = "${qt5.qtbase.dev}/bin/qmake";
+
+  preBuild = ''
+    export PROTOC=${buildPackages.protobuf}/bin/protoc
+  '';
+
+  cargoBuildFlags = [ "--workspace" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    qt5.qtbase
+    qt5.wrapQtAppsHook
+    protobuf
+    cmake
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qtdeclarative
+    qt5.qtimageformats
+    qt5.qtmultimedia
+    qt5.qtsvg
+    qt5.qttools
+    protobuf
+    sqlcipher
+    qt5.qtwayland
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(--unset QT_STYLE_OVERRIDE)
+  '';
+
+  meta = {
+    description = "Signal client originally for Sailfish OS";
+    homepage = "https://gitlab.com/whisperfish/whisperfish";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.onny ];
+    platforms = lib.platforms.all;
+    mainProgram = "harbour-whisperfish";
+  };
+})


### PR DESCRIPTION
Packaging [Whisperfish](https://gitlab.com/whisperfish/whisperfish), a QT Signal client for Sailfish OS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
