### PR TITLE
fnox: init at 1.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27530,6 +27530,12 @@
     githubId = 1334474;
     name = "Timothy Stott";
   };
+  tiptenbrink = {
+    email = "tip@tenbrinkmeijs.com";
+    github = "tiptenbrink";
+    githubId = 75669206;
+    name = "Tip ten Brink";
+  };
   tiramiseb = {
     email = "sebastien@maccagnoni.eu";
     github = "tiramiseb";

--- a/pkgs/by-name/fn/fnox/package.nix
+++ b/pkgs/by-name/fn/fnox/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  perl,
+  pkg-config,
+  testers,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "fnox";
+  version = "1.20.0";
+
+  src = fetchFromGitHub {
+    owner = "jdx";
+    repo = "fnox";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8LNMJEZNUlwpPT674/6SfR5dmFRALDI6X1WLKeaJ06M=";
+  };
+
+  cargoHash = "sha256-SoQseyrRqvq/XRmd/HhMX8r42pyn4Ncw6r9G4596bGc=";
+
+  nativeBuildInputs = [
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [ udev ];
+
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  checkFlags = [
+    # requires a D-Bus session unavailable in the sandbox
+    "--skip=providers::keychain::tests::test_keychain_set_and_get"
+  ];
+
+  meta = {
+    description = "Flexible secret management tool supporting multiple providers and encryption methods";
+    homepage = "https://github.com/jdx/fnox";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tiptenbrink ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This PR adds `fnox` to nixpkgs. [`fnox`](https://github.com/jdx/fnox) is a tool developed by the author of `mise` (jdx) that allows safely accessing and storing secrets (both in the cloud and locally and in Git) and use them from the terminal. Linux-only for now.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
    - Added simple version test. Also the build runs the cargo tests I believe.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
    - I'm already using it locally!
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
    - As far as I'm aware it follows the guidelines, sorry if I missed anything! 


