### PR TITLE
{lomiri,lomiri-qt6}.lomiri-api: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -111,6 +111,14 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-9YRWMV+1UT+EQd9Uq1+6enNzz+HDlSt3LTPM1BKJxiE=";
     })
 
+    # Compatibility with newer lomiri-api
+    # Remove when version > 0.5.0
+    (fetchpatch {
+      name = "0002-lomiri-Adjust-to-newer-lomiri-api.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/26cbfa458766df406ed7d2c351ec84522371b083.patch";
+      hash = "sha256-1mPDtitMpktuvLs3Zn+6pCaMGTwGvIglGBdrm4Y8QwA=";
+    })
+
     ./9901-lomiri-Disable-Wizard.patch
     (replaceVars ./9902-Layout-fallback-file.patch {
       nixosLayoutFile = "/etc/" + finalAttrs.finalPackage.passthru.etcLayoutsFile;

--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -20,18 +20,26 @@
   withDocumentation ? true,
 }:
 
+# Juuuuust in case this ever changes
+assert lib.asserts.assertMsg (lib.strings.hasPrefix "lib/" qtbase.qtQmlPrefix)
+  "Assumption that qtbase.qtQmlPrefix (${qtbase.qtQmlPrefix} starts with 'lib/' no longer holds, SHELL_PLUGINDIR_SUFFIX in lomiri-api needs to be adjusted!";
+
 let
   withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+
+  # TODO This is likely not supposed to be the regular Qt QML import prefix
+  # but otherwise i.e. lomiri-notifications cannot be found in lomiri
+  shellPlugindirSuffix = lib.strings.removePrefix "lib/" qtbase.qtQmlPrefix;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-api";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-api";
     tag = finalAttrs.version;
-    hash = "sha256-2CVSKPZXZ74KUU5xVYSVIZLSPSyIudUcKR0CSfSpJyw=";
+    hash = "sha256-5w1cXKi8RZL2tbYMnqVFnlCK4BxcpCBg4jRwI7jB6AQ=";
   };
 
   outputs = [
@@ -44,15 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs $(find test -name '*.py')
-
-    substituteInPlace data/liblomiri-api.pc.in \
-      --replace-fail "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" '@CMAKE_INSTALL_FULL_LIBDIR@'
-
-    # Variable is queried via pkg-config by reverse dependencies
-    # TODO This is likely not supposed to be the regular Qt QML import prefix
-    # but otherwise i.e. lomiri-notifications cannot be found in lomiri
+  ''
+  # Variable is queried via pkg-config by reverse dependencies
+  # Qt6 one is already correct as-is
+  + ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail 'SHELL_PLUGINDIR ''${CMAKE_INSTALL_LIBDIR}/lomiri/qml' 'SHELL_PLUGINDIR ${qtbase.qtQmlPrefix}'
+      --replace-fail 'SHELL_PLUGINDIR_SUFFIX lomiri/qml' 'SHELL_PLUGINDIR_SUFFIX ${shellPlugindirSuffix}' \
+      --replace-fail 'string(APPEND SHELL_PLUGINDIR_SUFFIX "6")' '# string(APPEND SHELL_PLUGINDIR_SUFFIX "6")'
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lomiri/qml/lomiri-notifications/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-notifications/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   cmake,
   dbus,
@@ -23,13 +24,28 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-rGs+MTt/Z+Gk3jSxU7tfNAUdypG/HJ4pDqvC+U722Eg=";
   };
 
+  patches = [
+    # Remove when version > 1.3.2
+    (fetchpatch {
+      name = "0001-lomiri-notifications-support-qt6-and-newer-lomiri-api.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-notifications/-/commit/55e9b61d2214edb31613d67fa66284acfa171dc5.patch";
+      excludes = [
+        "debian/*"
+      ];
+      hash = "sha256-BURficKpFd15RyNFWyZ+hqxFHnIbv4krFpTARQ86Ykw=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
-
-    # Need to replace prefix to not try to install into lomiri-api prefix
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt\''${QT_VERSION_MAJOR}/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+  ''
+  # Need to replace prefix to not try to install into lomiri-api prefix
+  + ''
     substituteInPlace src/CMakeLists.txt \
-      --replace-fail '--variable=plugindir' '--define-variable=prefix=''${CMAKE_INSTALL_PREFIX} --variable=plugindir'
+      --replace-fail \
+        '--variable=plugindir lomiri-shell-api' \
+        '--define-variable=libdir=''${CMAKE_INSTALL_LIBDIR} --variable=plugindir lomiri-shell-api'
   ''
   + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
     substituteInPlace CMakeLists.txt \


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-api/-/blob/0.3.2/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
