### PR TITLE
oxicloud: init at 0.5.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8954,6 +8954,13 @@
     matrix = "@flandweber:envs.net";
     name = "Finn Landweber";
   };
+  flashonfire = {
+    email = "flashonfire@proton.me";
+    github = "flashonfire";
+    githubId = 26602207;
+    matrix = "@flashonfire:lithium.ovh";
+    name = "Guillaume Calderon";
+  };
   fleaz = {
     email = "mail@felixbreidenstein.de";
     matrix = "@fleaz:rainbownerds.de";

--- a/pkgs/by-name/ox/oxicloud/package.nix
+++ b/pkgs/by-name/ox/oxicloud/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oxicloud";
+  version = "0.5.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "DioCrafts";
+    repo = "OxiCloud";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Nn8qgLdiw7w4PZIMCiI+UHZGNW64fjWZ5mErTJifRZU=";
+  };
+
+  cargoHash = "sha256-4KfrKL2AKkTt3cOXdl9Xr2qed+qy8WSWuqYfN8WJ0bQ=";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+  ];
+  buildInputs = [ openssl ];
+
+  cargoBuildFlags = [ "--bin=oxicloud" ];
+
+  postInstall = ''
+    mkdir -p $out/share/oxicloud
+    cp -r static-dist $out/share/oxicloud/static
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/oxicloud \
+      --set-default OXICLOUD_STATIC_PATH $out/share/oxicloud/static
+  '';
+
+  meta = {
+    description = "Ultra-fast, secure & lightweight self-hosted cloud storage";
+    homepage = "https://github.com/DioCrafts/OxiCloud";
+    changelog = "https://github.com/DioCrafts/OxiCloud/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "oxicloud";
+    maintainers = with lib.maintainers; [ flashonfire ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Description
Added oxicloud package: "Ultra-fast, secure & lightweight self-hosted cloud storage"
Upstream: https://github.com/DioCrafts/OxiCloud

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


Screenshot:
<img width="2203" height="1366" alt="image" src="https://github.com/user-attachments/assets/09604a6b-911d-4146-95f7-6af039e64c87" />
