### PR TITLE
[25.11] umami: 3.0.3 -> 3.1.0

### DIFF
--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -3,14 +3,15 @@
   stdenvNoCC,
   fetchFromGitHub,
   fetchurl,
+  inter,
   makeWrapper,
   nixosTests,
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpm,
-  prisma_6,
-  prisma-engines_6,
+  prisma_7,
+  prisma-engines_7,
   openssl,
   rustPlatform,
   # build variables
@@ -41,39 +42,40 @@ let
 
   # Pin the specific version of prisma to the one used by upstream
   # to guarantee compatibility.
-  prisma-engines' = prisma-engines_6.overrideAttrs (old: rec {
-    version = "6.19.0";
+  prisma-engines' = prisma-engines_7.overrideAttrs (old: rec {
+    version = "7.6.0";
     src = fetchFromGitHub {
       owner = "prisma";
       repo = "prisma-engines";
       tag = version;
-      hash = "sha256-icFgoKIrr3fGSVmSczlMJiT5KSb746kVldtrk+Q0wW8=";
+      hash = "sha256-NMoAaiTa68i51lR6iMCyHyCAsFuuhPx2+tHFSSoqWqA=";
     };
-    cargoHash = "sha256-PgCfBcmK9RCA5BMacJ5oYEpo2DnBKx2xPbdLb79yCCY=";
+    cargoHash = "sha256-uiFvzxwVJXCW9LUDFRC6ZkzSa7LQk+9ZJcaJw8mrBX4=";
 
     cargoDeps = rustPlatform.fetchCargoVendor {
       inherit (old) pname;
       inherit src version;
+      patches = old.cargoDeps.vendorStaging.patches or [ ];
       hash = cargoHash;
     };
   });
-  prisma' = (prisma_6.override { prisma-engines_6 = prisma-engines'; }).overrideAttrs (old: rec {
-    version = "6.19.0";
+  prisma' = (prisma_7.override { prisma-engines_7 = prisma-engines'; }).overrideAttrs (old: rec {
+    version = "7.6.0";
     src = fetchFromGitHub {
       owner = "prisma";
       repo = "prisma";
       tag = version;
-      hash = "sha256-lFPAu296cQMDnEcLTReSHuLuOz13kd7n0GV+ifcX+lQ=";
+      hash = "sha256-BesX2ySfgew6+9Q6fnhZ8gMnnxh4D4fefaA5BhehlHE=";
     };
     pnpmDeps = old.pnpmDeps.override {
       inherit src version;
-      hash = "sha256-9v30vhclD+sPcui/VG8dwaC8XGU6QFs/Gu8rjjoQy/w=";
+      hash = "sha256-ZOpNt+W5b1troicfkCi4wCCDtwhTB4VlPgxYMZetcs0=";
     };
   });
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "umami";
-  version = "3.0.3";
+  version = "3.1.0";
 
   nativeBuildInputs = [
     makeWrapper
@@ -86,8 +88,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "umami-software";
     repo = "umami";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rkOD52suE6bihJqKvMdIvqHRIcWhSxXzUkCfmdNbC40=";
+    hash = "sha256-EH3ebwTbajcNasn25ets2w068ZmCQRYUY2XON39J5HA=";
   };
+
+  # Umami uses next/font/google, which tries to download from Google Fonts at build time.
+  # Replace that code with a copy of the required font(s) from nixpkgs instead.
+  postPatch = ''
+    substituteInPlace ./src/app/layout.tsx \
+      --replace-fail "import { Inter } from 'next/font/google';" "import localFont from 'next/font/local';" \
+      --replace-fail 'const inter = Inter({' "const inter = localFont({ src: './Inter.ttf',"
+
+    cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
+  '';
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -96,7 +108,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       ;
     fetcherVersion = 3;
-    hash = "sha256-GFN94oySPCZA5K13XR8f/tByuHS571ohlYTFqaVw/Ns=";
+    hash = "sha256-QNWmCsVFh8xpsO4ZPTaKGszwuRaxTrWLMVh/6VV5oIw=";
   };
 
   env.CYPRESS_INSTALL_BINARY = "0";
