### PR TITLE
prometheus-kvrocks-exporter: init at 1.0.9

### DIFF
--- a/pkgs/by-name/ha/hat-trie/package.nix
+++ b/pkgs/by-name/ha/hat-trie/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hat-trie";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "Tessil";
+    repo = "hat-trie";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5L3qSlwYc2G60GPFrEz06eAWdUcdBQTVBLLOf1sLP0c=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/include
+    cp -r include/tsl $out/include/
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "C++ implementation of a fast and memory efficient HAT-trie";
+    homepage = "https://github.com/Tessil/hat-trie";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xyenon ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/kv/kvrocks/hook-test.nix
+++ b/pkgs/by-name/kv/kvrocks/hook-test.nix
@@ -1,0 +1,47 @@
+{
+  valkey,
+  kvrocks,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  name = "kvrocks-test-hook-test";
+
+  nativeCheckInputs = [
+    valkey
+    kvrocks.hook
+  ];
+
+  dontUnpack = true;
+  doCheck = true;
+
+  preCheck = ''
+    kvrocksTestPort=6380
+    KVROCKS_SOCKET=/tmp/customkvrocks.sock
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    echo "running test"
+    if redis-cli --scan -p $kvrocksTestPort; then
+      echo "connected to kvrocks via localhost"
+      PORT_TEST_RAN=1
+    fi
+
+    if redis-cli --scan -s $KVROCKS_SOCKET; then
+      echo "connected to kvrocks via domain socket"
+      SOCKET_TEST_RAN=1
+    fi
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    [[ $PORT_TEST_RAN == 1 && $SOCKET_TEST_RAN == 1 ]]
+    echo "test passed"
+    touch $out
+  '';
+
+  __darwinAllowLocalNetworking = true;
+}

--- a/pkgs/by-name/kv/kvrocks/hook.nix
+++ b/pkgs/by-name/kv/kvrocks/hook.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  makeSetupHook,
+  kvrocks,
+  valkey,
+}:
+
+makeSetupHook {
+  name = "kvrocks-test-hook";
+
+  substitutions = {
+    cli = lib.getExe' valkey "redis-cli";
+    server = lib.getExe' kvrocks "kvrocks";
+  };
+} ./hook.sh

