### PR TITLE
yaziPlugins: update on 2026-04-19

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mactag.yazi";
-  version = "26.1.22-unstable-2026-02-27";
+  version = "26.1.22-unstable-2026-04-10";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "0897e20d41b79a5ec8e80e645b041bb950547a0b";
-    hash = "sha256-tHOHWFH9E7aGrmHb8bUD1sLGU0OIdTjQ2p4SbJVfh/s=";
+    rev = "babfd0f6144aedcc7af11852ce962b989d052898";
+    hash = "sha256-y/UnRuZ2QytCdtGhxkbVvaGXglpqwufaUddXOzs7fzo=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "26.1.22-unstable-2026-03-31";
+  version = "26.1.22-unstable-2026-04-10";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "75f93be8f153709a22b798105462de6105f54d90";
-    hash = "sha256-G3Nh56OdQInByHDQbI+yFe0s2fEaQlejLdakcoJFf4I=";
+    rev = "49f5ab722d617a64b3bea87944e3e4e17ba3a46b";
+    hash = "sha256-PcGrFG06XiJYgBWq+c7fYsx1kjkCvIYRaBiWaJT+xkw=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.12.29-unstable-2026-01-31";
+  version = "25.12.29-unstable-2026-04-09";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "d078b01ecbdb0f85f6ea8836a851c6bf72f9f865";
-    hash = "sha256-aPe1AntPE76xq0VA/4FtBtRXmj+tfDjdMlQ9B9MkM+U=";
+    rev = "7749958b00d461d3c0fba4aa651940d778d1fc3f";
+    hash = "sha256-DZNhqIuGZIEEEH1TrCtAjZKa+7CWZeS1wO9aA9C0Eec=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/split-tabs/default.nix
@@ -6,13 +6,13 @@
 
 mkYaziPlugin {
   pname = "split-tabs.yazi";
-  version = "0-unstable-2026-04-09";
+  version = "0-unstable-2026-04-13";
 
   src = fetchFromGitHub {
     owner = "terrakok";
     repo = "split-tabs.yazi";
-    rev = "3f297277ed79cef5d22ea19883ce4d22e40c45a8";
-    hash = "sha256-exa9I5GaF5T2dBnKIcB1gSdtdp2QlzbHv2J9FGxfpBM=";
+    rev = "6c0931840d764bffa0c38677b6a84e69928e283f";
+    hash = "sha256-FqeXVVFk4+aXn8d+LLs8idRBkLLzRPeVol6vMCh6mQ4=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "vcs-files.yazi";
-  version = "26.1.22-unstable-2026-01-24";
+  version = "26.1.22-unstable-2026-04-10";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "6c71385af67c71cb3d62359e94077f2e940b15df";
-    hash = "sha256-+akz8E6Fmk6KwmeZOePEm/KqfbDaKeL4wiUgtm12SAE=";
+    rev = "babfd0f6144aedcc7af11852ce962b989d052898";
+    hash = "sha256-y/UnRuZ2QytCdtGhxkbVvaGXglpqwufaUddXOzs7fzo=";
   };
 
   meta = {


### PR DESCRIPTION
- mactag: 26.1.22-unstable-2026-02-27 → 26.1.22-unstable-2026-04-10
  Compare: https://github.com/yazi-rs/plugins/compare/0897e20d41b79a5ec8e80e645b041bb950547a0b...babfd0f6144aedcc7af11852ce962b989d052898
- mediainfo: 26.1.22-unstable-2026-03-31 → 26.1.22-unstable-2026-04-10
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/75f93be8f153709a22b798105462de6105f54d90...49f5ab722d617a64b3bea87944e3e4e17ba3a46b
- mount: 25.12.29-unstable-2026-01-31 → 25.12.29-unstable-2026-04-09
  Compare: https://github.com/yazi-rs/plugins/compare/d078b01ecbdb0f85f6ea8836a851c6bf72f9f865...7749958b00d461d3c0fba4aa651940d778d1fc3f
- split-tabs: 0-unstable-2026-04-09 → 0-unstable-2026-04-13
  Compare: https://github.com/terrakok/split-tabs.yazi/compare/3f297277ed79cef5d22ea19883ce4d22e40c45a8...6c0931840d764bffa0c38677b6a84e69928e283f
- vcs-files: 26.1.22-unstable-2026-01-24 → 26.1.22-unstable-2026-04-10
  Compare: https://github.com/yazi-rs/plugins/compare/6c71385af67c71cb3d62359e94077f2e940b15df...babfd0f6144aedcc7af11852ce962b989d052898


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
