### PR TITLE
opencryptoki: 3.25.0 -> 3.26.0-unstable-2026-04-09

### DIFF
--- a/pkgs/by-name/op/opencryptoki/package.nix
+++ b/pkgs/by-name/op/opencryptoki/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opencryptoki";
-  version = "3.25.0";
+  version = "3.26.0-unstable-2026-04-09";
 
   src = fetchFromGitHub {
     owner = "opencryptoki";
     repo = "opencryptoki";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-JIDy5LY2rJqMM1uWDWn6Q62kJ+7pYU4G7zptkbyvf9Q=";
+    rev = "ed378f463ef73364c89feb0fc923f4dc867332a3";
+    hash = "sha256-1DxlsjPoK3kIQkfguhOlzP2d7dneYRz/Qwp4cH30AhU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
diff: https://github.com/opencryptoki/opencryptoki/compare/v3.25.0...ed378f463ef73364c89feb0fc923f4dc867332a3

fixes: [CVE-2026-40253](https://nvd.nist.gov/vuln/detail/CVE-2026-40253)

Closes #510881

Supersedes #460652

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
