### PR TITLE
slimevr: 18.2.0 -> 20.1.0

### DIFF
--- a/pkgs/by-name/sl/slimevr-server/deps.json
+++ b/pkgs/by-name/sl/slimevr-server/deps.json
@@ -12,7 +12,6 @@
    "pom": "sha256-LvIhWi+XFxY/gDni5mBU64XOJ+JLGY2X0r4222bKXlo="
   },
   "SlimeVR/oscquery-kt#oscquery-kt/566a0cba58": {
-   "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
    "module": "sha256-ZqK7sz4yLUmYWICZSpFHgE/xcL5zjXSPUIkHneeBVOg=",
    "pom": "sha256-x573rzicYvlbWVFzRzAqNinkB4Himt6z8iLqhEdkA7c="
   },
@@ -44,57 +43,64 @@
    "module": "sha256-IFNqlfL+sr9DBRKMaq7Lb9idxFeYqchfJgK4qAnXUNs=",
    "pom": "sha256-Q1z/VXiZht7arXF/aPuo1UgklHhWLc2EsirU1lZvRAs="
   },
-  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/8.0.0": {
-   "pom": "sha256-P/Oh7RadAeWWadmHM4wl8jDaB9YpUlOPDdT5R3YokDY="
+  "com/diffplug/spotless#com.diffplug.spotless.gradle.plugin/8.2.1": {
+   "pom": "sha256-MGt3fcOfRP7GK1C97+QbcWvrD9fNP4FXInOhNMLhVbk="
   },
