### PR TITLE
rubberband: fix build with libc++ 21

### DIFF
--- a/pkgs/by-name/ru/rubberband/0001-Fix-an-error-with-libcxx-21.patch
+++ b/pkgs/by-name/ru/rubberband/0001-Fix-an-error-with-libcxx-21.patch
@@ -1,0 +1,29 @@
+From 9cb3e66870ae22d87222ee7636e5b6c85c776673 Mon Sep 17 00:00:00 2001
+From: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+Date: Sun, 27 Jul 2025 15:53:17 +0200
+Subject: [PATCH] missing include cstdlib
+
+Fix an error with libcxx-21
+
+>In file included from ../rubberband-4.0.0/src/common/mathmisc.cpp:24:
+>../rubberband-4.0.0/src/common/mathmisc.h:58:1:
+>error: unknown type name 'size_t'; did you mean 'std::size_t'?
+
+Signed-off-by: Nicolas PARLANT <nicolas.parlant@parhuet.fr>
+---
+ src/common/mathmisc.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/common/mathmisc.h b/src/common/mathmisc.h
+index d8bcc14d..66f3378c 100644
+--- a/src/common/mathmisc.h
++++ b/src/common/mathmisc.h
+@@ -26,6 +26,8 @@
+ 
+ #include "sysutils.h"
+ 
++#include <cstdlib>
++
+ #ifndef M_PI
+ #define M_PI 3.14159265358979323846
+ #endif // M_PI

--- a/pkgs/by-name/ru/rubberband/package.nix
+++ b/pkgs/by-name/ru/rubberband/package.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-rwUDE+5jvBizWy4GTl3OBbJ2qvbRqiuKgs7R/i+AKOk=";
   };
 
+  patches = [
+    # Fix missing size_t definition when building with libc++ 21.
+    # Source: https://github.com/breakfastquay/rubberband/pull/126
+    ./0001-Fix-an-error-with-libcxx-21.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     meson


### PR DESCRIPTION
The patch is vendored because it hasn’t been merged upstream yet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
