### PR TITLE
storrent: 0-unstable-2023-01-14 -> 0-unstable-2026-01-08

### DIFF
--- a/pkgs/by-name/st/storrent/package.nix
+++ b/pkgs/by-name/st/storrent/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule {
   pname = "storrent";
-  version = "0-unstable-2023-01-14";
+  version = "0-unstable-2026-01-08";
 
   src = fetchFromGitHub {
     owner = "jech";
     repo = "storrent";
-    rev = "86270ee777a19a521f8898a179485e0347f90ce0";
-    hash = "sha256-JYNtuyk4hhe1jZgY/5Bz91Ropdw/U7n1VKHYkdUjZ0I=";
+    rev = "7d7d956c3b7bc1c51a2a4ed5b6925d717fc280ff";
+    hash = "sha256-yAWKz85EqIJis+K4qP+5aOnx2YrhRx0+LPAAEawUUsU=";
   };
 
-  vendorHash = "sha256-iPKZPXsa6ya29N/u9QYd5LAm42+FtHZLGStRDxsAxe4=";
+  vendorHash = "sha256-/m+U4UsofU0vOFMh+omRzn/DWqr3ghgIl+a4v1foGjY=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes the build that is broken due to [GCC 15 changes](https://github.com/NixOS/nixpkgs/issues/475479). Technically only [this commit](https://github.com/jech/storrent/commit/051d88bdf63e33519e5634e532aa6c51a0aa7ca7) is needed to fix the build, but it makes more sense to update the package as a whole I think.
https://hydra.nixos.org/build/317946469

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
