### PR TITLE
nixos/fw-fanctrl: avoid IFD

### DIFF
--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -9,6 +9,11 @@ let
 
   settingsFormat = pkgs.formats.json { };
   cfg = config.hardware.fw-fanctrl;
+
+  userConfig = settingsFormat.generate "user.json" cfg.settings;
+  finalConfig = pkgs.runCommand "config.json" { } ''
+    ${lib.getExe pkgs.jq} -s '.[0] * .[1]' ${cfg.package}/share/fw-fanctrl/config.json ${userConfig} >$out
+  '';
 in
 {
   imports = [
@@ -105,34 +110,28 @@ in
     };
   };
 
-  config =
-    let
-      defaultConfig = builtins.fromJSON (builtins.readFile "${cfg.package}/share/fw-fanctrl/config.json");
-      finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.settings;
-      configFile = settingsFormat.generate "custom.json" finalConfig;
-    in
-    lib.mkIf cfg.enable {
-      environment.systemPackages = [
-        cfg.package
-        cfg.ectoolPackage
-      ];
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+      cfg.ectoolPackage
+    ];
 
-      systemd.services.fw-fanctrl = {
-        description = "Framework Fan Controller";
-        after = [ "multi-user.target" ];
-        serviceConfig = {
-          Type = "simple";
-          Restart = "always";
-          ExecStart = "${lib.getExe cfg.package} --output-format JSON run --config ${configFile} --silent ${lib.optionalString cfg.disableBatteryTempCheck "--no-battery-sensors"}";
-          ExecStopPost = "${lib.getExe cfg.ectoolPackage} autofanctrl";
-        };
-        wantedBy = [ "multi-user.target" ];
+    systemd.services.fw-fanctrl = {
+      description = "Framework Fan Controller";
+      after = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        ExecStart = "${lib.getExe cfg.package} --output-format JSON run --config ${finalConfig} --silent ${lib.optionalString cfg.disableBatteryTempCheck "--no-battery-sensors"}";
+        ExecStopPost = "${lib.getExe cfg.ectoolPackage} autofanctrl";
       };
-
-      # Create suspend config
-      environment.etc."systemd/system-sleep/fw-fanctrl-suspend.sh".source =
-        "${cfg.package}/share/fw-fanctrl/fw-fanctrl-suspend";
+      wantedBy = [ "multi-user.target" ];
     };
+
+    # Create suspend config
+    environment.etc."systemd/system-sleep/fw-fanctrl-suspend.sh".source =
+      "${cfg.package}/share/fw-fanctrl/fw-fanctrl-suspend";
+  };
 
   meta = {
     maintainers = [ lib.maintainers.Svenum ];

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -7,10 +7,17 @@
 let
   inherit (lib) types mkOption;
 
-  configFormat = pkgs.formats.json { };
+  settingsFormat = pkgs.formats.json { };
   cfg = config.hardware.fw-fanctrl;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "hardware" "fw-fanctrl" "config" ]
+      [ "hardware" "fw-fanctrl" "settings" ]
+    )
+  ];
+
   options.hardware.fw-fanctrl = {
     enable = lib.mkEnableOption "the fw-fanctrl systemd service and install the needed packages";
 
@@ -26,13 +33,13 @@ in
       '';
     };
 
