### PR TITLE
dioxus-cli: update version of wasm-bindgen-cli

### DIFF
--- a/pkgs/by-name/di/dioxus-cli/package.nix
+++ b/pkgs/by-name/di/dioxus-cli/package.nix
@@ -8,7 +8,7 @@
   rustfmt,
   makeWrapper,
   esbuild,
-  wasm-bindgen-cli_0_2_114,
+  wasm-bindgen-cli_0_2_118,
   testers,
   dioxus-cli,
   withTelemetry ? false,
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --suffix PATH : ${
         lib.makeBinPath [
           esbuild
-          wasm-bindgen-cli_0_2_114
+          wasm-bindgen-cli_0_2_118
         ]
       }
   '';

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_118/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_118/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.118";
+    hash = "sha256-ve783oYH0TGv8Z8lIPdGjItzeLDQLOT5uv/jbFOlZpI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-EYDfuBlH3zmTxACBL+sjicRna84CvoesKSQVcYiG9P0=";
+  };
+}


### PR DESCRIPTION
Else `dx serve` on a new project complains about `wasm-bindgen-cli` not having the correct version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
