### PR TITLE
python3Packages.inkex: Apply patch to fix binary DXF parsing on big-endian

### DIFF
--- a/pkgs/development/python-modules/inkex/1001-dxf-fix-binary-dxf-double-parsing-on-big-endian.patch
+++ b/pkgs/development/python-modules/inkex/1001-dxf-fix-binary-dxf-double-parsing-on-big-endian.patch
@@ -1,0 +1,30 @@
+From 7e103db5e99a82751361d4e9fa926200315bd9d3 Mon Sep 17 00:00:00 2001
+From: Amaan Qureshi <git@amaanq.com>
+Date: Fri, 20 Mar 2026 21:56:15 -0400
+Subject: [PATCH] dxf: fix binary DXF double parsing on big-endian
+
+struct.unpack("d") uses native byte order, but the DXF binary format
+is always little-endian. All other fields in the parser already use '<'
+for little-endian. Without this fix, double-precision coordinates are
+byte-swapped on big-endian hosts, producing garbage values that cascade
+into empty SVG transforms and ValueErrors.
+---
+ dxf_input.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/share/extensions/dxf_input.py b/share/extensions/dxf_input.py
+index 3f5ce96d..17f62034 100644
+--- a/share/extensions/dxf_input.py
++++ b/share/extensions/dxf_input.py
+@@ -1336,7 +1336,7 @@ class DxfInput(inkex.InputExtension):
+                     or 460 <= key <= 469
+                     or 1010 <= key <= 1059
+                 ):
+-                    value = struct.unpack("d", stream.read(8))[0]
++                    value = struct.unpack("<d", stream.read(8))[0]
+                 elif (
+                     60 <= key <= 79
+                     or 170 <= key <= 179
+-- 
+GitLab
+

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -35,6 +35,10 @@ buildPythonPackage {
       stripLen = 1;
       extraPrefix = "share/extensions/";
     })
+
+    # Fix binary DXF parsing on big-endian
+    # https://gitlab.com/inkscape/extensions/-/merge_requests/721
+    ./1001-dxf-fix-binary-dxf-double-parsing-on-big-endian.patch
   ];
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
Applies https://gitlab.com/inkscape/extensions/-/merge_requests/721 from @amaanq to fix the binary DXF tests (and binary DXF parsing in general) on big-endian platforms.

Closes #496213

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
