### PR TITLE
radioboat: 0.3.0 -> 0.6.0

### DIFF
--- a/pkgs/by-name/ra/radioboat/package.nix
+++ b/pkgs/by-name/ra/radioboat/package.nix
@@ -2,38 +2,40 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  buildGoModule,
-  mpv,
-  makeWrapper,
   installShellFiles,
+  makeWrapper,
+  mpv,
   nix-update-script,
-  testers,
-  radioboat,
+  rustPlatform,
+  versionCheckHook,
 }:
 
-buildGoModule (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radioboat";
-  version = "0.3.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "slashformotion";
     repo = "radioboat";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-4k+WK2Cxu1yBWgvEW9LMD2RGfiY7XDAe0qqph82zvlI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mPktliuWyrXuNzMCdMFZk5Q7lIkRk+y4nX3IBnCc5Mc=";
   };
 
-  vendorHash = "sha256-H2vo5gngXUcrem25tqz/1MhOgpNZcN+IcaQHZrGyjW8=";
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail 'version = "0.4.0"' 'version = "${finalAttrs.version}"'
+  '';
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/slashformotion/radioboat/internal/buildinfo.Version=${finalAttrs.version}"
-  ];
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-fRF1FvwtvVJSTCK8DcZib6wMLpo73YtV7j+kjt4nVTo=";
 
   nativeBuildInputs = [
     makeWrapper
     installShellFiles
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   preFixup = ''
     wrapProgram $out/bin/radioboat --prefix PATH ":" "${lib.makeBinPath [ mpv ]}";
@@ -46,20 +48,17 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/radioboat completion zsh)
   '';
 
-  passthru = {
-    updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = radioboat;
-      command = "radioboat version";
-    };
-  };
+  passthru.updateScript = nix-update-script { };
+
+  doInstallCheck = true;
 
   meta = {
     description = "Terminal web radio client";
-    mainProgram = "radioboat";
     homepage = "https://github.com/slashformotion/radioboat";
+    changelog = "https://github.com/slashformotion/radioboat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ zendo ];
+    mainProgram = "radioboat";
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ra/radioboat/package.nix
+++ b/pkgs/by-name/ra/radioboat/package.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radioboat";
-  version = "0.5.0";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "slashformotion";
     repo = "radioboat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mPktliuWyrXuNzMCdMFZk5Q7lIkRk+y4nX3IBnCc5Mc=";
+    hash = "sha256-1fTXXT0HxGOoy+oNK1ixzgFgjapreQEOoVlQlJwqbrA=";
   };
 
   postPatch = ''
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
-  cargoHash = "sha256-fRF1FvwtvVJSTCK8DcZib6wMLpo73YtV7j+kjt4nVTo=";
+  cargoHash = "sha256-ibDOUgprr5VziIvTpvDFISGVpVH5ZyQ1ZZ5tIQirPP8=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Changelog: https://github.com/slashformotion/radioboat/releases/tag/v0.5.0

Closes #510396
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
