### PR TITLE
nixos-test-driver: Add extra required features

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1466,6 +1466,24 @@
   "module-services-mailman-other-mtas": [
     "index.html#module-services-mailman-other-mtas"
   ],
+  "test-opt-requiredFeatures": [
+    "index.html#test-opt-requiredFeatures"
+  ],
+  "test-opt-requiredFeatures.apple-virt": [
+    "index.html#test-opt-requiredFeatures.apple-virt"
+  ],
+  "test-opt-requiredFeatures.devnet": [
+    "index.html#test-opt-requiredFeatures.devnet"
+  ],
+  "test-opt-requiredFeatures.kvm": [
+    "index.html#test-opt-requiredFeatures.kvm"
+  ],
+  "test-opt-requiredFeatures.nixos-test": [
+    "index.html#test-opt-requiredFeatures.nixos-test"
+  ],
+  "test-opt-requiredFeatures.uid-range": [
+    "index.html#test-opt-requiredFeatures.uid-range"
+  ],
   "trezor": [
     "index.html#trezor"
   ],

--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -3,6 +3,7 @@
   hostPkgs,
   lib,
   containers,
+  nodes,
   options,
   ...
 }:
@@ -28,9 +29,62 @@ let
     */
     f:
     lib.mkOverride (opt.highestPrio - 1) (f opt.value);
+
+  requiredFeaturesModuleType = {
+    freeformType = types.attrsOf types.bool;
+    options = {
+      devnet = mkOption {
+        type = types.bool;
+        default =
+          builtins.length (lib.attrNames containers) > 0 && builtins.length (lib.attrNames nodes) > 0;
+        defaultText = lib.literalMD "`true` if both VMs and containers are present.";
+        description = ''
+          This heuristic setting that assumes that the majority of tests requires VMs and containers
+          to communicate over network. To support such tests, adding "/dev/net" to `nix.settings.extra-sandbox-paths` is necessary.
+
+          Override this to `false` if the heuristic is wrong in some cases.
+        '';
+      };
+      nixos-test = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Standard requirement for NixOS integration tests";
+      };
+      uid-range = mkOption {
+        type = types.bool;
+        default = builtins.length (lib.attrNames containers) > 0;
+        defaultText = lib.literalMD "`true` if containers are present.";
+        description = "Containers use systemd-nspawn, which requires pid 0 inside of the sandbox. `uid-range` enables that.";
+      };
+      kvm = mkOption {
+        type = types.bool;
+        default = isLinux;
+        defaultText = lib.literalMD "`true` if built to run on Linux.";
+        description = "Whether Linux KVM virtualization is required when running this test. Can be disabled to allow emulated execution.";
+      };
+      apple-virt = mkOption {
+        type = types.bool;
+        default = isDarwin;
+        defaultText = lib.literalMD "`true` if built to run on Darwin.";
+        description = "Whether Apple virtualization functionality is required for running this test.";
+      };
+    };
+  };
 in
 {
   options = {
+    requiredFeatures = mkOption {
+      description = "Builder features that are required for running this test.";
+      example = lib.literalExpression ''
+        {
+          cuda = true;
+          devnet = mkForce false;
+        }
+      '';
+      type = types.submodule requiredFeaturesModuleType;
+      default = { }; # this is necessary due to a bug in the module system.
+    };
+
     passthru = mkOption {
       type = types.lazyAttrsOf types.raw;
       description = ''
@@ -98,13 +152,7 @@ in
       {
         name = "vm-test-run-${config.name}";
 
-        requiredSystemFeatures = [
-          "nixos-test"
-        ]
-        # Containers use systemd-nspawn, which requires pid 0 inside of the sandbox.
-        ++ lib.optional (builtins.length (lib.attrNames containers) > 0) "uid-range"
-        ++ lib.optional isLinux "kvm"
-        ++ lib.optional isDarwin "apple-virt";
+        requiredSystemFeatures = lib.attrNames (lib.filterAttrs (_: v: v) config.requiredFeatures);
 
         nativeBuildInputs = lib.optionals config.enableDebugHook [
           hostPkgs.openssh


### PR DESCRIPTION
This PR adds:

- a warning if you use containers + VMs and don't have a "devnet" feature in the nix builder config. this is better than just "not working" at this point if users don't add /dev/net to the sandbox.
  - this can be disabled with `requiredFeatures.requireDevNetSandbox = false;` if the heuristic is wrong in rare cases.
- Add an attribute `requiredFeatures.extraFeatures` where people can set it to `[ "cuda" ]` for example to run GPU stuff.

I will fix the nixos manual build once there is agreement on the naming of the options.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
