### PR TITLE
sfwbar: fix SVG icon rendering via wrapGAppsHook3

### DIFF
--- a/pkgs/by-name/sf/sfwbar/package.nix
+++ b/pkgs/by-name/sf/sfwbar/package.nix
@@ -16,6 +16,7 @@
   makeWrapper,
   docutils,
   wayland-scanner,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -47,12 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     makeWrapper
     wayland-scanner
+    wrapGAppsHook3
   ];
-
-  postFixup = ''
-    wrapProgram $out/bin/sfwbar \
-      --suffix XDG_DATA_DIRS : $out/share
-  '';
 
   meta = {
     homepage = "https://github.com/LBCrion/sfwbar";


### PR DESCRIPTION
Add `wrapGAppsHook3` to `nativeBuildInputs` to ensure `sfwbar` can successfully locate the `gdk-pixbuf` loaders required to render SVG symbolic icons in default GTK widgets (such as the battery, bluez, and volume modules).

The inclusion of this hook automatically generates a unified `loaders.cache` and wraps the resulting binary with the correct `GDK_PIXBUF_MODULE_FILE` environment variable. Furthermore, it automatically handles the population of `XDG_DATA_DIRS`, rendering the previous manual `wrapProgram` execution in `postFixup` redundant.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
