### PR TITLE
qboot: 20200423 -> 20220919; nixos/tests/qboot: switch from deprecated handleTestOn to runTestOn

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1358,7 +1358,7 @@ in
   pulseaudio-tcp = runTest ./pulseaudio-tcp.nix;
   pykms = runTest ./pykms.nix;
   qbittorrent = runTest ./qbittorrent.nix;
-  qboot = handleTestOn [ "x86_64-linux" "i686-linux" ] ./qboot.nix { };
+  qboot = runTestOn [ "x86_64-linux" "i686-linux" ] ./qboot.nix;
   qemu-vm-credentials-fwcfg = runTest {
     imports = [ ./qemu-vm-credentials.nix ];
     _module.args.mechanism = "fw_cfg";

--- a/nixos/tests/qboot.nix
+++ b/nixos/tests/qboot.nix
@@ -1,17 +1,15 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "qboot";
+{ pkgs, ... }:
+{
+  name = "qboot";
 
-    nodes.machine =
-      { ... }:
-      {
-        virtualisation.bios = pkgs.qboot;
-      };
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.bios = pkgs.qboot;
+    };
 
-    testScript = ''
-      start_all()
-      machine.wait_for_unit("multi-user.target")
-    '';
-  }
-)
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+  '';
+}

--- a/pkgs/applications/virtualization/qboot/default.nix
+++ b/pkgs/applications/virtualization/qboot/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "qboot";
-  version = "unstable-2020-04-23";
+  version = "unstable-2022-09-19";
 
   src = fetchFromGitHub {
     owner = "bonzini";
     repo = "qboot";
-    rev = "de50b5931c08f5fba7039ddccfb249a5b3b0b18d";
-    sha256 = "1d0h29zz535m0pq18k3aya93q7lqm2858mlcp8mlfkbq54n8c5d8";
+    rev = "8ca302e86d685fa05b16e2b208888243da319941";
+    hash = "sha256-YxVGFiyLdhq7yWaXARh7f0nBZgXfJuYvv1BxfyThupM=";
   };
 
   nativeBuildInputs = [
@@ -33,9 +33,7 @@ stdenv.mkDerivation {
     "pic"
   ];
 
-  passthru.tests = {
-    qboot = nixosTests.qboot;
-  };
+  passthru.tests.qboot = nixosTests.qboot;
 
   meta = {
     description = "Simple x86 firmware for booting Linux";


### PR DESCRIPTION
also fixes the hydra test failure `https://hydra.nixos.org/build/326501766/nixlog/1`

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
