### PR TITLE
ircd-hybrid: 8.2.46 -> 8.2.47

### DIFF
--- a/pkgs/by-name/ir/ircd-hybrid/package.nix
+++ b/pkgs/by-name/ir/ircd-hybrid/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  jansson,
   openssl,
   zlib,
   libxcrypt,
@@ -9,14 +10,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ircd-hybrid";
-  version = "8.2.46";
+  version = "8.2.47";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/ircd-hybrid/ircd-hybrid-${finalAttrs.version}.tgz";
-    sha256 = "sha256-pdXI8YiPqC+97XoxNFb1plm4cfLOB+b/getajXPzx0s=";
+  src = fetchFromGitHub {
+    owner = "ircd-hybrid";
+    repo = "ircd-hybrid";
+    tag = finalAttrs.version;
+    hash = "sha256-A6YWKtwqCWfP3fvuSxXFer21T+RMOfR+OhKiYbQpUao=";
   };
 
   buildInputs = [
+    jansson
     openssl
     zlib
     libxcrypt
@@ -32,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "IPv6-capable IRC server";
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.unix;
     homepage = "https://www.ircd-hybrid.org/";
   };


### PR DESCRIPTION
Update to 8.2.47

From changelog:
Noteworthy changes in version 8.2.47 (2025-04-04)
The general::max_away_length configuration directive has been added, allowing
servers to specify the maximum length of a AWAY message that the server will
accept from a client.
The general::disable_dns configuration directive has been added, allowing
servers to disable DNS lookups
K-lines, D-lines, X-lines, and RESVs are no longer stored in binary database format.
These entries are now stored in JSON format using libjansson.
The general::ident_timeout configuration directive has been added, allowing
servers to specify how long to wait for Ident replies


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
