### PR TITLE
Iloader: init at 2.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19554,6 +19554,12 @@
     github = "nosewings";
     githubId = 24929858;
   };
+  not-a-cowfr = {
+    name = "Andrew Gielow";
+    email = "agielow@proton.me";
+    github = "not-a-cowfr";
+    githubId = 104355555;
+  };
   not-my-segfault = {
     email = "michal@tar.black";
     matrix = "@michal:tar.black";

--- a/pkgs/by-name/il/iloader/package.nix
+++ b/pkgs/by-name/il/iloader/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  cargo-tauri,
+  jq,
+  moreutils,
+  nodejs,
+  pkg-config,
+  bun,
+
+  openssl,
+  webkitgtk_4_1,
+
+  writableTmpDirAsHomeHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "iloader";
+  version = "2.2.4";
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  src = fetchFromGitHub {
+    owner = "nab138";
+    repo = "iloader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cKUyxNsnqG1GSD+zMNjIoOkl4+IHRfWLQQo8IDjIS/o=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src cargoRoot;
+    hash = "sha256-ryXbUBNtMjZcQGivnjqRBxbGsW6UAJbU38rTqzwvH+Y=";
+  };
+
+  node_modules = stdenv.mkDerivation {
+    inherit (finalAttrs) src version;
+    pname = "iloader-node_modules";
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+    dontConfigure = true;
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+
+      bun install --no-progress --frozen-lockfile --no-cache
+
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/node_modules
+      cp -R ./node_modules $out
+
+      runHook postInstall
+    '';
+    outputHash =
+      {
+        x86_64-linux = "sha256-qQX+FjFdM5MuO//211RNghP1VTh1EHPYVhaU2D+nqbc=";
+        aarch64-linux = lib.fakeHash;
+        x86_64-darwin = lib.fakeHash;
+        aarch64-darwin = lib.fakeHash;
+      }
+      .${stdenv.hostPlatform.system};
+    # .${stdenv.hostPlatform.system}
+    # or (throw "${finalAttrs.pname}: Platform ${stdenv.hostPlatform.system} is not packaged yet. Supported platforms: x86_64-linux, aarch64-linux.");
+    outputHashMode = "recursive";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    rustPlatform.cargoSetupHook
+
+    jq
+    moreutils
+    nodejs
+    bun
+
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    webkitgtk_4_1
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+  };
+
+  postPatch = ''
+    jq '
+      .bundle.createUpdaterArtifacts = false |
+      .plugins.updater = {"active": false, "pubkey": "", "endpoints": []}
+    ' \
+    src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.node_modules}/node_modules .
+
+    # Bun takes executables from this folder
+    chmod -R u+rw node_modules
+    chmod -R u+x node_modules/.bin
+    patchShebangs node_modules
+
+    export HOME=$TMPDIR
+    export PATH="$PWD/node_modules/.bin:$PATH"
+
+    runHook postConfigure
+  '';
+
+  meta = with lib; {
+    description = "User friendly sideloader ";
+    homepage = "https://iloader.app";
+    changelog = "https://github.com/nab138/iloader/releases/tag/v${finalAttrs.version}";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ not-a-cowfr ];
+    license = licenses.mit;
+    mainProgram = finalAttrs.pname;
+  };
+})


### PR DESCRIPTION
https://github.com/nab138/iloader
https://iloader.app/

ios sideloading tool

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
