### PR TITLE
treewide: replace stdenv.is* with stdenv.hostPlatform.is*

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
@@ -34,7 +34,7 @@ let
     };
     makeCacheWritable = true;
 
-    buildInputs = lib.optionals stdenv.isLinux [
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
       libsecret
     ];
     nativeBuildInputs = [
@@ -42,10 +42,10 @@ let
       nodejs-slim.python
       npmHooks.npmConfigHook
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       pkg-config
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       cctools.libtool
       clang_20 # clang_21 breaks @vscode/vsce's optional dependency keytar
     ];

--- a/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
@@ -32,7 +32,7 @@ let
       hash = "sha256-vktxhQA2a+D9Nr4vhbmGCnNdGzt0U89K50g0SgiV5SE=";
     };
 
-    buildInputs = lib.optionals stdenv.isLinux [
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
       libsecret
     ];
 
@@ -41,10 +41,10 @@ let
       nodejs-slim.python
       npmHooks.npmConfigHook
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       pkg-config
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       clang_20 # clang_21 breaks @vscode/vsce's optional dependency keytar
     ];
 

--- a/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix
@@ -47,7 +47,7 @@ let
       pkg-config
 
     ]
-    ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks keytar
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks keytar
 
     # Follows https://github.com/rust-lang/rust-analyzer/blob/41949748a6123fd6061eb984a47f4fe780525e63/xtask/src/dist.rs#L39-L65
     installPhase = ''

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/node_deps.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/node_deps.nix
@@ -22,7 +22,7 @@ buildNpmPackage {
     python3
     pkg-config
   ]
-  ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks keytar
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks keytar
 
   buildInputs = [ libsecret ];
 

--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase =
-    if stdenv.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       ''
         mkdir -p "$out"
         mv diffpdf.app "$out"/

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -27,7 +27,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoBuildHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
     };
   } ./cargo-build-hook.sh;
@@ -41,7 +41,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoCheckHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
     };
   } ./cargo-check-hook.sh;
@@ -54,7 +54,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoInstallHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
     };
   } ./cargo-install-hook.sh;
@@ -68,7 +68,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoNextestHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
     };
   } ./cargo-nextest-hook.sh;
@@ -107,7 +107,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoSetupHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
     };
   } ./cargo-setup-hook.sh;

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -27,7 +27,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoBuildHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoBuildHook;
     };
   } ./cargo-build-hook.sh;
@@ -41,7 +41,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoCheckHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoCheckHook;
     };
   } ./cargo-check-hook.sh;
@@ -54,7 +54,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoInstallHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoInstallHook;
     };
   } ./cargo-install-hook.sh;
@@ -68,7 +68,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoNextestHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoNextestHook;
     };
   } ./cargo-nextest-hook.sh;
@@ -108,7 +108,7 @@
     passthru.tests = {
       test = tests.rust-hooks.cargoSetupHook;
     }
-    // lib.optionalAttrs (stdenv.isLinux) {
+    // lib.optionalAttrs (stdenv.hostPlatform.isLinux) {
       testCross = pkgsCross.riscv64.tests.rust-hooks.cargoSetupHook;
     };
   } ./cargo-setup-hook.sh;

--- a/pkgs/by-name/ab/abbaye-des-morts/package.nix
+++ b/pkgs/by-name/ab/abbaye-des-morts/package.nix
@@ -28,11 +28,11 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=${placeholder "out"}"
     "DESTDIR="
   ]
-  ++ lib.optional stdenv.isDarwin "PLATFORM=mac";
+  ++ lib.optional stdenv.hostPlatform.isDarwin "PLATFORM=mac";
 
   # Even with PLATFORM=mac, the Makefile specifies some GCC-specific CFLAGS that
   # are not supported by modern Clang on macOS
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace Makefile \
       --replace-fail "-funswitch-loops" "" \
       --replace-fail "-fgcse-after-reload" ""

--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -60,10 +60,10 @@ stdenv.mkDerivation {
     makeWrapper
     patchelf
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     fixDarwinDylibNames
   ];
 

--- a/pkgs/by-name/an/angle/package.nix
+++ b/pkgs/by-name/an/angle/package.nix
@@ -35,7 +35,7 @@ let
       llvmPackages.clang
     ];
     postBuild =
-      if stdenv.isDarwin then
+      if stdenv.hostPlatform.isDarwin then
         ''
           mkdir -p $out/lib/clang/${llvmMajorVersion}/lib/darwin
           ln -s $out/resource-root/lib/darwin/libclang_rt.osx.a \
@@ -67,12 +67,12 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     llvmPackages.bintools
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     xcbuild
   ];
 
   buildInputs =
-    lib.optionals stdenv.isLinux [
+    lib.optionals stdenv.hostPlatform.isLinux [
       glib
       libxcb.dev
       libx11.dev
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
       pciutils
       libGL
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_15
     ];
 

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_JAVA" false)
-    (lib.cmakeBool "STOP_BUILD_ON_WARNING" stdenv.isLinux)
+    (lib.cmakeBool "STOP_BUILD_ON_WARNING" stdenv.hostPlatform.isLinux)
     (lib.cmakeBool "INSTALL_VENDORED_LIBS" false)
   ]
   ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -55,7 +55,7 @@ buildGoModule (finalAttrs: {
   # skip tests on darwin due to some local networking failures
   # `__darwinAllowLocalNetworking = true;` wasn't sufficient for
   # aarch64 or x86_64
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
   preCheck = ''
     # some test data include SOURCE_DATE_EPOCH (which is different from our default)
     # and the default version info which we get by unsetting our ldflags

--- a/pkgs/by-name/at/atuin-desktop/package.nix
+++ b/pkgs/by-name/at/atuin-desktop/package.nix
@@ -153,7 +153,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=ui::viewport::tests::test_add_line_scrolling"
     "--skip=ui::viewport::tests::test_line_wrapping"
   ];
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   __structuredAttrs = true;
 

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -161,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "ENABLE_SSE42" enableSSE42)
   ];
 
-  installPhase = optionalString stdenv.isDarwin ''
+  installPhase = optionalString stdenv.hostPlatform.isDarwin ''
     runHook preInstall
 
     mkdir -p $out/Applications $out/bin
@@ -176,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
       --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
-      ${optionalString stdenv.isDarwin "--prefix DYLD_LIBRARY_PATH : ${
+      ${optionalString stdenv.hostPlatform.isDarwin "--prefix DYLD_LIBRARY_PATH : ${
         lib.makeLibraryPath [ moltenvk ]
       }"}
     )

--- a/pkgs/by-name/ba/basedpyright/package.nix
+++ b/pkgs/by-name/ba/basedpyright/package.nix
@@ -40,7 +40,7 @@ buildNpmPackage rec {
     docify
     pkg-config
   ]
-  ++ lib.optional stdenv.isDarwin [ clang_20 ]; # clang_21 breaks keytar
+  ++ lib.optional stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks keytar
 
   buildInputs = [ libsecret ];
 

--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -19,7 +19,7 @@ let
     {
       enableJavaFX = true;
     }
-    // lib.optionalAttrs stdenv.isLinux {
+    // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       openjfx_jdk = openjfx21.override { withWebKit = true; };
     }
   );

--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -62,7 +62,9 @@ stdenv.mkDerivation (finalAttrs: {
       "varmod-localtime"
     ]
     # TODO: drop the name-conditioning on stdenv rebuild
-    ++ lib.optional (stdenv.isDarwin && lib.getName stdenv != "bootstrap-stage1-stdenv-darwin") "export"
+    ++ lib.optional (
+      stdenv.hostPlatform.isDarwin && lib.getName stdenv != "bootstrap-stage1-stdenv-darwin"
+    ) "export"
   );
 
   strictDeps = true;

--- a/pkgs/by-name/br/brogue-ce/package.nix
+++ b/pkgs/by-name/br/brogue-ce/package.nix
@@ -46,10 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
     "DATADIR=$(out)/opt/brogue-ce"
     "TERMINAL=${if terminal then "YES" else "NO"}"
     "GRAPHICS=${if graphics then "YES" else "NO"}"
