### PR TITLE
yersinia: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ye/yersinia/package.nix
+++ b/pkgs/by-name/ye/yersinia/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchDebianPatch,
   autoreconfHook,
   pkg-config,
   ncurses,
@@ -24,6 +25,16 @@ stdenv.mkDerivation {
     rev = "867b309eced9e02b63412855440cd4f5f7727431";
     sha256 = "sha256-VShg9Nzd8dzUNiqYnKcDzRgqjwar/8XRGEJCJL25aR0=";
   };
+
+  patches = [
+    (fetchDebianPatch {
+      pname = "yersinia";
+      version = "0.8.2";
+      debianRevision = "2.3";
+      patch = "fix-ftbfs.patch";
+      hash = "sha256-qoD627fcIGmlWT2Uz+85tgIf7KtD11gtUu1N+Ol4T/A=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324356083

```
yersinia.c:930:1: error: conflicting types for 'posix_signal'; have 'int(int,  void (*)(void))'
  930 | posix_signal( int signo, void (*handler)() )
      | ^~~~~~~~~~~~
In file included from yersinia.c:97:
yersinia.h:54:7: note: previous declaration of 'posix_signal' with type 'int(int,  void (*)(int))'
   54 | int   posix_signal( int, void (*handler)(int) );
      |       ^~~~~~~~~~~~
yersinia.c: In function 'posix_signal':
yersinia.c:934:20: error: assignment to '__sighandler_t' {aka 'void (*)(int)'} from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
  934 |     act.sa_handler = handler;
      |                    ^
```

Apply debian patch: https://sources.debian.org/patches/yersinia/0.8.2-2.3/fix-ftbfs.patch/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
