### PR TITLE
envq: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26818,6 +26818,12 @@
     githubId = 4541968;
     name = "Nova King";
   };
+  techouse = {
+    name = "Klemen Tusar";
+    email = "techouse@gmail.com";
+    github = "techouse";
+    githubId = 1174328;
+  };
   teczito = {
     name = "Ruben";
     email = "ruben@teczito.com";

--- a/pkgs/by-name/en/envq/package.nix
+++ b/pkgs/by-name/en/envq/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "envq";
+  version = "0.1.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "techouse";
+    repo = "envq";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-yVzyzJDlrQ/X2vWrItYnJ+4s/oFpFPWdIDPG4JBdfD0=";
+  };
+
+  cargoHash = "sha256-6mwR05TKP7wVwHk8XULbcOSneUgE0lPrA6+xRR8tIaE=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd envq \
+      --bash <($out/bin/envq completion bash) \
+      --zsh <($out/bin/envq completion zsh) \
+      --fish <($out/bin/envq completion fish)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Byte-preserving .env query and editing tool";
+    homepage = "https://techouse.github.io/envq/";
+    changelog = "https://github.com/techouse/envq/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ techouse ];
+    mainProgram = "envq";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/en/envq/package.nix
+++ b/pkgs/by-name/en/envq/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "envq";
+  version = "0.1.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "techouse";
+    repo = "envq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yVzyzJDlrQ/X2vWrItYnJ+4s/oFpFPWdIDPG4JBdfD0=";
+  };
+
+  cargoHash = "sha256-6mwR05TKP7wVwHk8XULbcOSneUgE0lPrA6+xRR8tIaE=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd envq \
+      --bash <($out/bin/envq completion bash) \
+      --zsh <($out/bin/envq completion zsh) \
+      --fish <($out/bin/envq completion fish)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Byte-preserving .env query and editing tool";
+    homepage = "https://techouse.github.io/envq/";
+    changelog = "https://github.com/techouse/envq/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ techouse ];
+    mainProgram = "envq";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add `envq`, a byte-preserving `.env` query and editing CLI.

`envq` reads and edits `.env` files while preserving comments, spacing, duplicate-key semantics, line endings, and invalid UTF-8 bytes across unrelated edits. The package builds from the upstream Rust source, installs bash/zsh/fish completions, and uses `versionCheckHook` to verify the installed binary reports the packaged version.

Homepage: https://techouse.github.io/envq/
Release notes: https://github.com/techouse/envq/releases/tag/v0.1.3

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Built with `nix-build -A envq` in Docker using `nixos/nix`.
  - The build ran the upstream Rust test suite successfully.
  - `versionCheckHook` verified `envq --version` reports `envq 0.1.3`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test