### PR TITLE
odoo18: 18.0.20250506 -> 18.0.20260420

### DIFF
--- a/pkgs/by-name/od/odoo18/package.nix
+++ b/pkgs/by-name/od/odoo18/package.nix
@@ -9,7 +9,7 @@
 
 let
   odoo_version = "18.0";
-  odoo_release = "20250506";
+  odoo_release = "20260420";
   python = python312.override {
     self = python;
   };
@@ -21,9 +21,9 @@ python.pkgs.buildPythonApplication rec {
 
   src = fetchzip {
     # find latest version on https://nightly.odoo.com/${odoo_version}/nightly/src
-    url = "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.zip";
+    url = "https://nightly.odoo.com/${odoo_version}/nightly/src/odoo_${version}.tar.gz";
     name = "odoo-${version}";
-    hash = "sha256-rNG0He+51DnRT5g1SovGZ9uiE1HWXtcmAybcadBMjY4="; # odoo
+    hash = "sha256-+ilM07s33pdwZc3XoAXbID7MRz/m6PHnzjHzi183eyM="; # odoo
   };
 
   makeWrapperArgs = [

--- a/pkgs/by-name/od/odoo18/update.sh
+++ b/pkgs/by-name/od/odoo18/update.sh
@@ -27,6 +27,6 @@ fi
 
 cd "$SCRIPT_DIR"
 
-sed -ri "s| hash.+ # odoo| hash = \"$(nix-prefetch -q fetchzip --option extra-experimental-features flakes --url "https://nightly.odoo.com/${VERSION}/nightly/src/odoo_${latestVersion}.zip")\"; # odoo|g" package.nix
+sed -ri "s| hash.+ # odoo| hash = \"$(nix-prefetch -q fetchzip --option extra-experimental-features flakes --url "https://nightly.odoo.com/${VERSION}/nightly/src/odoo_${latestVersion}.tar.gz")\"; # odoo|g" package.nix
 sed -ri "s|odoo_version = .+|odoo_version = \"$VERSION\";|" package.nix
 sed -ri "s|odoo_release = .+|odoo_release = \"$RELEASE\";|" package.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently untested.

I've switched to tar.gz for the source download as it's smaller than the zip file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
