### PR TITLE
Rofi games update

### DIFF
--- a/pkgs/by-name/ro/rofi-games/package.nix
+++ b/pkgs/by-name/ro/rofi-games/package.nix
@@ -16,18 +16,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rofi-games";
-  version = "1.16.2";
+  version = "1.17.3";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "rofi-games";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LwzlBjRh9YdUGBl9+L3Vdetmy7lUdAIvjKvp8hSebvY=";
+    hash = "sha256-gqX+LN6nCisLq1Ge8aSqXi1fVGYz9laSZILybTacRx0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-opImhuLXj3/TtpmBjjMvrcdHalxYFyv5QZ0V8poYH7U=";
+    hash = "sha256-gqxzl0MUeS5KXoUtofNwYb4QDJkAjz8B0tfD0x4nMEw=";
   };
 
   patches = [

--- a/pkgs/by-name/ro/rofi-games/package.nix
+++ b/pkgs/by-name/ro/rofi-games/package.nix
@@ -61,7 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Rofi plugin which adds a mode that will list available games for launch along with their box art";
     homepage = "https://github.com/Rolv-Apneseth/rofi-games";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ tomasajt ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      koffydrop
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ro/rofi-games/package.nix
+++ b/pkgs/by-name/ro/rofi-games/package.nix
@@ -11,6 +11,7 @@
   cairo,
   pango,
   sqlite,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -52,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     pango
     sqlite
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/Rolv-Apneseth/rofi-games/blob/${finalAttrs.src.rev}/CHANGELOG.md";


### PR DESCRIPTION
- Added updateScript so the merge bot is able to update automatically
- Updated to 1.17.3 ([changelog](https://github.com/Rolv-Apneseth/rofi-games/blob/main/CHANGELOG.md))
- Added myself as maintainer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
