### PR TITLE
[Backport release-25.11] python3Packages.m2crypto: 0.45.1 -> 0.48.0

### DIFF
--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchPypi,
-  fetchurl,
+  fetchFromGitLab,
   openssl,
   pytestCheckHook,
   pythonOlder,
@@ -18,9 +17,12 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
+  src = fetchFromGitLab {
     inherit pname version;
-    hash = "sha256-0PyBqIKO2/QwhDKzBAvwa7JrrZWruefUaQthGFUeduw=";
+    owner = "m2crypto";
+    repo = "m2crypto";
+    tag = version;
+    hash = "sha256-jg7XcYE7oTOkePDJPXyM/X+vE8F2pIvJbwrVj6KJ3eM=";
   };
 
   build-system = [ setuptools ];
@@ -44,6 +46,14 @@ buildPythonPackage rec {
     pytestCheckHook
     openssl
   ];
+
+  disabledTests = [
+    # Connection refused
+    "test_makefile_err"
+  ];
+
+  # Tests require localhost access
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "M2Crypto" ];
 

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "m2crypto";
-  version = "0.46.2";
+  version = "0.47.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -22,8 +22,17 @@ buildPythonPackage rec {
     owner = "m2crypto";
     repo = "m2crypto";
     tag = version;
-    hash = "sha256-XV9aILSWfQ/xKDySflG3wiNRP4YVPVujuhIz2VdPuBc=";
+    hash = "sha256-yOpejD2lYbv8JrTXxXOwjAgftb9xojAYgC3iKu3bDSQ=";
   };
+
+  # https://lists.sr.ht/~mcepl/m2crypto/%3CCAPhw1+Hg6+OJZoqt1O6aezxnTUFmfFTMzDwkD2bJ74jnmygqrg@mail.gmail.com%3E
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/SWIG/_lib.h \
+      --replace-fail "|| defined(__clang__)" "&& !defined(__clang__)"
+    substituteInPlace src/SWIG/_m2crypto.i \
+      --replace-fail "PRAGMA_IGNORE_UNUSED_LABEL" "" \
+      --replace-fail "PRAGMA_WARN_STRICT_PROTOTYPES" ""
+  '';
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -62,6 +62,6 @@ buildPythonPackage rec {
     homepage = "https://gitlab.com/m2crypto/m2crypto";
     changelog = "https://gitlab.com/m2crypto/m2crypto/-/blob/${version}/CHANGES";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 }

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "m2crypto";
-  version = "0.47.0";
+  version = "0.48.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "m2crypto";
     repo = "m2crypto";
     tag = version;
-    hash = "sha256-yOpejD2lYbv8JrTXxXOwjAgftb9xojAYgC3iKu3bDSQ=";
+    hash = "sha256-Ya1og1x3EPbHkrY74tkdkMOJreS3x8x/1oVfwcpAEOU=";
   };
 
   # https://lists.sr.ht/~mcepl/m2crypto/%3CCAPhw1+Hg6+OJZoqt1O6aezxnTUFmfFTMzDwkD2bJ74jnmygqrg@mail.gmail.com%3E

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "m2crypto";
-  version = "0.45.1";
+  version = "0.46.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "m2crypto";
     repo = "m2crypto";
     tag = version;
-    hash = "sha256-jg7XcYE7oTOkePDJPXyM/X+vE8F2pIvJbwrVj6KJ3eM=";
+    hash = "sha256-XV9aILSWfQ/xKDySflG3wiNRP4YVPVujuhIz2VdPuBc=";
   };
 
   build-system = [ setuptools ];
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python crypto and SSL toolkit";
     homepage = "https://gitlab.com/m2crypto/m2crypto";
-    changelog = "https://gitlab.com/m2crypto/m2crypto/-/blob/${version}/CHANGES";
+    changelog = "https://gitlab.com/m2crypto/m2crypto/-/tags/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };


### PR DESCRIPTION
Changelog: https://gitlab.com/m2crypto/m2crypto/-/blob/0.48.0/CHANGES

Manual backport of:
* #478186
* #491175
* #502356

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
