### PR TITLE
[Backport release-25.11] tigervnc: 1.15.0 -> 1.16.2

### DIFF
--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -27,14 +27,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.15.0";
+  version = "1.16.0";
   pname = "tigervnc";
 
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZuuvRJe/lAqULWObPxGHVJrDPCTK4IVSqX0K1rWOctw=";
+    hash = "sha256-aIQcFX4GQ0VniacjYherpUSgzM55Han9oMvbjMUYgfE=";
   };
 
   postPatch =

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -33,14 +33,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.16.1";
+  version = "1.16.2";
   pname = "tigervnc";
 
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mK9WjnAyEqikykCa6AzB6aB+QTZtxyCBmZV+rNbLxYM=";
+    hash = "sha256-yyJCtv48gKftyYND0v18qvh4gimxJt22vxiZBSNZ07U=";
   };
 
   postPatch =

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -33,14 +33,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.16.0";
+  version = "1.16.1";
   pname = "tigervnc";
 
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aIQcFX4GQ0VniacjYherpUSgzM55Han9oMvbjMUYgfE=";
+    hash = "sha256-mK9WjnAyEqikykCa6AzB6aB+QTZtxyCBmZV+rNbLxYM=";
   };
 
   postPatch =

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -24,6 +24,12 @@
   ffmpeg,
   autoconf,
   automake,
+  libuuid,
+  libxkbcommon,
+  pipewire,
+  wayland,
+  wayland-scanner,
+  waylandSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver/vncserver.in
       fontPath=
       substituteInPlace vncviewer/vncviewer.cxx \
-         --replace '"/usr/bin/ssh' '"${openssh}/bin/ssh'
+         --replace-fail '"/usr/bin/ssh' '"${openssh}/bin/ssh'
       source_top="$(pwd)"
     ''
     + ''
@@ -54,9 +60,12 @@ stdenv.mkDerivation (finalAttrs: {
   dontUseCmakeBuildDir = true;
 
   cmakeFlags = [
-    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
-    "-DCMAKE_INSTALL_SBINDIR=${placeholder "out"}/bin"
-    "-DCMAKE_INSTALL_LIBEXECDIR=${placeholder "out"}/bin"
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" (placeholder "out"))
+    (lib.cmakeFeature "CMAKE_INSTALL_SBINDIR" "${placeholder "out"}/bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBEXECDIR" "${placeholder "out"}/bin")
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.cmakeBool "ENABLE_WAYLAND" waylandSupport)
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [
@@ -157,6 +166,12 @@ stdenv.mkDerivation (finalAttrs: {
       libXdamage
     ]
     ++ xorg.xorgserver.buildInputs
+    ++ lib.optionals waylandSupport [
+      libuuid
+      libxkbcommon
+      pipewire
+      wayland
+    ]
   );
 
   nativeBuildInputs = [
@@ -175,6 +190,9 @@ stdenv.mkDerivation (finalAttrs: {
       zlib
     ]
     ++ xorg.xorgserver.nativeBuildInputs
+    ++ lib.optionals waylandSupport [
+      wayland-scanner
+    ]
   );
 
   propagatedBuildInputs = lib.optional stdenv.hostPlatform.isLinux xorg.xorgserver.propagatedBuildInputs;


### PR DESCRIPTION
Backports:
- #485823
- #503205
- #504811

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
