### PR TITLE
yazi: use ffmpeg-headless for video previews

### DIFF
--- a/pkgs/by-name/ya/yazi/package.nix
+++ b/pkgs/by-name/ya/yazi/package.nix
@@ -9,7 +9,7 @@
     jq
     poppler-utils
     _7zz
-    ffmpeg
+    ffmpeg-headless
     fd
     ripgrep
     fzf
@@ -27,7 +27,7 @@
   jq,
   poppler-utils,
   _7zz,
-  ffmpeg,
+  ffmpeg-headless,
   fd,
   ripgrep,
   fzf,


### PR DESCRIPTION
The bundled video previewer only invokes `ffmpeg` and `ffprobe` ([`yazi-plugin/preset/plugins/video.lua`](https://github.com/sxyazi/yazi/blob/main/yazi-plugin/preset/plugins/video.lua)), never `ffplay`. The full `ffmpeg`'s `ffplay` links SDL, which transitively pulls gtk3, gtk4, zenity, gst-plugins-bad and flite into the closure of a TUI file manager.

```
$ nix path-info -Sh ./result-{before,after}
/nix/store/vid1fwpnf4vi0w2ngmcl6wmfd3lw8k79-yazi-26.1.22     1.1G
/nix/store/znjnm26cirjfxj6gv0sgalawdvr42m6v-yazi-26.1.22   494.5M
```

Matches what comparable in-tree consumers already do (`ffmpegthumbnailer`, `mcat`, `yt-dlp`, `navidrome`, `pipewire`, …).

The previewer passes `-hwaccel auto`; `ffmpeg-headless` drops VA-API/VDPAU so this falls back to software decode, users who want hw-accelerated previews can still `yazi.override { optionalDeps = [ … ffmpeg … ]; }`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
