### PR TITLE
isbntools: init at 4.3.29

### DIFF
--- a/pkgs/by-name/is/isbntools/package.nix
+++ b/pkgs/by-name/is/isbntools/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "isbntools";
+  version = "4.3.29";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xlcnd";
+    repo = "isbntools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s47y14YHL/ihAUCnneDcTlyVQj3rUgUnBLD2dPBGD/Y=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    isbnlib
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  disabledTests = [
+    # Require a network connection
+    "test_doi2tex"
+    "test_renfile"
+    "test_rencwdfiles"
+    "test_shelvecache_meta"
+    "test_shelvecache_editions"
+    "test_shelvecache_setget"
+    "test_shelvecache_contains"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Tools to validate, clean, transform, hyphenate and get metadata for ISBNs";
+    homepage = "https://github.com/xlcnd/isbntools";
+    changelog = "https://github.com/xlcnd/isbntools/releases/tag/v${finalAttrs.version}";
+    platforms = with lib.platforms; linux ++ darwin ++ windows;
+    license = with lib.licenses; [ lgpl3Plus ];
+    maintainers = with lib.maintainers; [ jwillikers ];
+  };
+})


### PR DESCRIPTION
Add [isbntools](https://github.com/xlcnd/isbntools) package which includes CLI tools to validate, clean, transform, hyphenate and get metadata for ISBNs. It's effectively several CLI utilities which wrap the `isbnlib` Python package already packaged in nixpkgs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
