### PR TITLE
veila: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19079,6 +19079,12 @@
     name = "Naufal Fikri";
     keys = [ { fingerprint = "1575 D651 E31EC 6117A CF0AA C1A3B 8BBC A515 8835"; } ];
   };
+  naurissteins = {
+    name = "Nauris Steins";
+    email = "me@naurissteins.com";
+    github = "naurissteins";
+    githubId = 5653746;
+  };
   naxdy = {
     name = "Naxdy";
     email = "naxdy@naxdy.org";

--- a/pkgs/by-name/ve/veila/package.nix
+++ b/pkgs/by-name/ve/veila/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  pkg-config,
+  pam,
+  wayland,
+  libxkbcommon,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "veila";
+  version = "0.1.5";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "naurissteins";
+    repo = "Veila";
+    tag = finalAttrs.version;
+    hash = "sha256-zpOhERNpnEqzdKm32hAWwxthWteV81XBHxNOdGpsh+A=";
+  };
+
+  cargoHash = "sha256-1h9DkF6PtkaBuyspPgt2jGHZl+y3/J63sJmzq2Pk94c=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    pam
+    wayland
+    libxkbcommon
+  ];
+
+  cargoBuildFlags = [ "--workspace" ];
+
+  postInstall = ''
+    pushd assets
+    for assetDir in bg fonts icons systemd themes; do
+      find "$assetDir" -type d -exec install -d "$out/share/veila/{}" ';'
+      find "$assetDir" -type f -exec install -Dm644 "{}" "$out/share/veila/{}" ';'
+    done
+    popd
+
+    wrapProgram "$out/bin/veila" \
+      --set VEILA_ASSET_DIR "$out/share/veila"
+
+    wrapProgram "$out/bin/veila-curtain" \
+      --set VEILA_ASSET_DIR "$out/share/veila"
+
+    wrapProgram "$out/bin/veilad" \
+      --set VEILA_ASSET_DIR "$out/share/veila" \
+      --set VEILA_CURTAIN_BIN "$out/bin/veila-curtain"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Screen locker for Wayland compositors";
+    homepage = "https://naurissteins.com/veila";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ naurissteins ];
+    platforms = lib.platforms.linux;
+    mainProgram = "veila";
+  };
+})

--- a/pkgs/by-name/ve/veila/package.nix
+++ b/pkgs/by-name/ve/veila/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  pkg-config,
+  pam,
+  wayland,
+  libxkbcommon,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "veila";
+  version = "0.4.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "naurissteins";
+    repo = "Veila";
+    tag = finalAttrs.version;
+    hash = "sha256-SrYG5rvywiPEfIjTbZfXOlXqnmdn0fZcOR16fxHJ0Ns=";
+  };
+
+  cargoHash = "sha256-jcZ33dJwvK94YqMFpXb9QXURjtOGrY4QdZh0I9LTwUU=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    pam
+    wayland
+    libxkbcommon
+  ];
+
+  cargoBuildFlags = [ "--workspace" ];
+
+  postInstall = ''
+    pushd assets
+    for assetDir in fonts icons systemd themes; do
+      find "$assetDir" -type d -exec install -d "$out/share/veila/{}" ';'
+      find "$assetDir" -type f -exec install -Dm644 "{}" "$out/share/veila/{}" ';'
+    done
+    popd
+
+    wrapProgram "$out/bin/veila" \
+      --set VEILA_ASSET_DIR "$out/share/veila"
+
+    wrapProgram "$out/bin/veila-curtain" \
+      --set VEILA_ASSET_DIR "$out/share/veila"
+
+    wrapProgram "$out/bin/veilad" \
+      --set VEILA_ASSET_DIR "$out/share/veila" \
+      --set VEILA_CURTAIN_BIN "$out/bin/veila-curtain"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Screen locker for Wayland compositors";
+    homepage = "https://naurissteins.com/veila";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ naurissteins ];
+    platforms = lib.platforms.linux;
+    mainProgram = "veila";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Veila](https://github.com/naurissteins/Veila) a screen locker for Wayland compositors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test