### PR TITLE
[Backport release-25.11] static-web-server: 2.39.0 -> 2.42.0, handle files from nix store epoch+1

### DIFF
--- a/pkgs/by-name/st/static-web-server/include-unix-time-plus-one.diff
+++ b/pkgs/by-name/st/static-web-server/include-unix-time-plus-one.diff
@@ -1,0 +1,13 @@
+diff --git a/src/response.rs b/src/response.rs
+index 25da3d3..92d6203 100644
+--- a/src/response.rs
++++ b/src/response.rs
+@@ -42,7 +42,7 @@ pub(crate) fn response_body(
+     let modified = meta
+         .modified()
+         .ok()
+-        .filter(|&t| t != std::time::UNIX_EPOCH)
++        .filter(|&t| t > (std::time::UNIX_EPOCH + std::time::Duration::from_secs(1)))
+         .map(LastModified::from);
+ 
+     match conditionals.check(modified) {

--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -18,9 +18,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-rNrGlgUvPezX7RnKhprRjl9DiJ/Crt4phmxnfY9tNXA=";
 
-  # Some tests rely on timestamps newer than 18 Nov 1974 00:00:00
-  preCheck = ''
-    find docker/public -exec touch -m {} \;
+  # static-web-server already has special handling for files with modification
+  # time = unix epoch, but the nix store is unix epoch + 1 second.
+  patches = [ ./include-unix-time-plus-one.diff ];
+
+  # Some tests which implicitly relied on the above behavior now break.  Force
+  # an mtime update to fix.
+  postUnpack = ''
+    find . -exec touch -m {} +
   '';
 
   # Need to copy in the systemd units for systemd.packages to discover them

--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       misilelab
+      progrm_jarvis
     ];
     mainProgram = "static-web-server";
   };

--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -3,29 +3,31 @@
   rustPlatform,
   fetchFromGitHub,
   nixosTests,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "static-web-server";
-  version = "2.39.0";
+  version = "2.42.0";
 
   src = fetchFromGitHub {
     owner = "static-web-server";
     repo = "static-web-server";
-    rev = "v${version}";
-    hash = "sha256-iprQlSHO+ac7v1odVoS/9IU+Zov8/xh1l9pm1PJE8fs=";
+    tag = "v${version}";
+    hash = "sha256-EWCkad2v937GPL7qeHxPp24wf3EWk+M5iQkZBhErv/Y=";
   };
 
-  cargoHash = "sha256-rNrGlgUvPezX7RnKhprRjl9DiJ/Crt4phmxnfY9tNXA=";
+  cargoHash = "sha256-RYTG54c4Q4uP4lAZpjfulP/BV4jDp5xxsa6vtSn+vOs=";
 
   # static-web-server already has special handling for files with modification
-  # time = unix epoch, but the nix store is unix epoch + 1 second.
+  # time = Unix epoch, but the nix store is Unix epoch + 1 second.
   patches = [ ./include-unix-time-plus-one.diff ];
 
-  # Some tests which implicitly relied on the above behavior now break.  Force
-  # an mtime update to fix.
+  # Some tests which implicitly relied on the above behavior now break.
+  # Force an mtime update to everything except symbolic inks to fix.
   postUnpack = ''
-    find . -exec touch -m {} +
+    find . -not -type l -exec touch -m {} +
   '';
 
   # Need to copy in the systemd units for systemd.packages to discover them
@@ -33,12 +35,18 @@ rustPlatform.buildRustPackage rec {
     install -Dm444 -t $out/lib/systemd/system/ systemd/static-web-server.{service,socket}
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) static-web-server;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) static-web-server;
+    };
   };
 
   meta = {
-    description = "Asynchronous web server for static files-serving";
+    description = "A cross-platform, high-performance and asynchronous web server for static files-serving";
     homepage = "https://static-web-server.net/";
     changelog = "https://github.com/static-web-server/static-web-server/blob/v${version}/CHANGELOG.md";
     license = with lib.licenses; [


### PR DESCRIPTION
Manual backport of #498890 and #505266.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