--- a/pkgs/by-name/kv/kvrocks/hook.sh
+++ b/pkgs/by-name/kv/kvrocks/hook.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+
+preCheckHooks+=('kvrocksStart')
+postCheckHooks+=('kvrocksStop')
+
+kvrocksStart() {
+  if [[ ${kvrocksTestPort:-} == "" ]]; then
+    kvrocksTestPort=6666
+  fi
+
+  mkdir -p "$NIX_BUILD_TOP/run/kvrocks"
+
+  if [[ "${KVROCKS_SOCKET:-}" == "" ]]; then
+    KVROCKS_SOCKET="$NIX_BUILD_TOP/run/kvrocks.sock"
+  fi
+  export KVROCKS_SOCKET
+
+  KVROCKS_CONF="$NIX_BUILD_TOP/run/kvrocks.conf"
+  export KVROCKS_CONF
+
+  cat <<EOF >"$KVROCKS_CONF"
+bind 127.0.0.1 ::1
+unixsocket ${KVROCKS_SOCKET}
+port ${kvrocksTestPort}
+dir $NIX_BUILD_TOP/run/kvrocks
+daemonize no
+EOF
+
+  echo 'starting kvrocks'
+
+  @server@ -c "$KVROCKS_CONF" &
+  KVROCKS_PID=$!
+
+  echo 'waiting for kvrocks to be ready'
+  kvrocks_start_timeout=60
+  kvrocks_start_deadline=$((SECONDS + kvrocks_start_timeout))
+  while ! @cli@ --scan -s "$KVROCKS_SOCKET"; do
+    if ! kill -0 "$KVROCKS_PID" 2>/dev/null; then
+      echo "kvrocks exited before becoming ready"
+      return 1
+    fi
+    if (( SECONDS >= kvrocks_start_deadline )); then
+      echo "timed out after ${kvrocks_start_timeout}s waiting for kvrocks to be ready"
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+kvrocksStop() {
+  echo 'stopping kvrocks'
+  kill "$KVROCKS_PID"
+}

--- a/pkgs/by-name/kv/kvrocks/package.nix
+++ b/pkgs/by-name/kv/kvrocks/package.nix
@@ -1,0 +1,330 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # keep-sorted start
+  cmake,
+  ninja,
+  pkg-config,
+  # keep-sorted end
+
+  # keep-sorted start
+  cpptrace,
+  fmt,
+  gtest,
+  hat-trie,
+  jemalloc,
+  jsoncons,
+  libevent,
+  lz4,
+  onetbb,
+  openssl,
+  pegtl,
+  range-v3,
+  rocksdb,
+  snappy,
+  span-lite,
+  spdlog,
+  xxHash,
+  zlib-ng,
+  zstd,
+  # keep-sorted end
+}:
+
+let
+  # Generate a cmake file that replaces FetchContent with system library finders.
+  #   findPackage: optional package name for find_package(name REQUIRED)
+  #   pkgConfig:   optional { varName; modules; } for pkg_check_modules
+  #   libraries:   list of { name; target?; linkLibs?; compileDefs?; }
+  #                  - if 'target' is set: add_library(name ALIAS target)
+  #                  - otherwise: add_library(name INTERFACE) with optional link/defs
+  #   extraLines:  optional list of extra cmake lines appended at the end
+  mkCmakeFile =
+    cmakeFile:
+    {
+      findPackage ? null,
+      pkgConfig ? null,
+      libraries ? [ ],
+      extraLines ? [ ],
+    }:
+    let
+      mkLibEntry =
+        entry:
+        if entry ? target then
+          [ "add_library(${entry.name} ALIAS ${entry.target})" ]
+        else
+          [ "add_library(${entry.name} INTERFACE)" ]
+          ++ lib.optional (
+            entry ? linkLibs
+          ) "target_link_libraries(${entry.name} INTERFACE ${entry.linkLibs})"
+          ++ lib.optional (
+            entry ? compileDefs
+          ) "target_compile_definitions(${entry.name} INTERFACE ${entry.compileDefs})";
+      lines = [
+        "include_guard()"
+      ]
+      ++ lib.optional (pkgConfig != null) "find_package(PkgConfig REQUIRED)"
+      ++ lib.optional (findPackage != null) "find_package(${findPackage} REQUIRED)"
+      ++ lib.optional (
+        pkgConfig != null
+      ) "pkg_check_modules(${pkgConfig.varName} REQUIRED IMPORTED_TARGET ${pkgConfig.modules})"
+      ++ lib.concatMap mkLibEntry libraries
+      ++ extraLines;
+      content = lib.concatStringsSep "\n" lines;
+    in
+    ''
+      cat > cmake/${cmakeFile}.cmake << 'EOF'
+      ${content}
+      EOF
+    '';
+
+  luajit-src = fetchFromGitHub {
+    owner = "RocksLabs";
+    repo = "LuaJIT";
+    rev = "c0a8e68325ec261a77bde1c8eabad398168ffe74";
+    hash = "sha256-Wjh14d0JR5ecAwdYVBjQYIHb2vJ1I61oR0N0LMmtq4E=";
+  };
+
+  zlib-ng' = zlib-ng.override { withZlibCompat = true; };
+  rocksdb' =
+    (rocksdb.override {
+      zlib = zlib-ng';
+      enableJemalloc = true;
+    }).overrideAttrs
+      (oldAttrs: {
+        cmakeFlags = (oldAttrs.cmakeFlags or [ ]) ++ [ (lib.cmakeBool "WITH_TBB" true) ];
+        buildInputs = (oldAttrs.buildInputs or [ ]) ++ [ onetbb ];
+        # On aarch64-darwin, libc++ hardening can trigger a SIGTRAP in
+        # RocksDB's startup path via unique_ptr<T[]> bounds checks.
+        hardeningDisable =
+          (oldAttrs.hardeningDisable or [ ])
+          ++ (lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+            "libcxxhardeningfast"
+          ]);
+      });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kvrocks";
+  version = "2.15.0";
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "kvrocks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s4saKuezPYvcmKSqVBVDbPJcQXr6pVfIWjff7Txg8tY=";
+  };
+
+  __structuredAttrs = true;
+
+  postPatch = ''
+    # Replace FetchContent-based cmake files with system library finders
+    ${mkCmakeFile "rocksdb" {
+      pkgConfig = {
+        varName = "ROCKSDB";
+        modules = "rocksdb";
+      };
+      libraries = [
+        {
+          name = "rocksdb_with_headers";
+          linkLibs = "PkgConfig::ROCKSDB";
+        }
+      ];
+    }}
+    ${mkCmakeFile "libevent" {
+      pkgConfig = {
+        varName = "LIBEVENT";
+        modules = "libevent libevent_pthreads";
+      };
+      libraries = [
+        {
+          name = "event_with_headers";
+          linkLibs = "PkgConfig::LIBEVENT";
+        }
+      ];
+      extraLines = [
+        "if(ENABLE_OPENSSL)"
+        "  pkg_check_modules(LIBEVENT_OPENSSL REQUIRED IMPORTED_TARGET libevent_openssl)"
+        "  target_link_libraries(event_with_headers INTERFACE PkgConfig::LIBEVENT_OPENSSL)"
+        "endif()"
+      ];
+    }}
+    ${mkCmakeFile "fmt" { findPackage = "fmt"; }}
+    ${mkCmakeFile "spdlog" { findPackage = "spdlog"; }}
+    ${mkCmakeFile "snappy" {
+      pkgConfig = {
+        varName = "SNAPPY";
+        modules = "snappy";
+      };
+      libraries = [
+        {
+          name = "snappy";
+          target = "PkgConfig::SNAPPY";
+        }
+      ];
+    }}
+    ${mkCmakeFile "lz4" {
+      pkgConfig = {
+        varName = "LZ4";
+        modules = "liblz4";
+      };
+      libraries = [
+        {
+          name = "lz4";
+          target = "PkgConfig::LZ4";
+        }
+      ];
+    }}
+    ${mkCmakeFile "zstd" {
+      pkgConfig = {
+        varName = "ZSTD";
+        modules = "libzstd";
+      };
+      libraries = [
+        {
+          name = "zstd";
+          target = "PkgConfig::ZSTD";
+        }
+      ];
+    }}
+    ${mkCmakeFile "zlib" {
+      findPackage = "ZLIB";
+      libraries = [
+        {
+          name = "zlib_with_headers";
+          linkLibs = "ZLIB::ZLIB";
+        }
+      ];
+    }}
+    ${mkCmakeFile "tbb" {
+      findPackage = "TBB";
+      libraries = [
+        {
+          name = "tbb";
+          target = "TBB::tbb";
+        }
+      ];
+    }}
+    ${mkCmakeFile "gtest" {
+      findPackage = "GTest";
+      libraries = [
+        {
+          name = "gtest_main";
+          linkLibs = "GTest::gtest_main GTest::gtest";
+        }
+        {
+          name = "gmock";
+          linkLibs = "GTest::gmock GTest::gtest";
+        }
+      ];
+    }}
+    ${mkCmakeFile "xxhash" {
+      pkgConfig = {
+        varName = "XXHASH";
+        modules = "libxxhash";
+      };
+      libraries = [
+        {
+          name = "xxhash";
+          target = "PkgConfig::XXHASH";
+        }
+      ];
+    }}
+    ${mkCmakeFile "jemalloc" {
+      pkgConfig = {
+        varName = "JEMALLOC";
+        modules = "jemalloc";
+      };
+      libraries = [
+        {
+          name = "jemalloc";
+          linkLibs = "PkgConfig::JEMALLOC";
+          compileDefs = "ENABLE_JEMALLOC";
+        }
+      ];
+    }}
+    ${mkCmakeFile "jsoncons" { libraries = [ { name = "jsoncons"; } ]; }}
+    ${mkCmakeFile "span" { libraries = [ { name = "span-lite"; } ]; }}
+    ${mkCmakeFile "trie" { libraries = [ { name = "tsl_hat_trie"; } ]; }}
+    ${mkCmakeFile "pegtl" { libraries = [ { name = "pegtl"; } ]; }}
+    ${mkCmakeFile "rangev3" { findPackage = "range-v3"; }}
+    ${mkCmakeFile "cpptrace" { findPackage = "cpptrace"; }}
+
+    # Remove static linking flags and git requirement
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(CMAKE_EXE_LINKER_FLAGS "''${CMAKE_EXE_LINKER_FLAGS} -static-libgcc")' "" \
+      --replace-fail 'set(CMAKE_EXE_LINKER_FLAGS "''${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")' "" \
+      --replace-fail 'find_package(Git REQUIRED)' "" \
+      --replace-fail 'target_include_directories(kvrocks_objs PUBLIC src src/common src/vendor' \
+                     'target_include_directories(kvrocks_objs PUBLIC src src/common src/config src/vendor'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    # keep-sorted start
+    cmake
+    ninja
+    pkg-config
+    # keep-sorted end
+  ];
+
+  buildInputs = [
+    # keep-sorted start
+    cpptrace
+    fmt
+    gtest
+    hat-trie
+    jemalloc
+    jsoncons
+    libevent
+    lz4
+    onetbb
+    openssl
+    pegtl
+    range-v3
+    rocksdb'
+    snappy
+    span-lite
+    spdlog
+    xxHash
+    zlib-ng'
+    zstd
+    # keep-sorted end
+  ];
+
+  preConfigure = ''
+    # Copy LuaJIT to writable location for in-source build
+    cp -r ${luajit-src} $TMPDIR/luajit
+    chmod -R u+w $TMPDIR/luajit
+    # LuaJIT defaults to gcc, which may be unavailable (e.g. Darwin stdenv).
+    substituteInPlace $TMPDIR/luajit/src/Makefile \
+      --replace-fail "DEFAULT_CC = gcc" "DEFAULT_CC = $CC"
+    cmakeFlagsArray+=("-DFETCHCONTENT_SOURCE_DIR_LUAJIT=$TMPDIR/luajit")
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "DISABLE_JEMALLOC" false)
+    (lib.cmakeBool "ENABLE_STATIC_LIBSTDCXX" false)
+    (lib.cmakeBool "ENABLE_LUAJIT" true)
+    (lib.cmakeBool "ENABLE_OPENSSL" true)
+    (lib.cmakeFeature "PORTABLE" "1")
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 kvrocks -t $out/bin
+    install -Dm755 kvrocks2redis -t $out/bin
+    install -Dm644 $src/kvrocks.conf -t $out/etc
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol";
+    homepage = "https://kvrocks.apache.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xyenon ];
+    platforms = lib.platforms.unix;
+    mainProgram = "kvrocks";
+  };
+})

