### PR TITLE
espeak-ng: Fix mbrola functionality due to broken path

### DIFF
--- a/pkgs/by-name/es/espeak-ng/mbrola.patch
+++ b/pkgs/by-name/es/espeak-ng/mbrola.patch
@@ -7,7 +7,7 @@ index e3e4b702..de06dd21 100644
  
  		snprintf(charbuf, sizeof(charbuf), "%g", mbr_volume);
 -		execlp("mbrola", "mbrola", "-e", "-v", charbuf,
-+		execlp("@mbrola/bin/mbrola@", "mbrola", "-e", "-v", charbuf,
++		execlp("@mbrola@/bin/mbrola", "mbrola", "-e", "-v", charbuf,
  		       voice_path, "-", "-.wav", (char *)NULL);
  		/* if execution reaches this point then the exec() failed */
  		snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),


### PR DESCRIPTION
espeak-ng's functionality that required calling out to mbrola was always broken due to `mbrola.patch` having a malformed substitution, expecting to substitute the entire path to the mbrola binary instead of just the path to the store folder.

This fixes that, as tested on aarch64-linux in a QEMU VM on MacOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
