### PR TITLE
xsokoban: fix build with gcc15

### DIFF
--- a/pkgs/by-name/xs/xsokoban/package.nix
+++ b/pkgs/by-name/xs/xsokoban/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     sed -e 's/getline/my_getline/' -i score.c
     sed -e 's/getpass/my_getpass/' -i externs.h display.c
+    # gcc15
+    sed -e 's/Score(_false_)/Score()/g' -i main.c
 
     chmod a+rw config.h
     cat >>config.h <<EOF


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324355699

```
main.c: In function 'VerifyScore':
main.c:370:15: error: too many arguments to function 'Score'; expected 0, have 1
  370 |         ret = Score(_false_);
      |               ^~~~~ ~~~~~~~
In file included from main.c:15:
score.h:17:14: note: declared here
   17 | extern short Score();
      |              ^~~~~
main.c: In function 'GameLoop':
main.c:405:20: error: too many arguments to function 'Score'; expected 0, have 1
  405 |             ret2 = Score(_false_);
      |                    ^~~~~ ~~~~~~~
score.h:17:14: note: declared here
   17 | extern short Score();
      |              ^~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
