### PR TITLE
nixos-test-driver: fix handling of type-check-disabled case

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -174,7 +174,11 @@ def generate_driver_symbols() -> None:
             vlans=[],
             global_timeout=0,
             enable_ssh_backdoor=False,
-            test_script=Path("testScriptWithTypes"),
+            test_script=(
+                Path("testScriptWithTypes")
+                if (Path("testScriptWithTypes").is_file())
+                else Path("testScriptFile")
+            ),
         ),
         out_dir=Path(),
         logger=CompositeLogger([]),

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -85,6 +85,8 @@ let
                 testScriptWithTypes
         ''}
 
+        echo -n "$testScript" > testScriptFile
+
         cp "${config.driverConfiguration.test_script}" $out/test-script
 
         ln -s ${testDriver}/bin/nixos-test-driver $out/bin/nixos-test-driver


### PR DESCRIPTION
f1bcb61731224bd8440510fc620d3c51f3e51c85 did not handle this correctly, causing failures (e.g. https://hydra.nixos.org/build/326659503)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (just for sway)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