-    config = mkOption {
+    settings = mkOption {
       default = { };
       description = ''
         Additional config entries for the fw-fanctrl service (documentation: <https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md>)
       '';
       type = types.submodule {
-        freeformType = types.attrsOf configFormat.type;
+        freeformType = types.attrsOf settingsFormat.type;
         options = {
           defaultStrategy = mkOption {
             type = types.str;
@@ -53,6 +60,7 @@ in
             '';
             type = types.attrsOf (
               types.submodule {
+                freeformType = types.attrsOf settingsFormat.type;
                 options = {
                   fanSpeedUpdateFrequency = mkOption {
                     type = types.ints.unsigned;
@@ -71,6 +79,7 @@ in
                     description = "How should the speed curve look like";
                     type = types.listOf (
                       types.submodule {
+                        freeformType = types.attrsOf settingsFormat.type;
                         options = {
                           temp = mkOption {
                             type = types.int;
@@ -99,8 +108,8 @@ in
   config =
     let
       defaultConfig = builtins.fromJSON (builtins.readFile "${cfg.package}/share/fw-fanctrl/config.json");
-      finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.config;
-      configFile = configFormat.generate "custom.json" finalConfig;
+      finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.settings;
+      configFile = settingsFormat.generate "custom.json" finalConfig;
     in
     lib.mkIf cfg.enable {
       environment.systemPackages = [

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -5,6 +5,8 @@
   ...
 }:
 let
+  inherit (lib) types mkOption;
+
   configFormat = pkgs.formats.json { };
   cfg = config.hardware.fw-fanctrl;
 in
@@ -16,72 +18,71 @@ in
 
     ectoolPackage = lib.mkPackageOption pkgs "fw-ectool" { };
 
-    disableBatteryTempCheck = lib.mkOption {
-      type = lib.types.bool;
+    disableBatteryTempCheck = mkOption {
+      type = types.bool;
       default = false;
       description = ''
         Disable checking battery temperature sensor
       '';
     };
 
-    config = lib.mkOption {
+    config = mkOption {
       default = { };
       description = ''
         Additional config entries for the fw-fanctrl service (documentation: <https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md>)
       '';
-      type = lib.types.submodule {
-        freeformType = lib.types.attrsOf configFormat.type;
+      type = types.submodule {
+        freeformType = types.attrsOf configFormat.type;
         options = {
-          defaultStrategy = lib.mkOption {
-            type = lib.types.str;
+          defaultStrategy = mkOption {
+            type = types.str;
             default = "lazy";
             description = "Default strategy to use";
           };
 
-          strategyOnDischarging = lib.mkOption {
-            type = lib.types.str;
+          strategyOnDischarging = mkOption {
+            type = types.str;
             default = "";
             description = "Default strategy on discharging";
           };
 
-          strategies = lib.mkOption {
+          strategies = mkOption {
             default = { };
             description = ''
               Additional strategies which can be used by fw-fanctrl
             '';
-            type = lib.types.attrsOf (
-              lib.types.submodule {
+            type = types.attrsOf (
+              types.submodule {
                 options = {
-                  fanSpeedUpdateFrequency = lib.mkOption {
-                    type = lib.types.ints.unsigned;
+                  fanSpeedUpdateFrequency = mkOption {
+                    type = types.ints.unsigned;
                     default = 5;
                     description = "How often the fan speed should be updated in seconds";
                   };
 
-                  movingAverageInterval = lib.mkOption {
-                    type = lib.types.ints.unsigned;
+                  movingAverageInterval = mkOption {
+                    type = types.ints.unsigned;
                     default = 25;
                     description = "Interval (seconds) of the last temperatures to use to calculate the average temperature";
                   };
 
-                  speedCurve = lib.mkOption {
+                  speedCurve = mkOption {
                     default = [ ];
                     description = "How should the speed curve look like";
-                    type = lib.types.listOf (
-                      lib.types.submodule {
+                    type = types.listOf (
+                      types.submodule {
                         options = {
-                          temp = lib.mkOption {
-                            type = lib.types.int;
+                          temp = mkOption {
+                            type = types.int;
                             default = 0;
                             description = "Temperature in °C at which the fan speed should be changed";
                           };
 
-                          speed = lib.mkOption {
-                            type = lib.types.ints.between 0 100;
+                          speed = mkOption {
+                            type = types.ints.between 0 100;
                             default = 0;
                             description = "Percent how fast the fan should run at";
                           };
-
                         };
                       }
                     );


### PR DESCRIPTION
The current module does IFD by reading from the default config file at eval time. The previous implementation using `runCommand` was fine.

You can test that there is no IFD by e.g. forcing a rebuild of `cfg.package`
```nix
{ pkgs, ... }:
{
  hardware.fw-fanctrl.package = pkgs.fw-fanctrl.overrideAttrs {
    env.FOO = "BAR";
  };
}
```
and then rebuilding your NixOS configuration, e.g.
```sh
nixos-rebuild build --option allow-import-from-derivation false
```

I also renamed `hardware.fw-fanctrl.{config -> settings}` per RFC42 but this change is not crucial.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
