### PR TITLE
gephgui-wry: 5.7.0, drop nodejs override and fix aarch64

### DIFF
--- a/pkgs/by-name/ge/gephgui-wry/package.nix
+++ b/pkgs/by-name/ge/gephgui-wry/package.nix
@@ -57,13 +57,13 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gephgui-wry";
-  version = "5.5.0";
+  version = "5.7.0";
 
   src = fetchFromGitHub {
     owner = "geph-official";
     repo = "gephgui-pkg";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NxtE26GPG2EvgtMa6eEOZmOcqu4yYr3zioF1CmrxLRk=";
+    hash = "sha256-f6IC9dRQ3CW3P0TRuOe1mmG3jOAvyMPBpylHJ82AUpM=";
     fetchSubmodules = true;
   };
 
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     inherit (finalAttrs) version src;
 
     sourceRoot = "${finalAttrs.src.name}/gephgui-wry/gephgui";
-    npmDepsHash = "sha256-dGzmdvzKp/JHCgDf3NJb0oolgW4Y/spagzpeVpMF28w=";
+    npmDepsHash = "sha256-GFeHowIv+TiejSNK6kAGAgYcwc2DHu3c4UBEeTScIPk=";
 
     installPhase = ''
       runHook preInstall
@@ -85,7 +85,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   sourceRoot = "${finalAttrs.src.name}/gephgui-wry";
-  cargoHash = "sha256-Dh1WuxU1rRDNu2cF9GCo1CIiph1sLc5j0GSPb7b7kJA=";
+  cargoHash = "sha256-Ekl03CvM32E3Q86YZL8eBFYAzDcpAXq8yVi2Fg3t5yc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ge/gephgui-wry/package.nix
+++ b/pkgs/by-name/ge/gephgui-wry/package.nix
@@ -28,11 +28,16 @@ let
 
     postPatch = ''
       rm binaries/*/pac
-      substituteInPlace Makefile --replace-fail 'uname -p' 'uname -m'
+      substituteInPlace Makefile \
+        --replace-fail 'uname -p' 'uname -m' \
+        --replace-fail 'ifneq ($(filter arm%,$(UNAME_P)),)' 'ifneq ($(filter aarch64 arm%,$(UNAME_P)),)'
     '';
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ glib ];
+    preBuild = ''
+      mkdir -p binaries/linux_arm
+    '';
     installPhase = ''
       runHook preInstall
 
@@ -68,9 +73,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     sourceRoot = "${finalAttrs.src.name}/gephgui-wry/gephgui";
     npmDepsHash = "sha256-dGzmdvzKp/JHCgDf3NJb0oolgW4Y/spagzpeVpMF28w=";
-
-    # npm dependency install fails with nodejs_24: https://github.com/NixOS/nixpkgs/issues/474535
-    nodejs = nodejs_22;
 
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
Upstream updated package-lock.json, and `npm ci` now works properly on non-linux-x64 platforms too. 

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/512982

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
