### PR TITLE
tmuxPlugins.agent-usage: init at 0.1.4

### DIFF
--- a/pkgs/by-name/ag/agent-usage/package.nix
+++ b/pkgs/by-name/ag/agent-usage/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "agent-usage";
+  version = "0.1.4";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "tmux-agent-usage";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iNXAx+hPjtNoUrAPFQZmZfFbXUgsGbqXsqHIDV4I5Ak=";
+  };
+
+  cargoHash = "sha256-Z5+4A8uZe3TwtyH7xM646MyvHM3JY4hTzStCHx0o4Bw=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Display AI agent rate limit usage in your tmux status bar";
+    homepage = "https://github.com/raine/tmux-agent-usage";
+    changelog = "https://github.com/raine/tmux-agent-usage/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "agent-usage";
+    maintainers = with lib.maintainers; [ sei40kr ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -75,6 +75,10 @@ in
 {
   inherit mkTmuxPlugin;
 
+  agent-usage = pkgs.callPackage ./tmux-agent-usage {
+    inherit mkTmuxPlugin;
+  };
+
   battery = mkTmuxPlugin rec {
     pluginName = "battery";
     version = "2.0.0";

--- a/pkgs/misc/tmux-plugins/tmux-agent-usage/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-agent-usage/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  mkTmuxPlugin,
+  agent-usage,
+  bash,
+  makeWrapper,
+}:
+
+mkTmuxPlugin {
+  inherit (agent-usage) version src;
+
+  pluginName = "agent-usage";
+  rtpFilePath = "plugin/tmux-agent-usage.tmux";
+
+  patches = [ ./skip-auto-install.patch ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ bash ];
+
+  postInstall = ''
+    patchShebangs $target/plugin/tmux-agent-usage.tmux $target/plugin/bin/status.sh
+    wrapProgram $target/plugin/bin/status.sh \
+      --prefix PATH : ${lib.makeBinPath [ agent-usage ]}
+  '';
+
+  meta = {
+    description = "Display AI agent rate limit usage in your tmux status bar";
+    homepage = "https://github.com/raine/tmux-agent-usage";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sei40kr ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/misc/tmux-plugins/tmux-agent-usage/skip-auto-install.patch
+++ b/pkgs/misc/tmux-plugins/tmux-agent-usage/skip-auto-install.patch
@@ -1,0 +1,19 @@
+--- a/plugin/tmux-agent-usage.tmux
++++ b/plugin/tmux-agent-usage.tmux
+@@ -1,16 +1,6 @@
+ #!/usr/bin/env bash
+ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+-# Auto-install binary if not found
+-if ! command -v agent-usage >/dev/null 2>&1; then
+-    tmux display-message "agent-usage: installing binary..."
+-    if bash "$CURRENT_DIR/../scripts/install.sh" >/dev/null 2>&1; then
+-        tmux display-message "agent-usage: installed successfully"
+-    else
+-        tmux display-message "agent-usage: install failed, see https://github.com/raine/tmux-agent-usage"
+-    fi
+-fi
+-
+ # Configurable providers: set -g @agent-usage-providers "codex claude"
+ # Defaults to "codex" if not set.
+ providers="$(tmux show-option -gqv @agent-usage-providers)"


### PR DESCRIPTION
## Summary

Adds [`tmux-agent-usage`](https://github.com/raine/tmux-agent-usage) — a tmux plugin that displays AI coding agent (Codex, Claude) rate-limit usage in the status bar.

- `agent-usage` (new, in `pkgs/by-name/ag/agent-usage`): the Rust CLI that queries each provider and renders a status snippet.
- `tmuxPlugins.agent-usage` (new, in `pkgs/misc/tmux-plugins/tmux-agent-usage`): wraps the upstream tmux plugin and points `status.sh` at `agent-usage` via `wrapProgram`.

Upstream's plugin script auto-downloads a prebuilt binary at runtime when `agent-usage` isn't on `PATH`; this is unwanted in a Nix-packaged plugin, so `skip-auto-install.patch` strips that block.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality: ran `result/share/tmux-plugins/agent-usage/bin/status.sh codex --tmux` and confirmed it invokes the wrapped `agent-usage` and produces tmux status output.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.