### PR TITLE
nixos/terminfo: Fix less in systemd stage 1

### DIFF
--- a/nixos/modules/config/terminfo.nix
+++ b/nixos/modules/config/terminfo.nix
@@ -66,6 +66,17 @@
       source = "${config.system.path}/share/terminfo";
     };
 
+    boot.initrd.systemd.contents = lib.listToAttrs (
+      lib.map
+        (ti: lib.nameValuePair "/etc/terminfo/${ti}" { source = "${pkgs.ncurses}/share/terminfo/${ti}"; })
+        [
+          "l/linux"
+          "v/vt100"
+          "v/vt102"
+          "v/vt220"
+        ]
+    );
+
     environment.profileRelativeSessionVariables = {
       TERMINFO_DIRS = [ "/share/terminfo" ];
     };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1560,6 +1560,7 @@ in
   };
   systemd-initrd-simple = runTest ./systemd-initrd-simple.nix;
   systemd-initrd-swraid = runTest ./systemd-initrd-swraid.nix;
+  systemd-initrd-terminfo = runTest ./systemd-initrd-terminfo.nix;
   systemd-initrd-vconsole = runTest ./systemd-initrd-vconsole.nix;
   systemd-initrd-vlan = runTest ./systemd-initrd-vlan.nix;
   systemd-journal = runTest ./systemd-journal.nix;

--- a/nixos/tests/systemd-initrd-terminfo.nix
+++ b/nixos/tests/systemd-initrd-terminfo.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+{
+  name = "systemd-initrd-terminfo";
+
+  meta.maintainers = [ lib.maintainers.elvishjerricco ];
+
+  nodes.machine =
+    { config, ... }:
+    {
+      boot.initrd.systemd = {
+        enable = true;
+        extraBin.script = "${config.boot.initrd.systemd.package.util-linux}/bin/script";
+      };
+      testing.initrdBackdoor = true;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("initrd.target")
+    rc, out = machine.execute("echo q | script -q -e -c 'yes | less' /dev/null")
+    assert "terminals database is inaccessible" not in out
+  '';
+}


### PR DESCRIPTION
Since `less` 691, we get `terminals database is inaccessible` in initrd. This is a problem because ordinary systemd commands like systemctl and journalctl often try to use the pager.

Bisected to: https://github.com/gwsw/less/commit/7bf5441da53139e834024cd4157915f4ebc0ee9e

Fedora only adds these few terminfos to their initramfs, see dracut: https://github.com/dracutdevs/dracut/blob/5d2bda46f4e75e85445ee4d3bd3f68bf966287b9/modules.d/95terminfo/module-setup.sh#L12


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
