### PR TITLE
Split silverbullet

### DIFF
--- a/nixos/modules/services/web-apps/silverbullet.nix
+++ b/nixos/modules/services/web-apps/silverbullet.nix
@@ -15,7 +15,7 @@ in
     services.silverbullet = {
       enable = lib.mkEnableOption "Silverbullet, an open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application";
 
-      package = lib.mkPackageOption pkgs "silverbullet" { };
+      package = lib.mkPackageOption pkgs "silverbullet-server" { };
 
       openFirewall = lib.mkOption {
         type = lib.types.bool;

--- a/nixos/tests/silverbullet.nix
+++ b/nixos/tests/silverbullet.nix
@@ -17,7 +17,7 @@
 
       services.silverbullet = {
         enable = true;
-        package = pkgs.silverbullet;
+        package = pkgs.silverbullet-server;
         listenPort = 3001;
         listenAddress = "localhost";
         spaceDir = "/home/test/silverbullet";

--- a/pkgs/by-name/si/silverbullet-cli/package.nix
+++ b/pkgs/by-name/si/silverbullet-cli/package.nix
@@ -1,0 +1,70 @@
+{
+  autoPatchelfHook,
+  common-updater-scripts,
+  fetchurl,
+  lib,
+  stdenv,
+  stdenvNoCC,
+  unzip,
+  writeShellScript,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "silverbullet-cli";
+  version = "2.6.1";
+
+  src =
+    finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  dontUnpack = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ] ++ [ unzip ];
+
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    unzip -j $src silverbullet-cli -d $out/bin
+    chmod +x $out/bin/silverbullet-cli
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchurl {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-linux-x86_64.zip";
+        hash = "sha256-zE8phpI69COeuJ7yOG5jPo/Qp4TjxmyHD4rOsaIwCrI=";
+      };
+      "aarch64-linux" = fetchurl {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-linux-aarch64.zip";
+        hash = "sha256-nrTjWWUUdeQSsPKHqoIYNkNAhmEjeqVWDWjMHyhQfPQ=";
+      };
+      "x86_64-darwin" = fetchurl {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-darwin-x86_64.zip";
+        hash = "sha256-OuWd0Iw/WZ97GbexhDkUXb+wDM5x+SJ4iGRINXan4Jw=";
+      };
+      "aarch64-darwin" = fetchurl {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-darwin-aarch64.zip";
+        hash = "sha256-7WMoHBfEVSFatLmKuEegSp02sAe4zt5csHrzDq/11ng=";
+      };
+    };
+
+    updateScript = writeShellScript "update-silverbullet-cli" ''
+      NEW_VERSION="$1"
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        ${lib.getExe' common-updater-scripts "update-source-version"} "silverbullet-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
+    '';
+  };
+
+  meta = {
+    changelog = "https://github.com/silverbulletmd/silverbullet/blob/${finalAttrs.version}/website/CHANGELOG.md";
+    description = "CLI for driving a remote SilverBullet server";
+    homepage = "https://silverbullet.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aorith ];
+    mainProgram = "silverbullet-cli";
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
+  };
+})

--- a/pkgs/by-name/si/silverbullet-server/package.nix
+++ b/pkgs/by-name/si/silverbullet-server/package.nix
@@ -9,7 +9,7 @@
   writeShellScript,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "silverbullet";
+  pname = "silverbullet-server";
   version = "2.6.1";
 
   src =
@@ -51,10 +51,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       };
     };
 
-    updateScript = writeShellScript "update-silverbullet" ''
+    updateScript = writeShellScript "update-silverbullet-server" ''
       NEW_VERSION="$1"
       for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
-        ${lib.getExe' common-updater-scripts "update-source-version"} "silverbullet" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+        ${lib.getExe' common-updater-scripts "update-source-version"} "silverbullet-server" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
       done
     '';
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1821,6 +1821,7 @@ mapAliases {
   sierra-breeze-enhanced = throw "'sierra-breeze-enhanced' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   signal-desktop-bin = throw "'signal-desktop-bin' has been replaced by 'signal-desktop' which is built from source"; # Added 2026-03-02
   signal-desktop-source = throw "'signal-desktop-source' has been renamed to/replaced by 'signal-desktop'"; # Converted to throw 2025-10-27
+  silverbullet = warnAlias "'silverbullet' has been renamed to 'silverbullet-server'" silverbullet-server; # Added 2026-04-17
   simpleBluez = warnAlias "'simpleBluez' has been renamed to 'simplebluez'" simplebluez; # Added 2026-02-18
   simpleDBus = warnAlias "'simpleDBus' has been renamed to 'simpledbus'" simpledbus; # Added 2026-02-12
   simplesamlphp = throw "'simplesamlphp' was removed because it was unmaintained in nixpkgs"; # Added 2025-10-17


### PR DESCRIPTION
Silverbullet 2.6.1 now has a server and a cli. See https://github.com/silverbulletmd/silverbullet/releases/tag/2.6.1.

This PR renames the `silverbullet` package to `silverbullet-server` and introduces `silverbullet-cli`. Both still rely on the shipped binary instead of building it ourselves.

I've deprecated `silverbullet` package with a suggestion to use `silverbullet-server`.

I was contemplating using the `silverbullet-cli` for the tests of `silverbullet-server`, but it doesn't seem to support the default 'space' and its cli is still considered experimental. I'd gather the subcommands and arguments will likely change.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
