### PR TITLE
python3Packages.matplotlib: fix 64 bit -> 32 bit cross

### DIFF
--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -117,6 +117,7 @@ buildPythonPackage rec {
     ffmpeg-headless
     freetype
     qhull
+    pybind11
   ]
   ++ lib.optionals enableGtk3 [
     cairo
@@ -129,7 +130,6 @@ buildPythonPackage rec {
   build-system = [
     certifi
     numpy
-    pybind11
     meson-python
     setuptools-scm
   ];

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -110,6 +110,7 @@ buildPythonPackage (finalAttrs: {
     ffmpeg-headless
     freetype
     qhull
+    pybind11
     libraqm
   ]
   ++ lib.optionals enableGtk3 [
@@ -123,7 +124,6 @@ buildPythonPackage (finalAttrs: {
   build-system = [
     certifi
     numpy
-    pybind11
     meson-python
     setuptools-scm
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

~I don't exactly know why this works, but figured it's better to post the PR so someone can either come up with a better solution or comment on why it works~

Alyssa clarified below that `build-system` maps to `nativeBuildInputs` which seems incorrect to do in this case. 

This fixes `nix-build -A pkgsCross.raspberryPi.python3Packages.matplotlib` (armv6l)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
