### PR TITLE
lmstudio: remove unnecessary --set-rpath from patchelf to fix lms segfault

### DIFF
--- a/pkgs/by-name/lm/lmstudio/linux.nix
+++ b/pkgs/by-name/lm/lmstudio/linux.nix
@@ -51,9 +51,6 @@ appimageTools.wrapType2 {
     # lms cli tool
     install -m 755 ${appimageContents}/resources/app/.webpack/lms $out/bin/
 
-    patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
-    --set-rpath "${lib.getLib stdenv.cc.cc}/lib:${lib.getLib stdenv.cc.cc}/lib64:$out/lib:${
-      lib.makeLibraryPath [ (lib.getLib stdenv.cc.cc) ]
-    }" $out/bin/lms
+    patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/bin/lms
   '';
 }


### PR DESCRIPTION
### Closes #510446

As described in #510446, the `lms` CLI tool segfaults due to an unnecessary `--set-rpath` argument being passed to `patchelf`.

The `lms` binary is a Node.js/webpack bundle that doesn't require custom library paths. Setting rpath on NixOS can cause ELF header corruption leading to segmentation faults. Only the interpreter needs fixing for AppImage-extracted binaries.

Removing the `--set-rpath` argument resolves the issue while keeping the necessary `--set-interpreter` fix.

### Before (broken):
```nix
patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" \
  --set-rpath "${lib.getLib stdenv.cc.cc}/lib:${lib.getLib stdenv.cc.cc}/lib64:$out/lib:${
    lib.makeLibraryPath [ (lib.getLib stdenv.cc.cc) ]
  }" $out/bin/lms
```
<img width="528" height="66" alt="image" src="https://github.com/user-attachments/assets/00808bb7-b15c-4a1d-a4bf-b132254a277b" />


### After (fixed)
```nix
patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $out/bin/lms
```
<img width="691" height="481" alt="image" src="https://github.com/user-attachments/assets/bc68d15d-28d7-4fb1-aa19-1265a431253c" />


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
