### PR TITLE
binaryen: patch lld.py to match '64' on basename

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation rec {
       sed -i '/gtest/d' third_party/CMakeLists.txt
       rmdir test/spec/testsuite
       ln -s ${testsuite} test/spec/testsuite
+      # scripts/test/lld.py checks `'64' in input_path` to enable the
+      # memory64/bigint flags; the full Nix build path leaks digits that
+      # can accidentally contain "64", wrongly triggering those flags for
+      # non-memory64 tests (e.g. duplicate_imports.wat). Match on basename.
+      substituteInPlace scripts/test/lld.py \
+        --replace-fail "'64' in input_path" "'64' in os.path.basename(input_path)"
     else
       cmakeFlagsArray=($cmakeFlagsArray -DBUILD_TESTS=0)
     fi


### PR DESCRIPTION
scripts/test/lld.py adds --enable-memory64 --bigint when '64' appears anywhere in the input path. The full Nix build directory is included, and its nonce digits can contain '64' — non-deterministically triggering the memory64 flags on unrelated tests (e.g. lld/duplicate_imports.wat) and causing output mismatches. Match on basename instead.

Followup to https://github.com/NixOS/nixpkgs/pull/511035, where I noticed a failure on hydra: https://hydra.nixos.org/build/326649073/log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
