### PR TITLE
treewide: substitute pname for strings (python-modules)

### DIFF
--- a/pkgs/development/python-modules/cddlparser/default.nix
+++ b/pkgs/development/python-modules/cddlparser/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "tidoust";
-    repo = pname;
+    repo = "cddlparser";
     tag = "v${version}";
     sha256 = "sha256-LcIxU77bYpsuE4j1QgzdD3d7CO/EUEA9xwn+uIV68Oc=";
   };

--- a/pkgs/development/python-modules/copier-template-tester/default.nix
+++ b/pkgs/development/python-modules/copier-template-tester/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "KyleKing";
-    repo = pname;
+    repo = "copier-template-tester";
     tag = version;
     hash = "sha256-n/39Gl4q24QKfVFaeeqqu0AQt2jRSRrcnEOFRHQ+SQE=";
   };

--- a/pkgs/development/python-modules/corallium/default.nix
+++ b/pkgs/development/python-modules/corallium/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "KyleKing";
-    repo = pname;
+    repo = "corallium";
     tag = version;
     hash = "sha256-0P8qmX+1zigL4jaA4TTuqAzFkyhQUfdGmPLxkFnT0qE=";
   };

--- a/pkgs/development/python-modules/cron-converter/default.nix
+++ b/pkgs/development/python-modules/cron-converter/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Sonic0";
-    repo = pname;
+    repo = "cron-converter";
     rev = "v${version}";
     hash = "sha256-zNDEBckvSwnqBfNyh5Gv7ICOsPaSx2NKl92ZlyDfukw=";
   };

--- a/pkgs/development/python-modules/pytest-insta/default.nix
+++ b/pkgs/development/python-modules/pytest-insta/default.nix
@@ -8,14 +8,14 @@
   wrapt,
 }:
 
-buildPythonPackage (finalAttrs: rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-insta";
   version = "0.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "vberlier";
-    repo = pname;
+    repo = "pytest-insta";
     tag = "v${finalAttrs.version}";
     hash = "sha256-zOhWDaCGkE/Ke2MLRyttDH85t+I9kfBZZwVDRN1sprs=";
   };

--- a/pkgs/development/python-modules/pytest-reraise/default.nix
+++ b/pkgs/development/python-modules/pytest-reraise/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "bjoluc";
-    repo = pname;
+    repo = "pytest-reraise";
     tag = "v${version}";
     hash = "sha256-mgNKoZ+2sinArTZhSwhLxzBTb4QfiT1LWBs7w5MHXWA=";
   };

--- a/pkgs/development/python-modules/qiskit-finance/default.nix
+++ b/pkgs/development/python-modules/qiskit-finance/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "qiskit";
-    repo = pname;
+    repo = "qiskit-finance";
     tag = version;
     hash = "sha256-zYhYhojCzlENzgYSenwewjeVHUBX2X6eQbbzc9znBsk=";
   };

--- a/pkgs/development/python-modules/qiskit-machine-learning/default.nix
+++ b/pkgs/development/python-modules/qiskit-machine-learning/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "qiskit";
-    repo = pname;
+    repo = "qiskit-machine-learning";
     tag = version;
     hash = "sha256-l7lzdGSarj1DiC0igeyr6kP+GYYE+eGKdW9+IN+2uh8=";
   };

--- a/pkgs/development/python-modules/qiskit-nature/default.nix
+++ b/pkgs/development/python-modules/qiskit-nature/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "Qiskit";
-    repo = pname;
+    repo = "qiskit-nature";
     tag = version;
     hash = "sha256-SVzg3McB885RMyAp90Kr6/iVKw3Su9ucTob2jBckBo0=";
   };

--- a/pkgs/development/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/development/python-modules/qiskit-optimization/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "qiskit";
-    repo = pname;
+    repo = "qiskit-optimization";
     tag = version;
     hash = "sha256-aonL08avVZlpGQ/FCZnrsPMvu1lbhRiadzKf/oPndZk=";
   };

--- a/pkgs/development/python-modules/sphinx-tippy/default.nix
+++ b/pkgs/development/python-modules/sphinx-tippy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "sphinx-extensions2";
-    repo = pname;
+    repo = "sphinx-tippy";
     tag = "v${version}";
     hash = "sha256-+EXvj8Q6eMu51Gh4hLD6h8I7PDZaeVH+2pZuQUMVH+4=";
   };

--- a/pkgs/development/python-modules/textx/default.nix
+++ b/pkgs/development/python-modules/textx/default.nix
@@ -16,8 +16,8 @@ let
     pyproject = true;
 
     src = fetchFromGitHub {
-      owner = pname;
-      repo = pname;
+      owner = "textx";
+      repo = "textx";
       tag = version;
       hash = "sha256-2sRMMbWJN9H34zD++9T499Y4+wv5ZSSkN6xevH2fuVs=";
     };
@@ -33,7 +33,7 @@ let
 
     postInstall = ''
       # FileNotFoundError: [Errno 2] No such file or directory: '$out/lib/python3.10/site-packages/textx/textx.tx
-      cp "$src/textx/textx.tx" "$out/${python.sitePackages}/${pname}/"
+      cp "$src/textx/textx.tx" "$out/${python.sitePackages}/textx/"
 
       # Install tests as the tests output.
       mkdir $testout


### PR DESCRIPTION
repeat of #410679 limited to `pkgs/development/python-modules/`, part of #346453


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
