### PR TITLE
maintainers: drop spalf

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25744,12 +25744,6 @@
     githubId = 44814450;
     name = "spaghetti-stack";
   };
-  spalf = {
-    email = "tom@tombarrett.xyz";
-    name = "tom barrett";
-    github = "70m6";
-    githubId = 105207964;
-  };
   spease = {
     email = "peasteven@gmail.com";
     github = "spease";

--- a/pkgs/by-name/lo/localproxy/package.nix
+++ b/pkgs/by-name/lo/localproxy/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "AWS IoT Secure Tunneling Local Proxy Reference Implementation C++";
     homepage = "https://github.com/aws-samples/aws-iot-securetunneling-localproxy";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ spalf ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "localproxy";
   };

--- a/pkgs/by-name/mq/mqtt_cpp/package.nix
+++ b/pkgs/by-name/mq/mqtt_cpp/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "MQTT client/server for C++14 based on Boost.Asio";
     homepage = "https://github.com/redboltz/mqtt_cpp";
     license = lib.licenses.boost;
-    maintainers = with lib.maintainers; [ spalf ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/nu/numcpp/package.nix
+++ b/pkgs/by-name/nu/numcpp/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Templatized Header Only C++ Implementation of the Python NumPy Library";
     homepage = "https://github.com/dpilger26/NumCpp";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ spalf ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3A70m6) since May 2025 despite 9 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-06-01+user-review-requested%3A70m6). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@70m6 if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
