### PR TITLE
sbb-tui: init at 1.13.4 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27723,6 +27723,12 @@
     githubId = 7727887;
     name = "Tomas Kala";
   };
+  tomasrivera = {
+      email = "tomas.riveral@icloud.com";
+      github = "tomasriveral";
+      githubId = 137088692;
+      name = "Tomás Rivera";
+  };
   tomberek = {
     email = "tomberek@gmail.com";
     matrix = "@tomberek:matrix.org";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27724,10 +27724,10 @@
     name = "Tomas Kala";
   };
   tomasrivera = {
-      email = "tomas.riveral@icloud.com";
-      github = "tomasriveral";
-      githubId = 137088692;
-      name = "Tomás Rivera";
+    email = "tomas.riveral@icloud.com";
+    github = "tomasriveral";
+    githubId = 137088692;
+    name = "Tomás Rivera";
   };
   tomberek = {
     email = "tomberek@gmail.com";

--- a/pkgs/by-name/sb/sbb-tui/package.nix
+++ b/pkgs/by-name/sb/sbb-tui/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule rec {
+  pname = "sbb-tui";
+  version = "1.13.4";
+  __structuredAttrs = true;
+  src = fetchFromGitHub {
+    owner = "Necrom4";
+    repo = "sbb-tui";
+    rev = "v${version}";
+    sha256 = "sha256-JLjAhs5UbqgNYqpA3cDucrAS6ell+0JiDJNf7G33Nhs=";
+  };
+
+  vendorHash = "sha256-K4DOu3rfSlKAa5JNKCzWWpnWZlXXxtN5Po7p1Spqe1w=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "TUI client for Switzerland's public transport timetables, inspired by SBB/CFF/FFS app";
+    homepage = "https://github.com/Necrom4/sbb-tui";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tomasrivera ];
+    mainProgram = "sbb-tui";
+  };
+}


### PR DESCRIPTION
Add sbb-tui, a terminal user interface for Swiss public transport timetables (SBB/CFF/FFS).

Homepage: https://github.com/Necrom4/sbb-tui

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
