### PR TITLE
libmonome, serialosc: init

### DIFF
--- a/pkgs/by-name/li/libmonome/package.nix
+++ b/pkgs/by-name/li/libmonome/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  udev,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libmonome";
+  version = "1.4.9";
+
+  src = fetchFromGitHub {
+    owner = "monome";
+    repo = "libmonome";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-a5r8HrR2x8NdC8E1fz+4fuEk+2CGDTYcJdIVZfX9hCA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [ udev ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "C library for interacting with monome devices (grids, arcs)";
+    homepage = "https://github.com/monome/libmonome";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ];
+  };
+})

--- a/pkgs/by-name/se/serialosc/package.nix
+++ b/pkgs/by-name/se/serialosc/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+  wafHook,
+  pkg-config,
+  git,
+  makeWrapper,
+  libmonome,
+  liblo,
+  libuv,
+  avahi-compat,
+  udev,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "serialosc";
+  version = "1.4.7";
+
+  src = fetchFromGitHub {
+    owner = "monome";
+    repo = "serialosc";
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-zglwhRXKJCvVwGIj+72ZUUxzhHaFHVggMrJunDcY2UE=";
+  };
+
+  # Upstream's wscript calls `git rev-parse` unconditionally but only
+  # catches CalledProcessError, not FileNotFoundError. Including git
+  # here keeps the call from raising an unhandled exception when the
+  # build runs outside a git checkout.
+  nativeBuildInputs = [
+    python3
+    wafHook
+    pkg-config
+    git
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libmonome
+    liblo
+    libuv
+    avahi-compat
+    udev
+  ];
+
+  # serialosc calls `dlopen("libdns_sd.so")` at runtime for its
+  # zeroconf/Bonjour code. Wrap the daemon so LD_LIBRARY_PATH covers
+  # avahi-compat's lib dir; otherwise the dlopen silently fails and
+  # LAN-visible device advertisement is disabled.
+  postInstall = ''
+    wrapProgram $out/bin/serialoscd \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ avahi-compat ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Multi-device, Bonjour-capable OSC server for monome devices";
+    homepage = "https://github.com/monome/serialosc";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.linux;
+    mainProgram = "serialoscd";
+    maintainers = with lib.maintainers; [ ];
+  };
+})


### PR DESCRIPTION
Adds libmonome 1.4.9 and serialosc 1.4.7 as two by-name packages.
Tested end-to-end on NixOS 26.05 (unstable) with a monome 256 grid.
Replaces the closed prior attempt #78659.