### PR TITLE
python3Packages.cuda-pathfinder: 1.4.0 -> 1.5.3; python3Packages.cuda-bindings: 12.8.0 -> 12.9.6

### DIFF
--- a/pkgs/development/python-modules/cuda-bindings/default.nix
+++ b/pkgs/development/python-modules/cuda-bindings/default.nix
@@ -7,11 +7,15 @@
 
   # build-system
   cython,
-  setuptools,
   pyclibrary,
+  setuptools,
+  setuptools-scm,
 
   # env
   symlinkJoin,
+
+  # dependencies
+  cuda-pathfinder,
 
   # tests
   numpy,
@@ -23,14 +27,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cuda-bindings";
-  version = "12.8.0";
+  version = "12.9.6";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cuda-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7e9w70KkC6Pcvyu6Cwt5Asrc3W9TgsjiGvArRTer6Oc=";
+    hash = "sha256-uRv27h2b6wXC8oOf5k2KxZ0bUFNvNu6XO05FBbJcU1k=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/cuda_bindings";
@@ -49,9 +54,6 @@ buildPythonPackage (finalAttrs: {
     ''
       substituteInPlace cuda/bindings/_internal/nvjitlink_linux.pyx \
         --replace-fail \
-          'so_name = "libnvJitLink.so"' \
-          'so_name = "${lib.getLib cudaPackages.libnvjitlink}/lib/libnvJitLink.so"' \
-        --replace-fail \
           "handle = dlopen('libcuda.so.1'" \
           "handle = dlopen('${libCudaPath}/lib/libcuda.so.1'"
 
@@ -59,16 +61,6 @@ buildPythonPackage (finalAttrs: {
         --replace-fail \
           "path = 'libcuda.so.1'" \
           "path = '${libCudaPath}/lib/libcuda.so.1'"
-
-      substituteInPlace cuda/bindings/_bindings/cynvrtc.pyx.in \
-        --replace-fail \
-          "dlfcn.dlopen('libnvrtc.so.12'" \
-          "dlfcn.dlopen('${lib.getLib cudaPackages.cuda_nvrtc}/lib/libnvrtc.so.12'"
-
-      substituteInPlace cuda/bindings/_lib/cyruntime/cyruntime.pyx.in \
-        --replace-fail \
-          "dlfcn.dlopen('libcudart.so.12'" \
-          "dlfcn.dlopen('${lib.getLib cudaPackages.cuda_cudart}/lib/libcudart.so.12'"
     '';
 
   preBuild = ''
@@ -79,6 +71,7 @@ buildPythonPackage (finalAttrs: {
     cython
     pyclibrary
     setuptools
+    setuptools-scm
   ];
 
   env = {
@@ -94,6 +87,11 @@ buildPythonPackage (finalAttrs: {
 
   buildInputs = [
     cudaPackages.cuda_nvcc # crt/host_defines.h
+    cudaPackages.libcufile # cufile.h
+  ];
+
+  dependencies = [
+    cuda-pathfinder
   ];
 
   pythonImportsCheck = [
@@ -133,7 +131,7 @@ buildPythonPackage (finalAttrs: {
   };
 
   meta = {
-    description = "CUDA Python: Performance meets Productivity";
+    description = "Standard set of low-level interfaces, providing access to the CUDA host APIs from Python";
     homepage = "https://github.com/NVIDIA/cuda-python/tree/main/cuda_bindings";
     changelog = "https://nvidia.github.io/cuda-python/${finalAttrs.version}/release/${finalAttrs.version}-notes.html";
     license = lib.licenses.unfreeRedistributable; # NVIDIA Proprietary Software

--- a/pkgs/development/python-modules/cuda-pathfinder/default.nix
+++ b/pkgs/development/python-modules/cuda-pathfinder/default.nix
@@ -14,14 +14,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cuda-pathfinder";
-  version = "1.4.0";
+  version = "1.5.3";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "cuda-python";
     tag = "cuda-pathfinder-v${finalAttrs.version}";
-    hash = "sha256-Bsou6vLyMBNbVMPT4vtnWpoi05lXG6pjhuee6Hg/Mm8=";
+    hash = "sha256-Tj+0p+nIsOl2pMpKAUpdZ3nIcQ0kHWrPi6Qeu14oMRQ=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/cuda_pathfinder";


### PR DESCRIPTION
## Things done

- **python3Packages.cuda-pathfinder: 1.4.0 -> 1.5.3**
- **python3Packages.cuda-bindings: 12.8.0 -> 12.9.6**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
