### PR TITLE
{lomiri,lomiri-qt6}.lomiri-download-manager: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-download-manager/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   boost,
@@ -33,13 +32,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-download-manager";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-download-manager";
     tag = finalAttrs.version;
-    hash = "sha256-/rb1Fx0TbBuff2dWAgxpd72opTnLe0itcGwLJ53Wu9U=";
+    hash = "sha256-FqpTEGbSwN+2oG/G2Zf80rSfezJP/ogtIkVdIrX4FMU=";
   };
 
   outputs = [
@@ -47,15 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ]
   ++ lib.optionals withDocumentation [ "doc" ];
-
-  patches = [
-    # Remove when version > 0.3.0
-    (fetchpatch {
-      name = "0001-lomiri-download-manager-Properly-include-lomiri-api-includedirs.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-download-manager/-/commit/b847aca92cea6f729b96f7a55f765ae4d9fbf741.patch";
-      hash = "sha256-hx/b80P5nbonlP3B8ekjZjxUGV3Ofm/lai0RU1ak9Gs=";
-    })
-  ];
 
   postPatch = ''
     # Substitute systemd's prefix in pkg-config call


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-download-manager/-/blob/0.3.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
