### PR TITLE
umami: use finalAttrs pattern on prisma override

### DIFF
--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -42,36 +42,40 @@ let
 
   # Pin the specific version of prisma to the one used by upstream
   # to guarantee compatibility.
-  prisma-engines' = prisma-engines_7.overrideAttrs (old: rec {
-    version = "7.6.0";
-    src = fetchFromGitHub {
-      owner = "prisma";
-      repo = "prisma-engines";
-      tag = version;
-      hash = "sha256-NMoAaiTa68i51lR6iMCyHyCAsFuuhPx2+tHFSSoqWqA=";
-    };
-    cargoHash = "sha256-uiFvzxwVJXCW9LUDFRC6ZkzSa7LQk+9ZJcaJw8mrBX4=";
+  prisma-engines' = prisma-engines_7.overrideAttrs (
+    finalAttrs: prevAttrs: {
+      version = "7.6.0";
+      src = fetchFromGitHub {
+        owner = "prisma";
+        repo = "prisma-engines";
+        tag = finalAttrs.version;
+        hash = "sha256-NMoAaiTa68i51lR6iMCyHyCAsFuuhPx2+tHFSSoqWqA=";
+      };
+      cargoHash = "sha256-uiFvzxwVJXCW9LUDFRC6ZkzSa7LQk+9ZJcaJw8mrBX4=";
 
-    cargoDeps = rustPlatform.fetchCargoVendor {
-      inherit (old) pname;
-      inherit src version;
-      patches = old.cargoDeps.vendorStaging.patches or [ ];
-      hash = cargoHash;
-    };
-  });
-  prisma' = (prisma_7.override { prisma-engines_7 = prisma-engines'; }).overrideAttrs (old: rec {
-    version = "7.6.0";
-    src = fetchFromGitHub {
-      owner = "prisma";
-      repo = "prisma";
-      tag = version;
-      hash = "sha256-BesX2ySfgew6+9Q6fnhZ8gMnnxh4D4fefaA5BhehlHE=";
-    };
-    pnpmDeps = old.pnpmDeps.override {
-      inherit src version;
-      hash = "sha256-ZOpNt+W5b1troicfkCi4wCCDtwhTB4VlPgxYMZetcs0=";
-    };
-  });
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        inherit (prevAttrs) pname;
+        inherit (finalAttrs) src version;
+        patches = prevAttrs.cargoDeps.vendorStaging.patches or [ ];
+        hash = finalAttrs.cargoHash;
+      };
+    }
+  );
+  prisma' = (prisma_7.override { prisma-engines_7 = prisma-engines'; }).overrideAttrs (
+    finalAttrs: prevAttrs: {
+      version = "7.6.0";
+      src = fetchFromGitHub {
+        owner = "prisma";
+        repo = "prisma";
+        tag = finalAttrs.version;
+        hash = "sha256-BesX2ySfgew6+9Q6fnhZ8gMnnxh4D4fefaA5BhehlHE=";
+      };
+      pnpmDeps = prevAttrs.pnpmDeps.override {
+        inherit (finalAttrs) src version;
+        hash = "sha256-ZOpNt+W5b1troicfkCi4wCCDtwhTB4VlPgxYMZetcs0=";
+      };
+    }
+  );
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umami";


### PR DESCRIPTION
Replace the `rec` with the more correct `final`/`prev` pattern.

Use GitHub's option of ignoring whitespace changes when looking at the diff, as a reformat changed indentation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
