### PR TITLE
nixos/prometheus: remove absolute path literals

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -386,7 +386,7 @@ let
           after = [ "network.target" ];
           serviceConfig.Restart = mkDefault "always";
           serviceConfig.PrivateTmp = mkDefault true;
-          serviceConfig.WorkingDirectory = mkDefault /tmp;
+          serviceConfig.WorkingDirectory = mkDefault "/tmp";
           serviceConfig.DynamicUser = mkDefault enableDynamicUser;
           serviceConfig.User = mkDefault conf.user;
           serviceConfig.Group = conf.group;

--- a/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/blackbox.nix
@@ -23,13 +23,10 @@ let
     if (builtins.isPath file) || (lib.isStorePath file) then
       file
     else
-      (
-        lib.warn ''
-          ${logPrefix}: configuration file "${file}" is being copied to the nix-store.
-          If you would like to avoid that, please set enableConfigCheck to false.
-        '' /.
-        + file
-      );
+      (lib.warn ''
+        ${logPrefix}: configuration file "${file}" is being copied to the nix-store.
+        If you would like to avoid that, please set enableConfigCheck to false.
+      '' (builtins.toFile (builtins.baseNameOf file) (builtins.readFile file)));
   checkConfigLocation =
     file:
     if lib.hasPrefix "/tmp/" file then

--- a/nixos/modules/services/monitoring/prometheus/exporters/ecoflow.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/ecoflow.nix
@@ -27,7 +27,7 @@ in
     };
     ecoflowAccessKeyFile = mkOption {
       type = types.path;
-      default = /etc/ecoflow-access-key;
+      default = "/etc/ecoflow-access-key";
       description = ''
         Path to the file with your personal api access string from the Ecoflow development website <https://developer-eu.ecoflow.com>.
         Do to share or commit your plaintext scecrets to a public repo use: agenix or soaps.
@@ -35,7 +35,7 @@ in
     };
     ecoflowSecretKeyFile = mkOption {
       type = types.path;
-      default = /etc/ecoflow-secret-key;
+      default = "/etc/ecoflow-secret-key";
       description = ''
         Path to the file with your personal api secret string from the Ecoflow development website <https://developer-eu.ecoflow.com>.
         Do to share or commit your plaintext scecrets to a public repo use: agenix or soaps.
@@ -43,7 +43,7 @@ in
     };
     ecoflowEmailFile = mkOption {
       type = types.path;
-      default = /etc/ecoflow-email;
+      default = "/etc/ecoflow-email";
       description = ''
         Path to the file with your personal ecoflow app login email address.
         Do to share or commit your plaintext scecrets to a public repo use: agenix or soaps.
@@ -51,7 +51,7 @@ in
     };
     ecoflowPasswordFile = mkOption {
       type = types.path;
-      default = /etc/ecoflow-password;
+      default = "/etc/ecoflow-password";
       description = ''
         Path to the file with your personal ecoflow app login email password.
         Do to share or commit your plaintext passwords to a public repo use: agenix or soaps here!
@@ -59,7 +59,7 @@ in
     };
     ecoflowDevicesFile = mkOption {
       type = types.path;
-      default = /etc/ecoflow-devices;
+      default = "/etc/ecoflow-devices";
       description = ''
         File must contain one line, example: R3300000,R3400000,NC430000,....
         The list of devices serial numbers separated by comma. For instance: SN1,SN2,SN3.
@@ -69,7 +69,7 @@ in
     };
     ecoflowDevicesPrettyNamesFile = mkOption {
       type = types.path;
-      default = /etc/ecoflow-devices-pretty-names;
+      default = "/etc/ecoflow-devices-pretty-names";
       description = ''
         File must contain one line, example: {"R3300000":"Delta 2","R3400000":"Delta Pro",...}
         The key/value map of custom names for your devices. Key is a serial number, value is a device name you want

--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -24,13 +24,10 @@ let
     if (builtins.isPath file) || (lib.isStorePath file) then
       file
     else
-      (
-        lib.warn ''
-          ${logPrefix}: configuration file "${file}" is being copied to the nix-store.
-          If you would like to avoid that, please set enableConfigCheck to false.
-        '' /.
-        + file
-      );
+      (lib.warn ''
+        ${logPrefix}: configuration file "${file}" is being copied to the nix-store.
+        If you would like to avoid that, please set enableConfigCheck to false.
+      '' (builtins.toFile (builtins.baseNameOf file) (builtins.readFile file)));
 
   checkConfig =
     file:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Absolute path literals are not portable.
Nix complains about the changed lines if the option `lint-absolute-path-literals` is set to `warn`.

`lint-absolute-path-literals` Option Documentation:
https://nix.dev/manual/nix/2.34/command-ref/conf-file.html#conf-lint-absolute-path-literals

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
