### PR TITLE
arftracksat: 1.0-unstable-2025-09-15 -> 1.0-unstable-2026-02-19

### DIFF
--- a/pkgs/by-name/ar/arftracksat/package.nix
+++ b/pkgs/by-name/ar/arftracksat/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation {
   pname = "arftracksat";
-  version = "unstable-2025-09-15";
+  version = "unstable-2026-02-19";
 
   src = fetchFromGitHub {
     owner = "arf20";
     repo = "arftracksat";
-    rev = "5c9b3866b6fcd95382ff56c68cdd38f3d08c1372";
-    hash = "sha256-inCgsxrJkBNGmdGPd28XnOJYCiatL35TxDcfvZjA2cY=";
+    rev = "a9b86878e2ee6f332dc1df07685b7d20970c2f7e";
+    hash = "sha256-guDgy4H0pnQCihYwG7HoKApOlEcDtcaRaj6fRuVdLlc=";
   };
 
   nativeBuildInputs = [
@@ -35,11 +35,13 @@ stdenv.mkDerivation {
   buildInputs = [
     curl
     nlohmann_json
+    curlpp
+    glm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     freeglut
     libGL
     libGLU
-    curlpp
-    glm
   ];
 
   meta = {

--- a/pkgs/by-name/ar/arftracksat/package.nix
+++ b/pkgs/by-name/ar/arftracksat/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation {
   pname = "arftracksat";
-  version = "1.0-unstable-2025-09-15";
+  version = "1.0-unstable-2026-02-19";
 
   src = fetchFromGitHub {
     owner = "arf20";
     repo = "arftracksat";
-    rev = "5c9b3866b6fcd95382ff56c68cdd38f3d08c1372";
-    hash = "sha256-inCgsxrJkBNGmdGPd28XnOJYCiatL35TxDcfvZjA2cY=";
+    rev = "a9b86878e2ee6f332dc1df07685b7d20970c2f7e";
+    hash = "sha256-guDgy4H0pnQCihYwG7HoKApOlEcDtcaRaj6fRuVdLlc=";
   };
 
   nativeBuildInputs = [
@@ -35,11 +35,13 @@ stdenv.mkDerivation {
   buildInputs = [
     curl
     nlohmann_json
+    curlpp
+    glm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     freeglut
     libGL
     libGLU
-    curlpp
-    glm
   ];
 
   meta = {


### PR DESCRIPTION
This bump includes a fix for darwin build:
https://github.com/arf20/arftracksat/commit/1dff9ad78d0feac5eac3d45a24d069f8a55d1cc0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
