### PR TITLE
workmux: init at 0.1.184

### DIFF
--- a/pkgs/by-name/wo/workmux/package.nix
+++ b/pkgs/by-name/wo/workmux/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  gitMinimal,
+  installShellFiles,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "workmux";
+  version = "0.1.184";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "workmux";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zrR1CNkAl9KiQp6B0cY/5kIh21zRDVVX67hSz3KtJCM=";
+  };
+
+  cargoHash = "sha256-2Q8ronyiU1ATwxMnWvr/rp7M09lphzHOUpvTyToVi/g=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  checkFlags = [
+    # Sandbox RPC and network proxy tests bind Unix/TCP sockets, which the
+    # Nix build sandbox on Darwin doesn't permit.
+    "--skip=sandbox::network_proxy::tests"
+    "--skip=sandbox::rpc::tests"
+  ];
+
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd workmux \
+        --bash <($out/bin/workmux completions bash) \
+        --fish <($out/bin/workmux completions fish) \
+        --zsh <($out/bin/workmux completions zsh)
+    ''
+    + ''
+      mkdir -p $out/share/workmux
+      cp -r skills $out/share/workmux/skills
+    '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  # workmux writes a log file under $HOME on startup; pass HOME (set by
+  # writableTmpDirAsHomeHook) through versionCheckHook's env-stripping subshell.
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git worktrees + tmux windows for zero-friction parallel dev";
+    homepage = "https://github.com/raine/workmux";
+    changelog = "https://github.com/raine/workmux/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "workmux";
+    maintainers = with lib.maintainers; [ sei40kr ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
New package: [workmux](https://github.com/raine/workmux) v0.1.184.

Giga-opinionated zero-friction workflow tool for managing
[git worktrees](https://git-scm.com/docs/git-worktree) and tmux windows as
isolated development environments, useful for running multiple AI agents in
parallel without conflict.

Ported from [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at \`passthru.tests\` — \`versionCheckHook\` runs \`workmux --version\` as an install check.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran \`nixpkgs-review\` on this PR.
- [x] Tested basic functionality: \`./result/bin/workmux --help\` and \`--version\` print expected output.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc