### PR TITLE
scran: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11225,6 +11225,11 @@
     github = "icewind1991";
     githubId = 1283854;
   };
+  iciclejj = {
+    name = "Stephan Bentze";
+    github = "iciclejj";
+    githubId = 55782191;
+  };
   icy-thought = {
     name = "Icy-Thought";
     email = "gilganyx@pm.me";

--- a/pkgs/by-name/sc/scran/package.nix
+++ b/pkgs/by-name/sc/scran/package.nix
@@ -1,0 +1,82 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
+  blend2d,
+  libxkbcommon,
+  ffmpeg,
+  pipewire,
+  basu,
+  systemd,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scran";
+  version = "0.8.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "iciclejj";
+    repo = "scran";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jDCyjP3BdldZXOj7Dz+TCGb4RA0fBjxy2fdEMfBz7H8=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    wayland-scanner
+    wayland-protocols
+    wayland
+    blend2d
+    libxkbcommon
+    ffmpeg
+    pipewire
+    (if systemdSupport then systemd else basu)
+  ];
+
+  buildType = "release";
+  buildFlags = [ finalAttrs.buildType ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D build/${finalAttrs.buildType}/scran $out/bin/scran
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "scran";
+      exec = "scran";
+      desktopName = "Scran";
+      genericName = "Screen Capture";
+      categories = [
+        "Utility"
+        "Graphics"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Sway screen capture";
+    mainProgram = "scran";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/iciclejj/scran";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      iciclejj
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Screen capture app for Wayland.

https://github.com/iciclejj/scran

Note: Compositors other than Sway, Hyprland and COSMIC are not yet officially supported, and will likely fail to run the program. More details in [the package's README.md](https://github.com/iciclejj/scran#compositor-support).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
