### PR TITLE
Add shadow and shadowtools (local discrete-event network simulator)

### DIFF
--- a/pkgs/by-name/sh/shadow-network-simulator/package.nix
+++ b/pkgs/by-name/sh/shadow-network-simulator/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cargo,
+  cmake,
+  glib,
+  makeWrapper,
+  pkg-config,
+  rustPlatform,
+  rustc,
+  util-linux,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "shadow";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "shadow";
+    repo = "shadow";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-kgWvrnpWUJ5OWy2+luju8SHDRcveVbdfCKntDgxVj0o=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoRoot = "src";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src cargoRoot;
+    hash = "sha256-haoVNmm0uW7LOTSj8/ryWaZ9nmRNA2G5QKv9cOKEjcs=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cargo
+    cmake
+    makeWrapper
+    pkg-config
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+    rustc
+  ];
+
+  buildInputs = [ glib ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SHADOW_TEST" false)
+  ];
+
+  postPatch = ''
+    substituteInPlace src/main/utility/mod.rs \
+      --replace-fail "/lib64/ld-linux-x86-64.so.2" "${stdenv.cc.bintools.dynamicLinker}"
+  '';
+
+  # Upstream drives Rust through CMake `ExternalProject_Add(... BUILD_ALWAYS 1)`.
+  # In a normal developer checkout that is a reasonable tradeoff, since repeated
+  # local builds can otherwise pick up stale Rust artifacts. In Nix each build
+  # already happens in a fresh, one-shot environment, so rebuilding during
+  # `make install` only adds cost. Running `cmake --install .` executes the
+  # generated install script directly, reusing the artifacts that were already
+  # built in `buildPhase` without re-triggering the build graph.
+  installPhase = ''
+    runHook preInstall
+    cmake --install .
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/shadow \
+      --prefix PATH : ${lib.makeBinPath [ util-linux ]}
+  '';
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Discrete-event network simulator that runs real application code";
+    homepage = "https://shadow.github.io/";
+    changelog = "https://github.com/shadow/shadow/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    mainProgram = "shadow";
+    maintainers = with lib.maintainers; [ starius ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/sh/shadowtools/package.nix
+++ b/pkgs/by-name/sh/shadowtools/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  bash,
+  coreutils,
+  fetchFromGitHub,
+  python3Packages,
+  shadow-network-simulator,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "shadowtools";
+  version = "3.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "shadow";
+    repo = "shadow";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-kgWvrnpWUJ5OWy2+luju8SHDRcveVbdfCKntDgxVj0o=";
+  };
+
+  __structuredAttrs = true;
+
+  postUnpack = ''
+    sourceRoot="$sourceRoot/shadowtools"
+  '';
+
+  postPatch = ''
+    # Upstream currently ships `shadowtools` from the Shadow release tarball but
+    # leaves its Python package version at a placeholder `0.0.1`.
+    # Patch it to the corresponding Shadow release so the built metadata matches
+    # the source we are packaging.
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.0.1"' 'version = "${finalAttrs.version}"'
+
+    # `shadow-exec` runs commands through a managed `bash` process inside Shadow.
+    # In regular distro environments that shell tends to have a usable default
+    # search path, but the Nix-packaged `bash` does not. Forward the launcher's
+    # PATH into the managed process so wrapped runtime tools such as `shadow`,
+    # `bash`, and basic coreutils commands are available there as well.
+    oldProcessDef=$'path="bash",\n                        args=['
+    newProcessDef=$'environment={"PATH":os.environ.get("PATH","")},path="bash",\nargs=['
+
+    substituteInPlace src/shadowtools/shadow_exec.py \
+      --replace-fail 'import argparse' \
+        $'import argparse\nimport os' \
+      --replace-fail "$oldProcessDef" "$newProcessDef"
+  '';
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [ pyyaml ];
+
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      bash
+      coreutils
+      shadow-network-simulator
+    ])
+  ];
+
+  pythonImportsCheck = [
+    "shadowtools.config"
+    "shadowtools.shadow_exec"
+  ];
+
+  # Upstream's tests run real Shadow simulations. Those start by reading host
+  # CPU topology from `/sys/devices/system/cpu/online`, which is unavailable in
+  # the Nix build sandbox, so the test suite aborts before reaching the Python
+  # assertions. Keep the package-level smoke test to remote/manual validation
+  # outside the sandbox instead.
+  doCheck = false;
+
+  meta = {
+    description = "Python tools for the Shadow network simulator";
+    homepage = "https://shadow.github.io/";
+    changelog = "https://github.com/shadow/shadow/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    mainProgram = "shadow-exec";
+    maintainers = with lib.maintainers; [ starius ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Shadow](https://github.com/shadow/shadow) is a local, discrete-event network simulator that directly executes real application code. It enables realistic, scalable private network experiments with distributed systems containing thousands of network-connected processes on a Linux laptop, desktop, or server.

Shadow was originally developed to simulate the Tor network locally, but it is also useful for similar tasks, such as a local regtest cluster for Bitcoin. It can inject random network packet loss defined by a deterministic seed. It also supports fast-forwarding through waiting, which lets it simulate wait-heavy scenarios, such as months of real network operation, while using only a small amount of wall-clock time.

The name `shadow` is already taken in nixpkgs, so this package is named `shadow-network-simulator`.

[shadowtools](https://github.com/shadow/shadow/tree/main/shadowtools) is a Python package containing tools for working with the [Shadow](https://shadow.github.io/) simulator. At the moment it contains a single tool, `shadow-exec`, which streamlines running a single command in a single-host Shadow simulation.

## Manual testing

- `shadow --version` and `shadow --help` work
- A minimal one-host simulation running `/bin/echo` completes successfully.
- The upstream [examples/apps/nginx](https://github.com/shadow/shadow/tree/main/examples/apps/nginx) scenario completes successfully, and the client receives the nginx welcome page.

Manual `shadow-exec` smoke tests also passed:

- `shadow-exec --help`
- `shadow-exec -- echo hello-from-shadowtools` -> `hello-from-shadowtools`
- `shadow-exec -- pwd` -> `/root`
- `shadow-exec -- date -u` -> `Sat Jan 1 00:00:00 GMT 2000`
- `shadow-exec -- bash -c 'date -u +%H:%M:%S; sleep 5; date -u +%H:%M:%S'` -> `00:00:00`, then `00:00:05`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (the only platform supported by Shadow)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
