### PR TITLE
lufus: init at 1.0.0b1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25221,6 +25221,11 @@
     github = "Simarra";
     githubId = 14372987;
   };
+  Simon-Weij = {
+    name = "Simon";
+    github = "Simon-Weij";
+    githubId = 175155691;
+  };
   simonchatts = {
     email = "code@chatts.net";
     github = "simonchatts";

--- a/pkgs/by-name/lu/lufus/package.nix
+++ b/pkgs/by-name/lu/lufus/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  python313Packages,
+  fetchFromGitHub,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+python313Packages.buildPythonApplication (finalAttrs: {
+  pname = "lufus";
+  version = "1.0.0b1.1";
+
+  src = fetchFromGitHub {
+    owner = "Hog185";
+    repo = "Lufus";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-3i0CnhGvLTXutz8CQoH5q4PwZ23lAwnUo8H5TRJx+KE=";
+  };
+
+  propagatedBuildInputs = with python313Packages; [
+    psutil
+    pyqt6
+    pyudev
+    requests
+    platformdirs
+  ];
+
+  pyproject = true;
+
+  build-system = with python313Packages; [
+    setuptools
+    wheel
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  __structuredAttrs = true;
+
+  postInstall = ''
+    makeWrapper ${python313Packages.python.interpreter} $out/bin/lufus \
+      --add-flags "-m lufus" \
+      --prefix PYTHONPATH : "$out/${python313Packages.python.sitePackages}:${python313Packages.makePythonPath finalAttrs.propagatedBuildInputs}"
+
+    install -Dm644 src/lufus/gui/assets/lufus.png $out/share/pixmaps/lufus.png
+
+    copyDesktopItems
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "lufus";
+      desktopName = "Lufus";
+      comment = "A rufus clone written in py and designed to work with linux";
+      exec = "lufus";
+      icon = "lufus";
+      categories = [
+        "Utility"
+        "System"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "A rufus clone written in py and designed to work with linux";
+    homepage = "https://github.com/Hog185/Lufus";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Simon-Weij ];
+    platforms = lib.platforms.linux;
+    mainProgram = "lufus";
+  };
+})


### PR DESCRIPTION
Added the Lufus package, a media-flasher similar to Rufus

https://github.com/Hog185/Lufus


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