-    "MAC_APP=${if stdenv.isDarwin then "YES" else "NO"}"
+    "MAC_APP=${if stdenv.hostPlatform.isDarwin then "YES" else "NO"}"
   ];
 
-  postBuild = lib.optionalString (stdenv.isDarwin && graphics) ''
+  postBuild = lib.optionalString (stdenv.hostPlatform.isDarwin && graphics) ''
     make Brogue.app $makeFlags
   '';
 
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postInstall = lib.optionalString (stdenv.isDarwin && graphics) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.isDarwin && graphics) ''
     mkdir -p $out/Applications
     mv Brogue.app "$out/Applications/Brogue CE.app"
   '';

--- a/pkgs/by-name/br/bruno-cli/package.nix
+++ b/pkgs/by-name/br/bruno-cli/package.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
   nativeBuildInputs = [
     pkg-config
   ]
-  ++ lib.optional stdenv.isDarwin clang_20; # clang_21 breaks gyp builds
+  ++ lib.optional stdenv.hostPlatform.isDarwin clang_20; # clang_21 breaks gyp builds
 
   buildInputs = [
     pango

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -42,7 +42,7 @@ buildNpmPackage rec {
   nativeBuildInputs = [
     pkg-config
   ]
-  ++ lib.optional stdenv.isDarwin clang_20 # clang_21 breaks gyp builds
+  ++ lib.optional stdenv.hostPlatform.isDarwin clang_20 # clang_21 breaks gyp builds
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     makeWrapper
     copyDesktopItems

--- a/pkgs/by-name/br/brush-splat/package.nix
+++ b/pkgs/by-name/br/brush-splat/package.nix
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     vulkan-loader
     zstd
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     wayland
   ];
 

--- a/pkgs/by-name/ca/caido-cli/package.nix
+++ b/pkgs/by-name/ca/caido-cli/package.nix
@@ -35,9 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
   );
 
   nativeBuildInputs =
-    lib.optionals stdenv.isLinux [ autoPatchelfHook ] ++ lib.optionals stdenv.isDarwin [ unzip ];
+    lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ unzip ];
 
-  buildInputs = lib.optionals stdenv.isLinux [ libgcc ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libgcc ];
 
   sourceRoot = ".";
 

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -113,9 +113,9 @@ let
   };
 
 in
-if stdenv.isLinux then
+if stdenv.hostPlatform.isLinux then
   linux
-else if stdenv.isDarwin then
+else if stdenv.hostPlatform.isDarwin then
   darwin
 else
   throw "caido-desktop: unsupported platform ${stdenv.hostPlatform.system}"

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -111,9 +111,9 @@ let
   };
 
 in
-if stdenv.isLinux then
+if stdenv.hostPlatform.isLinux then
   linux
-else if stdenv.isDarwin then
+else if stdenv.hostPlatform.isDarwin then
   darwin
 else
   throw "caido-desktop: unsupported platform ${stdenv.hostPlatform.system}"

--- a/pkgs/by-name/ca/cargo-nextest/package.nix
+++ b/pkgs/by-name/ca/cargo-nextest/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   # FIXME: we don't support dtrace probe generation on macOS until we have a dtrace build: https://github.com/NixOS/nixpkgs/pull/392918
-  patches = lib.optionals stdenv.isDarwin [
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
     ./no-dtrace-macos.patch
   ];
 

