### PR TITLE
python3Packages.ovirt-engine-sdk: init at 4.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26263,6 +26263,12 @@
     githubId = 65870;
     name = "Сухарик";
   };
+  sulfiore = {
+    email = "sulfiore@postnet.cc";
+    github = "sulfiore";
+    githubId = 3856645;
+    name = "Sulfiore";
+  };
   sumnerevans = {
     email = "me@sumnerevans.com";
     github = "sumnerevans";

--- a/pkgs/development/python-modules/ovirt-engine-sdk/default.nix
+++ b/pkgs/development/python-modules/ovirt-engine-sdk/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  libxml2,
+  pycurl,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "ovirt-engine-sdk";
+  version = "4.6.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "ovirt_engine_sdk_python";
+    inherit version;
+    hash = "sha256-nPAkJ5K4kQy3st7MOIbbLM/XeVB+Rqwc4qUlcwdf098=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ libxml2 ];
+
+  dependencies = [ pycurl ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "/usr/include/libxml2" "${libxml2.dev}/include/libxml2" \
+      --replace-fail "libraries=[" "library_dirs=['${libxml2.out}/lib'], libraries=["
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlagsArray = [
+    # examples/test_connection.py requires a real oVirt engine
+    "--ignore=examples"
+    # these tests fail at collection due to a missing TestServer mock
+    "--ignore=tests/test_cluster_service.py"
+    "--ignore=tests/test_connection_create.py"
+    "--ignore=tests/test_connection_error.py"
+    "--ignore=tests/test_datacenter_service.py"
+    "--ignore=tests/test_invalid_authentication.py"
+    "--ignore=tests/test_iscsi_discover.py"
+    "--ignore=tests/test_setupnetworks.py"
+    "--ignore=tests/test_storage_domain_service.py"
+    "--ignore=tests/test_vm_service.py"
+  ];
+
+  pythonImportsCheck = [ "ovirtsdk4" ];
+
+  meta = {
+    description = "The oVirt Python SDK is a Python package that simplifies access to the oVirt Engine API";
+    downloadPage = "https://pypi.org/project/ovirt-engine-sdk-python/";
+    homepage = "https://github.com/oVirt/ovirt-engine-sdk";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sulfiore ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12001,6 +12001,8 @@ self: super: with self; {
 
   ovh = callPackage ../development/python-modules/ovh { };
 
+  ovirt-engine-sdk = callPackage ../development/python-modules/ovirt-engine-sdk { };
+
   ovmfvartool = callPackage ../development/python-modules/ovmfvartool { };
 
   ovoenergy = callPackage ../development/python-modules/ovoenergy { };


### PR DESCRIPTION
Python SDK for Ovirt API

https://pypi.org/project/ovirt-engine-sdk-python/

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I had to do a postPatch because libxml2 is hardcoded into the setup.py and doesn,'t use pkg-config.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
