### PR TITLE
nixos/yazi: add dependency support to plugins

### DIFF
--- a/pkgs/by-name/ya/yazi/package.nix
+++ b/pkgs/by-name/ya/yazi/package.nix
@@ -43,7 +43,9 @@
 }:
 
 let
-  runtimePaths = [ file ] ++ optionalDeps ++ extraPackages;
+  pluginDeps = lib.concatMap (plugin: plugin.dependencies or [ ]) (lib.attrValues plugins);
+
+  runtimePaths = [ file ] ++ pluginDeps ++ optionalDeps ++ extraPackages;
 
   settingsFormat = formats.toml { };
 

--- a/pkgs/by-name/ya/yazi/plugins/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/default.nix
@@ -14,6 +14,7 @@ let
       src,
       meta ? { },
       installPhase ? null,
+      dependencies ? [ ],
       ...
     }:
     let
@@ -23,6 +24,8 @@ let
     stdenvNoCC.mkDerivation (
       args
       // {
+        propagatedBuildInputs = args.propagatedBuildInputs or [ ] ++ dependencies;
+
         installPhase =
           if installPhase != null then
             installPhase

--- a/pkgs/by-name/ya/yazi/plugins/yafg/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yafg/default.nix
@@ -2,6 +2,9 @@
   lib,
   fetchFromGitHub,
   mkYaziPlugin,
+
+  ripgrep,
+  fzf,
 }:
 mkYaziPlugin {
   pname = "yafg.yazi";
@@ -13,6 +16,11 @@ mkYaziPlugin {
     rev = "dd03b133d6cd1ff92368360558da193517169f9e";
     hash = "sha256-xTZ+6KRr85A4QpPWAE9QN1AnUVnCw/tvRvsWOmmayao=";
   };
+
+  dependencies = [
+    ripgrep
+    fzf
+  ];
 
   meta = {
     description = "Fuzzy find and grep plugin for Yazi file manager with interactive ripgrep and fzf search";


### PR DESCRIPTION
Exploring the idea of propagating yazi plugin dependencies as discussed in https://github.com/NixOS/nixpkgs/issues/511091

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
