### PR TITLE
planify: 4.18.3 -> 4.19.0

### DIFF
--- a/pkgs/by-name/pl/planify/package.nix
+++ b/pkgs/by-name/pl/planify/package.nix
@@ -24,18 +24,17 @@
   libsoup_3,
   libspelling,
   sqlite,
-  webkitgtk_6_0,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "planify";
-  version = "4.18.3";
+  version = "4.19.0";
 
   src = fetchFromGitHub {
     owner = "alainm23";
     repo = "planify";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VCLXQnB3JhhK3UvnGTfR+mZ/AYGQ2YNxa6hD4QCUfjM=";
+    hash = "sha256-swZ8kpfDLxe48PqHLiCjxYbsS7RILCPTPHybtrJi0rA=";
   };
 
   nativeBuildInputs = [
@@ -66,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     libsoup_3
     libspelling
     sqlite
-    webkitgtk_6_0
   ];
 
   meta = {


### PR DESCRIPTION
see https://github.com/alainm23/planify/releases/tag/v4.19.0

I also removed the not needed WebKitGTK dependency

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `dcee9baf2cd0496fd48274340e39d47dac120916`

---

### `x86_64-linux`

<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>planify</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
