### PR TITLE
wasm-pack: 0.13.1 -> 0.14.0, adopt

### DIFF
--- a/pkgs/by-name/wa/wasm-pack/package.nix
+++ b/pkgs/by-name/wa/wasm-pack/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false;
 
   meta = {
-    changelog = "https://github.com/wasm-bindgen/wasm-pack/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/wasm-bindgen/wasm-pack/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Utility that builds rust-generated WebAssembly package";
     mainProgram = "wasm-pack";
     homepage = "https://github.com/wasm-bindgen/wasm-pack";
@@ -40,6 +40,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20 # or
       mit
     ];
-    maintainers = [ lib.maintainers.dhkl ];
+    maintainers = with lib.maintainers; [
+      dhkl
+      hythera
+    ];
   };
 })

--- a/pkgs/by-name/wa/wasm-pack/package.nix
+++ b/pkgs/by-name/wa/wasm-pack/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasm-pack";
-  version = "0.13.1";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
-    owner = "rustwasm";
+    owner = "wasm-bindgen";
     repo = "wasm-pack";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CN1LcLX7ag+in9sosT2NYVKfhDLGv2m3zHOk2T4MFYc=";
+    hash = "sha256-ik6AJUKuT3GCDTZbHWcplcB7cS0CIcZwFNa6SvGzsIQ=";
   };
 
-  cargoHash = "sha256-nYWvk2v+4IAk/y7fg+Z/nMH+Ml+J5k5ER8uudCQOMB8=";
+  cargoHash = "sha256-n9xuwlj8+3fDTHMS2XobqWFc6mNHQcmmvebRDc82oSo=";
 
   nativeBuildInputs = [
     cmake
@@ -32,9 +32,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doCheck = false;
 
   meta = {
+    changelog = "https://github.com/wasm-bindgen/wasm-pack/releases/tag/v${finalAttrs.version}";
     description = "Utility that builds rust-generated WebAssembly package";
     mainProgram = "wasm-pack";
-    homepage = "https://github.com/rustwasm/wasm-pack";
+    homepage = "https://github.com/wasm-bindgen/wasm-pack";
     license = with lib.licenses; [
       asl20 # or
       mit


### PR DESCRIPTION
changelog: https://github.com/wasm-bindgen/wasm-pack/releases/tag/v0.14.0,
diff: https://github.com/wasm-bindgen/wasm-pack/compare/v0.13.1...v0.14.0

The old source redirects to wasm-bindgen/wasm-pack now.

Closes #484358

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
