### PR TITLE
apple-sdk: 26.0 -> 26.4

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -17,10 +17,10 @@
   },
   "26": {
     "urls": [
-      "https://swcdn.apple.com/content/downloads/27/62/093-35114-A_AAH24ZZQB5/yn87ru9qe9225m8hwq2ic3hjy5yc5vw7h9/CLTools_macOSNMOS_SDK.pkg",
-      "https://web.archive.org/web/20250915230423/https://swcdn.apple.com/content/downloads/27/62/093-35114-A_AAH24ZZQB5/yn87ru9qe9225m8hwq2ic3hjy5yc5vw7h9/CLTools_macOSNMOS_SDK.pkg"
+      "https://swcdn.apple.com/content/downloads/32/53/047-96692-A_OAHIHT53YB/ybtshxmrcju8m2qvw3w5elr4rajtg1x3y3/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20260406133131/https://swcdn.apple.com/content/downloads/32/53/047-96692-A_OAHIHT53YB/ybtshxmrcju8m2qvw3w5elr4rajtg1x3y3/CLTools_macOSNMOS_SDK.pkg"
     ],
-    "version": "26.0",
-    "hash": "sha256-54UtisDXHCxs7vO4fZSWOYwxLbdouLxWwGisez+tlAc="
+    "version": "26.4",
+    "hash": "sha256-7nrbCv1pNlpzEqwZWVfUPCvDfXEJJNOl7ApkeFpIOC0="
   }
 }

--- a/pkgs/os-specific/darwin/by-name/li/libcxx/package.nix
+++ b/pkgs/os-specific/darwin/by-name/li/libcxx/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "libcxx";
   # Keep this in sync with the corresponding LLVM libc++ version
   # defined as `_LIBCPP_VERSION` in `usr/include/c++/v1/__config`.
-  version = "20.1.0+apple-sdk-${apple-sdk_26.version}";
+  version = "21.1.6+apple-sdk-${apple-sdk_26.version}";
   inherit (apple-sdk_26) src;
 
   dontConfigure = true;


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode-release-notes/xcode-26_1-release-notes
https://developer.apple.com/documentation/xcode-release-notes/xcode-26_2-release-notes
https://developer.apple.com/documentation/xcode-release-notes/xcode-26_3-release-notes
https://developer.apple.com/documentation/xcode-release-notes/xcode-26_4-release-notes

The 26.4 SDK also bumps libc++ to be based on libc++ 21.

https://releases.llvm.org/21.1.0/projects/libcxx/docs/ReleaseNotes.html

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
