### PR TITLE
wrangler: 4.62.0 -> 4.90.0

### DIFF
--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   autoPatchelfHook,
@@ -19,13 +19,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wrangler";
-  version = "4.62.0";
+  version = "4.90.0";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "workers-sdk";
     rev = "wrangler@${finalAttrs.version}";
-    hash = "sha256-o6ARRNObHtRqAD71j7L2HkpIalPwGWR+PyQQuHJBKZE=";
+    hash = "sha256-M2m8dRhTjAYof3S7lVaFYP61p38LvXFSTxantCsUHtE=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -35,9 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
       src
       postPatch
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 2;
-    hash = "sha256-Crtjchu17OFPWqd3L0AYCpA76YRN4jJc+vLVLo1WLe4=";
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-Bo9V3MJaDnKR7TZO4u0mDy9223n7/En8aAdYOgHyYxE=";
   };
   # pnpm packageManager version in workers-sdk root package.json may not match nixpkgs
   postPatch = ''
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     jq
     moreutils
   ]
@@ -73,15 +73,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   # @cloudflare/vitest-pool-workers wanted to run a server as part of the build process
   # so I simply removed it
-  postBuild = ''
-    mv packages/vitest-pool-workers packages/~vitest-pool-workers
+  postBuild =
+    let
+      extraDeps = [
+        "unenv-preset"
+        "workers-utils"
+        "local-explorer-ui"
+        "codemod"
+        "cli-shared-helpers"
+        "miniflare"
+        "wrangler"
+      ];
+    in
+    ''
+      mv packages/vitest-pool-workers packages/~vitest-pool-workers
 
-    NODE_ENV="production" pnpm --filter unenv-preset run build
-    NODE_ENV="production" pnpm --filter workers-utils run build
-    NODE_ENV="production" pnpm --filter workers-shared run build
-    NODE_ENV="production" pnpm --filter miniflare run build
-    NODE_ENV="production" pnpm --filter wrangler run build
-  '';
+      for pkg in ${toString extraDeps}; do
+        NODE_ENV="production" pnpm --filter "$pkg" run build
+      done
+    '';
 
   # I'm sure this is suboptimal but it seems to work. Points:
   # - when build is run in the original repo, no specific executable seems to be generated; you run the resulting build with pnpm run start

--- a/pkgs/by-name/wr/wrangler/package.nix
+++ b/pkgs/by-name/wr/wrangler/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   nodejs,
-  pnpm_9,
+  pnpm,
   fetchPnpmDeps,
   pnpmConfigHook,
   autoPatchelfHook,
@@ -19,13 +19,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wrangler";
-  version = "4.62.0";
+  version = "4.85.0";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "workers-sdk";
     rev = "wrangler@${finalAttrs.version}";
-    hash = "sha256-o6ARRNObHtRqAD71j7L2HkpIalPwGWR+PyQQuHJBKZE=";
+    hash = "sha256-X7q5+6sXmWP7H3dQ9W44/ME0W/Z1KNRb/ZFwRcR6xnk=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -35,9 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       postPatch
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 2;
-    hash = "sha256-Crtjchu17OFPWqd3L0AYCpA76YRN4jJc+vLVLo1WLe4=";
+    fetcherVersion = 3;
+    hash = "sha256-cFcaiKkFaBPXqKfQThmaL8bcraDyUGy/HutJ9tcwrBA=";
   };
   # pnpm packageManager version in workers-sdk root package.json may not match nixpkgs
   postPatch = ''
@@ -63,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm
     jq
     moreutils
   ]
@@ -73,15 +72,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   # @cloudflare/vitest-pool-workers wanted to run a server as part of the build process
   # so I simply removed it
-  postBuild = ''
-    mv packages/vitest-pool-workers packages/~vitest-pool-workers
+  postBuild =
+    let
+      extraDeps = [
+        "unenv-preset"
+        "workers-utils"
+        "local-explorer-ui"
+        "codemod"
+        "cli-shared-helpers"
+        "miniflare"
+        "wrangler"
+      ];
+    in
+    ''
+      mv packages/vitest-pool-workers packages/~vitest-pool-workers
 
-    NODE_ENV="production" pnpm --filter unenv-preset run build
-    NODE_ENV="production" pnpm --filter workers-utils run build
-    NODE_ENV="production" pnpm --filter workers-shared run build
-    NODE_ENV="production" pnpm --filter miniflare run build
-    NODE_ENV="production" pnpm --filter wrangler run build
-  '';
+      for pkg in ${toString extraDeps}; do
+        NODE_ENV="production" pnpm --filter "$pkg" run build
+      done
+    '';
 
   # I'm sure this is suboptimal but it seems to work. Points:
   # - when build is run in the original repo, no specific executable seems to be generated; you run the resulting build with pnpm run start


### PR DESCRIPTION
https://github.com/cloudflare/workers-sdk/releases/tag/wrangler@4.90.0
Diff: https://github.com/cloudflare/workers-sdk/compare/wrangler@4.62.0...wrangler@4.90.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
