### PR TITLE
python3Packages.celery: remove pytest-xdist due to hangs w/o sandbox

### DIFF
--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -154,8 +154,12 @@ buildPythonPackage (finalAttrs: {
     pytest-celery
     pytest-click
     pytest-timeout
-    pytest-xdist
     pytestCheckHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # Using `pytest-xdist` leads to incomplete tests which hang `pytestRemoveBytecode`
+    # under `sandbox=false` (the default on Darwin).
+    pytest-xdist
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 


### PR DESCRIPTION
When built with `--option sandbox=false` (Hydra's default for Darwin), `pytestRemoveBytecodePhase` hangs forever (presumably due to tests not releasing their resources). The hang doesn't happen with the sandbox on/relaxed. 

Removing `pytest-xdist` solves this. 

`celery` also disables `pytest-xdist` on their CI for smoke tests [as of 5.6.0b1](https://github.com/celery/celery/blob/a9ebc863307c526a0a4aadd950fc883c8b67cf19/Changelog.rst#560b1)

Also tried disabling three tests that failed due to external exceptions, but this didn't help.

Found on Darwin and confirmed on x86 Linux.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
