### PR TITLE
openlinkhub: 0.7.5 -> 0.8.4

### DIFF
--- a/pkgs/by-name/op/openlinkhub/package.nix
+++ b/pkgs/by-name/op/openlinkhub/package.nix
@@ -1,40 +1,62 @@
 {
-  buildGoModule,
   lib,
+  buildGoModule,
   fetchFromGitHub,
-  udev,
   nix-update-script,
-  versionCheckHook,
+  pkg-config,
+  pipewire,
+  udev,
+  usbutils,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "openlinkhub";
-  version = "0.7.5";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "jurkovic-nikola";
     repo = "OpenLinkHub";
-    tag = version;
-    hash = "sha256-Jq31ZcJtl0ZmjNsMOiTTt2eZIIYn2DRVPE4Q5FTx6OM=";
+    tag = finalAttrs.version;
+    hash = "sha256-yxLRwYsBvwpPVeQWx8R9bfbtdkGu2qUsDiyoijcTD2g=";
   };
 
   proxyVendor = true;
+  vendorHash = "sha256-/itomxsbTDT7ML52bpUfDZIBZ/Rh/zx4Blg+PP7m7gE=";
 
-  vendorHash = "sha256-xpIaQzl2jrWRIUe/1woODKLlwxQrdlCLkIk0qmWs7m0=";
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
+    pipewire
     udev
+    usbutils
   ];
+
+  env.CGO_CFLAGS_ALLOW = "-fno-strict-overflow";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 644 -t $out/etc/udev/rules.d $src/99-openlinkhub.rules
+    install -Dm 755 -t $out/bin $GOPATH/bin/OpenLinkHub
+
+    mkdir -p $out/opt/OpenLinkHub
+    cp -r $src/{database,static,web} $out/opt/OpenLinkHub
+
+    runHook postInstall
+  '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/jurkovic-nikola/OpenLinkHub";
-    platforms = lib.platforms.linux;
     description = "Open source interface for iCUE LINK Hub and other Corsair AIOs, Hubs for Linux";
-    maintainers = with lib.maintainers; [ bot-wxt1221 ];
-    license = lib.licenses.gpl3Only;
+    changelog = "https://github.com/jurkovic-nikola/OpenLinkHub/releases/tag/${finalAttrs.version}";
     mainProgram = "OpenLinkHub";
-    changelog = "https://github.com/jurkovic-nikola/OpenLinkHub/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      bot-wxt1221
+      mikaeladev
+    ];
   };
-}
+})

--- a/pkgs/by-name/op/openlinkhub/package.nix
+++ b/pkgs/by-name/op/openlinkhub/package.nix
@@ -1,40 +1,62 @@
 {
-  buildGoModule,
   lib,
+  buildGoModule,
   fetchFromGitHub,
-  udev,
   nix-update-script,
-  versionCheckHook,
+  pkg-config,
+  pipewire,
+  udev,
+  usbutils,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "openlinkhub";
-  version = "0.7.5";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "jurkovic-nikola";
     repo = "OpenLinkHub";
-    tag = version;
-    hash = "sha256-Jq31ZcJtl0ZmjNsMOiTTt2eZIIYn2DRVPE4Q5FTx6OM=";
+    tag = finalAttrs.version;
+    hash = "sha256-yxLRwYsBvwpPVeQWx8R9bfbtdkGu2qUsDiyoijcTD2g=";
   };
 
   proxyVendor = true;
+  vendorHash = "sha256-/itomxsbTDT7ML52bpUfDZIBZ/Rh/zx4Blg+PP7m7gE=";
 
-  vendorHash = "sha256-xpIaQzl2jrWRIUe/1woODKLlwxQrdlCLkIk0qmWs7m0=";
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
+    pipewire
     udev
+    usbutils
   ];
+
+  env.CGO_CFLAGS_ALLOW = "-fno-strict-overflow";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 644 -t $out/etc/udev/rules.d 99-openlinkhub.rules
+    install -Dm 755 -t $out/bin $GOPATH/bin/OpenLinkHub
+
+    mkdir -p $out/opt/OpenLinkHub
+    cp -r {database,static,web} $out/opt/OpenLinkHub
+
+    runHook postInstall
+  '';
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/jurkovic-nikola/OpenLinkHub";
-    platforms = lib.platforms.linux;
     description = "Open source interface for iCUE LINK Hub and other Corsair AIOs, Hubs for Linux";
-    maintainers = with lib.maintainers; [ bot-wxt1221 ];
-    license = lib.licenses.gpl3Only;
+    changelog = "https://github.com/jurkovic-nikola/OpenLinkHub/releases/tag/${finalAttrs.version}";
     mainProgram = "OpenLinkHub";
-    changelog = "https://github.com/jurkovic-nikola/OpenLinkHub/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      bot-wxt1221
+      mikaeladev
+    ];
   };
-}
+})


### PR DESCRIPTION
upstream changes: https://github.com/jurkovic-nikola/OpenLinkHub/compare/0.7.5...0.8.4

alongside updating dependencies and hashes, i've added an install phase to include the static dependencies required to run the binary (this won't affect downstream modules as it's tucked away in `/opt`) and made some minor nitpicky tweaks like swapping out `rec` for `finalAttrs` and tidying up `meta`.

this package hasn't been updated for some time now and i'm [looking to develop a home-manager module for it](https://github.com/nix-community/home-manager/issues/9086) so i've added myself as a maintainer to help out in future!

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
