### PR TITLE
[25.11] dolibarr: add CVE-2026-23500 to knownVulnerabilities

### DIFF
--- a/pkgs/by-name/do/dolibarr/package.nix
+++ b/pkgs/by-name/do/dolibarr/package.nix
@@ -49,6 +49,9 @@ stdenv.mkDerivation (finalAttrs: {
     knownVulnerabilities = [
       # https://github.com/NixOS/nixpkgs/issues/505605
       "CVE-2026-34036"
+
+      # https://github.com/NixOS/nixpkgs/issues/511423
+      "CVE-2026-23500"
     ];
   };
 })


### PR DESCRIPTION
## Things done

Add [CVE-2026-23500](https://nvd.nist.gov/vuln/detail/CVE-2026-23500) to `meta.knownVulnerabilities`.
`master` has 23.02 which is not affected.

Fixes #511423

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
