### PR TITLE
dtsfmt: init at 0.8.0

### DIFF
--- a/pkgs/by-name/dt/dtsfmt/package.nix
+++ b/pkgs/by-name/dt/dtsfmt/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dtsfmt";
+  version = "0.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mskelton";
+    repo = "dtsfmt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2DKfmWnz9Iaxs4VN16BHOzsncEFXaX2mwR2Ta9AyYn0=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-BbX/IEfn5qhyW/IkgARfxD0rTx+hcoq8TmoDmUqclHQ=";
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Auto formatter for device tree files";
+    homepage = "https://github.com/mskelton/dtsfmt";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ toodeluna ];
+    mainProgram = "dtsfmt";
+  };
+})


### PR DESCRIPTION
Adds [dtsfmt](https://github.com/mskelton/dtsfmt), a formatter for device tree source files.

Supersedes #452221

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
