### PR TITLE
beanstalkd: fix build with gcc15

### DIFF
--- a/pkgs/by-name/be/beanstalkd/package.nix
+++ b/pkgs/by-name/be/beanstalkd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   installShellFiles,
   nixosTests,
 }:
@@ -11,11 +12,19 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "beanstalkd";
 
   src = fetchFromGitHub {
-    owner = "kr";
+    owner = "beanstalkd";
     repo = "beanstalkd";
     rev = "v${finalAttrs.version}";
     hash = "sha256-xoudhPad4diGGE8iZaY1/4LiENlKT2dYcIR6wlQdlTU=";
   };
+
+  patches = [
+    # Fix build with GCC 15, remove after next update
+    (fetchpatch {
+      url = "https://github.com/beanstalkd/beanstalkd/commit/85070765.patch";
+      hash = "sha256-QDDypvrQtjlG7iPE0GfvpZMActIw1gRx36+BpZ6WjMw=";
+    })
+  ];
 
   hardeningDisable = [ "fortify" ];
 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324208365

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
