### PR TITLE
Revert "nixos/amazon-image: default to raw format instead of vpc"

### DIFF
--- a/nixos/maintainers/scripts/ec2/amazon-image.nix
+++ b/nixos/maintainers/scripts/ec2/amazon-image.nix
@@ -66,7 +66,7 @@ in
         "qcow2"
         "vpc"
       ];
-      default = "raw";
+      default = "vpc";
       description = "The image format to output";
     };
   };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#510086

We need to revert this due to hydra size limits :(