### PR TITLE
mosquitto: 2.0.22 -> 2.1.2

### DIFF
--- a/pkgs/by-name/mo/mosquitto/package.nix
+++ b/pkgs/by-name/mo/mosquitto/package.nix
@@ -7,11 +7,13 @@
   libxslt,
   c-ares,
   cjson,
+  libargon2,
   libuuid,
   libuv,
   libwebsockets,
   openssl,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  sqlite,
   systemd,
   uthash,
   nixosTests,
@@ -32,13 +34,17 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mosquitto";
-  version = "2.0.22";
+  version = "2.1.2";
+  # Tests disabled: upstream test suite requires additional Python deps,
+  # uses chown() to fixed UIDs, and relies on signal handling that breaks
+  # in sandboxed builds. Re-enable once upstream tests are sandbox-friendly.
+  doCheck = false;
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-mosquitto";
     repo = "mosquitto";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PCiNxRG2AqVlS2t/u7Cqn8NbTrrYGO1OXl8zvPQRrJM=";
+    hash = "sha256-Zl55yjuzQY2fyaKs/zLaJ7a3OONKTDQPaT+DpPURdZI=";
   };
 
   postPatch = ''
@@ -63,22 +69,27 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     c-ares
     cjson
+    libargon2
     libuuid
     libuv
     libwebsockets'
     openssl
+    sqlite
     uthash
   ]
   ++ lib.optional withSystemd systemd;
+
+  propagatedBuildInputs = [ cjson ];
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_BUNDLED_DEPS" false)
     (lib.cmakeBool "WITH_WEBSOCKETS" true)
     (lib.cmakeBool "WITH_SYSTEMD" withSystemd)
+    (lib.cmakeBool "WITH_TESTS" finalAttrs.doCheck)
   ];
 
   postFixup = ''
-    sed -i "s|^prefix=.*|prefix=$lib|g" $dev/lib/pkgconfig/*.pc
+    sed -i "s|^libdir=.*|libdir=$lib/lib|g" $dev/lib/pkgconfig/*.pc
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Hi :) I updated mosquitto from 2.0.22 to 2.1.2. It now supports the `persist-sqlite` plugin and allows users to use `argon2id` additionally to `sha512-pbkdf2`. See [changelog](https://github.com/eclipse-mosquitto/mosquitto/blob/v2.1.2/ChangeLog.txt) for more details. Please let me know, if you want any changes :)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
