### PR TITLE
[Backport release-25.11] hyprmon: 0.0.14 -> 0.0.15

### DIFF
--- a/pkgs/by-name/hy/hyprmon/package.nix
+++ b/pkgs/by-name/hy/hyprmon/package.nix
@@ -1,21 +1,20 @@
 {
   lib,
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
 }:
-
-buildGoModule rec {
+buildGo126Module (finalAttrs: {
   pname = "hyprmon";
-  version = "0.0.12";
+  version = "0.0.15";
 
   src = fetchFromGitHub {
     owner = "erans";
     repo = "hyprmon";
-    rev = "v${version}";
-    hash = "sha256-jZUtdOMmpd75CyjaXdrqXcYxcQ9q7G2YGBHoUUvycX8=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-dcjEnxSQwXUPJ44gj7pVPQtZUkBXbqLvQgmhYvANz8o=";
   };
 
-  vendorHash = "sha256-THfdsr8jSvbcV1C2C2IJNvjeeonSZDfmCo6Ws2WreBA=";
+  vendorHash = "sha256-n4RZxpsrlSUD3B/GLVoM2CPckvDkbyaMyg6h4QNbuH0=";
 
   meta = {
     description = "TUI monitor configuration tool for Hyprland with visual layout, drag-and-drop, and profile management";
@@ -25,4 +24,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ onatustun ];
     mainProgram = "hyprmon";
   };
-}
+})


### PR DESCRIPTION
(cherry picked from commit f2530d3e397e5aa1bc8a92f10048581adad07ed5)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backport of https://github.com/NixOS/nixpkgs/pull/511126

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
