### PR TITLE
wrapGAppsHook: prepare for structuredAttrs

### DIFF
--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/wrap-gapps-hook.sh
@@ -42,11 +42,16 @@ wrapGApp() {
     wrapProgram "$program" "${gappsWrapperArgs[@]}" "$@"
 }
 
+wrapGAppsHookHasRunForOutput=()
+
 # Note: $gappsWrapperArgs still gets defined even if ${dontWrapGApps-} is set.
 wrapGAppsHook() {
-    # guard against running multiple times (e.g. due to propagation)
-    [ -z "$wrapGAppsHookHasRun" ] || return 0
-    wrapGAppsHookHasRun=1
+    # guard against running multiple times for the same output (e.g. due to propagation)
+    local o
+    for o in "${wrapGAppsHookHasRunForOutput[@]}"; do
+        [ "$o" = "$output" ] || return 0
+    done
+    wrapGAppsHookHasRunForOutput+=("$output")
 
     if [[ -z "${dontWrapGApps:-}" ]]; then
         targetDirsThatExist=()

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/wrap-gapps-hook.sh
@@ -42,11 +42,13 @@ wrapGApp() {
     wrapProgram "$program" "${gappsWrapperArgs[@]}" "$@"
 }
 
+declare -gA wrapGAppsHookHasRunForOutput
+
 # Note: $gappsWrapperArgs still gets defined even if ${dontWrapGApps-} is set.
 wrapGAppsHook() {
-    # guard against running multiple times (e.g. due to propagation)
-    [ -z "$wrapGAppsHookHasRun" ] || return 0
-    wrapGAppsHookHasRun=1
+    # guard against running multiple times for the same output (e.g. due to propagation)
+    [ "${wrapGAppsHookHasRunForOutput["$output"]:-}" = 1 ] && return 0
+    wrapGAppsHookHasRunForOutput["$output"]=1
 
     if [[ -z "${dontWrapGApps:-}" ]]; then
         targetDirsThatExist=()


### PR DESCRIPTION
This hook is called in the fixupPhase via

```
local output
for output in $(getAllOutputNames); do
  prefix="${!output}" runHook fixupOutput
done
```

Without `__structuredAttrs`, `getAllOutputNames` returns the `output` array, in order. However, with `__structuredAttrs`, it returns the keys of the `output` associative array, which are no longer necessarily ordered in the same way.

In the case of some packages (e.g. `mate-panel-with-applets`) this means that instead of `[ "out" "man" ]`, we process `[ "man" "out" ]`. Running the hook for `"man"` then sets `wrapGAppsHookHasRun` and no wrapping is done for `"out"`, which is what was really needed.

Instead, keep track of whether the hook has run on a per-output basis. That way, the order does not matter and any executables that are spread around multiple outputs are wrapped.

I tried to do this using an associative array to keep track of which outputs we've already seen, but I couldn't get the syntax to work for some reason (maybe due to lack of sleep :)) - if the general approach makes sense I can take another stab at that.

This should allow https://github.com/NixOS/nixpkgs/pull/511162 to be reverted.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
