### PR TITLE
neovim-unwrapped: keep test-only lua modules out of runtime closure

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -64,26 +64,29 @@ stdenv.mkDerivation (
         }))
       else
         luapkgs.lpeg;
-    requiredLuaPkgs =
+    runtimeLuaPkgs = ps: [
+      (nvim-lpeg-dylib ps)
+      ps.luabitop
+      ps.mpack
+    ];
+    checkLuaPkgs =
       ps:
-      (
-        with ps;
-        [
-          (nvim-lpeg-dylib ps)
-          luabitop
-          mpack
-        ]
-        ++ lib.optionals finalAttrs.finalPackage.doCheck [
-          luv
-          coxpcall
-          busted
-          luafilesystem
-          penlight
-          inspect
-        ]
-      );
-    neovimLuaEnv = lua.withPackages requiredLuaPkgs;
-    neovimLuaEnvOnBuild = lua.luaOnBuild.withPackages requiredLuaPkgs;
+      runtimeLuaPkgs ps
+      ++ (with ps; [
+        luv
+        coxpcall
+        busted
+        luafilesystem
+        penlight
+        inspect
+      ]);
+    # neovimLuaEnv ends up in buildInputs and its lib path is baked into the
+    # nvim binary, so it must only contain runtime modules; otherwise
+    # busted -> luarocks -> cmake leak into the runtime closure.
+    neovimLuaEnv = lua.withPackages runtimeLuaPkgs;
+    neovimLuaEnvOnBuild = lua.luaOnBuild.withPackages (
+      if finalAttrs.finalPackage.doCheck then checkLuaPkgs else runtimeLuaPkgs
+    );
     codegenLua =
       if lua.luaOnBuild.pkgs.isLuaJIT then
         let
@@ -207,7 +210,15 @@ stdenv.mkDerivation (
         -e "s|\$<TARGET_FILE:nvim|\${stdenv.hostPlatform.emulator buildPackages} &|g"
     '';
     # check that the above patching actually works
-    disallowedRequisites = [ stdenv.cc ] ++ lib.optional (lua != codegenLua) codegenLua;
+    disallowedRequisites = [
+      stdenv.cc
+    ]
+    ++ lib.optional (lua != codegenLua) codegenLua
+    # Ensure test-only lua modules (busted, ...) don't leak into the
+    # runtime closure via LUA_PRG. When doCheck is off (and we're not
+    # cross-compiling) the two envs are the same derivation, hence the
+    # guard.
+    ++ lib.optional (neovimLuaEnvOnBuild != neovimLuaEnv) neovimLuaEnvOnBuild;
 
     cmakeFlags = [
       # Don't use downloaded dependencies. At the end of the configurePhase one


### PR DESCRIPTION
Since #509368 flipped `doCheck` to `true`, `busted`/`coxpcall`/`penlight`/etc. are added to `neovimLuaEnv`, which sits in `buildInputs` and has its lib path baked into `bin/nvim`. `busted`'s wrapper references `luarocks_bootstrap`, whose own wrapper carries `cmake`/`zip`/`unzip` on `PATH`, so cmake ends up in neovim's runtime closure:

```
$ nix why-depends --precise nixpkgs#neovim-unwrapped nixpkgs#cmake
neovim-unwrapped-0.12.1
└───bin/nvim → luajit-2.1.1741730670-env
    └───bin/.busted-wrapped → luajit2.1-busted-2.3.0-1
        └───bin/.busted-wrapped: LUAROCKS_SYSCONFDIR='…/luarocks_bootstrap-3.13.0/etc/luarocks'
            └───bin/luarocks: PATH … cmake-4.1.2/bin
```

Split the lua package set: `neovimLuaEnv` (runtime, in `buildInputs`) gets only `lpeg`/`luabitop`/`mpack`; the check-only modules go into `neovimLuaEnvOnBuild` (`LUA_PRG`, build-time only). Add the build env to `disallowedRequisites` so this can't regress.

```
$ nix path-info -Sh ./result-{before,after}
/nix/store/0k0l4wp0b96zi5krv3lkin4hi3z4656r-neovim-unwrapped-0.12.1   192.1M
/nix/store/5vyg13lpb4kvwspsaiq98cskdyh1nrwj-neovim-unwrapped-0.12.1    94.0M
```

`make functionaltest__treesitter` still passes.

cc @teto

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
