### PR TITLE
treewide: substitute pname for strings (by-name)

### DIFF
--- a/pkgs/by-name/li/libtypec/package.nix
+++ b/pkgs/by-name/li/libtypec/package.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "libtypec";
-    repo = pname;
-    rev = "${pname}-${version}";
+    repo = "libtypec";
+    rev = "libtypec-${version}";
     hash = "sha256-XkT0bgBjoJTAFa9NLZdzbJSpchiXxKjeu88PeT/AlPY=";
   };
 

--- a/pkgs/by-name/na/nano-syntax-highlighting/package.nix
+++ b/pkgs/by-name/na/nano-syntax-highlighting/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   src = fetchFromGitHub {
     owner = "galenguyer";
-    repo = pname;
+    repo = "nano-syntax-highlighting";
     tag = version;
     hash = "sha256-H0F57b8M+onhpVtvna03t919xk6+z/dJP37y9hcqfCY=";
   };
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: rec {
           for nanorcPath in ${finalAttrs.finalPackage}/share/*.nanorc; do
             nano --rcfile "$nanorcPath" --listsyntaxes \
             | tail --lines +2 \
-            | xargs --max-args 1 expect -f ${expectScript}/bin/${pname}-test-syntax.exp "$nanorcPath"
+            | xargs --max-args 1 expect -f ${expectScript}/bin/nano-syntax-highlighting-test-syntax.exp "$nanorcPath"
           done;
           touch $out
         ''

--- a/pkgs/by-name/nv/nvfancontrol/package.nix
+++ b/pkgs/by-name/nv/nvfancontrol/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
 
   src = fetchFromGitHub {
     owner = "foucault";
-    repo = pname;
+    repo = "nvfancontrol";
     rev = version;
     sha256 = "sha256-0WBQSnTYVc3sNmZf/KFzznMg9AVsyaBgdx/IvG1dZAw=";
   };

--- a/pkgs/by-name/pr/prometheus-artifactory-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-artifactory-exporter/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "peimanja";
-    repo = pname;
+    repo = "artifactory_exporter";
     rev = rev;
     hash = "sha256-ffICacOaYD3/wB38qQ/qYOfDwQxe1tndRdR2BHxolcA=";
   };

--- a/pkgs/by-name/pr/prometheus-bitcoin-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-bitcoin-exporter/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "jvstein";
-    repo = pname;
+    repo = "bitcoin-prometheus-exporter";
     tag = "v${version}";
     sha256 = "sha256-08QG/5Kj++rjWz7OciqKSJUk00lSJCbfB5XwwP+h4so=";
   };
@@ -31,8 +31,8 @@ python3Packages.buildPythonApplication rec {
     mkdir -p $out/bin
     cp bitcoind-monitor.py $out/bin/
 
-    mkdir -p $out/share/${pname}
-    cp -r dashboard README.md $out/share/${pname}/
+    mkdir -p $out/share/bitcoin-prometheus-exporter
+    cp -r dashboard README.md $out/share/bitcoin-prometheus-exporter/
   '';
 
   meta = {

--- a/pkgs/by-name/pr/prometheus-cloudflare-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-cloudflare-exporter/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "lablabs";
-    repo = pname;
+    repo = "cloudflare-exporter";
     tag = "cloudflare-exporter-${version}";
     sha256 = "sha256-rfnAGBuY6HoWzZkYp9u+Ee3xhWb6Se2RkkSIWBvjUYY=";
   };

--- a/pkgs/by-name/pr/prometheus-flow-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-flow-exporter/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "neptune-networks";
-    repo = pname;
+    repo = "flow-exporter";
     sha256 = "sha256-6FqupoYWRvex7XhM7ly8f7ICnuS9JvCRIVEBIJe+64k=";
   };
 

--- a/pkgs/by-name/pr/prometheus-gitlab-ci-pipelines-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-gitlab-ci-pipelines-exporter/package.nix
@@ -10,12 +10,12 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "mvisonneau";
-    repo = pname;
+    repo = "gitlab-ci-pipelines-exporter";
     rev = "v${version}";
     sha256 = "sha256-r/6tRecbLN9bX2+HYyk4tT0uNiAqtZwMoMMQUJ7niJI=";
   };
 
-  subPackages = [ "cmd/${pname}" ];
+  subPackages = [ "cmd/gitlab-ci-pipelines-exporter" ];
 
   ldflags = [
     "-X main.version=v${version}"

--- a/pkgs/by-name/pr/prometheus-nats-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-nats-exporter/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "nats-io";
-    repo = pname;
+    repo = "prometheus-nats-exporter";
     rev = "v${version}";
     sha256 = "sha256-siucc55qi1SS2R07xgxh25CWYjxncUqvzxo0XoIPyOo=";
   };

--- a/pkgs/by-name/pr/prometheus-php-fpm-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-php-fpm-exporter/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "hipages";
-    repo = pname;
+    repo = "php-fpm_exporter";
     rev = "v${version}";
     hash = "sha256-ggrFnyEdGBoZVh4dHMw+7RUm8nJ1hJXo/fownO3wvzE=";
   };

--- a/pkgs/by-name/pr/prometheus-pihole-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-pihole-exporter/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "eko";
-    repo = pname;
+    repo = "pihole-exporter";
     rev = "v${version}";
     sha256 = "sha256-ge4+sWQkJ2Zc7Y7+IYAq6OK6pYkaE3jjFo1rhTaDMu4=";
   };

--- a/pkgs/by-name/pr/prometheus-process-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-process-exporter/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "ncabatoff";
-    repo = pname;
+    repo = "process-exporter";
     rev = "v${version}";
     sha256 = "sha256-dxXBhrZdYM+mH73K/cdaSmfzbzZaPJYCTzcfXGYMlyY=";
   };

--- a/pkgs/by-name/pr/prometheus-sabnzbd-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-sabnzbd-exporter/package.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "msroest";
-    repo = pname;
+    repo = "sabnzbd_exporter";
     tag = version;
     hash = "sha256-9oL9Zbzzbr0hZjOdkaH86Tho6gaR+/6uAMreLwYzB8o=";
   };
@@ -29,8 +29,8 @@ python3Packages.buildPythonApplication rec {
     mkdir -p $out/bin
     cp sabnzbd_exporter.py $out/bin/
 
-    mkdir -p $out/share/${pname}
-    cp examples/* $out/share/${pname}/
+    mkdir -p $out/share/sabnzbd_exporter
+    cp examples/* $out/share/sabnzbd_exporter/
 
     runHook postInstall
   '';

--- a/pkgs/by-name/pr/prometheus-script-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-script-exporter/package.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "ricoberger";
-    repo = pname;
+    repo = "script_exporter";
     rev = "v${version}";
     hash = "sha256-TanhxXQYiMVkY89TfuzlHNrExe0u6FCPUlmuLgCN1RQ=";
   };

--- a/pkgs/by-name/pr/prometheus-sql-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-sql-exporter/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "justwatchcom";
-    repo = pname;
+    repo = "sql_exporter";
     rev = "v${version}";
     sha256 = "sha256-fbPjUMSDNqF8TPnhRaTgIRsuTcHhaRkTND9KdCwaCUI=";
   };

--- a/pkgs/by-name/pr/prometheus-systemd-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-systemd-exporter/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "prometheus-community";
-    repo = pname;
+    repo = "systemd_exporter";
     rev = "v${version}";
     sha256 = "sha256-wWXtAyQ48fsh/9BBo2tHXf4QS3Pbsmj6rha28TdBRWI=";
   };

--- a/pkgs/by-name/pr/prometheus-xmpp-alerts/package.nix
+++ b/pkgs/by-name/pr/prometheus-xmpp-alerts/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "jelmer";
-    repo = pname;
+    repo = "prometheus-xmpp-alerts";
     rev = "v${version}";
     sha256 = "sha256-kXcadJnPPhMKF/1CHMLdGCqWouAKDBFTdvPpn80yK4A=";
   };

--- a/pkgs/by-name/pr/prometheus-zfs-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-zfs-exporter/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "pdf";
-    repo = pname;
+    repo = "zfs_exporter";
     rev = "v" + version;
     hash = "sha256-4nuZhPqBqGOR5zM1yyxPD0M4bVZNaIm72uSus6CvCrU=";
   };
@@ -28,7 +28,7 @@ buildGoModule rec {
   ];
 
   postInstall = ''
-    install -Dm444 -t $out/share/doc/${pname} *.md
+    install -Dm444 -t $out/share/doc/zfs_exporter *.md
   '';
 
   meta = {

--- a/pkgs/by-name/sc/scopehal-apps/package.nix
+++ b/pkgs/by-name/sc/scopehal-apps/package.nix
@@ -33,12 +33,12 @@ let
   version = "0.1.1";
 in
 stdenv.mkDerivation {
-  pname = "${pname}";
+  pname = "scopehal-apps";
   version = "${version}";
 
   src = fetchFromGitHub {
     owner = "ngscopeclient";
-    repo = "${pname}";
+    repo = "scopehal-apps";
     tag = "v${version}";
     hash = "sha256-7ZXfxfRa+1fbMj2IDF/boNL/qCy4i9IyMnzIgOZunDw=";
     fetchSubmodules = true;


### PR DESCRIPTION
repeat of #410679 as-is, part of #346453


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