@@ -144,6 +156,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     cp -R public $out/public
     cp -R prisma $out/prisma
+    cp prisma.config.ts $out/prisma.config.ts
+    substituteInPlace $out/prisma.config.ts \
+      --replace-fail "import 'dotenv/config';" "" \
+      --replace-fail "from 'prisma/config';" "from '${finalAttrs.passthru.prisma}/lib/prisma/packages/config';"
 
     ln -s ${finalAttrs.passthru.geocities} $out/geo
 

--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -112,8 +112,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   # Allow prisma-cli to find prisma-engines without having to download them
   # Only needed at build time for `prisma generate`.
-  env.PRISMA_QUERY_ENGINE_LIBRARY = "${prisma-engines'}/lib/libquery_engine.node";
-  env.PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines'}/bin/schema-engine";
+  env.PRISMA_QUERY_ENGINE_LIBRARY = "${finalAttrs.passthru.prisma-engines}/lib/libquery_engine.node";
+  env.PRISMA_SCHEMA_ENGINE_BINARY = "${finalAttrs.passthru.prisma-engines}/bin/schema-engine";
 
   buildPhase = ''
     runHook preBuild
@@ -145,7 +145,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -R public $out/public
     cp -R prisma $out/prisma
 
-    ln -s ${geocities} $out/geo
+    ln -s ${finalAttrs.passthru.geocities} $out/geo
 
     mkdir -p $out/bin
     # Run database migrations before starting umami.
@@ -161,7 +161,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         ]
       } \
       --chdir $out \
-      --run "${lib.getExe prisma'} migrate deploy" \
+      --run "${lib.getExe finalAttrs.passthru.prisma} migrate deploy" \
       --add-flags "$out/server.js"
 
     runHook postInstall

--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -121,6 +121,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   # Needs to be non-empty during build
   env.DATABASE_URL = "postgresql://";
+  # No DB is available during build
+  env.SKIP_DB_CHECK = "1";
+
+  # Geocities is handled manually
+  env.SKIP_BUILD_GEO = "1";
 
   # Allow prisma-cli to find prisma-engines without having to download them
   # Only needed at build time for `prisma generate`.
@@ -130,10 +135,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm build-db-client # prisma generate
-
-    pnpm build-tracker
-    pnpm build-app
+    pnpm build
 
     runHook postBuild
   '';
@@ -161,8 +163,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace-fail "import 'dotenv/config';" "" \
       --replace-fail "from 'prisma/config';" "from '${finalAttrs.passthru.prisma}/lib/prisma/packages/config';"
 
-    ln -s ${finalAttrs.passthru.geocities} $out/geo
-
     mkdir -p $out/bin
     # Run database migrations before starting umami.
     # Add openssl to PATH since it is required for prisma to make SSL connections.
@@ -170,6 +170,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper ${nodejs}/bin/node $out/bin/umami-server  \
       --set NODE_ENV production \
       --set NEXT_TELEMETRY_DISABLED 1 \
+      --set GEOLITE_DB_PATH ${lib.escapeShellArg "${finalAttrs.passthru.geocities}/GeoLite2-City.mmdb"} \
       --prefix PATH : ${
         lib.makeBinPath [
           openssl

--- a/pkgs/by-name/um/umami/sources.json
+++ b/pkgs/by-name/um/umami/sources.json
@@ -1,7 +1,7 @@
 {
   "geocities": {
-    "rev": "c311451d8c87eff88329f08a0fae5f84fc0303fe",
-    "date": "2025-12-11",
-    "hash": "sha256-tDK2p1VUmVfbzl0EhcGZbWP/1ao/U3f9vcK49f0MErc="
+    "rev": "6a3ef689a4673ff2bf292548716e7cc6c5a2c903",
+    "date": "2026-04-16",
+    "hash": "sha256-GUUeFU1DKGL+NpzK1oJlsyB/VrFWe6Lj7U7yJXj8mNo="
   }
 }


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/510928

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
(cherry picked from commit b5ee858)