### PR TITLE
source2viewer-cli: init at 19.1

### DIFF
--- a/pkgs/by-name/so/source2viewer-cli/deps.json
+++ b/pkgs/by-name/so/source2viewer-cli/deps.json
@@ -1,0 +1,102 @@
+[
+  {
+    "pname": "Blake3",
+    "version": "2.0.0",
+    "hash": "sha256-WN+SuzMiv8UfT3r0r124wcbs/8OOixjpZkYwdTfeHvc="
+  },
+  {
+    "pname": "ConsoleAppFramework",
+    "version": "5.7.13",
+    "hash": "sha256-ZI9IqVb5EjVbvItoqYj4PBaxWqUZ3LCmPXvTnJh3Yfg="
+  },
+  {
+    "pname": "K4os.Compression.LZ4",
+    "version": "1.3.8",
+    "hash": "sha256-OmT3JwO4qpkZDL7XqiFqZCyxySj64s9t+mXcN1T+IyA="
+  },
+  {
+    "pname": "KeyValues2",
+    "version": "0.8.0",
+    "hash": "sha256-aE0bZIn1mFlUVUYJBQf8VdlOTmbeaawLoLLjuxZE7G8="
+  },
+  {
+    "pname": "SharpGLTF.Core",
+    "version": "1.0.6",
+    "hash": "sha256-aG6/X5cLoKRBxyvXl/4iX6kWAba7LuMgG86M4CsOVlA="
+  },
+  {
+    "pname": "SharpGLTF.Runtime",
+    "version": "1.0.6",
+    "hash": "sha256-rcvhtFPFQUH1rVt1NW10PFRTJFGeAe5PQU6Mrtz1txg="
+  },
+  {
+    "pname": "SharpGLTF.Toolkit",
+    "version": "1.0.6",
+    "hash": "sha256-cNoihUH9VjaNz2WTSJnO8s0jaPd+aIX3c6YkIDf7tnw="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "3.119.2",
+    "hash": "sha256-A9F397K5FfLeOsNZacKmUh4IU/WMK60B4Z6TEtS/oqo="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux.NoDependencies",
+    "version": "3.119.2",
+    "hash": "sha256-79BCLZAYjfHP1DZKgB+hsyyBlhnyZQPi+Swvs0RYnng="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "3.119.2",
+    "hash": "sha256-KEeGqSiyAiMbzLgH/0JkwUz/pWcL49gYB1T1YLkMPaI="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "3.119.2",
+    "hash": "sha256-CI6dg+MlxX8t+vbnkxtd5QE3xalMKkA8LUSudxg7TNU="
+  },
+  {
+    "pname": "System.IO.Hashing",
+    "version": "10.0.5",
+    "hash": "sha256-iZrjJEZU+GnKBWYLi0+NUc+yYKrCSQkaLmQrGDQyyeE="
+  },
+  {
+    "pname": "System.IO.Hashing",
+    "version": "9.0.11",
+    "hash": "sha256-TlrAIz1kWyCBCpEZzcvR9Bir1NMJUqKxXtbgjPjPFYs="
+  },
+  {
+    "pname": "TinyBCSharp",
+    "version": "0.1.2",
+    "hash": "sha256-iDoc6eebSXFYN2mzjdKI3yOlRsD3VMFS5MLx1RNE5UQ="
+  },
+  {
+    "pname": "TinyEXR.NET",
+    "version": "0.3.11",
+    "hash": "sha256-/FRb3ZKlACiSM+q8Fj5zEvVMyNmOaO1O/w2c/NULBgA="
+  },
+  {
+    "pname": "ValveKeyValue",
+    "version": "0.70.0.499",
+    "hash": "sha256-HMMO3hXpCK7D+xXJ6RfA/sPPmjDubbZN4fWdv7kTBhg="
+  },
+  {
+    "pname": "ValvePak",
+    "version": "4.0.0.142",
+    "hash": "sha256-NjrVgZgXIQOZ2lHrnN1cLlZprsL5PstiqQ9hwUsgC00="
+  },
+  {
+    "pname": "Vortice.SPIRV",
+    "version": "1.0.5",
+    "hash": "sha256-CMq4YA1ZM5M5t9IKOS8CPM+/W8HGnjA93YiuIvuHRZA="
+  },
+  {
+    "pname": "Vortice.SpirvCross",
+    "version": "1.5.4",
+    "hash": "sha256-T+tgMCiRm9wnbd4qkmjHip7jErEWOnXOju5A3EV8dGk="
+  },
+  {
+    "pname": "ZstdSharp.Port",
+    "version": "0.8.7",
+    "hash": "sha256-WsuDTZOv3TgiE8NV/TXbKRMHBsZKgWB8iDdKKr9OvAo="
+  }
+]

--- a/pkgs/by-name/so/source2viewer-cli/package.nix
+++ b/pkgs/by-name/so/source2viewer-cli/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildDotnetModule (finalAttrs: {
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pname = "source2viewer-cli";
+  version = "19.1";
+
+  src = fetchFromGitHub {
+    owner = "ValveResourceFormat";
+    repo = "ValveResourceFormat";
+    tag = finalAttrs.version;
+    hash = "sha256-eH/qAnStEjin/OM83JT1BfvWqwhjR0OoukIbAgxBNZU=";
+  };
+
+  projectFile = "CLI/CLI.csproj";
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+  nugetDeps = ./deps.json;
+
+  executables = [ "Source2Viewer-CLI" ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Parser, decompiler, and exporter for Valve's Source 2 resource file format (VRF)";
+    homepage = "https://github.com/ValveResourceFormat/ValveResourceFormat";
+    changelog = "https://github.com/ValveResourceFormat/ValveResourceFormat/releases/tag/${finalAttrs.version}";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    license = lib.licenses.mit;
+    mainProgram = "Source2Viewer-CLI";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ cr0n ];
+  };
+})

--- a/pkgs/by-name/so/source2viewer-cli/update.sh
+++ b/pkgs/by-name/so/source2viewer-cli/update.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+set -eu -o pipefail
+
+pkg_file="$(dirname "${BASH_SOURCE[0]}")/package.nix"
+
+new_version=$(
+    curl -s "https://api.github.com/repos/ValveResourceFormat/ValveResourceFormat/releases/latest" \
+       | jq -r '.tag_name'
+)
+
+old_version=$(sed -nE 's/^\s*version = "([^"]+)";/\1/p' $pkg_file)
+
+if [[ $new_version == $old_version ]]; then
+    echo "latest version, no update required"
+    exit 0
+fi
+
+[[ $new_version =~ ^[0-9]+\.[0-9]+$ ]] \
+    && update-source-version source2viewer-cli "$new_version" \
+    && $(nix-build -A source2viewer-cli.fetch-deps --no-out-link)


### PR DESCRIPTION
Add the CLI of [Source 2 Viewer](https://github.com/ValveResourceFormat/ValveResourceFormat), a parser, decompiler, and exporter for Valve's Source 2 resource file format (VRF).

Homepage: https://s2v.app/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
