### PR TITLE
haskellPackages.postgresql-simple-postgresql-types: unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2694,7 +2694,6 @@ dont-distribute-packages:
  - postgresql-common-persistent
  - postgresql-pure
  - postgresql-simple-ltree
- - postgresql-simple-postgresql-types
  - postgresql-simple-queue
  - postgresql-simple-typed
  - postgresql-tx-query

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1480,6 +1480,9 @@ builtins.intersectAttrs super {
   # integration-tests suite needs docker/testcontainers; run only unit-tests.
   postgresql-types = overrideCabal { testTargets = [ "unit-tests" ]; } super.postgresql-types;
 
+  # only test suite is testcontainers/docker-based
+  postgresql-simple-postgresql-types = dontCheck super.postgresql-simple-postgresql-types;
+
   users-postgresql-simple = lib.pipe super.users-postgresql-simple [
     (addTestToolDepends [
       pkgs.postgresql


### PR DESCRIPTION
## Summary

Follows #511704. Once `postgresql-types` is unbroken, the only reason
`postgresql-simple-postgresql-types` was transitively broken disappears.
Its single test suite uses `testcontainers-postgresql` (docker), so
dontCheck it and drop its entry from `transitive-broken.yaml`.

`hasql-postgresql-types` stays in transitive-broken.yaml because it
also depends on the still-broken `hasql-mapping`.

> Note: this PR is stacked on #511704. The first commit is from that
> PR; after #511704 merges I'll rebase this onto `haskell-updates` so
> only the single postgresql-simple-postgresql-types commit remains.

## Things done

- [x] ofBorg / haskell-updates CI