### PR TITLE
python3Packages.scikits-odes{,-daepack}: fix build

### DIFF
--- a/pkgs/development/python-modules/scikits-odes-daepack/default.nix
+++ b/pkgs/development/python-modules/scikits-odes-daepack/default.nix
@@ -30,6 +30,9 @@ buildPythonPackage rec {
   # no tests
   doCheck = false;
 
+  # https://github.com/bmcage/odes/pull/204
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   meta = scikits-odes-core.meta // {
     description = "Wrapper around daepack";
     homepage = "https://github.com/bmcage/odes/blob/master/packages/scikits-odes-daepack";

--- a/pkgs/development/python-modules/scikits-odes/default.nix
+++ b/pkgs/development/python-modules/scikits-odes/default.nix
@@ -17,6 +17,19 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/packages/scikits-odes";
 
+  patches = [
+    # https://github.com/bmcage/odes/pull/205
+    ./numpy24-compat.patch
+  ];
+
+  postPatch = ''
+    # scipy 1.17.x's rewritten VODE integrator have bugs such as:
+    # https://github.com/scipy/scipy/issues/24933
+    # revisit after new scipy release
+    substituteInPlace src/scikits/odes/tests/test_dae.py \
+      --replace-fail "StiffVODECompare," ""
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/scikits-odes/numpy24-compat.patch
+++ b/pkgs/development/python-modules/scikits-odes/numpy24-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/src/scikits/odes/tests/test_user_return_vals_cvode.py b/src/scikits/odes/tests/test_user_return_vals_cvode.py
+index 58fae63..8866fe3 100644
+--- a/src/scikits/odes/tests/test_user_return_vals_cvode.py
++++ b/src/scikits/odes/tests/test_user_return_vals_cvode.py
+@@ -8,7 +8,7 @@ def normal_rhs(t, y, ydot):
+     ydot[0] = t
+ 
+ def complex_rhs(t, y, ydot):
+-    ydot[0] = t - y
++    ydot[0] = t - y[0]
+ 
+ def rhs_with_return(t, y, ydot):
+     ydot[0] = t
+diff --git a/src/scikits/odes/tests/test_user_return_vals_ida.py b/src/scikits/odes/tests/test_user_return_vals_ida.py
+index 0c38035..4ae4e70 100644
+--- a/src/scikits/odes/tests/test_user_return_vals_ida.py
++++ b/src/scikits/odes/tests/test_user_return_vals_ida.py
+@@ -5,17 +5,17 @@ from .. import dae
+ from ..sundials.ida import StatusEnumIDA
+ 
+ def normal_rhs(t, y, ydot, res):
+-    res[0] = ydot - t
++    res[0] = ydot[0] - t
+ 
+ def complex_rhs(t, y, ydot, res):
+-    res[0] = ydot - t + y
++    res[0] = ydot[0] - t + y[0]
+ 
+ def rhs_with_return(t, y, ydot, res):
+-    res[0] = ydot - t
++    res[0] = ydot[0] - t
+     return 0
+ 
+ def rhs_problem_late(t, y, ydot, res):
+-    res[0] = ydot - t
++    res[0] = ydot[0] - t
+     if t > 0.5:
+         return 1
+ 
+@@ -23,7 +23,7 @@ def rhs_problem_immediate(t, y, ydot, res):
+     return 1
+ 
+ def rhs_error_late(t, y, ydot, res):
+-    res[0] = ydot - t
++    res[0] = ydot[0] - t
+     if t > 0.5:
+         return -1
+ 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324299168

`scikits-odes-daepack` fails with gcc15, the underlying issue seems to be f2py related.
`scikits-odes` tests tests with updated versions of numpy and scipy, added workarounds.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
