### PR TITLE
libcdio: fix Darwin build by setting `-std=gnu17`

### DIFF
--- a/pkgs/by-name/li/libcdio/package.nix
+++ b/pkgs/by-name/li/libcdio/package.nix
@@ -49,7 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     (lib.enableFeature withMan "maintainer-mode")
+    "CFLAGS=-std=gnu17"
   ];
+
+  # autoconf 2.73's AM_ICONV "working iconv" runtime probe reports "no" on
+  # Darwin's libiconv; skip it via the cache variable. Refs #511329.
+  preConfigure = ''
+    export am_cv_func_iconv_works=yes
+  '';
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Refs: https://github.com/NixOS/nixpkgs/issues/511329

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
