### PR TITLE
stash: 0.29.1 -> 0.31.1

### DIFF
--- a/pkgs/by-name/st/stash/package.nix
+++ b/pkgs/by-name/st/stash/package.nix
@@ -1,15 +1,15 @@
 {
   buildGoModule,
   fetchFromGitHub,
-  fetchYarnDeps,
+  fetchPnpmDeps,
+  pnpm_10,
+  pnpmConfigHook,
   lib,
   nixosTests,
   nodejs,
   stash,
   stdenv,
   testers,
-  yarnBuildHook,
-  yarnConfigHook,
 }:
 let
   inherit (lib.importJSON ./version.json)
@@ -17,10 +17,11 @@ let
     srcHash
     vendorHash
     version
-    yarnHash
+    pnpmHash
     ;
 
   pname = "stash";
+  pnpm = pnpm_10;
 in
 buildGoModule (
   finalAttrs:
@@ -30,14 +31,21 @@ buildGoModule (
       inherit (finalAttrs) version gitHash;
       src = "${finalAttrs.src}/ui/v2.5";
 
-      yarnOfflineCache = fetchYarnDeps {
-        yarnLock = "${final.src}/yarn.lock";
-        hash = finalAttrs.yarnHash;
+      pnpmDeps = fetchPnpmDeps {
+        inherit (finalAttrs)
+          pname
+          version
+          src
+          pnpmHash
+          ;
+        sourceRoot = "${finalAttrs.src.name}/ui/v2.5";
+        hash = "${finalAttrs.pnpmHash}";
+        fetcherVersion = 1;
       };
 
       nativeBuildInputs = [
-        yarnConfigHook
-        yarnBuildHook
+        pnpmConfigHook
+        pnpm
         # Needed for executing package.json scripts
         nodejs
       ];
@@ -56,8 +64,8 @@ buildGoModule (
         export VITE_APP_STASH_VERSION=v${finalAttrs.version}
         export VITE_APP_NOLEGACY=true
 
-        yarn --offline run gqlgen
-        yarn --offline build
+        npm run gqlgen
+        npm run build
 
         mv build $out
 
@@ -73,7 +81,7 @@ buildGoModule (
       pname
       version
       gitHash
-      yarnHash
+      pnpmHash
       vendorHash
       ;
 

--- a/pkgs/by-name/st/stash/update.py
+++ b/pkgs/by-name/st/stash/update.py
@@ -1,8 +1,7 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p python3 prefetch-yarn-deps nix-prefetch-git nix-prefetch
+#! nix-shell -i python3 -p python3 nix-prefetch-git nix-prefetch
 
 from pathlib import Path
-from shutil import copyfile
 from urllib.request import Request, urlopen
 import json
 import os
@@ -34,12 +33,29 @@ def prefetch_github(rev: str):
 
     return json.loads(proc)
 
-def prefetch_yarn(lock_file: str):
-    print(f"Prefetching yarn deps")
+def prefetch_pnpm():
+    print("Prefetching pnpm deps")
 
-    hash = run_external(["prefetch-yarn-deps", lock_file])
+    nixpkgs_path = Path(__file__).parent / "../../../../"
+    output = subprocess.run(["nix-build", "-A", "stash"], text=True, cwd=nixpkgs_path, capture_output=True)
 
-    return run_external(["nix", "hash", "convert", "--hash-algo", "sha256", hash])
+    # The line is of the form "    got:    sha256-xxx"
+    lines = [i.strip() for i in output.stderr.splitlines()]
+    new_hash_lines = [i.strip("got:").strip() for i in lines if i.startswith("got:")]
+
+    if len(new_hash_lines) == 0:
+        if output.returncode != 0:
+            print("Error while fetching new hash with nix build")
+            print(output.stderr)
+        print("No hash change is needed")
+        return None
+
+    if len(new_hash_lines) > 1:
+        print(new_hash_lines)
+        raise Exception("Got an unexpected number of new hash lines:")
+
+    return new_hash_lines[0]
+
 
 def prefetch_go_modules(src: str, version: str):
     print(f"Prefetching go modules")
@@ -59,6 +75,9 @@ def prefetch_go_modules(src: str, version: str):
         expr
     ])
 
+def get_version_json():
+    with open(Path(__file__).parent / "version.json", 'r') as f:
+        return json.load(f)
 
 def save_version_json(version: dict[str, str]):
     print("Writing version.json")
@@ -67,16 +86,16 @@ def save_version_json(version: dict[str, str]):
         f.write("\n")
 
 if __name__ == "__main__":
+    version = get_version_json()
+
     release = get_latest_release_tag()
 
-    src = prefetch_github(release['name'])
+    src = prefetch_github(release["name"])
 
-    yarn_hash = prefetch_yarn(f"{src['path']}/ui/v2.5/yarn.lock")
+    version["version"] = release["name"][1:]
+    version["gitHash"] = release["commit"]["sha"][:8]
+    version["srcHash"] = src["hash"]
+    version["vendorHash"] = prefetch_go_modules(src["path"], release["name"][1:])
+    version["pnpmHash"] = prefetch_pnpm() or version["pnpmHash"] # If hash is unchanged, fall back to existing hash
 
-    save_version_json({
-        "version": release["name"][1:],
-        "gitHash": release["commit"]["sha"][:8],
-        "srcHash": src["hash"],
-        "yarnHash": yarn_hash,
-        "vendorHash": prefetch_go_modules(src["path"], release["name"][1:])
-    })
+    save_version_json(version)

--- a/pkgs/by-name/st/stash/version.json
+++ b/pkgs/by-name/st/stash/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.29.1",
-  "gitHash": "869cbd49",
-  "srcHash": "sha256-OM2tpa8m4QuUs/HABRt8t/WHNeHWtrbJPZvlKBHcj9Y=",
-  "yarnHash": "sha256-E5JJZa+P83CnNDyhfrMwjC0xoXIV2DfyslQTLard4uE=",
-  "vendorHash": "sha256-1YVtA+kE7QHW/ACr9GPh7P0yQHdmF2NdrQR06ke2idY="
+  "version": "0.31.1",
+  "gitHash": "4de2351e",
+  "srcHash": "sha256-YGWf2aJaVn2kdICkFhvaoPq0OW+jHF8IgLLf8/duqIo=",
+  "pnpmHash": "sha256-XWkpDC74JG9rl3Cc3Jlm4dQO2wb1/mE2c1EakdoQo1Y=",
+  "vendorHash": "sha256-fqnbOB3ZbU2i8op/wfyt7lEpEOEAtTdgiHbDfbd6qtQ="
 }


### PR DESCRIPTION
Release notes: https://discourse.stashapp.cc/t/release-v0-31-1-stashapp-stash/6753

The project switched package manager to pnpm for the frontend component in November 2025. Since then, the nix-community bot has been unable to update stash because the nixpkgs script is still trying to use yarn.

https://github.com/stashapp/stash/pull/6186


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
