### PR TITLE
treewide: remove empty buildInputs assignments

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -91,7 +91,6 @@ let
     neovim-drv: buildCommand:
     runCommandLocal "test-${neovim-drv.name}"
       {
-        nativeBuildInputs = [ ];
         meta.platforms = neovim-drv.meta.platforms;
       }
       (

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -75,7 +75,6 @@
 
   cargoSetupHook = makeSetupHook {
     name = "cargo-setup-hook.sh";
-    propagatedBuildInputs = [ ];
     substitutions = {
       defaultConfig = ../fetchcargo-default-config.toml;
 

--- a/pkgs/by-name/im/immer/package.nix
+++ b/pkgs/by-name/im/immer/package.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   # immer is a header only library
   dontBuild = true;
-  buildInputs = [ ];
   dontUseCmakeBuildDir = true;
 
   doCheck = false;

--- a/pkgs/development/interpreters/lua-5/hooks/default.nix
+++ b/pkgs/development/interpreters/lua-5/hooks/default.nix
@@ -34,6 +34,5 @@ in
   # we move the files around ourselves
   luarocksMoveDataFolder = makeSetupHook {
     name = "luarocks-move-rock";
-    propagatedBuildInputs = [ ];
   } ./luarocks-move-data.sh;
 }

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -40,7 +40,6 @@ in
     { makePythonHook }:
     makePythonHook {
       name = "conda-unpack-hook";
-      propagatedBuildInputs = [ ];
     } ./conda-unpack-hook.sh
   ) { };
 
@@ -48,7 +47,6 @@ in
     { makePythonHook }:
     makePythonHook {
       name = "egg-build-hook.sh";
-      propagatedBuildInputs = [ ];
     } ./egg-build-hook.sh
   ) { };
 
@@ -67,7 +65,6 @@ in
     { makePythonHook }:
     makePythonHook {
       name = "egg-unpack-hook.sh";
-      propagatedBuildInputs = [ ];
     } ./egg-unpack-hook.sh
   ) { };
 

--- a/pkgs/development/libraries/qt-5/modules/qtspeech.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtspeech.nix
@@ -8,7 +8,6 @@
 
 qtModule {
   pname = "qtspeech";
-  propagatedBuildInputs = [ ];
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ speechd-minimal ];
   nativeBuildInputs = [ pkg-config ];
   outputs = [

--- a/pkgs/development/ocaml-modules/camlgpc/default.nix
+++ b/pkgs/development/ocaml-modules/camlgpc/default.nix
@@ -24,9 +24,7 @@ buildDunePackage {
       hash = "sha256-znm+mX60RwYNCYXwm9HYCO8BRbzUM0Bm6dI1f1FzncA=";
     })
   ];
-  propagatedBuildInputs = [ ];
   doCheck = true;
-  checkInputs = [ ];
   meta = {
     description = "OCaml interface to Alan Murta's General Polygon Clipper";
     homepage = "https://github.com/johnwhitington/camlgpc";

--- a/pkgs/development/ocaml-modules/curl/default.nix
+++ b/pkgs/development/ocaml-modules/curl/default.nix
@@ -22,7 +22,6 @@ buildDunePackage (finalAttrs: {
     curl
   ];
 
-  checkInputs = [ ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/curl/lwt.nix
+++ b/pkgs/development/ocaml-modules/curl/lwt.nix
@@ -14,7 +14,6 @@ buildDunePackage (finalAttrs: {
     lwt
   ];
 
-  checkInputs = [ ];
   doCheck = true;
 
   meta = curl.meta // {

--- a/pkgs/development/ocaml-modules/dates_calc/default.nix
+++ b/pkgs/development/ocaml-modules/dates_calc/default.nix
@@ -20,8 +20,6 @@ buildDunePackage (finalAttrs: {
     sha256 = "sha256-B4li8vIK6AnPXJ1QSJ8rtr+JOcy4+h5sc1SH97U+Vgw=";
   };
 
-  propagatedBuildInputs = [ ];
-
   doCheck = true;
   checkInputs = [
     alcotest

--- a/pkgs/development/python-modules/simplenote/default.nix
+++ b/pkgs/development/python-modules/simplenote/default.nix
@@ -16,8 +16,6 @@ buildPythonPackage rec {
     sha256 = "1grvvgzdybhxjydalnsgh2aaz3f48idv5lqs48gr0cn7n18xwhd5";
   };
 
-  propagatedBuildInputs = [ ];
-
   meta = {
     description = "Python library for the simplenote.com web service";
     homepage = "http://readthedocs.org/docs/simplenotepy/en/latest/api.html";

--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation {
   setupHook = [ ./setup-hook.sh ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ];
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 


### PR DESCRIPTION
Repeats #69479. `*Inputs = [ ];` lines keep piling back up. Removes the noise across `buildInputs` / `nativeBuildInputs` / `propagatedBuildInputs` / check-inputs variants.

12 files, 17 lines. A handful of empty-list assignments were intentionally kept where the `[]` overrides an inherited default (wrapper clobbers, `overrideAttrs` resets, `mkKdeDerivation` autodiscovery opt-out). Tracking: #346453.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.