### PR TITLE
firebird_3: 3.0.13 -> 3.0.14; firebird_4: 4.0.6 -> 4.0.7; firebird_5: init at 5.0.4

### DIFF
--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -5,6 +5,7 @@
   fetchDebianPatch,
   libedit,
   autoreconfHook,
+  cmake,
   zlib,
   unzip,
   libtommath,
@@ -47,6 +48,9 @@ let
     ++ (lib.optional superServer "--enable-superserver");
 
     enableParallelBuilding = true;
+
+    __structuredAttrs = true;
+    strictDeps = true;
 
     installPhase = ''
       runHook preInstall
@@ -113,5 +117,32 @@ rec {
     }
   );
 
-  firebird = firebird_4;
+  firebird_5 = stdenv.mkDerivation (
+    base
+    // rec {
+      version = "5.0.4";
+
+      src = fetchFromGitHub {
+        owner = "FirebirdSQL";
+        repo = "firebird";
+        rev = "v${version}";
+        hash = "sha256-wAiOyCVS7fjVqrDlJJwDFxw5ZD5spnXlYKCAQ8gctHI=";
+      };
+
+      # CMake is just used for libcds
+      dontUseCmakeConfigure = true;
+
+      nativeBuildInputs = base.nativeBuildInputs ++ [
+        cmake
+        unzip
+      ];
+      buildInputs = base.buildInputs ++ [
+        zlib
+        libtommath
+        libtomcrypt
+      ];
+    }
+  );
+
+  firebird = firebird_5;
 }

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -95,13 +95,13 @@ rec {
   firebird_4 = stdenv.mkDerivation (
     base
     // rec {
-      version = "4.0.6";
+      version = "4.0.7";
 
       src = fetchFromGitHub {
         owner = "FirebirdSQL";
         repo = "firebird";
         rev = "v${version}";
-        hash = "sha256-65wfG6huDzvG/tEVllA58OfZqoL4U/ilw5YIDqQywTs=";
+        hash = "sha256-EnD0cTQSOh1fARjKdoOCR5UjpvVA96EZVVWfqlH+m48=";
       };
 
       nativeBuildInputs = base.nativeBuildInputs ++ [ unzip ];

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -62,13 +62,13 @@ rec {
   firebird_3 = stdenv.mkDerivation (
     base
     // rec {
-      version = "3.0.13";
+      version = "3.0.14";
 
       src = fetchFromGitHub {
         owner = "FirebirdSQL";
         repo = "firebird";
         rev = "v${version}";
-        hash = "sha256-ti3cFfByM2wxOLkAebwtFe25B5W7jOwi3f7MPYo/yUA=";
+        hash = "sha256-X6Jv32VniAefIWjLTPwEipsQVRl7HBb4EKyi2IL1VWM=";
       };
 
       patches = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8009,6 +8009,7 @@ with pkgs;
   dovecot_pigeonhole_2_4 = dovecot_pigeonhole;
 
   inherit (callPackages ../servers/firebird { })
+    firebird_5
     firebird_4
     firebird_3
     firebird


### PR DESCRIPTION
Closes #511458
Closes #511434
Closes #511431
Closes #511432
Closes #511428
Closes #511442
Closes #511433
Closes #511429


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
