### PR TITLE
xinit: include launchd files when sandboxed

### DIFF
--- a/pkgs/by-name/xi/xinit/package.nix
+++ b/pkgs/by-name/xi/xinit/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-xserver=${xorg-server.out}/bin/X"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "--with-launchd=yes"
     "--with-bundle-id-prefix=org.nixos.xquartz"
     "--with-launchdaemons-dir=${placeholder "out"}/LaunchDaemons"
     "--with-launchagents-dir=${placeholder "out"}/LaunchAgents"


### PR DESCRIPTION
In sandbox, `autoconf` can't detect presence of `/sbin/launchd`, which
makes the derivation not include `launchd` specific files. Later,
`xquartz` fails because it relies on these files being present in
`xinit` output.

This patch forces installation of these files regardless of whether the
`launchd` binary is seen in the build environment.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
