### PR TITLE
exa-py: init at 2.12.0-unstable-2026-04-15

### DIFF
--- a/pkgs/development/python-modules/exa-py/default.nix
+++ b/pkgs/development/python-modules/exa-py/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build
+  poetry-core,
+
+  # deps
+  httpcore,
+  httpx,
+  openai,
+  pydantic,
+  python-dotenv,
+  requests,
+  typing-extensions,
+
+  # tests
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-mock,
+  pytestCheckHook,
+
+  # passthru
+  unstableGitUpdater,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "exa-py";
+  version = "2.12.0-unstable-2026-04-15";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # pypi doesn't include tests but there aren't any upstream git tags
+  src = fetchFromGitHub {
+    owner = "exa-labs";
+    repo = "exa-py";
+    rev = "af7f88999763f1cb7e3c4a67f4aa24cef5f6eb11";
+    hash = "sha256-7rLEvjngSRObFdT1DcrZfqWBCsvWVxdNIgxBNhNNk+4=";
+  };
+
+  # https://github.com/pytest-dev/pytest-asyncio/issues/658
+  # default behaviour changes with new python version.
+  # planning on trying to vendor upstream
+  postPatch = ''
+    substituteInPlace tests/unit/test_search_monitors.py --replace-fail \
+      'get_event_loop().run_until_complete' 'run'
+  '';
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    httpcore
+    httpx
+    openai
+    pydantic
+    python-dotenv
+    requests
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "exa_py"
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pytestFlags = [ "tests/" ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Official Python SDK for Exa, the web search API for AI";
+    homepage = "https://github.com/exa-labs/exa-py/";
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5190,6 +5190,8 @@ self: super: with self; {
 
   ewmhlib = callPackage ../development/python-modules/ewmhlib { };
 
+  exa-py = callPackage ../development/python-modules/exa-py { };
+
   example-robot-data = callPackage ../development/python-modules/example-robot-data {
     inherit (pkgs) example-robot-data;
   };


### PR DESCRIPTION
Homepage: https://github.com/exa-labs/exa-py


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
