### PR TITLE
xdg-user-dirs: 0.19 -> 0.20

### DIFF
--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -15,11 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-user-dirs";
-  version = "0.19";
+  version = "0.20";
 
   src = fetchurl {
     url = "https://user-dirs.freedesktop.org/releases/xdg-user-dirs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-6S3rkpwQ1LKTKTl6+KJYUQEkf35hd6xvHSjoITDtjBk=";
+    hash = "sha256-uONChiePT+8+G/6WhcOVzMDrUMFNOi+0lT3QD7/Trzk=";
   };
 
   outputs = [
@@ -51,9 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     # fallback values need to be last
     wrapProgram "$out/bin/xdg-user-dirs-update" \
       --suffix XDG_CONFIG_DIRS : "$out/etc/xdg"
-
-    substituteInPlace "$out/lib/systemd/user/xdg-user-dirs.service" \
-      --replace-fail "/usr/bin/xdg-user-dirs-update" "$out/bin/xdg-user-dirs-update"
 
     # Autostart, because the installed service is never explicitly enabled in NixOS
     substituteInPlace "$out/etc/xdg/autostart/xdg-user-dirs.desktop" \


### PR DESCRIPTION
[Blog post from maintainer](https://blog.tenstral.net/2026/04/hello-projects-directory.html).

- `xdg-user-dir` was rewritten from a shell script, to C program.
- A ~/Projects directory has been added, enabled by default.
- Upstream got rid of the autoconf-based build system.
- The xdg-user-dirs.service substitution is no longer needed, they substitute it with the value of `@bindir@` now.

https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/compare/v0.19...v0.20

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
