### PR TITLE
xorgxrdp: 0.10.4 -> 0.10.5, xrdp: 0.10.4.1 -> 0.10.6

### DIFF
--- a/pkgs/by-name/xr/xrdp/package.nix
+++ b/pkgs/by-name/xr/xrdp/package.nix
@@ -33,13 +33,13 @@
 let
   xorgxrdp = stdenv.mkDerivation rec {
     pname = "xorgxrdp";
-    version = "0.10.4";
+    version = "0.10.5";
 
     src = fetchFromGitHub {
       owner = "neutrinolabs";
       repo = "xorgxrdp";
       rev = "v${version}";
-      hash = "sha256-TuzUerfOn8+3YfueG00IBP9sMpvy2deyL16mWQ8cRHg=";
+      hash = "sha256-P7mgdHIq7/Vkk5CR4mUYtQ0xBjh3J2QrYAobKbw1KXM=";
     };
 
     nativeBuildInputs = [
@@ -78,7 +78,7 @@ let
 
   xrdp = stdenv.mkDerivation rec {
     pname = "xrdp";
-    version = "0.10.4.1";
+    version = "0.10.6";
 
     src = applyPatches {
       inherit version;
@@ -89,7 +89,7 @@ let
         repo = "xrdp";
         rev = "v${version}";
         fetchSubmodules = true;
-        hash = "sha256-ula1B9/eriJ+0r6d9r2LAzh7J3s6/uvAiTKeRzLuVL0=";
+        hash = "sha256-BoIpWafUWznRHN8BaZmld8vVbZtywaGiooGPnDtDCjM=";
       };
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

xorgxrdp release: https://github.com/neutrinolabs/xorgxrdp/releases/tag/v0.10.5 ([diff](https://github.com/neutrinolabs/xorgxrdp/compare/v0.10.4...v0.10.5))
xrdp release: https://github.com/neutrinolabs/xrdp/releases/tag/v0.10.6 (includes fixes for 8 CVEs (including one rated 8.8); [diff](https://github.com/neutrinolabs/xrdp/compare/v0.10.4.1...v0.10.6))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result for [#511287](https://github.com/NixOS/nixpkgs/pull/511287)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 511287`
Commit: [`ee7720b24b366708a25f022695daa0b995546a89`](https://github.com/NixOS/nixpkgs/commit/ee7720b24b366708a25f022695daa0b995546a89) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/ee7720b24b366708a25f022695daa0b995546a89..pull/511287/head))
Merge: [`976e0e16384544f5743794f5fc33993ed6104368`](https://github.com/NixOS/nixpkgs/commit/976e0e16384544f5743794f5fc33993ed6104368)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/24618539118


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>xrdp</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>xrdp</li>
  </ul>
</details>

---
### `x86_64-darwin`
:white_check_mark: *No rebuilds*

---
### `aarch64-darwin`
:white_check_mark: *No rebuilds*
