### PR TITLE
gollvm: init at unstable-2025-04-07

### DIFF
--- a/pkgs/by-name/go/gollvm/0001-use-nix-system-libs.patch
+++ b/pkgs/by-name/go/gollvm/0001-use-nix-system-libs.patch
@@ -1,0 +1,113 @@
+From a04dbb2a6c484e85c5c1c08f6f0a8a1c3a31f9f0 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 20:10:00 -0500
+Subject: [PATCH 1/10] cmake: allow using preinstalled GMP, MPFR, and MPC
+
+Gollvm normally downloads and builds GMP, MPFR, and MPC with
+ExternalProject. That is convenient for ad hoc builds, but it does not
+work well for Nix packaging: dependencies must already be present in
+the store and builds must not fetch sources from the network.
+
+Teach the build to accept an existing prefix for these libraries. When
+the prefix is set, reuse its include and library directories, replace
+the ExternalProject targets with empty compatibility targets, and link
+against the preinstalled libraries. The old in-tree download path stays
+unchanged when the cache variable is not provided.
+---
+ CMakeLists.txt                       | 14 ++++++++++++++
+ driver-main/CMakeLists.txt           |  2 +-
+ unittests/BackendCore/CMakeLists.txt |  3 ++-
+ unittests/Driver/CMakeLists.txt      |  2 +-
+ 4 files changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f5b8baa64c28..0462943bb1eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,6 +25,11 @@ include(AddGollvm)
+ processorcount(PROCESSOR_COUNT)
+ 
+ set(EXTINSTALLDIR ${CMAKE_CURRENT_BINARY_DIR}/external/install)
++set(GOLLVM_SYSTEM_EXTINSTALLDIR "" CACHE PATH
++  "Existing prefix containing include/ and lib/ directories for GMP, MPFR, and MPC")
++if(NOT "${GOLLVM_SYSTEM_EXTINSTALLDIR}" STREQUAL "")
++  set(EXTINSTALLDIR "${GOLLVM_SYSTEM_EXTINSTALLDIR}")
++endif()
+ set(EXTLIBDIR "${EXTINSTALLDIR}/lib")
+ set(EXTINCLUDEDIR "${EXTINSTALLDIR}/include")
+ set(EXTCPPFLAGS "CFLAGS=-I${EXTINCLUDEDIR}")
+@@ -36,6 +41,8 @@ if(LLVM_ENABLE_PIC)
+ endif()
+ set(EXTLDFLAGS "LDFLAGS=-L${EXTLIBDIR}")
+ set(EXTCC "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}")
++set(GOLLVM_EXTLIB_LINK_FLAGS
++  "-L${EXTLIBDIR}" "-Wl,--push-state" "-Wl,-Bstatic" "-lmpc" "-lmpfr" "-lgmp" "-Wl,--pop-state")
+ 
+ set(gollvm_binroot "${CMAKE_CURRENT_BINARY_DIR}")
+ 
+@@ -54,6 +61,12 @@ else()
+   message(SEND_ERROR "Arch ${llarch} not yet supported")
+ endif()
+ 
++if(NOT "${GOLLVM_SYSTEM_EXTINSTALLDIR}" STREQUAL "")
++  add_custom_target(libgmp)
++  add_custom_target(libmpfr DEPENDS libgmp)
++  add_custom_target(libmpc DEPENDS libgmp libmpfr)
++  set(GOLLVM_EXTLIB_LINK_FLAGS "-L${EXTLIBDIR}" "-lmpc" "-lmpfr" "-lgmp")
++else()
+ externalproject_add(libgmp
+   URL https://gmplib.org/download/gmp/gmp-6.2.0.tar.bz2 https://mirrors.kernel.org/gnu/gmp/gmp-6.2.0.tar.bz2
+   URL_MD5 c24161e0dd44cae78cd5f67193492a21
+@@ -95,6 +108,7 @@ externalproject_add(libmpc
+   LOG_BUILD 1
+   LOG_INSTALL 1
+   )
++endif()
+ 
+ # Top level targets for building, installing
+ add_custom_target(gollvm ALL)
+diff --git a/driver-main/CMakeLists.txt b/driver-main/CMakeLists.txt
+index c3c59aa76294..7a491e9df051 100644
+--- a/driver-main/CMakeLists.txt
++++ b/driver-main/CMakeLists.txt
+@@ -40,7 +40,7 @@ add_dependencies(llvm-goc libmpfr libmpc libgmp)
+ # Add in the libraries for the llvm-goc dependencies.
+ target_link_libraries(llvm-goc
+   PRIVATE
+-  "-L${EXTLIBDIR}" "-Wl,--push-state" "-Wl,-Bstatic" "-lmpc" "-lmpfr" "-lgmp" "-Wl,--pop-state"
++  ${GOLLVM_EXTLIB_LINK_FLAGS}
+   )
+ 
+ # Create a "compiler built" file each time llvm-goc is built.
+diff --git a/unittests/BackendCore/CMakeLists.txt b/unittests/BackendCore/CMakeLists.txt
+index 96182d316166..3c9de03ff6d0 100644
+--- a/unittests/BackendCore/CMakeLists.txt
++++ b/unittests/BackendCore/CMakeLists.txt
+@@ -30,6 +30,7 @@ add_gobackend_unittest(GoBackendCoreTests
+   )
+ 
+ include_directories(${unittest_testutils_src})
++include_directories(${EXTINSTALLDIR}/include)
+ include_directories(${MPCINSTALL}/include)
+ include_directories(${MPFRINSTALL}/include)
+ include_directories(${GMPINSTALL}/include)
+@@ -41,5 +42,5 @@ add_dependencies(GoBackendCoreTests libmpfr libmpc libgmp)
+ target_link_libraries(GoBackendCoreTests
+   PRIVATE
+   GoUnitTestUtils
+-  "-L${EXTLIBDIR}" "-Wl,--push-state" "-Wl,-Bstatic" "-lmpc" "-lmpfr" "-lgmp" "-Wl,--pop-state"
++  ${GOLLVM_EXTLIB_LINK_FLAGS}
+   )
+diff --git a/unittests/Driver/CMakeLists.txt b/unittests/Driver/CMakeLists.txt
+index 0fc07e4196c0..e3bae5df70cf 100644
+--- a/unittests/Driver/CMakeLists.txt
++++ b/unittests/Driver/CMakeLists.txt
+@@ -33,5 +33,5 @@ add_dependencies(DriverTests libmpfr libmpc libgmp)
+ target_link_libraries(DriverTests
+   PRIVATE
+   GoUnitTestUtils
+-  "-L${EXTLIBDIR}" "-Wl,--push-state" "-Wl,-Bstatic" "-lmpc" "-lmpfr" "-lgmp" "-Wl,--pop-state"
++  ${GOLLVM_EXTLIB_LINK_FLAGS}
+   )
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0002-find-tools-in-path.patch
+++ b/pkgs/by-name/go/gollvm/0002-find-tools-in-path.patch
@@ -1,0 +1,43 @@
+From 9627f4ef3c9fb7b0c9bf6e26d3964e9f9fcf77c7 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 20:11:00 -0500
+Subject: [PATCH 2/10] cmake: discover shell and awk through PATH
+
+The build currently falls back to /bin/bash and /usr/bin/awk. Those
+paths are not reliable in Nix sandboxes and they are not required by
+the tools themselves; any functional shell and awk implementation is
+enough.
+
+When SHELL is not set, look up a shell via PATH, and always discover awk
+the same way. This keeps the upstream behaviour while removing fixed
+filesystem assumptions that break hermetic packaging.
+---
+ cmake/modules/GoVars.cmake | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/modules/GoVars.cmake b/cmake/modules/GoVars.cmake
+index 5aa2c32b8626..f4502f7fb3ea 100644
+--- a/cmake/modules/GoVars.cmake
++++ b/cmake/modules/GoVars.cmake
+@@ -32,10 +32,10 @@ else()
+ endif()
+ 
+ # We need a working shell. 
+-if(DEFINED ENV{SHELL})
++if(DEFINED ENV{SHELL} AND NOT "$ENV{SHELL}" STREQUAL "")
+   set(shell $ENV{SHELL})
+ else()
+-  set(shell "/bin/bash")
++  find_program(shell NAMES bash sh REQUIRED)
+ endif()
+ execute_process(COMMAND "${shell}" "-c" "echo foo" OUTPUT_VARIABLE echofoo)
+ if(echofoo STREQUAL "")
+@@ -47,5 +47,4 @@ message(FATAL_ERROR "fatal: shell ${shell} missing or not functional")
+ endif()
+ 
+ # FIXME: write cmake to discover awk, test to make sure it works
+-set(awk "/usr/bin/awk")
+-
++find_program(awk NAMES gawk awk REQUIRED)
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0003-support-nix-dynamic-linker.patch
+++ b/pkgs/by-name/go/gollvm/0003-support-nix-dynamic-linker.patch
@@ -1,0 +1,60 @@
+From c20e3925db81b0b57f13a63d8d7dcf33976e4b53 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 20:12:00 -0500
+Subject: [PATCH 3/10] driver: make the default dynamic linker configurable
+
+On ordinary distributions the Linux driver can usually fall back to a
+loader path such as /lib64/ld-linux-x86-64.so.2. Nix does not provide
+that layout: the ELF interpreter lives in the store and its path must be
+passed in explicitly when no sysroot is in use.
+
+Add a cache variable for the default dynamic linker and use it before
+falling back to the hard-coded FHS path. Existing builds keep the old
+behaviour unless they opt in to the new setting.
+---
+ cmake/modules/AddGollvm.cmake | 1 +
+ driver/GollvmConfig.h.cmake   | 3 +++
+ driver/LinuxToolChain.cpp     | 5 +++++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/cmake/modules/AddGollvm.cmake b/cmake/modules/AddGollvm.cmake
+index 3fd4162..2085d41 100644
+--- a/cmake/modules/AddGollvm.cmake
++++ b/cmake/modules/AddGollvm.cmake
+@@ -22,6 +22,7 @@ set(GOLLVM_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}")
+ set(GOLLVM_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${libsubdir}")
+ 
+ message(STATUS "default linker set to \"${GOLLVM_DEFAULT_LINKER}\"")
++set(GOLLVM_DEFAULT_DYNAMIC_LINKER "" CACHE STRING "Absolute path to the default ELF dynamic linker")
+ 
+ # Check to see whether the build compiler supports -fcf-protection=branch
+ set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+diff --git a/driver/GollvmConfig.h.cmake b/driver/GollvmConfig.h.cmake
+index b03bbcc..df2df37 100644
+--- a/driver/GollvmConfig.h.cmake
++++ b/driver/GollvmConfig.h.cmake
+@@ -22,4 +22,7 @@
+ // Gollvm default linker
+ #define GOLLVM_DEFAULT_LINKER "@GOLLVM_DEFAULT_LINKER@"
+ 
++// Default dynamic linker used when no sysroot is set
++#cmakedefine GOLLVM_DEFAULT_DYNAMIC_LINKER "@GOLLVM_DEFAULT_DYNAMIC_LINKER@"
++
+ #endif // GOLLVM_CONFIG_H
+diff --git a/driver/LinuxToolChain.cpp b/driver/LinuxToolChain.cpp
+index 8d1f4a1..95e53d4 100644
+--- a/driver/LinuxToolChain.cpp
++++ b/driver/LinuxToolChain.cpp
+@@ -148,5 +148,10 @@ std::string Linux::getDynamicLinker(const llvm::opt::ArgList &args)
+     std::string Sysroot = Arg->getValue();
+     return Sysroot + "/" + LibDir + "/" + Loader;
+   }
++#ifdef GOLLVM_DEFAULT_DYNAMIC_LINKER
++  if (GOLLVM_DEFAULT_DYNAMIC_LINKER[0] != '\0') {
++    return GOLLVM_DEFAULT_DYNAMIC_LINKER;
++  }
++#endif
+   return "/" + LibDir + "/" + Loader;
+ }
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0004-relax-triple-match.patch
+++ b/pkgs/by-name/go/gollvm/0004-relax-triple-match.patch
@@ -1,0 +1,36 @@
+From 9fb01294fd5e53342fb4bfe409ac13f4fc03db40 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 20:13:00 -0500
+Subject: [PATCH 4/10] driver: match triples by arch, OS, and environment
+
+The architecture table currently matches target triples by exact string.
+That is too strict for packaged toolchains: nixpkgs uses triples such as
+x86_64-pc-linux-gnu, while gollvm's table uses
+x86_64-unknown-linux-gnu. The vendor field should not affect CPU
+attribute selection.
+
+Compare the triple components that matter for this lookup instead of the
+full spelling. This keeps the existing behaviour for known targets while
+accepting equivalent triples with a different vendor component.
+---
+ driver/ArchCpuSetup.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/driver/ArchCpuSetup.cpp b/driver/ArchCpuSetup.cpp
+index bf91983..4aafcfb 100644
+--- a/driver/ArchCpuSetup.cpp
++++ b/driver/ArchCpuSetup.cpp
+@@ -37,7 +37,10 @@ bool gollvm::driver::setupArchCpu(opt::Arg *cpuarg, std::string &cpu,
+   // Locate correct entry in architectures table for this triple
+   const gollvm::arch::CpuAttrs *cpuAttrs = nullptr;
+   for (unsigned i = 0; gollvm::arch::triples[i].cpuattrs != nullptr; i += 1) {
+-    if (!strcmp(triple.str().c_str(), gollvm::arch::triples[i].triple)) {
++    Triple entryTriple(gollvm::arch::triples[i].triple);
++    if (entryTriple.getArch() == triple.getArch() &&
++        entryTriple.getOS() == triple.getOS() &&
++        entryTriple.getEnvironment() == triple.getEnvironment()) {
+       cpuAttrs = gollvm::arch::triples[i].cpuattrs;
+       break;
+     }
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0005-pass-cmake-cflags-to-mkgensysinfo.patch
+++ b/pkgs/by-name/go/gollvm/0005-pass-cmake-cflags-to-mkgensysinfo.patch
@@ -1,0 +1,35 @@
+From 5062d6a7649a1e7c8a7fb711b7f5d80a3d4a1f2e Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 20:14:00 -0500
+Subject: [PATCH 5/10] cmake: propagate project C flags to mkgensysinfo
+
+The mkgensysinfo helper invokes the C compiler directly but only uses
+the flags passed by its caller. That skips project-wide C flags from
+CMAKE_C_FLAGS, even though those flags still describe how the rest of
+the build expects helper sources to be compiled.
+
+This matters for packaged builds that force an older C dialect. In
+particular, the Nix build uses -std=gnu17 so sysinfo.c is not compiled
+as C23 by GCC 15, which otherwise makes llvm-godumpspec trip over
+nullptr_t in the generated DWARF.
+---
+ cmake/modules/AutoGenGo.cmake | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/modules/AutoGenGo.cmake b/cmake/modules/AutoGenGo.cmake
+--- a/cmake/modules/AutoGenGo.cmake
++++ b/cmake/modules/AutoGenGo.cmake
+@@ -541,7 +541,9 @@ endfunction()
+ function(mkgensysinfo tmpfile outfile macrofile objfile godumpspec sysinfoc)
+   CMAKE_PARSE_ARGUMENTS(ARG "" "" "DEPS;CFLAGS" ${ARGN})
+ 
+   set(ccomp ${CMAKE_C_COMPILER})
+-  set(cflags ${ARG_CFLAGS})
++  separate_arguments(project_cflags NATIVE_COMMAND "${CMAKE_C_FLAGS}")
++  set(cflags ${project_cflags})
++  list(APPEND cflags ${ARG_CFLAGS})
+   if(NOT "${CMAKE_SYSROOT}" STREQUAL "")
+     set(cflags ${cflags} "--sysroot=${CMAKE_SYSROOT}")
+   endif()
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0006-gotools-shell-quote-extra-flags.patch
+++ b/pkgs/by-name/go/gollvm/0006-gotools-shell-quote-extra-flags.patch
@@ -1,0 +1,36 @@
+From b70ae8f7e1cf7b8e31ab948cf9014b7d4a45c0d1 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 21:08:00 -0500
+Subject: [PATCH 6/10] gotools: shell-quote extra compiler flags
+
+The gotools build emits a small `run-gccgo` helper script and appends
+`GOLLVM_EXTRA_GOCFLAGS` to that script. In CMake, those extra flags are
+stored as a list, so writing the list directly into the shell script
+produces semicolon-separated entries.
+
+That breaks on Nix, where the extra driver flags are critical for
+finding the GCC toolchain, startup objects and libc when `go test`
+links temporary binaries. Emit the flags one by one instead so the
+generated script is valid shell.
+---
+ gotools/CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/gotools/CMakeLists.txt b/gotools/CMakeLists.txt
+--- a/gotools/CMakeLists.txt
++++ b/gotools/CMakeLists.txt
+@@ -118,7 +118,10 @@ file(REMOVE ${rungoctmp})
+ file(WRITE ${rungoctmp} "#!/bin/sh\n")
+ file(APPEND ${rungoctmp} "exec ${gocompiler} \"$@\"")
+ file(APPEND ${rungoctmp} " -I ${libgo_binroot}")
+ file(APPEND ${rungoctmp} " -L ${libgo_binroot}")
+-file(APPEND ${rungoctmp} " ${gotools_extra_gocflags}\n")
++foreach(gocflag IN LISTS gotools_extra_gocflags)
++  file(APPEND ${rungoctmp} " \"${gocflag}\"")
++endforeach()
++file(APPEND ${rungoctmp} "\n")
+ 
+ # Copy with correct perms.
+ file(COPY ${rungoctmp}
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0007-gotools-tests-run-in-gopath-mode.patch
+++ b/pkgs/by-name/go/gollvm/0007-gotools-tests-run-in-gopath-mode.patch
@@ -1,0 +1,29 @@
+From 10c1af4d0e464e6db84a1f802e01eb7630df258e Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 21:09:00 -0500
+Subject: [PATCH 7/10] gotools: force GOPATH mode in gotestprogram
+
+`gotestprogram.sh` builds a synthetic GOPATH-style tree and then runs
+`go test` inside it. Modern Go defaults to module mode, which makes the
+helper abort before the actual tests start because there is no `go.mod`
+file in that temporary tree.
+
+Force GOPATH mode inside the helper so the gotools tests run in the
+environment they were written for.
+---
+ gotools/gotestprogram.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gotools/gotestprogram.sh b/gotools/gotestprogram.sh
+--- a/gotools/gotestprogram.sh
++++ b/gotools/gotestprogram.sh
+@@ -163,6 +163,7 @@ if [ ! -z "${CC}" ]; then
+   setenv CC="${CC}"
+ fi
+ setenv GOROOT=${LIBDIR}
++setenv GO111MODULE=off
+ HERE=`pwd`
+ cd $WORKDIR
+ #
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0008-gotools-check-go-tool-vendor-x-tools.patch
+++ b/pkgs/by-name/go/gollvm/0008-gotools-check-go-tool-vendor-x-tools.patch
@@ -1,0 +1,28 @@
+From 1c4e52d3128575dcb2afde09f88f01ad5003c0dc Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 21:10:00 -0500
+Subject: [PATCH 8/10] gotools: vendor x/tools into cmd/go tests
+
+The copied `cmd/go` test tree now imports `golang.org/x/tools/txtar`,
+but the gotools check target only stages the `x/mod`, `x/crypto` and
+`x/xerrors` vendor directories. As a result, `check_go_tool` fails
+during package loading before any of the actual tests run.
+
+Copy the vendored `x/tools` tree into the temporary GOPATH as well.
+---
+ gotools/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gotools/CMakeLists.txt b/gotools/CMakeLists.txt
+--- a/gotools/CMakeLists.txt
++++ b/gotools/CMakeLists.txt
+@@ -169,6 +169,7 @@ add_custom_target(
+        "${cmd_srcroot}/go/testdata:src/cmd/go"
+        "${libgo_srcroot}/go/golang.org/x/mod:src/cmd/vendor/golang.org/x"
+        "${libgo_srcroot}/go/golang.org/x/crypto:src/cmd/vendor/golang.org/x"
++       "${libgo_srcroot}/go/golang.org/x/tools:src/cmd/vendor/golang.org/x"
+        "${libgo_srcroot}/go/golang.org/x/xerrors:src/cmd/vendor/golang.org/x"
+     "COPYFILES"
+        "${libgo_binroot}/zdefaultcc.go:src/cmd/go/internal/cfg/"
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0009-cmd-go-tests-accept-lld-undefined-symbol.patch
+++ b/pkgs/by-name/go/gollvm/0009-cmd-go-tests-accept-lld-undefined-symbol.patch
@@ -1,0 +1,31 @@
+From 914a5eb47063568e98b3639d6a61da60feae9939 Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 21:11:00 -0500
+Subject: [PATCH 9/10] cmd/go: accept lld wording in link_external_undef
+
+The `link_external_undef` script test checks that the external linker
+reports an undefined symbol instead of crashing. The current regex
+matches GNU ld's `undefined reference to` wording, but Nix builds
+gollvm with `lld`, which reports `undefined symbol`.
+
+Accept either spelling so the test keeps asserting the intended
+behavior without being tied to a specific linker implementation.
+---
+ gofrontend/libgo/go/cmd/go/testdata/script/link_external_undef.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gofrontend/libgo/go/cmd/go/testdata/script/link_external_undef.txt b/gofrontend/libgo/go/cmd/go/testdata/script/link_external_undef.txt
+--- a/gofrontend/libgo/go/cmd/go/testdata/script/link_external_undef.txt
++++ b/gofrontend/libgo/go/cmd/go/testdata/script/link_external_undef.txt
+@@ -8,7 +8,7 @@
+ 
+ ! go build -ldflags='-linkmode=external' .
+ ! stderr 'panic'
+ [!gccgo] stderr '^.*unreachable sym in relocation.*'
+-[gccgo] stderr '^.*undefined reference to.*'
++[gccgo] stderr '^.*undefined (reference to|symbol:).*$'
+ 
+ -- go.mod --
+ 
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/0010-gotools-export-cpath-for-local-headers.patch
+++ b/pkgs/by-name/go/gollvm/0010-gotools-export-cpath-for-local-headers.patch
@@ -1,0 +1,38 @@
+From b07a3814d34ab07db8f2724f2e248fed4560f6aa Mon Sep 17 00:00:00 2001
+From: Boris Nagaev <bnagaev@gmail.com>
+Date: Sun, 19 Apr 2026 22:35:00 -0500
+Subject: [PATCH 10/10] gotools: export CPATH for copied local headers
+
+The gotools tests copy Go sources into a temporary GOPATH-like work tree
+and then run `go test` there. Some cgo tests rely on local headers, such
+as `issue8331.h`, that live beside the copied Go files.
+
+Under Nix, the C compiler in the build environment is the wrapped GCC
+driver from `stdenv`. That wrapper drops non-store include directories
+passed with `-I`, so cgo's generated compile commands no longer find
+headers from the temporary test tree even though they were copied
+correctly.
+
+Export `CPATH=$PWD` after changing into the package-under-test. GCC
+honors `CPATH` under the wrapper, which restores local header lookup for
+the copied cgo tests without changing their command lines.
+---
+ gotools/gotestprogram.sh | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gotools/gotestprogram.sh b/gotools/gotestprogram.sh
+--- a/gotools/gotestprogram.sh
++++ b/gotools/gotestprogram.sh
+@@ -164,6 +164,9 @@ cd ${SUBDIR}
+ if [ $? != 0 ]; then
+   echo "can't change to ${SUBDIR}"
+   exit 1
+ fi
++
++# gcc-wrapper drops non-store -I paths; export CPATH for local test headers.
++setenv CPATH="${PWD}${CPATH:+:${CPATH}}"
+ CMD="go test -compiler gccgo -test.short -test.timeout=${TIMEOUT}s -test.v ${TESTARG}"
+ #
+ # Set up environment
+-- 
+2.50.1

--- a/pkgs/by-name/go/gollvm/package.nix
+++ b/pkgs/by-name/go/gollvm/package.nix
@@ -1,0 +1,273 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchgit,
+  llvmPackages_20,
+  bash,
+  binutils,
+  cmake,
+  gawk,
+  gmp,
+  libmpc,
+  m4,
+  makeBinaryWrapper,
+  mpfr,
+  ninja,
+  python3,
+  runCommand,
+  zlib,
+}:
+
+let
+  llvmPackages = llvmPackages_20;
+  llvm = llvmPackages.llvm;
+  gccToolchain = toString stdenv.cc.cc;
+  glibcLib = lib.getLib stdenv.cc.libc;
+  gccLib = lib.getLib stdenv.cc.cc;
+  gccInstallPath = "${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${stdenv.cc.cc.version}";
+  compilerDriverFlags = [
+    "--gcc-toolchain=${gccToolchain}"
+    "-B${llvmPackages.lld}/bin/"
+    "-B${glibcLib}/lib/"
+    "-B${gccInstallPath}/"
+    "-Wl,-dynamic-linker,${stdenv.cc.bintools.dynamicLinker}"
+    "-L${glibcLib}/lib"
+    "-L${gccLib}/lib"
+  ];
+  buildGocFlags = lib.concatStringsSep " " compilerDriverFlags;
+  buildLibraryPath = lib.makeLibraryPath [
+    zlib
+    gmp
+    mpfr
+    libmpc
+    (lib.getLib stdenv.cc.cc)
+  ];
+  canRunChecks = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  version = "unstable-2025-04-07";
+
+  gollvmSrc = fetchgit {
+    url = "https://go.googlesource.com/gollvm";
+    rev = "605d1b6368b72e7bc15f66fac1f33f754537a090";
+    hash = "sha256-c+RdtJ2Jh011yYnQWlUq53Hw2WyNzVFQGPIlzmWR4ys=";
+  };
+
+  gofrontendSrc = fetchgit {
+    url = "https://go.googlesource.com/gofrontend";
+    rev = "d7cb797c46170ea43381064745514fd597cb8d7d";
+    hash = "sha256-J79S6iskZLj1g7sbHlPGzXZphe6Ov5WIt1esg34LTvs=";
+  };
+
+  libbacktraceSrc = fetchFromGitHub {
+    owner = "ianlancetaylor";
+    repo = "libbacktrace";
+    rev = "b9e40069c0b47a722286b94eb5231f7f05c08713";
+    hash = "sha256-vi33Bhg2LT5uWN63PHkD8CaOjTXBwZhBwFFhaezJ0e4=";
+  };
+
+  libffiSrc = fetchFromGitHub {
+    owner = "libffi";
+    repo = "libffi";
+    rev = "v3.4.8";
+    hash = "sha256-wnjpQPStzti7li5iyWEClhiTv/lRe95WSZNgQwx43o0=";
+  };
+
+  gollvmSource = runCommand "gollvm-source-${version}" { } ''
+    mkdir -p "$out"
+    cp -r ${gollvmSrc}/. "$out/"
+    chmod -R u+w "$out"
+
+    rm -rf "$out/gofrontend" "$out/libgo/libbacktrace" "$out/libgo/libffi"
+    cp -r ${gofrontendSrc} "$out/gofrontend"
+    cp -r ${libbacktraceSrc} "$out/libgo/libbacktrace"
+    cp -r ${libffiSrc} "$out/libgo/libffi"
+    chmod -R u+w "$out/gofrontend" "$out/libgo/libbacktrace" "$out/libgo/libffi"
+
+    patch -d "$out" -p1 < ${./0001-use-nix-system-libs.patch}
+    patch -d "$out" -p1 < ${./0002-find-tools-in-path.patch}
+    patch -d "$out" -p1 < ${./0003-support-nix-dynamic-linker.patch}
+    patch -d "$out" -p1 < ${./0004-relax-triple-match.patch}
+    patch -d "$out" -p1 < ${./0005-pass-cmake-cflags-to-mkgensysinfo.patch}
+    patch -d "$out" -p1 < ${./0006-gotools-shell-quote-extra-flags.patch}
+    patch -d "$out" -p1 < ${./0007-gotools-tests-run-in-gopath-mode.patch}
+    patch -d "$out" -p1 < ${./0008-gotools-check-go-tool-vendor-x-tools.patch}
+    patch -d "$out" -p1 < ${./0009-cmd-go-tests-accept-lld-undefined-symbol.patch}
+    patch -d "$out" -p1 < ${./0010-gotools-export-cpath-for-local-headers.patch}
+  '';
+
+  mathDeps = runCommand "gollvm-math-deps" { } ''
+    mkdir -p "$out/include" "$out/lib"
+
+    ln -s ${lib.getDev gmp}/include/gmp.h "$out/include/"
+    ln -s ${lib.getDev gmp}/include/gmpxx.h "$out/include/"
+    ln -s ${lib.getDev mpfr}/include/mpfr.h "$out/include/"
+    ln -s ${lib.getDev libmpc}/include/mpc.h "$out/include/"
+
+    ln -s ${lib.getLib gmp}/lib/libgmp.so* "$out/lib/"
+    ln -s ${lib.getLib mpfr}/lib/libmpfr.so* "$out/lib/"
+    ln -s ${lib.getLib libmpc}/lib/libmpc.so* "$out/lib/"
+  '';
+
+  binPath = lib.makeBinPath [
+    binutils
+    llvmPackages.lld
+    stdenv.cc.cc
+  ];
+in
+stdenv.mkDerivation {
+  pname = "gollvm";
+  inherit version;
+  __structuredAttrs = true;
+
+  # Gollvm currently tracks a narrow LLVM compatibility window. Build against
+  # the LLVM 20 monorepo used by nixpkgs, following the external-project
+  # pattern used by cling.
+  src = llvm.monorepoSrc;
+
+  nativeBuildInputs = [
+    binutils
+    cmake
+    gawk
+    llvmPackages.lld
+    m4
+    makeBinaryWrapper
+    ninja
+    python3
+  ];
+
+  buildInputs = [ zlib ];
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+  doCheck = canRunChecks;
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  buildTargets = [ "gollvm" ];
+  installTargets = [ "install-gollvm" ];
+
+  preConfigure = ''
+    export SHELL=${bash}/bin/bash
+    export LD_LIBRARY_PATH=${buildLibraryPath}
+    cmakeFlagsArray+=("-DGOLLVM_EXTRA_GOCFLAGS=${buildGocFlags}")
+    cd llvm
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    (lib.cmakeFeature "CMAKE_C_FLAGS" "-std=gnu17")
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-std=gnu++17")
+    (lib.cmakeFeature "LLVM_EXTERNAL_PROJECTS" "gollvm")
+    (lib.cmakeFeature "LLVM_EXTERNAL_GOLLVM_SOURCE_DIR" (toString gollvmSource))
+    (lib.cmakeFeature "LLVM_TARGETS_TO_BUILD" "X86")
+    (lib.cmakeBool "LLVM_BUILD_TESTS" canRunChecks)
+    (lib.cmakeBool "LLVM_INCLUDE_TESTS" canRunChecks)
+    (lib.cmakeBool "LLVM_INCLUDE_EXAMPLES" false)
+    (lib.cmakeBool "LLVM_INCLUDE_BENCHMARKS" false)
+    (lib.cmakeBool "LLVM_ENABLE_TERMINFO" false)
+    (lib.cmakeBool "LLVM_ENABLE_LIBXML2" false)
+    (lib.cmakeFeature "LLVM_USE_LINKER" "lld")
+    (lib.cmakeFeature "GOLLVM_DEFAULT_LINKER" "lld")
+    (lib.cmakeFeature "GOLLVM_DEFAULT_DYNAMIC_LINKER" stdenv.cc.bintools.dynamicLinker)
+    (lib.cmakeFeature "GOLLVM_SYSTEM_EXTINSTALLDIR" (toString mathDeps))
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    if [ -f CMakeCache.txt ]; then
+      checkBuildDir="$PWD"
+    elif [ -n "''${cmakeBuildDir:-}" ] && [ -f "''${cmakeBuildDir}/CMakeCache.txt" ]; then
+      checkBuildDir="$PWD/''${cmakeBuildDir}"
+    elif [ -n "''${sourceRoot:-}" ] && [ -f "''${sourceRoot}/llvm/''${cmakeBuildDir:-build}/CMakeCache.txt" ]; then
+      checkBuildDir="''${sourceRoot}/llvm/''${cmakeBuildDir:-build}"
+    else
+      cacheFile="$(find "''${sourceRoot:-$PWD}" -path '*/llvm/build/CMakeCache.txt' | head -n1)"
+      if [ -z "$cacheFile" ]; then
+        echo "could not find CMake build directory" >&2
+        exit 1
+      fi
+      checkBuildDir="$(dirname "$cacheFile")"
+    fi
+    cd "$checkBuildDir"
+
+    cmake --build . --target GoBackendUnitTests --parallel "''${NIX_BUILD_CORES:-1}"
+    ./tools/gollvm/unittests/BackendCore/GoBackendCoreTests
+    ./tools/gollvm/unittests/Driver/DriverTests
+    ./tools/gollvm/unittests/DriverUtils/DriverUtilsTests
+    ./tools/gollvm/unittests/GoDumpSpec/GoDumpSpecTests
+
+    export GO111MODULE=off
+    cmake --build . --target check_go_tool --parallel 1
+    cmake --build . --target check_vet_tool --parallel 1
+    cmake --build . --target check_cgo_tool --parallel 1
+    cmake --build . --target check_carchive_tool --parallel 1
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    runtimePath="$out/bin:$out/tools:${binPath}"
+    runtimeLibPath="${buildLibraryPath}:$out/lib64"
+
+    compilerFlags=(
+      ${lib.concatMapStringsSep "\n      " (flag: "\"${flag}\"") compilerDriverFlags}
+    )
+
+    commonCompilerArgs=(
+      --prefix PATH : "$runtimePath"
+      --prefix LD_LIBRARY_PATH : "$runtimeLibPath"
+      --add-flags "-Wl,-rpath,$out/lib64"
+    )
+
+    for flag in "''${compilerFlags[@]}"; do
+      commonCompilerArgs+=(--add-flags "$flag")
+    done
+
+    mv "$out/bin/llvm-goc" "$out/bin/.llvm-goc-wrapped"
+    makeBinaryWrapper "$out/bin/.llvm-goc-wrapped" "$out/bin/llvm-goc" \
+      "''${commonCompilerArgs[@]}" \
+      --argv0 llvm-goc
+
+    rm -f "$out/bin/gccgo"
+    makeBinaryWrapper "$out/bin/.llvm-goc-wrapped" "$out/bin/gccgo" \
+      "''${commonCompilerArgs[@]}" \
+      --argv0 gccgo
+
+    mv "$out/bin/go" "$out/bin/.go-wrapped"
+    makeBinaryWrapper "$out/bin/.go-wrapped" "$out/bin/go" \
+      --prefix PATH : "$runtimePath" \
+      --prefix LD_LIBRARY_PATH : "$runtimeLibPath"
+
+    if [ -d "$out/tools" ]; then
+      while IFS= read -r -d "" tool; do
+        toolName="$(basename "$tool")"
+        mv "$tool" "$tool.orig"
+        makeBinaryWrapper "$tool.orig" "$tool" \
+          --prefix PATH : "$runtimePath" \
+          --prefix LD_LIBRARY_PATH : "$runtimeLibPath" \
+          --argv0 "$toolName"
+      done < <(find "$out/tools" -mindepth 1 -maxdepth 1 -type f -perm -0100 -print0)
+    fi
+  '';
+
+  meta = {
+    description = "LLVM-based Go compiler";
+    homepage = "https://go.googlesource.com/gollvm";
+    license = with lib.licenses; [
+      # llvm-project: legacy LLVM files are still under the UIUC/NCSA license.
+      ncsa
+      # llvm-project: current LLVM 20 sources are Apache-2.0 with LLVM exception.
+      asl20
+      llvm-exception
+      # gollvm, gofrontend, and libbacktrace use BSD-style terms.
+      bsd3
+      # libffi is MIT-licensed.
+      mit
+    ];
+    mainProgram = "go";
+    maintainers = with lib.maintainers; [ starius ];
+    platforms = [ "x86_64-linux" ];
+    badPlatforms = lib.systems.inspect.patterns.isMusl;
+  };
+}


### PR DESCRIPTION
Add `gollvm`, an LLVM-based Go compiler, as a new package in `pkgs/by-name/go/gollvm`.

This packages gollvm as an LLVM external project, following the general approach used by `cling`: build against nixpkgs' LLVM 20 monorepo while overlaying the pinned `gollvm`, `gofrontend`, `libbacktrace`, and `libffi` sources into the expected upstream layout.

The package carries a small patch series to make the build and tests work in a Nix environment:

- use preinstalled GMP/MPFR/MPC instead of `ExternalProject` downloads
- discover shell and awk via `PATH`
- allow configuring the default dynamic linker
- relax target triple matching for nixpkgs-style triples
- pass `CMAKE_C_FLAGS` to `mkgensysinfo`
- fix gotools helper flag quoting
- force GOPATH mode in gotools tests
- stage vendored `x/tools` for `cmd/go` tests
- accept `lld` wording in one `cmd/go` script test
- export `CPATH` so copied local headers are visible to cgo tests under `gcc-wrapper`

The package enables upstream unit tests and the relevant gotools checks on native builds. On `x86_64-linux`, the following were verified:

- upstream unit tests: `GoBackendCoreTests`, `DriverTests`, `DriverUtilsTests`, `GoDumpSpecTests`
- gotools checks: `check_go_tool`, `check_vet_tool`, `check_cgo_tool`, `check_carchive_tool`
- smoke tests from the installed package:
  - `go version`
  - `go run` on a hello-world program
  - `llvm-goc -S -emit-llvm`
  - a simple complex-number Go program

Homepage: https://go.googlesource.com/gollvm

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
