### PR TITLE
lomiri.teleports: 1.21 -> 1.22

### DIFF
--- a/pkgs/desktops/lomiri/applications/teleports/1001-app-CMakeLists.txt-Drop-explicit-dependency-on-rlottie.patch
+++ b/pkgs/desktops/lomiri/applications/teleports/1001-app-CMakeLists.txt-Drop-explicit-dependency-on-rlottie.patch
@@ -1,4 +1,4 @@
-From f9dfacc4b92faa7b60ae37489aa58520b4da95d7 Mon Sep 17 00:00:00 2001
+From cb4a928db740de48d84d47c21705786bb141af02 Mon Sep 17 00:00:00 2001
 From: OPNA2608 <opna2608@protonmail.com>
 Date: Sun, 5 Oct 2025 14:34:43 +0200
 Subject: [PATCH] app/CMakeLists.txt: Drop explicit dependency on rlottie
@@ -11,7 +11,7 @@ Subject: [PATCH] app/CMakeLists.txt: Drop explicit dependency on rlottie
  1 file changed, 1 deletion(-)
 
 diff --git a/app/CMakeLists.txt b/app/CMakeLists.txt
-index c1f0b85..7a59db5 100644
+index c1f0b852..7a59db59 100644
 --- a/app/CMakeLists.txt
 +++ b/app/CMakeLists.txt
 @@ -1,7 +1,6 @@
@@ -23,5 +23,5 @@ index c1f0b85..7a59db5 100644
  
  #"qtdclient.cpp" "qtdthread.cpp" "qml.qrc"
 -- 
-2.51.0
+2.51.2
 

--- a/pkgs/desktops/lomiri/applications/teleports/default.nix
+++ b/pkgs/desktops/lomiri/applications/teleports/default.nix
@@ -49,13 +49,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "teleports";
-  version = "1.21";
+  version = "1.22";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/teleports";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-V9yOQbVXtZGxdiieggPwHd17ilRZ0xMEI2yphgjx188=";
+    hash = "sha256-y0oXlhu2cvOGYZCEHfL6DcyStCQcIz7JtIpR4Tygm/4=";
   };
 
   patches = [
@@ -64,19 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
       name = "0001-teleports-Call-i18n.bindtextdomain.patch";
       url = "https://gitlab.com/ubports/development/apps/teleports/-/commit/dd537c08453be9bfcdb2ee1eb692514c7e867e41.patch";
       hash = "sha256-zxxFvoj6jluGPCA9GQsxuYYweaSOVrkD01hZwCtq52U=";
-    })
-
-    # Fix CMake 4 compatibility
-    # Remove when version > 1.21
-    (fetchpatch {
-      name = "0002-teleports-CMakeLists.txt-Support-building-with-CMake-4.patch";
-      url = "https://gitlab.com/ubports/development/apps/teleports/-/commit/ffb4e745889a473a208a86a29b7e439129930b01.patch";
-      hash = "sha256-EdcCHH/0Zq8wcF6UPyvy16wntDeSqTV9LWQat91LNRo=";
-    })
-    (fetchpatch {
-      name = "0003-teleports-libs-qtdlib-CMakeLists.txt-Support-building-with-CMake-4.patch";
-      url = "https://gitlab.com/ubports/development/apps/teleports/-/commit/fe7f0cb304ddaefae9f97917d3edc89de5f21b1f.patch";
-      hash = "sha256-yIc/l6iHb5qWI0QZOx8Hhd0lgEYyPozL+AjrmF2L89k=";
     })
 
     # Remove when https://gitlab.com/ubports/development/apps/teleports/-/merge_requests/586 merged & in release


### PR DESCRIPTION
https://gitlab.com/ubports/development/apps/teleports/-/blob/v1.22/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
