### PR TITLE
okapi-ed: add nadir-ishiguro to maintainers

### DIFF
--- a/pkgs/by-name/ok/okapi-ed/package.nix
+++ b/pkgs/by-name/ok/okapi-ed/package.nix
@@ -5,6 +5,7 @@
   ripgrep,
   rustPlatform,
   versionCheckHook,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
@@ -31,9 +32,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Find lines across files by regex and edit them all at once with your $EDITOR";
     homepage = "https://github.com/nk9/okapi";
+    changelog = "https://github.com/nk9/okapi/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     mainProgram = "okapi";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ok/okapi-ed/package.nix
+++ b/pkgs/by-name/ok/okapi-ed/package.nix
@@ -37,6 +37,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "okapi";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ toelke ];
+    maintainers = with lib.maintainers; [
+      toelke
+      nadir-ishiguro
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Was just about to open a PR to add okapi-ed when I found out it was already merged. Thank you, @toelke!

I'd like to add myself to the maintainers and have added the usual nix-update-script passthrough. As far as I understand it, it's not always necessary, but as okapi-ed isn't on repology, [it might be in this case](https://github.com/NixOS/nixpkgs/pull/502056)?

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
