### PR TITLE
check-meta.nix: fix check for license type attr

### DIFF
--- a/pkgs/stdenv/generic/check-meta-test.nix
+++ b/pkgs/stdenv/generic/check-meta-test.nix
@@ -22,14 +22,17 @@ let
     assertMsg
     generators
     licenses
+    nameValuePair
     recurseIntoAttrs
+    replaceString
     ;
 
-  mkUnfreePkg = name: {
+  mkPkg = name: license: {
     pname = name;
     version = "1.0";
-    meta.license = licenses.unfree;
+    meta.license = license;
   };
+
   assertValidity =
     {
       nixpkgsConfig,
@@ -52,77 +55,97 @@ let
       toPretty = generators.toPretty { };
     in
     assertMsg (actual.success == expected) ''
-      Expected validity of package ${lib.getName pkg} to be ${toPretty expected},
-      but got ${toPretty actual} with config:
+      Expected validity of package '${lib.getName pkg}' with unfree license
+      '${licenses.toSPDX pkg.meta.license}' to be ${toPretty expected}, but got
+      ${toPretty actual}
+      with config:
       ${toPretty nixpkgsConfig}
     '';
 
   runAssertions = assertions: lib.deepSeq assertions "";
 
-in
-recurseIntoAttrs {
-
-  allowOnlyFreePackagesByDefault = assertValidity {
-    nixpkgsConfig = { };
-    pkg = mkUnfreePkg "forbidden";
-    expected = false;
-  };
-
-  allowAllUnfreePackages = assertValidity {
-    nixpkgsConfig = {
-      allowUnfree = true;
+  mkTests = mkUnfreePkg: {
+    allowOnlyFreePackagesByDefault = assertValidity {
+      nixpkgsConfig = { };
+      pkg = mkUnfreePkg "forbidden";
+      expected = false;
     };
-    pkg = mkUnfreePkg "allowed";
+
+    allowAllUnfreePackages = assertValidity {
+      nixpkgsConfig = {
+        allowUnfree = true;
+      };
+      pkg = mkUnfreePkg "allowed";
+    };
+
+    allowUnfreePackagesWithPredicate =
+      let
+        nixpkgsConfig = {
+          allowUnfreePredicate = pkg: lib.getName pkg == "allowed-by-predicate";
+        };
+      in
+      [
+        (assertValidity {
+          inherit nixpkgsConfig;
+          pkg = mkUnfreePkg "allowed-by-predicate";
+        })
+        (assertValidity {
+          inherit nixpkgsConfig;
+          pkg = mkUnfreePkg "allowed-by-nothing";
+          expected = false;
+        })
+      ];
+
+    allowUnfreeWithPackages = runAssertions [
+      (assertValidity {
+        nixpkgsConfig = {
+          allowUnfreePackages = [ "unfree" ];
+        };
+        pkg = mkUnfreePkg "unfree";
+        expected = true;
+      })
+    ];
+
+    allowUnfreePackagesOrPredicate =
+      let
+        nixpkgsConfig = {
+          allowUnfreePackages = [ "allowed-by-packages" ];
+          allowUnfreePredicate = pkg: lib.getName pkg == "allowed-by-predicate";
+        };
+      in
+      runAssertions [
+        (assertValidity {
+          inherit nixpkgsConfig;
+          pkg = mkUnfreePkg "allowed-by-packages";
+        })
+        (assertValidity {
+          inherit nixpkgsConfig;
+          pkg = mkUnfreePkg "allowed-by-predicate";
+        })
+        (assertValidity {
+          inherit nixpkgsConfig;
+          pkg = mkUnfreePkg "forbidden";
+          expected = false;
+        })
+      ];
   };
 
-  allowUnfreePackagesWithPredicate =
-    let
-      nixpkgsConfig = {
-        allowUnfreePredicate = pkg: lib.getName pkg == "allowed-by-predicate";
-      };
-    in
-    [
-      (assertValidity {
-        inherit nixpkgsConfig;
-        pkg = mkUnfreePkg "allowed-by-predicate";
-      })
-      (assertValidity {
-        inherit nixpkgsConfig;
-        pkg = mkUnfreePkg "allowed-by-nothing";
-        expected = false;
-      })
-    ];
-
-  allowUnfreeWithPackages = runAssertions [
-    (assertValidity {
-      nixpkgsConfig = {
-        allowUnfreePackages = [ "unfree" ];
-      };
-      pkg = mkUnfreePkg "unfree";
-      expected = true;
-    })
+  unfreeLicenses = [
+    licenses.unfree
+    (licenses.AND [
+      licenses.free
+      licenses.unfree
+    ])
   ];
+in
 
-  allowUnfreePackagesOrPredicate =
-    let
-      nixpkgsConfig = {
-        allowUnfreePackages = [ "allowed-by-packages" ];
-        allowUnfreePredicate = pkg: lib.getName pkg == "allowed-by-predicate";
-      };
-    in
-    runAssertions [
-      (assertValidity {
-        inherit nixpkgsConfig;
-        pkg = mkUnfreePkg "allowed-by-packages";
-      })
-      (assertValidity {
-        inherit nixpkgsConfig;
-        pkg = mkUnfreePkg "allowed-by-predicate";
-      })
-      (assertValidity {
-        inherit nixpkgsConfig;
-        pkg = mkUnfreePkg "forbidden";
-        expected = false;
-      })
-    ];
-}
+recurseIntoAttrs (
+  builtins.listToAttrs (
+    map (
+      license:
+      nameValuePair (replaceString " " "-" (licenses.toSPDX license)) (
+        recurseIntoAttrs (mkTests (name: mkPkg name license))
+      )
+    ) unfreeLicenses
+  )
+)

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -90,7 +90,7 @@ let
       && (
         if isList attrs.meta.license then
           any (l: elem l list) attrs.meta.license
-        else if attrs.meta.license ? "type" then
+        else if attrs.meta.license ? "licenseType" then
           lib.licenses.containsLicenses list attrs.meta.license
         else
           elem attrs.meta.license list
@@ -105,7 +105,7 @@ let
 
   isUnfree =
     licenses:
-    if isAttrs licenses && licenses ? "type" then
+    if isAttrs licenses && licenses ? "licenseType" then
       !(lib.licenses.isFree licenses)
     else if isAttrs licenses then
       !(licenses.free or true)


### PR DESCRIPTION
I noticed that, after adding a compound license to an unfree package I maintain in https://github.com/NixOS/nixpkgs/pull/510722, `nix-build` doesn't require me to set `NIXPKGS_ALLOW_UNFREE=1` to evaluate that package anymore.

It looks like the relevant checks in `check-meta.nix` check for a `type` attribute on licenses, where they should probably check for `licenseType` from what I can tell after looking at the changes introduced by #468378.

This PR adds tests for this issue and a fix. Note that although the diff of `check-meta-test.nix` looks messy, I mostly just indented stuff.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
