### PR TITLE
{opencode,opencode-desktop}: 1.4.11 -> 1.14.19

### DIFF
--- a/pkgs/by-name/op/opencode-desktop/package.nix
+++ b/pkgs/by-name/op/opencode-desktop/package.nix
@@ -6,10 +6,10 @@
   glib,
   glib-networking,
   gst_all_1,
-  gtk3,
+  gtk4,
   jq,
   lib,
-  libappindicator-gtk3,
+  libappindicator,
   librsvg,
   libsoup_3,
   makeBinaryWrapper,
@@ -25,8 +25,7 @@
 }:
 
 let
-  gtk = gtk3;
-  libappindicator-gtk = libappindicator-gtk3;
+  gtk = gtk4;
   libsoup = libsoup_3;
   webkitgtk = webkitgtk_4_1;
 in
@@ -61,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       glib
       glib-networking
       gtk
-      libappindicator-gtk
+      libappindicator
       librsvg
       libsoup
       openssl

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -16,13 +16,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "1.4.11";
+  version = "1.14.19";
 
   src = fetchFromGitHub {
     owner = "anomalyco";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-jlxR2BODV8wk0sP4Kkyza7Zr5I+Q003gldCfp2eYOt8=";
+    hash = "sha256-kKFqMf+l+V1kaf6bZtKfUSRYYjKc3VNgxlxic2fM2fo=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -44,12 +44,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     buildPhase = ''
       runHook preBuild
 
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
       bun install \
         --cpu="*" \
         --frozen-lockfile \
+        --filter ./ \
         --filter ./packages/app \
         --filter ./packages/desktop \
         --filter ./packages/opencode \
+        --filter ./packages/shared \
         --ignore-scripts \
         --no-progress \
         --os="*"
@@ -72,7 +75,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-rF+l0Hho0QEvMS5jaImhMlhKjjf1R66X20R6lEZcZeg=";
+    outputHash = "sha256-RYyYp7LXMZP8RWZps1Esu8tW/rBM30QbH9Qrwi00adI=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
Bumps [opencode](https://github.com/anomalyco/opencode) and opencode-desktop from 1.4.11 to 1.14.19.

Release notes: 
- https://github.com/anomalyco/opencode/releases/tag/v1.14.17
- https://github.com/anomalyco/opencode/releases/tag/v1.14.18
- https://github.com/anomalyco/opencode/releases/tag/v1.14.19

Upstream jumped version numbering from 1.4.x directly to 1.14.x (there is no 1.5 through 1.13).

### Notable build changes

**opencode:**
- Set `BUN_INSTALL_CACHE_DIR` to a temp directory during `node_modules` fetch to avoid impure cache access
- Added `--filter ./` and `--filter ./packages/shared` to `bun install` to match updated workspace layout

**opencode-desktop:**
- Switched from gtk3 to gtk4, matching upstream's Tauri 2.x migration
- Use `libappindicator` directly instead of the gtk3-specific variant

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test