### PR TITLE
{lomiri,lomiri-qt6}.lomiri-content-hub: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-content-hub/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   nixosTests,
   testers,
@@ -37,13 +36,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-content-hub";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-content-hub";
     tag = finalAttrs.version;
-    hash = "sha256-ukaEur2RgdIVPYm90OUCs0L+F9OQ3zaypreyx33iD5M=";
+    hash = "sha256-48G17gzvk1ENgZHDjjvuHyyCiUfK8rkyokU2gNJ9KVg=";
   };
 
   outputs = [
@@ -53,15 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals withDocumentation [
     "doc"
-  ];
-
-  patches = [
-    # Remove when version > 2.2.2
-    (fetchpatch {
-      name = "0001-lomiri-content-hub-Properly-include-lomiri-api-includedirs.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-content-hub/-/commit/dab1854e5ec0a91fd28c9d84f06dcdd0af39518b.patch";
-      hash = "sha256-aQB8kLL2ZkKUOvFoDQ9rottFsCSNJ66wUjUZxP+kr5k=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-content-hub/-/blob/2.2.3/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
