### PR TITLE
handy: init at 0.8.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29487,6 +29487,12 @@
     githubId = 1595132;
     name = "Kranium Gikos Mendoza";
   };
+  wondermr = {
+    email = "alexey.zhuchkov@gmail.com";
+    github = "WonderMr";
+    githubId = 5370211;
+    name = "Alexey Zhuchkov";
+  };
   workflow = {
     email = "4farlion@gmail.com";
     github = "workflow";

--- a/pkgs/by-name/ha/handy/package.nix
+++ b/pkgs/by-name/ha/handy/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  alsa-lib,
+  glib,
+  glib-networking,
+  gtk3,
+  gtk-layer-shell,
+  libayatana-appindicator,
+  libsoup_3,
+  libx11,
+  openssl,
+  vulkan-loader,
+  webkitgtk_4_1,
+  xdotool,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "handy";
+  version = "0.8.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src =
+    let
+      debArch =
+        {
+          x86_64-linux = "amd64";
+          aarch64-linux = "arm64";
+        }
+        .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    in
+    fetchurl {
+      url = "https://github.com/cjpais/Handy/releases/download/v${finalAttrs.version}/Handy_${finalAttrs.version}_${debArch}.deb";
+      hash =
+        {
+          x86_64-linux = "sha256-RtIHytX8WRjG+tzEzhZKfNthYlC8EjoiRZFl42k+MlA=";
+          aarch64-linux = "sha256-nkOEhT8HxAeMY+OUKA5skSz9ZdlZ2Ea9r6qNSlqPb/Q=";
+        }
+        .${stdenv.hostPlatform.system};
+    };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    alsa-lib
+    glib
+    glib-networking
+    gtk3
+    gtk-layer-shell
+    libsoup_3
+    libx11
+    openssl
+    stdenv.cc.cc.lib
+    vulkan-loader
+    webkitgtk_4_1
+  ];
+
+  runtimeDependencies = [
+    libayatana-appindicator
+    xdotool
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x "$src" .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/bin $out/bin
+    cp -r usr/lib $out/lib
+    cp -r usr/share $out/share
+
+    # Tauri emits a '256x256@2' icon directory that is not a valid hicolor size;
+    # rename to the equivalent 512x512 bucket so the icon is picked up.
+    if [ -d "$out/share/icons/hicolor/256x256@2" ]; then
+      mv "$out/share/icons/hicolor/256x256@2" "$out/share/icons/hicolor/512x512"
+    fi
+
+    # Upstream ships an empty Categories= entry, which is invalid per the XDG
+    # Desktop Entry Specification and causes some launchers to hide the app.
+    substituteInPlace $out/share/applications/Handy.desktop \
+      --replace-fail 'Categories=' 'Categories=Utility;AudioVideo;Accessibility;'
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Free, open-source, offline speech-to-text application";
+    longDescription = ''
+      Handy is a privacy-preserving speech-to-text tool built with Tauri:
+      press a shortcut, speak, and the transcription is inserted into the
+      active text field. All audio is processed locally — nothing is sent
+      to the cloud.
+
+      On Linux, the default Paste Method ("Direct", which simulates
+      individual keystrokes through rdev/enigo) can fail silently under
+      Wayland compositors that restrict synthetic input. If transcriptions
+      do not appear in your target application, open Handy's settings and
+      switch Paste Method to "Clipboard + Ctrl+V".
+    '';
+    homepage = "https://handy.computer";
+    changelog = "https://github.com/cjpais/Handy/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "handy";
+    maintainers = with lib.maintainers; [ wondermr ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description

Adds [handy.computer](https://handy.computer) — a free, open-source, privacy-preserving speech-to-text desktop app (Tauri + Rust + onnxruntime). Push a shortcut, speak, the transcription is inserted into the active text field. All audio stays on-device.

Upstream: https://github.com/cjpais/Handy (MIT).

### Packaging notes

The package repackages the upstream Debian archive. A source build is not practical today:

- Upstream pins a patched fork of Tauri (`cjpais/tauri`) plus several git-sourced Rust crates (`rdev`, `vad-rs`, `rodio`).
- `transcribe-rs` ships bundled `whisper.cpp` with Vulkan features enabled.
- The frontend is built with Bun.

All three combined make a reproducible offline build significantly more expensive than is justified for a first-cut init. If there's interest, a follow-up can move to source once upstream's Tauri patches land or when we have ergonomic Bun-lockfile fetching in nixpkgs.

### Packaging details

- `autoPatchelfHook` resolves all direct `DT_NEEDED` entries; `runtimeDependencies` covers `libayatana-appindicator` (Tauri tray icon) and `xdotool` (libxdo for `enigo`/`rdev` keystroke simulation).
- `wrapGAppsHook3` sets up the GTK/GSettings environment.
- The `.desktop` file's empty `Categories=` (upstream bug) is filled in with sensible defaults.
- The non-standard `hicolor/256x256@2` icon directory emitted by the Tauri bundler is renamed to `hicolor/512x512`.
- `meta.longDescription` notes that Linux users may need to switch the in-app Paste Method from "Direct" to "Clipboard + Ctrl+V" under Wayland — the default keystroke simulation via `rdev` can be blocked by some compositors.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux (hash + attribute wired, not built — no aarch64 hardware available)
  - [ ] x86_64-darwin (not applicable — Linux-only package)
  - [ ] aarch64-darwin (not applicable — Linux-only package)
- Tested, as applicable:
  - [ ] [NixOS tests]
  - [ ] [Package tests] at `passthru.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test]
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. `handy --help` exits 0; launching `handy --start-hidden --no-tray --debug` cleanly initialises the SQLite history store, Whisper/ORT accelerators and the GTK window under Wayland.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test