### PR TITLE
nirimod: init at 0-unstable-2026-07-27

### DIFF
--- a/pkgs/by-name/ni/nirimod/package.nix
+++ b/pkgs/by-name/ni/nirimod/package.nix
@@ -12,7 +12,7 @@
 
 python3Packages.buildPythonApplication {
   pname = "nirimod";
-  version = "0-unstable-2026-04-18";
+  version = "0-unstable-2026-04-30";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -20,8 +20,8 @@ python3Packages.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "srinivasr";
     repo = "nirimod";
-    rev = "6dbda782788caed4e8691e372e79b5c73d6871ba";
-    hash = "sha256-l3q0hxUpgW7Fmb2zz3IY+dhbTffhUy2oYc80sf6p6LA=";
+    rev = "afb2b7c31746aa762e47b0497281196898232a92";
+    hash = "sha256-2wIaTPDTCuYerUIQJSHO884vRcoDFVxWTgGB4FXN0wk=";
   };
 
   build-system = [ python3Packages.hatchling ];
@@ -38,11 +38,6 @@ python3Packages.buildPythonApplication {
   ];
 
   dependencies = [ python3Packages.pygobject3 ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'nirimod = "nirimod.main:main"' 'nirimod = "nirimod.__main__:main"'
-  '';
 
   postInstall = ''
     install -Dm644 data/nirimod.svg $out/share/icons/hicolor/scalable/apps/nirimod.svg

--- a/pkgs/by-name/ni/nirimod/package.nix
+++ b/pkgs/by-name/ni/nirimod/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  copyDesktopItems,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  makeDesktopItem,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "nirimod";
+  version = "0-unstable-2026-04-18";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "srinivasr";
+    repo = "nirimod";
+    rev = "6dbda782788caed4e8691e372e79b5c73d6871ba";
+    hash = "sha256-l3q0hxUpgW7Fmb2zz3IY+dhbTffhUy2oYc80sf6p6LA=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = [ python3Packages.pygobject3 ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'nirimod = "nirimod.main:main"' 'nirimod = "nirimod.__main__:main"'
+  '';
+
+  postInstall = ''
+    install -Dm644 data/nirimod.svg $out/share/icons/hicolor/scalable/apps/nirimod.svg
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "io.github.nirimod";
+      exec = "nirimod";
+      icon = "nirimod";
+      desktopName = "NiriMod";
+      genericName = "Compositor Settings";
+      comment = "GUI configuration manager for the niri Wayland compositor";
+      categories = [
+        "Utility"
+        "Settings"
+        "DesktopSettings"
+      ];
+      keywords = [
+        "compositor"
+        "windowmanager"
+        "wayland"
+        "niri"
+        "settings"
+        "config"
+      ];
+      startupNotify = true;
+      startupWMClass = "nirimod";
+    })
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = {
+    description = "Visual configuration interface for the niri Wayland compositor";
+    homepage = "https://github.com/srinivasr/nirimod";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.linux;
+    mainProgram = "nirimod";
+  };
+}

--- a/pkgs/by-name/ni/nirimod/package.nix
+++ b/pkgs/by-name/ni/nirimod/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  copyDesktopItems,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  makeDesktopItem,
+  unstableGitUpdater,
+  wrapGAppsHook4,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "nirimod";
+  version = "0-unstable-2026-07-27";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "srinivasr";
+    repo = "nirimod";
+    rev = "fb62bb30a060cb37868231846810c98bc1eb22d4";
+    hash = "sha256-h4p5Nn7xFTJ+aHw2FALwMygDM5l0GXakvEwRxadx87k=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = [ python3Packages.pygobject3 ];
+
+  postInstall = ''
+    install -Dm644 data/nirimod.svg $out/share/icons/hicolor/scalable/apps/nirimod.svg
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "io.github.nirimod";
+      exec = "nirimod";
+      icon = "nirimod";
+      desktopName = "NiriMod";
+      genericName = "Compositor Settings";
+      comment = "GUI configuration manager for the niri Wayland compositor";
+      categories = [
+        "Utility"
+        "Settings"
+        "DesktopSettings"
+      ];
+      keywords = [
+        "compositor"
+        "windowmanager"
+        "wayland"
+        "niri"
+        "settings"
+        "config"
+      ];
+      startupNotify = true;
+      startupWMClass = "nirimod";
+    })
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Visual configuration interface for the niri Wayland compositor";
+    homepage = "https://github.com/srinivasr/nirimod";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.linux;
+    mainProgram = "nirimod";
+  };
+}


### PR DESCRIPTION
NiriMod is a GTK4/libadwaita GUI configurator for the [niri](https://github.com/YaLTeR/niri) Wayland compositor. It provides a visual interface for managing niri settings instead of hand-editing KDL configuration files, and talks to a running niri session via `niri msg` IPC.

Homepage: https://github.com/srinivasr/nirimod

Upstream has no tagged releases yet, so this is pinned to the latest `main` commit using the `0-unstable-<date>` versioning scheme.

Notes:
- Upstream `pyproject.toml` declares entry point `nirimod.main:main` but the module is actually `nirimod.__main__`; patched via `substituteInPlace` in `postPatch`.
- Upstream `pyproject.toml` metadata says `GPL-3.0-or-later` but the repo `LICENSE` file is MIT; using MIT here since the LICENSE file is the canonical source.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
