### PR TITLE
lute: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2857,6 +2857,12 @@
     name = "Fabian Möller";
     keys = [ { fingerprint = "6309 E212 29D4 DA30 AF24  BDED 754B 5C09 63C4 2C50"; } ];
   };
+  b5e596 = {
+    email = "bok-easiest-sequel@duck.com";
+    name = "b5e596";
+    github = "b5e596";
+    githubId = 275270624;
+  };
   babbaj = {
     name = "babbaj";
     email = "babbaj45@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2893,6 +2893,12 @@
     name = "Fabian Möller";
     keys = [ { fingerprint = "6309 E212 29D4 DA30 AF24  BDED 754B 5C09 63C4 2C50"; } ];
   };
+  b5e596 = {
+    email = "bok-easiest-sequel@duck.com";
+    name = "b5e596";
+    github = "b5e596";
+    githubId = 275270624;
+  };
   baba = {
     name = "Baba";
     email = "babakinha@proton.me";

--- a/pkgs/by-name/lu/lute/deps.nix
+++ b/pkgs/by-name/lu/lute/deps.nix
@@ -1,0 +1,30 @@
+{ linkFarm, fetchFromGitHub }:
+linkFarm "lute-deps" [
+  {
+    name = "luau";
+    path = fetchFromGitHub {
+      owner = "luau-lang";
+      repo = "luau";
+      rev = "4ca11dbc3b31ddf27ee8ec1ab6c036676de9f240";
+      hash = "sha256-nfXJ16zkw9snA6dByPbP+OntPC4qXq5DK9ZnN5pvV98=";
+    };
+  }
+  {
+    name = "uSockets";
+    path = fetchFromGitHub {
+      owner = "uNetworking";
+      repo = "uSockets";
+      rev = "833497e8e0988f7fd8d33cd4f6f36056c68d225d";
+      hash = "sha256-ZlyY2X0aDdjfV0zjcecOLaozwp1crDibx6GBbUnDyAk=";
+    };
+  }
+  {
+    name = "uWebSockets";
+    path = fetchFromGitHub {
+      owner = "uNetworking";
+      repo = "uWebSockets";
+      rev = "c445faa38125bf782eed3fec97f83b4733c7fb91";
+      hash = "sha256-BEArW6TILz1Z39rjkge1PTz3defKwgITO6nBpyS13b8=";
+    };
+  }
+]

--- a/pkgs/by-name/lu/lute/dont-build-dependencies.patch
+++ b/pkgs/by-name/lu/lute/dont-build-dependencies.patch
@@ -1,0 +1,82 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 87a24860..83023c26 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,67 +31,6 @@ set(LUAU_BUILD_TESTS OFF)
+ 
+ add_subdirectory(extern/luau)
+ 
+-# libuv setup
+-set(LIBUV_BUILD_SHARED OFF)
+-set(BUILD_SHARED_LIBS OFF) # why does an option for LIBUV_BUILD_SHARED exist separately
+-set(LIBUV_BUILD_TESTS OFF)
+-set(LIBUV_BUILD_BENCH OFF)
+-add_subdirectory(extern/libuv)
+-
+-# Define libuv include directory here, before it's needed by other subdirectories
+-set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
+-
+-# zlib setup
+-#
+-set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
+-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
+-add_subdirectory(extern/zlib)
+-
+-set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
+-
+-set(ZLIB_FOUND TRUE CACHE BOOL "" FORCE)
+-
+-if(MSVC)
+-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib")
+-    else()
+-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib")
+-    endif()
+-else()
+-    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a")
+-endif()
+-set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR})
+-set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
+-
+-# boringssl setup
+-add_subdirectory(extern/boringssl)
+-set(BORINGSSL_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/boringssl")
+-set(BORINGSSL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/boringssl/include)
+-
+-# Suppress frame-size warnings in boringssl when sanitizers are enabled
+-if (LUTE_ENABLE_SANITIZERS AND NOT MSVC)
+-    target_compile_options(crypto PRIVATE -Wno-frame-larger-than)
+-endif()
+-
+-# curl setup
+-
+-set(USE_LIBIDN2 OFF)
+-set(USE_NGHTTP2 OFF)
+-set(CURL_USE_LIBPSL OFF)
+-set(CURL_USE_LIBSSH2 OFF)
+-set(CURL_ZLIB ON)
+-SET(CURL_ZSTD OFF CACHE STRING "Disable ZSTD" FORCE)
+-set(CURL_BROTLI OFF CACHE STRING "Disable brotli support" FORCE)
+-set(CURL_ENABLE_SSL ON)
+-set(CURL_USE_OPENSSL ON)
+-set(BUILD_EXAMPLES OFF)
+-set(BUILD_CURL_EXE OFF)
+-set(BUILD_SHARED_LIBS OFF)
+-set(BUILD_STATIC_LIBS ON)
+-
+-set(HAVE_BORINGSSL ON)
+-add_subdirectory(extern/curl)
+-
+ # uWebSockets setup
+ set(WITH_BORINGSSL ON)
+ set(WITH_LIBUV ON)
+@@ -105,9 +44,6 @@ include(uWebSockets)
+ # Define include directories for uWebSockets and uSockets
+ set(UWEBSOCKETS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/uWebSockets/src)
+ 
+-# libsodium for `pwhash`
+-include(libsodium)
+-
+ # Lute
+ set(LUTE_OPTIONS)
+ 

--- a/pkgs/by-name/lu/lute/package.nix
+++ b/pkgs/by-name/lu/lute/package.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  gitMinimal,
+  openssl,
+  curlFull,
+  libuv,
+  libsodium,
+  zlib,
+  writableTmpDirAsHomeHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lute";
+  version = "1.0.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "luau-lang";
+    repo = "lute";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g52fa/dQ4/Fk+NwbckrPtSkEjjql/+EU3tHsiV4jH40=";
+  };
+
+  env = {
+    # to get ninja to print logs without being verbose
+    TERM = "dumb";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+
+    # Luthier invokes git to get git's version
+    gitMinimal
+  ];
+
+  buildInputs = [
+    curlFull # for websocket support
+    openssl
+    libuv
+    libsodium
+    zlib
+  ];
+
+  patches = [
+    ./dont-build-dependencies.patch
+    ./rename-link-libraries.patch
+    ./rename-crypto-symbols.patch
+  ];
+
+  deps = callPackage ./deps.nix { };
+
+  preConfigure = ''
+    rm -rf extern
+    cp -r $deps extern
+
+    # Below copied from tools/bootstrap.sh from upstream Lute
+
+    # place empty versions of the standard library
+    mkdir -p lute/std/src/generated
+    cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
+    cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
+
+    # place empty versions of the luau-based lute subcommands for the cli
+    mkdir -p lute/cli/generated
+    cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
+    cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
+
+    # place empty versions of the batteries library
+    mkdir -p lute/batteries/generated
+    cp ./tools/templates/batteries_impl.cpp ./lute/batteries/generated/batteries.cpp
+    cp ./tools/templates/batteries_header.h ./lute/batteries/generated/batteries.h
+
+    # place empty versions of the lute definitions
+    mkdir -p lute/definitions/src/generated
+    cp ./tools/templates/definitions_impl.cpp ./lute/definitions/src/generated/modules.cpp
+    cp ./tools/templates/definitions_header.h ./lute/definitions/src/generated/modules.h
+  '';
+
+  cmakeFlags = [
+    "-GNinja"
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # bootstrap lute0
+    ninja lute/cli/lute
+
+    # generate Luau code
+    pushd ..
+    build/lute/cli/lute tools/luthier.luau generate
+    popd
+
+    # build final lute
+    ninja lute/cli/lute
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  checkPhase = ''
+    runHook preCheck
+
+    ninja tests/lute-tests
+
+    # the doctests and Standard Library tests have to be run from lute source root
+    pushd ..
+    build/tests/lute-tests
+    build/lute/cli/lute test
+    popd
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    install -Dm555 -t $out/bin lute/cli/lute
+
+    mkdir -p $out/share
+    cp -r ../batteries $out/share
+  '';
+
+  meta = {
+    description = "Standalone Luau runtime for general-purpose programming";
+    homepage = "https://lute.luau.org";
+    changelog = "https://github.com/luau-lang/lute/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ b5e596 ];
+    mainProgram = "lute";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/lu/lute/package.nix
+++ b/pkgs/by-name/lu/lute/package.nix
@@ -127,6 +127,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r ../batteries $out/share
   '';
 
+  passthru.updateScript = ./update.nu;
+
   meta = {
     description = "Standalone Luau runtime for general-purpose programming";
     homepage = "https://lute.luau.org";

--- a/pkgs/by-name/lu/lute/rename-crypto-symbols.patch
+++ b/pkgs/by-name/lu/lute/rename-crypto-symbols.patch
@@ -1,0 +1,52 @@
+diff --git a/lute/crypto/src/crypto.cpp b/lute/crypto/src/crypto.cpp
+index c82114f1..6de72822 100644
+--- a/lute/crypto/src/crypto.cpp
++++ b/lute/crypto/src/crypto.cpp
+@@ -4,7 +4,7 @@
+ #include "lua.h"
+ #include "lualib.h"
+ 
+-#include "openssl/digest.h"
++#include "openssl/evp.h"
+ #include "sodium/crypto_pwhash.h"
+ #include "sodium/crypto_secretbox.h"
+ #include "sodium/randombytes.h"
+@@ -34,7 +34,7 @@ static const char kVerifyPasswordHashName[] = "verify";
+ struct HashFunction
+ {
+     std::string name;
+-    const env_md_st* md;
++    const evp_md_st* md;
+ };
+ 
+ static const HashFunction hashFunctions[] = {
+@@ -42,7 +42,7 @@ static const HashFunction hashFunctions[] = {
+     {"sha1", EVP_sha1()},
+     {"sha256", EVP_sha256()},
+     {"sha512", EVP_sha512()},
+-    {"blake2b256", EVP_blake2b256()},
++    {"blake2b256", EVP_blake2s256()},
+ };
+ 
+ int makeHashFunctionMap(lua_State* L)
+@@ -58,9 +58,9 @@ int makeHashFunctionMap(lua_State* L)
+     return 1;
+ }
+ 
+-const env_md_st* getHashFunction(lua_State* L, int idx)
++const evp_md_st* getHashFunction(lua_State* L, int idx)
+ {
+-    if (auto typ = static_cast<const env_md_st*>(lua_tolightuserdatatagged(L, idx, kHashFunctionTag)))
++    if (auto typ = static_cast<const evp_md_st*>(lua_tolightuserdatatagged(L, idx, kHashFunctionTag)))
+         return typ;
+ 
+     luaL_typeerrorL(L, idx, "hash function");
+@@ -104,7 +104,7 @@ int lua_digest(lua_State* L)
+     if (argumentCount != 2)
+         luaL_error(L, "%s: expected 2 arguments, but got %d", kDigestName, argumentCount);
+ 
+-    const env_md_st* hashFunction = getHashFunction(L, 1);
++    const evp_md_st* hashFunction = getHashFunction(L, 1);
+     BinaryData message = extractData(L, 2);
+ 
+     uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, EVP_MD_size(hashFunction)));

--- a/pkgs/by-name/lu/lute/rename-link-libraries.patch
+++ b/pkgs/by-name/lu/lute/rename-link-libraries.patch
@@ -1,0 +1,171 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 83023c26..09cc0199 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,7 +37,7 @@ set(WITH_LIBUV ON)
+ set(WITH_ZLIB ON)
+ 
+ # Set the correct libuv library name for uWebSockets
+-set(LIBUV_LIBRARY uv_a)
++set(LIBUV_LIBRARY uv)
+ include(uSockets)
+ include(uWebSockets)
+ 
+diff --git a/lute/batteries/CMakeLists.txt b/lute/batteries/CMakeLists.txt
+index 83d7e046..83f6f04d 100644
+--- a/lute/batteries/CMakeLists.txt
++++ b/lute/batteries/CMakeLists.txt
+@@ -10,7 +10,7 @@ target_sources(Lute.Batteries PRIVATE
+ 
+ target_compile_features(Lute.Batteries PUBLIC cxx_std_17)
+ target_include_directories(Lute.Batteries PUBLIC include generated)
+-target_link_libraries(Lute.Batteries PRIVATE uv_a)
++target_link_libraries(Lute.Batteries PRIVATE uv)
+ target_compile_options(Lute.Batteries PRIVATE ${LUTE_OPTIONS})
+ 
+ set(BATTERIES_GENERATED_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+diff --git a/lute/cli/CMakeLists.txt b/lute/cli/CMakeLists.txt
+index 14a71c43..d6e55fcc 100644
+--- a/lute/cli/CMakeLists.txt
++++ b/lute/cli/CMakeLists.txt
+@@ -48,7 +48,7 @@ target_sources(Lute.CLI.lib PRIVATE
+ 
+ target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
+ target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
+-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Common Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Luau Lute.Process Lute.Require Lute.Runtime Luau.CLI.lib Lute.Common zlibstatic)
++target_link_libraries(Lute.CLI.lib PRIVATE Luau.Common Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Luau Lute.Process Lute.Require Lute.Runtime Luau.CLI.lib Lute.Common z)
+ target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
+ 
+ add_executable(Lute.CLI)
+diff --git a/lute/crypto/CMakeLists.txt b/lute/crypto/CMakeLists.txt
+index 8407e685..7ab82620 100644
+--- a/lute/crypto/CMakeLists.txt
++++ b/lute/crypto/CMakeLists.txt
+@@ -8,5 +8,5 @@ target_sources(Lute.Crypto PRIVATE
+ 
+ target_compile_features(Lute.Crypto PUBLIC cxx_std_17)
+ target_include_directories(Lute.Crypto PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.Crypto PRIVATE Lute.Runtime Luau.VM uv_a ssl crypto sodium)
++target_link_libraries(Lute.Crypto PRIVATE Lute.Runtime Luau.VM uv ssl crypto sodium)
+ target_compile_options(Lute.Crypto PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/fs/CMakeLists.txt b/lute/fs/CMakeLists.txt
+index 57f0b5a1..4daec2e7 100644
+--- a/lute/fs/CMakeLists.txt
++++ b/lute/fs/CMakeLists.txt
+@@ -10,5 +10,5 @@ target_sources(Lute.Fs PRIVATE
+ 
+ target_compile_features(Lute.Fs PUBLIC cxx_std_17)
+ target_include_directories(Lute.Fs PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.Fs PRIVATE Lute.Common Lute.Runtime Lute.Time Luau.VM uv_a)
++target_link_libraries(Lute.Fs PRIVATE Lute.Common Lute.Runtime Lute.Time Luau.VM uv)
+ target_compile_options(Lute.Fs PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/io/CMakeLists.txt b/lute/io/CMakeLists.txt
+index 6d3c9c9f..e621a4d9 100644
+--- a/lute/io/CMakeLists.txt
++++ b/lute/io/CMakeLists.txt
+@@ -8,5 +8,5 @@ target_sources(Lute.IO PRIVATE
+ 
+ target_compile_features(Lute.IO PUBLIC cxx_std_17)
+ target_include_directories(Lute.IO PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.IO PRIVATE Lute.Runtime Luau.VM uv_a)
++target_link_libraries(Lute.IO PRIVATE Lute.Runtime Luau.VM uv)
+ target_compile_options(Lute.IO PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/luau/CMakeLists.txt b/lute/luau/CMakeLists.txt
+index 3d69a257..afe7c3a8 100644
+--- a/lute/luau/CMakeLists.txt
++++ b/lute/luau/CMakeLists.txt
+@@ -16,5 +16,5 @@ target_sources(Lute.Luau PRIVATE
+ 
+ target_compile_features(Lute.Luau PUBLIC cxx_std_17)
+ target_include_directories(Lute.Luau PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.Luau PRIVATE Lute.Common Lute.Require Lute.Runtime uv_a Luau.Analysis Luau.Ast Luau.Compiler Luau.CLI.lib Luau.Require Luau.VM)
++target_link_libraries(Lute.Luau PRIVATE Lute.Common Lute.Require Lute.Runtime uv Luau.Analysis Luau.Ast Luau.Compiler Luau.CLI.lib Luau.Require Luau.VM)
+ target_compile_options(Lute.Luau PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/net/CMakeLists.txt b/lute/net/CMakeLists.txt
+index a6037e5e..6fef2afd 100644
+--- a/lute/net/CMakeLists.txt
++++ b/lute/net/CMakeLists.txt
+@@ -11,5 +11,5 @@ target_sources(Lute.Net PRIVATE
+ 
+ target_compile_features(Lute.Net PUBLIC cxx_std_17)
+ target_include_directories(Lute.Net PUBLIC "include" ${LIBUV_INCLUDE_DIR} ${UWEBSOCKETS_INCLUDE_DIR})
+-target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a libcurl uWS zlibstatic)
++target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM uv curl uWS z)
+ target_compile_options(Lute.Net PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/process/CMakeLists.txt b/lute/process/CMakeLists.txt
+index 2dd1391a..5efa6ea3 100644
+--- a/lute/process/CMakeLists.txt
++++ b/lute/process/CMakeLists.txt
+@@ -8,5 +8,5 @@ target_sources(Lute.Process PRIVATE
+ 
+ target_compile_features(Lute.Process PUBLIC cxx_std_17)
+ target_include_directories(Lute.Process PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.Process PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a)
++target_link_libraries(Lute.Process PRIVATE Lute.Common Lute.Runtime Luau.VM uv)
+ target_compile_options(Lute.Process PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/runtime/CMakeLists.txt b/lute/runtime/CMakeLists.txt
+index 7cdabb8d..9e4399b6 100644
+--- a/lute/runtime/CMakeLists.txt
++++ b/lute/runtime/CMakeLists.txt
+@@ -16,5 +16,5 @@ target_sources(Lute.Runtime PRIVATE
+ target_compile_features(Lute.Runtime PUBLIC cxx_std_17)
+ target_include_directories(Lute.Runtime PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+ target_link_libraries(Lute.Runtime PUBLIC Lute.Common)
+-target_link_libraries(Lute.Runtime PRIVATE Luau.Require Luau.Compiler Luau.VM uv_a)
++target_link_libraries(Lute.Runtime PRIVATE Luau.Require Luau.Compiler Luau.VM uv)
+ target_compile_options(Lute.Runtime PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/std/CMakeLists.txt b/lute/std/CMakeLists.txt
+index fcbdc909..03611a7c 100644
+--- a/lute/std/CMakeLists.txt
++++ b/lute/std/CMakeLists.txt
+@@ -10,5 +10,5 @@ target_sources(Lute.Std PRIVATE
+ 
+ target_compile_features(Lute.Std PUBLIC cxx_std_17)
+ target_include_directories(Lute.Std PUBLIC "include")
+-target_link_libraries(Lute.Std PRIVATE Lute.Runtime Luau.VM uv_a)
++target_link_libraries(Lute.Std PRIVATE Lute.Runtime Luau.VM uv)
+ target_compile_options(Lute.Std PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/system/CMakeLists.txt b/lute/system/CMakeLists.txt
+index 61e62693..020f98bc 100644
+--- a/lute/system/CMakeLists.txt
++++ b/lute/system/CMakeLists.txt
+@@ -8,5 +8,5 @@ target_sources(Lute.System PRIVATE
+ 
+ target_compile_features(Lute.System PUBLIC cxx_std_17)
+ target_include_directories(Lute.System PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.System PRIVATE Lute.Runtime Luau.VM uv_a)
++target_link_libraries(Lute.System PRIVATE Lute.Runtime Luau.VM uv)
+ target_compile_options(Lute.System PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/task/CMakeLists.txt b/lute/task/CMakeLists.txt
+index 01d9daa0..2828a254 100644
+--- a/lute/task/CMakeLists.txt
++++ b/lute/task/CMakeLists.txt
+@@ -8,5 +8,5 @@ target_sources(Lute.Task PRIVATE
+ 
+ target_compile_features(Lute.Task PUBLIC cxx_std_17)
+ target_include_directories(Lute.Task PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.Task PRIVATE Lute.Runtime Lute.Common Lute.Time Luau.VM uv_a)
++target_link_libraries(Lute.Task PRIVATE Lute.Runtime Lute.Common Lute.Time Luau.VM uv)
+ target_compile_options(Lute.Task PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/time/CMakeLists.txt b/lute/time/CMakeLists.txt
+index 39a69393..874a9601 100644
+--- a/lute/time/CMakeLists.txt
++++ b/lute/time/CMakeLists.txt
+@@ -8,5 +8,5 @@ target_sources(Lute.Time PRIVATE
+ 
+ target_compile_features(Lute.Time PUBLIC cxx_std_17)
+ target_include_directories(Lute.Time PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.Time PRIVATE Lute.Runtime Luau.VM uv_a)
++target_link_libraries(Lute.Time PRIVATE Lute.Runtime Luau.VM uv)
+ target_compile_options(Lute.Time PRIVATE ${LUTE_OPTIONS})
+diff --git a/lute/vm/CMakeLists.txt b/lute/vm/CMakeLists.txt
+index 6a7d134b..c1962680 100644
+--- a/lute/vm/CMakeLists.txt
++++ b/lute/vm/CMakeLists.txt
+@@ -10,5 +10,5 @@ target_sources(Lute.VM PRIVATE
+ 
+ target_compile_features(Lute.VM PUBLIC cxx_std_17)
+ target_include_directories(Lute.VM PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+-target_link_libraries(Lute.VM PRIVATE Lute.Require Lute.Runtime Luau.VM Luau.Require uv_a)
++target_link_libraries(Lute.VM PRIVATE Lute.Require Lute.Runtime Luau.VM Luau.Require uv)
+ target_compile_options(Lute.VM PRIVATE ${LUTE_OPTIONS})

--- a/pkgs/by-name/lu/lute/update.nu
+++ b/pkgs/by-name/lu/lute/update.nu
@@ -1,0 +1,45 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p nushell semver-tool nurl nixfmt common-updater-scripts
+
+# MAINTENANCE NOTES:
+# - keep the DEPENDENCIES list in sync with the derivation
+
+let DEPENDENCIES = [
+    "uSockets.tune"
+    "uWebSockets.tune"
+    "luau.tune"
+]
+
+let latest_version = http get https://api.github.com/repos/luau-lang/lute/releases
+| where prerelease == false
+| sort-by created_at
+| last
+
+let latest_version_name = $latest_version.tag_name | str trim --char "v" --left
+let current_version_name = $env.UPDATE_NIX_OLD_VERSION
+
+if (^semver compare $current_version_name $latest_version_name) != "-1" {
+    # same or older version, exit early
+    exit 0
+}
+
+let package_dir = $env.PWD | path join "pkgs/by-name/lu/lute"
+
+# Update package.nix
+^update-source-version lute $latest_version_name
+
+# Update deps.nix
+^git clone https://github.com/luau-lang/lute --branch $"v($latest_version_name)" --depth 1
+cd lute/extern
+
+let dependencies = (ls | sort-by name) | where $it.name in $DEPENDENCIES | each {|file|
+  let tune = open $file.name | from toml | get "dependency"
+  let attr_name = $file.name | path parse | get "stem"
+
+  let output = ^nurl $tune.remote $tune.revision --fetcher fetchFromGitHub
+  $"{name = \"($attr_name)\"; path = ($output);}"
+}
+
+let deps_file = $"{linkFarm, fetchFromGitHub}: linkFarm \"lute-deps\" [($dependencies | str join)]"
+
+$deps_file | ^nixfmt | save $"($package_dir)/deps.nix" --force


### PR DESCRIPTION
Lute released 1.0.0 just a few days ago. Currently cross-compilation does not work due to the build process requiring a two-stage build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
