### PR TITLE
steam: copy ldconfig instead of symlinking

### DIFF
--- a/pkgs/by-name/st/steam/package.nix
+++ b/pkgs/by-name/st/steam/package.nix
@@ -56,12 +56,6 @@ let
             xz
             zenity
 
-            # Steam expects it to be /sbin specifically
-            (pkgs.runCommand "sbin-ldconfig" { } ''
-              mkdir -p $out/sbin
-              ln -s /bin/ldconfig $out/sbin/ldconfig
-            '')
-
             # crashes on startup if it can't find libx11 locale files
             (pkgs.runCommand "xorg-locale" { } ''
               mkdir -p $out
@@ -132,6 +126,13 @@ let
         '';
 
         inherit extraPreBwrapCmds;
+
+        # Steam expects /sbin/ldconfig to exist, and since SinceRT3
+        # symlinking it results in a symlink loop in nested containers.
+        # Thus, just copy it.
+        extraBuildCommands = ''
+          cp -f $out/usr/{bin,sbin}/ldconfig
+        '';
 
         extraBwrapArgs = [
           # Steam will dump crash reports here, make those more accessible


### PR DESCRIPTION
Somehow this unconfuses srt-runtime-tools enough for it to actually work consistently. Fixes #505824.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
