### PR TITLE
graphify,tree-sitter-grammars.tree-sitter-objc: init

### DIFF
--- a/pkgs/by-name/gr/graphify/package.nix
+++ b/pkgs/by-name/gr/graphify/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  __structuredAttrs = true;
+  pname = "graphify";
+  version = "0.4.23";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "safishamsi";
+    repo = "graphify";
+    rev = "v${version}";
+    hash = "sha256-QEzB1tFBqGhpmI7oudMRC1Ia0CDcm+GYt6AgxMA5zDo=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  dependencies =
+    with python3.pkgs;
+    [
+      networkx
+      tree-sitter
+    ]
+    ++ (with python3.pkgs.tree-sitter-grammars; [
+      tree-sitter-c
+      tree-sitter-c-sharp
+      tree-sitter-cpp
+      tree-sitter-elixir
+      tree-sitter-go
+      tree-sitter-java
+      tree-sitter-javascript
+      tree-sitter-julia
+      tree-sitter-kotlin
+      tree-sitter-lua
+      tree-sitter-objc
+      tree-sitter-php
+      tree-sitter-powershell
+      tree-sitter-python
+      tree-sitter-ruby
+      tree-sitter-rust
+      tree-sitter-scala
+      tree-sitter-swift
+      tree-sitter-typescript
+      tree-sitter-verilog
+      tree-sitter-zig
+    ]);
+
+  optional-dependencies = with python3.pkgs; {
+    all = [
+      faster-whisper
+      graspologic
+      html2text
+      matplotlib
+      mcp
+      neo4j
+      openpyxl
+      pypdf
+      python-docx
+      watchdog
+      yt-dlp
+    ];
+    leiden = [
+      graspologic
+    ];
+    mcp = [
+      mcp
+    ];
+    neo4j = [
+      neo4j
+    ];
+    office = [
+      openpyxl
+      python-docx
+    ];
+    pdf = [
+      html2text
+      pypdf
+    ];
+    svg = [
+      matplotlib
+    ];
+    video = [
+      faster-whisper
+      yt-dlp
+    ];
+    watch = [
+      watchdog
+    ];
+  };
+
+  meta = {
+    description = "AI coding assistant skill. Turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph.";
+    homepage = "https://github.com/safishamsi/graphify";
+    changelog = "https://github.com/safishamsi/graphify/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stunkymonkey ];
+    mainProgram = "graphify";
+  };
+}

--- a/pkgs/by-name/gr/graphify/package.nix
+++ b/pkgs/by-name/gr/graphify/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3Packages.buildPythonApplication rec {
+  __structuredAttrs = true;
+  pname = "graphify";
+  version = "0.4.23";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "safishamsi";
+    repo = "graphify";
+    tag = "v${version}";
+    hash = "sha256-QEzB1tFBqGhpmI7oudMRC1Ia0CDcm+GYt6AgxMA5zDo=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  dependencies =
+    with python3.pkgs;
+    [
+      networkx
+      tree-sitter
+    ]
+    ++ (with python3.pkgs.tree-sitter-grammars; [
+      tree-sitter-c
+      tree-sitter-c-sharp
+      tree-sitter-cpp
+      tree-sitter-elixir
+      tree-sitter-go
+      tree-sitter-java
+      tree-sitter-javascript
+      tree-sitter-julia
+      tree-sitter-kotlin
+      tree-sitter-lua
+      tree-sitter-objc
+      tree-sitter-php
+      tree-sitter-powershell
+      tree-sitter-python
+      tree-sitter-ruby
+      tree-sitter-rust
+      tree-sitter-scala
+      tree-sitter-swift
+      tree-sitter-typescript
+      tree-sitter-verilog
+      tree-sitter-zig
+    ]);
+
+  optional-dependencies = with python3.pkgs; {
+    leiden = [
+      graspologic
+    ];
+    mcp = [
+      mcp
+    ];
+    neo4j = [
+      neo4j
+    ];
+    office = [
+      openpyxl
+      python-docx
+    ];
+    pdf = [
+      html2text
+      pypdf
+    ];
+    svg = [
+      matplotlib
+    ];
+    video = [
+      faster-whisper
+      yt-dlp
+    ];
+    watch = [
+      watchdog
+    ];
+  };
+
+  meta = {
+    description = "AI coding assistant skill. Turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph.";
+    homepage = "https://github.com/safishamsi/graphify";
+    changelog = "https://github.com/safishamsi/graphify/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stunkymonkey ];
+    mainProgram = "graphify";
+  };
+}

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -1778,6 +1778,18 @@
     };
   };
 
+  objc = {
+    version = "3.0.2";
+    url = "github:tree-sitter-grammars/tree-sitter-objc";
+    hash = "sha256-aK8Cf8F05NzlXnYS47jPjSyouaajsr1H+vRg2aXsPrs=";
+    meta = {
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        stunkymonkey
+      ];
+    };
+  };
+
   ocaml = {
     version = "0.24.2";
     url = "github:tree-sitter/tree-sitter-ocaml";

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -1762,6 +1762,15 @@
     };
   };
 
+  objc = {
+    version = "3.0.2";
+    url = "github:tree-sitter-grammars/tree-sitter-objc";
+    hash = "sha256-aK8Cf8F05NzlXnYS47jPjSyouaajsr1H+vRg2aXsPrs=";
+    meta = {
+      license = lib.licenses.mit;
+    };
+  };
+
   ocaml = {
     version = "0.24.2";
     url = "github:tree-sitter/tree-sitter-ocaml";


### PR DESCRIPTION
init:

- graphify: https://github.com/safishamsi/graphify
- tree-sitter-objc: https://github.com/tree-sitter-grammars/tree-sitter-objc

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
