### PR TITLE
treewide: use `desktopItems` (plural) instead of `desktopItem`

### DIFF
--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # ensure eclipse.ini does not try to use a justj jvm, as those aren't compatible with nix
     perl -i -p0e 's|-vm\nplugins/org.eclipse.justj.*/jre/bin.*\n||' $out/eclipse/eclipse.ini
-  ''; # */
+  '';
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/applications/editors/jetbrains/builder/linux.nix
+++ b/pkgs/applications/editors/jetbrains/builder/linux.nix
@@ -3,6 +3,7 @@
 {
   stdenv,
   lib,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   patchelf,
@@ -64,22 +65,11 @@ lib.extendMkDerivation {
           ''--add-flags "\''${WAYLAND_DISPLAY:+-Dawt.toolkit.name=WLToolkit}"''
         ];
 
-      desktopItem = makeDesktopItem {
-        name = finalAttrs.pname;
-        exec = finalAttrs.meta.mainProgram;
-        comment = lib.trim (lib.replaceString "\n" " " finalAttrs.meta.longDescription);
-        desktopName = product;
-        genericName = finalAttrs.meta.description;
-        categories = [ "Development" ];
-        icon = pname;
-        startupWMClass = wmClass;
-      };
-
       vmoptsIDE = if hiName == "WEBSTORM" then "WEBIDE" else hiName;
       vmoptsFile = lib.optionalString (vmopts != null) (writeText vmoptsName vmopts);
     in
     {
-      inherit desktopItem vmoptsIDE vmoptsFile;
+      inherit vmoptsIDE vmoptsFile;
 
       buildInputs = buildInputs ++ [
         stdenv.cc.cc
@@ -89,6 +79,7 @@ lib.extendMkDerivation {
       ];
 
       nativeBuildInputs = nativeBuildInputs ++ [
+        copyDesktopItems
         makeWrapper
         patchelf
         unzip
@@ -125,6 +116,19 @@ lib.extendMkDerivation {
       ''
       + postPatch;
 
+      desktopItems = [
+        (makeDesktopItem {
+          name = finalAttrs.pname;
+          exec = finalAttrs.meta.mainProgram;
+          comment = lib.trim (lib.replaceString "\n" " " finalAttrs.meta.longDescription);
+          desktopName = product;
+          genericName = finalAttrs.meta.description;
+          categories = [ "Development" ];
+          icon = pname;
+          startupWMClass = wmClass;
+        })
+      ];
+
       installPhase = ''
         runHook preInstall
 
@@ -136,7 +140,6 @@ lib.extendMkDerivation {
         cp ${fsnotifier}/bin/fsnotifier $out/$pname/bin/fsnotifier
 
         jdk=${jdk.home}
-        item=${desktopItem}
 
         needsWrapping=()
 
@@ -181,7 +184,6 @@ lib.extendMkDerivation {
         echo -e '#!/usr/bin/env bash\n'"$out/$pname/bin/remote-dev-server.sh"' "$@"' > $out/$pname/bin/remote-dev-server-wrapped.sh
         chmod +x $out/$pname/bin/remote-dev-server-wrapped.sh
         ln -s "$out/$pname/bin/remote-dev-server-wrapped.sh" $out/bin/$pname-remote-dev-server
-        ln -s "$item/share/applications" $out/share
 
         runHook postInstall
       '';

--- a/pkgs/applications/misc/michabo/default.nix
+++ b/pkgs/applications/misc/michabo/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   makeDesktopItem,
   fetchFromGitLab,
   qmake,
@@ -9,15 +10,6 @@
   qtbase,
   qtwebsockets,
 }:
-
-let
-  desktopItem = makeDesktopItem {
-    name = "Michabo";
-    desktopName = "Michabo";
-    exec = "Michabo";
-  };
-
-in
 stdenv.mkDerivation rec {
   pname = "michabo";
   version = "0.1";
@@ -31,6 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     qmake
     wrapQtAppsHook
   ];
@@ -44,9 +37,13 @@ stdenv.mkDerivation rec {
     "DESTDIR=${placeholder "out"}/bin"
   ];
 
-  postInstall = ''
-    ln -s ${desktopItem}/share $out/share
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Michabo";
+      desktopName = "Michabo";
+      exec = "Michabo";
+    })
+  ];
 
   meta = {
     description = "Native desktop app for Pleroma and Mastodon servers";

--- a/pkgs/applications/misc/xpdf/default.nix
+++ b/pkgs/applications/misc/xpdf/default.nix
@@ -6,6 +6,7 @@
   stdenv,
   fetchzip,
   cmake,
+  copyDesktopItems,
   makeDesktopItem,
   zlib,
   libpng,
@@ -40,7 +41,11 @@ stdenv.mkDerivation rec {
         'cmake_minimum_required(VERSION 2.8.12)' 'cmake_minimum_required(VERSION 3.1.0)'
   '';
 
-  nativeBuildInputs = [ cmake ] ++ lib.optional enableGUI wrapQtAppsHook;
+  nativeBuildInputs = [
+    copyDesktopItems
+    cmake
+  ]
+  ++ lib.optional enableGUI wrapQtAppsHook;
 
   cmakeFlags = [
     "-DSYSTEM_XPDFRC=/etc/xpdfrc"
@@ -57,17 +62,16 @@ stdenv.mkDerivation rec {
   ++ lib.optional enablePrinting cups
   ++ lib.optional enablePDFtoPPM freetype;
 
-  desktopItem = makeDesktopItem {
+  desktopItems = lib.optional (!stdenv.hostPlatform.isDarwin) (makeDesktopItem {
     name = "xpdf";
     desktopName = "Xpdf";
     comment = "Views Adobe PDF files";
     icon = "xpdf";
     exec = "xpdf %f";
     categories = [ "Office" ];
-  };
+  });
 
   postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    install -Dm644 ${desktopItem}/share/applications/xpdf.desktop -t $out/share/applications
     install -Dm644 $src/xpdf-qt/xpdf-icon.svg $out/share/pixmaps/xpdf.svg
   '';
 

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   makeWrapper,
   makeDesktopItem,
   fetchurl,
@@ -20,31 +21,6 @@ let
       updateScript ? null,
       ...
     }@attrs:
-    let
-      desktopItem = makeDesktopItem {
-        categories = [
-          "Network"
-          "Development"
-          "WebDevelopment"
-          "Java"
-        ];
-        desktopName = "Charles";
-        exec = "charles %F";
-        genericName = "Web Debugging Proxy";
-        icon = "charles-proxy" + lib.optionalString (lib.versionAtLeast version "5.0") "5";
-        mimeTypes = [
-          "application/x-charles-savedsession"
-          "application/x-charles-savedsession+xml"
-          "application/x-charles-savedsession+json"
-          "application/har+json"
-          "application/vnd.tcpdump.pcap"
-          "application/x-charles-trace"
-        ];
-        name = "Charles";
-        startupNotify = true;
-      };
-
-    in
     stdenv.mkDerivation {
       pname = "charles";
       inherit version;
@@ -58,7 +34,35 @@ let
         inherit hash;
       };
 
-      nativeBuildInputs = [ makeWrapper ];
+      nativeBuildInputs = [
+        copyDesktopItems
+        makeWrapper
+      ];
+
+      desktopItems = [
+        (makeDesktopItem {
+          categories = [
+            "Network"
+            "Development"
+            "WebDevelopment"
+            "Java"
+          ];
+          desktopName = "Charles";
+          exec = "charles %F";
+          genericName = "Web Debugging Proxy";
+          icon = "charles-proxy" + lib.optionalString (lib.versionAtLeast version "5.0") "5";
+          mimeTypes = [
+            "application/x-charles-savedsession"
+            "application/x-charles-savedsession+xml"
+            "application/x-charles-savedsession+json"
+            "application/har+json"
+            "application/vnd.tcpdump.pcap"
+            "application/x-charles-trace"
+          ];
+          name = "Charles";
+          startupNotify = true;
+        })
+      ];
 
       installPhase = ''
         runHook preInstall
@@ -69,9 +73,6 @@ let
         for fn in lib/*.jar; do
           install -D -m644 $fn $out/share/java/$(basename $fn)
         done
-
-        mkdir -p $out/share/applications
-        ln -s ${desktopItem}/share/applications/* $out/share/applications/
 
         ${
           if lib.versionOlder version "4.0" then

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -7,6 +7,7 @@
   desktopName,
   self,
   autoPatchelfHook,
+  copyDesktopItems,
   makeDesktopItem,
   lib,
   stdenv,
@@ -112,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     cups
     libdrm
     libuuid
@@ -213,8 +215,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     ln -s $out/opt/${binaryName}/discord.png $out/share/icons/hicolor/256x256/apps/${pname}.png
 
-    ln -s "$desktopItem/share/applications" $out/share/
-
     runHook postInstall
   '';
 
@@ -241,19 +241,21 @@ stdenv.mkDerivation (finalAttrs: {
       echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > $out/opt/${binaryName}/resources/app/injector.js
     '';
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = binaryName;
-    icon = pname;
-    inherit desktopName;
-    genericName = meta.description;
-    categories = [
-      "Network"
-      "InstantMessaging"
-    ];
-    mimeTypes = [ "x-scheme-handler/discord" ];
-    startupWMClass = "discord";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = binaryName;
+      icon = pname;
+      inherit desktopName;
+      genericName = meta.description;
+      categories = [
+        "Network"
+        "InstantMessaging"
+      ];
+      mimeTypes = [ "x-scheme-handler/discord" ];
+      startupWMClass = "discord";
+    })
+  ];
 
   passthru = {
     # make it possible to run disableBreakingUpdates standalone

--- a/pkgs/applications/science/electronics/eagle/eagle.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   wrapQtAppsHook,
+  copyDesktopItems,
   makeDesktopItem,
   libxrender,
   libxrandr,
@@ -59,17 +60,22 @@ stdenv.mkDerivation rec {
     sha256 = "18syygnskl286kn8aqfzzdsyzq59d2w19y1h1ynyxsnrvkyv71h0";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "eagle";
-    exec = "eagle";
-    icon = "eagle";
-    comment = "Schematic capture and PCB layout";
-    desktopName = "Eagle";
-    genericName = "Schematic editor";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "eagle";
+      exec = "eagle";
+      icon = "eagle";
+      comment = "Schematic capture and PCB layout";
+      desktopName = "Eagle";
+      genericName = "Schematic editor";
+      categories = [ "Development" ];
+    })
+  ];
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     libxrender
@@ -120,9 +126,6 @@ stdenv.mkDerivation rec {
     rm -r "$out"/eagle-${version}/libexec
     rm -r "$out"/eagle-${version}/plugins
 
-    # Make desktop item
-    mkdir -p "$out"/share/applications
-    cp "$desktopItem"/share/applications/* "$out"/share/applications/
     mkdir -p "$out"/share/pixmaps
     ln -s "$out/eagle-${version}/bin/eagle-logo.png" "$out"/share/pixmaps/eagle.png
   '';

--- a/pkgs/applications/science/electronics/eagle/eagle.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle.nix
@@ -100,6 +100,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     # Extract eagle tarball
     mkdir "$out"
     tar -xzf "$src" -C "$out"
@@ -128,6 +130,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p "$out"/share/pixmaps
     ln -s "$out/eagle-${version}/bin/eagle-logo.png" "$out"/share/pixmaps/eagle.png
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/applications/science/logic/tlaplus/tlaps.nix
+++ b/pkgs/applications/science/logic/tlaplus/tlaps.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -pv "$out"
     export HOME="$TMPDIR"
     export PATH=$out/bin:$PATH
@@ -53,6 +55,8 @@ stdenv.mkDerivation rec {
     ./configure --prefix $out
     make all
     make install
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
+  copyDesktopItems,
   makeDesktopItem,
   libx11,
   libxt,
@@ -28,19 +29,6 @@ let
   version = "9.31";
   description = "Clone of the well-known terminal emulator rxvt";
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = "urxvt";
-    icon = "utilities-terminal";
-    comment = description;
-    desktopName = "URxvt";
-    genericName = pname;
-    categories = [
-      "System"
-      "TerminalEmulator"
-    ];
-  };
-
   fetchPatchFromAUR =
     {
       package,
@@ -64,7 +52,10 @@ stdenv.mkDerivation {
     sha256 = "qqE/y8FJ/g8/OR+TMnlYD3Spb9MS1u0GuP8DwtRmcug=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
   buildInputs = [
     libx11
     libxt
@@ -159,8 +150,22 @@ stdenv.mkDerivation {
   postInstall = ''
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
-    cp -r ${desktopItem}/share/applications/ $out/share/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "urxvt";
+      icon = "utilities-terminal";
+      comment = description;
+      desktopName = "URxvt";
+      genericName = pname;
+      categories = [
+        "System"
+        "TerminalEmulator"
+      ];
+    })
+  ];
 
   passthru.tests.test = nixosTests.terminal-emulators.urxvt;
 

--- a/pkgs/applications/video/clipgrab/default.nix
+++ b/pkgs/applications/video/clipgrab/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   ffmpeg,
   qmake,
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
     qtwebengine
   ];
   nativeBuildInputs = [
+    copyDesktopItems
     qmake
     qttools
     wrapQtAppsHook
@@ -58,26 +60,27 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [ "clipgrab.pro" ];
 
-  desktopItem = makeDesktopItem rec {
-    name = "clipgrab";
-    exec = name;
-    icon = name;
-    desktopName = "ClipGrab";
-    comment = meta.description;
-    genericName = "Web video downloader";
-    categories = [
-      "Qt"
-      "AudioVideo"
-      "Audio"
-      "Video"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "clipgrab";
+      exec = name;
+      icon = name;
+      desktopName = "ClipGrab";
+      comment = meta.description;
+      genericName = "Web video downloader";
+      categories = [
+        "Qt"
+        "AudioVideo"
+        "Audio"
+        "Video"
+      ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
     install -Dm755 clipgrab $out/bin/clipgrab
     install -Dm644 icon.png $out/share/pixmaps/clipgrab.png
-    cp -r ${desktopItem}/share/applications $out/share
     runHook postInstall
   '';
 

--- a/pkgs/by-name/a-/a-keys-path/package.nix
+++ b/pkgs/by-name/a-/a-keys-path/package.nix
@@ -51,15 +51,17 @@ stdenv.mkDerivation (finalAttrs: {
     libglvnd
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "a-keys-path";
-    exec = "a-keys-path";
-    icon = "a-keys-path";
-    desktopName = "a-keys-path";
-    comment = "A game where you build your way with your keys";
-    genericName = "A Key's Path";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "a-keys-path";
+      exec = "a-keys-path";
+      icon = "a-keys-path";
+      desktopName = "a-keys-path";
+      comment = "A game where you build your way with your keys";
+      genericName = "A Key's Path";
+      categories = [ "Game" ];
+    })
+  ];
 
   buildPhase = ''
     runHook preBuild
@@ -94,9 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
       $out/share/a-keys-path/a-keys-path
 
     install -D icon.png $out/share/icons/hicolor/256x256/apps/a-keys-path.png
-
-    install -Dm644 ${finalAttrs.desktopItem}/share/applications/a-keys-path.desktop \
-      $out/share/applications/a-keys-path.desktop
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ah/ahk_x11/package.nix
+++ b/pkgs/by-name/ah/ahk_x11/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   crystal,
-  copyDesktopItems,
   gtk3,
   libxkbcommon,
   libxinerama,
@@ -77,7 +76,6 @@ crystal.buildCrystalPackage {
     libnotify
   ];
   nativeBuildInputs = [
-    copyDesktopItems
     gobject-introspection
   ];
   nativeCheckInputs = [

--- a/pkgs/by-name/al/alephone/package.nix
+++ b/pkgs/by-name/al/alephone/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   alsa-lib,
   boost,
+  copyDesktopItems,
   curl,
   ffmpeg_6,
   icoutils,
@@ -117,18 +118,21 @@ stdenv.mkDerivation (finalAttrs: {
       {
         inherit version;
 
-        desktopItem = makeDesktopItem {
-          name = desktopName;
-          exec = "alephone";
-          genericName = "alephone";
-          categories = [ "Game" ];
-          comment = meta.description;
-          inherit desktopName icon;
-        };
+        desktopItems = [
+          (makeDesktopItem {
+            name = desktopName;
+            exec = "alephone";
+            genericName = "alephone";
+            categories = [ "Game" ];
+            comment = meta.description;
+            inherit desktopName icon;
+          })
+        ];
 
         src = zip;
 
         nativeBuildInputs = [
+          copyDesktopItems
           makeWrapper
           unzip
         ];
@@ -139,7 +143,6 @@ stdenv.mkDerivation (finalAttrs: {
         installPhase = ''
           mkdir -p $out/bin $out/data/alephone $out/share/applications
           cp -a * $out/data/alephone
-          cp $desktopItem/share/applications/* $out/share/applications
           makeWrapper ${finalAttrs.finalPackage}/bin/alephone $out/bin/alephone \
             --add-flags $out/data/alephone
         '';

--- a/pkgs/by-name/al/alephone/package.nix
+++ b/pkgs/by-name/al/alephone/package.nix
@@ -141,10 +141,14 @@ stdenv.mkDerivation (finalAttrs: {
         dontBuild = true;
 
         installPhase = ''
+          runHook preInstall
+
           mkdir -p $out/bin $out/data/alephone $out/share/applications
           cp -a * $out/data/alephone
           makeWrapper ${finalAttrs.finalPackage}/bin/alephone $out/bin/alephone \
             --add-flags $out/data/alephone
+
+          runHook postInstall
         '';
       }
       // extraArgs

--- a/pkgs/by-name/ap/apache-directory-studio/package.nix
+++ b/pkgs/by-name/ap/apache-directory-studio/package.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     dest="$out/libexec/ApacheDirectoryStudio"
     mkdir -p "$dest"
     cp -r . "$dest"
@@ -78,6 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
         --run "mkdir -p /tmp/SWT-GDBusServer"
     mkdir -p $out/share/icons/hicolor/48x48/apps
     magick icon.xpm $out/share/icons/hicolor/48x48/apps/apache-directory-studio.png
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/ap/apache-directory-studio/package.nix
+++ b/pkgs/by-name/ap/apache-directory-studio/package.nix
@@ -5,6 +5,7 @@
   jdk,
   makeWrapper,
   autoPatchelfHook,
+  copyDesktopItems,
   makeDesktopItem,
   glib,
   libsecret,
@@ -26,24 +27,27 @@ stdenv.mkDerivation (finalAttrs: {
     else
       throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
-  desktopItem = makeDesktopItem {
-    name = "apache-directory-studio";
-    exec = "ApacheDirectoryStudio";
-    icon = "apache-directory-studio";
-    comment = "Eclipse-based LDAP browser and directory client";
-    desktopName = "Apache Directory Studio";
-    genericName = "Apache Directory Studio";
-    categories = [
-      "Java"
-      "Network"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "apache-directory-studio";
+      exec = "ApacheDirectoryStudio";
+      icon = "apache-directory-studio";
+      comment = "Eclipse-based LDAP browser and directory client";
+      desktopName = "Apache Directory Studio";
+      genericName = "Apache Directory Studio";
+      categories = [
+        "Java"
+        "Network"
+      ];
+    })
+  ];
 
   buildInputs = [
     glib
     libsecret
   ];
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     autoPatchelfHook
     imagemagick
@@ -74,7 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
         --run "mkdir -p /tmp/SWT-GDBusServer"
     mkdir -p $out/share/icons/hicolor/48x48/apps
     magick icon.xpm $out/share/icons/hicolor/48x48/apps/apache-directory-studio.png
-    install -D -t "$out/share/applications" ${finalAttrs.desktopItem}/share/applications/*
   '';
 
   meta = {

--- a/pkgs/by-name/ap/apidog/package.nix
+++ b/pkgs/by-name/ap/apidog/package.nix
@@ -52,9 +52,9 @@ appimageTools.wrapType2 {
   extraInstallCommands = ''
     install -Dm444 ${appimageContents}/apidog.png \
       $out/share/icons/hicolor/512x512/apps/apidog.png
+    install -Dm444 ${desktopItem}/share/applications/apidog.desktop \
+      $out/share/applications/apidog.desktop
   '';
-
-  desktopItems = [ desktopItem ];
 
   meta = with lib; {
     description = "All-in-one API design, test, mock and documentation platform";

--- a/pkgs/by-name/ap/apotris/package.nix
+++ b/pkgs/by-name/ap/apotris/package.nix
@@ -21,6 +21,7 @@
   libxcursor,
   libxi,
   libxscrnsaver,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
@@ -42,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
+    copyDesktopItems
     meson
     ninja
     python3
@@ -70,15 +72,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontUseCmakeConfigure = true;
 
-  desktopItem = makeDesktopItem {
-    name = "Apotris";
-    exec = "Apotris";
-    comment = "A block stacking game";
-    desktopName = "Apotris";
-    categories = [
-      "Game"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Apotris";
+      exec = "Apotris";
+      comment = "A block stacking game";
+      desktopName = "Apotris";
+      categories = [
+        "Game"
+      ];
+    })
+  ];
 
   meta = {
     description = "Block stacking game";
@@ -90,9 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
       plethora of settings, you can tailor the game to your preferences,
       ensuring a fresh and challenging experience every time you play. Whether
       you're a casual player or a hardcore enthusiast, Apotris has something for
-      everyone. You can even battle your friends using the Gameboy Advance Link
+      everyone. You can even battle your friends using the Game boy Advance Link
       Cable or Wireless Adapters in 2-Player Battle! While Apotris was
-      originally designed for Gameboy Advance, it now supports all kinds of
+      originally designed for Game boy Advance, it now supports all kinds of
       platforms, so between the ports and emulation you can play Apotris on
       almost anything.
     '';

--- a/pkgs/by-name/av/avocode/package.nix
+++ b/pkgs/by-name/av/avocode/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  makeDesktopItem,
   fetchurl,
   unzip,
   gdk-pixbuf,
@@ -91,16 +90,6 @@ stdenv.mkDerivation rec {
     libgbm
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "Avocode";
-    exec = "avocode";
-    icon = "avocode";
-    desktopName = "Avocode";
-    genericName = "Design Inspector";
-    categories = [ "Development" ];
-    comment = "The bridge between designers and developers";
-  };
-
   nativeBuildInputs = [
     makeWrapper
     wrapGAppsHook3
@@ -123,9 +112,9 @@ stdenv.mkDerivation rec {
       --replace /path/to/avocode-dir/Avocode $out/bin/avocode \
       --replace /path/to/avocode-dir/avocode.png avocode
 
-    mkdir -p share/applications share/pixmaps
+    mkdir -p share/applications share/icons
     mv avocode.desktop.in share/applications/avocode.desktop
-    mv avocode.png share/pixmaps/
+    mv avocode.png share/icons/
 
     rm resources/cjpeg
     cp -av . $out

--- a/pkgs/by-name/av/avocode/package.nix
+++ b/pkgs/by-name/av/avocode/package.nix
@@ -108,6 +108,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     substituteInPlace avocode.desktop.in \
       --replace /path/to/avocode-dir/Avocode $out/bin/avocode \
       --replace /path/to/avocode-dir/avocode.png avocode
@@ -122,6 +124,8 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     ln -s $out/avocode $out/bin/avocode
     ln -s ${mozjpeg}/bin/cjpeg $out/resources/cjpeg
+
+    runHook postInstall
   '';
 
   postFixup = ''

--- a/pkgs/by-name/be/betaflight-configurator/package.nix
+++ b/pkgs/by-name/be/betaflight-configurator/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   unzip,
+  copyDesktopItems,
   makeDesktopItem,
   nwjs,
   wrapGAppsHook3,
@@ -12,14 +13,6 @@
 
 let
   pname = "betaflight-configurator";
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = "Betaflight configuration tool";
-    desktopName = "Betaflight Configurator";
-    genericName = "Flight controller configuration tool";
-  };
 in
 stdenv.mkDerivation rec {
   inherit pname;
@@ -35,6 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
+    copyDesktopItems
     wrapGAppsHook3
     unzip
   ];
@@ -44,6 +38,17 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "Betaflight configuration tool";
+      desktopName = "Betaflight Configurator";
+      genericName = "Flight controller configuration tool";
+    })
+  ];
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin \
@@ -51,7 +56,6 @@ stdenv.mkDerivation rec {
 
     cp -r . $out/opt/${pname}/
     install -m 444 -D icon/bf_icon_128.png $out/share/icons/hicolor/128x128/apps/${pname}.png
-    cp -r ${desktopItem}/share/applications $out/share/
 
     makeWrapper ${nwjs}/bin/nw $out/bin/${pname} --add-flags $out/opt/${pname}
     runHook postInstall

--- a/pkgs/by-name/bl/blackvoxel/package.nix
+++ b/pkgs/by-name/bl/blackvoxel/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  copyDesktopItems,
   makeDesktopItem,
   imagemagick,
   glew_1_10,
@@ -20,7 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Uj3TfxAsLddsPiWDcLKjpduqvgVjnESZM4YPHT90YYY=";
   };
 
-  nativeBuildInputs = [ imagemagick ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+  ];
 
   buildInputs = [
     glew_1_10

--- a/pkgs/by-name/cc/ccemux/package.nix
+++ b/pkgs/by-name/cc/ccemux/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   fetchurl,
   makeDesktopItem,
   makeWrapper,
@@ -29,15 +30,6 @@ let
     url = "https://github.com/CCEmuX/CCEmuX/raw/${rev}/src/main/resources/img/icon.png";
     hash = "sha256-gqWURXaOFD/4aZnjmgtKb0T33NbrOdyRTMmLmV42q+4=";
   };
-  desktopItem = makeDesktopItem {
-    name = "CCEmuX";
-    exec = "ccemux";
-    icon = desktopIcon;
-    comment = "A modular ComputerCraft emulator";
-    desktopName = "CCEmuX";
-    genericName = "ComputerCraft Emulator";
-    categories = [ "Emulator" ];
-  };
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -47,14 +39,16 @@ stdenv.mkDerivation (finalAttrs: {
   src = jar;
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
   buildInputs = [ jre ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/{bin,share/ccemux}
-    cp -r ${desktopItem}/share/applications $out/share/applications
 
     install -D ${finalAttrs.src} $out/share/ccemux/ccemux.jar
     install -D ${desktopIcon} $out/share/icons/hicolor/256x256/apps/ccemux.png
@@ -64,6 +58,18 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "CCEmuX";
+      exec = "ccemux";
+      icon = desktopIcon;
+      comment = "A modular ComputerCraft emulator";
+      desktopName = "CCEmuX";
+      genericName = "ComputerCraft Emulator";
+      categories = [ "Emulator" ];
+    })
+  ];
 
   meta = {
     description = "Modular ComputerCraft emulator";

--- a/pkgs/by-name/cl/clonehero/package.nix
+++ b/pkgs/by-name/cl/clonehero/package.nix
@@ -19,6 +19,7 @@
   udev,
   vulkan-loader, # (not used by default, enable in settings menu)
   wayland, # (not used by default, enable with SDL_VIDEODRIVER=wayland - doesn't support HiDPI)
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
@@ -36,7 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+  ];
 
   buildInputs = [
     # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
@@ -61,14 +65,16 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "clonehero";
-    desktopName = "Clone Hero";
-    comment = finalAttrs.meta.description;
-    icon = "clonehero";
-    exec = "clonehero";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "clonehero";
+      desktopName = "Clone Hero";
+      comment = finalAttrs.meta.description;
+      icon = "clonehero";
+      exec = "clonehero";
+      categories = [ "Game" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -80,7 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r clonehero_Data "$out/share/clonehero"
     ln -s "$out/share/clonehero" "$out/bin/clonehero_Data"
     ln -s "$out/share/clonehero/Resources/UnityPlayer.png" "$out/share/icons/hicolor/128x128/apps/clonehero.png"
-    install -Dm644 "$desktopItem/share/applications/clonehero.desktop" "$out/share/applications/clonehero.desktop"
 
     mkdir -p "$doc/share/doc/clonehero"
     cp -r CLONE_HERO_MANUAL.{pdf,txt} Custom EULA.txt THIRDPARTY.txt "$doc/share/doc/clonehero"

--- a/pkgs/by-name/cy/cyberchef/package.nix
+++ b/pkgs/by-name/cy/cyberchef/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/share/cyberchef"
     mkdir -p "$out/bin"
 
@@ -45,6 +47,8 @@ stdenv.mkDerivation {
     install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/cyberchef.png
 
     mkdir -p $out/share/applications/
+
+    runHook postInstall
   '';
 
   desktopItems = [

--- a/pkgs/by-name/cy/cyberchef/package.nix
+++ b/pkgs/by-name/cy/cyberchef/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  copyDesktopItems,
   fetchzip,
   fetchurl,
   stdenv,
@@ -11,16 +12,6 @@ let
     url = "https://raw.githubusercontent.com/gchq/CyberChef/c57556f49f723863b9be15668fd240672cd15b09/src/web/static/images/cyberchef-512x512.png";
     hash = "sha256-Lg9JbVHhdILdrRtxYFWSv9HNJUx98JOaTbs+IbS1eO0=";
   };
-  desktopItem = (
-    makeDesktopItem {
-      name = "cyberchef";
-      desktopName = "Cyberchef";
-      exec = "cyberchef";
-      icon = "cyberchef";
-      comment = "Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";
-      categories = [ "Development" ];
-    }
-  );
   version = "10.21.0";
 in
 stdenv.mkDerivation {
@@ -32,6 +23,10 @@ stdenv.mkDerivation {
     hash = "sha256-5w5Bl8LAmpx3dHAwfq4ALKKoS6zRBsh1X7p7ek4dy/s=";
     stripRoot = false;
   };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
 
   installPhase = ''
     mkdir -p "$out/share/cyberchef"
@@ -50,8 +45,18 @@ stdenv.mkDerivation {
     install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/cyberchef.png
 
     mkdir -p $out/share/applications/
-    cp ${desktopItem}/share/applications/*.desktop $out/share/applications/
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cyberchef";
+      desktopName = "Cyberchef";
+      exec = "cyberchef";
+      icon = "cyberchef";
+      comment = "Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";
+      categories = [ "Development" ];
+    })
+  ];
 
   meta = {
     description = "Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -189,6 +189,7 @@ let
           test -f $out/lib/udev/rules.d/99-BlackmagicDevices.rules
           test -f $out/lib/udev/rules.d/99-ResolveKeyboardHID.rules
           test -f $out/lib/udev/rules.d/99-DavinciPanel.rules
+
           runHook postInstall
         '';
 

--- a/pkgs/by-name/de/deadlock-mod-manager/package.nix
+++ b/pkgs/by-name/de/deadlock-mod-manager/package.nix
@@ -21,7 +21,6 @@
   openssl,
   bzip2,
   gst_all_1,
-  makeDesktopItem,
   fontconfig,
   nix-update-script,
 }:
@@ -102,22 +101,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --add-flags "--disable-auto-update"
     )
   '';
-
-  desktopItems = [
-    (makeDesktopItem {
-      desktopName = "deadlock-mod-manager";
-      name = "Deadlock Mod Manager";
-      exec = "deadlock-mod-manager %u";
-      terminal = false;
-      type = "Application";
-      icon = "deadlock-mod-manager";
-      mimeTypes = [ "x-scheme-handler/deadlock-mod-manager" ];
-      categories = [
-        "Utility"
-        "Game"
-      ];
-    })
-  ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/du/duckmarines/package.nix
+++ b/pkgs/by-name/du/duckmarines/package.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     mkdir -p $out/share/games/lovegames
 
@@ -72,6 +74,8 @@ stdenv.mkDerivation rec {
     makeWrapper ${lib.getExe love} $out/bin/duckmarines --add-flags $out/share/games/lovegames/duckmarines.love
 
     chmod +x $out/bin/duckmarines
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/du/duckmarines/package.nix
+++ b/pkgs/by-name/du/duckmarines/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   fetchFromGitHub,
   fetchurl,
   love,
@@ -20,15 +21,17 @@ stdenv.mkDerivation rec {
     sha256 = "07ypbwqcgqc5f117yxy9icix76wlybp1cmykc8f3ivdps66hl0k5";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "duckmarines";
-    exec = "duckmarines";
-    icon = icon;
-    comment = "Duck-themed action puzzle video game";
-    desktopName = "Duck Marines";
-    genericName = "duckmarines";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "duckmarines";
+      exec = "duckmarines";
+      icon = icon;
+      comment = "Duck-themed action puzzle video game";
+      desktopName = "Duck Marines";
+      genericName = "duckmarines";
+      categories = [ "Game" ];
+    })
+  ];
 
   src = fetchFromGitHub {
     owner = "SimonLarsen";
@@ -43,6 +46,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     strip-nondeterminism
     zip
@@ -68,8 +72,6 @@ stdenv.mkDerivation rec {
     makeWrapper ${lib.getExe love} $out/bin/duckmarines --add-flags $out/share/games/lovegames/duckmarines.love
 
     chmod +x $out/bin/duckmarines
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
   '';
 
   meta = {

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -39,6 +39,8 @@ let
 
   inherit (lib) importJSON;
 
+  removePostInstallHook = builtins.replaceStrings [ "runHook postInstall" ] [ "" ];
+
   mods = args.mods or [ ];
 
   helpMsg =
@@ -187,12 +189,16 @@ let
     dontBuild = true;
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/{bin,share/factorio}
       cp -a data $out/share/factorio
       cp -a bin/${tarDirectory}/factorio $out/bin/factorio
       patchelf \
         --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
         $out/bin/factorio
+
+      runHook postInstall
     '';
 
     passthru.updateScript = ./update.py;
@@ -261,7 +267,7 @@ let
         })
       ];
 
-      installPhase = base.installPhase + ''
+      installPhase = (removePostInstallHook base.installPhase) + ''
         wrapProgram $out/bin/factorio                                \
           --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$libPath \
           --run "$out/share/factorio/update-config.sh"               \
@@ -298,12 +304,16 @@ let
         mkdir -p $out/share/icons/hicolor/{64x64,128x128}/apps
         cp -a data/core/graphics/factorio-icon.png $out/share/icons/hicolor/64x64/apps/factorio.png
         cp -a data/core/graphics/factorio-icon@2x.png $out/share/icons/hicolor/128x128/apps/factorio.png
+
+        runHook postInstall
       '';
     };
     alpha = demo // {
 
-      installPhase = demo.installPhase + ''
+      installPhase = (removePostInstallHook demo.installPhase) + ''
         cp -a doc-html $out/share/factorio
+
+        runHook postInstall
       '';
     };
     expansion = alpha;

--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   alsa-lib,
+  copyDesktopItems,
   factorio-utils,
   fetchurl,
   libGL,
@@ -80,15 +81,6 @@ let
           factorio.src
         ];
     '';
-
-  desktopItem = makeDesktopItem {
-    name = "factorio";
-    desktopName = "Factorio";
-    comment = "A game in which you build and maintain factories.";
-    exec = "factorio";
-    icon = "factorio";
-    categories = [ "Game" ];
-  };
 
   branch = if experimental then "experimental" else "stable";
 
@@ -236,7 +228,10 @@ let
     headless = base;
     demo = base // {
 
-      nativeBuildInputs = [ makeWrapper ];
+      nativeBuildInputs = [
+        copyDesktopItems
+        makeWrapper
+      ];
       buildInputs = [ libpulseaudio ];
 
       libPath = lib.makeLibraryPath [
@@ -253,6 +248,17 @@ let
         libpulseaudio
         libxkbcommon
         wayland
+      ];
+
+      desktopItems = [
+        (makeDesktopItem {
+          name = "factorio";
+          desktopName = "Factorio";
+          comment = "A game in which you build and maintain factories.";
+          exec = "factorio";
+          icon = "factorio";
+          categories = [ "Game" ];
+        })
       ];
 
       installPhase = base.installPhase + ''
@@ -292,7 +298,6 @@ let
         mkdir -p $out/share/icons/hicolor/{64x64,128x128}/apps
         cp -a data/core/graphics/factorio-icon.png $out/share/icons/hicolor/64x64/apps/factorio.png
         cp -a data/core/graphics/factorio-icon@2x.png $out/share/icons/hicolor/128x128/apps/factorio.png
-        ln -s ${desktopItem}/share/applications $out/share/
       '';
     };
     alpha = demo // {

--- a/pkgs/by-name/fa/fastqc/package.nix
+++ b/pkgs/by-name/fa/fastqc/package.nix
@@ -34,17 +34,16 @@ stdenv.mkDerivation (finalAttrs: {
     perl
   ];
 
-  desktopItem = (
-    makeDesktopItem {
+  desktopItems = [
+    (makeDesktopItem {
       name = "FastQC";
       exec = "fastqc";
       icon = "fastqc";
       desktopName = "FastQC";
       comment = finalAttrs.meta.description;
       categories = [ "Science" ];
-    }
-  );
-  desktopItems = [ finalAttrs.desktopItem ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -52,8 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/{bin,FastQC}
     cp -r $src/* $out/FastQC
 
-    # Create desktop item
-    mkdir -p $out/share/{applications,icons}
+    mkdir -p $out/share/icons
     # Freedesktop doesn't support windows ICO files. Use imagemagick to convert it to PNG
     convert $out/FastQC/fastqc_icon.ico $out/share/icons/fastqc.png
 

--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildNpmPackage,
+  copyDesktopItems,
   fetchFromGitHub,
   makeDesktopItem,
   desktopToDarwinBundle,
@@ -16,24 +17,6 @@ let
   packageName = "filen-desktop";
   packageVersion = "3.0.47";
   desktopName = "Filen Desktop";
-  desktopItem = makeDesktopItem {
-    name = packageName;
-    exec = packageName;
-    icon = packageName;
-    startupWMClass = packageName;
-    desktopName = desktopName;
-    comment = "Encrypted Cloud Storage";
-    categories = [
-      "Network"
-      "FileTransfer"
-      "Utility"
-    ];
-    keywords = [
-      "cloud"
-      "storage"
-      "encrypted"
-    ];
-  };
 
   iconPrefix = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
   iconSuffix = if stdenv.hostPlatform.isDarwin then "icns" else "png";
@@ -59,6 +42,7 @@ buildNpmPackage {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     pkg-config
     electron
     makeWrapper
@@ -85,17 +69,35 @@ buildNpmPackage {
     install -D $src/assets/icons/app/${iconPrefix}Notification.${iconSuffix} $out/share/icons/hicolor/128x128/apps/${packageName}-notification.${iconSuffix}
   '';
 
-  # Create binary wrapper and desktopItem
-  # desktopItem auto-creates the .app bundle for Darwin
+  # Create binary wrapper
   postInstall = ''
     makeWrapper ${electron}/bin/electron $out/bin/${packageName} \
       --set-default ELECTRON_IS_DEV 0 \
       --add-flags $out/lib/node_modules/@filen/desktop/dist/index.js \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
-
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications/
   '';
+
+  # desktopItem auto-creates the .app bundle for Darwin
+  desktopItems = [
+    (makeDesktopItem {
+      name = packageName;
+      exec = packageName;
+      icon = packageName;
+      startupWMClass = packageName;
+      desktopName = desktopName;
+      comment = "Encrypted Cloud Storage";
+      categories = [
+        "Network"
+        "FileTransfer"
+        "Utility"
+      ];
+      keywords = [
+        "cloud"
+        "storage"
+        "encrypted"
+      ];
+    })
+  ];
 
   # Write correct darwin icons to .app contents
   postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   imagemagick,
   lib,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   nodejs,
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     nodejs
     pnpmConfigHook
     pnpm_10_29_2
@@ -67,15 +69,17 @@ stdenv.mkDerivation rec {
 
   dontCheckForBrokenSymlinks = true;
 
-  desktopItem = makeDesktopItem {
-    name = "folo";
-    desktopName = "Folo";
-    comment = "Next generation information browser";
-    icon = "follow";
-    exec = "follow";
-    categories = [ "Utility" ];
-    mimeTypes = [ "x-scheme-handler/follow" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "folo";
+      desktopName = "Folo";
+      comment = "Next generation information browser";
+      icon = "follow";
+      exec = "follow";
+      categories = [ "Utility" ];
+      mimeTypes = [ "x-scheme-handler/follow" ];
+    })
+  ];
 
   icon = src + "/apps/desktop/resources/icon.png";
 
@@ -108,9 +112,6 @@ stdenv.mkDerivation rec {
       --inherit-argv0 \
       --add-flags $out/share/follow/apps/desktop \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
-
-    install -m 444 -D "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
 
     for size in 16 24 32 48 64 128 256 512; do
       mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps

--- a/pkgs/by-name/fr/freenukum/package.nix
+++ b/pkgs/by-name/fr/freenukum/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   fetchFromGitLab,
+  copyDesktopItems,
   makeDesktopItem,
   installShellFiles,
   dejavu_fonts,
@@ -13,21 +14,6 @@
 let
   pname = "freenukum";
   description = "Clone of the original Duke Nukum 1 Jump'n Run game";
-
-  desktopItem = makeDesktopItem {
-    desktopName = pname;
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = description;
-    categories = [
-      "Game"
-      "ArcadeGame"
-      "ActionGame"
-    ];
-    genericName = pname;
-  };
-
 in
 rustPlatform.buildRustPackage rec {
   inherit pname;
@@ -44,6 +30,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-lQZ9Z/1tbL7BeLmGxJXNUvrXsOGtgzGXNt6WYGezxi0=";
 
   nativeBuildInputs = [
+    copyDesktopItems
     installShellFiles
   ];
 
@@ -58,6 +45,22 @@ rustPlatform.buildRustPackage rec {
       --replace /usr $out
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = pname;
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = description;
+      categories = [
+        "Game"
+        "ArcadeGame"
+        "ActionGame"
+      ];
+      genericName = pname;
+    })
+  ];
+
   postInstall = ''
     mkdir -p $out/share/fonts/truetype/dejavu
     ln -sf \
@@ -66,7 +69,6 @@ rustPlatform.buildRustPackage rec {
     mkdir -p $out/share/doc/freenukum
     install -Dm644 README.md CHANGELOG.md $out/share/doc/freenukum/
     installManPage doc/freenukum.6
-    install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
   '';
 
   meta = {

--- a/pkgs/by-name/ga/ganttproject-bin/package.nix
+++ b/pkgs/by-name/ga/ganttproject-bin/package.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
     in
     # bash
     ''
+      runHook preInstall
+
       mkdir -pv "$out/share/ganttproject"
       cp -rv *  "$out/share/ganttproject"
 
@@ -57,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix _JAVA_OPTIONS " " "${toString javaOptions}"
 
       mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
+
+      runHook postInstall
     '';
 
   meta = {

--- a/pkgs/by-name/ga/ganttproject-bin/package.nix
+++ b/pkgs/by-name/ga/ganttproject-bin/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchzip,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   openjdk17,
@@ -21,27 +22,31 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-tiEq/xdC0gXiUInLS9xGR/vI/BpdSA+mSf5yukuejc4=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
   buildInputs = [ jre ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ganttproject";
+      exec = "ganttproject";
+      icon = "ganttproject";
+      desktopName = "GanttProject";
+      genericName = "Schedule and manage projects";
+      comment = finalAttrs.meta.description;
+      categories = [ "Office" ];
+    })
+  ];
 
   installPhase =
     let
-
-      desktopItem = makeDesktopItem {
-        name = "ganttproject";
-        exec = "ganttproject";
-        icon = "ganttproject";
-        desktopName = "GanttProject";
-        genericName = "Shedule and manage projects";
-        comment = finalAttrs.meta.description;
-        categories = [ "Office" ];
-      };
-
       javaOptions = [
         "-Dawt.useSystemAAFontSettings=gasp"
       ];
-
     in
+    # bash
     ''
       mkdir -pv "$out/share/ganttproject"
       cp -rv *  "$out/share/ganttproject"
@@ -52,8 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix _JAVA_OPTIONS " " "${toString javaOptions}"
 
       mv -v "$out/share/ganttproject/ganttproject" "$out/bin"
-
-      cp -rv "${desktopItem}/share/applications" "$out/share"
     '';
 
   meta = {

--- a/pkgs/by-name/ge/geogebra/package.nix
+++ b/pkgs/by-name/ge/geogebra/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   fetchurl,
   libGL,
   libxxf86vm,
@@ -17,24 +18,6 @@ let
   srcIcon = fetchurl {
     url = "https://web.archive.org/web/20200227000442if_/https://static.geogebra.org/images/geogebra-logo.svg";
     hash = "sha256-Vd7Wteya04JJT4WNirXe8O1sfVKUgc0hKGOy7d47Xgc=";
-  };
-
-  desktopItem = makeDesktopItem {
-    name = "geogebra";
-    exec = "geogebra";
-    icon = "geogebra";
-    desktopName = "Geogebra";
-    genericName = "Geogebra";
-    comment = meta.description;
-    categories = [
-      "Education"
-      "Science"
-      "Math"
-    ];
-    mimeTypes = [
-      "application/vnd.geogebra.file"
-      "application/vnd.geogebra.tool"
-    ];
   };
 
   meta = {
@@ -68,7 +51,6 @@ let
       version
       meta
       srcIcon
-      desktopItem
       ;
 
     preferLocalBuild = true;
@@ -81,7 +63,30 @@ let
       hash = "sha256-cL4ERKZpE9Y6IdOjvYiX3nIIW3E2qoqkpMyTszvFseM=";
     };
 
-    nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [
+      copyDesktopItems
+      makeWrapper
+    ];
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "geogebra";
+        exec = "geogebra";
+        icon = "geogebra";
+        desktopName = "Geogebra";
+        genericName = "Geogebra";
+        comment = meta.description;
+        categories = [
+          "Education"
+          "Science"
+          "Math"
+        ];
+        mimeTypes = [
+          "application/vnd.geogebra.file"
+          "application/vnd.geogebra.tool"
+        ];
+      })
+    ];
 
     installPhase = ''
       install -D geogebra/* -t "$out/libexec/geogebra/"
@@ -99,9 +104,6 @@ let
         --set JAVACMD "${jre}/bin/java" \
         --set GG_PATH "$out/libexec/geogebra" \
         --add-flags "--language=${language}"
-
-      install -Dm644 "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
 
       install -Dm644 "${srcIcon}" \
         "$out/share/icons/hicolor/scalable/apps/geogebra.svg"

--- a/pkgs/by-name/ge/geogebra/package.nix
+++ b/pkgs/by-name/ge/geogebra/package.nix
@@ -89,6 +89,8 @@ let
     ];
 
     installPhase = ''
+      runHook preInstall
+
       install -D geogebra/* -t "$out/libexec/geogebra/"
 
       # The bundled jogl (required for 3D graphics) links to libxxf86vm, and loads libGL at runtime
@@ -107,6 +109,8 @@ let
 
       install -Dm644 "${srcIcon}" \
         "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
+
+      runHook postInstall
     '';
   };
 

--- a/pkgs/by-name/ge/geogebra6/package.nix
+++ b/pkgs/by-name/ge/geogebra6/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   unzip,
   fetchurl,
+  copyDesktopItems,
   electron,
   makeWrapper,
   geogebra,
@@ -12,7 +13,6 @@ let
   version = "6-0-794-0";
 
   srcIcon = geogebra.srcIcon;
-  desktopItem = geogebra.desktopItem;
 
   meta = {
     description = "Dynamic mathematics software with graphics, algebra and spreadsheets";
@@ -37,6 +37,7 @@ let
 
   linuxPkg = stdenv.mkDerivation {
     inherit pname version meta;
+    inherit (geogebra) desktopItems;
 
     src = fetchurl {
       urls = [
@@ -50,6 +51,7 @@ let
     dontBuild = true;
 
     nativeBuildInputs = [
+      copyDesktopItems
       unzip
       makeWrapper
     ];
@@ -64,8 +66,6 @@ let
       makeWrapper ${lib.getBin electron}/bin/electron $out/bin/geogebra \
         --add-flags "$out/resources/app" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
-      install -Dm644 "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
 
       install -Dm644 "${srcIcon}" \
         "$out/share/icons/hicolor/scalable/apps/geogebra.svg"

--- a/pkgs/by-name/ge/geogebra6/package.nix
+++ b/pkgs/by-name/ge/geogebra6/package.nix
@@ -61,6 +61,8 @@ let
     '';
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/libexec/geogebra/ $out/bin
       cp -r GeoGebra-linux-x64/{resources,locales} "$out/"
       makeWrapper ${lib.getBin electron}/bin/electron $out/bin/geogebra \
@@ -69,6 +71,8 @@ let
 
       install -Dm644 "${srcIcon}" \
         "$out/share/icons/hicolor/scalable/apps/geogebra.svg"
+
+      runHook postInstall
     '';
   };
 

--- a/pkgs/by-name/go/go-hass-agent/package.nix
+++ b/pkgs/by-name/go/go-hass-agent/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  copyDesktopItems,
   writeShellScriptBin,
   installShellFiles,
   mage,
@@ -47,6 +48,7 @@ buildGoModule (finalAttrs: {
       '';
     in
     [
+      copyDesktopItems
       fakeGit
       installShellFiles
       mage
@@ -95,13 +97,13 @@ buildGoModule (finalAttrs: {
     description = "Home Assistant native app for desktop/laptop devices";
     mainProgram = "go-hass-agent";
     longDescription = ''
-      Go Hass Agent is an application to expose sensors, controls, and events
+      Go Hash Agent is an application to expose sensors, controls, and events
       from a device to Home Assistant. You can think of it as something similar
       to the Home Assistant companion app for mobile devices, but for your
       desktop, server, Raspberry Pi, Arduino, toaster, whatever. If it can run
-      Go and Linux, it can run Go Hass Agent!
+      Go and Linux, it can run Go Hash Agent!
 
-      Out of the box, Go Hass Agent will report lots of details about the system
+      Out of the box, Go Hash Agent will report lots of details about the system
       it is running on. You can extend it with additional sensors and controls
       by hooking it up to MQTT. You can extend it even further with your own
       custom sensors and controls with scripts/programs.

--- a/pkgs/by-name/go/golden-cheetah/package.nix
+++ b/pkgs/by-name/go/golden-cheetah/package.nix
@@ -10,20 +10,9 @@
   bison,
   flex,
   zlib,
+  copyDesktopItems,
   makeDesktopItem,
 }:
-
-let
-  desktopItem = makeDesktopItem {
-    name = "goldencheetah";
-    exec = "GoldenCheetah";
-    icon = "goldencheetah";
-    desktopName = "GoldenCheetah";
-    genericName = "GoldenCheetah";
-    comment = "Performance software for cyclists, runners and triathletes";
-    categories = [ "Utility" ];
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "golden-cheetah";
   version = "3.8-DEV2603";
@@ -55,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
       zlib
     ];
   nativeBuildInputs = [
+    copyDesktopItems
     bison
     flex
   ]
@@ -92,6 +82,18 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i 's,^#LIBUSB_LIBS.*,LIBUSB_LIBS = -L${libusb-compat-0_1}/lib -lusb,' src/gcconfig.pri
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "goldencheetah";
+      exec = "GoldenCheetah";
+      icon = "goldencheetah";
+      desktopName = "GoldenCheetah";
+      genericName = "GoldenCheetah";
+      comment = "Performance software for cyclists, runners and triathletes";
+      categories = [ "Utility" ];
+    })
+  ];
+
   installPhase =
     if stdenv.hostPlatform.isLinux then
       ''
@@ -99,7 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
 
         mkdir -p $out/bin
         cp src/GoldenCheetah $out/bin
-        install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
         install -Dm644 src/Resources/images/gc.png $out/share/icons/hicolor/512x512/apps/goldencheetah.png
 
         runHook postInstall

--- a/pkgs/by-name/gr/groove/package.nix
+++ b/pkgs/by-name/gr/groove/package.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/groove
     cp -r bin lib $out/share/groove/
 
@@ -59,6 +61,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons/hicolor/{16x16,32x32}/apps
     icotool -x -i 1 -o $out/share/icons/hicolor/32x32/apps/groove.png groove-green-g.ico
     icotool -x -i 2 -o $out/share/icons/hicolor/16x16/apps/groove.png groove-green-g.ico
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/gr/groove/package.nix
+++ b/pkgs/by-name/gr/groove/package.nix
@@ -4,25 +4,11 @@
   fetchurl,
   unzip,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
   icoutils,
   jre8,
 }:
-
-let
-  desktopItem = makeDesktopItem {
-    name = "groove-simulator";
-    exec = "groove-simulator";
-    icon = "groove";
-    desktopName = "GROOVE Simulator";
-    comment = "GRaphs for Object-Oriented VErification";
-    categories = [
-      "Science"
-      "ComputerScience"
-    ];
-  };
-
-in
 stdenv.mkDerivation rec {
   pname = "groove";
   version = "5.8.1";
@@ -35,12 +21,27 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     unzip
     makeWrapper
     icoutils
   ];
 
   dontBuild = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "groove-simulator";
+      exec = "groove-simulator";
+      icon = "groove";
+      desktopName = "GROOVE Simulator";
+      comment = "GRaphs for Object-Oriented VErification";
+      categories = [
+        "Science"
+        "ComputerScience"
+      ];
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/share/groove
@@ -54,9 +55,6 @@ stdenv.mkDerivation rec {
       makeWrapper ${jre8}/bin/java $out/bin/groove-''${bin,,} \
         --add-flags "-jar $out/share/groove/bin/$bin.jar"
     done
-
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
 
     mkdir -p $out/share/icons/hicolor/{16x16,32x32}/apps
     icotool -x -i 1 -o $out/share/icons/hicolor/32x32/apps/groove.png groove-green-g.ico

--- a/pkgs/by-name/ha/hakuneko/package.nix
+++ b/pkgs/by-name/ha/hakuneko/package.nix
@@ -2,6 +2,7 @@
   autoPatchelfHook,
   dpkg,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   udev,
@@ -15,19 +16,6 @@
   libxtst,
   libxscrnsaver,
 }:
-let
-  desktopItem = makeDesktopItem {
-    desktopName = "HakuNeko Desktop";
-    genericName = "Manga & Anime Downloader";
-    categories = [
-      "Network"
-      "FileTransfer"
-    ];
-    exec = "hakuneko";
-    icon = "hakuneko-desktop";
-    name = "hakuneko-desktop";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hakuneko";
   version = "6.1.7";
@@ -53,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   # TODO: migrate off autoPatchelfHook and use nixpkgs' electron
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     dpkg
     makeWrapper
     wrapGAppsHook3
@@ -74,10 +63,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     cp -R usr "$out"
-    # Overwrite existing .desktop file.
-    cp "${desktopItem}/share/applications/hakuneko-desktop.desktop" \
-       "$out/share/applications/hakuneko-desktop.desktop"
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "HakuNeko Desktop";
+      genericName = "Manga & Anime Downloader";
+      categories = [
+        "Network"
+        "FileTransfer"
+      ];
+      exec = "hakuneko";
+      icon = "hakuneko-desktop";
+      name = "hakuneko-desktop";
+    })
+  ];
 
   runtimeDependencies = [
     (lib.getLib udev)

--- a/pkgs/by-name/hd/hdfview/package.nix
+++ b/pkgs/by-name/hd/hdfview/package.nix
@@ -57,17 +57,19 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postBuild
     '';
 
-  desktopItem = makeDesktopItem rec {
-    name = "HDFView";
-    desktopName = name;
-    exec = name;
-    icon = name;
-    comment = finalAttrs.finalPackage.meta.description;
-    categories = [
-      "Science"
-      "DataVisualization"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "HDFView";
+      desktopName = name;
+      exec = name;
+      icon = name;
+      comment = finalAttrs.finalPackage.meta.description;
+      categories = [
+        "Science"
+        "DataVisualization"
+      ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ho/hottext/package.nix
+++ b/pkgs/by-name/ho/hottext/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildNimPackage,
+  copyDesktopItems,
   fetchFromSourcehut,
   gentium-plus,
   makeDesktopItem,
@@ -17,21 +18,21 @@ buildNimPackage (finalAttrs: {
     hash = "sha256-ncH/1PV4vZY7JCUJ87FPz5bdrQsNlYxzGdc5BQNfQeA=";
   };
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   lockFile = ./lock.json;
 
   env.HOTTEXT_FONT_PATH = "${gentium-plus}/share/fonts/truetype/GentiumPlus-Regular.ttf";
 
-  desktopItem = makeDesktopItem {
-    categories = [ "Utility" ];
-    comment = finalAttrs.meta.description;
-    desktopName = "hottext";
-    exec = "hottext";
-    name = "hottext";
-  };
-
-  postInstall = ''
-    cp -r $desktopItem/* $out
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Utility" ];
+      comment = finalAttrs.meta.description;
+      desktopName = "hottext";
+      exec = "hottext";
+      name = "hottext";
+    })
+  ];
 
   meta = finalAttrs.src.meta // {
     description = "Simple RSVP speed-reading utility";

--- a/pkgs/by-name/ic/icestudio/package.nix
+++ b/pkgs/by-name/ic/icestudio/package.nix
@@ -3,6 +3,7 @@
   fetchurl,
   fetchFromGitHub,
   buildNpmPackage,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   unstableGitUpdater,
@@ -36,16 +37,6 @@ let
     installPhase = ''
       cp -r . $out
     '';
-  };
-
-  desktopItem = makeDesktopItem {
-    desktopName = "Icestudio";
-    comment = "Visual editor for open FPGA boards";
-    name = "icestudio";
-    exec = "icestudio";
-    icon = "icestudio";
-    terminal = false;
-    categories = [ "Development" ];
   };
 in
 buildNpmPackage rec {
@@ -84,6 +75,18 @@ buildNpmPackage rec {
     runHook postBuild
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Icestudio";
+      comment = "Visual editor for open FPGA boards";
+      name = "icestudio";
+      exec = "icestudio";
+      icon = "icestudio";
+      terminal = false;
+      categories = [ "Development" ];
+    })
+  ];
+
   installPhase = ''
     runHook preInstall
 
@@ -93,8 +96,6 @@ buildNpmPackage rec {
       install -Dm644 docs/resources/icons/"$size"x"$size"/apps/icon.png \
         $out/share/icons/hicolor/"$size"x"$size"/apps/icestudio.png
     done
-
-    install -Dm644 ${desktopItem}/share/applications/icestudio.desktop -t $out/share/applications
 
     makeWrapper ${nwjs}/bin/nw $out/bin/${pname} \
         --add-flags $out \
@@ -106,7 +107,10 @@ buildNpmPackage rec {
     tagPrefix = "v";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   buildInputs = [ python3 ];
 

--- a/pkgs/by-name/ip/ipmiview/package.nix
+++ b/pkgs/by-name/ip/ipmiview/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   patchelf,
@@ -29,6 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     patchelf
     makeWrapper
   ];
@@ -61,21 +63,21 @@ stdenv.mkDerivation rec {
       runHook postBuild
     '';
 
-  desktopItem = makeDesktopItem rec {
-    name = "IPMIView";
-    exec = "IPMIView";
-    desktopName = name;
-    genericName = "Supermicro BMC manager";
-    categories = [ "Network" ];
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "IPMIView";
+      exec = "IPMIView";
+      desktopName = name;
+      genericName = "Supermicro BMC manager";
+      categories = [ "Network" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
     cp -R . $out/
-
-    ln -s ${desktopItem}/share $out/share
 
     # LD_LIBRARY_PATH: fontconfig is used from java code
     # PATH: iputils is used for ping, and psmisc is for killall

--- a/pkgs/by-name/is/isabelle/components/isabelle-linter.nix
+++ b/pkgs/by-name/is/isabelle/components/isabelle-linter.nix
@@ -19,15 +19,23 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [ isabelle ];
 
   buildPhase = ''
+    runHook preBuild
+
     export HOME=$TMP
     isabelle components -u $(pwd)
     isabelle scala_build
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     dir=$out/Isabelle${isabelle.version}/contrib/${pname}-${version}
     mkdir -p $dir
     cp -r * $dir/
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -18,6 +18,7 @@
   rlwrap,
   perl,
   procps,
+  copyDesktopItems,
   makeDesktopItem,
   isabelle-components,
   symlinkJoin,
@@ -144,7 +145,10 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-ZQqWabSgh2da+zQpTYLe0vBwTUfVgN2e1FzdyfF2S90=";
       };
 
-  nativeBuildInputs = [ java ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    java
+  ];
 
   buildInputs = [
     polyml'
@@ -309,24 +313,22 @@ stdenv.mkDerivation (finalAttrs: {
     # icon
     mkdir -p "$out/share/icons/hicolor/isabelle/apps"
     cp "$out/Isabelle${finalAttrs.version}/lib/icons/isabelle.xpm" "$out/share/icons/hicolor/isabelle/apps/"
-
-    # desktop item
-    mkdir -p "$out/share"
-    cp -r "${finalAttrs.desktopItem}/share/applications" "$out/share/applications"
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "isabelle";
-    exec = "isabelle jedit";
-    icon = "isabelle";
-    desktopName = "Isabelle";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "Education"
-      "Science"
-      "Math"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "isabelle";
+      exec = "isabelle jedit";
+      icon = "isabelle";
+      desktopName = "Isabelle";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Education"
+        "Science"
+        "Math"
+      ];
+    })
+  ];
 
   meta = {
     description = "Generic proof assistant";

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -305,6 +305,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     mv $TMP/$dirname $out
     cd $out/$dirname
@@ -313,6 +315,8 @@ stdenv.mkDerivation (finalAttrs: {
     # icon
     mkdir -p "$out/share/icons/hicolor/isabelle/apps"
     cp "$out/Isabelle${finalAttrs.version}/lib/icons/isabelle.xpm" "$out/share/icons/hicolor/isabelle/apps/"
+
+    runHook postInstall
   '';
 
   desktopItems = [

--- a/pkgs/by-name/ja/jameica/package.nix
+++ b/pkgs/by-name/ja/jameica/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   wrapGAppsHook3,
@@ -28,16 +29,6 @@ let
       "macos-aarch64"
     else
       throw "Unsupported system: ${stdenv.hostPlatform.system}";
-
-  desktopItem = makeDesktopItem {
-    name = "jameica";
-    exec = "jameica";
-    comment = "Free Runtime Environment for Java Applications.";
-    desktopName = "Jameica";
-    genericName = "Jameica";
-    icon = "jameica";
-    categories = [ "Office" ];
-  };
 in
 stdenv.mkDerivation rec {
   pname = "jameica";
@@ -52,6 +43,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     ant
+    copyDesktopItems
     jdk
     wrapGAppsHook3
     makeWrapper
@@ -74,6 +66,18 @@ stdenv.mkDerivation rec {
     runHook postBuild
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jameica";
+      exec = "jameica";
+      comment = "Free Runtime Environment for Java Applications.";
+      desktopName = "Jameica";
+      genericName = "Jameica";
+      icon = "jameica";
+      categories = [ "Office" ];
+    })
+  ];
+
   installPhase = ''
     runHook preInstall
 
@@ -87,7 +91,6 @@ stdenv.mkDerivation rec {
     install -Dm644 releases/${version}/jameica/jameica.jar $out/share/java/
     install -Dm644 plugin.xml $out/share/java/
     install -Dm644 build/jameica-icon.png $out/share/icons/hicolor/64x64/apps/jameica.png
-    cp ${desktopItem}/share/applications/* $out/share/applications/
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
 

--- a/pkgs/by-name/jm/jmol/package.nix
+++ b/pkgs/by-name/jm/jmol/package.nix
@@ -3,36 +3,18 @@
   lib,
   fetchurl,
   unzip,
+  copyDesktopItems,
   makeDesktopItem,
   jre8,
 }:
 
 let
-  desktopItem = makeDesktopItem {
-    name = "jmol";
-    exec = "jmol";
-    desktopName = "JMol";
-    genericName = "Molecular Modeler";
-    mimeTypes = [
-      "chemical/x-pdb"
-      "chemical/x-mdl-molfile"
-      "chemical/x-mol2"
-      "chemical/seq-aa-fasta"
-      "chemical/seq-na-fasta"
-      "chemical/x-xyz"
-      "chemical/x-mdl-sdf"
-    ];
-    categories = [
-      "Graphics"
-      "Education"
-      "Science"
-      "Chemistry"
-    ];
-  };
 in
 stdenv.mkDerivation (finalAttrs: {
   version = "16.3.49";
   pname = "jmol";
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   src =
     let
@@ -53,9 +35,32 @@ stdenv.mkDerivation (finalAttrs: {
     ${unzip}/bin/unzip jsmol.zip -d "$out/share/"
 
     cp *.jar jmol.sh "$out/share/jmol"
-    cp -r ${desktopItem}/share/applications $out/share
     cp jmol $out/bin
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jmol";
+      exec = "jmol";
+      desktopName = "JMol";
+      genericName = "Molecular Modeler";
+      mimeTypes = [
+        "chemical/x-pdb"
+        "chemical/x-mdl-molfile"
+        "chemical/x-mol2"
+        "chemical/seq-aa-fasta"
+        "chemical/seq-na-fasta"
+        "chemical/x-xyz"
+        "chemical/x-mdl-sdf"
+      ];
+      categories = [
+        "Graphics"
+        "Education"
+        "Science"
+        "Chemistry"
+      ];
+    })
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/jm/jmol/package.nix
+++ b/pkgs/by-name/jm/jmol/package.nix
@@ -30,12 +30,16 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/share/jmol" "$out/bin"
 
     ${unzip}/bin/unzip jsmol.zip -d "$out/share/"
 
     cp *.jar jmol.sh "$out/share/jmol"
     cp jmol $out/bin
+
+    runHook postInstall
   '';
 
   desktopItems = [

--- a/pkgs/by-name/jp/jpexs/package.nix
+++ b/pkgs/by-name/jp/jpexs/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper ${jdk8}/bin/java $out/bin/ffdec \
       --add-flags "-jar $out/share/ffdec/ffdec.jar"
+
+    runHook postInstall
   '';
 
   desktopItems = [

--- a/pkgs/by-name/jp/jpexs/package.nix
+++ b/pkgs/by-name/jp/jpexs/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchzip,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
   jdk8,
 }:
@@ -19,7 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontBuild = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -30,25 +34,26 @@ stdenv.mkDerivation (finalAttrs: {
     cp ffdec.jar $out/share/ffdec
     cp -r lib $out/share/ffdec
     cp icon.png $out/share/icons/hicolor/512x512/apps/ffdec.png
-    cp -r ${finalAttrs.desktopItem}/share/applications $out/share
 
     makeWrapper ${jdk8}/bin/java $out/bin/ffdec \
       --add-flags "-jar $out/share/ffdec/ffdec.jar"
   '';
 
-  desktopItem = makeDesktopItem rec {
-    name = "ffdec";
-    exec = name;
-    icon = name;
-    desktopName = "JPEXS Free Flash Decompiler";
-    genericName = "Flash Decompiler";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "Development"
-      "Java"
-    ];
-    startupWMClass = "com-jpexs-decompiler-flash-gui-Main";
-  };
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "ffdec";
+      exec = name;
+      icon = name;
+      desktopName = "JPEXS Free Flash Decompiler";
+      genericName = "Flash Decompiler";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Development"
+        "Java"
+      ];
+      startupWMClass = "com-jpexs-decompiler-flash-gui-Main";
+    })
+  ];
 
   meta = {
     description = "Flash SWF decompiler and editor";

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -15,6 +15,7 @@
   unixtools,
   glib,
   gtk2,
+  copyDesktopItems,
   makeDesktopItem,
   plugins ? [ ],
 }:
@@ -62,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   sourceRoot = ".";
 
   nativeBuildInputs = [
+    copyDesktopItems
     unzip
     mono
     makeWrapper
@@ -137,10 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : "$binPaths" \
       --prefix LD_LIBRARY_PATH : "$dynlibPath"
 
-    # setup desktop item with icon
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
-
     ${./extractWinRscIconsToStdFreeDesktopDir.sh} \
       "./Translation/TrlUtil/Resources/KeePass.ico" \
       '[^\.]+_[0-9]+_([0-9]+x[0-9]+)x[0-9]+\.png' \
@@ -152,16 +150,18 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "keepass";
-    exec = "keepass";
-    comment = "Password manager";
-    icon = "keepass";
-    desktopName = "Keepass";
-    genericName = "Password manager";
-    categories = [ "Utility" ];
-    mimeTypes = [ "application/x-keepass2" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "keepass";
+      exec = "keepass";
+      comment = "Password manager";
+      icon = "keepass";
+      desktopName = "Keepass";
+      genericName = "Password manager";
+      categories = [ "Utility" ];
+      mimeTypes = [ "application/x-keepass2" ];
+    })
+  ];
 
   meta = {
     description = "GUI password manager with strong cryptography";

--- a/pkgs/by-name/le/leo-editor/package.nix
+++ b/pkgs/by-name/le/leo-editor/package.nix
@@ -4,6 +4,7 @@
   python3,
   fetchFromGitHub,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
   libsForQt5,
 }:
@@ -22,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   dontBuild = true;
 
   nativeBuildInputs = [
+    copyDesktopItems
     libsForQt5.wrapQtAppsHook
     makeWrapper
     python3
@@ -32,64 +34,63 @@ stdenv.mkDerivation (finalAttrs: {
     docutils
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "leo-editor";
-    exec = "leo %U";
-    icon = "leoapp32";
-    type = "Application";
-    comment = finalAttrs.meta.description;
-    desktopName = "Leo";
-    genericName = "Text Editor";
-    categories = [
-      "Application"
-      "Development"
-      "IDE"
-    ];
-    startupNotify = false;
-    mimeTypes = [
-      "text/plain"
-      "text/asp"
-      "text/x-c"
-      "text/x-script.elisp"
-      "text/x-fortran"
-      "text/html"
-      "application/inf"
-      "text/x-java-source"
-      "application/x-javascript"
-      "application/javascript"
-      "text/ecmascript"
-      "application/x-ksh"
-      "text/x-script.ksh"
-      "application/x-tex"
-      "text/x-script.rexx"
-      "text/x-pascal"
-      "text/x-script.perl"
-      "application/postscript"
-      "text/x-script.scheme"
-      "text/x-script.guile"
-      "text/sgml"
-      "text/x-sgml"
-      "application/x-bsh"
-      "application/x-sh"
-      "application/x-shar"
-      "text/x-script.sh"
-      "application/x-tcl"
-      "text/x-script.tcl"
-      "application/x-texinfo"
-      "application/xml"
-      "text/xml"
-      "text/x-asm"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "leo-editor";
+      exec = "leo %U";
+      icon = "leoapp32";
+      type = "Application";
+      comment = finalAttrs.meta.description;
+      desktopName = "Leo";
+      genericName = "Text Editor";
+      categories = [
+        "Application"
+        "Development"
+        "IDE"
+      ];
+      startupNotify = false;
+      mimeTypes = [
+        "text/plain"
+        "text/asp"
+        "text/x-c"
+        "text/x-script.elisp"
+        "text/x-fortran"
+        "text/html"
+        "application/inf"
+        "text/x-java-source"
+        "application/x-javascript"
+        "application/javascript"
+        "text/ecmascript"
+        "application/x-ksh"
+        "text/x-script.ksh"
+        "application/x-tex"
+        "text/x-script.rexx"
+        "text/x-pascal"
+        "text/x-script.perl"
+        "application/postscript"
+        "text/x-script.scheme"
+        "text/x-script.guile"
+        "text/sgml"
+        "text/x-sgml"
+        "application/x-bsh"
+        "application/x-sh"
+        "application/x-shar"
+        "text/x-script.sh"
+        "application/x-tcl"
+        "text/x-script.tcl"
+        "application/x-texinfo"
+        "application/xml"
+        "text/xml"
+        "text/x-asm"
+      ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p "$out/share/icons/hicolor/32x32/apps"
     cp leo/Icons/leoapp32.png "$out/share/icons/hicolor/32x32/apps"
-
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
 
     mkdir -p $out/share/leo-editor
     mv * $out/share/leo-editor

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -14,6 +14,7 @@
   libxi,
   file,
   binutils,
+  copyDesktopItems,
   makeDesktopItem,
 
   # Forces libTAS to run in X11.
@@ -46,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoreconfHook
+    copyDesktopItems
     qt5.wrapQtAppsHook
     pkg-config
   ];

--- a/pkgs/by-name/li/linyaps/package.nix
+++ b/pkgs/by-name/li/linyaps/package.nix
@@ -3,7 +3,6 @@
   lib,
   stdenv,
   cmake,
-  copyDesktopItems,
   pkg-config,
   qt6Packages,
   linyaps-box,
@@ -91,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    copyDesktopItems
     pkg-config
     qt6Packages.wrapQtAppsHook
   ];

--- a/pkgs/by-name/ly/lyrebird/package.nix
+++ b/pkgs/by-name/ly/lyrebird/package.nix
@@ -68,9 +68,13 @@ python3Packages.buildPythonApplication rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/{bin,share/{applications,lyrebird}}
     cp -at $out/share/lyrebird/ app icon.png
     install -Dm755 app.py $out/bin/lyrebird
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/ly/lyrebird/package.nix
+++ b/pkgs/by-name/ly/lyrebird/package.nix
@@ -2,6 +2,7 @@
   python3Packages,
   lib,
   fetchFromGitHub,
+  copyDesktopItems,
   makeDesktopItem,
   wrapGAppsHook3,
   gtk3,
@@ -9,19 +10,6 @@
   sox,
   pulseaudio,
 }:
-let
-  desktopItem = makeDesktopItem {
-    name = "lyrebird";
-    exec = "lyrebird";
-    icon = "${placeholder "out"}/share/lyrebird/icon.png";
-    desktopName = "Lyrebird";
-    genericName = "Voice Changer";
-    categories = [
-      "AudioVideo"
-      "Audio"
-    ];
-  };
-in
 python3Packages.buildPythonApplication rec {
   pname = "lyrebird";
   version = "1.2.0";
@@ -42,6 +30,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeBuildInputs = [
+    copyDesktopItems
     wrapGAppsHook3
     gobject-introspection
   ];
@@ -64,10 +53,23 @@ python3Packages.buildPythonApplication rec {
     ''"''${gappsWrapperArgs[@]}"''
   ];
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "lyrebird";
+      exec = "lyrebird";
+      icon = "${placeholder "out"}/share/lyrebird/icon.png";
+      desktopName = "Lyrebird";
+      genericName = "Voice Changer";
+      categories = [
+        "AudioVideo"
+        "Audio"
+      ];
+    })
+  ];
+
   installPhase = ''
     mkdir -p $out/{bin,share/{applications,lyrebird}}
     cp -at $out/share/lyrebird/ app icon.png
-    cp -at $out/share/applications/ ${desktopItem}
     install -Dm755 app.py $out/bin/lyrebird
   '';
 

--- a/pkgs/by-name/ma/maelstrom/package.nix
+++ b/pkgs/by-name/ma/maelstrom/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   SDL2,
   SDL2_net,
@@ -24,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
     # fix build with gcc14
     ./add-maelstrom-netd-include-time.diff
   ];
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   buildInputs = [
     SDL2

--- a/pkgs/by-name/mi/minion/package.nix
+++ b/pkgs/by-name/mi/minion/package.nix
@@ -4,6 +4,7 @@
   fetchzip,
   openjfx21,
   openjdk21,
+  copyDesktopItems,
   makeDesktopItem,
   wrapGAppsHook3,
   makeBinaryWrapper,
@@ -37,6 +38,7 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [
     makeBinaryWrapper
     wrapGAppsHook3
+    copyDesktopItems
   ];
 
   dontWrapGApps = true;

--- a/pkgs/by-name/mi/mission-planner/package.nix
+++ b/pkgs/by-name/mi/mission-planner/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   unzip,
@@ -11,14 +12,6 @@
 
 let
   pname = "mission-planner";
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = "MissionPlanner GCS & Ardupilot configuration tool";
-    desktopName = "MissionPlanner";
-    genericName = "Ground Control Station";
-  };
 in
 stdenv.mkDerivation rec {
   inherit pname;
@@ -30,6 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     mono
     unzip
@@ -64,12 +58,22 @@ stdenv.mkDerivation rec {
     runHook preInstall
     mkdir -p $out/{bin,opt/mission-planner}
     install -m 444 -D mpdesktop150.png $out/share/icons/mission-planner.png
-    cp -r ${desktopItem}/share/applications $out/share/
     mv * $out/opt/mission-planner
     makeWrapper ${mono}/bin/mono $out/bin/mission-planner \
       --add-flags $out/opt/mission-planner/MissionPlanner.exe
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = "MissionPlanner GCS & Ardupilot configuration tool";
+      desktopName = "MissionPlanner";
+      genericName = "Ground Control Station";
+    })
+  ];
 
   meta = {
     description = "ArduPilot ground station";

--- a/pkgs/by-name/ml/mlterm/package.nix
+++ b/pkgs/by-name/ml/mlterm/package.nix
@@ -5,13 +5,14 @@
   fetchpatch,
   pkg-config,
   autoconf,
+  copyDesktopItems,
   makeDesktopItem,
   nixosTests,
   vte,
   harfbuzz, # can be replaced with libotf
   fribidi,
   m17n_lib,
-  libssh2, # build-in ssh
+  libssh2, # built-in ssh
   fcitx5,
   fcitx5-gtk,
   ibus,
@@ -122,6 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
+    copyDesktopItems
     pkg-config
     autoconf
   ]
@@ -188,16 +190,13 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (gtk != null) [
     "--with-gtk=${lib.versions.major gtk.version}.0"
   ]
-  ++ (lib.mapAttrsToList (n: v: lib.enableFeature v n) enableFeatures)
-  ++ [
-  ];
+  ++ (lib.mapAttrsToList (n: v: lib.enableFeature v n) enableFeatures);
 
   enableParallelBuilding = true;
 
   postInstall = ''
     install -D contrib/icon/mlterm-icon.svg "$out/share/icons/hicolor/scalable/apps/mlterm.svg"
     install -D contrib/icon/mlterm-icon-gnome2.png "$out/share/icons/hicolor/48x48/apps/mlterm.png"
-    install -D -t $out/share/applications $desktopItem/share/applications/*
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications/
@@ -205,20 +204,22 @@ stdenv.mkDerivation (finalAttrs: {
     install $out/bin/mlterm -Dt $out/Applications/mlterm.app/Contents/MacOS/
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "mlterm";
-    exec = "${desktopBinary} %U";
-    icon = "mlterm";
-    type = "Application";
-    comment = "Multi Lingual TERMinal emulator";
-    desktopName = "mlterm";
-    genericName = "Terminal emulator";
-    categories = [
-      "System"
-      "TerminalEmulator"
-    ];
-    startupNotify = false;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mlterm";
+      exec = "${desktopBinary} %U";
+      icon = "mlterm";
+      type = "Application";
+      comment = "Multi Lingual TERMinal emulator";
+      desktopName = "mlterm";
+      genericName = "Terminal emulator";
+      categories = [
+        "System"
+        "TerminalEmulator"
+      ];
+      startupNotify = false;
+    })
+  ];
 
   passthru = {
     tests.test = nixosTests.terminal-emulators.mlterm;

--- a/pkgs/by-name/mo/monero-gui/package.nix
+++ b/pkgs/by-name/mo/monero-gui/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  copyDesktopItems,
   makeDesktopItem,
   boost186,
   cmake,
@@ -38,6 +39,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     cmake
     pkg-config
     qt5.wrapQtAppsHook
@@ -111,23 +113,21 @@ stdenv.mkDerivation rec {
     "-DCMAKE_CXX_FLAGS=-fpermissive"
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "monero-wallet-gui";
-    exec = "monero-wallet-gui";
-    icon = "monero";
-    desktopName = "Monero";
-    genericName = "Wallet";
-    categories = [
-      "Network"
-      "Utility"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "monero-wallet-gui";
+      exec = "monero-wallet-gui";
+      icon = "monero";
+      desktopName = "Monero";
+      genericName = "Wallet";
+      categories = [
+        "Network"
+        "Utility"
+      ];
+    })
+  ];
 
   postInstall = ''
-    # install desktop entry
-    install -Dm644 -t $out/share/applications \
-      ${desktopItem}/share/applications/*
-
     # install icons
     for n in 16 24 32 48 64 96 128 256; do
       size=$n"x"$n

--- a/pkgs/by-name/mr/mrrescue/package.nix
+++ b/pkgs/by-name/mr/mrrescue/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchurl,
+  copyDesktopItems,
   love,
   lua,
   makeWrapper,
@@ -10,25 +11,6 @@
   strip-nondeterminism,
   zip,
 }:
-
-let
-  icon = fetchurl {
-    url = "http://tangramgames.dk/img/thumb/mrrescue.png";
-    sha256 = "1y5ahf0m01i1ch03axhvp2kqc6lc1yvh59zgvgxw4w7y3jryw20k";
-  };
-
-  desktopItem = makeDesktopItem {
-    name = "mrrescue";
-    exec = "mrrescue";
-    icon = icon;
-    comment = "Arcade-style fire fighting game";
-    desktopName = "Mr. Rescue";
-    genericName = "mrrescue";
-    categories = [ "Game" ];
-  };
-
-in
-
 stdenv.mkDerivation {
   pname = "mrrescue";
   version = "1.02d-unstable-2018-08-18";
@@ -41,6 +23,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     lua
     love
     makeWrapper
@@ -64,9 +47,26 @@ stdenv.mkDerivation {
     makeWrapper ${lib.getExe love} $out/bin/mrrescue --add-flags $out/share/games/lovegames/mrrescue.love
 
     chmod +x $out/bin/mrrescue
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
   '';
+
+  desktopItems =
+    let
+      icon = fetchurl {
+        url = "http://tangramgames.dk/img/thumb/mrrescue.png";
+        sha256 = "1y5ahf0m01i1ch03axhvp2kqc6lc1yvh59zgvgxw4w7y3jryw20k";
+      };
+    in
+    [
+      (makeDesktopItem {
+        name = "mrrescue";
+        exec = "mrrescue";
+        icon = icon;
+        comment = "Arcade-style fire fighting game";
+        desktopName = "Mr. Rescue";
+        genericName = "mrrescue";
+        categories = [ "Game" ];
+      })
+    ];
 
   meta = {
     description = "Arcade-style fire fighting game";

--- a/pkgs/by-name/mr/mrrescue/package.nix
+++ b/pkgs/by-name/mr/mrrescue/package.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     mkdir -p $out/share/games/lovegames
 
@@ -47,6 +49,8 @@ stdenv.mkDerivation {
     makeWrapper ${lib.getExe love} $out/bin/mrrescue --add-flags $out/share/games/lovegames/mrrescue.love
 
     chmod +x $out/bin/mrrescue
+
+    runHook postInstall
   '';
 
   desktopItems =

--- a/pkgs/by-name/ne/netron/package.nix
+++ b/pkgs/by-name/ne/netron/package.nix
@@ -5,6 +5,7 @@
   electron_39,
   fetchFromGitHub,
   jq,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
@@ -27,7 +28,10 @@ buildNpmPackage (finalAttrs: {
 
   npmDepsHash = "sha256-HyqfrkO9Cbo6KVY1QuA4i6od6M7ZQaIfkUWA2P/bvfI=";
 
-  nativeBuildInputs = [ jq ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    jq
+  ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -4,6 +4,7 @@
   lib,
   makeWrapper,
   electron_39, # as in upstream bundle, see https://github.com/NixOS/nixpkgs/pull/510075
+  copyDesktopItems,
   makeDesktopItem,
   imagemagick,
   autoPatchelfHook,
@@ -53,27 +54,17 @@ let
     hash = "sha256-EZsBuWyZ9zYJh0LDKfRAMTtnY70q6iLK/ggXlplDEoA=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "obsidian";
-    desktopName = "Obsidian";
-    comment = "Knowledge base";
-    icon = "obsidian";
-    exec = "obsidian %u";
-    categories = [ "Office" ];
-    mimeTypes = [ "x-scheme-handler/obsidian" ];
-  };
-
   linux = stdenv.mkDerivation {
     inherit
       pname
       version
       src
-      desktopItem
       icon
       meta
       ;
     nativeBuildInputs = [
       autoPatchelfHook
+      copyDesktopItems
       makeWrapper
       imagemagick
     ];
@@ -87,14 +78,24 @@ let
       install -m 755 -D obsidian-cli $out/bin/obsidian-cli
       install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
       install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
-      install -m 444 -D "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
       for size in 16 24 32 48 64 128 256 512; do
         mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
         magick -background none ${icon} -resize "$size"x"$size" $out/share/icons/hicolor/"$size"x"$size"/apps/obsidian.png
       done
       runHook postInstall
     '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "obsidian";
+        desktopName = "Obsidian";
+        comment = "Knowledge base";
+        icon = "obsidian";
+        exec = "obsidian %u";
+        categories = [ "Office" ];
+        mimeTypes = [ "x-scheme-handler/obsidian" ];
+      })
+    ];
 
     passthru.updateScript = writeScript "updater" ''
       #!/usr/bin/env nix-shell

--- a/pkgs/by-name/on/onlykey/package.nix
+++ b/pkgs/by-name/on/onlykey/package.nix
@@ -1,5 +1,6 @@
 {
   buildNpmPackage,
+  copyDesktopItems,
   fetchFromGitHub,
   fetchpatch2,
   lib,
@@ -27,17 +28,21 @@ buildNpmPackage (finalAttrs: {
     })
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "onlykey";
-    exec = "onlykey";
-    icon = "onlykey";
-    desktopName = "OnlyKey";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "Utility"
-    ];
-    terminal = false;
-  };
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "onlykey";
+      exec = "onlykey";
+      icon = "onlykey";
+      desktopName = "OnlyKey";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Utility"
+      ];
+      terminal = false;
+    })
+  ];
 
   npmDepsHash = "sha256-DpjB95KEHfAc4GBxY40uUjlN7ifBMUncufVTmTXqDo8=";
 
@@ -51,8 +56,6 @@ buildNpmPackage (finalAttrs: {
 
     mkdir -p "$out/share"
     cp -r build "$out/share/onlykey"
-
-    ln -s "${finalAttrs.desktopItem}/share/applications" "$out/share/applications"
 
     mkdir -p "$out/share/icons/hicolor/128x128/apps"
     install -D resources/onlykey_logo_128.png "$out/share/icons/hicolor/128x128/apps/onlykey.png"

--- a/pkgs/by-name/on/onyx/package.nix
+++ b/pkgs/by-name/on/onyx/package.nix
@@ -3,6 +3,7 @@
   flutter335,
   lib,
   libsecret,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
@@ -18,6 +19,8 @@ flutter335.buildFlutterApplication rec {
   };
 
   sourceRoot = "${src.name}/apps/onyx";
+
+  nativeBuildInputs = [ copyDesktopItems ];
 
   buildInputs = [
     libsecret

--- a/pkgs/by-name/op/open-ecard/package.nix
+++ b/pkgs/by-name/op/open-ecard/package.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/java
     cp ${srcs.richclient} $out/share/java/richclient-${version}.jar
     cp ${srcs.cifs} $out/share/java/cifs-${version}.jar
@@ -67,6 +69,8 @@ stdenv.mkDerivation rec {
       --add-flags "-cp $out/share/java/cifs-${version}.jar" \
       --add-flags "-jar $out/share/java/richclient-${version}.jar" \
       --suffix LD_LIBRARY_PATH ':' ${lib.getLib pcsclite}/lib
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/op/open-ecard/package.nix
+++ b/pkgs/by-name/op/open-ecard/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   jre,
   pcsclite,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
 }:
@@ -33,28 +34,32 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    desktopName = "Open eCard App";
-    genericName = "eCard App";
-    comment = "Client side implementation of the eCard-API-Framework";
-    icon = "oec_logo_bg-transparent.svg";
-    exec = pname;
-    categories = [
-      "Utility"
-      "Security"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Open eCard App";
+      genericName = "eCard App";
+      comment = "Client side implementation of the eCard-API-Framework";
+      icon = "oec_logo_bg-transparent.svg";
+      exec = pname;
+      categories = [
+        "Utility"
+        "Security"
+      ];
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/share/java
     cp ${srcs.richclient} $out/share/java/richclient-${version}.jar
     cp ${srcs.cifs} $out/share/java/cifs-${version}.jar
 
-    mkdir -p $out/share/applications $out/share/pixmaps
-    cp $desktopItem/share/applications/* $out/share/applications
+    mkdir -p $out/share/pixmaps
     cp ${srcs.logo} $out/share/pixmaps/oec_logo_bg-transparent.svg
 
     mkdir -p $out/bin

--- a/pkgs/by-name/os/osmium/package.nix
+++ b/pkgs/by-name/os/osmium/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   fetchurl,
   lib,
+  copyDesktopItems,
   makeDesktopItem,
   makeShellWrapper,
   autoPatchelfHook,
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     makeShellWrapper
   ];
 
@@ -75,24 +77,24 @@ stdenv.mkDerivation rec {
     ln -s $out/opt/resources/assets/icons/256x256.png $out/share/pixmaps/osmium.png
     ln -s $out/opt/resources/assets/icons/256x256.png $out/share/icons/hicolor/256x256/apps/osmium.png
 
-    ln -s "$desktopItem/share/applications" $out/share
-
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "osmium";
-    exec = "osmium";
-    icon = "osmium";
-    desktopName = "Osmium";
-    genericName = "A globally distributed community messaging and voice/video platform.";
-    categories = [
-      "Network"
-      "InstantMessaging"
-    ];
-    mimeTypes = [ "x-scheme-handler/osmium" ];
-    startupWMClass = "Osmium";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "osmium";
+      exec = "osmium";
+      icon = "osmium";
+      desktopName = "Osmium";
+      genericName = "A globally distributed community messaging and voice/video platform.";
+      categories = [
+        "Network"
+        "InstantMessaging"
+      ];
+      mimeTypes = [ "x-scheme-handler/osmium" ];
+      startupWMClass = "Osmium";
+    })
+  ];
 
   meta = {
     description = "Globally distributed community messaging and voice/video platform";

--- a/pkgs/by-name/ou/outfly/package.nix
+++ b/pkgs/by-name/ou/outfly/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromCodeberg,
   rustPlatform,
+  copyDesktopItems,
   makeDesktopItem,
   pkg-config,
   libxkbcommon,
@@ -41,7 +42,10 @@ rustPlatform.buildRustPackage rec {
     wayland
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
   doCheck = false; # no meaningful tests
 
   postFixup = ''

--- a/pkgs/by-name/po/popcorntime/package.nix
+++ b/pkgs/by-name/po/popcorntime/package.nix
@@ -76,6 +76,8 @@ stdenv.mkDerivation rec {
 
   # Extract and copy executable in $out/bin
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/applications $out/bin $out/opt/bin $out/share/icons/hicolor/scalable/apps/
     # we can't unzip it in $out/lib, because nw.js will start with
     # an empty screen. Therefore it will be unzipped in a non-typical
@@ -85,6 +87,8 @@ stdenv.mkDerivation rec {
     ln -s $out/opt/popcorntime/Popcorn-Time $out/bin/popcorntime
 
     ln -s $out/opt/popcorntime/src/app/images/icon.png $out/share/icons/hicolor/scalable/apps/popcorntime.png
+
+    runHook postInstall
   '';
 
   # GSETTINGS_SCHEMAS_PATH is not set in installPhase

--- a/pkgs/by-name/po/popcorntime/package.nix
+++ b/pkgs/by-name/po/popcorntime/package.nix
@@ -58,19 +58,21 @@ stdenv.mkDerivation rec {
     "--prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}"
   ];
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    comment = meta.description;
-    genericName = meta.description;
-    type = "Application";
-    desktopName = "Popcorn-Time";
-    categories = [
-      "Video"
-      "AudioVideo"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      comment = meta.description;
+      genericName = meta.description;
+      type = "Application";
+      desktopName = "Popcorn-Time";
+      categories = [
+        "Video"
+        "AudioVideo"
+      ];
+    })
+  ];
 
   # Extract and copy executable in $out/bin
   installPhase = ''
@@ -83,8 +85,6 @@ stdenv.mkDerivation rec {
     ln -s $out/opt/popcorntime/Popcorn-Time $out/bin/popcorntime
 
     ln -s $out/opt/popcorntime/src/app/images/icon.png $out/share/icons/hicolor/scalable/apps/popcorntime.png
-
-    ln -s ${desktopItem}/share/applications/popcorntime.desktop $out/share/applications/popcorntime.desktop
   '';
 
   # GSETTINGS_SCHEMAS_PATH is not set in installPhase

--- a/pkgs/by-name/po/portfolio/package.nix
+++ b/pkgs/by-name/po/portfolio/package.nix
@@ -1,5 +1,6 @@
 {
   autoPatchelfHook,
+  copyDesktopItems,
   fetchurl,
   glib,
   glib-networking,
@@ -15,16 +16,6 @@
   gitUpdater,
 }:
 let
-  desktopItem = makeDesktopItem {
-    name = "Portfolio";
-    exec = "portfolio";
-    icon = "portfolio";
-    comment = "Calculate Investment Portfolio Performance";
-    desktopName = "Portfolio Performance";
-    categories = [ "Office" ];
-    startupWMClass = "Portfolio Performance";
-  };
-
   runtimeLibs = lib.makeLibraryPath [
     glib
     glib-networking
@@ -44,6 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     wrapGAppsHook3
     imagemagick
   ];
@@ -94,13 +86,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --prefix PATH : ${openjdk21}/bin
 
     # Create desktop item
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
     mkdir -p $out/share/icons/hicolor/256x256/apps
     magick $out/portfolio/icon.xpm $out/share/icons/hicolor/256x256/apps/portfolio.png
 
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Portfolio";
+      exec = "portfolio";
+      icon = "portfolio";
+      comment = "Calculate Investment Portfolio Performance";
+      desktopName = "Portfolio Performance";
+      categories = [ "Office" ];
+      startupWMClass = "Portfolio Performance";
+    })
+  ];
 
   passthru.updateScript = gitUpdater { url = "https://github.com/buchen/portfolio.git"; };
 

--- a/pkgs/by-name/ps/psst/package.nix
+++ b/pkgs/by-name/ps/psst/package.nix
@@ -4,6 +4,7 @@
   cairo,
   dbus,
   fetchFromGitHub,
+  copyDesktopItems,
   gdk-pixbuf,
   glib,
   gtk3,
@@ -17,20 +18,6 @@
   stdenv,
 }:
 
-let
-  desktopItem = makeDesktopItem {
-    categories = [
-      "Audio"
-      "AudioVideo"
-    ];
-    comment = "Spotify client with native GUI written in Rust, without Electron";
-    desktopName = "Psst";
-    exec = "psst-gui %U";
-    icon = "psst";
-    name = "Psst";
-    startupWMClass = "psst-gui";
-  };
-in
 rustPlatform.buildRustPackage {
   pname = "psst";
   version = "0-unstable-2025-11-16";
@@ -51,7 +38,10 @@ rustPlatform.buildRustPackage {
     LIBCLANG_PATH = "${lib.getLib libclang}/lib";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
 
   buildInputs = [
     atk
@@ -73,8 +63,22 @@ rustPlatform.buildRustPackage {
 
   postInstall = ''
     install -Dm644 psst-gui/assets/logo_512.png -t $out/share/icons/hicolor/512x512/apps/psst.png
-    install -Dm644 ${desktopItem}/share/applications/* -t $out/share/applications
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+      comment = "Spotify client with native GUI written in Rust, without Electron";
+      desktopName = "Psst";
+      exec = "psst-gui %U";
+      icon = "psst";
+      name = "Psst";
+      startupWMClass = "psst-gui";
+    })
+  ];
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 

--- a/pkgs/by-name/py/pymol/package.nix
+++ b/pkgs/by-name/py/pymol/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   fetchpatch,
+  copyDesktopItems,
   makeDesktopItem,
   cmake,
   python3Packages,
@@ -20,29 +21,6 @@ let
   pname = "pymol";
   description = "Python-enhanced molecular graphics tool";
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    desktopName = "PyMol Molecular Graphics System";
-    genericName = "Molecular Modeler";
-    comment = description;
-    icon = pname;
-    mimeTypes = [
-      "chemical/x-pdb"
-      "chemical/x-mdl-molfile"
-      "chemical/x-mol2"
-      "chemical/seq-aa-fasta"
-      "chemical/seq-na-fasta"
-      "chemical/x-xyz"
-      "chemical/x-mdl-sdf"
-    ];
-    categories = [
-      "Graphics"
-      "Education"
-      "Science"
-      "Chemistry"
-    ];
-  };
 in
 python3Packages.buildPythonApplication rec {
   inherit pname;
@@ -90,6 +68,7 @@ python3Packages.buildPythonApplication rec {
   dontUseCmakeConfigure = true;
 
   nativeBuildInputs = [
+    copyDesktopItems
     cmake
     qt5.wrapQtAppsHook
   ];
@@ -115,23 +94,42 @@ python3Packages.buildPythonApplication rec {
 
   env.NIX_CFLAGS_COMPILE = "-I ${libxml2.dev}/include/libxml2";
 
-  postInstall =
-    with python3Packages;
-    ''
-      wrapProgram $out/bin/pymol \
-        --prefix PYTHONPATH : ${
-          lib.makeSearchPathOutput "lib" python3Packages.python.sitePackages [
-            pyqt5
-            pyqt5.pyqt5-sip
-          ]
-        }
+  postInstall = with python3Packages; ''
+    wrapProgram $out/bin/pymol \
+      --prefix PYTHONPATH : ${
+        lib.makeSearchPathOutput "lib" python3Packages.python.sitePackages [
+          pyqt5
+          pyqt5.pyqt5-sip
+        ]
+      }
 
-      mkdir -p "$out/share/icons/"
-      ln -s $out/${python3Packages.python.sitePackages}/pymol/pymol_path/data/pymol/icons/icon2.svg "$out/share/icons/pymol.svg"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      cp -r "${desktopItem}/share/applications/" "$out/share/"
-    '';
+    mkdir -p "$out/share/icons/"
+    ln -s $out/${python3Packages.python.sitePackages}/pymol/pymol_path/data/pymol/icons/icon2.svg "$out/share/icons/pymol.svg"
+  '';
+
+  desktopItems = lib.lists.optional stdenv.hostPlatform.isLinux (makeDesktopItem {
+    name = pname;
+    exec = pname;
+    desktopName = "PyMol Molecular Graphics System";
+    genericName = "Molecular Modeler";
+    comment = description;
+    icon = pname;
+    mimeTypes = [
+      "chemical/x-pdb"
+      "chemical/x-mdl-molfile"
+      "chemical/x-mol2"
+      "chemical/seq-aa-fasta"
+      "chemical/seq-na-fasta"
+      "chemical/x-xyz"
+      "chemical/x-mdl-sdf"
+    ];
+    categories = [
+      "Graphics"
+      "Education"
+      "Science"
+      "Chemistry"
+    ];
+  });
 
   pythonImportsCheck = [ "pymol" ];
 

--- a/pkgs/by-name/qp/qpaeq/package.nix
+++ b/pkgs/by-name/qp/qpaeq/package.nix
@@ -2,31 +2,19 @@
   lib,
   stdenv,
   pulseaudio,
+  copyDesktopItems,
   makeDesktopItem,
   qt5,
   python3,
 }:
-
-let
-  desktopItem = makeDesktopItem {
-    name = "qpaeq";
-    exec = "@out@/bin/qpaeq";
-    icon = "audio-volume-high";
-    desktopName = "qpaeq";
-    genericName = "Audio equalizer";
-    categories = [
-      "AudioVideo"
-      "Audio"
-      "Mixer"
-    ];
-    startupNotify = false;
-  };
-in
 stdenv.mkDerivation {
   pname = "qpaeq";
   inherit (pulseaudio) version src;
 
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    qt5.wrapQtAppsHook
+  ];
 
   buildInputs = [
     (python3.withPackages (
@@ -40,10 +28,25 @@ stdenv.mkDerivation {
   dontBuild = true;
   dontConfigure = true;
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "qpaeq";
+      exec = "@out@/bin/qpaeq";
+      icon = "audio-volume-high";
+      desktopName = "qpaeq";
+      genericName = "Audio equalizer";
+      categories = [
+        "AudioVideo"
+        "Audio"
+        "Mixer"
+      ];
+      startupNotify = false;
+    })
+  ];
+
   installPhase = ''
     runHook preInstall
     install -D ./src/utils/qpaeq $out/bin/qpaeq
-    install -D ${desktopItem}/share/applications/qpaeq.desktop $out/share/applications/qpaeq.desktop
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ro/robo3t/package.nix
+++ b/pkgs/by-name/ro/robo3t/package.nix
@@ -17,6 +17,7 @@
   libGL,
   freetype,
   xkeyboard_config,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
 }:
@@ -36,20 +37,25 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2PkUxBq2ow0wl09k8B6LJJUQ+y4GpnmoAeumKN1u5xg=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "robo3t";
-    exec = "robo3t";
-    icon = icon;
-    comment = "Query GUI for mongodb";
-    desktopName = "Robo3T";
-    genericName = "MongoDB management tool";
-    categories = [
-      "Development"
-      "IDE"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "robo3t";
+      exec = "robo3t";
+      icon = icon;
+      comment = "Query GUI for mongodb";
+      desktopName = "Robo3T";
+      genericName = "MongoDB management tool";
+      categories = [
+        "Development"
+        "IDE"
+      ];
+    })
+  ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   ldLibraryPath = lib.makeLibraryPath [
     stdenv.cc.cc
@@ -79,9 +85,6 @@ stdenv.mkDerivation rec {
 
     mkdir -p $BASEDIR/lib
     cp -r lib/* $BASEDIR/lib
-
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications
 
     mkdir -p $out/share/icons
     cp ${icon} $out/share/icons/robomongo.png

--- a/pkgs/by-name/ro/roomeqwizard/package.nix
+++ b/pkgs/by-name/ro/roomeqwizard/package.nix
@@ -5,6 +5,7 @@
   gnused,
   jdk8,
   lib,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   stdenv,
@@ -26,14 +27,16 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = pname;
-    icon = pname;
-    desktopName = "REW";
-    genericName = "Software for audio measurements";
-    categories = [ "AudioVideo" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = pname;
+      desktopName = "REW";
+      genericName = "Software for audio measurements";
+      categories = [ "AudioVideo" ];
+    })
+  ];
 
   responseFile = writeTextFile {
     name = "response.varfile";
@@ -54,7 +57,10 @@ stdenv.mkDerivation rec {
     SUBSYSTEM=="usb", ATTR{idVendor}=="2752", ATTR{idProduct}=="0007", TAG+="uaccess"
   '';
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   buildPhase = ''
     runHook preBuild
@@ -86,7 +92,6 @@ stdenv.mkDerivation rec {
         ]
       }
 
-    cp -r "$desktopItem/share/applications" $out/share/
     cp $out/share/roomeqwizard/.install4j/roomeqwizard.png "$out/share/icons/hicolor/256x256/apps/${pname}.png"
 
     ${lib.optionalString recommendedUdevRules ''echo "$udevRules" > $out/lib/udev/rules.d/90-roomeqwizard.rules''}

--- a/pkgs/by-name/ru/rusty-psn/package.nix
+++ b/pkgs/by-name/ru/rusty-psn/package.nix
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage rec {
     mv $out/bin/rusty-psn $out/bin/rusty-psn-gui
   '';
 
-  desktopItem = lib.optionalString withGui (makeDesktopItem {
+  desktopItems = lib.lists.optional withGui (makeDesktopItem {
     name = "rusty-psn";
     desktopName = "rusty-psn";
     exec = "rusty-psn-gui";
@@ -92,7 +92,6 @@ rustPlatform.buildRustPackage rec {
       "update"
     ];
   });
-  desktopItems = lib.optionals withGui [ desktopItem ];
 
   meta = {
     description = "Simple tool to grab updates for PS3 games, directly from Sony's servers using their updates API";

--- a/pkgs/by-name/sa/saleae-logic/package.nix
+++ b/pkgs/by-name/sa/saleae-logic/package.nix
@@ -29,6 +29,7 @@
   libxcb,
   zlib,
   pciutils,
+  copyDesktopItems,
   makeDesktopItem,
   xkeyboard-config,
   dbus,
@@ -73,17 +74,22 @@ stdenv.mkDerivation rec {
     sha256 = "0lhair2vsg8sjvzicvfcjfmvy30q7i01xj4z02iqh7pgzpb025h8";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "saleae-logic";
-    exec = "saleae-logic";
-    icon = ""; # the package contains no icon
-    comment = "Software for Saleae logic analyzers";
-    desktopName = "Saleae Logic";
-    genericName = "Logic analyzer";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "saleae-logic";
+      exec = "saleae-logic";
+      icon = ""; # the package contains no icon
+      comment = "Software for Saleae logic analyzers";
+      desktopName = "Saleae Logic";
+      genericName = "Logic analyzer";
+      categories = [ "Development" ];
+    })
+  ];
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    unzip
+  ];
 
   installPhase = ''
     # Copy prebuilt app to $out
@@ -116,10 +122,6 @@ stdenv.mkDerivation rec {
     exec "$out/Logic" "\$@"
     EOF
     chmod a+x "$out"/bin/saleae-logic
-
-    # Copy the generated .desktop file
-    mkdir -p "$out/share/applications"
-    cp "$desktopItem"/share/applications/* "$out/share/applications/"
 
     # Install provided udev rules
     mkdir -p "$out/etc/udev/rules.d"

--- a/pkgs/by-name/sa/saleae-logic/package.nix
+++ b/pkgs/by-name/sa/saleae-logic/package.nix
@@ -92,6 +92,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     # Copy prebuilt app to $out
     mkdir "$out"
     cp -r * "$out"
@@ -126,6 +128,8 @@ stdenv.mkDerivation rec {
     # Install provided udev rules
     mkdir -p "$out/etc/udev/rules.d"
     cp Drivers/99-SaleaeLogic.rules "$out/etc/udev/rules.d/"
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/sa/samplebrain/package.nix
+++ b/pkgs/by-name/sa/samplebrain/package.nix
@@ -58,9 +58,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp samplebrain $out/bin
     install -m 444 -D desktop/samplebrain.svg $out/share/icons/hicolor/scalable/apps/samplebrain.svg
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/sa/samplebrain/package.nix
+++ b/pkgs/by-name/sa/samplebrain/package.nix
@@ -6,6 +6,7 @@
   fftw,
   liblo,
   libsndfile,
+  copyDesktopItems,
   makeDesktopItem,
   portaudio,
   libsForQt5,
@@ -31,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = with libsForQt5; [
+    copyDesktopItems
     qmake
     wrapQtAppsHook
   ];
@@ -43,15 +45,17 @@ stdenv.mkDerivation (finalAttrs: {
     libsForQt5.qtbase
   ];
 
-  desktopItem = makeDesktopItem {
-    type = "Application";
-    desktopName = "samplebrain";
-    name = "samplebrain";
-    comment = "A sample masher designed by Aphex Twin";
-    exec = "samplebrain";
-    icon = "samplebrain";
-    categories = [ "Audio" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      desktopName = "samplebrain";
+      name = "samplebrain";
+      comment = "A sample masher designed by Aphex Twin";
+      exec = "samplebrain";
+      icon = "samplebrain";
+      categories = [ "Audio" ];
+    })
+  ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/sc/scenic-view/package.nix
+++ b/pkgs/by-name/sc/scenic-view/package.nix
@@ -5,6 +5,7 @@
   openjdk,
   openjfx,
   gradle_7,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
 }:
@@ -45,6 +46,7 @@ in
 stdenv.mkDerivation rec {
   inherit pname version src;
   nativeBuildInputs = [
+    copyDesktopItems
     gradle
     makeWrapper
   ];

--- a/pkgs/by-name/sc/scid-vs-pc/package.nix
+++ b/pkgs/by-name/sc/scid-vs-pc/package.nix
@@ -7,6 +7,7 @@
   zlib,
   makeWrapper,
   which,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
@@ -26,6 +27,7 @@ tcl.mkTclDerivation rec {
   '';
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     which
   ];
@@ -41,24 +43,23 @@ tcl.mkTclDerivation rec {
   ];
 
   postInstall = ''
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications/
-
     install -D icons/scid.png "$out"/share/icons/hicolor/128x128/apps/scid.png
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "scid-vs-pc";
-    desktopName = "Scid vs. PC";
-    genericName = "Chess Database";
-    comment = meta.description;
-    icon = "scid";
-    exec = "scid";
-    categories = [
-      "Game"
-      "BoardGame"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "scid-vs-pc";
+      desktopName = "Scid vs. PC";
+      genericName = "Chess Database";
+      comment = meta.description;
+      icon = "scid";
+      exec = "scid";
+      categories = [
+        "Game"
+        "BoardGame"
+      ];
+    })
+  ];
 
   meta = {
     description = "Chess database with play and training functionality";

--- a/pkgs/by-name/sc/scummvm/games.nix
+++ b/pkgs/by-name/sc/scummvm/games.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   unzip,
   writeText,
@@ -10,21 +11,6 @@
 }:
 
 let
-  desktopItem =
-    name: short: long: description:
-    makeDesktopItem {
-      categories = [
-        "Game"
-        "AdventureGame"
-      ];
-      comment = description;
-      desktopName = long;
-      exec = "@out@/bin/${short}";
-      genericName = description;
-      icon = "scummvm";
-      name = name;
-    };
-
   run =
     name: short: code:
     writeText "${short}.sh" ''
@@ -63,7 +49,10 @@ let
       {
         inherit pname version;
 
-        nativeBuildInputs = [ unzip ];
+        nativeBuildInputs = [
+          copyDesktopItems
+          unzip
+        ];
 
         dontBuild = true;
         dontFixup = true;
@@ -78,15 +67,26 @@ let
 
           substitute ${run pname pshort pcode} $out/bin/${pshort} \
             --subst-var out
-          substitute ${
-            desktopItem pname pshort plong description
-          }/share/applications/${pname}.desktop $out/share/applications/${pname}.desktop \
-            --subst-var out
 
           chmod 0755 $out/bin/${pshort}
 
           runHook postInstall
         '';
+
+        desktopItems = [
+          (makeDesktopItem {
+            categories = [
+              "Game"
+              "AdventureGame"
+            ];
+            comment = description;
+            desktopName = plong;
+            exec = pshort;
+            genericName = description;
+            icon = "scummvm";
+            name = pname;
+          })
+        ];
 
         meta = {
           homepage = "https://www.scummvm.org";

--- a/pkgs/by-name/sm/smartgit/package.nix
+++ b/pkgs/by-name/sm/smartgit/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   openjdk21,
   gtk3,
@@ -25,7 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-YqueTbwA9KcXEJG5TeWkPzzNyAnnJQ1+VQYsqZKS2/I=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     jre
@@ -64,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -av bin/smartgit.sh $out/bin/smartgit
     ln -sfv $out/bin/smartgit $out/bin/smartgithg
 
-    cp -av $desktopItem/share/applications/* $out/share/applications/
     for icon_size in 32 48 64 128 256; do
         path=$icon_size'x'$icon_size
         icon=bin/smartgit-$icon_size.png
@@ -77,25 +80,27 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "smartgit";
-    exec = "smartgit";
-    comment = finalAttrs.meta.description;
-    icon = "smartgit";
-    desktopName = "SmartGit";
-    categories = [
-      "Development"
-      "RevisionControl"
-    ];
-    mimeTypes = [
-      "x-scheme-handler/git"
-      "x-scheme-handler/smartgit"
-      "x-scheme-handler/sourcetree"
-    ];
-    startupNotify = true;
-    startupWMClass = "smartgit";
-    keywords = [ "git" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "smartgit";
+      exec = "smartgit";
+      comment = finalAttrs.meta.description;
+      icon = "smartgit";
+      desktopName = "SmartGit";
+      categories = [
+        "Development"
+        "RevisionControl"
+      ];
+      mimeTypes = [
+        "x-scheme-handler/git"
+        "x-scheme-handler/smartgit"
+        "x-scheme-handler/sourcetree"
+      ];
+      startupNotify = true;
+      startupWMClass = "smartgit";
+      keywords = [ "git" ];
+    })
+  ];
 
   meta = {
     description = "Git GUI client";

--- a/pkgs/by-name/sm/smartsynchronize/package.nix
+++ b/pkgs/by-name/sm/smartsynchronize/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   openjdk21,
   gtk3,
@@ -25,7 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-F+Yrr029nPnnCvFEhIxgeXloyt2JRKSw8uOmVySWKzo=";
   };
 
-  nativeBuildInputs = [ wrapGAppsHook3 ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     jre
@@ -59,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -av ./lib $out/
     cp -av bin/smartsynchronize.sh $out/bin/smartsynchronize
 
-    cp -av $desktopItem/share/applications/* $out/share/applications/
     for icon_size in 32 48 64 128 256; do
         path=$icon_size'x'$icon_size
         icon=bin/smartsynchronize-$icon_size.png
@@ -72,20 +75,22 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "smartsynchronize";
-    exec = "smartsynchronize";
-    comment = finalAttrs.meta.description;
-    icon = "smartsynchronize";
-    desktopName = "SmartSynchronize";
-    categories = [ "Development" ];
-    startupNotify = true;
-    startupWMClass = "smartsynchronize";
-    keywords = [
-      "compare"
-      "file manager"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "smartsynchronize";
+      exec = "smartsynchronize";
+      comment = finalAttrs.meta.description;
+      icon = "smartsynchronize";
+      desktopName = "SmartSynchronize";
+      categories = [ "Development" ];
+      startupNotify = true;
+      startupWMClass = "smartsynchronize";
+      keywords = [
+        "compare"
+        "file manager"
+      ];
+    })
+  ];
 
   meta = {
     description = "File Manager, File/Directory Compare";

--- a/pkgs/by-name/sn/snowemu/package.nix
+++ b/pkgs/by-name/sn/snowemu/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
   SDL2,
   pkg-config,
@@ -31,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     makeWrapper
+    copyDesktopItems
   ];
 
   buildInputs = [

--- a/pkgs/by-name/sp/speed-dreams/package.nix
+++ b/pkgs/by-name/sp/speed-dreams/package.nix
@@ -34,7 +34,6 @@
   cjson,
   minizip,
   rhash,
-  copyDesktopItems,
   makeWrapper,
 }:
 
@@ -128,7 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     cmake
-    copyDesktopItems
     makeWrapper
   ];
 

--- a/pkgs/by-name/st/stretchly/package.nix
+++ b/pkgs/by-name/st/stretchly/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   makeWrapper,
   electron,
+  copyDesktopItems,
   makeDesktopItem,
   nix-update-script,
 }:
@@ -22,7 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-tO0cNKopG/recQus7KDUTyGpApvR5/tpmF5C4V14DnI=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -30,23 +34,22 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/bin $out/share/stretchly/
     mv resources/app.asar* $out/share/stretchly/
 
-    mkdir -p $out/share/applications
-    ln -s ${finalAttrs.desktopItem}/share/applications/* $out/share/applications/
-
     makeWrapper ${electron}/bin/electron $out/bin/stretchly \
       --add-flags $out/share/stretchly/app.asar
 
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "stretchly";
-    exec = "stretchly";
-    icon = finalAttrs.icon;
-    desktopName = "Stretchly";
-    genericName = "Stretchly";
-    categories = [ "Utility" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "stretchly";
+      exec = "stretchly";
+      icon = finalAttrs.icon;
+      desktopName = "Stretchly";
+      genericName = "Stretchly";
+      categories = [ "Utility" ];
+    })
+  ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/st/structorizer/package.nix
+++ b/pkgs/by-name/st/structorizer/package.nix
@@ -3,10 +3,8 @@
   lib,
   fetchFromGitHub,
   jdk11,
-  makeDesktopItem,
   makeWrapper,
   wrapGAppsHook3,
-  copyDesktopItems,
   nix-update-script,
 }:
 

--- a/pkgs/by-name/st/styluslabs-write-bin/package.nix
+++ b/pkgs/by-name/st/styluslabs-write-bin/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ copyDesktopItems ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp -R Write $out/
     # symlink the binary to bin/
@@ -32,6 +34,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/share/icons
     ln -s $out/Write/Write144x144.png $out/share/icons/write_stylus.png
+
+    runHook postInstall
   '';
 
   desktopItems = [

--- a/pkgs/by-name/st/styluslabs-write-bin/package.nix
+++ b/pkgs/by-name/st/styluslabs-write-bin/package.nix
@@ -6,22 +6,9 @@
   libx11,
   libxi,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
 }:
-let
-  desktopItem = makeDesktopItem {
-    name = "Write";
-    exec = "Write";
-    comment = "A word processor for handwriting";
-    icon = "write_stylus";
-    desktopName = "Write";
-    genericName = "Write";
-    categories = [
-      "Office"
-      "Graphics"
-    ];
-  };
-in
 stdenv.mkDerivation rec {
   pname = "styluslabs-write-bin";
   version = "300";
@@ -35,18 +22,33 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
+  nativeBuildInputs = [ copyDesktopItems ];
+
   installPhase = ''
     mkdir -p $out/bin
     cp -R Write $out/
     # symlink the binary to bin/
     ln -s $out/Write/Write $out/bin/Write
 
-    # Create desktop item
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
     mkdir -p $out/share/icons
     ln -s $out/Write/Write144x144.png $out/share/icons/write_stylus.png
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Write";
+      exec = "Write";
+      comment = "A word processor for handwriting";
+      icon = "write_stylus";
+      desktopName = "Write";
+      genericName = "Write";
+      categories = [
+        "Office"
+        "Graphics"
+      ];
+    })
+  ];
+
   preFixup =
     let
       libPath = lib.makeLibraryPath [

--- a/pkgs/by-name/su/super-slicer/package.nix
+++ b/pkgs/by-name/su/super-slicer/package.nix
@@ -2,14 +2,12 @@
   lib,
   fetchFromGitHub,
   fetchpatch,
-  makeDesktopItem,
   wxwidgets_3_1,
   prusa-slicer,
   libspnav,
   opencascade-occt_7_6,
 }:
 let
-  appname = "SuperSlicer";
   pname = "super-slicer";
   description = "PrusaSlicer fork with more features and faster development cycle";
 
@@ -115,18 +113,6 @@ let
 
       buildInputs = super.buildInputs ++ [
         libspnav
-      ];
-
-      desktopItems = [
-        (makeDesktopItem {
-          name = "superslicer";
-          exec = "superslicer";
-          icon = appname;
-          comment = description;
-          desktopName = appname;
-          genericName = "3D printer tool";
-          categories = [ "Development" ];
-        })
       ];
 
       meta = {

--- a/pkgs/by-name/sw/swingsane/package.nix
+++ b/pkgs/by-name/sw/swingsane/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   unzip,
   jre,
@@ -17,7 +18,10 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/swingsane/swingsane-${finalAttrs.version}-bin.zip";
   };
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    unzip
+  ];
 
   dontConfigure = true;
 
@@ -29,16 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
         exec ${jre}/bin/java -jar $out/share/java/swingsane/swingsane-${finalAttrs.version}.jar "$@"
       '';
 
-      desktopItem = makeDesktopItem {
-        name = "swingsane";
-        exec = "swingsane";
-        icon = "swingsane";
-        desktopName = "SwingSane";
-        genericName = "Scan from local or remote SANE servers";
-        comment = finalAttrs.meta.description;
-        categories = [ "Office" ];
-      };
-
     in
     ''
       install -v -m 755    -d $out/share/java/swingsane/
@@ -49,9 +43,19 @@ stdenv.mkDerivation (finalAttrs: {
 
       unzip -j swingsane-${finalAttrs.version}.jar "com/swingsane/images/*.png"
       install -v -D -m 644 swingsane_512x512.png $out/share/icons/hicolor/512x512/apps/swingsane.png
-
-      cp -v -r ${desktopItem}/share/applications $out/share
     '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "swingsane";
+      exec = "swingsane";
+      icon = "swingsane";
+      desktopName = "SwingSane";
+      genericName = "Scan from local or remote SANE servers";
+      comment = finalAttrs.meta.description;
+      categories = [ "Office" ];
+    })
+  ];
 
   meta = {
     description = "Java GUI for SANE scanner servers (saned)";
@@ -60,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       using both local and remote Scanner Access Now Easy (SANE) servers.
       The most powerful feature is its ability to query back-ends for scanner
       specific options which can be set by the user as a scanner profile.
-      It also has support for authentication, mutlicast DNS discovery,
+      It also has support for authentication, multicast DNS discovery,
       simultaneous scan jobs, image transformation jobs (deskew, binarize,
       crop, etc), PDF and PNG output.
     '';

--- a/pkgs/by-name/sw/swingsane/package.nix
+++ b/pkgs/by-name/sw/swingsane/package.nix
@@ -34,7 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
     in
+    # bash
     ''
+      runHook preInstall
+
       install -v -m 755    -d $out/share/java/swingsane/
       install -v -m 644 *.jar $out/share/java/swingsane/
 
@@ -43,6 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
 
       unzip -j swingsane-${finalAttrs.version}.jar "com/swingsane/images/*.png"
       install -v -D -m 644 swingsane_512x512.png $out/share/icons/hicolor/512x512/apps/swingsane.png
+
+      runHook postInstall
     '';
 
   desktopItems = [

--- a/pkgs/by-name/te/techmino/package.nix
+++ b/pkgs/by-name/te/techmino/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   callPackage,
+  copyDesktopItems,
   makeWrapper,
   makeDesktopItem,
   love,
@@ -16,20 +17,6 @@
 let
   pname = "techmino";
   description = "Modern Tetris clone with many features";
-
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = "techmino";
-    icon = fetchurl {
-      name = "techmino.png";
-      url = "https://github.com/26F-Studio/Techmino/assets/9590981/95981af1-f39a-47d9-bd99-a78ab767c08f";
-      hash = "sha256-+j+8m2vwaWgHYSFL6urvTcB0vA+PCZ+FYJ22CNXfcSc=";
-    };
-    comment = description;
-    desktopName = "Techmino";
-    genericName = "Tetris Clone";
-    categories = [ "Game" ];
-  };
 in
 
 stdenv.mkDerivation rec {
@@ -41,7 +28,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-8gMIyNP1FS52LnbpQ+G9XNtK3rQruzkMDRz7Gk9LZcQ=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   dontUnpack = true;
 
@@ -56,11 +46,24 @@ stdenv.mkDerivation rec {
       --add-flags $out/share/games/lovegames/techmino.love \
       --suffix LUA_CPATH : ${ccloader}/lib/lua/${luajit.luaversion}/CCLoader.so
 
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
-
     runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "techmino";
+      icon = fetchurl {
+        name = "techmino.png";
+        url = "https://github.com/26F-Studio/Techmino/assets/9590981/95981af1-f39a-47d9-bd99-a78ab767c08f";
+        hash = "sha256-+j+8m2vwaWgHYSFL6urvTcB0vA+PCZ+FYJ22CNXfcSc=";
+      };
+      comment = description;
+      desktopName = "Techmino";
+      genericName = "Tetris Clone";
+      categories = [ "Game" ];
+    })
+  ];
 
   passthru = {
     inherit ccloader libcoldclear;

--- a/pkgs/by-name/te/tensor/package.nix
+++ b/pkgs/by-name/te/tensor/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   libsForQt5,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
@@ -22,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     libsForQt5.qmake
     libsForQt5.wrapQtAppsHook
   ];
@@ -31,19 +33,21 @@ stdenv.mkDerivation (finalAttrs: {
     libsForQt5.qtquickcontrols
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "tensor";
-    exec = "@bin@";
-    icon = "tensor.png";
-    comment = finalAttrs.meta.description;
-    desktopName = "Tensor Matrix Client";
-    genericName = finalAttrs.meta.description;
-    categories = [
-      "Chat"
-      "Utility"
-    ];
-    mimeTypes = [ "application/x-chat" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "tensor";
+      exec = "tensor";
+      icon = "tensor.png";
+      comment = finalAttrs.meta.description;
+      desktopName = "Tensor Matrix Client";
+      genericName = finalAttrs.meta.description;
+      categories = [
+        "Chat"
+        "Utility"
+      ];
+      mimeTypes = [ "application/x-chat" ];
+    })
+  ];
 
   installPhase =
     if stdenv.hostPlatform.isDarwin then
@@ -62,11 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
         install -Dm755 tensor $out/bin/tensor
         install -Dm644 client/logo.png \
                        $out/share/icons/hicolor/512x512/apps/tensor.png
-        install -Dm644 ${finalAttrs.desktopItem}/share/applications/tensor.desktop \
-                       $out/share/applications/tensor.desktop
-
-        substituteInPlace $out/share/applications/tensor.desktop \
-          --subst-var-by bin $out/bin/tensor
 
         runHook postInstall
       '';

--- a/pkgs/by-name/te/termius/package.nix
+++ b/pkgs/by-name/te/termius/package.nix
@@ -3,6 +3,7 @@
   squashfsTools,
   alsa-lib,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   stdenv,
@@ -31,15 +32,17 @@ stdenv.mkDerivation rec {
     hash = "sha512-jthbZ8j2ek4eq7l13UAJPdFJScgTtb1FRRP7neGFQTxF2PuGZzkp4gEuXRPbrwDTG+7C/fw+k+sCoxu+uBGClQ==";
   };
 
-  desktopItem = makeDesktopItem {
-    categories = [ "Network" ];
-    comment = "The SSH client that works on Desktop and Mobile";
-    desktopName = "Termius";
-    exec = "termius-app";
-    genericName = "Cross-platform SSH client";
-    icon = "termius-app";
-    name = "termius-app";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Network" ];
+      comment = "The SSH client that works on Desktop and Mobile";
+      desktopName = "Termius";
+      exec = "termius-app";
+      genericName = "Cross-platform SSH client";
+      icon = "termius-app";
+      name = "termius-app";
+    })
+  ];
 
   dontBuild = true;
   dontConfigure = true;
@@ -49,6 +52,7 @@ stdenv.mkDerivation rec {
   # TODO: migrate off autoPatchelfHook and use nixpkgs' electron
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     squashfsTools
     makeWrapper
     wrapGAppsHook3
@@ -73,8 +77,6 @@ stdenv.mkDerivation rec {
     mkdir -p $out/opt/termius
     cp -r ./ $out/opt/termius
 
-    mkdir -p $out/share/applications
-    cp "${desktopItem}/share/applications/"* "$out/share/applications"
     install -Dm644 meta/gui/icon.png $out/share/icons/termius-app.png
 
     runHook postInstall

--- a/pkgs/by-name/to/tome2/package.nix
+++ b/pkgs/by-name/to/tome2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  copyDesktopItems,
   makeDesktopItem,
   ncurses,
   libx11,
@@ -12,20 +13,6 @@
 let
   pname = "tome2";
   description = "Dungeon crawler similar to Angband, based on the works of Tolkien";
-
-  desktopItem = makeDesktopItem {
-    desktopName = pname;
-    name = pname;
-    exec = "${pname}-x11";
-    icon = pname;
-    comment = description;
-    type = "Application";
-    categories = [
-      "Game"
-      "RolePlaying"
-    ];
-    genericName = pname;
-  };
 
 in
 stdenv.mkDerivation {
@@ -45,16 +32,30 @@ stdenv.mkDerivation {
     boost
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+  ];
 
   cmakeFlags = [
     "-DSYSTEM_INSTALL=ON"
   ];
 
-  postInstall = ''
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/*.desktop $out/share/applications
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = pname;
+      name = pname;
+      exec = "${pname}-x11";
+      icon = pname;
+      comment = description;
+      type = "Application";
+      categories = [
+        "Game"
+        "RolePlaying"
+      ];
+      genericName = pname;
+    })
+  ];
 
   meta = {
     inherit description;

--- a/pkgs/by-name/tr/transgui/package.nix
+++ b/pkgs/by-name/tr/transgui/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
+  copyDesktopItems,
   makeDesktopItem,
   unzip,
   fpc,
@@ -30,6 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     pkg-config
     unzip
   ];
@@ -73,30 +75,30 @@ stdenv.mkDerivation rec {
 
   env.LCL_PLATFORM = "gtk2";
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = "${pname} %U";
-    icon = pname;
-    type = "Application";
-    comment = meta.description;
-    desktopName = "Transmission Remote GUI";
-    genericName = "BitTorrent Client";
-    categories = [
-      "Network"
-      "FileTransfer"
-      "P2P"
-      "GTK"
-    ];
-    startupNotify = true;
-    mimeTypes = [
-      "application/x-bittorrent"
-      "x-scheme-handler/magnet"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "${pname} %U";
+      icon = pname;
+      type = "Application";
+      comment = meta.description;
+      desktopName = "Transmission Remote GUI";
+      genericName = "BitTorrent Client";
+      categories = [
+        "Network"
+        "FileTransfer"
+        "P2P"
+        "GTK"
+      ];
+      startupNotify = true;
+      mimeTypes = [
+        "application/x-bittorrent"
+        "x-scheme-handler/magnet"
+      ];
+    })
+  ];
 
   postInstall = ''
-    mkdir -p "$out/share/applications"
-    cp $desktopItem/share/applications/* $out/share/applications
     mkdir -p "$out/share/icons/hicolor/48x48/apps"
     cp transgui.png "$out/share/icons/hicolor/48x48/apps"
     mkdir -p "$out/share/transgui"

--- a/pkgs/by-name/un/unigine-heaven/package.nix
+++ b/pkgs/by-name/un/unigine-heaven/package.nix
@@ -14,6 +14,7 @@
   libglvnd,
   openal,
   imagemagick,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 let
@@ -26,14 +27,6 @@ let
       "x86"
     else
       throw "Unsupported platform ${stdenv.hostPlatform.system}";
-
-  desktopItem = makeDesktopItem {
-    name = "Heaven";
-    exec = "heaven";
-    genericName = "A GPU Stress test tool from the UNIGINE";
-    icon = "Heaven";
-    desktopName = "Heaven Benchmark";
-  };
 in
 stdenv.mkDerivation {
   pname = "unigine-heaven";
@@ -70,11 +63,20 @@ stdenv.mkDerivation {
         mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
         convert $out/lib/unigine/heaven/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Heaven.png
     done
-
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Heaven";
+      exec = "heaven";
+      genericName = "A GPU Stress test tool from the UNIGINE";
+      icon = "Heaven";
+      desktopName = "Heaven Benchmark";
+    })
+  ];
+
   nativeBuildInputs = [
+    copyDesktopItems
     autoPatchelfHook
     makeWrapper
     imagemagick

--- a/pkgs/by-name/un/unigine-heaven/package.nix
+++ b/pkgs/by-name/un/unigine-heaven/package.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation {
   };
 
   installPhase = ''
+    runHook preInstall
+
     sh $src --target $name
 
     mkdir -p $out/lib/unigine/heaven/bin
@@ -63,6 +65,8 @@ stdenv.mkDerivation {
         mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
         convert $out/lib/unigine/heaven/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Heaven.png
     done
+
+    runHook postInstall
   '';
 
   desktopItems = [

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   makeWrapper,
   makeDesktopItem,
   pnpm_10_29_2,
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     nodejs
     pnpm_10_29_2
@@ -96,18 +98,20 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   # The desktop item properties should be kept in sync with data from upstream:
-  desktopItem = makeDesktopItem {
-    name = "vikunja-desktop";
-    exec = executableName;
-    icon = "vikunja";
-    desktopName = "Vikunja Desktop";
-    genericName = "To-Do list app";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "ProjectManagement"
-      "Office"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vikunja-desktop";
+      exec = executableName;
+      icon = "vikunja";
+      desktopName = "Vikunja Desktop";
+      genericName = "To-Do list app";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "ProjectManagement"
+        "Office"
+      ];
+    })
+  ];
 
   meta = {
     description = "Desktop App of the Vikunja to-do list app";

--- a/pkgs/by-name/vi/visualvm/package.nix
+++ b/pkgs/by-name/vi/visualvm/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     find . -type f -name "*.dll" -o -name "*.exe"  -delete;
 
     substituteInPlace etc/visualvm.conf \
@@ -43,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "/path/to/jdk" "${jdk.home}" \
 
     cp -r . $out
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/vi/visualvm/package.nix
+++ b/pkgs/by-name/vi/visualvm/package.nix
@@ -3,6 +3,7 @@
   fetchzip,
   lib,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
   jdk,
 }:
@@ -18,16 +19,21 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-xEqzSNM5Mkt9SQ+23Edb2NMN/o8koBjhQWTGuyZ/0m4=";
   };
 
-  desktopItem = makeDesktopItem {
-    name = "visualvm";
-    exec = "visualvm";
-    comment = "Java Troubleshooting Tool";
-    desktopName = "VisualVM";
-    genericName = "Java Troubleshooting Tool";
-    categories = [ "Development" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "visualvm";
+      exec = "visualvm";
+      comment = "Java Troubleshooting Tool";
+      desktopName = "VisualVM";
+      genericName = "Java Troubleshooting Tool";
+      categories = [ "Development" ];
+    })
+  ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
   installPhase = ''
     find . -type f -name "*.dll" -o -name "*.exe"  -delete;

--- a/pkgs/by-name/wa/wasabiwallet/package.nix
+++ b/pkgs/by-name/wa/wasabiwallet/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   autoPatchelfHook,
+  copyDesktopItems,
   makeWrapper,
   fetchurl,
   makeDesktopItem,
@@ -38,20 +39,23 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  desktopItem = makeDesktopItem {
-    name = "wasabi";
-    exec = "wasabiwallet-desktop";
-    desktopName = "Wasabi";
-    genericName = "Bitcoin wallet";
-    comment = meta.description;
-    categories = [
-      "Network"
-      "Utility"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "wasabi";
+      exec = "wasabiwallet-desktop";
+      desktopName = "Wasabi";
+      genericName = "Bitcoin wallet";
+      comment = meta.description;
+      categories = [
+        "Network"
+        "Utility"
+      ];
+    })
+  ];
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     makeWrapper
   ];
   buildInputs = runtimeLibs ++ [
@@ -69,8 +73,6 @@ stdenv.mkDerivation rec {
       makeWrapper "$out/opt/${pname}/$filename" "$out/bin/${pname}-$wrappedname" \
         --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
     done
-
-    cp -v $desktopItem/share/applications/* $out/share/applications
   '';
 
   meta = {

--- a/pkgs/by-name/wa/wasabiwallet/package.nix
+++ b/pkgs/by-name/wa/wasabiwallet/package.nix
@@ -63,6 +63,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/opt/${pname} $out/bin $out/share/applications
 
     # The weird path is an upstream packaging error and could be fixed in the upcoming release
@@ -73,6 +75,8 @@ stdenv.mkDerivation rec {
       makeWrapper "$out/opt/${pname}/$filename" "$out/bin/${pname}-$wrappedname" \
         --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
     done
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/wa/wayst/package.nix
+++ b/pkgs/by-name/wa/wayst/package.nix
@@ -16,27 +16,9 @@
 
   libnotify,
   xdg-utils,
+  copyDesktopItems,
   makeDesktopItem,
 }:
-
-let
-  desktopItem = makeDesktopItem {
-    desktopName = "Wayst";
-    name = "wayst";
-    genericName = "Terminal";
-    exec = "wayst";
-    icon = "wayst";
-    categories = [
-      "System"
-      "TerminalEmulator"
-    ];
-    keywords = [
-      "wayst"
-      "terminal"
-    ];
-    comment = "A simple terminal emulator";
-  };
-in
 stdenv.mkDerivation {
   pname = "wayst";
   version = "0-unstable-2023-07-16";
@@ -50,7 +32,10 @@ stdenv.mkDerivation {
 
   makeFlags = [ "INSTALL_DIR=\${out}/bin" ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
 
   buildInputs = [
     fontconfig
@@ -76,9 +61,25 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "Wayst";
+      name = "wayst";
+      genericName = "Terminal";
+      exec = "wayst";
+      icon = "wayst";
+      categories = [
+        "System"
+        "TerminalEmulator"
+      ];
+      keywords = [
+        "wayst"
+        "terminal"
+      ];
+      comment = "A simple terminal emulator";
+    })
+  ];
   postInstall = ''
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
     install -D icons/wayst.svg $out/share/icons/hicolor/scalable/apps/wayst.svg
   '';
 

--- a/pkgs/by-name/wh/wheelwizard/package.nix
+++ b/pkgs/by-name/wh/wheelwizard/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildDotnetModule,
+  copyDesktopItems,
   desktop-file-utils,
   dotnetCorePackages,
   fetchFromGitHub,
@@ -34,6 +35,7 @@ buildDotnetModule rec {
   mapNuGetDependencies = true;
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     desktop-file-utils
   ];
@@ -55,8 +57,6 @@ buildDotnetModule rec {
     makeWrapper $out/lib/wheelwizard/WheelWizard $out/bin/WheelWizard \
       --prefix PATH : ${lib.makeBinPath [ dotnet-runtime ]}
 
-    install -D $desktopItem/share/applications/* -t $out/share/applications
-
     runHook postInstall
   '';
 
@@ -64,13 +64,15 @@ buildDotnetModule rec {
     rm $out/bin/*.{so,dylib}
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "wheelwizard";
-    exec = "WheelWizard";
-    comment = "WheelWizard, Retro Rewind Launcher";
-    desktopName = "Wheel Wizard";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "wheelwizard";
+      exec = "WheelWizard";
+      comment = "WheelWizard, Retro Rewind Launcher";
+      desktopName = "Wheel Wizard";
+      categories = [ "Game" ];
+    })
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -2,6 +2,7 @@
   autoPatchelfHook,
   dpkg,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   stdenv,
@@ -95,21 +96,23 @@ let
       inherit hash;
     };
 
-    desktopItem = makeDesktopItem {
-      categories = [
-        "Network"
-        "InstantMessaging"
-        "Chat"
-        "VideoConference"
-      ];
-      comment = "Secure messenger for everyone";
-      desktopName = "Wire";
-      exec = "wire-desktop %U";
-      genericName = "Secure messenger";
-      icon = "wire-desktop";
-      name = "wire-desktop";
-      startupWMClass = "Wire";
-    };
+    desktopItems = [
+      (makeDesktopItem {
+        categories = [
+          "Network"
+          "InstantMessaging"
+          "Chat"
+          "VideoConference"
+        ];
+        comment = "Secure messenger for everyone";
+        desktopName = "Wire";
+        exec = "wire-desktop %U";
+        genericName = "Secure messenger";
+        icon = "wire-desktop";
+        name = "wire-desktop";
+        startupWMClass = "Wire";
+      })
+    ];
 
     dontBuild = true;
     dontConfigure = true;
@@ -119,6 +122,7 @@ let
     # TODO: migrate off autoPatchelfHook and use nixpkgs' electron
     nativeBuildInputs = [
       autoPatchelfHook
+      copyDesktopItems
       dpkg
       makeWrapper
       (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
@@ -139,10 +143,6 @@ let
       cp -R "opt" "$out"
       cp -R "usr/share" "$out/share"
       chmod -R g-w "$out"
-
-      # Desktop file
-      mkdir -p "$out/share/applications"
-      cp "${desktopItem}/share/applications/"* "$out/share/applications"
 
       runHook postInstall
     '';

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -31,7 +31,6 @@
   libva,
   libx11,
   libxrandr,
-  makeDesktopItem,
   nix-update-script,
   nlohmann_json,
   opencomposite,
@@ -192,19 +191,6 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]} \
       --prefix PATH : ${lib.makeBinPath [ android-tools ]}
   '';
-
-  desktopItems = lib.optionals (!clientLibOnly) [
-    (makeDesktopItem {
-      name = "WiVRn Server";
-      desktopName = "WiVRn Server";
-      genericName = "WiVRn Server";
-      comment = "Play your PC VR games on a standalone headset";
-      icon = "io.github.wivrn.wivrn";
-      exec = "wivrn-dashboard";
-      type = "Application";
-      categories = [ "Network" ];
-    })
-  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/wo/worldofgoo/package.nix
+++ b/pkgs/by-name/wo/worldofgoo/package.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/256x256/apps
 
     install -t $out/bin -m755 data/${arch}/WorldOfGoo.bin.${arch}
@@ -74,6 +76,8 @@ stdenv.mkDerivation rec {
     cp data/noarch/game/gooicon.png $out/share/icons/hicolor/256x256/apps/2dboy-worldofgoo.png
 
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath $libPath $out/bin/WorldOfGoo.bin.${arch}
+
+    runHook postInstall
   '';
 
   dontStrip = true;

--- a/pkgs/by-name/wo/worldofgoo/package.nix
+++ b/pkgs/by-name/wo/worldofgoo/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  copyDesktopItems,
   requireFile,
   unzip,
   makeDesktopItem,
@@ -12,16 +13,6 @@
 
 let
   arch = if stdenv.system == "x86_64-linux" then "x86_64" else "x86";
-
-  desktopItem = makeDesktopItem {
-    desktopName = "World of Goo";
-    genericName = "World of Goo";
-    categories = [ "Game" ];
-    exec = "WorldOfGoo.bin.${arch}";
-    icon = "2dboy-worldofgoo";
-    name = "worldofgoo";
-  };
-
 in
 
 stdenv.mkDerivation rec {
@@ -41,7 +32,10 @@ stdenv.mkDerivation rec {
     sha256 = "175e4b0499a765f1564942da4bd65029f8aae1de8231749c56bec672187d53ee";
   };
 
-  nativeBuildInputs = [ unzip ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    unzip
+  ];
   sourceRoot = pname;
 
   libPath = lib.makeLibraryPath [
@@ -61,14 +55,23 @@ stdenv.mkDerivation rec {
     unzip -q ${src}.zip -d ${pname}
   '';
 
+  desktopItems = [
+    (makeDesktopItem {
+      desktopName = "World of Goo";
+      genericName = "World of Goo";
+      categories = [ "Game" ];
+      exec = "WorldOfGoo.bin.${arch}";
+      icon = "2dboy-worldofgoo";
+      name = "worldofgoo";
+    })
+  ];
+
   installPhase = ''
     mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/256x256/apps
 
     install -t $out/bin -m755 data/${arch}/WorldOfGoo.bin.${arch}
     cp -R data/noarch/* $out/bin
     cp data/noarch/game/gooicon.png $out/share/icons/hicolor/256x256/apps/2dboy-worldofgoo.png
-    cp ${desktopItem}/share/applications/worldofgoo.desktop \
-      $out/share/applications/worldofgoo.desktop
 
     patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" --set-rpath $libPath $out/bin/WorldOfGoo.bin.${arch}
   '';

--- a/pkgs/by-name/xn/xnviewmp/package.nix
+++ b/pkgs/by-name/xn/xnviewmp/package.nix
@@ -4,7 +4,6 @@
   runCommand,
   lib,
   makeDesktopItem,
-  copyDesktopItems,
   imagemagick,
   writeShellScript,
   nix-update,
@@ -22,6 +21,15 @@ let
       ''
         magick $src -resize 512x512 $out
       '';
+
+  desktopItem = makeDesktopItem {
+    name = "xnviewmp";
+    desktopName = "XnView MP";
+    exec = "xnviewmp %F";
+    icon = "xnviewmp";
+    comment = "An efficient multimedia viewer, browser and converter";
+    categories = [ "Graphics" ];
+  };
 in
 appimageTools.wrapType2 rec {
   pname = "xnviewmp";
@@ -32,27 +40,14 @@ appimageTools.wrapType2 rec {
     hash = "sha256-BGdjVwinH2P9vG3aiWeUpFTIftmbYjdJEmcrXXi7XFw=";
   };
 
-  nativeBuildInputs = [
-    copyDesktopItems
-  ];
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "xnviewmp";
-      desktopName = "XnView MP";
-      exec = "xnviewmp %F";
-      icon = "xnviewmp";
-      comment = "An efficient multimedia viewer, browser and converter";
-      categories = [ "Graphics" ];
-    })
-  ];
-
   extraPkgs = pkgs: [
     pkgs.qt5.qtbase
   ];
 
   extraInstallCommands = ''
     install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/xnviewmp.png
+    install -m 444 -D ${desktopItem}/share/applications/xnviewmp.desktop \
+      $out/share/applications/xnviewmp.desktop
   '';
 
   passthru = {

--- a/pkgs/by-name/xp/xpipe/package.nix
+++ b/pkgs/by-name/xp/xpipe/package.nix
@@ -2,6 +2,7 @@
   stdenvNoCC,
   lib,
   fetchzip,
+  copyDesktopItems,
   makeDesktopItem,
   autoPatchelfHook,
   zlib,
@@ -57,6 +58,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
+    copyDesktopItems
     makeShellWrapper
   ];
 
@@ -86,15 +88,17 @@ stdenvNoCC.mkDerivation rec {
     socat
   ];
 
-  desktopItem = makeDesktopItem {
-    categories = [ "Network" ];
-    comment = "Your entire server infrastructure at your fingertips";
-    desktopName = displayname;
-    exec = "/opt/${pname}/bin/xpipe open %U";
-    genericName = "Shell connection hub";
-    icon = "/opt/${pname}/logo.png";
-    name = displayname;
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      categories = [ "Network" ];
+      comment = "Your entire server infrastructure at your fingertips";
+      desktopName = displayname;
+      exec = "xpipe open %U";
+      genericName = "Shell connection hub";
+      icon = "logo";
+      name = displayname;
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -105,12 +109,6 @@ stdenvNoCC.mkDerivation rec {
 
     mkdir -p "$out/bin"
     ln -s "$out/opt/$pkg/bin/xpipe" "$out/bin/$pkg"
-
-    mkdir -p "$out/share/applications"
-    cp -r "${desktopItem}/share/applications/" "$out/share/"
-
-    substituteInPlace "$out/share/applications/${displayname}.desktop" --replace "Exec=" "Exec=$out"
-    substituteInPlace "$out/share/applications/${displayname}.desktop" --replace "Icon=" "Icon=$out"
 
     mv "$out/opt/$pkg/bin/xpiped" "$out/opt/$pkg/bin/xpiped_raw"
     mv "$out/opt/$pkg/lib/app/xpiped.cfg" "$out/opt/$pkg/lib/app/xpiped_raw.cfg"

--- a/pkgs/by-name/xx/xxe-pe/package.nix
+++ b/pkgs/by-name/xx/xxe-pe/package.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "${pkg_path}"
     mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
@@ -72,6 +74,8 @@ stdenv.mkDerivation rec {
       mkdir -pv "$out/share/icons/hicolor/$res/apps"
       mv "$f" "$out/share/icons/hicolor/$res/apps/xxe.png"
     done;
+
+    runHook postInstall
   '';
 
   postFixup = ''

--- a/pkgs/by-name/xx/xxe-pe/package.nix
+++ b/pkgs/by-name/xx/xxe-pe/package.nix
@@ -5,6 +5,7 @@
   unzip,
   makeWrapper,
   openjdk11,
+  copyDesktopItems,
   makeDesktopItem,
   icoutils,
   config,
@@ -13,20 +14,6 @@
 
 let
   pkg_path = "$out/lib/xxe";
-
-  desktopItem = makeDesktopItem {
-    name = "XMLmind XML Editor Personal Edition";
-    exec = "xxe";
-    icon = "xxe";
-    desktopName = "xxe";
-    genericName = "XML Editor";
-    categories = [
-      "Development"
-      "IDE"
-      "TextEditor"
-      "Java"
-    ];
-  };
 in
 stdenv.mkDerivation rec {
   pname = "xxe-pe";
@@ -49,6 +36,7 @@ stdenv.mkDerivation rec {
     };
 
   nativeBuildInputs = [
+    copyDesktopItems
     unzip
     makeWrapper
     icoutils
@@ -56,11 +44,26 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "XMLmind XML Editor Personal Edition";
+      exec = "xxe";
+      icon = "xxe";
+      desktopName = "xxe";
+      genericName = "XML Editor";
+      categories = [
+        "Development"
+        "IDE"
+        "TextEditor"
+        "Java"
+      ];
+    })
+  ];
+
   installPhase = ''
     mkdir -p "${pkg_path}"
     mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
 
     icotool -x "${pkg_path}/bin/icon/xxe.ico"
     ls

--- a/pkgs/by-name/ya/yarg/package.nix
+++ b/pkgs/by-name/ya/yarg/package.nix
@@ -20,6 +20,7 @@
   udev,
   vulkan-loader,
   wayland, # (not used by default, enable with SDL_VIDEODRIVER=wayland - doesn't support HiDPI)
+  copyDesktopItems,
   makeDesktopItem,
   nix-update-script,
 }:
@@ -34,7 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-l83tnEO9hHFiaks7D/y9D1HJKihU7+cvsvkbIKkNeuk=";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+  ];
 
   buildInputs = [
     # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
@@ -60,14 +64,16 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "yarg";
-    desktopName = "YARG";
-    comment = finalAttrs.meta.description;
-    icon = "yarg";
-    exec = "yarg";
-    categories = [ "Game" ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "yarg";
+      desktopName = "YARG";
+      comment = finalAttrs.meta.description;
+      icon = "yarg";
+      exec = "yarg";
+      categories = [ "Game" ];
+    })
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -79,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r YARG_Data "$out/share/yarg"
     ln -s "$out/share/yarg" "$out/bin/yarg_Data"
     ln -s "$out/share/yarg/Resources/UnityPlayer.png" "$out/share/icons/hicolor/128x128/apps/yarg.png"
-    install -Dm644 "$desktopItem/share/applications/yarg.desktop" "$out/share/applications/yarg.desktop"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ze/zepp-simulator/package.nix
+++ b/pkgs/by-name/ze/zepp-simulator/package.nix
@@ -3,7 +3,6 @@
   lib,
   fetchurl,
   makeWrapper,
-  copyDesktopItems,
   autoPatchelfHook,
 
   # Upstream is officially built with Electron 18
@@ -71,7 +70,6 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    copyDesktopItems
     makeWrapper
     dpkg
     asar
@@ -110,7 +108,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    # Create output file strucure
+    # Create output file structure
     mkdir -p $out/{bin,opt,share}
     cp -r opt/simulator $out/opt
     cp -r usr/share/* $out/share

--- a/pkgs/development/tools/database/squirrel-sql/default.nix
+++ b/pkgs/development/tools/database/squirrel-sql/default.nix
@@ -4,6 +4,7 @@
   lib,
   stdenv,
   fetchurl,
+  copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
   unzip,
@@ -20,6 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     unzip
   ];
@@ -61,20 +63,21 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/icons/hicolor/32x32/apps
     ln -s $out/share/squirrel-sql/icons/acorn.png \
       $out/share/icons/hicolor/32x32/apps/squirrel-sql.png
-    ln -s ${desktopItem}/share/applications $out/share
 
     runHook postInstall
   '';
 
-  desktopItem = makeDesktopItem {
-    name = "squirrel-sql";
-    exec = "squirrel-sql";
-    comment = meta.description;
-    desktopName = "SQuirreL SQL";
-    genericName = "SQL Client";
-    categories = [ "Development" ];
-    icon = "squirrel-sql";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "squirrel-sql";
+      exec = "squirrel-sql";
+      comment = meta.description;
+      desktopName = "SQuirreL SQL";
+      genericName = "SQL Client";
+      categories = [ "Development" ];
+      icon = "squirrel-sql";
+    })
+  ];
 
   meta = {
     description = "Universal SQL Client";

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -6,25 +6,13 @@
   autoPatchelfHook,
   openjdk21,
   pam,
+  copyDesktopItems,
   makeDesktopItem,
   icoutils,
 }:
 
 let
-
   pkg_path = "$out/lib/ghidra";
-
-  desktopItem = makeDesktopItem {
-    name = "ghidra";
-    exec = "ghidra";
-    icon = "ghidra";
-    desktopName = "Ghidra";
-    genericName = "Ghidra Software Reverse Engineering Suite";
-    categories = [ "Development" ];
-    terminal = false;
-    startupWMClass = "ghidra-Ghidra";
-  };
-
 in
 stdenv.mkDerivation rec {
   pname = "ghidra";
@@ -36,6 +24,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     icoutils
   ]
@@ -48,11 +37,23 @@ stdenv.mkDerivation rec {
 
   dontStrip = true;
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ghidra";
+      exec = "ghidra";
+      icon = "ghidra";
+      desktopName = "Ghidra";
+      genericName = "Ghidra Software Reverse Engineering Suite";
+      categories = [ "Development" ];
+      terminal = false;
+      startupWMClass = "ghidra-Ghidra";
+    })
+  ];
+
   installPhase = ''
     mkdir -p "${pkg_path}"
     mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
-    ln -s ${desktopItem}/share/applications/* $out/share/applications
 
     icotool -x "${pkg_path}/support/ghidra.ico"
     rm ghidra_4_40x40x32.png

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "${pkg_path}"
     mkdir -p "${pkg_path}" "$out/share/applications"
     cp -a * "${pkg_path}"
@@ -62,6 +64,8 @@ stdenv.mkDerivation rec {
       mkdir -pv "$out/share/icons/hicolor/$res/apps"
       mv "$f" "$out/share/icons/hicolor/$res/apps/ghidra.png"
     done;
+
+    runHook postInstall
   '';
 
   postFixup = ''

--- a/pkgs/tools/system/nvidia-system-monitor-qt/default.nix
+++ b/pkgs/tools/system/nvidia-system-monitor-qt/default.nix
@@ -8,22 +8,6 @@
   makeDesktopItem,
   copyDesktopItems,
 }:
-
-let
-  # Based in desktop files from official packages:
-  # https://github.com/congard/nvidia-system-monitor-qt/tree/master/package
-  desktopItem = makeDesktopItem {
-    name = "nvidia-system-monitor-qt";
-    desktopName = "NVIDIA System Monitor";
-    icon = "qnvsm";
-    exec = "qnvsm";
-    categories = [
-      "System"
-      "Utility"
-      "Qt"
-    ];
-  };
-in
 stdenv.mkDerivation rec {
   pname = "nvidia-system-monitor-qt";
   version = "1.6-1";
@@ -56,7 +40,21 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  desktopItems = [ desktopItem ];
+  # Based in desktop files from official packages:
+  # https://github.com/congard/nvidia-system-monitor-qt/tree/master/package
+  desktopItems = [
+    (makeDesktopItem {
+      name = "nvidia-system-monitor-qt";
+      desktopName = "NVIDIA System Monitor";
+      icon = "qnvsm";
+      exec = "qnvsm";
+      categories = [
+        "System"
+        "Utility"
+        "Qt"
+      ];
+    })
+  ];
 
   meta = rec {
     description = "Task Manager for Linux for NVIDIA graphics cards";


### PR DESCRIPTION
[`copyDesktopItems`](https://github.com/NixOS/nixpkgs/blob/12ad31e743833e5321c99fe42a5fa84f0304e40b/pkgs/build-support/setup-hooks/copy-desktop-items.sh#L27) (a hook that produces `.desktop` files) only supports `desktopItems` (plural), but many packages set `desktopItem` (singular) instead. This PR fixes all packages that do that and fixes other things too (a second commit adds `preInstall`/`postInstall`, because without them `copyDesktopItems` does not work)

## Decisions

- Didn't try to figure out how to use hook with FHS envs ([`buildFHSEnv`](https://nixos.org/manual/nixpkgs/unstable/#sec-fhs-environments), [`appimageTools.wrapType2`](https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs-appimageTools))
- The same for packages that use `buildCommand`
- If I removed some desktop item definitions, it is because upstream already provides `.desktop` files (and they are in `$out`)

## Validations done

- Built all packages and manually diffed all `.desktop` files with master
- `desktopItems` without hook: `rg -l desktopItems pkgs | xargs rg --files-without-match copyDesktopItems`
- Hook without `desktopItems`: `rg -l copyDesktopItems pkgs | xargs rg --files-without-match 'desktopItems ='`
- Singular `desktopItem`:
  ```sh
  rg -l 'desktopItem =' pkgs \
    | xargs rg --files-without-match buildFHSEnv \
    | xargs rg --files-without-match appimageTools.wrapType2 \
    | xargs rg --files-without-match buildCommand \
    | xargs rg --files-without-match 'desktopItems ='
  ```
- Hook in the wrong places:
  ```sh
  all=""
  all+=$(
    rg -l copyDesktopItems pkgs \
    | xargs rg -l buildFHSEnv
  )
  all+=$'\n'
  all+=$(
    rg -l copyDesktopItems pkgs \
    | xargs rg -l appimageTools.wrapType2
  )
  all+=$'\n'
  all+=$(
    rg -l copyDesktopItems pkgs \
    | xargs rg -l buildCommand
  )
  echo "$all" | sort -u
  ```


