### PR TITLE
dnsmasq: apply patch for CVE-2026-6507

### DIFF
--- a/pkgs/by-name/dn/dnsmasq/CVE-2026-6507.patch
+++ b/pkgs/by-name/dn/dnsmasq/CVE-2026-6507.patch
@@ -1,0 +1,28 @@
+From 9ad74926d4f7f34ff902e1db5235535aa813c33f Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Mon, 6 Apr 2026 22:22:43 +0100
+Subject: [PATCH] Fix 1-byte buffer overflow in relay_reply4()
+
+Potential SIGSEGV when using DHCPv4-relay.
+
+Thanks to Asim Viladi Oglu Manizada for finding this.
+---
+ src/rfc2131.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rfc2131.c b/src/rfc2131.c
+index 7bdfefd..55aad03 100644
+--- a/src/rfc2131.c
++++ b/src/rfc2131.c
+@@ -3248,7 +3248,7 @@ unsigned int relay_reply4(struct dhcp_packet *mess, size_t sz, char *arrival_int
+ 
+ 	      /* delete agent info before return RFC 3046 para 2.1 */
+ 	      *opt = OPTION_END;
+-	      memset(opt + 1, 0, option_len(opt) + 2);
++	      memset(opt + 1, 0, option_len(opt) + 1);
+ 	    }
+ 	}
+       else if (mess->giaddr.s_addr == relay->local.addr4.s_addr)
+-- 
+2.20.1
+

--- a/pkgs/by-name/dn/dnsmasq/package.nix
+++ b/pkgs/by-name/dn/dnsmasq/package.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-S/UMLBAY+fvCYDffUbkOzqDLc9RhYoRnY7kt8NbDpFg=";
   };
 
+  patches = [
+    # https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=patch;h=9ad74926d4f7f34ff902e1db5235535aa813c33f
+    ./CVE-2026-6507.patch
+  ];
+
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     sed '1i#include <linux/sockios.h>' -i src/dhcp.c
   '';


### PR DESCRIPTION
Fixes #511439

Vendored the patch, access to the upstream cgit is filtered.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
