### PR TITLE
gss: fix Darwin build by pinning autoconf269

### DIFF
--- a/pkgs/by-name/gs/gss/package.nix
+++ b/pkgs/by-name/gs/gss/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchzip,
-  autoconf,
+  autoconf269,
   automake,
   gengetopt,
   gettext,
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    autoconf
+    autoconf269
     automake
     gengetopt
     gettext


### PR DESCRIPTION
> autoconf269, but that's best avoided, so try leaving a comment here first — maybe somebody has a better idea.

If anyone has better idea please let me know and I'll do it, otherwise this should do?

----

The autoconf 2.73 update on staging-next broke gnulib's stdint.h
generation: the `GNULIBHEADERS_OVERRIDE_WINT_T` AC_SUBST variable ends
up empty in the generated Makefile, so sed substitutes it as the empty
string in `stdint.h` line 89 (from `stdint.in.h` line 88, plus the one
`DO NOT EDIT` header line the generator prepends), producing a bare
`#if` that fails to parse:

    In file included from strverscmp.c:25:
    ./stdint.h:89:5: error: expected value in expression
       89 | #if
          |     ^

Template line:
https://github.com/coreutils/gnulib/blob/0a01f6737dc5666c730bdfe6a038da53a4156cc2/lib/stdint.in.h#L88

A `CFLAGS=-std=gnu17` pin does not help: autoconf still reports C11
features as "none needed" (same as the previously-succeeding autoconf
2.72 build), yet the substitution is still empty

The nixpkgs gnulib pin (2024-10-01) is too old for this autoconf

Refs: https://github.com/NixOS/nixpkgs/issues/511329


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
