### PR TITLE
zig-zlint: 0.7.9 -> 0.8.1

### DIFF
--- a/pkgs/by-name/zi/zig-zlint/build.zig.zon.nix
+++ b/pkgs/by-name/zi/zig-zlint/build.zig.zon.nix
@@ -8,24 +8,25 @@
 
 linkFarm "zig-packages" [
   {
-    name = "chameleon-3.0.0-bqfnCfhtAAAAxXGw5t9odkb4ayCTTqOcPvL-TgSMUacF";
-    path = fetchzip {
-      url = "https://github.com/DonIsaac/chameleon/archive/7c7477fa76da53c2791f9e1f860481f64140ccbc.zip";
-      hash = "sha256-fbKhLQLE/6aHmpYr8+daxyUSWNpDq5zApHP4brRYvlo=";
+    name = "chameleon-2.0.1-ZOxajZ17AADmYCpHFqqoGfaXQiRkXM8B5lYJfir9tqsz";
+    path = fetchgit {
+      url = "https://github.com/tr1ckydev/chameleon";
+      rev = "414169dede742d9ac8261d31b9fca6e31a1d7246";
+      hash = "sha256-/TGzbVh+Z6dPEKtW0M0Tv1vXvc6jmb+kHf6Q0rHmEPE=";
     };
   }
   {
-    name = "recover-1.1.0-Zd97oqomAADqISI8KEhW_UUjiPSExhw9hzeoNpg1Nveo";
+    name = "recover-1.3.0-Zd97opwlAAB5ocfOuy8Fxp7_prPehOuEnh0R_8rBsNCk";
     path = fetchzip {
-      url = "https://github.com/dimdin/zig-recover/archive/36133afaa1b085db7063ffc97c08ae0bddc2de4e.zip";
-      hash = "sha256-0oPP6BLVEIR79Q8KcvOlSeDfNLT+8inmIU6ZkuJWrfU=";
+      url = "https://github.com/dimdin/zig-recover/archive/refs/tags/1.3.0.tar.gz";
+      hash = "sha256-3x7ptCcmGjCop703ftS/KWuTlAdcCw431C8Q4VAdLIs=";
     };
   }
   {
-    name = "smart_pointers-0.0.3-NPos2MOwAABoujUzLcVLofXqRAgYWLc5pG-TKDhyK0cq";
+    name = "smart_pointers-0.0.4-NPos2JOtAACuxKEoBGQgkmncI0APAPl-QwaI6klLObuP";
     path = fetchzip {
-      url = "https://github.com/DonIsaac/smart-pointers/archive/refs/tags/v0.0.3.tar.gz";
-      hash = "sha256-oSI76wyiAX7YDvKGhzRbZdEvl7+DPLtMb56w0QsYrkg=";
+      url = "https://github.com/DonIsaac/smart-pointers/archive/refs/tags/v0.0.4.tar.gz";
+      hash = "sha256-gSvAggi0qQgTd9avuqI9AspTGXr+w5ZkgNiI3kf0+dU=";
     };
   }
 ]

--- a/pkgs/by-name/zi/zig-zlint/package.nix
+++ b/pkgs/by-name/zi/zig-zlint/package.nix
@@ -3,24 +3,27 @@
   stdenv,
   fetchFromGitHub,
   callPackage,
-  zig_0_14,
+  zig_0_15,
   versionCheckHook,
 }:
 
+let
+  zig = zig_0_15;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zig-zlint";
-  version = "0.7.9";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     name = "zlint"; # tests expect this
     owner = "DonIsaac";
     repo = "zlint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qJPOFMBvkvF10ixE17pV9X5LX3EyCVzzhrMGx1omTzE=";
+    hash = "sha256-yjMgmO/kjLA9eBPXY+TgfVLyOLIpBtBigItJuon+t9k=";
   };
 
   nativeBuildInputs = [
-    zig_0_14
+    zig
   ];
 
   zigBuildFlags = [
@@ -50,6 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ christoph-heiss ];
     mainProgram = "zlint";
-    inherit (zig_0_14.meta) platforms;
+    inherit (zig.meta) platforms;
   };
 })


### PR DESCRIPTION
Changelog: https://github.com/DonIsaac/zlint/releases/tag/v0.8.1
Diff: https://github.com/DonIsaac/zlint/compare/v0.7.9...v0.8.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
