### PR TITLE
python3Packages.pyschemes: unstable-2017-11-08 -> 0-unstable-2022-09-12

### DIFF
--- a/pkgs/development/python-modules/pyschemes/default.nix
+++ b/pkgs/development/python-modules/pyschemes/default.nix
@@ -3,29 +3,20 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
-  fetchpatch,
 }:
 
 buildPythonPackage {
   pname = "pyschemes";
-  version = "unstable-2017-11-08";
+  version = "0-unstable-2022-09-12";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "spy16";
     repo = "pyschemes";
-    rev = "ca6483d13159ba65ba6fc2f77b90421c40f2bbf2";
-    hash = "sha256-PssucudvlE8mztwVme70+h+2hRW/ri9oV9IZayiZhdU=";
+    rev = "c8afdbc045c1ff2bd7cc5a963e7084fc096f5257";
+    hash = "sha256-jv6dlZlLuJlTqw2V21BUEhCIc/UGvyjbhggw82eGMz0=";
   };
 
-  patches = [
-    # Fix python 3.10 compatibility. Tracked upstream in
-    # https://github.com/spy16/pyschemes/pull/6
-    (fetchpatch {
-      url = "https://github.com/spy16/pyschemes/commit/23011128c6c22838d4fca9e00fd322a20bb566c4.patch";
-      hash = "sha256-vDaWxMrn2aC2wmd035EWRZ3cd/XME81z/BWG0f2T9jc=";
-    })
-  ];
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "pyschemes" ];

--- a/pkgs/development/python-modules/pyschemes/default.nix
+++ b/pkgs/development/python-modules/pyschemes/default.nix
@@ -3,12 +3,13 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage {
   pname = "pyschemes";
   version = "0-unstable-2022-09-12";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "spy16";
@@ -16,6 +17,8 @@ buildPythonPackage {
     rev = "c8afdbc045c1ff2bd7cc5a963e7084fc096f5257";
     hash = "sha256-jv6dlZlLuJlTqw2V21BUEhCIc/UGvyjbhggw82eGMz0=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
Previously included a patch for python 3.10+ which is no longer needed.

Tracking https://github.com/NixOS/nixpkgs/issues/410837

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
