### PR TITLE
lix_2_93: drop

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -175,73 +175,6 @@ lib.makeExtensible (
   {
     inherit makeLixScope;
 
-    lix_2_93 = self.makeLixScope {
-      attrName = "lix_2_93";
-
-      lix-args = rec {
-        version = "2.93.3";
-
-        src = fetchFromGitea {
-          domain = "git.lix.systems";
-          owner = "lix-project";
-          repo = "lix";
-          rev = version;
-          hash = "sha256-Oqw04eboDM8rrUgAXiT7w5F2uGrQdt8sGX+Mk6mVXZQ=";
-        };
-
-        cargoDeps = rustPlatform.fetchCargoVendor {
-          name = "lix-${version}";
-          inherit src;
-          hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
-        };
-
-        patches = [
-          # Support for lowdown >= 1.4, https://gerrit.lix.systems/c/lix/+/3731
-          (fetchpatch2 {
-            name = "lix-lowdown-1.4.0.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/858de5f47a1bfd33835ec97794ece339a88490f1.patch";
-            hash = "sha256-FfLO2dFSWV1qwcupIg8dYEhCHir2XX6/Hs89eLwd+SY=";
-          })
-
-          # Support for toml11 >= 4.0, https://gerrit.lix.systems/c/lix/+/3953
-          (fetchpatch {
-            name = "lix-2.93-toml11-4-1.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/96a39dc464165a3e503a6dc7bd44518a116fe846.patch";
-            hash = "sha256-j1DOScY2IFvcouhoap9CQwIZf99MZ92HtY7CjInF/s4=";
-          })
-          (fetchpatch {
-            name = "lix-2.93-toml11-4-2.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/699d3a63a6351edfdbc8c05f814cc93d6c3637ca.patch";
-            hash = "sha256-2iUynAdimxhe5ZSDB7DlzFG3tu1yWhq+lTvjf6+M0pM=";
-          })
-          (fetchpatch {
-            name = "lix-2.93-toml11-4-3.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/ad52cbde2faa677b711ec950dae74e4aede965a4.patch";
-            hash = "sha256-ajQwafL3yZDJMVrR+D9eTGh7L0xbDbqhAUagRur4HDE=";
-          })
-          (fetchpatch {
-            name = "lix-2.93-toml11-4-4.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/e29a1ccf0af2e2890ec7b7fde82f0e53a1d0aad9.patch";
-            hash = "sha256-sXqZxCUtZsO7uEVk2AZx3IkP8b8EPVghYboetcQTp2A=";
-          })
-          (fetchpatch {
-            name = "lix-2.93-toml11-4-5.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/176b834464b7285b74a72d35df7470a46362ce60.patch";
-            hash = "sha256-/KIszfHf2XoB+GeVvXad2AV8pazffYdQRDtIXb9tbj8=";
-          })
-          (fetchpatch {
-            name = "lix-2.93-toml11-4-6.patch";
-            url = "https://git.lix.systems/lix-project/lix/commit/b6d5670bcffebdd43352ea79b36135e35a8148d9.patch";
-            hash = "sha256-f4s0TR5MhNMNM5TYLOR7K2/1rtZ389KDjTCKFVK0OcE=";
-          })
-
-          lixMdbookPatch
-
-          lixLowdown30Patch
-        ];
-      };
-    };
-
     lix_2_94 = self.makeLixScope {
       attrName = "lix_2_94";
 
@@ -344,5 +277,6 @@ lib.makeExtensible (
     lix_2_90 = throw (removedMessage "2.90"); # added in 2025-09-11
     lix_2_91 = throw (removedMessage "2.91"); # added in 2025-09-11
     lix_2_92 = throw (removedMessage "2.92"); # added in 2025-09-11
+    lix_2_93 = throw (removedMessage "2.93"); # added in 2026-04-19
   }
 )


### PR DESCRIPTION
Lix 2.93 is removed because it has been deprecated. Lix 2.93.3 has a known series of issues and 2.94 is superior along all dimensions to the current knowledge.

Change-Id: Ie95b6ac3a25e67702c5618aecf39f86f2e1293ad

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
