### PR TITLE
sinit: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/si/sinit/package.nix
+++ b/pkgs/by-name/si/sinit/package.nix
@@ -2,8 +2,8 @@
   lib,
   stdenv,
   fetchgit,
-  rcinit ? null,
-  rcshutdown ? null,
+  rcinit ? "/etc/rc.d/rc.init",
+  rcshutdown ? "/etc/rc.d/rc.shutdown",
   rcreboot ? null,
 }:
 

--- a/pkgs/by-name/si/sinit/package.nix
+++ b/pkgs/by-name/si/sinit/package.nix
@@ -7,14 +7,14 @@
   rcreboot ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sinit";
   version = "1.1";
 
   src = fetchgit {
     url = "https://git.suckless.org/sinit/";
-    sha256 = "sha256-VtXkgixgElKKOT26uKN9feXDVjjtSgTWvcgk5o5MLmw=";
-    tag = "v${version}";
+    hash = "sha256-VtXkgixgElKKOT26uKN9feXDVjjtSgTWvcgk5o5MLmw=";
+    tag = "v${finalAttrs.version}";
   };
   buildInputs = [
     (lib.getOutput "static" stdenv.cc.libc)
@@ -41,4 +41,4 @@ stdenv.mkDerivation rec {
     homepage = "https://tools.suckless.org/sinit";
     downloadPage = "https://git.suckless.org/sinit";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8716,11 +8716,6 @@ with pkgs;
     protobuf = protobuf_33;
   };
 
-  sinit = callPackage ../os-specific/linux/sinit {
-    rcinit = "/etc/rc.d/rc.init";
-    rcshutdown = "/etc/rc.d/rc.shutdown";
-  };
-
   sysdig = callPackage ../os-specific/linux/sysdig {
     kernel = null;
   }; # sysdig is a client, for a driver look at linuxPackagesFor


### PR DESCRIPTION
This pull request reorganizes and refactors the packaging of the `sinit` init system. The main changes involve moving the package to a new location, updating its default script paths, and modernizing the Nix expression.

Key changes:

**Package relocation and refactoring:**
* Moved the `sinit` package from `pkgs/os-specific/linux/sinit/default.nix` to `pkgs/by-name/si/sinit/package.nix` and updated the code style to use the modern `mkDerivation` function signature.

**Default script path updates:**
* Changed the default values for the `rcinit` and `rcshutdown` script paths to `/etc/rc.d/rc.init` and `/etc/rc.d/rc.shutdown` respectively, instead of requiring them to be passed as arguments.

**Top-level package cleanup:**
* Removed the explicit `sinit` package definition from `all-packages.nix`, as it is now handled in the new location and with updated defaults.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
