### PR TITLE
[Backport release-25.11] tinyproxy: 1.11.2 -> 1.11.3, tinyproxy: add patch for CVE-2026-31842

### DIFF
--- a/pkgs/by-name/ti/tinyproxy/package.nix
+++ b/pkgs/by-name/ti/tinyproxy/package.nix
@@ -10,10 +10,10 @@
 
 stdenv.mkDerivation rec {
   pname = "tinyproxy";
-  version = "1.11.2";
+  version = "1.11.3";
 
   src = fetchFromGitHub {
-    hash = "sha256-bpr/O723FmW2gb+85aJrwW5/U7R2HwbePTx15i3rpsE=";
+    hash = "sha256-In/ZG50i2jKl0x7yfSs3KHlBdm8NdXtspMJPiv4BW6g=";
     rev = version;
     repo = "tinyproxy";
     owner = "tinyproxy";

--- a/pkgs/by-name/ti/tinyproxy/package.nix
+++ b/pkgs/by-name/ti/tinyproxy/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   autoreconfHook,
   perl,
   nixosTests,
@@ -18,6 +19,15 @@ stdenv.mkDerivation rec {
     repo = "tinyproxy";
     owner = "tinyproxy";
   };
+
+  patches = [
+    # Fix case-sensitive matching of "chunked" (CVE-2026-31842)
+    (fetchpatch2 {
+      name = "fix-chunked-case-sensitivity.patch";
+      url = "https://github.com/tinyproxy/tinyproxy/commit/879bf844abffa0bf5fae6aff0c73179024dd9f98.patch";
+      hash = "sha256-Nav3nXyxdoM/tIvfyPJHEYEjAtrRrJlvkMXzsQCZan4=";
+    })
+  ];
 
   # perl is needed for man page generation.
   nativeBuildInputs = [


### PR DESCRIPTION
Backports #509511.

- **tinyproxy: 1.11.2 -> 1.11.3**
- **tinyproxy: add patch for CVE-2026-31842**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
