### PR TITLE
pywal16: refactor

### DIFF
--- a/pkgs/by-name/py/pywal16/wip-refactor.nix
+++ b/pkgs/by-name/py/pywal16/wip-refactor.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  python3,
+}:
+
+python3.pkgs.toPythonApplication python3.pkgs.pywal16
+
+python3.pkgs.buildPythonPackage (finalAttrs: {
+
+  optional-dependencies = with python3.pkgs; {
+    colorthief = [ colorthief ];
+    colorz = [ colorz ];
+    fast-colorthief = [ fast-colorthief ];
+    haishoku = [ haishoku ];
+    modern_colorthief = [ modern-colorthief ];
+    all = [
+      colorthief
+      colorz
+      fast-colorthief
+      haishoku
+      modern-colorthief
+    ];
+  };
+
+})

--- a/pkgs/development/python-modules/pywal16/default.nix
+++ b/pkgs/development/python-modules/pywal16/default.nix
@@ -3,10 +3,17 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+
   imagemagick,
   feh,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
+
+  withColorthief ? false,
+  withColorz ? false,
+  withFastColorthief ? false,
+  withHaishoku ? false,
+  withModernColorthief ? false,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -23,12 +30,23 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  dependencies =
+    lib.optionals withColorthief optional-dependencies.colorthief
+    ++ lib.optionals withColorz optional-dependencies.colorz
+    ++ lib.optionals withFastColorthief optional-dependencies.fast-colorthief
+    ++ lib.optionals withHaishoku optional-dependencies.haishoku
+    ++ lib.optionals withModernColorthief optional-dependencies.modern_colorthief;
+
   nativeCheckInputs = [
     feh
     imagemagick
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];
+
+  postInstall = ''
+    installManPage data/man/man1/wal.1
+  '';
 
   meta = {
     description = "Generate and change colorschemes on the fly. A 'wal' rewrite in Python 3";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm creating this pull to ask for help refactoring and so that there is something on the record.

This refactors the toplevel `pywal16` package to call out to the `python314Packages` scoped [package](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/pywal16/default.nix) by using `toPythonApplication`, per the discussion on #510166. This is similar to what [beets](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/be/beets/package.nix) does.

Previously, the package was (unintentionally) duplicated in both scopes, with the python scoped package being introduced in an [automatic update](https://github.com/NixOS/nixpkgs/commit/f7d0aa8579b54381a6e06678b12cc6c1e6172971).

The new package should expose overridable attributes for color generation backends like the old package, without it needing double maintenance.

(I am currently unsure how to do this and haven't had time to figure out how, help is much appreciated.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
