### PR TITLE
tinyauth: 5.0.6 -> 5.0.7

### DIFF
--- a/pkgs/by-name/ti/tinyauth/package.nix
+++ b/pkgs/by-name/ti/tinyauth/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
   stdenvNoCC,
   bun,
   nixosTests,
@@ -11,17 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "tinyauth";
-  version = "5.0.6";
+  version = "5.0.7";
 
   src = fetchFromGitHub {
     owner = "steveiliop56";
     repo = "tinyauth";
     tag = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    hash = "sha256-V75kjO34b1DBBI5aJMfn9finHSbVbWqQ34CH68gzrig=";
+    hash = "sha256-VeII5jSNUJpGZgqons1o1fp6KXxDOBhSMciSqtQfaC4=";
   };
 
-  vendorHash = "sha256-iyduJgKt9OAkOY6J8J1GztCkYEssr/TcB43L6/Qdzmc=";
+  vendorHash = "sha256-XP+kVfcDKWAvBdrvGjiTdWh7jNe6qiDsgVjPrFFPoDU=";
 
   subPackages = [ "cmd/tinyauth" ];
 
@@ -35,10 +33,6 @@ buildGoModule (finalAttrs: {
 
   preBuild = ''
     cp -r ${finalAttrs.frontend}/dist internal/assets/dist
-  '';
-
-  postPatch = ''
-    ${lib.getExe git} apply --directory paerser/ patches/nested_maps.diff
   '';
 
   frontend = stdenvNoCC.mkDerivation {
@@ -83,7 +77,7 @@ buildGoModule (finalAttrs: {
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-pd5v5lD8Lyhf21OQvzjDTh63EcAe7E1OAoQuFGhAOX8=";
+    outputHash = "sha256-FRACDa1akm+JnYIRwNXRcomzDIMCIAlJDbjMyS77sNA=";
   };
 
   passthru = {


### PR DESCRIPTION
https://github.com/steveiliop56/tinyauth/releases/tag/v5.0.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