--- a/pkgs/by-name/kv/kvrocks/package.nix
+++ b/pkgs/by-name/kv/kvrocks/package.nix
@@ -1,4 +1,5 @@
 {
+  callPackage,
   lib,
   stdenv,
   fetchFromGitHub,
@@ -318,6 +319,13 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 $src/kvrocks.conf -t $out/etc
     runHook postInstall
   '';
+
+  passthru = {
+    hook = callPackage ./hook.nix { kvrocks = finalAttrs.finalPackage; };
+    tests = {
+      hook = callPackage ./hook-test.nix { kvrocks = finalAttrs.finalPackage; };
+    };
+  };
 
   meta = {
     description = "Distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol";

--- a/pkgs/by-name/pr/prometheus-kvrocks-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-kvrocks-exporter/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  kvrocks,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kvrocks_exporter";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "RocksLabs";
+    repo = "kvrocks_exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nyNdQfSXD6mAusO5VCEfvKuyvNawH4C5xDGOZSnTn7A=";
+  };
+
+  vendorHash = "sha256-QVbcHQQr6o3jnF3CWw2NCCeRkGBDdA8OkmDd/GPfHuI=";
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-X main.BuildVersion=${finalAttrs.version}"
+    "-X main.BuildCommitSha=unknown"
+    "-X main.BuildDate=unknown"
+  ];
+
+  nativeCheckInputs = [ kvrocks.hook ];
+
+  preCheck = ''
+    export TEST_REDIS_URI="redis://127.0.0.1:6666"
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags =
+    let
+      skippedTests = [
+        # The following tests require a real Redis/Kvrocks instance with specific configuration
+        # or multiple instances which are not easily provided by a single kvrocks.hook.
+        "TestPasswordProtectedInstance" # Requires TEST_PWD_REDIS_URI and TEST_USER_PWD_REDIS_URI
+        "TestPasswordInvalid" # Requires TEST_PWD_REDIS_URI
+        "TestHTTPScrapeWithPasswordFile" # Requires specific redis instances from password file
+        "TestSimultaneousMetricsHttpRequests" # Requires multiple redis instances
+        "TestClusterMaster" # Requires TEST_REDIS_CLUSTER_MASTER_URI
+        "TestClusterSlave" # Requires TEST_REDIS_CLUSTER_SLAVE_URI
+
+        # The following tests fail due to "target" parameter requirement in kvrocks_exporter's /scrape endpoint
+        # which is not satisfied in the test's HTTP requests in http_test.go.
+        "TestHTTPScrapeMetricsEndpoints"
+
+        # These tests require a running instance and are sensitive to the environment
+        "TestIncludeSystemMemoryMetric"
+
+        # These tests require valid JSON in password files or valid certs
+        "TestLoadPwdFile"
+        "TestPasswordMap"
+        "TestCreateClientTLSConfig"
+        "TestGetServerCertificateFunc"
+      ];
+    in
+    [ "-skip=^(${builtins.concatStringsSep "|" skippedTests})$" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Prometheus exporter for Kvrocks metrics";
+    homepage = "https://github.com/RocksLabs/kvrocks_exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xyenon ];
+    mainProgram = "kvrocks_exporter";
+  };
+})

