### PR TITLE
x2x: unstable-2023-04-30 -> 1.30-unstable-2025-02-17

### DIFF
--- a/pkgs/by-name/x2/x2x/package.nix
+++ b/pkgs/by-name/x2/x2x/package.nix
@@ -12,19 +12,20 @@
 
 stdenv.mkDerivation {
   pname = "x2x";
-  version = "unstable-2023-04-30";
+  version = "1.30-unstable-2025-02-17";
 
   src = fetchFromGitHub {
     owner = "dottedmag";
     repo = "x2x";
-    rev = "53692798fa0e991e0dd67cdf8e8126158d543d08";
-    hash = "sha256-FUl2z/Yz9uZlUu79LHdsXZ6hAwSlqwFV35N+GYDNvlQ=";
+    rev = "08842516fa443a2cf799c6372f83466062f612c9";
+    hash = "sha256-0ZVpG4ZrygrFZ0mVmNLWWdyqM43LtQPGwvZZPC92zuY=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
   ];
+
   buildInputs = [
     libx11
     libxtst


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324354856

Updated to last official commit. It's actually just an extra gcc15 fix commit over our last version.
Only tested compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
