### PR TITLE
lucida-downloader: 0.7.0 -> 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12377,6 +12377,13 @@
     githubId = 9425955;
     name = "Jean-François Labonté";
   };
+  jelni = {
+    email = "nixpkgs@jel.gay";
+    github = "jelni";
+    githubId = 25802745;
+    matrix = "@me:jel.gay";
+    name = "jel";
+  };
   jemand771 = {
     email = "willy@jemand771.net";
     github = "jemand771";

--- a/pkgs/by-name/lu/lucida-downloader/package.nix
+++ b/pkgs/by-name/lu/lucida-downloader/package.nix
@@ -7,25 +7,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lucida-downloader";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "jelni";
     repo = "lucida-downloader";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-f5cegAucJSiRekTAZBkrdn0HoEELvINN6Rd5Ehb7InA=";
+    hash = "sha256-284f3+yKkE37wZzmyW7qupvYwEkmLvco8lc5dFSiLAQ=";
   };
 
   passthru.updateScript = nix-update-script { };
 
-  cargoHash = "sha256-ADo0AuMsvd86ytlVStBXPJ9vFG/JeSm2kDMGM5VCqzA=";
+  cargoHash = "sha256-PT8E9AqvhChKk76AA2qsAf2ICy5maQ9SK96V/vkmwy8=";
 
   meta = {
     description = "Multithreaded client for downloading music for free with lucida";
     homepage = "https://github.com/jelni/lucida-downloader";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.agpl3Plus;
     mainProgram = "lucida";
     maintainers = with lib.maintainers; [
+      jelni
       surfaceflinger
     ];
   };


### PR DESCRIPTION
- i updated `lucida-downloader` to the latest version, `0.8.0`,
- updated the license to match,
- added myself to Nixpkgs maintainers,
- added myself to `lucida-downloader` maintainers

diff: https://github.com/jelni/lucida-downloader/compare/v0.7.0...v0.8.0 - there should not be any breaking changes

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test