### PR TITLE
osrm-backend: 26.4.0 -> 26.5.0

### DIFF
--- a/pkgs/by-name/os/osrm-backend/package.nix
+++ b/pkgs/by-name/os/osrm-backend/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "osrm-backend";
-  version = "26.4.0";
+  version = "26.4.1";
 
   src = fetchFromGitHub {
     owner = "Project-OSRM";
     repo = "osrm-backend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DV0oy++PrOwbybFEFRWnNxGfYshgsqDaHrHuVoTlIXE=";
+    hash = "sha256-/oJ+vhx1nQ0YVxOzQ9hMDVcXTPraCQ6q0KVjUYtpCLw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/os/osrm-backend/package.nix
+++ b/pkgs/by-name/os/osrm-backend/package.nix
@@ -4,31 +4,44 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
+  ninja,
   bzip2,
   libxml2,
   libzip,
   boost,
-  lua,
+  lua5_4,
   luabind,
   onetbb,
   expat,
+  libarchive,
+  fmt,
+  rapidjson,
+  sol2,
+  flatbuffers,
+  protozero,
+  vtzero,
+  libosmium,
   nixosTests,
 }:
 
+let
+  lua = lua5_4;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "osrm-backend";
-  version = "26.4.1";
+  version = "26.6.0";
 
   src = fetchFromGitHub {
     owner = "Project-OSRM";
     repo = "osrm-backend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/oJ+vhx1nQ0YVxOzQ9hMDVcXTPraCQ6q0KVjUYtpCLw=";
+    hash = "sha256-004vgTKqY6prrmV7KAv4rCHQdk4VGk25d4QVBW/5FMg=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
+    ninja
   ];
 
   buildInputs = [
@@ -37,16 +50,24 @@ stdenv.mkDerivation (finalAttrs: {
     libzip
     boost
     lua
-    luabind
+    (luabind.override { inherit lua; })
     onetbb
     expat
+    libarchive
+    fmt
+    rapidjson
+    sol2
+    flatbuffers
+    protozero
+    vtzero
+    libosmium
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [
-    # Needed with GCC 12
-    "-Wno-error=uninitialized"
-    # Needed with GCC 14
-    "-Wno-error=maybe-uninitialized"
+    # # Needed with GCC 12
+    # "-Wno-error=uninitialized"
+    # # Needed with GCC 14
+    # "-Wno-error=maybe-uninitialized"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/os/osrm-backend/package.nix
+++ b/pkgs/by-name/os/osrm-backend/package.nix
@@ -29,13 +29,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "osrm-backend";
-  version = "26.6.0";
+  version = "26.6.4";
 
   src = fetchFromGitHub {
     owner = "Project-OSRM";
     repo = "osrm-backend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-004vgTKqY6prrmV7KAv4rCHQdk4VGk25d4QVBW/5FMg=";
+    hash = "sha256-13Qwi/RNChWHoL4bbY2O3O73jYQZpzRJW4Omtp6t1SI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/so/sol2/package.nix
+++ b/pkgs/by-name/so/sol2/package.nix
@@ -7,12 +7,12 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "sol2";
-  version = "3.5.0";
+  version = "3.3.1";
   src = fetchFromGitHub {
     owner = "ThePhD";
     repo = "sol2";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-bW6HD9WLOWizli6LnrkFZKxiT8IdN0QESlok+xCFz1w=";
+    hash = "sha256-7QHZRudxq3hdsfEAYKKJydc4rv6lyN6UIt/2Zmaejx8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vt/vtzero/package.nix
+++ b/pkgs/by-name/vt/vtzero/package.nix
@@ -1,0 +1,35 @@
+{ lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  protozero,
+  ctestCheckHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vtzero";
+  version = "1.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mapbox";
+    repo = "vtzero";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-lT9H2dlFPT12CcSj9DzZLKvqX4tu8DsZxLEhms0c3g8=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ protozero ];
+
+  doCheck = true;
+  nativeCheckInputs = [ ctestCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/mapbox/vtzero";
+    changelog = "https://github.com/mapbox/vtzero/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.erictapen ];
+  };
+})


### PR DESCRIPTION
Diff: https://github.com/Project-OSRM/osrm-backend/compare/v26.4.0...v26.4.1

Changelog: https://github.com/Project-OSRM/osrm-backend/releases/tag/v26.4.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
