### PR TITLE
gip: init at 0.7.1

### DIFF
--- a/pkgs/by-name/gi/gip/package.nix
+++ b/pkgs/by-name/gi/gip/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gip";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "dalance";
+    repo = "gip";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UgvXaDNdH8ZN00oJ/DjIlBs86ua3JmVz1JfLk2XBVFw=";
+  };
+
+  cargoHash = "sha256-C38pV8c7znbBua130qDaguUAWamGhxfI8y0Vy0yadWc=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  __structuredAttrs = true;
+
+  # Tests that require network access
+  doCheck = false;
+
+  meta = {
+    description = "Command-line tool to get global IP address";
+    homepage = "https://github.com/dalance/gip";
+    changelog = "https://github.com/dalance/gip/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "gip";
+  };
+})


### PR DESCRIPTION
Command-line tool to get global IP address

https://github.com/dalance/gip


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