--- a/pkgs/by-name/do/dovecot/generic.nix
+++ b/pkgs/by-name/do/dovecot/generic.nix
@@ -139,9 +139,11 @@ stdenv.mkDerivation (finalAttrs: {
     export systemdsystemunitdir=$out/etc/systemd/system
   '';
 
-  preBuild = lib.optionalString (lib.strings.versionOlder version "2.4" && stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -undefined dynamic_lookup"
-  '';
+  preBuild =
+    lib.optionalString (lib.strings.versionOlder version "2.4" && stdenv.hostPlatform.isDarwin)
+      ''
+        export NIX_LDFLAGS="$NIX_LDFLAGS -undefined dynamic_lookup"
+      '';
 
   # We need this for sysconfdir, see remark below.
   installFlags = [ "DESTDIR=$(out)" ];

--- a/pkgs/by-name/do/dovecot/generic.nix
+++ b/pkgs/by-name/do/dovecot/generic.nix
@@ -147,9 +147,11 @@ stdenv.mkDerivation (finalAttrs: {
       'NOPLUGIN_LDFLAGS="-undefined dynamic_lookup"'
   '';
 
-  preBuild = lib.optionalString (lib.strings.versionOlder version "2.4" && stdenv.isDarwin) ''
-    export NIX_LDFLAGS="$NIX_LDFLAGS -undefined dynamic_lookup"
-  '';
+  preBuild =
+    lib.optionalString (lib.strings.versionOlder version "2.4" && stdenv.hostPlatform.isDarwin)
+      ''
+        export NIX_LDFLAGS="$NIX_LDFLAGS -undefined dynamic_lookup"
+      '';
 
   # We need this for sysconfdir, see remark below.
   installFlags = [ "DESTDIR=$(out)" ];

--- a/pkgs/by-name/do/dovecot_pigeonhole/generic.nix
+++ b/pkgs/by-name/do/dovecot_pigeonhole/generic.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withLDAP "--with-ldap";
 
-  preBuild = lib.optionalString (!isCurrent && stdenv.isDarwin) ''
+  preBuild = lib.optionalString (!isCurrent && stdenv.hostPlatform.isDarwin) ''
     export NIX_LDFLAGS="$NIX_LDFLAGS -undefined dynamic_lookup"
   '';
 

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableNFD [
     nativefiledialog-extended
   ]
-  ++ lib.optionals (enableNFD && stdenv.isLinux) [
+  ++ lib.optionals (enableNFD && stdenv.hostPlatform.isLinux) [
     gtk3
   ]
   ++ lib.optionals enablePython [
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = enableTests;
 
-  nativeCheckInputs = lib.optionals (enableTests && stdenv.isLinux) [
+  nativeCheckInputs = lib.optionals (enableTests && stdenv.hostPlatform.isLinux) [
     xvfb-run
   ];
 
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preCheck
 
     cd feather-tk/src/feather-tk-build
-    ${if stdenv.isLinux then "xvfb-run" else ""} ctest --verbose -C Release
+    ${if stdenv.hostPlatform.isLinux then "xvfb-run" else ""} ctest --verbose -C Release
 
     runHook postCheck
   '';

--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -63,7 +63,7 @@ buildNpmPackage {
     electron
     makeWrapper
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     desktopToDarwinBundle
   ];
 

--- a/pkgs/by-name/fi/filtr/package.nix
+++ b/pkgs/by-name/fi/filtr/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -45,7 +45,7 @@ let
     # Timeouts
     "TestRunJob_WithConnectionFromCommandOptions"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Uses docker-specific options, unsupported on Darwin
     "TestMergeJobOptions"
   ];

--- a/pkgs/by-name/fv/fverb/package.nix
+++ b/pkgs/by-name/fv/fverb/package.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     # clang++: error: unsupported option '-mfpu=' for target 'arm64-apple-darwin'
     # clang++: error: unsupported option '-mfloat-abi=' for target 'arm64-apple-darwin'
-    broken = stdenv.isDarwin && stdenv.isAarch64;
+    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/by-name/ga/gate12/package.nix
+++ b/pkgs/by-name/ga/gate12/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -28,14 +28,14 @@ buildNpmPackage (finalAttrs: {
 
   npmDepsHash = "sha256-T3fxNFvkLR7f49GQjzzTnl3VM+VUUgJfFF5d2GGe7L4=";
 
-  dontPatchElf = stdenv.isDarwin;
+  dontPatchElf = stdenv.hostPlatform.isDarwin;
 
   nativeBuildInputs = [
     jq
     pkg-config
     makeWrapper
   ]
-  ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optionalDependencies keytar
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optionalDependencies keytar
 
   buildInputs = [
     ripgrep

--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -28,14 +28,14 @@ buildNpmPackage (finalAttrs: {
 
   npmDepsHash = "sha256-4znN1YR3AX2SKeCJjUS8cm6WGcOGPXI27xrQCotBjgQ=";
 
-  dontPatchElf = stdenv.isDarwin;
+  dontPatchElf = stdenv.hostPlatform.isDarwin;
 
   nativeBuildInputs = [
     jq
     pkg-config
     makeWrapper
   ]
-  ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optionalDependencies keytar
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optionalDependencies keytar
 
   buildInputs = [
     ripgrep

--- a/pkgs/by-name/gi/gitaly/git.nix
+++ b/pkgs/by-name/gi/gitaly/git.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   # required to support pthread_cancel()
   NIX_LDFLAGS =
     lib.optionalString (stdenv.cc.isGNU && stdenv.hostPlatform.libc == "glibc") "-lgcc_s"
-    + lib.optionalString stdenv.isFreeBSD "-lthr";
+    + lib.optionalString stdenv.hostPlatform.isFreeBSD "-lthr";
 
   # The build phase already installs it all
   GIT_PREFIX = placeholder "out";

--- a/pkgs/by-name/gr/grype/package.nix
+++ b/pkgs/by-name/gr/grype/package.nix
@@ -106,7 +106,7 @@ buildGoModule (finalAttrs: {
         "Test_dpkgUseCPEsForEOLEnvVar"
         "Test_rpmUseCPEsForEOLEnvVar"
       ]
-      ++ lib.optionals stdenv.isDarwin [
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # fails to generate x509 certificate
         # cat: /etc/ssl/openssl.cnf: Operation not permitted
         "Test_defaultHTTPClientHasCert"

--- a/pkgs/by-name/gt/gts/package.nix
+++ b/pkgs/by-name/gt/gts/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ gettext ];
   propagatedBuildInputs = [ glib ];
 
-  env = lib.optionalAttrs stdenv.isDarwin {
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # Doesn't build on Darwin with -std=gnu23.
     NIX_CFLAGS_COMPILE = "-std=gnu17";
   };

--- a/pkgs/by-name/hy/hygg/package.nix
+++ b/pkgs/by-name/hy/hygg/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ## Skipping this test due to the high variability of its outcome
   ## When the package was merged the test was passing but on hydra its not
   ## Look at PR #448907
-  ++ (if pkgs.stdenv.isDarwin then [ "--skip=test_stdin_processing" ] else [ ]);
+  ++ (if pkgs.stdenv.hostPlatform.isDarwin then [ "--skip=test_stdin_processing" ] else [ ]);
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/id/idris2/libidris2_support.nix
+++ b/pkgs/by-name/id/idris2/libidris2_support.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [
     "PREFIX=${placeholder "out"}"
   ]
-  ++ lib.optional stdenv.isDarwin "OS=";
+  ++ lib.optional stdenv.hostPlatform.isDarwin "OS=";
 
   buildFlags = [ "support" ];
 

--- a/pkgs/by-name/in/inetutils/package.nix
+++ b/pkgs/by-name/in/inetutils/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3
     ./inetutils-1_9-PATH_PROCNET_DEV.patch
 
-    (if stdenv.isDarwin then ./tests-libls-2.sh.patch else ./tests-libls.sh.patch)
+    (if stdenv.hostPlatform.isDarwin then ./tests-libls-2.sh.patch else ./tests-libls.sh.patch)
 
     (fetchpatch {
       name = "CVE-2026-24061_1.patch";
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-servers";
 
-  ${if stdenv.isDarwin then "hardeningDisable" else null} = [ "format" ];
+  ${if stdenv.hostPlatform.isDarwin then "hardeningDisable" else null} = [ "format" ];
 
   doCheck = true;
 

--- a/pkgs/by-name/in/inetutils/package.nix
+++ b/pkgs/by-name/in/inetutils/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3
     ./inetutils-1_9-PATH_PROCNET_DEV.patch
 
-    (if stdenv.isDarwin then ./tests-libls-2.sh.patch else ./tests-libls.sh.patch)
+    (if stdenv.hostPlatform.isDarwin then ./tests-libls-2.sh.patch else ./tests-libls.sh.patch)
 
     (fetchpatch {
       name = "CVE-2026-24061_1.patch";
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-servers";
 
-  ${if stdenv.isDarwin then "hardeningDisable" else null} = [ "format" ];
+  ${if stdenv.hostPlatform.isDarwin then "hardeningDisable" else null} = [ "format" ];
 
   doCheck = true;
 

--- a/pkgs/by-name/is/isle-portable/unwrapped.nix
+++ b/pkgs/by-name/is/isle-portable/unwrapped.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace packaging/macos/CMakeLists.txt \
       --replace-fail "fixup_bundle" "#fixup_bundle"
   '';

--- a/pkgs/by-name/ja/jabref/package.nix
+++ b/pkgs/by-name/ja/jabref/package.nix
@@ -173,8 +173,8 @@ stdenv.mkDerivation rec {
     zip -d $out/lib/javafx-web-*-*.jar "*.so"
 
     # Use postgresql from nixpkgs since the bundled binary doesn't work on NixOS
-    ARCH1=${if stdenv.isAarch64 then "arm64v8" else "amd64"}
-    ARCH2=${if stdenv.isAarch64 then "arm_64" else "x86_64"}
+    ARCH1=${if stdenv.hostPlatform.isAarch64 then "arm64v8" else "amd64"}
+    ARCH2=${if stdenv.hostPlatform.isAarch64 then "arm_64" else "x86_64"}
     mkdir postgresql
     cd postgresql
     ln -s ${postgresql}/{lib,share} ./

--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -75,7 +75,7 @@ python3Packages.buildPythonPackage {
     echo -e 'quit()' | env -i ./kresd -a 127.0.0.1#53535 -c test-http.lua
   '';
 
-  doCheck = python3Packages.stdenv.isLinux; # maybe in future
+  doCheck = python3Packages.stdenv.hostPlatform.isLinux; # maybe in future
   nativeCheckInputs = with python3Packages; [
     augeas
     dnspython

--- a/pkgs/by-name/li/libxkbcommon_8/package.nix
+++ b/pkgs/by-name/li/libxkbcommon_8/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     doxygen
   ]
-  ++ lib.optional stdenv.isLinux xvfb
+  ++ lib.optional stdenv.hostPlatform.isLinux xvfb
   ++ lib.optional withWaylandTools wayland-scanner;
 
   buildInputs = [
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Denable-wayland=${lib.boolToString withWaylandTools}"
   ];
 
-  doCheck = stdenv.isLinux; # TODO: disable just a part of the tests
+  doCheck = stdenv.hostPlatform.isLinux; # TODO: disable just a part of the tests
   preCheck = ''
     patchShebangs ../test/
   '';

--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -81,7 +81,7 @@ buildGoModule (finalAttrs: {
 
   checkFlags =
     let
-      skippedTests = lib.optionals (stdenv.isDarwin) [
+      skippedTests = lib.optionals (stdenv.hostPlatform.isDarwin) [
         # Fail only on *-darwin intermittently
         # https://github.com/mostlygeek/llama-swap/issues/320
         "TestProcess_AutomaticallyStartsUpstream"

--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -34,7 +34,7 @@ buildGoModule {
   tags = [
     "sqlite_omit_load_extension"
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     "netgo"
     "osusergo"
   ];

--- a/pkgs/by-name/mi/microfetch/package.nix
+++ b/pkgs/by-name/mi/microfetch/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-vGvpjRJr4ez322JWUwboVml22vnRVRlwpZ9W4F5wATA=";
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ mold ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ mold ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/nu/nusmv/package.nix
+++ b/pkgs/by-name/nu/nusmv/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
         throw "only linux and mac x86_64 are currently supported"
     );
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
   installPhase = ''
     install -m755 -D bin/NuSMV $out/bin/NuSMV

--- a/pkgs/by-name/op/open5gs/package.nix
+++ b/pkgs/by-name/op/open5gs/package.nix
@@ -83,10 +83,10 @@ stdenv.mkDerivation (finalAttrs: {
     gnutls
     libnghttp2.dev
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     lksctp-tools
   ]
-  ++ lib.optionals (!stdenv.isLinux) [
+  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
     usrsctp
   ];
 

--- a/pkgs/by-name/pa/paisa/package.nix
+++ b/pkgs/by-name/pa/paisa/package.nix
@@ -96,7 +96,7 @@ buildGoModule (finalAttrs: {
     # darwin clang compiler the native node-addon-api cannot be built anymore.
     # this can only be fixed by upstream upgrading dependencies (especially
     # node-gyp and node-addon-api).
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://paisa.fyi/";
     changelog = "https://github.com/ananthakumaran/paisa/releases/tag/v${finalAttrs.version}";
     description = "Personal finance manager, building on top of the ledger double entry accounting tool";

--- a/pkgs/by-name/pg/pgsql-tools/package.nix
+++ b/pkgs/by-name/pg/pgsql-tools/package.nix
@@ -39,11 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
   ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     libxcrypt-legacy
     (lib.getLib stdenv.cc.cc)
   ];
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r _internal $out/lib/pgsql-tools/
 
     makeBinaryWrapper $out/lib/pgsql-tools/ossdbtoolsservice_main $out/bin/ossdbtoolsservice_main \
-      ${lib.optionalString stdenv.isLinux ''--prefix LD_LIBRARY_PATH : "${
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''--prefix LD_LIBRARY_PATH : "${
         lib.makeLibraryPath [
           libxcrypt-legacy
           (lib.getLib stdenv.cc.cc)

--- a/pkgs/by-name/pi/pinta/package.nix
+++ b/pkgs/by-name/pi/pinta/package.nix
@@ -47,7 +47,7 @@ buildDotnetModule rec {
     glib
     libadwaita
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Transitive dylib deps that Pinta's NativeImportResolver dlopen's by bare name.
     # These are not pulled in by wrapGAppsHook4's LD_LIBRARY_PATH on Darwin, so symlink is needed.
     graphene
@@ -73,7 +73,7 @@ buildDotnetModule rec {
 
   projectFile = "Pinta";
 
-  env = lib.optionalAttrs (!stdenv.isDarwin) {
+  env = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
     LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
   };
 
@@ -93,7 +93,7 @@ buildDotnetModule rec {
     mkdir -p "$out/share/icons"
     cp -r "$out/lib/Pinta/icons/." "$out/share/icons/"
   ''
-  + lib.optionalString (!stdenv.isDarwin) ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     dotnet build installer/linux/install.proj \
       -target:Install \
       -p:ContinuousIntegrationBuild=true \
@@ -102,7 +102,7 @@ buildDotnetModule rec {
       -p:PublishDir="$out/lib/Pinta" \
       -p:InstallPrefix="$out"
   ''
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Symlink all dylibs from runtimeDeps into the assembly dir.
     # GirCore and Pinta's own NativeImportResolver both search here by bare name.
     for dir in ${lib.concatMapStringsSep " " (d: "${lib.getLib d}/lib") runtimeDeps}; do

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
         # mount: fusermount: exec: "fusermount": executable file not found in $PATH
         "TestExecuteCmdMountDefault"
       ]
-      ++ lib.optionals stdenv.isDarwin [
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
         "TestBTreeScanMemory"
         "TestBTreeScanPebble"
       ];

--- a/pkgs/by-name/pl/plakar/package.nix
+++ b/pkgs/by-name/pl/plakar/package.nix
@@ -33,7 +33,7 @@ buildGo125Module (finalAttrs: {
         # mount: fusermount: exec: "fusermount": executable file not found in $PATH
         "TestExecuteCmdMountDefault"
       ]
-      ++ lib.optionals stdenv.isDarwin [
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
         "TestBTreeScanMemory"
         "TestBTreeScanPebble"
         "TestExecuteCmdServerDefault"

--- a/pkgs/by-name/qd/qdelay/package.nix
+++ b/pkgs/by-name/qd/qdelay/package.nix
@@ -18,7 +18,7 @@
   writableTmpDirAsHomeHook,
 
   buildVST3 ? true,
-  buildLV2 ? stdenv.isLinux,
+  buildLV2 ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
     zlib
   ];

--- a/pkgs/by-name/re/reevr/package.nix
+++ b/pkgs/by-name/re/reevr/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/rk/rkdeveloptool/package.nix
+++ b/pkgs/by-name/rk/rkdeveloptool/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   # main.cpp:1568:36: error: '%s' directive output may be truncated writing up to 557 bytes into a region of size 5
   env.CPPFLAGS = toString (
     lib.optionals stdenv.cc.isGNU [ "-Wno-error=format-truncation" ]
-    ++ lib.optionals stdenv.isDarwin [ "-Wno-error=vla-cxx-extension" ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ "-Wno-error=vla-cxx-extension" ]
   );
 
   meta = {

--- a/pkgs/by-name/ro/roc/package.nix
+++ b/pkgs/by-name/ro/roc/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage {
     cmake
     zig_0_13
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
   ];
 
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage {
     llvmPackages.llvm.dev
     makeBinaryWrapper
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     glibc
     stdenv.cc.cc.lib
   ];
@@ -67,13 +67,13 @@ rustPlatform.buildRustPackage {
     '';
 
   postInstall =
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       wrapProgram $out/bin/roc \
         --set NIX_GLIBC_PATH ${glibc.out}/lib \
         --set NIX_LIBGCC_S_PATH ${stdenv.cc.cc.lib}/lib \
         --prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}
     ''
-    + lib.optionalString (!stdenv.isLinux) ''
+    + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
       wrapProgram $out/bin/roc --prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}
     '';
 
@@ -84,12 +84,12 @@ rustPlatform.buildRustPackage {
   ];
 
   checkPhase =
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       runHook preCheck
       NIX_GLIBC_PATH=${glibc.out}/lib NIX_LIBGCC_S_PATH=${stdenv.cc.cc.lib}/lib cargo test --release --workspace --exclude test_mono --exclude uitest -- --skip=glue_cli_tests --skip=test_snapshots
       runHook postCheck
     ''
-    + lib.optionalString (!stdenv.isLinux) ''
+    + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
       runHook preCheck
       cargo test --release --workspace --exclude test_mono --exclude uitest -- --skip=glue_cli_tests --skip=test_snapshots
       runHook postCheck

--- a/pkgs/by-name/sc/scipopt-zimpl/package.nix
+++ b/pkgs/by-name/sc/scipopt-zimpl/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     maintainers = with lib.maintainers; [ pmeinhold ];
     platforms = lib.platforms.linux;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     changelog = "https://zimpl.zib.de/download/CHANGELOG.txt";
     description = "Zuse Institute Mathematical Programming Language";
     longDescription = ''

--- a/pkgs/by-name/sd/sdcc/package.nix
+++ b/pkgs/by-name/sd/sdcc/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "doc"
   ]
-  ++ lib.optionals (!stdenv.isDarwin) [
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     "man"
   ];
 

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -199,9 +199,9 @@ let
   };
 
   buildAttrs =
-    if stdenv.isLinux then
+    if stdenv.hostPlatform.isLinux then
       buildAttrsLinux
-    else if stdenv.isDarwin then
+    else if stdenv.hostPlatform.isDarwin then
       buildAttrsDarwin
     else
       throw "platform not supported";

--- a/pkgs/by-name/sg/sg-323/package.nix
+++ b/pkgs/by-name/sg/sg-323/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/si/signal-desktop/webrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/webrtc.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Chromium's Darwin toolchain defines _LIBCPP_HARDENING_MODE itself; keep
   # cc-wrapper from injecting a conflicting default.
-  hardeningDisable = lib.optionals stdenv.isDarwin [
+  hardeningDisable = lib.optionals stdenv.hostPlatform.isDarwin [
     "libcxxhardeningfast"
     "libcxxhardeningextensive"
   ];
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     gclient2nix.gclientUnpackHook
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk
     xcodebuild
   ];
@@ -78,10 +78,10 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     pulseaudio
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     llvmPackages.compiler-rt
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
   ];
 
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace modules/audio_device/linux/pulseaudiosymboltable_linux.cc \
       --replace-fail "libpulse.so.0" "${pulseaudio}/lib/libpulse.so.0"
   ''
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Fix Darwin Python script shebangs for sandbox builds
     patchShebangs build/mac/should_use_hermetic_xcode.py build/toolchain/apple/linker_driver.py
 
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace build/config/mac/BUILD.gn \
       --replace-fail "apple-macos" "apple-darwin"
   ''
-  + lib.optionalString stdenv.isLinux ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace modules/audio_device/linux/alsasymboltable_linux.cc \
       --replace-fail "libasound.so.2" "${alsa-lib}/lib/libasound.so.2"
   '';
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   gnFlags =
-    lib.optionals stdenv.isLinux [
+    lib.optionals stdenv.hostPlatform.isLinux [
       # webrtc uses chromium's `src/build/BUILDCONFIG.gn`. many of these flags
       # are copied from pkgs/applications/networking/browsers/chromium/common.nix.
       ''target_os="linux"''
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
       ''custom_toolchain="//build/toolchain/linux/unbundle:default"''
       ''host_toolchain="//build/toolchain/linux/unbundle:default"''
     ]
-    ++ lib.optionals stdenv.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       ''target_os="mac"''
       ''mac_deployment_target="${stdenv.hostPlatform.darwinMinVersion}"''
       "use_sysroot=true"
@@ -164,7 +164,7 @@ stdenv.mkDerivation (finalAttrs: {
       "use_custom_libcxx=false"
       ''rust_sysroot_absolute="${buildPackages.rustc}"''
     ]
-    ++ lib.optionals (stdenv.isLinux && stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.buildPlatform != stdenv.hostPlatform) [
       ''host_toolchain="//build/toolchain/linux/unbundle:host"''
       ''v8_snapshot_toolchain="//build/toolchain/linux/unbundle:host"''
     ];

--- a/pkgs/by-name/si/sirial/package.nix
+++ b/pkgs/by-name/si/sirial/package.nix
@@ -18,7 +18,7 @@
   writableTmpDirAsHomeHook,
 
   buildVST3 ? true,
-  buildLV2 ? stdenv.isLinux,
+  buildLV2 ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/sp/spacetimedb/package.nix
+++ b/pkgs/by-name/sp/spacetimedb/package.nix
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=codegen"
     "--skip=publish"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # flakes on darwin in nix build sandbox, timing out waiting for listen addr
     "--skip=cli_can_ping_spacetimedb_on_disk"
     "--skip=cli_can_publish_spacetimedb_on_disk"

--- a/pkgs/by-name/sp/speed-dreams/package.nix
+++ b/pkgs/by-name/sp/speed-dreams/package.nix
@@ -39,7 +39,7 @@
 }:
 
 let
-  glLibs = lib.optionals stdenv.isLinux [
+  glLibs = lib.optionals stdenv.hostPlatform.isLinux [
     libGL
     libGLU
     libglut
@@ -73,7 +73,7 @@ let
     stdenv.cc.cc.lib
   ];
   runtimeLibPath = lib.makeLibraryPath runtimeLibs;
-  libPathVar = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+  libPathVar = if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
 in
 stdenv.mkDerivation (finalAttrs: {
   version = "2.4.2";
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     substituteInPlace "$out/share/applications/speed-dreams.desktop" \
       --replace-fail "Exec=$out/games/speed-dreams-2" "Exec=speed-dreams"
-    ${lib.optionalString stdenv.isLinux ''
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
       # Symlink for desktop icon
       mkdir -p $out/share/icons/hicolor/{96x96,scalable}/apps
       ln -s "$out/share/games/speed-dreams-2/data/icons/icon.png" "$out/share/icons/hicolor/96x96/apps/speed-dreams-2.png"
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapperArgs=(
       --prefix ${libPathVar} : "$out/lib/games/speed-dreams-2/lib:$out/lib:${runtimeLibPath}"
     )
-    ${lib.optionalString stdenv.isLinux "makeWrapperArgs+=(--set SDL_VIDEODRIVER x11)"}
+    ${lib.optionalString stdenv.hostPlatform.isLinux "makeWrapperArgs+=(--set SDL_VIDEODRIVER x11)"}
     makeWrapper "$out/games/speed-dreams-2" "$out/bin/speed-dreams" "''${makeWrapperArgs[@]}"
   '';
 
@@ -161,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
     minizip
     rhash
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libGL
     libGLU
     libglut

--- a/pkgs/by-name/st/star/package.nix
+++ b/pkgs/by-name/st/star/package.nix
@@ -28,13 +28,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ xxd ];
 
-  buildInputs = [ zlib ] ++ lib.optionals stdenv.isDarwin [ llvmPackages.openmp ];
+  buildInputs = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
 
   enableParallelBuilding = true;
 
   makeFlags = lib.optionals stdenv.hostPlatform.isAarch64 [ "CXXFLAGS_SIMD=" ];
 
-  preBuild = lib.optionalString stdenv.isDarwin ''
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
     export CXXFLAGS="$CXXFLAGS -DSHM_NORESERVE=0"
   '';
 

--- a/pkgs/by-name/st/starboard/package.nix
+++ b/pkgs/by-name/st/starboard/package.nix
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
   preCheck = ''
     # Remove test that requires networking
     rm pkg/plugin/aqua/client/client_integration_test.go
-    ${lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+    ${lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
       # Remove "[It] should make a request to fetch registries" test that fails on x86_64-darwin
       rm pkg/plugin/aqua/client/client_test.go
     ''}

--- a/pkgs/by-name/su/superfile/package.nix
+++ b/pkgs/by-name/su/superfile/package.nix
@@ -37,7 +37,7 @@ buildGoModule {
   checkFlags = [
     "-skip=^TestReturnDirElement/Sort_by_Date$"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Only failing on nix darwin. I suspect this is due to the way
     # darwin handles file permissions.
     "-skip=^TestCompressSelectedFiles"

--- a/pkgs/by-name/ti/time12/package.nix
+++ b/pkgs/by-name/ti/time12/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     fontconfig
     freetype
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     libx11
     libxcomposite

--- a/pkgs/by-name/ti/timr-tui/package.nix
+++ b/pkgs/by-name/ti/timr-tui/package.nix
@@ -28,10 +28,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Enable upstream "sound" feature when requested
   buildFeatures = lib.optionals enableSound [ "sound" ];
 
-  nativeBuildInputs = lib.optionals (enableSound && stdenv.isLinux) [ pkg-config ];
+  nativeBuildInputs = lib.optionals (enableSound && stdenv.hostPlatform.isLinux) [ pkg-config ];
 
   # Runtime/FFI deps for the sound feature (Linux)
-  buildInputs = lib.optionals (enableSound && stdenv.isLinux) [
+  buildInputs = lib.optionals (enableSound && stdenv.hostPlatform.isLinux) [
     (alsa-lib-with-plugins.override {
       plugins = [
         alsa-plugins

--- a/pkgs/by-name/tr/transito/package.nix
+++ b/pkgs/by-name/tr/transito/package.nix
@@ -74,6 +74,6 @@ buildGoModule (finalAttrs: {
     maintainers = [ lib.maintainers.McSinyx ];
     mainProgram = "transito";
     platforms = lib.platforms.unix;
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -22,7 +22,7 @@
 }:
 
 let
-  turingstdenv = if stdenv.isDarwin then llvmPackages_20.stdenv else stdenv;
+  turingstdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_20.stdenv else stdenv;
 in
 turingstdenv.mkDerivation (finalAttrs: {
   pname = "turingdb";
@@ -71,7 +71,7 @@ turingstdenv.mkDerivation (finalAttrs: {
     zlib
   ]
   ++ lib.optionals turingstdenv.isDarwin [ llvmPackages_20.openmp ]
-  ++ lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
 
   cmakeFlags = [
     (lib.cmakeBool "NIX_BUILD" true)
@@ -80,7 +80,7 @@ turingstdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_EXE_LINKER_FLAGS" "-lgomp")
     (lib.cmakeFeature "FLEX_INCLUDE_DIR" "${lib.getDev flex}/include")
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeFeature "OpenMP_CXX_FLAGS" "-fopenmp")
     (lib.cmakeFeature "OpenMP_CXX_LIB_NAMES" "omp")
     (lib.cmakeFeature "OpenMP_omp_LIBRARY" "${lib.getLib llvmPackages_20.openmp}/lib/libomp.dylib")

--- a/pkgs/by-name/un/unnix/package.nix
+++ b/pkgs/by-name/un/unnix/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   installShellFiles,
   pkg-config,
-  withBubblewrap ? stdenv.isLinux,
+  withBubblewrap ? stdenv.hostPlatform.isLinux,
   makeBinaryWrapper,
   xz,
   zstd,

--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -249,13 +249,13 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     zstd
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
     imagemagick
     libicns
     wrapGAppsHook3
   ]
-  ++ lib.optionals stdenv.isDarwin [ rsync ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ rsync ];
 
   buildInputs = [
     curl
@@ -320,7 +320,7 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 icon_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/Rack.png
     done;
   ''
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/{bin,Applications}
     mv dist/'VCV Rack ${lib.versions.major finalAttrs.version} Free.app' \
       $out/Applications

--- a/pkgs/by-name/ve/vengi-tools/package.nix
+++ b/pkgs/by-name/ve/vengi-tools/package.nix
@@ -133,6 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
     # Segfaults when building shaders
-    broken = stdenv.isLinux;
+    broken = stdenv.hostPlatform.isLinux;
   };
 })

--- a/pkgs/by-name/vi/vips/package.nix
+++ b/pkgs/by-name/vi/vips/package.nix
@@ -49,7 +49,7 @@
   withDevDoc ?
     !stdenv.hostPlatform.isDarwin
     && !stdenv.hostPlatform.isFreeBSD
-    && !(stdenv.hostPlatform.isRiscV && stdenv.isLinux),
+    && !(stdenv.hostPlatform.isRiscV && stdenv.hostPlatform.isLinux),
 
   # passthru
   testers,

--- a/pkgs/by-name/vs/vsce/package.nix
+++ b/pkgs/by-name/vs/vsce/package.nix
@@ -32,7 +32,7 @@ buildNpmPackage (finalAttrs: {
     pkg-config
     nodejs-slim.python
   ]
-  ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optional dependency keytar
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optional dependency keytar
 
   buildInputs = [ libsecret ];
 

--- a/pkgs/by-name/vs/vscode-solidity-server/package.nix
+++ b/pkgs/by-name/vs/vscode-solidity-server/package.nix
@@ -21,7 +21,7 @@ buildNpmPackage {
 
   npmDepsHash = "sha256-zXhWtPuiu+CRk712KskuHP4vglogJmFoCak6qWczPFM=";
 
-  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks keytar
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks keytar
 
   buildInputs = [ libsecret ];
 

--- a/pkgs/by-name/we/weasis/package.nix
+++ b/pkgs/by-name/we/weasis/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     copyDesktopItems
     makeBinaryWrapper
   ]
-  ++ lib.optional stdenv.isDarwin unzip;
+  ++ lib.optional stdenv.hostPlatform.isDarwin unzip;
 
   desktopItems = [
     (makeDesktopItem {
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
   ''
-  + lib.optionalString stdenv.isLinux ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
     mkdir -p $out/{bin,opt/Weasis,share/{applications,icons/hicolor/64x64/apps}}
 
     mv weasis-${platform}-jdk${lib.versions.major jdk25.version}-${finalAttrs.version}/Weasis/* $out/opt/Weasis
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeDeps}
     done
   ''
-  + lib.optionalString stdenv.isDarwin ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications
     mv weasis-${platform}-jdk${lib.versions.major jdk25.version}-${finalAttrs.version}/Weasis.app $out/Applications/
   ''

--- a/pkgs/by-name/wh/whisper-cpp/package.nix
+++ b/pkgs/by-name/wh/whisper-cpp/package.nix
@@ -100,7 +100,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     for target in examples/{bench,command,cli,quantize,server,stream,talk-llama}/CMakeLists.txt; do
       if ! grep -q -F 'install('; then
         echo 'install(TARGETS ''${TARGET} RUNTIME)' >> $target
-        ${lib.optionalString stdenv.isDarwin "echo 'install(TARGETS whisper.coreml LIBRARY)' >> src/CMakeLists.txt"}
+        ${lib.optionalString stdenv.hostPlatform.isDarwin "echo 'install(TARGETS whisper.coreml LIBRARY)' >> src/CMakeLists.txt"}
       fi
     done
   '';

--- a/pkgs/by-name/xa/xash3d-fwgs/package.nix
+++ b/pkgs/by-name/xa/xash3d-fwgs/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
       bzip2
       SDL2
     ]
-    ++ lib.optionals (!buildServer && stdenv.isLinux) [
+    ++ lib.optionals (!buildServer && stdenv.hostPlatform.isLinux) [
       libx11
     ];
 

--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  checkInputs = lib.optionals stdenv.isLinux [ acl ];
+  checkInputs = lib.optionals stdenv.hostPlatform.isLinux [ acl ];
 
   # disable tests depending on special filesystem features
   checkNoDefaultFeatures = true;
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # had concurrency issues on 64 cores, also tests are quite fast compared to build
   dontUseCargoParallelTests = true;
-  checkFlags = lib.optionals stdenv.isDarwin [
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     # ---- test_socket_file::test_with_parallel_file_driver stdout ----
     # STDOUT: 12:20:56 [WARN] Socket copy not supported by this OS: /private/tmp/nix-build-xcp-0.24.1.drv-0/source/targ>
     #

--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     libintl
   ];
 
-  env = lib.optionalAttrs stdenv.isDarwin {
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     NIX_LDFLAGS = "-liconv";
   };
 

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests
   ]
-  ++ lib.optionals (!stdenv.isDarwin) [
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     # required by test_man_completion
     man
     util-linux
@@ -104,7 +104,7 @@ buildPythonPackage rec {
     "test_vc_get_branch"
     "test_dirty_working_directory"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fails on Darwin
     "test_bash_and_is_alias_is_only_functional_alias"
     "test_complete_command"

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     # required by test_xonsh_activator
     virtualenv
   ]
-  ++ lib.optionals (!stdenv.isDarwin) [
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     # required by test_man_completion
     man
     util-linux
@@ -110,7 +110,7 @@ buildPythonPackage rec {
     "test_vc_get_branch"
     "test_dirty_working_directory"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fails on Darwin
     "test_bash_and_is_alias_is_only_functional_alias"
     "test_complete_command"

--- a/pkgs/development/compilers/dotnet/source/vmr.nix
+++ b/pkgs/development/compilers/dotnet/source/vmr.nix
@@ -508,10 +508,11 @@ stdenv.mkDerivation {
       runHook postInstall
     '';
 
-  ${if stdenv.isDarwin && lib.versionAtLeast version "10" then "postInstall" else null} = ''
-    mkdir -p "$out"/nix-support
-    echo ${sigtool} > "$out"/nix-support/manual-sdk-deps
-  '';
+  ${if stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "10" then "postInstall" else null} =
+    ''
+      mkdir -p "$out"/nix-support
+      echo ${sigtool} > "$out"/nix-support/manual-sdk-deps
+    '';
 
   # stripping dlls results in:
   # Failed to load System.Private.CoreLib.dll (error code 0x8007000B)

--- a/pkgs/development/interpreters/love/11.nix
+++ b/pkgs/development/interpreters/love/11.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postFixup = lib.optionalString stdenv.isDarwin ''
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Fix rpath so love binary can find libliblove.dylib
     install_name_tool -change "@rpath/libliblove.dylib" "$out/lib/libliblove.dylib" "$out/bin/love"
   '';

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -56,7 +56,7 @@ deployAndroidPackage {
       libxkbfile
       libxshmfence
     ])
-    ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
+    ++ lib.optional (os == "linux" && stdenv.hostPlatform.isx86_64) pkgsi686Linux.glibc;
   patchInstructions =
     (lib.optionalString (os == "linux") ''
       addAutoPatchelfSearchPath $packageBaseDir/lib

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -55,7 +55,7 @@ deployAndroidPackage {
       libxkbfile
       libxshmfence
     ])
-    ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
+    ++ lib.optional (os == "linux" && stdenv.hostPlatform.isx86_64) pkgsi686Linux.glibc;
   patchInstructions =
     (lib.optionalString (os == "linux") ''
       addAutoPatchelfSearchPath $packageBaseDir/lib

--- a/pkgs/development/mobile/androidenv/tools.nix
+++ b/pkgs/development/mobile/androidenv/tools.nix
@@ -28,7 +28,7 @@ deployAndroidPackage {
       libxrender
       libxext
     ])
-    ++ lib.optionals (os == "linux" && stdenv.isx86_64) (
+    ++ lib.optionals (os == "linux" && stdenv.hostPlatform.isx86_64) (
       with pkgsi686Linux;
       [
         glibc

--- a/pkgs/development/python-modules/agate/default.nix
+++ b/pkgs/development/python-modules/agate/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # Output is slightly different on macOS
     "test_cast_format_locale"
   ];

--- a/pkgs/development/python-modules/ai-edge-litert/default.nix
+++ b/pkgs/development/python-modules/ai-edge-litert/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage {
   passthru.updateScript = ./update.py;
 
   meta = {
-    broken = stdenv.isDarwin; # elftools.common.exceptions.ELFError: Magic number does not match
+    broken = stdenv.hostPlatform.isDarwin; # elftools.common.exceptions.ELFError: Magic number does not match
     changelog = "https://github.com/google-ai-edge/LiteRT/releases/tag/v${release.version}";
     description = "LiteRT is for mobile and embedded devices";
     downloadPage = "https://github.com/google-ai-edge/LiteRT";

--- a/pkgs/development/python-modules/anndata/default.nix
+++ b/pkgs/development/python-modules/anndata/default.nix
@@ -126,7 +126,7 @@ buildPythonPackage rec {
     # Tests that are seemingly broken. See https://github.com/scverse/anndata/issues/2017.
     "test_concat_dask_sparse_matches_memory"
   ]
-  ++ lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [
+  ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin) [
     # RuntimeError: Cluster failed to start: [Errno 1] Operation not permitted
     "test_dask_distributed_write"
     "test_read_lazy_h5_cluster"

--- a/pkgs/development/python-modules/ar/default.nix
+++ b/pkgs/development/python-modules/ar/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "ar" ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     "test_list"
     "test_read_content"
     "test_read_binary"

--- a/pkgs/development/python-modules/beziers/default.nix
+++ b/pkgs/development/python-modules/beziers/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     pythonImportsCheckHook
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # Fails on macOS with Trace/BPT trap: 5 - something to do with recursion depth
     "test_cubic_cubic"
   ];

--- a/pkgs/development/python-modules/mpv/default.nix
+++ b/pkgs/development/python-modules/mpv/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pyvirtualdisplay
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     xvfb
   ];
 

--- a/pkgs/development/python-modules/primp/default.nix
+++ b/pkgs/development/python-modules/primp/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage (finalAttrs: {
 
   # Tests crash with Abort trap: 6 on Darwin due to tokio runtime
   # initialization in PyInit_pyo3_async_runtimes being blocked by the sandbox.
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   pythonImportsCheck = [ "primp" ];
 

--- a/pkgs/development/python-modules/primp/default.nix
+++ b/pkgs/development/python-modules/primp/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage (finalAttrs: {
 
   # Tests crash with Abort trap: 6 on Darwin due to tokio runtime
   # initialization in PyInit_pyo3_async_runtimes being blocked by the sandbox.
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   pythonImportsCheck = [ "primp" ];
 

--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     let
       ext = stdenv.hostPlatform.extensions.sharedLibrary;
     in
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       cat > pyglet/lib.py <<EOF
       import ctypes
       def load_library(*names, **kwargs):
@@ -95,7 +95,7 @@ buildPythonPackage rec {
           raise Exception("Could not load library {}".format(names))
       EOF
     ''
-    + lib.optionalString stdenv.isDarwin ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
       cat > pyglet/lib.py <<EOF
       import os
       import ctypes
@@ -133,7 +133,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   preCheck = # libEGL only available on Linux (despite meta.platforms on libGL)
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       export PYGLET_HEADLESS=True
     '';
 

--- a/pkgs/development/python-modules/pystray/default.nix
+++ b/pkgs/development/python-modules/pystray/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     xlib
     libayatana-appindicator
   ]
-  ++ lib.optionals stdenv.isDarwin [ pyobjc-framework-Quartz ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ pyobjc-framework-Quartz ];
 
   nativeCheckInputs = [ pytest ] ++ lib.optionals stdenv.hostPlatform.isLinux [ xvfb-run ];
 

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -77,7 +77,7 @@ buildPythonPackage rec {
   meta = {
     description = "High performance simulators for Qiskit";
     # broken on darwin for unknown reasons
-    broken = stdenv.isDarwin;
+    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://qiskit.github.io/qiskit-aer/";
     downloadPage = "https://github.com/QISKit/qiskit-aer/releases";
     changelog = "https://qiskit.github.io/qiskit-aer/release_notes.html";

--- a/pkgs/development/python-modules/resvg-py/default.nix
+++ b/pkgs/development/python-modules/resvg-py/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
     pytest
     pyperclip
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     xclip
     xvfb-run
   ];

--- a/pkgs/development/python-modules/screeninfo/default.nix
+++ b/pkgs/development/python-modules/screeninfo/default.nix
@@ -26,12 +26,12 @@ buildPythonPackage rec {
 
   build-system = [ poetry-core ];
 
-  dependencies = lib.optionals (stdenv.isDarwin) [
+  dependencies = lib.optionals (stdenv.hostPlatform.isDarwin) [
     pyobjc-framework-Cocoa
     cython
   ];
 
-  postPatch = lib.optionalString (stdenv.isLinux) ''
+  postPatch = lib.optionalString (stdenv.hostPlatform.isLinux) ''
     substituteInPlace screeninfo/enumerators/xinerama.py \
       --replace 'load_library("X11")' 'ctypes.cdll.LoadLibrary("${libx11}/lib/libX11.so")' \
       --replace 'load_library("Xinerama")' 'ctypes.cdll.LoadLibrary("${libxinerama}/lib/libXinerama.so")'

--- a/pkgs/development/python-modules/tiledb/default.nix
+++ b/pkgs/development/python-modules/tiledb/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
   # otherwise it cannot be imported because extension modules are not compiled in sources
   checkPhase = ''
     pushd "$TMPDIR"
-    ${python.interpreter} -m pytest --pyargs tiledb${lib.optionalString stdenv.isDarwin " -k 'not test_ctx_thread_cleanup and not test_array'"}
+    ${python.interpreter} -m pytest --pyargs tiledb${lib.optionalString stdenv.hostPlatform.isDarwin " -k 'not test_ctx_thread_cleanup and not test_array'"}
     popd
   '';
 

--- a/pkgs/development/tools/build-managers/gnumake/default.nix
+++ b/pkgs/development/tools/build-managers/gnumake/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     # gettext gets pulled in via autoreconfHook because strictDeps is not set,
     # and is linked against. Without this, it doesn't end up in HOST_PATH.
     # TODO: enable strictDeps, and either make this dependency explicit, or remove it
-    ++ lib.optional stdenv.isCygwin gettext;
+    ++ lib.optional stdenv.hostPlatform.isCygwin gettext;
 
   configureFlags =
     lib.optional guileEnabled "--with-guile"

--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -78,7 +78,7 @@ buildNodejs {
         revert = true;
       })
     ]
-    ++ lib.optionals stdenv.is32bit [
+    ++ lib.optionals stdenv.hostPlatform.is32bit [
       # see: https://github.com/nodejs/node/issues/58458
       ./v24-32bit.patch
       # TODO: remove once included in an future upstream release

--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -73,7 +73,7 @@ buildNodejs {
         revert = true;
       })
     ]
-    ++ lib.optionals stdenv.is32bit [
+    ++ lib.optionals stdenv.hostPlatform.is32bit [
       # see: https://github.com/nodejs/node/issues/58458
       ./v24-32bit.patch
       # TODO: remove once included in an future upstream release

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
     zstd
     uthash
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     bpftools
     elfutils
     libbpf
@@ -153,7 +153,7 @@ stdenv.mkDerivation {
   '';
 
   postInstall =
-    lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.hostPlatform.isLinux ''
       # Fix the bash completion location
       installShellCompletion --bash $out/etc/bash_completion.d/sysdig
       rm $out/etc/bash_completion.d/sysdig

--- a/pkgs/os-specific/linux/zfs/2_3.nix
+++ b/pkgs/os-specific/linux/zfs/2_3.nix
@@ -21,7 +21,7 @@ callPackage ./generic.nix args {
   tests = {
     inherit (nixosTests.zfs) series_2_3;
   }
-  // lib.optionalAttrs stdenv.isx86_64 {
+  // lib.optionalAttrs stdenv.hostPlatform.isx86_64 {
     inherit (nixosTests.zfs) installer;
   };
 

--- a/pkgs/os-specific/linux/zfs/2_4.nix
+++ b/pkgs/os-specific/linux/zfs/2_4.nix
@@ -21,7 +21,7 @@ callPackage ./generic.nix args {
   tests = {
     inherit (nixosTests.zfs) series_2_4;
   }
-  // lib.optionalAttrs stdenv.isx86_64 {
+  // lib.optionalAttrs stdenv.hostPlatform.isx86_64 {
     inherit (nixosTests.zfs) installer;
   };
 

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -69,7 +69,7 @@ let
 
       patches =
         lib.optionals
-          (stdenv.isDarwin && lib.versionAtLeast version "7.7" && lib.versionOlder version "8.0")
+          (stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "7.7" && lib.versionOlder version "8.0")
           [
             # Fix VMOD section attribute on macOS
             # Unreleased commit on master
@@ -81,7 +81,7 @@ let
             # PR: https://github.com/varnishcache/varnish-cache/pull/4339
             ./patches/0001-fix-endian-h-compatibility-on-macos.patch
           ]
-        ++ lib.optionals (stdenv.isDarwin && lib.versionOlder version "7.6") [
+        ++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.versionOlder version "7.6") [
           # Fix duplicate OS_CODE definitions on macOS
           # PR: https://github.com/varnishcache/varnish-cache/pull/4347
           ./patches/0002-fix-duplicate-os-code-definitions-on-macos.patch
@@ -147,7 +147,7 @@ let
           lib.maintainers.osnyx
         ];
         platforms = lib.platforms.unix;
-        broken = stdenv.isDarwin && version == "8.0.1"; # https://github.com/NixOS/nixpkgs/issues/495368
+        broken = stdenv.hostPlatform.isDarwin && version == "8.0.1"; # https://github.com/NixOS/nixpkgs/issues/495368
       };
     };
 in

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -69,7 +69,7 @@ let
 
       patches =
         lib.optionals
-          (stdenv.isDarwin && lib.versionAtLeast version "7.7" && lib.versionOlder version "8.0")
+          (stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "7.7" && lib.versionOlder version "8.0")
           [
             # Fix VMOD section attribute on macOS
             # Unreleased commit on master
@@ -81,7 +81,7 @@ let
             # PR: https://github.com/varnishcache/varnish-cache/pull/4339
             ./patches/0001-fix-endian-h-compatibility-on-macos.patch
           ]
-        ++ lib.optionals (stdenv.isDarwin && lib.versionOlder version "7.6") [
+        ++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.versionOlder version "7.6") [
           # Fix duplicate OS_CODE definitions on macOS
           # PR: https://github.com/varnishcache/varnish-cache/pull/4347
           ./patches/0002-fix-duplicate-os-code-definitions-on-macos.patch
@@ -150,7 +150,7 @@ let
         knownVulnerabilities = lib.optionals (lib.versions.major version == "7") [
           "VSV00018: https://vinyl-cache.org/security/VSV00018.html"
         ];
-        broken = stdenv.isDarwin && version == "8.0.1"; # https://github.com/NixOS/nixpkgs/issues/495368
+        broken = stdenv.hostPlatform.isDarwin && version == "8.0.1"; # https://github.com/NixOS/nixpkgs/issues/495368
       };
     };
 in

--- a/pkgs/tools/misc/fltrdr/default.nix
+++ b/pkgs/tools/misc/fltrdr/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     sed -i '/stdc++fs/d' CMakeLists.txt
   '';
 

--- a/pkgs/tools/misc/tdarr/common.nix
+++ b/pkgs/tools/misc/tdarr/common.nix
@@ -113,9 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     copyDesktopItems
   ]
-  ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     stdenv.cc.cc.lib
     gtk3
     libayatana-appindicator
@@ -182,7 +182,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + "";
 
-  desktopItems = lib.optionals stdenv.isLinux [
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
     (makeDesktopItem {
       desktopName = "Tdarr ${componentUpper} Tray";
       name = "Tdarr ${componentUpper} Tray";

--- a/pkgs/tools/misc/tdarr/common.nix
+++ b/pkgs/tools/misc/tdarr/common.nix
@@ -112,9 +112,9 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     copyDesktopItems
   ]
-  ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  buildInputs = lib.optionals stdenv.isLinux [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     stdenv.cc.cc.lib
     gtk3
     libayatana-appindicator
@@ -174,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + "";
 
-  desktopItems = lib.optionals stdenv.isLinux [
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
     (makeDesktopItem {
       desktopName = "Tdarr ${componentUpper} Tray";
       name = "Tdarr ${componentUpper} Tray";

--- a/pkgs/tools/package-management/nix/modular/packaging/everything.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/everything.nix
@@ -180,7 +180,7 @@ stdenv.mkDerivation (finalAttrs: {
       ln -sT ${nix-manual} $doc
       ln -sT ${nix-manual.man} $man
     ''
-    + lib.optionalString (stdenv.isLinux && lib.versionAtLeast version "2.34pre") ''
+    + lib.optionalString (stdenv.hostPlatform.isLinux && lib.versionAtLeast version "2.34pre") ''
       lndir ${nix-nswrapper} $out
     '';
 

--- a/pkgs/tools/package-management/nix/modular/packaging/everything.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/everything.nix
@@ -189,7 +189,7 @@ stdenv.mkDerivation (finalAttrs: {
       ln -sT ${nix-manual} $doc
       ln -sT ${nix-manual.man} $man
     ''
-    + lib.optionalString (stdenv.isLinux && lib.versionAtLeast version "2.34pre") ''
+    + lib.optionalString (stdenv.hostPlatform.isLinux && lib.versionAtLeast version "2.34pre") ''
       lndir ${nix-nswrapper} $out
     '';
 

--- a/pkgs/tools/package-management/nix/modular/src/perl/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/perl/package.nix
@@ -32,7 +32,7 @@ perl.pkgs.toPerlModule (
     ];
 
     # `perlPackages.Test2Harness` is marked broken for Darwin
-    doCheck = !stdenv.isDarwin;
+    doCheck = !stdenv.hostPlatform.isDarwin;
 
     nativeCheckInputs = [
       perlPackages.Test2Harness


### PR DESCRIPTION
Repeats #341407. New occurrences have drifted back in. Mechanical rewrite of `stdenv.is{Linux,Darwin,Aarch64,x86_64,...}` to the explicit `stdenv.hostPlatform.is*` form across `pkgs/` and `nixos/`.

109 files, 180 occurrences. No behavior change; the short forms are aliases. Tracking: #346453.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.