### PR TITLE
fix(lib/types): submodule emptyValue must evaluate sub-option defaults

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -590,7 +590,16 @@ rec {
           );
         }
         //
-          optionalAttrs (opt ? defaultText || opt ? default || ((opt.type or { }).emptyValue or { }) ? value)
+          optionalAttrs
+            (
+              opt ? defaultText
+              || opt ? default
+              # Render emptyValue-based defaults, but only for types without
+              # submodules (e.g. types.submodule). Submodules may evaluate to
+              # error without user defs, and their sub-options are documented
+              # individually, so best to skip those here.
+              || ((opt.type or { }).emptyValue or { }) ? value && (opt.type or { }).getSubModules or null == null
+            )
             {
               default =
                 builtins.addErrorContext

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -686,6 +686,8 @@ checkConfigOutput "\[\]" config.unique ./defaults.nix
 checkConfigOutput "\[\]" config.coercedTo ./defaults.nix
 # These types don't have empty values
 checkConfigError 'The option .int. was accessed but has no value defined. Try setting the option.' config.int ./defaults.nix
+## submodule emptyValue must evaluate sub-option defaults
+checkConfigOutput "ok" config.result ./defaults.nix
 
 # types.unique
 #   requires a single definition

--- a/lib/tests/modules/defaults.nix
+++ b/lib/tests/modules/defaults.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, config, ... }:
 let
   inherit (lib) types;
 in
@@ -19,6 +19,18 @@ in
     submodule = lib.mkOption {
       type = types.submodule { };
     };
+    submoduleWithDefaults = lib.mkOption {
+      type = types.submodule {
+        options.enabled = lib.mkOption {
+          type = types.bool;
+          default = true;
+        };
+        options.count = lib.mkOption {
+          type = types.int;
+          default = 13;
+        };
+      };
+    };
     unique = lib.mkOption {
       type = types.unique { message = "hi"; } (types.listOf types.int);
     };
@@ -28,6 +40,17 @@ in
     # no empty value
     int = lib.mkOption {
       type = types.int;
+    };
+
+    result = lib.mkOption {
+      type = types.str;
+      default =
+        assert
+          config.submoduleWithDefaults == {
+            enabled = true;
+            count = 13;
+          };
+        "ok";
     };
   };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1320,7 +1320,7 @@ rec {
           };
       };
       emptyValue = {
-        value = { };
+        value = base.config;
       };
       getSubOptions =
         prefix:


### PR DESCRIPTION
`emptyValue` for `types.submodule` was `{ value = { }; }`, i.e. none of the type-declared options or their defaults.

Previously submodules without defs would simply fail for lack of a default, but since PR #500104 repurposed `emptyValue` as the fallback when no definitions exist, submodule options without an explicit `default = { }` (new additions) silently lost their sub-option defaults (e.g. `requiredFeatures.devnet` in the nixos-test-driver, #511413).

Main change: `emptyValue`: `{ value = { }; }` -> `{ value = base.config; }`

Additionally, skip `emptyValue`-based default rendering in docs for types with submodules, because their sub-options are already documented individually, and forcing evaluation here can break on modules with invalid or incomplete definitions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
