### PR TITLE
joystickwake: 0.4.2 -> 0.5.1

### DIFF
--- a/pkgs/by-name/jo/joystickwake/package.nix
+++ b/pkgs/by-name/jo/joystickwake/package.nix
@@ -1,18 +1,18 @@
 {
   lib,
   python3,
-  fetchFromGitHub,
+  fetchFromCodeberg,
 }:
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "joystickwake";
   version = "0.4.2";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "foresto";
+  src = fetchFromCodeberg {
+    owner = "forestix";
     repo = "joystickwake";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-vSvIpbcDIbRyitVjx3wNSxt5vTIZ9/NPWokOJt0p6oQ=";
+    hash = "sha256-vSvIpbcDIbRyitVjx3wNSxt5vTIZ9/NPWokOJt0p6oQ=";
   };
 
   build-system = with python3.pkgs; [

--- a/pkgs/by-name/jo/joystickwake/package.nix
+++ b/pkgs/by-name/jo/joystickwake/package.nix
@@ -5,14 +5,14 @@
 }:
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "joystickwake";
-  version = "0.4.2";
+  version = "0.5.2";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "forestix";
     repo = "joystickwake";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vSvIpbcDIbRyitVjx3wNSxt5vTIZ9/NPWokOJt0p6oQ=";
+    hash = "sha256-qIXXlwZec4CQk93gmY5O3mdGdlNCeXWTr/DDw4vwRUM=";
   };
 
   build-system = with python3.pkgs; [
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   dependencies = with python3.pkgs; [
-    dbus-next
+    dbus-fast
     pyudev
     xlib
   ];


### PR DESCRIPTION
- Update source to codeberg:
  Development as moved to codeberg a indicated by [this commit](https://github.com/foresto/joystickwake/commit/8a0cc3ed987e69adb83ad1576c96382efd70a58f)
- Update version to 0.5.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