--- a/pkgs/by-name/pr/prometheus-kvrocks-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-kvrocks-exporter/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  kvrocks,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "prometheus-kvrocks-exporter";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "RocksLabs";
+    repo = "kvrocks_exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nyNdQfSXD6mAusO5VCEfvKuyvNawH4C5xDGOZSnTn7A=";
+  };
+
+  vendorHash = "sha256-QVbcHQQr6o3jnF3CWw2NCCeRkGBDdA8OkmDd/GPfHuI=";
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-X main.BuildVersion=${finalAttrs.version}"
+    "-X main.BuildCommitSha=unknown"
+    "-X main.BuildDate=unknown"
+  ];
+
+  nativeCheckInputs = [ kvrocks.hook ];
+
+  preCheck = ''
+    export TEST_REDIS_URI="redis://127.0.0.1:6666"
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags =
+    let
+      skippedTests = [
+        # The following tests require a real Redis/Kvrocks instance with specific configuration
+        # or multiple instances which are not easily provided by a single kvrocks.hook.
+        "TestPasswordProtectedInstance" # Requires TEST_PWD_REDIS_URI and TEST_USER_PWD_REDIS_URI
+        "TestPasswordInvalid" # Requires TEST_PWD_REDIS_URI
+        "TestHTTPScrapeWithPasswordFile" # Requires specific redis instances from password file
+        "TestSimultaneousMetricsHttpRequests" # Requires multiple redis instances
+        "TestClusterMaster" # Requires TEST_REDIS_CLUSTER_MASTER_URI
+        "TestClusterSlave" # Requires TEST_REDIS_CLUSTER_SLAVE_URI
+
+        # The following tests fail due to "target" parameter requirement in kvrocks_exporter's /scrape endpoint
+        # which is not satisfied in the test's HTTP requests in http_test.go.
+        "TestHTTPScrapeMetricsEndpoints"
+
+        # These tests require a running instance and are sensitive to the environment
+        "TestIncludeSystemMemoryMetric"
+
+        # These tests require valid JSON in password files or valid certs
+        "TestLoadPwdFile"
+        "TestPasswordMap"
+        "TestCreateClientTLSConfig"
+        "TestGetServerCertificateFunc"
+      ];
+    in
+    [ "-skip=^(${builtins.concatStringsSep "|" skippedTests})$" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Prometheus exporter for Kvrocks metrics";
+    homepage = "https://github.com/RocksLabs/kvrocks_exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xyenon ];
+    mainProgram = "kvrocks_exporter";
+  };
+})


### PR DESCRIPTION
https://github.com/RocksLabs/kvrocks_exporter

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
