### PR TITLE
python3Packages.llama-cpp-python: 0.3.16 -> 0.3.22

### DIFF
--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -4,7 +4,6 @@
   gcc13Stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # nativeBuildInputs
   cmake,
@@ -41,28 +40,16 @@ let
 in
 buildPythonPackage.override { stdenv = stdenvTarget; } rec {
   pname = "llama-cpp-python";
-  version = "0.3.16";
+  version = "0.3.22";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "abetlen";
     repo = "llama-cpp-python";
     tag = "v${version}";
-    hash = "sha256-EUDtCv86J4bznsTqNsdgj1IYkAu83cf+RydFTUb2NEE=";
+    hash = "sha256-Mdz8aTBo3bwoqtjarXnQuNYjcaU+p4HKdMQfSoYwq60=";
     fetchSubmodules = true;
   };
-  # src = /home/gaetan/llama-cpp-python;
-
-  patches = [
-    # Fix test failure on a machine with no metal devices (e.g. nix-community darwin builder)
-    # https://github.com/ggml-org/llama.cpp/pull/15531
-    (fetchpatch {
-      url = "https://github.com/ggml-org/llama.cpp/pull/15531/commits/63a83ffefe4d478ebadff89300a0a3c5d660f56a.patch";
-      stripLen = 1;
-      extraPrefix = "vendor/llama.cpp/";
-      hash = "sha256-9LGnzviBgYYOOww8lhiLXf7xgd/EtxRXGQMredOO4qM=";
-    })
-  ];
 
   dontUseCmakeConfigure = true;
   cmakeFlags = [
@@ -75,7 +62,6 @@ buildPythonPackage.override { stdenv = stdenvTarget; } rec {
     #
     # cc1: error: unknown value ‘native+nodotprod+noi8mm+nosve’ for ‘-mcpu’
     (lib.cmakeBool "GGML_NATIVE" false)
-    (lib.cmakeFeature "GGML_BUILD_NUMBER" "1")
   ]
   ++ lib.optionals cudaSupport [
     (lib.cmakeBool "GGML_CUDA" true)


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://llama-cpp-python.readthedocs.io/en/latest/changelog/
Diff: https://github.com/abetlen/llama-cpp-python/compare/v0.3.16...v0.3.22

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
