### PR TITLE
rustup-toolchain-install-master: 1.10.0 -> 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22351,6 +22351,14 @@
     github = "QuiNzX";
     githubId = 76129478;
   };
+  quio = {
+    name = "Dominik Schwaiger";
+    email = "mail@dominik-schwaiger.ch";
+    matrix = "@quio:matrix.dominik-schwaiger.ch";
+    github = "quiode";
+    githubId = 51075975;
+    keys = [ { fingerprint = "D9FE 655C CD52 8F80 3D27  8F75 F7E7 E19B C69F 7DF5"; } ];
+  };
   quodlibetor = {
     email = "quodlibetor@gmail.com";
     github = "quodlibetor";

--- a/pkgs/development/tools/rust/rustup-toolchain-install-master/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup-toolchain-install-master/0001-dynamically-patchelf-binaries.patch
@@ -1,61 +1,66 @@
 diff --git a/src/main.rs b/src/main.rs
-index 3cb6896..7f070e0 100644
+index d8b46b5..55b8cba 100644
 --- a/src/main.rs
 +++ b/src/main.rs
-@@ -275,7 +275,9 @@ fn install_single_toolchain(
-
-     // install
-     if maybe_dry_client.is_some() {
--        rename(&toolchain.dest, toolchain_path)?;
-+        rename(&toolchain.dest, toolchain_path.clone())?;
-+        nix_patchelf(toolchain_path)
-+            .expect("failed to patch toolchain for NixOS");
-         eprintln!(
-             "toolchain `{}` is successfully installed!",
-             toolchain.dest.display()
-@@ -291,6 +293,45 @@ fn install_single_toolchain(
-     Ok(())
+@@ -360,7 +360,9 @@ impl<'a> Installer<'a> {
+ 
+         // install
+         if self.actually_install {
+-            rename(&toolchain.dest, toolchain_path)?;
++            rename(&toolchain.dest, toolchain_path.clone())?;
++            nix_patchelf(toolchain_path, toolchain.host_target)
++                .expect("failed to patch toolchain for NixOS");
+             eprintln!(
+                 "toolchain `{}` is successfully installed!",
+                 toolchain.dest.display()
+@@ -377,6 +379,50 @@ impl<'a> Installer<'a> {
+     }
  }
-
-+fn nix_patchelf(mut toolchain_path: PathBuf) -> Result<(), Error> {
-+    toolchain_path.push("bin");
+ 
++fn nix_patchelf(toolchain_path: PathBuf, host_target: &str) -> Result<(), Error> {
++    for toolchain_path in [
++        &toolchain_path.join("bin"),
++        &toolchain_path.join("lib"),
++        &toolchain_path
++            .join("lib")
++            .join("rustlib")
++            .join(host_target)
++            .join("bin"),
++        &toolchain_path
++            .join("lib")
++            .join("rustlib")
++            .join(host_target)
++            .join("bin")
++            .join("gcc-ld"),
++        &toolchain_path
++            .join("lib")
++            .join("rustlib")
++            .join(host_target)
++            .join("lib"),
++    ] {
++        for entry in toolchain_path.read_dir()? {
++            let entry = entry?;
++            eprintln!(
++                "info: you seem to be running NixOS. Attempting to patch {}",
++                entry.path().to_str().unwrap()
++            );
 +
-+    for entry in toolchain_path.read_dir()? {
-+        let entry = entry?;
-+        if !entry.file_type()?.is_file() {
-+            continue;
++            let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++                .arg("--set-interpreter")
++                .arg("@dynamicLinker@")
++                .arg(entry.path())
++                .output();
++            let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
++                .arg("--set-rpath")
++                .arg("@libPath@")
++                .arg(entry.path())
++                .output();
 +        }
-+
-+        eprintln!("info: you seem to be running NixOS. Attempting to patch {}",
-+                  entry.path().to_str().unwrap());
-+        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
-+            .arg("--set-interpreter")
-+            .arg("@dynamicLinker@")
-+            .arg(entry.path())
-+            .output();
-+    }
-+
-+    toolchain_path.pop();
-+    toolchain_path.push("lib");
-+
-+    for entry in toolchain_path.read_dir()? {
-+        let entry = entry?;
-+        if !entry.file_type()?.is_file() {
-+            continue;
-+        }
-+
-+        eprintln!("info: you seem to be running NixOS. Attempting to patch {}",
-+                  entry.path().to_str().unwrap());
-+        let _ = ::std::process::Command::new("@patchelf@/bin/patchelf")
-+            .arg("--set-rpath")
-+            .arg("@libPath@")
-+            .arg(entry.path())
-+            .output();
 +    }
 +
 +    Ok(())
 +}
 +
  fn fetch_master_commit(client: &Client, github_token: Option<&str>) -> Result<String, Error> {
-     eprintln!("fetching master commit hash... ");
+     eprintln!("fetching HEAD commit hash... ");
      fetch_master_commit_via_git()

--- a/pkgs/development/tools/rust/rustup-toolchain-install-master/default.nix
+++ b/pkgs/development/tools/rust/rustup-toolchain-install-master/default.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustup-toolchain-install-master";
-  version = "1.10.0";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "kennytm";
     repo = "rustup-toolchain-install-master";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F2lMUNl+ZQTTaSpzzeIl6ijXou7J6tbPz6eQY9703qU=";
+    hash = "sha256-rcA+kZ53FdrImgQe9vIuSPXyU2i+akyYny+/kgRG6Zk=";
   };
 
-  cargoHash = "sha256-yEIkiOn8FTyfoTBFdbdJAfolgai8VFnnwSl/a8vDqbY=";
+  cargoHash = "sha256-rK+SSZ/EoaQflxkzhnxAab/AnJvpnEYb5RbwcR4VUow=";
 
   patches = lib.optional stdenv.hostPlatform.isLinux (
     replaceVars ./0001-dynamically-patchelf-binaries.patch {
@@ -46,6 +46,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "rustup-toolchain-install-master";
     homepage = "https://github.com/kennytm/rustup-toolchain-install-master";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ quio ];
   };
 })


### PR DESCRIPTION
Release: https://github.com/kennytm/rustup-toolchain-install-master/releases/tag/v1.12.0

Update rustup-toolchain-install-master from 1.1.0 to 1.12.0. The patch file also had to be updated. Changed the patch substantially to address #507949. It patches more binaries to be able be able to build more crates. Most importantly, it now can be used to build miri.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
