### PR TITLE
contour: 0.6.2.8008 -> 0.6.3.8249

### DIFF
--- a/pkgs/by-name/co/contour/package.nix
+++ b/pkgs/by-name/co/contour/package.nix
@@ -28,19 +28,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "contour";
-  version = "0.6.2.8008";
+  version = "0.6.3.8249";
 
   src = fetchFromGitHub {
     owner = "contour-terminal";
     repo = "contour";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xbJxV1q7+ddhnH0jDYzqVHwARCD0EyVh3POFRkl4d1Q=";
+    hash = "sha256-+rr1bn4O5v9rXyoIx+ejL+qe5Kf2bFpgWA3DkWRcDYk=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     ./dont-fix-app-bundle.diff
     ./remove-deep-flag-from-codesign.diff
   ];
+
+  # Dependencies are already managed by nix
+  cmakeFlags = [ "-DCONTOUR_USE_CPM=OFF" ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/li/libunicode/package.nix
+++ b/pkgs/by-name/li/libunicode/package.nix
@@ -21,13 +21,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libunicode";
-  version = "0.7.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "contour-terminal";
     repo = "libunicode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-J8qawT1oiUO9xTVEMQvsY0K2NtIfkUq9PoCbFt6wqek=";
+    hash = "sha256-EBu8zn5XritudZmBvQmjOmU08XLjhyKI6hVCrnWoR6k=";
   };
 
   # Fix: set_target_properties Can not find target to add properties to: Catch2, et al.

--- a/pkgs/by-name/li/libunicode/remove-target-properties.diff
+++ b/pkgs/by-name/li/libunicode/remove-target-properties.diff
@@ -1,17 +1,17 @@
 diff --git a/src/libunicode/CMakeLists.txt b/src/libunicode/CMakeLists.txt
-index bb1a824..166834c 100644
+index 25abbd1..99f8b8d 100644
 --- a/src/libunicode/CMakeLists.txt
 +++ b/src/libunicode/CMakeLists.txt
-@@ -235,10 +235,10 @@ if(LIBUNICODE_TESTING)
-         # supress conversion warnings for Catch2
+@@ -317,10 +317,10 @@ if(LIBUNICODE_TESTING)
+     if(NOT Catch2_FOUND)
+         # Suppress all warnings for embedded third-party Catch2.
          # https://github.com/catchorg/Catch2/issues/2583
-         # https://github.com/SFML/SFML/blob/e45628e2ebc5843baa3739781276fa85a54d4653/test/CMakeLists.txt#L18-L22
--        set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
--        set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+-        suppress_thirdparty_warnings(Catch2)
+-        suppress_thirdparty_warnings(Catch2WithMain)
 -        get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
 -        target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
-+        # set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
-+        # set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
++        # suppress_thirdparty_warnings(Catch2)
++        # suppress_thirdparty_warnings(Catch2WithMain)
 +        # get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
 +        # target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
      endif()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
