### PR TITLE
gfan: disable hardening, enable tests

### DIFF
--- a/pkgs/by-name/gf/gfan/package.nix
+++ b/pkgs/by-name/gf/gfan/package.nix
@@ -35,7 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = lib.optionalString stdenv.cc.isClang ''
+  # This test assumes that our implementation of sort behaves identically to the
+  # one used during development, which is not necessarily the case; update the
+  # expected result to be sorted using our copy of sort.
+  postPatch = ''
+    sort testsuite/0008PolynomialSetUnion/output -o testsuite/0008PolynomialSetUnion/output
+    sort testsuite/0008PolynomialSetUnion/outputNew -o testsuite/0008PolynomialSetUnion/outputNew
+  ''
+  + lib.optionalString stdenv.cc.isClang ''
     substituteInPlace Makefile --replace "-fno-guess-branch-probability" ""
 
     for f in $(find -name "*.h" -or -name "*.cpp"); do
@@ -53,6 +60,15 @@ stdenv.mkDerivation (finalAttrs: {
     mpir
     cddlib
   ];
+  hardeningDisable = [ "libcxxhardeningfast" ];
+
+  doCheck = true;
+  # The test runner still exits successfully when there are failed tests, so check
+  # stdout to see if anything failed.
+  checkPhase = ''
+    make check | tee "$TMPDIR/test.log"
+    ! grep -q "Failed tests:" "$TMPDIR/test.log"
+  '';
 
   meta = {
     description = "Software package for computing Gröbner fans and tropical varieties";


### PR DESCRIPTION
`libcxxhardeningfast` was causing some of Sage's tests to fail on Darwin. I disabled it, and then enabled gfan's tests so that failures like this will be attributed to gfan itself in future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
