### PR TITLE
yasr: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ya/yasr/package.nix
+++ b/pkgs/by-name/ya/yasr/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,6 +20,13 @@ stdenv.mkDerivation (finalAttrs: {
     ./20_maxpathlen.patch
     ./30_conf.patch
     ./40_dectalk_extended_chars.patch
+    (fetchDebianPatch {
+      pname = "yasr";
+      version = "0.6.9";
+      debianRevision = "12";
+      patch = "gcc-15";
+      hash = "sha256-KraGxm1RegJpDGQMlo7OaLFBf8l+V8VO65ftjGDOJeg=";
+    })
   ]; # taken from the debian yasr package
 
   meta = {


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324355946

```
config.c:25:4: error: initialization of 'void (*)(void)' from incompatible pointer type 'void (*)(int *)' [-Wincompatible-pointer-types]
   25 |   {&rev_line, "say line"},      /* 0 */
      |    ^
config.c:25:4: note: (near initialization for 'funcs[0].f')
In file included from config.c:19:
yasr.h:223:13: note: 'rev_line' declared here
  223 | extern void rev_line(int *argp);
      |             ^~~~~~~~
```

Fixed with debian patch: https://sources.debian.org/patches/yasr/0.6.9-12/gcc-15/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
