### PR TITLE
nginx: 1.28.3 -> 1.30.0

### DIFF
--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.28.3";
-  hash = "sha256-LJapRr+wiCohdE7UKXcKISOuGCjHxIZlCSmT3e6RqRg=";
+  version = "1.30.0";
+  hash = "sha256-BYGIxkvyK67KpyuAmmMYpPm6YjiJxVT+qwP3y4U6sxs=";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8150,6 +8150,7 @@ with pkgs;
   nginx = nginxStable;
 
   nginxStable = callPackage ../servers/http/nginx/stable.nix {
+    openssl = openssl_4_0;
     zlib-ng = zlib-ng.override { withZlibCompat = true; };
     withPerl = false;
     # We don't use `with` statement here on purpose!


### PR DESCRIPTION
https://nginx.org/en/CHANGES-1.30


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 511564 --additional-package nginx.tests`
Commit: `d5b8f4fdd73d9eb9f72b873c102a5dfcf957ddb6`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>nginx.tests.variants.tengine</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 39 packages built:</summary>
  <ul>
    <li>devpi-client</li>
    <li>devpi-client.dist</li>
    <li>devpi-server</li>
    <li>nginx (nginxStable)</li>
    <li>nginx.doc (nginxStable.doc)</li>
    <li>nginx.tests.acme-integration</li>
    <li>nginx.tests.acme-integration-without-reload</li>
    <li>nginx.tests.nginx</li>
    <li>nginx.tests.nginx-auth</li>
    <li>nginx.tests.nginx-etag</li>
    <li>nginx.tests.nginx-etag-compression</li>
    <li>nginx.tests.nginx-globalredirect</li>
    <li>nginx.tests.nginx-http3.angie</li>
    <li>nginx.tests.nginx-http3.nginx</li>
    <li>nginx.tests.nginx-proxyprotocol</li>
    <li>nginx.tests.nginx-pubhtml</li>
    <li>nginx.tests.nginx-sso</li>
    <li>nginx.tests.nginx-status-page</li>
    <li>nginx.tests.nginx-unix-socket</li>
    <li>nginx.tests.variants.angie</li>
    <li>nginx.tests.variants.nginxMainline</li>
    <li>nginx.tests.variants.nginxShibboleth</li>
    <li>nginx.tests.variants.nginxStable</li>
    <li>nginx.tests.variants.openresty</li>
    <li>nginxShibboleth</li>
    <li>nginxShibboleth.doc</li>
    <li>python313Packages.devpi-ldap</li>
    <li>python313Packages.devpi-ldap.dist</li>
    <li>python313Packages.devpi-server</li>
    <li>python313Packages.devpi-server.dist</li>
    <li>python313Packages.devpi-web</li>
    <li>python313Packages.devpi-web.dist</li>
    <li>python314Packages.devpi-ldap</li>
    <li>python314Packages.devpi-ldap.dist</li>
    <li>python314Packages.devpi-server</li>
    <li>python314Packages.devpi-server.dist</li>
    <li>python314Packages.devpi-web</li>
    <li>python314Packages.devpi-web.dist</li>
    <li>tests.testers.lycheeLinkCheck.network</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
