### PR TITLE
haskellPackages.postgresql-types: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4988,7 +4988,6 @@ broken-packages:
   - postgresql-tx-monad-logger # failure in job https://hydra.nixos.org/build/233227034 at 2023-09-02
   - postgresql-tx-simple # failure in job https://hydra.nixos.org/build/233242850 at 2023-09-02
   - postgresql-typed-lifted # failure in job https://hydra.nixos.org/build/233215141 at 2023-09-02
-  - postgresql-types # failure in job https://hydra.nixos.org/build/326308328 at 2026-04-12
   - postgrest-ws # failure in job https://hydra.nixos.org/build/233247807 at 2023-09-02
   - postie # failure in job https://hydra.nixos.org/build/233259075 at 2023-09-02
   - postmark-streams # failure in job https://hydra.nixos.org/build/233233210 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1477,6 +1477,9 @@ builtins.intersectAttrs super {
     (dontCheckIf (!pkgs.postgresql.doInstallCheck || !self.testcontainers.doCheck))
   ];
 
+  # integration-tests suite needs docker/testcontainers; run only unit-tests.
+  postgresql-types = overrideCabal { testTargets = [ "unit-tests" ]; } super.postgresql-types;
+
   users-postgresql-simple = lib.pipe super.users-postgresql-simple [
     (addTestToolDepends [
       pkgs.postgresql


### PR DESCRIPTION
## Summary

Unbreaks `postgresql-types`.

We cannot run the full `integration-tests` because they rely on docker, but instead of `dontCheck` we atleast run the unit tests.

## Things done

- [x] ofBorg / haskell-updates CI


(extracted from the ihp pr https://github.com/NixOS/nixpkgs/pull/505221)