### PR TITLE
darwin.xcode: add 26.4.1

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -129,6 +129,8 @@ lib.makeExtensible (self: {
   xcode_26_3_Apple_silicon = requireXcode "26.3_Apple_silicon" "sha256-q2p45zqAZUH6Z1Q3DHbZgpuuFTjZoMPhEfFdeIUvclw=";
   xcode_26_4 = requireXcode "26.4_Universal" "sha256-0Cg4Ytu2+JOLEqw1ZZoB6hxFXNA2KriTLwLpT8bmA7I=";
   xcode_26_4_Apple_silicon = requireXcode "26.4_Apple_silicon" "sha256-urkJVqUY6+5z0YiEqCru9M/OneDLAMzdGfOt7i3d1WI=";
+  xcode_26_4_1 = requireXcode "26.4.1_Universal" "sha256-N9QgPKfZV64gJPlr4r/0gPS0yAgJd3a+qlr0YbzMCU4=";
+  xcode_26_4_1_Apple_silicon = requireXcode "26.4.1_Apple_silicon" "sha256-8MtGX97e/2+zvY2Et9Jm9eXqVmyr+U02UqsKmffh9hs=";
   xcode =
     self."xcode_${
       lib.replaceStrings [ "." ] [ "_" ] (

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -162,6 +162,8 @@ makeScopeWithSplicing' {
         xcode_26_3_Apple_silicon
         xcode_26_4
         xcode_26_4_Apple_silicon
+        xcode_26_4_1
+        xcode_26_4_1_Apple_silicon
         xcode
         requireXcode
         ;


### PR DESCRIPTION
<table role="table">
<thead>
<tr>
<th><code>NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_4_1</code></th>
<th><code>NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_4_1_Apple_silicon</code></th>
</tr>
</thead>
<tbody>
<tr>
<td>
<pre>
<code>/nix/store/cgj22al60h3pcyb1vclmkms0p66bgs6w-Xcode.app</code>
</pre>
</td>
<td>
<pre>
<code>/nix/store/idv46rb32f0cfbr8lbapzfbmgjm7qhgb-Xcode.app</code>
</pre>
</td>
</tr>
</tbody>
</table>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
