### PR TITLE
vesta-viewer: fix crash on File > Save/Export

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15037,6 +15037,12 @@
     githubId = 632767;
     name = "Guillaume Maudoux";
   };
+  layzyoldman = {
+    email = "ricardopaivacampos@gmail.com";
+    github = "layzyoldman";
+    githubId = 193278607;
+    name = "Ricardo Campos";
+  };
   LazilyStableProton = {
     email = "LazilyStable@proton.me";
     github = "LazyStability";

--- a/pkgs/by-name/ve/vesta-viewer/package.nix
+++ b/pkgs/by-name/ve/vesta-viewer/package.nix
@@ -6,9 +6,10 @@
   makeDesktopItem,
   copyDesktopItems,
   autoPatchelfHook,
+  wrapGAppsHook3,
   _7zz,
-
   glib,
+  gsettings-desktop-schemas,
   libGL,
   libGLU,
   libgcc,
@@ -32,7 +33,10 @@ let
       "x86_64-linux"
       "x86_64-darwin"
     ];
-    maintainers = with lib.maintainers; [ ulysseszhan ];
+    maintainers = with lib.maintainers; [
+      ulysseszhan
+      layzyoldman
+    ];
     mainProgram = "VESTA";
   };
 
@@ -40,9 +44,11 @@ let
     nativeBuildInputs = [
       copyDesktopItems
       autoPatchelfHook
+      wrapGAppsHook3
     ];
     buildInputs = [
       glib
+      gsettings-desktop-schemas
       libGL
       libGLU
       libgcc
@@ -67,6 +73,15 @@ let
       mkdir -p $out/bin
       ln -s $out/lib/VESTA/VESTA{,-core,-gui} -t $out/bin
 
+      # VESTA resolves resources (img/, *.ini, *.dat) relative to argv[0].
+      # wrapProgram replaces the binary with a wrapper script, changing argv[0].
+      # Symlinking data files into $out/bin/ ensures they are found correctly.
+      for f in $out/lib/VESTA/*.ini $out/lib/VESTA/*.dat $out/lib/VESTA/asfdc; do
+        ln -s $f $out/bin/$(basename $f)
+      done
+
+      ln -s $out/lib/VESTA/img $out/bin/img
+
       mkdir -p $out/share/icons/hicolor/{128x128,256x256}/apps
       ln -s $out/lib/VESTA/img/logo.png $out/share/icons/hicolor/128x128/apps/VESTA.png
       ln -s $out/lib/VESTA/img/logo@2x.png $out/share/icons/hicolor/256x256/apps/VESTA.png
@@ -83,14 +98,18 @@ let
         exec = "VESTA %u";
         icon = "VESTA";
         categories = [ "Science" ];
-        mimeTypes = [ "application/x-vesta" ];
+        mimeTypes = [
+          "chemical/x-cif"
+          "chemical/x-pdb"
+          "chemical/x-xyz"
+        ];
       })
     ];
   };
 
   darwinArgs = {
     nativeBuildInputs = [
-      _7zz # instead of undmg because of APFS
+      _7zz
     ];
     src = fetchurl {
       url = "https://jp-minerals.org/vesta/archives/${version}/VESTA.dmg";
@@ -111,7 +130,7 @@ stdenvNoCC.mkDerivation (
   {
     inherit pname version meta;
     # I could've written an update script here,
-    # but I didn't bother because the stable version hasn't been updated for years.
+    # but I didn't bother because the stable version hasn't been updated foryears.
   }
   // {
     "x86_64-linux" = linuxArgs;

--- a/pkgs/by-name/ve/vesta-viewer/package.nix
+++ b/pkgs/by-name/ve/vesta-viewer/package.nix
@@ -7,6 +7,7 @@
   copyDesktopItems,
   autoPatchelfHook,
   wrapGAppsHook3,
+  makeWrapper,
   _7zz,
   glib,
   gsettings-desktop-schemas,
@@ -45,6 +46,7 @@ let
       copyDesktopItems
       autoPatchelfHook
       wrapGAppsHook3
+      makeWrapper
     ];
     buildInputs = [
       glib
@@ -59,6 +61,9 @@ let
       libxtst
     ];
 
+    # Prevent wrapGAppsHook3 from auto-wrapping binaries.
+    dontWrapGApps = true;
+
     src = fetchzip {
       url = "https://jp-minerals.org/vesta/archives/${version}/VESTA-gtk3.tar.bz2";
       hash = "sha256-Dm4exMUgNZ6Sh8dVhsvLZGS38UXxe9t+9s3ttBQajGg=";
@@ -71,22 +76,18 @@ let
       cp -r * $out/lib/VESTA
 
       mkdir -p $out/bin
-      ln -s $out/lib/VESTA/VESTA{,-core,-gui} -t $out/bin
-
-      # VESTA resolves resources (img/, *.ini, *.dat) relative to argv[0].
-      # wrapProgram replaces the binary with a wrapper script, changing argv[0].
-      # Symlinking data files into $out/bin/ ensures they are found correctly.
-      for f in $out/lib/VESTA/*.ini $out/lib/VESTA/*.dat $out/lib/VESTA/asfdc; do
-        ln -s $f $out/bin/$(basename $f)
-      done
-
-      ln -s $out/lib/VESTA/img $out/bin/img
+      ln -s $out/lib/VESTA/VESTA{-core,-gui} -t $out/bin
 
       mkdir -p $out/share/icons/hicolor/{128x128,256x256}/apps
       ln -s $out/lib/VESTA/img/logo.png $out/share/icons/hicolor/128x128/apps/VESTA.png
       ln -s $out/lib/VESTA/img/logo@2x.png $out/share/icons/hicolor/256x256/apps/VESTA.png
 
       runHook postInstall
+    '';
+
+    # Wrap GSettings/XDG_DATA_DIRS into a single wrapper.
+    postFixup = ''
+      makeWrapper $out/lib/VESTA/VESTA $out/bin/VESTA "''${gappsWrapperArgs[@]}"
     '';
 
     desktopItems = [
@@ -130,7 +131,7 @@ stdenvNoCC.mkDerivation (
   {
     inherit pname version meta;
     # I could've written an update script here,
-    # but I didn't bother because the stable version hasn't been updated foryears.
+    # but I didn't bother because the stable version hasn't been updated for years.
   }
   // {
     "x86_64-linux" = linuxArgs;


### PR DESCRIPTION
## The Problem
Running `journalctl -f` and VESTA yields
```console
nixos systemd[1532]: Started VESTA - VESTA.
```
When pressing `File > Save/Export` buttons, 
```console
nixos VESTA-gui[6483]: No GSettings schemas are installed on the system
nixos kernel: traps: VESTA-gui[6483] trap int3 ip:7f8cc3fc116f sp:7ffdd0022150 error:0 in libglib-2.0.so.0.8600.3[6f16f,7f8cc3f75000+aa000] 
nixos systemd-coredump[6649]: Process 6483 (VESTA gui) of user 1000 terminated abnormally with signal 5/TRAP, processing...
```

### The Cause
When clicking any of the buttons, VESTA calls `GtkFileChooserDialog`, which instantiates a `GSettings` object (`org.gtk.Settings.FileChooser`). On NixOS, schemas are not at standard FHS paths, causing GLib to call `g_error()`, which invokes `G_BREAKPOINT()` and crashes.

### The Fix
Fixed by adding `wrapGAppsHook3` and `gsettings-desktop-schemas` to `buildInputs` so `XDG_DATA_DIRS` is correctly set to include the schema paths at runtime. Since `wrapGAppsHook3` changes `argv[0]`, resource files (`img/`, `*.ini`, `*.dat`) that VESTA resolves relative to `argv[0]` are additionally symlinked into `$out/bin/`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.