### PR TITLE
Update geph and switch to update.sh

### DIFF
--- a/pkgs/by-name/ge/geph/package.nix
+++ b/pkgs/by-name/ge/geph/package.nix
@@ -23,16 +23,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "geph5";
-  version = "0.2.93";
+  version = "0.2.99";
 
   src = fetchFromGitHub {
     owner = "geph-official";
     repo = "geph5";
     rev = "geph5-client-v${finalAttrs.version}";
-    hash = "sha256-ZYcGW6Ssauf5BUs75KBV+4Zub2ZCVN29cWTxeNi87cI=";
+    hash = "sha256-AWdVFpIP+LIZz6zqcx0GJxDs4ZWGR6JgpHDVAg0mHaU=";
   };
 
-  cargoHash = "sha256-0Ml8tgWghxhDJzUMMD+YGwy3fyFjKcNjbV8MDJW8rZk=";
+  cargoHash = "sha256-zFCq29vtsbwbo6JBRdX+CziKZVoxwpt6y3BYVlIqZfc=";
 
   postPatch = ''
     substituteInPlace binaries/geph5-client/src/vpn/*.sh \

--- a/pkgs/by-name/ge/geph/package.nix
+++ b/pkgs/by-name/ge/geph/package.nix
@@ -11,7 +11,6 @@
   coreutils,
   iproute2,
   iptables,
-  nix-update-script,
 }:
 let
   binPath = lib.makeBinPath [
@@ -82,12 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     done
   '';
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "geph5-client-v(.*)"
-    ];
-  };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Modular Internet censorship circumvention system designed specifically to deal with national filtering";

--- a/pkgs/by-name/ge/geph/update.sh
+++ b/pkgs/by-name/ge/geph/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash coreutils git gnugrep gnused gawk common-updater-scripts
+
+set -euo pipefail
+
+script_dir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+nixpkgs=$(realpath "$script_dir"/../../../..)
+attrPath="${UPDATE_NIX_ATTR_PATH:-geph}"
+
+if [[ -n "${UPDATE_NIX_OLD_VERSION:-}" ]]; then
+  oldVersion="$UPDATE_NIX_OLD_VERSION"
+else
+  oldVersion=$(cd "$nixpkgs" && nix-instantiate --eval -A "$attrPath.version" | tr -d '"')
+fi
+
+if [[ $# -gt 0 ]]; then
+  targetVersion="$1"
+else
+  targetVersion=$(
+    git ls-remote --tags --refs --sort="v:refname" https://github.com/geph-official/geph5.git \
+      | awk '{ print $2 }' \
+      | sed -nE 's,^refs/tags/geph5-client-v([0-9]+\.[0-9]+\.[0-9]+)$,\1,p' \
+      | tail -1
+  )
+fi
+
+if [[ -z "${targetVersion:-}" ]]; then
+  echo "Failed to find any geph5-client tags" >&2
+  exit 1
+fi
+
+if [[ "$oldVersion" == "$targetVersion" ]]; then
+  echo "geph is already up-to-date"
+  exit 0
+fi
+
+(
+  cd "$nixpkgs"
+  update-source-version "$attrPath" "$targetVersion"
+  update-source-version "$attrPath" --ignore-same-version --source-key=cargoDeps.vendorStaging
+)


### PR DESCRIPTION
Due to issues with the [update bot](https://nixpkgs-update-logs.nix-community.org/geph/2026-04-13.log), I’ve replaced the tag matching method with a custom script.
Of course, this is a bit of a hack, and I’d still prefer to use the previous configuration.

```
--- SHOWING ERROR LOG FOR geph5-0.2.93 ----------------------

Traceback (most recent call last):
  File "/nix/store/wcgd7rkrfilbwdd7nm67d345bqmjxjfw-nix-update-1.14.0/bin/.nix-update-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/wcgd7rkrfilbwdd7nm67d345bqmjxjfw-nix-update-1.14.0/lib/python3.13/site-packages/nix_update/__init__.py", line 467, in main
    package = update(options)
  File "/nix/store/wcgd7rkrfilbwdd7nm67d345bqmjxjfw-nix-update-1.14.0/lib/python3.13/site-packages/nix_update/update.py", line 209, in update
    update_hash = update_version(
        opts,
    ...<3 lines>...
        opts.version_regex,
    )
  File "/nix/store/wcgd7rkrfilbwdd7nm67d345bqmjxjfw-nix-update-1.14.0/lib/python3.13/site-packages/nix_update/update.py", line 113, in update_version
    new_version = fetch_new_version(opts, package, version, preference, version_regex)
  File "/nix/store/wcgd7rkrfilbwdd7nm67d345bqmjxjfw-nix-update-1.14.0/lib/python3.13/site-packages/nix_update/update.py", line 103, in fetch_new_version
    return fetch_latest_version(package.parsed_url, config)
  File "/nix/store/wcgd7rkrfilbwdd7nm67d345bqmjxjfw-nix-update-1.14.0/lib/python3.13/site-packages/nix_update/version/__init__.py", line 196, in fetch_latest_version
    raise VersionError(
    ...<2 lines>...
    )
nix_update.errors.VersionError: No version matched the regex. The following versions were found:
sillad-v0.2.7
sillad-sosistab3-v0.2.17
sillad-native-tls-v0.2.12
sillad-meeklike-v0.1.2
sillad-hex-v0.1.1
sillad-conntest-v0.2.1
picomux-v0.1.15
nanorpc-sillad-v0.1.3
mizaru2-v0.2.16
geph5-misc-rpc-v0.2.90


--- SHOWING ERROR LOG FOR geph5-0.2.93 ----------------------
The update script for geph5-0.2.93 failed with exit code 1
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
