### PR TITLE
[Backport release-25.11] python3Packages.qh3: 1.5.6 -> 1.7.1

### DIFF
--- a/pkgs/development/python-modules/qh3/default.nix
+++ b/pkgs/development/python-modules/qh3/default.nix
@@ -14,19 +14,19 @@
 
 buildPythonPackage rec {
   pname = "qh3";
-  version = "1.7.0";
+  version = "1.7.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "qh3";
     tag = "v${version}";
-    hash = "sha256-ACunwdSVSt7yamaoXaW3wc61PnuptbqI1T+cddwNi/8=";
+    hash = "sha256-duZstcheiv3eLPp2IMaZvYo5vq5SMBxcy7HQmBI0SaI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-uSsNR7+ORAGT72axqkc8NjtDj9Ccg0sKLkwSYeSjwoc=";
+    hash = "sha256-BqUofzjfDNUhE27GYcV7CXUK2dT/BQ16Z5aQkHyYUIE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/qh3/default.nix
+++ b/pkgs/development/python-modules/qh3/default.nix
@@ -13,19 +13,19 @@
 
 buildPythonPackage rec {
   pname = "qh3";
-  version = "1.5.6";
+  version = "1.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "qh3";
     tag = "v${version}";
-    hash = "sha256-QJfun9CjqdtVmn7Ws4+VJaeGCQgxnEy+L3SMCZFMK1o=";
+    hash = "sha256-/kmRTxXKoi7aSs4WzlhvoYHWfV60sjFkA+gwp4rqiwY=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-4CLvkyOd0GYh4/v40Qtv3rPJXRwOPXHg9Oo+eWN0luA=";
+    hash = "sha256-1yaVYJ6+nmRvi8TUR/bWYEXlIdARk03SQv++28OOqIc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/qh3/default.nix
+++ b/pkgs/development/python-modules/qh3/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   cmake,
   cryptography,
+  dnspython,
   fetchFromGitHub,
   lib,
   pytest-asyncio,
@@ -13,19 +14,19 @@
 
 buildPythonPackage rec {
   pname = "qh3";
-  version = "1.6.0";
+  version = "1.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "qh3";
     tag = "v${version}";
-    hash = "sha256-/kmRTxXKoi7aSs4WzlhvoYHWfV60sjFkA+gwp4rqiwY=";
+    hash = "sha256-ACunwdSVSt7yamaoXaW3wc61PnuptbqI1T+cddwNi/8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-1yaVYJ6+nmRvi8TUR/bWYEXlIdARk03SQv++28OOqIc=";
+    hash = "sha256-uSsNR7+ORAGT72axqkc8NjtDj9Ccg0sKLkwSYeSjwoc=";
   };
 
   nativeBuildInputs = [
@@ -47,6 +48,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     cryptography
+    dnspython
     pytest-asyncio
     pytest-mock
     pytestCheckHook

--- a/pkgs/development/python-modules/qh3/default.nix
+++ b/pkgs/development/python-modules/qh3/default.nix
@@ -61,9 +61,11 @@ buildPythonPackage rec {
     rm -r qh3
   '';
 
-  disabledTests = lib.optionals stdenv.buildPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # ConnectionError
     "test_connect_and_serve_ipv4"
+    "test_ech_accepted"
+    "test_grease_ech_no_rejection"
   ];
 
   meta = {


### PR DESCRIPTION
Changelog: https://github.com/jawah/qh3/blob/v1.7.1/CHANGELOG.rst

Backports:
* #497198
* #503258
* #505131
* #507107

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