-  "com/diffplug/spotless#spotless-lib-extra/4.0.0": {
-   "jar": "sha256-eU/w7Rnmc9WDQiAay+mWa7V8opNptlkapAfpH3EIc2c=",
-   "module": "sha256-dqvsZm0K6Bu7X0LZSYmo9NBgzIv4HAWXyzycbJ8weA0=",
-   "pom": "sha256-mFOj57ehlVHOyeTfguC9ODVt9gOmFcOjOZCEYD8ZPTQ="
+  "com/diffplug/spotless#spotless-lib-extra/4.3.0": {
+   "jar": "sha256-dU+ATAnfouuNU5YzEdK+aPG0pWIQEdy1UNcC6tKGUdk=",
+   "module": "sha256-yImJBeaSp+CHATV8PK0NT+JqogjNerDe2NcNOSnLoRI=",
+   "pom": "sha256-C5N93//pxrgmIDYU755aLQs8INjMa3kitIgdl9MbaJ0="
   },
-  "com/diffplug/spotless#spotless-lib/4.0.0": {
-   "jar": "sha256-N40MNuxkPDeA+rUo52uvANqE/ZRKp1epM/Z3rCg9M84=",
-   "module": "sha256-92+01yygh52jJV5JO6u5d9b/zZjBRnpQ68oDHCqhBls=",
-   "pom": "sha256-+cBI1/AcYo5IvXJAaj3WVp2p1ic1wgv1Tf8/XwxdqAI="
+  "com/diffplug/spotless#spotless-lib/4.3.0": {
+   "jar": "sha256-Zp+ETsCpdJQcbaBLZwdI9DF4I5ttmf3bWwYs6dBtCTk=",
+   "module": "sha256-I1HAgP4kVTNGAv/QqCHYit9ipT5uoYTEOV9PVQXeNyM=",
+   "pom": "sha256-dPwsK8oRHUP/q/jWPYuegjpEOIWHevxxWInI6ckUaNM="
   },
-  "com/diffplug/spotless#spotless-plugin-gradle/8.0.0": {
-   "jar": "sha256-SBsYKnFP49cVsGv7aNYcwSv5legJIsSSu+BJVp7ImSg=",
-   "module": "sha256-r/+o5mZMvgJa0XGjawqR2EoPmR66Ppyw8QBMOn5cDJk=",
-   "pom": "sha256-1bqWuk97BrrT2ObX/uAcy+vrA7tvvzoq509UApXddYU="
+  "com/diffplug/spotless#spotless-plugin-gradle/8.2.1": {
+   "jar": "sha256-2/RPjfGDKAAkHU8TUSn8khuoL7ItckMMxC1NPVu/nTw=",
+   "module": "sha256-OPb28k3QWmJskcwWOvTThnq9UPCGdnqmTaJfMg+ik5s=",
+   "pom": "sha256-s578nCtRfx6eiNa+IvYyYZ3oOqDi49F1RaAXUDtxNPg="
   },
-  "com/fasterxml#oss-parent/38": {
-   "pom": "sha256-yD+PRd/cqNC2s2YcYLP4R4D2cbEuBvka1dHBodH5Zug="
+  "com/fasterxml#oss-parent/55": {
+   "pom": "sha256-D14Y8rNev22Dn3/VSZcog/aWwhD5rjIwr9LCC6iGwE0="
   },
-  "com/fasterxml#oss-parent/50": {
-   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
+  "com/fasterxml#oss-parent/61": {
+   "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
   },
-  "com/fasterxml#oss-parent/58": {
-   "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
+  "com/fasterxml#oss-parent/68": {
+   "pom": "sha256-Jer9ltriQra1pxCPVbLBQBW4KNqlq+I0KJ/W53Shzlc="
   },
-  "com/fasterxml/jackson#jackson-bom/2.17.2": {
-   "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
+  "com/fasterxml/jackson#jackson-bom/2.19.1": {
+   "pom": "sha256-um1o7qs6HME6d6it4hl/+aMqoc/+rHKEfUm63YLhuc4="
   },
-  "com/fasterxml/jackson#jackson-parent/2.17": {
-   "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
+  "com/fasterxml/jackson#jackson-parent/2.19.2": {
+   "pom": "sha256-Y5orY90F2k44EIEwOYXKrfu3rZ+FsdIyBjj2sR8gg2U="
   },
-  "com/fasterxml/woodstox#woodstox-core/6.5.1": {
-   "jar": "sha256-ySjWBmXGQV+xw5d1z5XPxE9/RYDPWrAbHDgOv/12iH8=",
-   "pom": "sha256-SDllThaxcU509Rq8s3jYNWgUq49NUnPR3S8c6KOQrdw="
+  "com/fasterxml/woodstox#woodstox-core/7.1.0": {
+   "jar": "sha256-gSZpIKHNxHMGqKK0cmyZ7Imz+/McJHDk9eR32dhXyp8=",
+   "pom": "sha256-+ZXFCx0gl18KjW8OUyK8jRPHiuPcGCcXdoQUlypmzIU="
   },
-  "com/github/gmazzo/buildconfig#com.github.gmazzo.buildconfig.gradle.plugin/5.5.0": {
-   "pom": "sha256-VLsX6z8pKCFD2TiyS1vnkg1EBm52b3FtpUQ7xp785/g="
+  "com/github/gmazzo/buildconfig#com.github.gmazzo.buildconfig.gradle.plugin/6.0.7": {
+   "pom": "sha256-HLtsknmESba6qhO62o4i6IrsvQRfqKWUMTZtvg4aNNI="
   },
-  "com/github/gmazzo/buildconfig#plugin/5.5.0": {
-   "jar": "sha256-rf1HIagM0l8M9z2z26t4RV/HCi/9bkjuGLjzDZCWvyU=",
-   "module": "sha256-O5YZPjLFtbyxtYha8mA6vSPl82+AID6j1NNGbn6BBZI=",
-   "pom": "sha256-zmdHCwkwZgynvmTQ9NGTsUdLNTU8SoNEUFSFe1ZCLd4="
+  "com/github/gmazzo/buildconfig#plugin/6.0.7": {
+   "jar": "sha256-UoUjRhdLuey1cgKYsN+0TfuVVb2E9J0TiXmAC9KyJpU=",
+   "module": "sha256-Srfu8Nsfqedd2xcZvrUySxuHH430gjdzqpdWnOfOfTw=",
+   "pom": "sha256-Vc2Z3PSMj8dgBPRU/s429g8csF/G2w1CgCDrW9HfDlI="
   },
-  "com/google/code/gson#gson-parent/2.8.9": {
-   "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
+  "com/google/code/gson#gson-parent/2.11.0": {
+   "pom": "sha256-issfO3Km8CaRasBzW62aqwKT1Sftt7NlMn3vE6k2e3o="
   },
-  "com/google/code/gson#gson/2.8.9": {
-   "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
-   "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
+  "com/google/code/gson#gson/2.11.0": {
+   "jar": "sha256-V5KNblpu3rKr03cKj5W6RNzkXzsjt6ncKzCcWBVSp4s=",
+   "pom": "sha256-wOVHvqmYiI5uJcWIapDnYicryItSdTQ90sBd7Wyi42A="
+  },
+  "com/google/errorprone#error_prone_annotations/2.27.0": {
+   "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
+   "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
+  },
+  "com/google/errorprone#error_prone_parent/2.27.0": {
+   "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
   "com/googlecode/concurrent-trees#concurrent-trees/2.6.1": {
    "jar": "sha256-BONySYTipcv1VgbPo3KlvT08XSohUzpwBOPN5Tl2H6U=",
@@ -104,26 +110,26 @@
    "jar": "sha256-1lImlJcTxMYaeE9BxRFn57Axb5N2Q5jrup5DNrPZVMI=",
    "pom": "sha256-5O1sZpYgNm+ZOSBln+CsfLyD11PbwNwOseUplzr5byM="
   },
-  "com/gradleup/shadow#com.gradleup.shadow.gradle.plugin/8.3.2": {
-   "pom": "sha256-szOyGpOZQspQU6SeLX5q2zN15DgL+wGwm+TBlU4qENA="
+  "com/gradleup/shadow#com.gradleup.shadow.gradle.plugin/9.3.1": {
+   "pom": "sha256-yIQ/agfj0unj0+swNOFVvW/ctWE5kEyShO/95R16X6Q="
   },
-  "com/gradleup/shadow#shadow-gradle-plugin/8.3.2": {
-   "jar": "sha256-47sBT4DY/AbxJLnuN84qW0NYjtrZfuNXcAXZzBPI+mk=",
-   "module": "sha256-BUonHjgERAFbXnzvp9efTC7yvvfPjPUH7GQoEM0fESg=",
-   "pom": "sha256-Mjrk4FkMBPurCWKJcVxhzy40MF9QgOGLqiqyAKShmaM="
+  "com/gradleup/shadow#shadow-gradle-plugin/9.3.1": {
+   "jar": "sha256-lGB42YbsVs6P+NAWN9kPcJ8zPVg6tSCq3Y5EnTcE2Gc=",
+   "module": "sha256-IuNwRjPPGSGbTVGUqNKJDPfPTbctRA5g6BIlcS+na2w=",
+   "pom": "sha256-nLrNpEyjh3wt54LMo5iIGUYCimh4H/kOypnamAgO/JE="
   },
   "com/squareup#javapoet/1.13.0": {
    "jar": "sha256-THUX6EinGzbQadErs79Gpw/UzaMQXYIrDtLhnAC2kpE=",
    "pom": "sha256-VKNPqFAqRryQ79tJJiYAWR+oC/mjT1pMeYMRrsFsqXc="
   },
-  "com/squareup#kotlinpoet-jvm/1.18.1": {
-   "jar": "sha256-s+x+8cJzRtGIwRMVm89kd6I2s0DTJD5ST3xFTjkixWQ=",
-   "module": "sha256-+1tTJWd4xiTRlZSXMZeAjwiFn8ZWNUuxIvwMl3U9mdc=",
-   "pom": "sha256-+ucsMCnUZuEBauSXrTJeuFOlAUBo/kpeZb7ZtPuvCbs="
+  "com/squareup#kotlinpoet-jvm/2.2.0": {
+   "jar": "sha256-h7qDV24rvakp4tTYMDXq95hLmtwHmIN7jo0etJU6F9o=",
+   "module": "sha256-66/Fkkz3G9T0bzdxJKGl6GaxCgBFtxY/twTadDt3R/k=",
+   "pom": "sha256-VsoDa3gKO/kuCbmu00ewsHI+5xd7I3jljz5ld/UHXo4="
   },
-  "com/squareup#kotlinpoet/1.18.1": {
-   "module": "sha256-6AmDh4Z7X+tHZBbd6HztYFpmDDlsKSAaiaxm42FSgUw=",
-   "pom": "sha256-csHy89blWKZkLTUye98mGyGumOQ6tolJMqeTXzVO4xU="
+  "com/squareup#kotlinpoet/2.2.0": {
+   "module": "sha256-aIYavQlTRpvtUDik3//+I8oKbBwyHgBeXlkBoblb8jU=",
+   "pom": "sha256-MObMgHCWcYvtg4loYN4/DYhUnXiAKnryEAOzmGREk7w="
   },
   "com/squareup/okhttp3#okhttp/4.12.0": {
    "jar": "sha256-sQUAgbFLt6On5VpNPvAbXc+rxFO0VzpPwBl2cZHV9OA=",
@@ -139,13 +145,13 @@
    "module": "sha256-akesUDZOZZhFlAH7hvm2z832N7mzowRbHMM8v0xAghg=",
    "pom": "sha256-rrO3CiTBA+0MVFQfNfXFEdJ85gyuN2pZbX1lNpf4zJU="
   },
-  "commons-codec#commons-codec/1.18.0": {
-   "jar": "sha256-ugBfMEzvkqPe3iSjitWsm4r8zw2PdYOdbBM4Y0z39uQ=",
-   "pom": "sha256-dLkW2ksDhMYZ5t1MGN7+iqQ4f3lSBSU8+0u7L0WM3c4="
+  "commons-codec#commons-codec/1.20.0": {
+   "jar": "sha256-avZllfn2p7tYzmZRjWiI1AtUfDZtImLwZnbu4ZUo/2Y=",
+   "pom": "sha256-r/ZFxYzUGsUYTZds6O443laU2Zq4dk1u5/FPcOrV+Ys="
   },
-  "commons-io#commons-io/2.16.1": {
-   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
-   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  "commons-io#commons-io/2.21.0": {
+   "jar": "sha256-fWQ6Kv6osFi3YqpvuQ5bJW9scpc5+LN4TDNw3cYJ6I0=",
+   "pom": "sha256-rkd5XnIYA+yP8d7tdL4oqBGgJxO9WjqwrGfCtYy2Nas="
   },
   "dev/equo/ide#solstice/1.8.1": {
    "jar": "sha256-bluizOgTvh1xzNwuzz5JJxsU5pG/u7GhFM86MOdzsQ0=",
@@ -158,11 +164,8 @@
   "jakarta/platform#jakartaee-api-parent/9.1.0": {
    "pom": "sha256-p3AsSHAmgCeEtXl7YjMKi41lkr8PRzeyXGel6sgmWcA="
   },
-  "org/apache#apache/31": {
-   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
-  },
-  "org/apache#apache/33": {
-   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  "org/apache#apache/35": {
+   "pom": "sha256-6il9zRFBNui46LYwIw1Sp2wvxp9sXbJdZysYVwAHKLg="
   },
   "org/apache/ant#ant-launcher/1.10.15": {
    "jar": "sha256-XIVRmQMHoDIzbZjdrtVJo5ponwfU1Ma5UGAb8is9ahs=",
@@ -175,90 +178,69 @@
    "jar": "sha256-djrNpKaViMnqiBepUoUf8ML8S/+h0IHCVl3EB/KdV5Q=",
    "pom": "sha256-R4DmHoeBbu4fIdGE7Jl7Zfk9tfS5BCwXitsp4j50JdY="
   },
-  "org/apache/commons#commons-parent/69": {
-   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  "org/apache/commons#commons-parent/91": {
+   "pom": "sha256-0vi2/UgAtqrxIPWjgibV+dX8bbg3r5ni+bMwZ4aLmHI="
   },
-  "org/apache/commons#commons-parent/79": {
-   "pom": "sha256-Yo3zAUis08SRz8trc8euS1mJ5VJqsTovQo3qXUrRDXo="
+  "org/apache/groovy#groovy-bom/4.0.27": {
+   "module": "sha256-1sIlTINHuEzahMr3SRShh8Lzd+QoTo2Ls/kBUhgQqos=",
+   "pom": "sha256-qkTrUr/f5h0ns+RQ0rNI2I3qo0N6tNnUmoQJU0j59vs="
   },
-  "org/apache/logging#logging-parent/11.2.0": {
-   "pom": "sha256-dya9j66DWy0BJIYRvLY+07qZj9TqUaxEJTv57UxyjeA="
+  "org/apache/logging/log4j#log4j-api/2.25.3": {
+   "jar": "sha256-6IZoKSD6D7nW62OV3LTeCIRD+GRsicXlhG4WjjJ/QG8=",
+   "module": "sha256-W+T3N0jWz53pXLci63n8rVvCQnk6l4p+cmbyNZGBHAw=",
+   "pom": "sha256-MoS+ZXOuuDNGz/a3RvoyXSPq3Z0JyOKG7R11kEoS3W4="
   },
-  "org/apache/logging/log4j#log4j-api/2.24.0": {
-   "jar": "sha256-3pm1JXjGLuASXdNF5xIVAvrP4pKUMUrmhKShIxTE5Vo=",
-   "pom": "sha256-pgbigYVtMdSE3lGJME+yMGnsOaHCKE/Uo5sS3Cbe+CA="
+  "org/apache/logging/log4j#log4j-bom/2.25.3": {
+   "pom": "sha256-ZleICHEo/mw6+dAlJEhTKvl4cRdmSB20k5a/AyWibK0="
   },
-  "org/apache/logging/log4j#log4j-bom/2.24.0": {
-   "pom": "sha256-jTySt3fh819yCRUziBoEJdnn5lXLA6OMD0Wlp614QFE="
+  "org/apache/logging/log4j#log4j-core/2.25.3": {
+   "jar": "sha256-Nit/y2W3OqRsxLxTq/TrIW9ESoO10aA3y2/f/wrp8Pk=",
+   "module": "sha256-ChRnoKtPxLJSc7VVHGCL15UguZ/SgRGgM9M4jwJVYwA=",
+   "pom": "sha256-ysGDRqDJErAmrVF/SE78POgyZ/LPambKhGmRL/GYaw0="
   },
-  "org/apache/logging/log4j#log4j-core/2.24.0": {
-   "jar": "sha256-P1uTyA8PPS6M+xZqfWTsWJ+Mkyb6DXxB101jso9v1i4=",
-   "pom": "sha256-+Uoc4WqvWGfQapi74TtYfwtx7B02eun2mXVNThE4L3E="
+  "org/apache/logging/log4j#log4j/2.25.3": {
+   "pom": "sha256-pbdIJFris5b1vKlHpJbtwI29vfeWmuLMsattS0lznn8="
   },
-  "org/apache/logging/log4j#log4j/2.24.0": {
-   "pom": "sha256-gF3bFP3N7dA0/e8QU0eZH3cEvrTyI52kS/r0NDYDMeo="
+  "org/apache/maven#maven-api-annotations/4.0.0-rc-3": {
+   "jar": "sha256-XTSQ9yrTp+gr6IsnYp83xZ/SUxuuURw7E4ZkINXYYr0=",
+   "pom": "sha256-83HUqkRgxMwP4x0W20WC2+eGHvzS5nqvGEPimR8Xx0I="
   },
-  "org/apache/maven#maven-api-meta/4.0.0-alpha-9": {
-   "jar": "sha256-MsT1yturaAw0lS+ctXBFehODzOxMmlewOSYH1xkcaUk=",
-   "pom": "sha256-2ePDXW/aysuNGLn2QoYJDH/65yjWbLJq9aJmgZUNvnk="
+  "org/apache/maven#maven-api-xml/4.0.0-rc-3": {
+   "jar": "sha256-8+OzZCNzxp1MdEHUDroHZeHXROmStiGURS9epUUd/bo=",
+   "pom": "sha256-XxSOOelo08K3a4426hN3mJ8KeetDpqWa5yPZElzLXGE="
   },
-  "org/apache/maven#maven-api-xml/4.0.0-alpha-9": {
-   "jar": "sha256-KbJijQ8CgRlxWRaEnBnu1FsyzcZ+sTVReYxzr6SqI9Y=",
-   "pom": "sha256-N2bjAzOTTJIvUlj6M0uHXyi7ABJ/8D3vANl/KlOnrps="
+  "org/apache/maven#maven-xml/4.0.0-rc-3": {
+   "jar": "sha256-BjxCTLR/dRZBJdXuolFnuTHdaU40Jo1QJHN050IR3Rk=",
+   "pom": "sha256-nZZekiyqwDYkl9J7v6UaRI+UydcTYjZnnGhSNwb3KYI="
   },
-  "org/apache/maven#maven-api/4.0.0-alpha-9": {
-   "pom": "sha256-ZYvglXcymzX5TemWdb8O/HI26ZYbXHhfMyqkfyKUcfA="
+  "org/codehaus/plexus#plexus-utils/4.0.2": {
+   "jar": "sha256-iVcnTnX+LCeLFCjdFqDa7uHdOBUstu/4Fhd6wo/Mtpc=",
+   "pom": "sha256-UVHBO918w6VWlYOn9CZzkvAT/9MRXquNtfht5CCjZq8="
   },
-  "org/apache/maven#maven-bom/4.0.0-alpha-9": {
-   "pom": "sha256-4EfSnTUI/yd6Wsk1u5J/NUkQLMbTec5a4p4pYzeE0Rw="
+  "org/codehaus/plexus#plexus-xml/4.1.0": {
+   "jar": "sha256-huan8HSE6LH3r2bZfTujyz1pKlRhtLHQordnDPV0jok=",
+   "pom": "sha256-uKO6h7WsMXVJUEngIXiIDKJczJ6rGkR9OKGbU3xXgk4="
   },
-  "org/apache/maven#maven-parent/41": {
-   "pom": "sha256-di/N1M6GIcX6Ciz2SVrSaXKoCT60Mqo+QCvC1OJQDFM="
+  "org/codehaus/plexus#plexus/20": {
+   "pom": "sha256-p7WUsAL8eRczyOlEcNCQRfT9aak61cN1dS8gV/hGM7Q="
   },
-  "org/apache/maven#maven-xml-impl/4.0.0-alpha-9": {
-   "jar": "sha256-JucCuIHVeuTuiNAsAJQLpkBjcF7mkgWuiVi/g5qLBrE=",
-   "pom": "sha256-us0USYVzbUMmuuRChHM78eMTKX3NolNGTkYpsddoGPc="
-  },
-  "org/apache/maven#maven/4.0.0-alpha-9": {
-   "pom": "sha256-5QzZ/zefQ3H3/ywsrFF5YfPS9n7fgJCHU8e9UGuRPX4="
-  },
-  "org/codehaus/groovy#groovy-bom/3.0.22": {
-   "pom": "sha256-kqci1+KztXJ8mr5uF44yfcjJN0mpX+qpEtHSannhn5M="
-  },
-  "org/codehaus/plexus#plexus-utils/4.0.1": {
-   "jar": "sha256-lrnMREORkdLQY1l04tROdoc2tPsqvLZflM2V5BkS+os=",
-   "pom": "sha256-vEI1qVzR665CZEyB67qcHUxSVl+B6WqyBLblbj43jME="
-  },
-  "org/codehaus/plexus#plexus-xml/4.0.4": {
-   "jar": "sha256-Bp54tTcQjcYSSmcHP8mYJkeR9rZJnpVaOOcrs+T+Gt8=",
-   "pom": "sha256-Ohb3yn7CRzFFtGHgpylREI1H4SThjIRMCFsaY3jGEVE="
-  },
-  "org/codehaus/plexus#plexus/17": {
-   "pom": "sha256-kVJu5mMnx/UPuyW9Qb/LkW4oRBS4aOMdUKIwBL197qc="
-  },
-  "org/codehaus/plexus#plexus/18": {
-   "pom": "sha256-tD7onIiQueW8SNB5/LTETwgrUTklM1bcRVgGozw92P0="
-  },
-  "org/codehaus/woodstox#stax2-api/4.2.1": {
-   "jar": "sha256-Z4Vn5ItRpCxlxpnyZlOa09Z21LGlsK19iezoudV3JXk=",
-   "pom": "sha256-edpBDIwPRqP46K2zDWwkzNYGW272v96HvZfpiB6gouc="
+  "org/codehaus/woodstox#stax2-api/4.2.2": {
+   "jar": "sha256-phxI1VPvrXi8Af/8SsUovruuZMuuwXCypeOc9h61Gr4=",
+   "pom": "sha256-TpAuxVb8ZZi0HClS7BVz7cgVA35zMOxJIuq2GUImhuI="
   },
   "org/eclipse/ee4j#project/1.0.7": {
    "pom": "sha256-IFwDmkLLrjVW776wSkg+s6PPlVC9db+EJg3I8oIY8QU="
   },
-  "org/eclipse/jetty#jetty-bom/9.4.55.v20240627": {
-   "pom": "sha256-plq2UZjcP22y/2kBBlc31UgL52e+wyDgFzqJB68LGdg="
+  "org/eclipse/jgit#org.eclipse.jgit-parent/7.5.0.202512021534-r": {
+   "pom": "sha256-fjiAaoU2kaSdsW6sg2/mtiYnaUOxCLZ3VKPVx0D7vA4="
   },
-  "org/eclipse/jgit#org.eclipse.jgit-parent/7.3.0.202506031305-r": {
-   "pom": "sha256-EuCm1BYOBfIGFJVPhMPmemiCdBhQJTysHHTj+5nXmjQ="
+  "org/eclipse/jgit#org.eclipse.jgit/7.5.0.202512021534-r": {
+   "jar": "sha256-FZe8eKjYwBFpdtRqlIcqLMKGVnDrpNsLn1GBGzSTbXI=",
+   "pom": "sha256-bJVN/BDxwwG9uiXT1jCfd0eYBDY891VuUei7NxRVXGQ="
   },
-  "org/eclipse/jgit#org.eclipse.jgit/7.3.0.202506031305-r": {
-   "jar": "sha256-xMTho+sa/p3Gqck7HIkG6qq5panNtcld5MyA7/TKDcE=",
-   "pom": "sha256-vWj77cwn8P6jA6dOS4JFmyRaL8IR0DZDrda/XpxYVyg="
-  },
-  "org/eclipse/platform#org.eclipse.osgi/3.23.200": {
-   "jar": "sha256-jZQFjq0/RlGQAWaSSmd8O+tumW8HL6vzhf/dcFELxJM=",
-   "pom": "sha256-py2jWv3kgc2hDp2UsxpUwbkKe2hQqt5MmtnpVtdIWtA="
+  "org/eclipse/platform#org.eclipse.osgi/3.24.0": {
+   "jar": "sha256-eJRUAUwVDyrfaBzYD47PSYF9k+15DzZZs2LcoHreh7g=",
+   "pom": "sha256-ok2dkGpHjhJrIZqdJFGLgztm2ksQP5Y+ILkFC+virhU="
   },
   "org/jdom#jdom2/2.0.6.1": {
    "jar": "sha256-CyD0XjoP2PDRLNxTFrBndukCsTZdsAEYh2+RdcYPMCw=",
@@ -268,89 +250,86 @@
    "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
    "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
   },
-  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
-   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
-   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  "org/jetbrains/kotlin#abi-tools-api/2.3.10": {
+   "jar": "sha256-E2nLVCrmR6nVVJ5thkkh6g+GApdJWRmXteWqFhyXGIs=",
+   "pom": "sha256-x12MiniT5DijbBZeA1I+uHRDZ6wNaV4sdrZ48LAjnE8="
   },
-  "org/jetbrains/kotlin#kotlin-build-statistics/2.0.20": {
-   "jar": "sha256-c6fXFRN1WzF9Kxttp2bW5reiXcmdzv5DEzJTNkIuzhE=",
-   "pom": "sha256-10GK0lyAbeg2FQvdNQsAvmwtJQmeXXQd3+PzgcUurY0="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.10": {
+   "module": "sha256-S6VmEYmH5t40LreG9cBlq/KOD1GxChn5urHQnQ8BgAg=",
+   "pom": "sha256-Lq0FKRNzQaRlNuKfJLUrjci875dxQRBZvIeXikqlcFI="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-api/2.0.20": {
-   "jar": "sha256-V+1QIg547DnoqAAUMw8pXlSFtWOMESmvntfVPXhYxcI=",
-   "pom": "sha256-nHrVho+yGJsb9NbCL2yUmDs6jhopTpWlQSy4Lg9C3bI="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.3.10/gradle813": {
+   "jar": "sha256-aR4tKmjLngoIjxlX3nz7pWjiSRh2mUhhI9YHX9/znRc="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.0.20": {
-   "jar": "sha256-o2BL81DIvM4nECFYu7OD+k0YFLxIaq7VnyeOraUf9q0=",
-   "pom": "sha256-WXBD+4xlJ/QpmcoE7TUpY5Is0W5piKqlLT2zLaHbhZ0="
+  "org/jetbrains/kotlin#kotlin-build-statistics/2.3.10": {
+   "jar": "sha256-rATm9NehsNONNMb//SM90SpmzikVjyX68Ax17KzUQ7w=",
+   "pom": "sha256-D412s88lmTbUu/J7bZOrZtxor4wBaf4fXhMuQY9Ano0="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-runner/2.0.20": {
-   "jar": "sha256-4DzwSwNA8a4VEhBjC10pFcKXmIxuIuTe206nz7dKz2c=",
-   "pom": "sha256-3M3xugxPzYvUIwNFroP6fb6SglY9ilP9XmHFM1tbcYA="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.3.10": {
+   "jar": "sha256-EYZyC5EGhN+drZy5YBXM8ZF27FZVzrCbAfvEUjC9H2Q=",
+   "pom": "sha256-3pBa7tBWHZduxSEU8vPk5mls05Mg9DqxFvF/79c9U8I="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-client/2.0.20": {
-   "jar": "sha256-cxUswf2CHQcTlHOry/jH0B0A5oaEuWHhkurogNycfaQ=",
-   "pom": "sha256-qUcReIj0z/tjk9QurqYRtj31ib8pYXgmzLclNxK/OsM="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.3.10": {
+   "jar": "sha256-CpGS+4AlHMrRzb8sq6KEiOjUaGnS5eSVfKF5wnwKTuA=",
+   "pom": "sha256-4CtYvQDZCjExN9L18ZIZ2tt3FXVebd1t74mYpa/RgCc="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.0.20": {
-   "jar": "sha256-W9URO4WrhSjhkuK7P8GX9bw0SLzb0Fh5Czf9N/TuV68=",
-   "pom": "sha256-IZgoJm6keO7rQuT1L5bQuQfYykhHz4aq45FprYsupKU="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.3.10": {
+   "jar": "sha256-0hpvd9mAOmFebRUIVzd+EKnox80Grm4cHrmZIP2ji5M=",
+   "pom": "sha256-sOpstyMer+j7oN+zf8MZhJkED3TE00EmPtq2yE0Z2sA="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.0.20": {
-   "jar": "sha256-i2O0/7e6aOKHIFaa1HqWzAZclFZO0WHuoVrIZIh7pN4=",
-   "pom": "sha256-D8eaPIg8fbbsD6lU1cimiugRBlIm+4WRbhy/9pnlwUc="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.3.10": {
+   "jar": "sha256-yz8A2nIhxzuf45W3HFxXnuMmJgxXOjjCGd6t7vUkdks=",
+   "pom": "sha256-W4tTzgpFIWup6yZRWQfmdFi+cp+OqvXBlS9ssuCfcac="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.0.20": {
-   "jar": "sha256-D3NXvFzMjjaB7DtGQ8cMrSiDskbIt699bZccQeOTTy0=",
-   "module": "sha256-CJ8SCJE61calM09nu8pI/HsK+hCv0L2lFT+8tSzCqWw=",
-   "pom": "sha256-IQOK734wtxG0qE3grS1TO9MgXhOKrWfP1YnXl+/afII="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.3.10": {
+   "module": "sha256-p7RKyP2FrLVZaQdkrIl8Haz7eUlefoXmY6IMRhECXa4=",
+   "pom": "sha256-qty9XFeR9sVMi0IgpGAvxFBOjrpsjs+kumG0AkRuutI="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.0.20/gradle85": {
-   "jar": "sha256-D3NXvFzMjjaB7DtGQ8cMrSiDskbIt699bZccQeOTTy0="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.3.10/gradle813": {
+   "jar": "sha256-KSEBw7xFdm5gKUIbOJkyJEbM79WrzQJ4hj9SENNJSSI="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.0.20": {
-   "jar": "sha256-Ce2wJ7mh899xYnGuyte7QaHdvC+cETFyl5ANTyvc6Iw=",
-   "pom": "sha256-wZireMJmzzvnodJHBeW7GIbUlF/cpPcX9U77hv9M10o="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.3.10": {
+   "jar": "sha256-aBZWUlkS6+BkS2uQraFIPBOcXpMNT46kiCDb4YHP+9o=",
+   "pom": "sha256-AjxvG3UBfGU0IsaaeUiTaR5B7+jC47nxi1uMHsTQhIo="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.0.20": {
-   "jar": "sha256-wfTqDBkmfx7tR0tUGwdxXEkWes+/AnqKL9B8u8gbjnI=",
-   "module": "sha256-wy8Uw0SXgCqOjXk7K11nkj4gIlOUePNm4Yp+9kFOut4=",
-   "pom": "sha256-Vn7N8kaceWkMLgmdz6r8PhF67GTe3BejtJ/Uo/ptDgg="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.3.10": {
+   "jar": "sha256-lS5zlI4qINOYwmuHprtwzPZkGPuvFSfDUVsYjqnUvWA=",
+   "module": "sha256-nKavltr37lkKDlnJ7+HfkBmrAegPRHZ2udyo/F/q9LU=",
+   "pom": "sha256-nAGu0VT697j/vvhlQZ8XFkBj9reptVgTJppQxrSOlxI="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/2.0.20": {
-   "jar": "sha256-UUx/F9xeVO5dFqdhs2S500OVa8rUnf0I4IWWIldzfhk=",
-   "module": "sha256-HPn20+xtMFqgiQMqyJL/rogcwQUAP0VvLBX9PDAyCm4=",
-   "pom": "sha256-SEIbKUnHKiDU4OPybYcYxruScIbHbF/AlSCg1jbPumc="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.3.10": {
+   "module": "sha256-+zIU9bn6DZ/MvLxt8tG71VHloQ/lvFh7dsN03xL0mTI=",
+   "pom": "sha256-5fmNcJdy/v3XWP0KOcT3x1ny8BcdGqDMDMK58Ltv45U="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.0.20": {
-   "module": "sha256-aBPMpB7w+/FciL7MQB44cGuWlEwhtr7HPdiM+QoPIB4=",
-   "pom": "sha256-eEmYfUbGj7neKvOwReEq1nPm1mOvbqpf2MYRlCt3LF0="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.3.10/gradle813": {
+   "jar": "sha256-uBYPRY9Qkj3wP9AbIE2V6A9jxK2xQPiUnOULQ9eUveM="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.0.20/gradle85": {
-   "jar": "sha256-gSn2LLfGJ7XOghh+QqbYfEKVK8e6ZLgFo1R/aFIxlmI="
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.3.10": {
+   "module": "sha256-0WC3nI5dfs7/uQbYx0RhUO3J8bQ8ZXylBcqvH/UCzuk=",
+   "pom": "sha256-Kk97RKPQrHrsfb9bGqiNuTi/VC9zUVYfsdO1z4G2DQU="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.0.20": {
-   "module": "sha256-GwMjHvp7O20xsJNocpQfh+J6gZwANxiz0JiAt25j180=",
-   "pom": "sha256-TDLrNQlMFjWd943q7BHOUjvjYEB0FPoK7Miu/GftSkM="
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.3.10": {
+   "jar": "sha256-K04jpJa9pG8kPL+6pm6xxMkBtTHB/uzGnnnxvET1hpM=",
+   "pom": "sha256-zKwUWegEbV4FD1MJ4qi2Zk5IBrVaXUBFCFWI1+0ZOkk="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.0.20": {
-   "jar": "sha256-QsQvvic/oDBOThf3OSxms56R+Z01+FwGixG91Wuemdw=",
-   "pom": "sha256-5f4GjE69XIhYw1w56GI6vrnIb4oXJUdC5/VZjkP62jw="
+  "org/jetbrains/kotlin#kotlin-metadata-jvm/2.3.0": {
+   "jar": "sha256-DGQgOZHQIy2YnNXjZtYCjSexsIckCBgXi9UMJo7qtW8=",
+   "pom": "sha256-N51JdplIjLxv11nTN2QrRWLD2lI4g8NMH201PgZZvJc="
   },
-  "org/jetbrains/kotlin#kotlin-native-utils/2.0.20": {
-   "jar": "sha256-wWbyBR6R0ZnpYP/HsnZEhcFRDNF2dN17jOPC/NBqhys=",
-   "pom": "sha256-mISZMftwkWhS6qfCDm2Pr1IsUNd627r9k2T1JrfN7EI="
+  "org/jetbrains/kotlin#kotlin-native-utils/2.3.10": {
+   "jar": "sha256-kgDRaWeyIar2AU5OsCVzFnmKR7soFnI9PZxkaFPXLhM=",
+   "pom": "sha256-inkaCCnJ8U8F7jxRq2OQWxdofTIfW7p8Vx446+7kdC0="
   },
   "org/jetbrains/kotlin#kotlin-reflect/2.0.21": {
    "jar": "sha256-OtL8rQwJ3cCSLeurRETWEhRLe0Zbdai7dYfiDd+v15k=",
    "pom": "sha256-Aqt66rA8aPQBAwJuXpwnc2DLw2CBilsuNrmjqdjosEk="
   },
-  "org/jetbrains/kotlin#kotlin-serialization/2.0.20": {
-   "module": "sha256-rsyQ8DJ7IQJTYRNdyJQBDmHDVzVFBtLTP3pZeakRxGQ=",
-   "pom": "sha256-wYgmEN73pFKwREi8GVqr+D6CqMEcUSmFYUAbGyxfKCw="
+  "org/jetbrains/kotlin#kotlin-serialization/2.3.10": {
+   "module": "sha256-y4SHb+infUQ6gbhjVDIUuMT3e9DXcFnNO4m5Nww8MZ8=",
+   "pom": "sha256-BdRcpwksNSXEYlGEktwffhXwrhzCO8BySexKQhscdNU="
   },
-  "org/jetbrains/kotlin#kotlin-serialization/2.0.20/gradle85": {
-   "jar": "sha256-Jjd6xiKasd8/ojVJPYxWfkcLjYa2PolUSMwmbL/Ob1o="
+  "org/jetbrains/kotlin#kotlin-serialization/2.3.10/gradle813": {
+   "jar": "sha256-36XL+qo7OQVI6AXeABvJQBGS4z4CJRLRdsFA6raQOwQ="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-common/1.9.10": {
    "pom": "sha256-fUtwVHkQZ2s738iSWojztr+yRYLJeEVCgFVEzu9JCpI="
@@ -378,75 +357,60 @@
    "module": "sha256-gf1tGBASSH7jJG7/TiustktYxG5bWqcpcaTd8b0VQe0=",
    "pom": "sha256-/LraTNLp85ZYKTVw72E3UjMdtp/R2tHKuqYFSEA+F9o="
   },
-  "org/jetbrains/kotlin#kotlin-tooling-core/2.0.20": {
-   "jar": "sha256-W28UhUj+ngdN9R9CJTREM78DdaxbOf/NPXvX1/YC1ik=",
-   "pom": "sha256-XhIxEeAQewRmSIOgpAjB/zvbXQR+SQH4L0xC8QV4Bi0="
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.3.10": {
+   "jar": "sha256-NnFCeBKZvA+RIMHe7A5ik0oa+ep/AaqpxaU1TcXY19k=",
+   "pom": "sha256-5hhz7dWo3QMaa6l1nAXRVpBlnmEuPUjB7RInN9q0SYY="
   },
-  "org/jetbrains/kotlin#kotlin-util-io/2.0.20": {
-   "jar": "sha256-ZGTbjUFywhoXp5C20XiQIu1nrbN8UL5ri59YK1UrhSI=",
-   "pom": "sha256-LrBxVfqEF46ZVjnOe3aRcofK5UKjXSm1a7CZEB0oajw="
+  "org/jetbrains/kotlin#kotlin-util-io/2.3.10": {
+   "jar": "sha256-4Bw3Dn83/E0Ck7lXEUH1NwnlEJ4o7J1QgnMtOCDWfy4=",
+   "pom": "sha256-LZfqo2d6QEoFKTIaZ4rrLRzDn5EwwRSamNFm3TL8K3Q="
   },
-  "org/jetbrains/kotlin#kotlin-util-klib/2.0.20": {
-   "jar": "sha256-h92Djcd3gsuVZ/GnYUmbPkpQ9SjABbJjii4+V0EKljs=",
-   "pom": "sha256-fbTRw72mdZvifuk35gfoscRpWNwIR3Ey/a7t4BbnOP8="
+  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.3.10": {
+   "jar": "sha256-1uBU2zAOXqeyCOjjZoPNbE10dNiLaRaVFbew69e1DIs=",
+   "pom": "sha256-eT/ktDjwB3hoJDXOGxvPW6feZSR6JIuZpe6pmSov5aA="
   },
-  "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.0.20": {
-   "pom": "sha256-JyOoqUP6SkTTcD8VTEW31UcMcZ1OYKvz4ixzt3s4i5M="
+  "org/jetbrains/kotlin#kotlin-util-klib/2.3.10": {
+   "jar": "sha256-5b3gT8jS8h1wWfBcp01UtYkKC4zCqJD/IgjChB7HZfg=",
+   "pom": "sha256-SzSk2Br5xUmg8BOj6gAQeM5EotBEZweUakkhBbaSkx0="
   },
-  "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.0.20": {
-   "pom": "sha256-0s2V9THwNRgW+fg0bsbWB2xxyt9jLz6PZX3dft+RukE="
+  "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/2.3.10": {
+   "pom": "sha256-0OzGk5CQFi+LIGtt4uumJVZzzJ0EOico5yUWmt07NP0="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
-   "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
+  "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.10": {
+   "pom": "sha256-OXldry8vLwxty3VxvpVp232e1jJnGMKRmM3cc6Bing4="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
-   "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
-   "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
-   "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.0": {
+   "pom": "sha256-Ejnp2+E5fNWXE0KVayURvDrOe2QYQuQ3KgiNz6i5rVU="
   },
-  "org/junit#junit-bom/5.10.1": {
-   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
-   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
-  },
-  "org/junit#junit-bom/5.10.2": {
-   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
-   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
-  },
-  "org/junit#junit-bom/5.10.3": {
-   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
-   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.0": {
+   "jar": "sha256-mGCQahk3SQv187BtLw4Q70UeZblbJp8i2vaKPR9QZcU=",
+   "module": "sha256-/2oi2kAECTh1HbCuIRd+dlF9vxJqdnlvVCZye/dsEig=",
+   "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
   },
   "org/junit#junit-bom/5.11.4": {
    "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
    "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
   },
+  "org/junit#junit-bom/5.13.2": {
+   "module": "sha256-7WfhUiFASsQrXlmBAu33Yt1qlS3JUAHpwMTudKBOgoM=",
+   "pom": "sha256-Q7EQT7P9TvS3KpdR1B4Jwp8AHIvgD/OXIjjcFppzS0k="
+  },
+  "org/junit#junit-bom/5.13.4": {
+   "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
+   "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
+  },
   "org/mockito#mockito-bom/4.11.0": {
    "pom": "sha256-2FMadGyYj39o7V8YjN6pRQBq6pk+xd+eUk4NJ9YUkdo="
   },
-  "org/mockito#mockito-bom/5.7.0": {
-   "pom": "sha256-dlcAW89JAw1nzF1S3rxm3xj0jVTbs+1GZ/1yWwZ5+6A="
+  "org/slf4j#slf4j-api/2.0.17": {
+   "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
+   "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
   },
-  "org/ow2#ow2/1.5.1": {
-   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  "org/slf4j#slf4j-bom/2.0.17": {
+   "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
   },
-  "org/ow2/asm#asm-commons/9.7": {
-   "jar": "sha256-OJvCR5WOBJ/JoECNOYySxtNwwYA1EgOV1Muh2dkwS3o=",
-   "pom": "sha256-Ws7j7nJS7ZC4B0x1XQInh0malfr/+YrEpoUQfE2kCbQ="
-  },
-  "org/ow2/asm#asm-tree/9.7": {
-   "jar": "sha256-YvSzvENgRcGstcO6LY7FVuwzaQk9f10Gx0frBLVtUrE=",
-   "pom": "sha256-o06h4+QSjAEDjbQ8aXbojHec9a+EsFBdombf5pZWaOw="
-  },
-  "org/ow2/asm#asm/9.7": {
-   "jar": "sha256-rfRtXjSUC98Ujs3Sap7o7qlElqcgNP9xQQZrPupcTp0=",
-   "pom": "sha256-3gARXx2E86Cy7jpLb2GS0Gb4bRhdZ7nRUi8sgP6sXwA="
-  },
-  "org/slf4j#slf4j-api/1.7.36": {
-   "jar": "sha256-0+9XXj5JeWeNwBvx3M5RAhSTtNEft/G+itmCh3wWocA=",
-   "pom": "sha256-+wRqnCKUN5KLsRwtJ8i113PriiXmDL0lPZhSEN7cJoQ="
-  },
-  "org/slf4j#slf4j-parent/1.7.36": {
-   "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+  "org/slf4j#slf4j-parent/2.0.17": {
+   "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
   },
   "org/sonatype/oss#oss-parent/5": {
    "pom": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
@@ -462,46 +426,46 @@
    "jar": "sha256-IRswbPxE+Plt86Cj3a91uoxSie7XfWDXL4ibuFX1NeU=",
    "pom": "sha256-CTvhsDMxvOKTLWglw36YJy12Ieap6fuTKJoAJRi43Vo="
   },
-  "org/vafer#jdependency/2.11": {
-   "jar": "sha256-zdoDAD+pVRMVpMw/wWPxhJXxkbSaj3CjquIy8Emn/dA=",
-   "pom": "sha256-2mymcCFlPxUMHVNDLKxApzkH0tkqjzR65eRAHk+iJ+c="
+  "org/vafer#jdependency/2.14": {
+   "jar": "sha256-HT3hIYOiqJada8b/Wtdx3l1W0ISXxdk+FopctxDiy/E=",
+   "pom": "sha256-yGRf/88P5qu8IVS8i/0Jysbgd2M4Kz6cGLXbmR7IFjk="
   }
  },
  "https://repo.maven.apache.org/maven2": {
-  "com/fasterxml#oss-parent/50": {
-   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
+  "com/fasterxml#oss-parent/75": {
+   "pom": "sha256-/LvxwYyQR+aRfThPIGTiG0Klj8hfsFI6ni4BXv98YZ0="
   },
-  "com/fasterxml/jackson#jackson-base/2.15.1": {
-   "pom": "sha256-qdc9e+y/QhF0Vow4KrFik2EYD6lvwEHCzUokX2ljsJ0="
+  "com/fasterxml/jackson#jackson-base/2.21.0": {
+   "pom": "sha256-3Ohqkmt2uojZPStl0y2sJSnOhkCXy9d4CPW7YEbI64s="
   },
-  "com/fasterxml/jackson#jackson-bom/2.15.1": {
-   "pom": "sha256-xRdH0RSll5SfgRQHJ9nmzWPj9DkI82R++qcLGelNqk0="
+  "com/fasterxml/jackson#jackson-bom/2.21.0": {
+   "pom": "sha256-KLBsTl9RMwxPztKzvWGUGIz9I3Bo6hflkhORZFN3If8="
   },
-  "com/fasterxml/jackson#jackson-parent/2.15": {
-   "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
+  "com/fasterxml/jackson#jackson-parent/2.21": {
+   "pom": "sha256-OFHfYn+utGiHuVYQRjC3Sou7X33iLpdM8VmC4g4Dc94="
   },
-  "com/fasterxml/jackson/core#jackson-annotations/2.15.1": {
-   "jar": "sha256-NEwbND2YGdXdQ5XyUHl3uRuyRjd4zy73sNAXJOyP+rI=",
-   "module": "sha256-hVNrLUbNnrN+TpGNKDOrvQ9Qd6aPlWuaLNRdsDtEwBM=",
-   "pom": "sha256-DKy1qFN8cteOQSWdbX5PCf/g96+ehsWIU21/WOg34uc="
+  "com/fasterxml/jackson/core#jackson-annotations/2.21": {
+   "jar": "sha256-U8oIX0oVD3A/SeGqvZNb0DtD4eo9VdE1Q4KSryLO9Ws=",
+   "module": "sha256-yuj/7OwzKLbsuxOOJ0IY8v4cdymg6CTaVZJogQCVrUQ=",
+   "pom": "sha256-ccrFOSFR4qUozJoJF58KM0F58FxS+OWWz1jd8Suyfys="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.15.1": {
-   "jar": "sha256-nZhDGcyXboXEn0DakoAhrNLXc+JZqf+fgy7c2saSDu0=",
-   "module": "sha256-rdmSwmM0eNdXpuEcHee5z1BNxoHc1h0oL9o8u4F4M0c=",
-   "pom": "sha256-fHKqaK699Qz1EBA2TYWJa6gYjRX79O55b4oGFNYTtoY="
+  "com/fasterxml/jackson/core#jackson-core/2.21.0": {
+   "jar": "sha256-4iYEvNmyTkYtXfECAHywbh7YEehvHOYIHKYvOF8tuHs=",
+   "module": "sha256-5l6JWHmz/4XewbsriWZJbAHGzU/C7Jr426h4gpeEKwY=",
+   "pom": "sha256-oK3Z0hmBbU2lCgPWKuISIjKTiIIsuKrItas9CvFqp9Y="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.15.1": {
-   "jar": "sha256-wfA0fOJpbJT1MdCVzZ7yLmSOwJDpscPe4Xk4sHod8XY=",
-   "module": "sha256-e9QxX2gFmSVlRTq/cVf+muzrjWqslisaZM9gubAbJc4=",
-   "pom": "sha256-7cmvJRy1QoPCy0FZ3bM4CZJ/DIkS7UIeKQLC064GIYQ="
+  "com/fasterxml/jackson/core#jackson-databind/2.21.0": {
+   "jar": "sha256-AFeBfuQLxxVEBy3Co7pXXvkdzlOi2HSJvekcBfOiJiE=",
+   "module": "sha256-1IfT9FkCvL8TzXLLaHBVC5Z2lr9P8OfPjS4rBCtFzG0=",
+   "pom": "sha256-3GtWyKkD2LUSeRGDpoZ2mjUXJb1K+410rnASzm8HQLM="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.15.1": {
-   "jar": "sha256-iX8bNQmt4OcPFJi4POQQyEKLkTsSrkp8GmsLIkOLsYI=",
-   "module": "sha256-/HW18yHXnKdjB2n3oJfXa8ke9P4ubpUSJhjCPLllnAQ=",
-   "pom": "sha256-qggBh9FCfkU/J3YD+QqlLhJc+4Y5VORnbKPD3N3ngjU="
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.21.0": {
+   "jar": "sha256-XRhFeRRHgMOJYqX0de0kheiinzbMWcojcTWxnptkJCA=",
+   "module": "sha256-RGvZj4UAOzk+/h4PeGYkN8zme+aQofpXRIk4PJDsmAc=",
+   "pom": "sha256-HQ+AsgUVCcI7UoFDEeBk+FwEW4wm3MXWKFyYH8lHp0U="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.15.1": {
-   "pom": "sha256-xLCopnocY3IgeJlhd5bYafE/UerrGsN/wHqcpxPaQjU="
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.21.0": {
+   "pom": "sha256-pIBxUDnBwFibVkxlxCSgnlgZniSxnPwBI+PoMa2h+B0="
   },
   "com/fazecast#jSerialComm/2.11.3": {
    "jar": "sha256-gL3emsm4iVTy4kmInJg/CSQkBymotuKtipbygFhfzYg=",
@@ -538,7 +502,6 @@
    "pom": "sha256-bcKY6cIqgE35qSXwt0MI2XOcaO/Y16YTdndiry99LoI="
   },
   "com/mayakapps/kache#kache/2.1.0": {
-   "jar": "sha256-MKRjEaZRESk51De/E/5FJAgMsYuJqrmbkqIu0GUGSUc=",
    "module": "sha256-tJZEwfTNkvRk844MXEwqFJp7s+0VsyrJCO5XypCHfqg=",
    "pom": "sha256-qRWJAaDp8uNB+jtHPwK7mOIC+gkY1Fxo3/n602z+X2Y="
   },
@@ -557,9 +520,16 @@
    "jar": "sha256-itpMGFznJBZxLWPgta/cXwCcDN9AXl8m7+zfFWql37Y=",
    "pom": "sha256-tn6vqd0iD/h9ANumiACDpSlqXgxsAxA/XUuOHaEDD/M="
   },
-  "commons-cli#commons-cli/1.8.0": {
-   "jar": "sha256-+UyYu8+hwdrGlW1sP0lOxAJlxnv1Td78ld9P/dc65tU=",
-   "pom": "sha256-PufcBh65En2wwwIglz5aqDVBME/6g9fqsjUNHIhfgZk="
+  "commons-cli#commons-cli/1.11.0": {
+   "jar": "sha256-j3+GBdaOFb8y22HslOrG/a/FGxvb4eDggCtX0j84d5I=",
+   "pom": "sha256-lmUfVz48CA4RBS/wi/wuTPBM9usaPjaDAQ9JeUluCAg="
+  },
+  "io/github/java-diff-utils#java-diff-utils-parent/4.12": {
+   "pom": "sha256-2BHPnxGMwsrRMMlCetVcF01MCm8aAKwa4cm8vsXESxk="
+  },
+  "io/github/java-diff-utils#java-diff-utils/4.12": {
+   "jar": "sha256-mZCiA5d49rTMlHkBQcKGiGTqzuBiDGxFlFESGpAc1bU=",
+   "pom": "sha256-wm4JftyOxoBdExmBfSPU5JbMEBXMVdxSAhEtj2qRZfw="
   },
   "io/ktor#ktor-events-jvm/2.3.9": {
    "jar": "sha256-QGw59U3lHZQ+8LTcLthWTh2dAvoBXeL6BWI4AML2HIM=",
@@ -753,19 +723,19 @@
   "org/apache#apache/16": {
    "pom": "sha256-n4X/L9fWyzCXqkf7QZ7n8OvoaRCfmKup9Oyj9J50pA4="
   },
-  "org/apache#apache/21": {
-   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
   },
-  "org/apache#apache/32": {
-   "pom": "sha256-z9hywOwn9Trmj0PbwP7N7YrddzB5pTr705DkB7Qs5y8="
+  "org/apache#apache/35": {
+   "pom": "sha256-6il9zRFBNui46LYwIw1Sp2wvxp9sXbJdZysYVwAHKLg="
   },
-  "org/apache/commons#commons-collections4/4.4": {
-   "jar": "sha256-Hfi5QwtcjtFD14FeQD4z71NxskAKrb6b2giDdi4IRtE=",
-   "pom": "sha256-JxvWc4Oa9G5zr/lX4pGNS/lvWsT2xs9NW+k/0fEnHE0="
+  "org/apache/commons#commons-collections4/4.5.0": {
+   "jar": "sha256-APkyY8JnviAbiuUhtEpxNycbFmiENTQL9inbG6wKWEU=",
+   "pom": "sha256-xwD5mOHXpqXArvHUzutrrH0XAt1tbtpzoX1n9dbyRn0="
   },
-  "org/apache/commons#commons-lang3/3.15.0": {
-   "jar": "sha256-SQUJACLe84Cel5Y4MvyLJCH9qACFPJTTzb8a0wEdl1Y=",
-   "pom": "sha256-DLdcseh9KLTEVJL8jGzIHXzKPLSIKJZzXijkSM34EM4="
+  "org/apache/commons#commons-lang3/3.20.0": {
+   "jar": "sha256-aeXJ+jXaelGl/SCZ3+VqLY0yzyM+L213DnlhRkQCY/Q=",
+   "pom": "sha256-fKg7JwnB56ngO1ds1BQiGQN5SJqAhm5UL4yLlVQRoqo="
   },
   "org/apache/commons#commons-math3/3.6.1": {
    "jar": "sha256-HlbXsFjSi2Wr0la4RY44hbZ0wdWI+kPNfRy7nH7yswg=",
@@ -774,14 +744,14 @@
   "org/apache/commons#commons-parent/39": {
    "pom": "sha256-h80n4aAqXD622FBZzphpa7G0TCuLZQ8FZ8ht9g+mHac="
   },
-  "org/apache/commons#commons-parent/48": {
-   "pom": "sha256-Hh996TcKe3kB8Sjx2s0UIr504/R/lViw954EwGN8oLQ="
+  "org/apache/commons#commons-parent/81": {
+   "pom": "sha256-NI1OfBMb5hFMhUpxnOekQwenw5vTZghJd7JP0prQ7bQ="
   },
-  "org/apache/commons#commons-parent/70": {
-   "pom": "sha256-YDNaNOkfSc5QcjsAfXwSUU/Vdm2hff/7ZzLhEx5YzRs="
+  "org/apache/commons#commons-parent/91": {
+   "pom": "sha256-0vi2/UgAtqrxIPWjgibV+dX8bbg3r5ni+bMwZ4aLmHI="
   },
-  "org/apache/commons#commons-parent/71": {
-   "pom": "sha256-lbe+cPMWrkyiL2+90I3iGC6HzYdKZQ3nw9M4anR6gqM="
+  "org/apache/commons#commons-parent/92": {
+   "pom": "sha256-lPbAJ7FfZAKZXdGyx+o1v+HryItoMrMTQ2i0GZhyGVM="
   },
   "org/apiguardian#apiguardian-api/1.1.2": {
    "jar": "sha256-tQlEisUG1gcxnxglN/CzXXEAdYLsdBgyofER5bW3Czg=",
@@ -825,83 +795,92 @@
    "jar": "sha256-ew8ZckCCy/y8ZuWr6iubySzwih6hHhkZM+1DgB6zzQU=",
    "pom": "sha256-yUkPZVEyMo3yz7z990P1P8ORbWwdEENxdabKbjpndxw="
   },
-  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
-   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
-   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  "org/jetbrains/kotlin#abi-tools-api/2.3.10": {
+   "jar": "sha256-E2nLVCrmR6nVVJ5thkkh6g+GApdJWRmXteWqFhyXGIs=",
+   "pom": "sha256-x12MiniT5DijbBZeA1I+uHRDZ6wNaV4sdrZ48LAjnE8="
   },
-  "org/jetbrains/kotlin#kotlin-build-common/2.0.20": {
-   "jar": "sha256-NvDXXOmviQZNnbT9IeIsVQdyAP5OOufZnjREmCZ6oNs=",
-   "pom": "sha256-EOhYxaCAxN21Wx0GvujV6Ea4YQX1aw5A8ojj+mGWEXI="
+  "org/jetbrains/kotlin#abi-tools/2.3.10": {
+   "jar": "sha256-lbCSwjPTRrHTScN0ovZpHozCx5dLjCI8blhlVo5r4xw=",
+   "pom": "sha256-dF+mCZPgkwSOup63kIAcUPDvs4NKK9GDTZAbXwCuHdY="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-api/2.0.20": {
-   "jar": "sha256-V+1QIg547DnoqAAUMw8pXlSFtWOMESmvntfVPXhYxcI=",
-   "pom": "sha256-nHrVho+yGJsb9NbCL2yUmDs6jhopTpWlQSy4Lg9C3bI="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.3.10": {
+   "jar": "sha256-EYZyC5EGhN+drZy5YBXM8ZF27FZVzrCbAfvEUjC9H2Q=",
+   "pom": "sha256-3pBa7tBWHZduxSEU8vPk5mls05Mg9DqxFvF/79c9U8I="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.0.20": {
-   "jar": "sha256-nOb4Gmmcw32zY6KDcVC8YqJJA9r2EhA00Sl5qpUBRGs=",
-   "pom": "sha256-DyiqOx3o2AWm+HlX08PWbDOeDEMmaZlc9Zf58r6J4II="
+  "org/jetbrains/kotlin#kotlin-build-tools-compat/2.3.10": {
+   "jar": "sha256-2CMtB+usVuEXJqBmYUPdSmF77b46C/HxQCD4BF2KybM=",
+   "pom": "sha256-D4sDOmFBIvxEBuu+rSSKRYoEkKikvJfYSpb8U3DD88Y="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.0.20": {
-   "jar": "sha256-o2BL81DIvM4nECFYu7OD+k0YFLxIaq7VnyeOraUf9q0=",
-   "pom": "sha256-WXBD+4xlJ/QpmcoE7TUpY5Is0W5piKqlLT2zLaHbhZ0="
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.3.10": {
+   "jar": "sha256-MvAqavcrjgyC8mNDto4NHaHIRIJ0eP6y+p3EDfX5u1o=",
+   "pom": "sha256-21a2yydSjXKzGHKFbO2rCOx7GBJ0VMBux3iAhQQR21g="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-runner/2.0.20": {
-   "jar": "sha256-4DzwSwNA8a4VEhBjC10pFcKXmIxuIuTe206nz7dKz2c=",
-   "pom": "sha256-3M3xugxPzYvUIwNFroP6fb6SglY9ilP9XmHFM1tbcYA="
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.3.10": {
+   "jar": "sha256-rGoYJ4U0U4C121CF2+6j9fDpJeLhAOVKsFm1eH1PbkA=",
+   "pom": "sha256-/i/NN7clxYZIc8/3jOZNEyBuFOCPS5guEVD2jJwOiW0="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-client/2.0.20": {
-   "jar": "sha256-cxUswf2CHQcTlHOry/jH0B0A5oaEuWHhkurogNycfaQ=",
-   "pom": "sha256-qUcReIj0z/tjk9QurqYRtj31ib8pYXgmzLclNxK/OsM="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.3.10": {
+   "jar": "sha256-CpGS+4AlHMrRzb8sq6KEiOjUaGnS5eSVfKF5wnwKTuA=",
+   "pom": "sha256-4CtYvQDZCjExN9L18ZIZ2tt3FXVebd1t74mYpa/RgCc="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.0.20": {
-   "jar": "sha256-W9URO4WrhSjhkuK7P8GX9bw0SLzb0Fh5Czf9N/TuV68=",
-   "pom": "sha256-IZgoJm6keO7rQuT1L5bQuQfYykhHz4aq45FprYsupKU="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.3.10": {
+   "jar": "sha256-0hpvd9mAOmFebRUIVzd+EKnox80Grm4cHrmZIP2ji5M=",
+   "pom": "sha256-sOpstyMer+j7oN+zf8MZhJkED3TE00EmPtq2yE0Z2sA="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.0.20": {
-   "jar": "sha256-ZzHCVkuXOXGDWCVJAUC3rZ63Jtk4/gzvTr7y7Fkt6wM=",
-   "pom": "sha256-rVSg2nLxASl08e7sdp2EopMnzzfMrVUxt4cT/GD0tnY="
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.3.10": {
+   "jar": "sha256-NZcReADmCSO8rdAYf6XbyqZvgpAIKdaSXR6kHdfiejA=",
+   "pom": "sha256-2Hj9fQeNtQmxK/bHQK6jHPckUxN6hMd1vU5SHJ77eP0="
   },
-  "org/jetbrains/kotlin#kotlin-native-prebuilt/2.0.20": {
-   "pom": "sha256-xYoRfPul4AVC+QrYLytqsh4Z46Ifzvy0mLq5k69FDwY="
+  "org/jetbrains/kotlin#kotlin-klib-abi-reader/2.3.10": {
+   "jar": "sha256-nRYKDGxhKhFEhhRN8Fd7VXlfXaC4Z/4458uvYUzAQM0=",
+   "pom": "sha256-YNkcF6pipglPHMEJUybmqWjCjCtUBtrOmiYNsBtEa5Q="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/2.3.10": {
+   "jar": "sha256-4jjzNyD2Tlk3klr3cvi9hzivM3EJvzYiPryjgqUyS2A=",
+   "pom": "sha256-2RshiOZU+OhfcoQDbE+hzl8xJ/B60GeQn1kRBCQEafg="
+  },
+  "org/jetbrains/kotlin#kotlin-metadata-jvm/2.3.10": {
+   "jar": "sha256-wd9bxlMLTHRLE3iNv4VApGmJj9+83mq8qRGRhPXTcHw=",
+   "pom": "sha256-M4BDrrtxc3PkFFgTeehvS0ztfs+9HcKH3zPRX8FXm+I="
   },
   "org/jetbrains/kotlin#kotlin-reflect/1.6.10": {
    "jar": "sha256-MnesECrheq0QpVq+x1/1aWyNEJeQOWQ0tJbnUIeFQgM=",
    "pom": "sha256-V5BVJCdKAK4CiqzMJyg/a8WSWpNKBGwcxdBsjuTW1ak="
   },
-  "org/jetbrains/kotlin#kotlin-reflect/2.0.20": {
-   "jar": "sha256-GPRR5rS3vR0fnWCEnDy/Fg4RUwL5eiAIwZDVBcQ5xnA=",
-   "pom": "sha256-Y+Y4sFbdRJ5vUtcenCxdxdsNFkRDI5cOFtf8DWWDk9s="
+  "org/jetbrains/kotlin#kotlin-reflect/2.3.10": {
+   "jar": "sha256-ELShteOVfv6Q9HS9BKdHJJolmyYVpvBQRQfTI8K+NQs=",
+   "pom": "sha256-RIBX32rS8btqzEU8oJ/LSWJJae/pd3Boc+WQsKjQzxM="
   },
-  "org/jetbrains/kotlin#kotlin-script-runtime/2.0.20": {
-   "jar": "sha256-/pcAKmeY9yB1ZGSJGdbuzPszi5XcBLSIhthWZVvGSk4=",
-   "pom": "sha256-o6N2KcmFzt17+d12rGdJaz+ApZIoVB6WiAKg7obEuRQ="
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.3.10": {
+   "jar": "sha256-0LOwjs+JAcZhCqDo77Kds3Mb+9lq/U+YfMgXAWseAD4=",
+   "pom": "sha256-wiijGFXV31s4bhGfFyjPqeQ9Lc23gTnCkqjT7SZ6xYc="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-common/2.0.20": {
-   "jar": "sha256-XTdTOT5/7PHSG67l2314gyZ4K9v4qOxqKyzM97Ve5sY=",
-   "pom": "sha256-BesUmiCZ8ILJf1xFQ1HQuMphLFUwo6wyHSyMB12wEVU="
+  "org/jetbrains/kotlin#kotlin-scripting-common/2.3.10": {
+   "jar": "sha256-fpFD0iyAs9AslpgkMbHJa6CR7/e/Q5CrS4lJ7O5D8oU=",
+   "pom": "sha256-dYvXM25rfVJwtwbCgO+qcSKwT+cWzwmZbhUhWQ8zB0E="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.0.20": {
-   "jar": "sha256-Ie8wOrS54Pnzl8FIliU6rkkCV7+w3VAInBwcBPAYcXE=",
-   "pom": "sha256-zr8swRmuHPJqP2tECxidwrruhS0nASU06qNqrNue4VI="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.3.10": {
+   "jar": "sha256-cjlPfxS2o7mvwuHMncF6HZYQNXFVtMuazGY6O0QuwpA=",
+   "pom": "sha256-A2sKrxS+1njEO47BXQGqXIRan+kjA3q8r0TKaWC3vk4="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.0.20": {
-   "jar": "sha256-WgaucwO1TL0XdYnWEFumv9WbGxgur7W2aHJf9ypf0y0=",
-   "pom": "sha256-z6al9YOJy3K0SRLTABoB9eqL+vx5mbr6BRGz7t/LYdI="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.3.10": {
+   "jar": "sha256-Ezqc4YWqR9FRphLyzFli0yuMpgX44ieh1/HhsJ4m7m4=",
+   "pom": "sha256-NFeCP8HSlV8GBVk7m+nWUIbwwaEeGzdt9BHwqifkAuU="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.0.20": {
-   "jar": "sha256-sLtQD2MztLFsjraeo5TvaE8zRT+NNDEDSokHqfGNtvE=",
-   "pom": "sha256-m8uNHCOvcm21KpNrpbkXeyRoKSBYxT8Ckd5MwNpOzh4="
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.3.10": {
+   "jar": "sha256-vyMqUZrwKVLhAQhvq9SIRDYldlbEXbCBeDysSxSWZLc=",
+   "pom": "sha256-gzabR9onQj0BR+UZh/tY4YbjWt7KQUDxfysOu7uYPTc="
   },
-  "org/jetbrains/kotlin#kotlin-serialization-compiler-plugin-embeddable/2.0.20": {
-   "jar": "sha256-zI9QG2dslESLAWgNyvZ68cjFfOqEFQKnFuttEX+Xy4Y=",
-   "pom": "sha256-X74y6I+ly4WFjb1wpPZKWsJTSaTijzlQ3zJrMSRmUGY="
+  "org/jetbrains/kotlin#kotlin-serialization-compiler-plugin-embeddable/2.3.10": {
+   "jar": "sha256-ddZuSpUHKpXnAkU+oH/MFHmsg1wWI9565znQROb182Y=",
+   "pom": "sha256-v0Km4mvetFGIxtf4N7PXltGIeT8uoeuO6IvSNNwYI2M="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-common/1.8.22": {
    "pom": "sha256-pysR3wi1Mi16Xo5iB4nuPkz+846GxDDn0RO/qeVMWB4="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.0.20": {
-   "module": "sha256-tZe3Be/U4tgnFCCQw2BUJlVI7VG09SN38r+JxFlNU28=",
-   "pom": "sha256-o11/wINw+TE6S5U7zu7d2F4OHnLTEGLTe/jHeBs/b18="
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.3.10": {
+   "module": "sha256-GrI+xfbZ3iNeKNRjo/IKJD96VY+aht3VOpSEyHfmeS8=",
+   "pom": "sha256-xTKXlnQm4FsXVVyEzWmqKo3Q3guFkXLoDsdH/5vq/tA="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.9.0": {
    "jar": "sha256-t5eaeqyUBV8Nnx/TtHzl/+HLYDKoQrqfvnGG8IUokXg=",
@@ -911,45 +890,35 @@
    "jar": "sha256-pZ+iT98f+1lLrs2/D9EAEPl3zqECNtSH/jRkl3pzd/o=",
    "pom": "sha256-ZNWY3YjiUEZnMeIDBKtvBsu7urfuMitHA7a1n4gcT5I="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.0.20": {
-   "jar": "sha256-+xaVlmWaUYNXxLLBb0PcdascSYBWXtS0oxegUOXjkAY=",
-   "module": "sha256-3AUdwExqGW8tBtDTya8zufErybT+E5rhKQFAUII2tns=",
-   "pom": "sha256-Cu6WIJHn3QKIzDykz0qSjFYgcUYCEb+PQXkAkwbmGf4="
+  "org/jetbrains/kotlin#kotlin-stdlib/2.3.10": {
+   "jar": "sha256-9hZixtOi+O9b00NioC2Hd3LDnzk805T+slnfr39NhDc=",
+   "module": "sha256-6ocfZjGc2ierJSL6jZKRMdXm/LUzROT1TNrgMRHRUKo=",
+   "pom": "sha256-Sj+O2KRMftizGuUQEzSIBYfBCXBlP0s7lE/bI4MLJCA="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.0.20/all": {
-   "jar": "sha256-UP+t6yC00kVqUmWVpPep6FiJaCcVBz5s26Gx2A461Fg="
+  "org/jetbrains/kotlin#kotlin-test-junit5/2.3.10": {
+   "jar": "sha256-z4yjKiCxgTCs3eP2uOKbAcx+p/eSMmoSLG/lQ0IUyIk=",
+   "module": "sha256-SRoscIzJfHBjZAAe5/boPmN27TeZI3TnZoMBlH0+Gmg=",
+   "pom": "sha256-wbvt7L35wumoip9MZOlbFUscRAJpM2JFMWfOm4FuZSk="
   },
-  "org/jetbrains/kotlin#kotlin-test-junit5/2.0.20": {
-   "jar": "sha256-2WksVbn4Zx29W1WXhxi3FGhNXYQrgxzIMtZPF8OFhjQ=",
-   "module": "sha256-Fk2+AREL7thci+BhcSdE1oKTMCG4Y1YxuwleOI17Hkk=",
-   "pom": "sha256-DtoRyJe+vgRSFCJG1vCB5Q/4A9vmFwK+7GEcuO1Qe20="
+  "org/jetbrains/kotlin#kotlin-test/2.3.10": {
+   "jar": "sha256-JecGJ04oFe4A4FHisnrcJQ3MZFDNjsT3n3Il9bWhPLg=",
+   "module": "sha256-Lyum5EueMjOJwxl1KgXRpOiPEwsPbv5dUYQvAWVH89E=",
+   "pom": "sha256-i6EDsYg284cYBTS1fQZa+oZ+s5ha7V7H926/Tl9EAoo="
   },
-  "org/jetbrains/kotlin#kotlin-test/2.0.20": {
-   "jar": "sha256-oVbXu3S7hHABkQ2s++5JyXF/jrZwxBQ3qSdoezN6Bf8=",
-   "module": "sha256-0wJTt8l9i4KWVQUITlTJ1qP2NWe4/G7H73kPR/gREcw=",
-   "pom": "sha256-yCDFnJRFdVYiqsuhkTg5lhSdfM3mBiMWLfHGnCxG+yE="
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.3.10": {
+   "jar": "sha256-NnFCeBKZvA+RIMHe7A5ik0oa+ep/AaqpxaU1TcXY19k=",
+   "pom": "sha256-5hhz7dWo3QMaa6l1nAXRVpBlnmEuPUjB7RInN9q0SYY="
   },
-  "org/jetbrains/kotlin#kotlin-test/2.0.20/all": {
-   "jar": "sha256-2iho+pWj+4814rTjMcouKTIUhnAZZex2a66CD5jgJ3w="
-  },
-  "org/jetbrains/kotlin/kotlin-native-prebuilt/2.0.20/kotlin-native-prebuilt-2.0.20-linux-x86_64": {
-   "tar.gz": "sha256-soKRi19RWLL41bU94ICTpyIG/CO5E4Lh3dJjDHIChCc="
-  },
-  "org/jetbrains/kotlinx#atomicfu/0.23.1": {
-   "jar": "sha256-fbhmDr5LkbtHjts2FsTjpQulnAfcpRfR4ShMA/6GrFc=",
-   "module": "sha256-Pokf5ja1UQgZIQD884saObzRwlM+I8Ri/AdkTur8sg8=",
-   "pom": "sha256-aIt5ABn0F87APmldZWexc7o7skGJVBZi8U/2ZEG1Pas="
-  },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
-   "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.0": {
+   "pom": "sha256-Ejnp2+E5fNWXE0KVayURvDrOe2QYQuQ3KgiNz6i5rVU="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.1": {
    "pom": "sha256-Vj5Kop+o/gmm4XRtCltRMI98fe3EaNxaDKgQpIWHcDA="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
-   "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
-   "module": "sha256-DZTIpBSD58Jwfr1pPhsTV6hBUpmM6FVQ67xUykMho6c=",
-   "pom": "sha256-Cdlg+FkikDwuUuEmsX6fpQILQlxGnsYZRLPAGDVUciQ="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.0": {
+   "jar": "sha256-mGCQahk3SQv187BtLw4Q70UeZblbJp8i2vaKPR9QZcU=",
+   "module": "sha256-/2oi2kAECTh1HbCuIRd+dlF9vxJqdnlvVCZye/dsEig=",
+   "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.8.1": {
    "jar": "sha256-89T13hw5G7zCDzs0Ncy6wBNSHna2kC19WWNewVwfeX4=",
@@ -957,7 +926,6 @@
    "pom": "sha256-R8alCxQVHo+vfzUKlSNcN9EqvDi/sFW2aJdCkxctryw="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.8.1": {
-   "jar": "sha256-2vUPHJQEsiSh1t1Shvjo7n1j/oB/eOqY9xeVwYO2Al8=",
    "module": "sha256-CMuvMyW1Tg+O+NqF5OtZb32Ub4Q+XRYAOFRj8yaKTvA=",
    "pom": "sha256-+IkY2/qHh8TRcasCVToUrR3viqmwxcLCDMmUVdMkHiI="
   },
@@ -966,79 +934,82 @@
    "module": "sha256-Ifl7EL6TJkGBfTULclRP+LoyQYf/uREMbo2IESdv2TM=",
    "pom": "sha256-3uCuamO2M1ETIAqW2eHHgJ32DQ1CS7/xy7tTsxQWWvk="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.7.3": {
-   "pom": "sha256-QiakkcW1nOkJ9ztlqpiUQZHI3Kw4JWN8a+EGnmtYmkY="
+  "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.10.0": {
+   "pom": "sha256-Lpc+Tfw7xjjdLmg9qVncK5eSMpe/O49gx/8A1h6sOwc="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.7.3": {
-   "jar": "sha256-8K3eRYZBREdThc9Kp+C3/rJ/Yfz5RyZl7ZjMlxsGses=",
-   "module": "sha256-c7tMAnk/h8Ke9kvqS6AlgHb01Mlj/NpjPRJI7yS0tO8=",
-   "pom": "sha256-c09fdJII3QvvPZjKpZTPkiKv3w/uW2hDNHqP5k4kBCc="
+  "org/jetbrains/kotlinx#kotlinx-serialization-core-jvm/1.10.0": {
+   "jar": "sha256-FNbyfOKPYevEpRbVYvkRt7wBz75Tl/uITEXqDbBExjU=",
+   "module": "sha256-7tVPsrYUrZV8CP7iDeZeAK1dVs6jkORLpgorhUKBtgw=",
+   "pom": "sha256-XEwMgBAEK39UKrSE3qijaHuWwglE5ywGPqwWonOa2OQ="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.7.3": {
-   "jar": "sha256-SFBoLg5ZdoYmlTMNhOuGmfHcXVCEn2JSY5lcyIvG83s=",
-   "module": "sha256-OdCabgLfKzJVhECmTGKPnGBfroxPYJAyF5gzTIIXfmQ=",
-   "pom": "sha256-MdERd2ua93fKFnED8tYfvuqjLa5t1mNZBrdtgni6VzA="
+  "org/jetbrains/kotlinx#kotlinx-serialization-core/1.10.0": {
+   "module": "sha256-pJJxm8QF9QTg2EjzTpQfL5RvgntHhzayW6nGlwjZyao=",
+   "pom": "sha256-ZCi5KEMl0zYxmSHrBY71Fd8BzY6O9s3BNB7PqO9rNXQ="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.7.3": {
-   "jar": "sha256-sekThJntjSA3Xt2j8rHJXzEDoljv9q+e3F6gcQDyspw=",
-   "module": "sha256-D/cOITHypldYIvdhHAXig8SuCBczA/QQSUy0Eom9PvY=",
-   "pom": "sha256-0zRdKAgXvgfpwnrNYHPUleF73/VxxHADTglmQgeGp90="
+  "org/jetbrains/kotlinx#kotlinx-serialization-json-jvm/1.10.0": {
+   "jar": "sha256-rx4+Ho7jF2Ro4exynfhTsgZgcd6UqExBKtn6E1yzfzo=",
+   "module": "sha256-pf5GHIQaWLDKWZaUF8ZaWe9wWHzJw4eD3ox4sKP5UMg=",
+   "pom": "sha256-eGypyBw8fsU9kkuyNqAI8hTCwJbRMX3J97N47NEP1c0="
   },
-  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.7.3": {
-   "jar": "sha256-qpP6PJY5LLE5WTE0Qw3C1RNn9Z1VPl43R+vYAHsmPxs=",
-   "module": "sha256-HPAiijWIcx1rrzvLvbCKMiUB9wQg1Q4pKrUB5V2Mz08=",
-   "pom": "sha256-BaiftqSvoKHUB51YgsrTSaF/4IqYv5a30A0GplUh3H0="
+  "org/jetbrains/kotlinx#kotlinx-serialization-json/1.10.0": {
+   "module": "sha256-yfNeuGIPLTiZoFgoXEF3NciVbu0rGFO+2jrBPHeCuMc=",
+   "pom": "sha256-+uXntE6iGb3qzoSlC/8y06x/bdGb5KjiRTbhgzxUoNY="
   },
-  "org/junit#junit-bom/5.10.3": {
-   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
-   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  "org/jspecify#jspecify/1.0.0": {
+   "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
+   "module": "sha256-0wfKd6VOGKwe8artTlu+AUvS9J8p4dL4E+R8J4KDGVs=",
+   "pom": "sha256-zauSmjuVIR9D0gkMXi0N/oRllg43i8MrNYQdqzJEM6Y="
   },
-  "org/junit#junit-bom/5.11.0-M1": {
-   "module": "sha256-j2MviWXptvQGnj1YueomuaW8dqmOibQyM3d6zm2tsjc=",
-   "pom": "sha256-tQl19cuoYgSr2j3Nbwl6+Rn+IuIe9pR43WuRn2x0DYU="
+  "org/junit#junit-bom/5.11.4": {
+   "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
+   "pom": "sha256-GdS3R7IEgFMltjNFUylvmGViJ3pKwcteWTpeTE9eQRU="
   },
-  "org/junit#junit-bom/5.11.0-M2": {
-   "module": "sha256-hkd6vPSQ1soFmqmXPLEI0ipQb0nRpVabsyzGy/Q8LM4=",
-   "pom": "sha256-Sj/8Sk7c/sLLXWGZInBqlAcWF5hXGTn4VN/ac+ThfMg="
+  "org/junit#junit-bom/5.13.4": {
+   "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
+   "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
   },
-  "org/junit#junit-bom/5.9.2": {
-   "module": "sha256-qxN7pajjLJsGa/kSahx23VYUtyS6XAsCVJdyten0zx8=",
-   "pom": "sha256-LtB9ZYRRMfUzaoZHbJpAVrWdC1i5gVqzZ5uw82819wU="
+  "org/junit#junit-bom/5.14.1": {
+   "module": "sha256-J4rLEczJmYaUIkOG+W+0lBoi7bQstEbJLg8fMwFLa0g=",
+   "pom": "sha256-AbAd+jZlULQKxXYFSKfXKLYQnRfEUeg4ZNHl4M6GLJQ="
   },
-  "org/junit/jupiter#junit-jupiter-api/5.10.3": {
-   "jar": "sha256-bv5uAcof95t79Mbx7tCykpLhZsJ+r3sArJgaFNTeYao=",
-   "module": "sha256-HH5GU3/EOyd29N5BmpCEpkAREQn6QLSHiUCynOI4vh4=",
-   "pom": "sha256-c0ocaMNMWt870vW8pL9JjLtPScSJ18JNgM8OIQK+bxQ="
+  "org/junit#junit-bom/6.0.2": {
+   "module": "sha256-CXdtx1DgfltFk690n/aPkYB/nFTDMHUcn0tPHqZScdY=",
+   "pom": "sha256-w1iXvlPvCDmGw/CRGt53SctCrrQAyZH7ruUeRjn3uak="
   },
-  "org/junit/jupiter#junit-jupiter-engine/5.10.3": {
-   "jar": "sha256-u9POjcEemSUHHvlpHWivGrbnEvqmhR98UnW8iq/IhnM=",
-   "module": "sha256-t34vIrhuzSrvh/C3LGoHDwsOdqNKvaqKd1ECweDRYSE=",
-   "pom": "sha256-g+8P1otgv2vHmnj+sRiCxiXEgu9p1iv+LRFwQKZEgUQ="
+  "org/junit/jupiter#junit-jupiter-api/6.0.2": {
+   "jar": "sha256-QHsgre1AeBrVRAMJY57wxCjnNbK2+IMcXS/5BBYTGV0=",
+   "module": "sha256-m0IZfs4uhSb/k97ysJ48tIACdjh9RzsIC9/8iKjANjA=",
+   "pom": "sha256-23UFjKyPW4WpVpNirMdghakehZNGaLbdCQVGi/s//jU="
   },
-  "org/junit/jupiter#junit-jupiter-params/5.10.3": {
-   "jar": "sha256-fD7YzvsSSWt2xTw9qYbqjwvz9CZ4GGlHVVGuOlBsGtg=",
-   "module": "sha256-TnM9YVyqFuDs17mum/6I+YqUAgkpMzx+4rT6CaegTZE=",
-   "pom": "sha256-bNnfkGpi/mTMMBw9YAeX9iTb1CJff6UFpajtsx/5iQY="
+  "org/junit/jupiter#junit-jupiter-engine/6.0.2": {
+   "jar": "sha256-KnIBz0iQSDwbtQRekaWbcFKoGJspMKm+lRTGPh5Ys7Y=",
+   "module": "sha256-EE0f6yTeklH8eVpz1HenP6pXmpjYecftsZ/dGP20CJs=",
+   "pom": "sha256-MS3kqvSL6RZPiX8G1hFKkFK/W7ADRltOMzH5R6YFr3o="
   },
-  "org/junit/jupiter#junit-jupiter/5.10.3": {
-   "jar": "sha256-5vwJ+IHrqLjYp2YKbH9NWC+niB8wYTav4tgpZKLnwi8=",
-   "module": "sha256-hrCGx1WStDQ9pPdL6V4mhSxMqqWzToLVaqg/MYBLyBA=",
-   "pom": "sha256-Jd7AgvAkZ81iKQ7xOJv0smhu9QVKGo7d+xtbfVTeGZE="
+  "org/junit/jupiter#junit-jupiter-params/6.0.2": {
+   "jar": "sha256-TG9Yd+hSp7iRIHxujWpesZaA0lsMQB0JpknR6hcRe1k=",
+   "module": "sha256-fdfWnOPlTkDuM0Z1qEkNJIi5bo3xIPXgqteaXSegur8=",
+   "pom": "sha256-XjLbpZkb2lFqzpu8ZaFBfW4KiFIeiobTP9IQjSqJIV8="
   },
-  "org/junit/platform#junit-platform-commons/1.10.3": {
-   "jar": "sha256-l4fwTUnbWTl83XVV1CGlvS0URWZpl9MnuU+F44vtV/E=",
-   "module": "sha256-n9gMr9DRm5pTrhnq4Eq94bIwVfQXXXbI52ibzkRImCs=",
-   "pom": "sha256-dZdXLFnxl1Ji+Nj8+I7GeDN2hUvwjOipPZnb3InuQ/k="
+  "org/junit/jupiter#junit-jupiter/6.0.2": {
+   "jar": "sha256-ylRmpDWgsPEAOCxad+kerm1MozD2C00kATqaPwzXQug=",
+   "module": "sha256-SdwJtzTvpDJHDO65Dhry0wviY/MBCXhlXDVA8qgeqtY=",
+   "pom": "sha256-f9YZ4a5GOpmfjblWj6h9EJltFZo1P/zNy9O/h18spjU="
   },
-  "org/junit/platform#junit-platform-engine/1.10.3": {
-   "jar": "sha256-33wyv3XPR8TI3dGUIJECeUen12XTC3Mf4AgwEV+voTM=",
-   "module": "sha256-D7CUb/Z+Q9A2K71CwjRNUUc4nkMVKCN3EW/rZOJrgNE=",
-   "pom": "sha256-b5uZvKDBfdwZ9RvAN+OxfKsPx+bx2nA4ejCrTgUgcig="
+  "org/junit/platform#junit-platform-commons/6.0.2": {
+   "jar": "sha256-HEnquO09gSgEWePz4fEZuSj5z8Uwx1AMKhWpro560w0=",
+   "module": "sha256-kx7oBBhnzXyu/UQCYYAs7o1Vm5uPSbOUkI4XwEpk+p4=",
+   "pom": "sha256-bivMHUT1ckbR03duMQ5Ybg9fTQTjrsA3eOgBCmtiDS8="
   },
-  "org/junit/platform#junit-platform-launcher/1.10.3": {
-   "jar": "sha256-3q7t4vAR6vlPW8aB4E7uL0oPbWl3Hhp5qpUNiYtAXY0=",
-   "module": "sha256-t8tPKSY20uTbEbgazAMRJsfOvhLotss9JF6t5/3Qg0M=",
-   "pom": "sha256-cBNMufwHJ1YgZdX+faWPEF5KHHh36JnUkUm10/j9bRc="
+  "org/junit/platform#junit-platform-engine/6.0.2": {
+   "jar": "sha256-MUlbdUuogrppPBn6nYh+Ya9vOFD1h0G9WMPxKd7KVRc=",
+   "module": "sha256-mgE8iVsXgJnmIfvNuJ3rxldDqW1i7TL4xuWfzu/BN8M=",
+   "pom": "sha256-6tUsFcvLoTHf7NLSrVOFjwEdfHUwCMAU/pldUolaEeI="
+  },
+  "org/junit/platform#junit-platform-launcher/6.0.2": {
+   "jar": "sha256-vZkQ97ykqdQFC6heHwduO4VzI51F33lnOGKqsphZV5I=",
+   "module": "sha256-1SKe2c1l4Uoi2Lk4Z7H7lbg/drJUUHO04LxpxOnGyi0=",
+   "pom": "sha256-/8xw6oNXyJK5Bbr+/g+zOZ6uktqxxNSMxbJ9EYkKUnY="
   },
   "org/opentest4j#opentest4j/1.3.0": {
    "jar": "sha256-SOLfY2yrZWPO1k3N/4q7I1VifLI27wvzdZhoLd90Lxs=",
@@ -1078,9 +1049,9 @@
   "org/sonatype/oss#oss-parent/9": {
    "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
   },
-  "org/yaml#snakeyaml/2.0": {
-   "jar": "sha256-iAydiW5LdKBsVJwVyklkUBZdaQn6FdfmYr7o9qZtevo=",
-   "pom": "sha256-Q8dh+StUnIsI+5kggCU+SfCpg+VE7wZjwfT51o61JhY="
+  "org/yaml#snakeyaml/2.4": {
+   "jar": "sha256-73ea9dKand6MxwzgNB9cb3c14j7f+Whc6qnTU1m3u38=",
+   "pom": "sha256-4VSjIxzWzeaKq/J0/RiWTUmpwaX16e079HHprnvfCOY="
   }
  }
 }

--- a/pkgs/by-name/sl/slimevr/nixos-udev-instructions.patch
+++ b/pkgs/by-name/sl/slimevr/nixos-udev-instructions.patch
@@ -1,0 +1,26 @@
+diff --git a/gui/public/i18n/en/translation.ftl b/gui/public/i18n/en/translation.ftl
+index fd804a0e..35762e45 100644
+--- a/gui/public/i18n/en/translation.ftl
++++ b/gui/public/i18n/en/translation.ftl
+@@ -1034,7 +1034,7 @@ onboarding-reset_tutorial-2 = Tap the highlighted tracker { $taps } times to tri
+ 
+ ## Install info
+ install-info_udev-rules_modal_title = Hardware udev access rules not found
+-install-info_udev-rules_warning = Access rules via udev are required for serial console access & dongle connection. Paste the following command into your terminal to add the udev rules.
++install-info_udev-rules_warning = Access rules via udev are required for serial console access & dongle connection. Add the following to your NixOS config to install the udev rules.
+ install-info_udev-rules_modal_button = Close
+ install-info_udev-rules_modal-dont-show-again_checkbox = Don't show again
+ ## Setup start
+diff --git a/gui/src/components/onboarding/UdevRulesModal.tsx b/gui/src/components/onboarding/UdevRulesModal.tsx
+index b89af1e7..00955544 100644
+--- a/gui/src/components/onboarding/UdevRulesModal.tsx
++++ b/gui/src/components/onboarding/UdevRulesModal.tsx
+@@ -25,7 +25,7 @@ export function UdevRulesModal() {
+       const dir = await electron.api.getInstallDir();
+       const rulesPath = `${dir}/69-slimevr-devices.rules`;
+       setUdevContent(
+-        `cat ${rulesPath} | sudo sh -c 'tee /etc/udev/rules.d/69-slimevr-devices.rules >/dev/null && udevadm control --reload-rules && udevadm trigger'`
++        `{\n  services.udev.packages = [ pkgs.slimevr ];\n}`
+       );
+     }
+   };

--- a/pkgs/by-name/sl/slimevr/no-java-tool-options-warning.patch
+++ b/pkgs/by-name/sl/slimevr/no-java-tool-options-warning.patch
@@ -1,13 +1,13 @@
-diff --git a/gui/src-tauri/src/main.rs b/gui/src-tauri/src/main.rs
-index 8191f0ed..01e764d8 100644
---- a/gui/src-tauri/src/main.rs
-+++ b/gui/src-tauri/src/main.rs
-@@ -188,7 +188,7 @@ fn setup_webview2() -> Result<()> {
+diff --git a/gui/electron/main/index.ts b/gui/electron/main/index.ts
+index 0210e5eb..a52bbb5b 100644
+--- a/gui/electron/main/index.ts
++++ b/gui/electron/main/index.ts
+@@ -361,7 +361,7 @@ function createWindow() {
+ }
  
- fn check_environment_variables() {
- 	use itertools::Itertools;
--	const ENVS_TO_CHECK: &[&str] = &["_JAVA_OPTIONS", "JAVA_TOOL_OPTIONS"];
-+	const ENVS_TO_CHECK: &[&str] = &["_JAVA_OPTIONS"];
- 	let checked_envs = ENVS_TO_CHECK
- 		.into_iter()
- 		.filter_map(|e| {
+ const checkEnvironmentVariables = () => {
+-  const to_check = ['_JAVA_OPTIONS', 'JAVA_TOOL_OPTIONS'];
++  const to_check = ['_JAVA_OPTIONS'];
+ 
+   const set = to_check.filter((env) => !!process.env[env]);
+   if (set.length > 0) {

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -1,73 +1,40 @@
 {
   lib,
-  fetchFromGitHub,
   stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
   replaceVars,
+  fetchpatch2,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_9,
+  electron,
   makeWrapper,
   slimevr-server,
-  nodejs,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  rustPlatform,
-  cargo-tauri,
-  wrapGAppsHook3,
-  pkg-config,
-  openssl,
-  glib-networking,
-  webkitgtk_4_1,
-  gst_all_1,
-  libayatana-appindicator,
+  copyDesktopItems,
+  makeDesktopItem,
   udevCheckHook,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "slimevr";
-  version = "18.2.0";
+  version = "19.0.0";
 
   src = fetchFromGitHub {
     owner = "SlimeVR";
     repo = "SlimeVR-Server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7QU+xQ72t722DOhrurI1XXpILLNnk8lE0yrD1P5XJbA=";
+    hash = "sha256-8kduLKJkGsTYZidlo0NwpE3d3S6o3RoaHznes8YuF1Y=";
     # solarxr
     fetchSubmodules = true;
   };
-
-  buildAndTestSubdir = "gui/src-tauri";
-
-  cargoHash = "sha256-X5IgWZlkvsstMN3YS4r+NJl6RVfREfZqKUrfsrUPQuU=";
 
   pnpmDeps = fetchPnpmDeps {
     pname = "${finalAttrs.pname}-pnpm-deps";
     inherit (finalAttrs) version src;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-deVfRZcMFkOVWXmNUiixmd5WBfIFKxG2Gw3CfshspYo=";
+    hash = "sha256-Lonwn3YPBRQrD/L2ob0GDOjX6p8fXf5VD8cBpbAb5bw=";
   };
-
-  nativeBuildInputs = [
-    nodejs
-    pnpmConfigHook
-    pnpm_9
-    cargo-tauri.hook
-    pkg-config
-    wrapGAppsHook3
-    makeWrapper
-    udevCheckHook
-  ];
-
-  buildInputs = [
-    openssl
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-plugins-bad
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    glib-networking
-    libayatana-appindicator
-    webkitgtk_4_1
-  ];
 
   patches = [
     # Upstream code uses Git to find the program version.
@@ -76,20 +43,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
     })
     # By default, SlimeVR will give a big warning about our `JAVA_TOOL_OPTIONS` changes.
     ./no-java-tool-options-warning.patch
+    # For Wayland Electron arugments.
+    (fetchpatch2 {
+      name = "allow-passing-excess-cli-arguments-to-electron.patch";
+      url = "https://github.com/SlimeVR/SlimeVR-Server/commit/be77ff73d71238a586e27fbad768e18a31877b74.patch?full_index=1";
+      hash = "sha256-xK8/PrjWEREFa3s0xOoiDpR5tsolFY+4psiHk8KfcTM=";
+    })
   ];
 
-  postPatch = ''
-    # Tauri bundler expects slimevr.jar to exist.
-    mkdir -p server/desktop/build/libs
-    touch server/desktop/build/libs/slimevr.jar
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    # Both libappindicator-rs and SlimeVR need to know where Nix's appindicator lib is.
-    substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
-      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-    substituteInPlace gui/src-tauri/src/tray.rs \
-      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-  '';
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_9
+    makeWrapper
+    copyDesktopItems
+    udevCheckHook
+  ];
 
   # solarxr needs to be installed after compiling its Typescript files. This isn't
   # done the first time, because `pnpmConfigHook` ignores `package.json` scripts.
@@ -100,22 +71,61 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false; # No tests
   doInstallCheck = true; # Check udev
 
-  # Get rid of placeholder slimevr.jar
-  postInstall = ''
-    rm $out/share/slimevr/slimevr.jar
-    rm -d $out/share/slimevr
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-    install -Dm644 -t $out/lib/udev/rules.d/ gui/src-tauri/69-slimevr-devices.rules
+  buildPhase = ''
+    runHook preBuild
+
+    pushd gui
+    pnpm build
+    pnpm exec electron-builder \
+      --dir \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
+    popd
+
+    runHook postBuild
   '';
 
-  # `JAVA_HOME`, `JAVA_TOOL_OPTIONS`, and `--launch-from-path` are so the GUI can
-  # launch the server.
-  postFixup = ''
-    wrapProgram "$out/bin/slimevr" \
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/slimevr
+    cp -r gui/dist/artifacts/*/*-unpacked/{locales,resources{,.pak}} $out/share/slimevr/
+    # `JAVA_HOME`, `JAVA_TOOL_OPTIONS`, and `--path` are so the GUI can
+    # launch the server.
+    makeWrapper ${lib.getExe electron} $out/bin/slimevr \
+      --add-flags $out/share/slimevr/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
       --set JAVA_HOME "${slimevr-server.passthru.java.home}" \
       --set JAVA_TOOL_OPTIONS "${slimevr-server.passthru.javaOptions}" \
-      --add-flags "--launch-from-path ${slimevr-server}/share/slimevr"
+      --add-flags "--path ${slimevr-server}/share/slimevr" \
+      --inherit-argv0
+
+    install -Dm444 gui/electron/resources/icons/icon.png $out/share/icons/hicolor/512x512/apps/slimevr.png
+    install -Dm644 -t $out/lib/udev/rules.d/ gui/electron/resources/69-slimevr-devices.rules
+
+    runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "slimevr";
+      desktopName = "SlimeVR";
+      genericName = "Full-body tracking";
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+      keywords = [
+        "FBT"
+        "VR"
+        "Steam"
+        "VRChat"
+        "IMU"
+      ];
+      icon = "slimevr";
+      exec = "slimevr";
+    })
+  ];
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -1,73 +1,39 @@
 {
   lib,
-  fetchFromGitHub,
   stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
   replaceVars,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_9,
+  electron,
   makeWrapper,
   slimevr-server,
-  nodejs,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  rustPlatform,
-  cargo-tauri,
-  wrapGAppsHook3,
-  pkg-config,
-  openssl,
-  glib-networking,
-  webkitgtk_4_1,
-  gst_all_1,
-  libayatana-appindicator,
+  copyDesktopItems,
+  makeDesktopItem,
   udevCheckHook,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "slimevr";
-  version = "18.2.0";
+  version = "20.1.0";
 
   src = fetchFromGitHub {
     owner = "SlimeVR";
     repo = "SlimeVR-Server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7QU+xQ72t722DOhrurI1XXpILLNnk8lE0yrD1P5XJbA=";
+    hash = "sha256-8ti1uyDtgf9JuWurAkE0Twj3/ROOd9ai94htEvoVo50=";
     # solarxr
     fetchSubmodules = true;
   };
-
-  buildAndTestSubdir = "gui/src-tauri";
-
-  cargoHash = "sha256-X5IgWZlkvsstMN3YS4r+NJl6RVfREfZqKUrfsrUPQuU=";
 
   pnpmDeps = fetchPnpmDeps {
     pname = "${finalAttrs.pname}-pnpm-deps";
     inherit (finalAttrs) version src;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-deVfRZcMFkOVWXmNUiixmd5WBfIFKxG2Gw3CfshspYo=";
+    hash = "sha256-gGBwE6QxJsbVmQc1e390SSXAjs/T992ju8y9wz1H1QQ=";
   };
-
-  nativeBuildInputs = [
-    nodejs
-    pnpmConfigHook
-    pnpm_9
-    cargo-tauri.hook
-    pkg-config
-    wrapGAppsHook3
-    makeWrapper
-    udevCheckHook
-  ];
-
-  buildInputs = [
-    openssl
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-    gst_all_1.gst-plugins-bad
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    glib-networking
-    libayatana-appindicator
-    webkitgtk_4_1
-  ];
 
   patches = [
     # Upstream code uses Git to find the program version.
@@ -76,20 +42,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     })
     # By default, SlimeVR will give a big warning about our `JAVA_TOOL_OPTIONS` changes.
     ./no-java-tool-options-warning.patch
+    # Correct udev instructions for NixOS.
+    ./nixos-udev-instructions.patch
   ];
 
-  postPatch = ''
-    # Tauri bundler expects slimevr.jar to exist.
-    mkdir -p server/desktop/build/libs
-    touch server/desktop/build/libs/slimevr.jar
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    # Both libappindicator-rs and SlimeVR need to know where Nix's appindicator lib is.
-    substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
-      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-    substituteInPlace gui/src-tauri/src/tray.rs \
-      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-  '';
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_9
+    makeWrapper
+    copyDesktopItems
+    udevCheckHook
+  ];
 
   # solarxr needs to be installed after compiling its Typescript files. This isn't
   # done the first time, because `pnpmConfigHook` ignores `package.json` scripts.
@@ -100,22 +66,61 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false; # No tests
   doInstallCheck = true; # Check udev
 
-  # Get rid of placeholder slimevr.jar
-  postInstall = ''
-    rm $out/share/slimevr/slimevr.jar
-    rm -d $out/share/slimevr
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-    install -Dm644 -t $out/lib/udev/rules.d/ gui/src-tauri/69-slimevr-devices.rules
+  buildPhase = ''
+    runHook preBuild
+
+    pushd gui
+    pnpm build
+    pnpm exec electron-builder \
+      --dir \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
+    popd
+
+    runHook postBuild
   '';
 
-  # `JAVA_HOME`, `JAVA_TOOL_OPTIONS`, and `--launch-from-path` are so the GUI can
-  # launch the server.
-  postFixup = ''
-    wrapProgram "$out/bin/slimevr" \
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/slimevr
+    cp -r gui/dist/artifacts/*/*-unpacked/{locales,resources{,.pak}} $out/share/slimevr/
+    # `JAVA_HOME`, `JAVA_TOOL_OPTIONS`, and `--path` are so the GUI can
+    # launch the server.
+    makeWrapper ${lib.getExe electron} $out/bin/slimevr \
+      --add-flags $out/share/slimevr/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
       --set JAVA_HOME "${slimevr-server.passthru.java.home}" \
       --set JAVA_TOOL_OPTIONS "${slimevr-server.passthru.javaOptions}" \
-      --add-flags "--launch-from-path ${slimevr-server}/share/slimevr"
+      --add-flags "--path ${slimevr-server}/share/slimevr" \
+      --inherit-argv0
+
+    install -Dm444 gui/electron/resources/icons/icon.png $out/share/icons/hicolor/512x512/apps/slimevr.png
+    install -Dm644 -t $out/lib/udev/rules.d/ gui/electron/resources/69-slimevr-devices.rules
+
+    runHook postInstall
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "slimevr";
+      desktopName = "SlimeVR";
+      genericName = "Full-body tracking";
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+      keywords = [
+        "FBT"
+        "VR"
+        "Steam"
+        "VRChat"
+        "IMU"
+      ];
+      icon = "slimevr";
+      exec = "slimevr";
+    })
+  ];
 
   passthru.updateScript = ./update.sh;
 


### PR DESCRIPTION
SlimeVR now uses Electron instead of Tauri.

Should close #405212.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.