### PR TITLE
protoc-gen-connect-rust: init at 0.3.2

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-connect-rust/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-connect-rust/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "protoc-gen-connect-rust";
+  version = "0.3.2";
+
+  src = fetchCrate {
+    pname = "connectrpc-codegen";
+    inherit (finalAttrs) version;
+    hash = "sha256-cEG00Zn9wF4YGhrF1qHABN9ZcqAUeRJU50ZNi142SX4=";
+  };
+
+  cargoHash = "sha256-Wox9oH1gX35gh1w6Q0eh54rG4GnVA54hr1felQKDtog=";
+
+  meta = {
+    description = "Protoc plugin for generating ConnectRPC Rust service bindings";
+    homepage = "https://github.com/anthropics/connect-rust";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ macalinao ];
+    mainProgram = "protoc-gen-connect-rust";
+  };
+})


### PR DESCRIPTION
## Description

Add [protoc-gen-connect-rust](https://github.com/anthropics/connect-rust), protoc plugin for generating ConnectRPC Rust service bindings.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Cross-platform builds verified via CI in [macalinao/additional-nix-packages](https://github.com/macalinao/additional-nix-packages), which runs `nix flake check` on x86_64-linux, aarch64-linux, x86_64-darwin, and aarch64-darwin.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test