### PR TITLE
xonsh: 0.22.8 -> 0.23.0

### DIFF
--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -16,9 +16,12 @@
   pip,
   pyte,
   pytest-mock,
+  pytest-rerunfailures,
   pytest-subprocess,
+  pytest-timeout,
   pytestCheckHook,
   requests,
+  virtualenv,
 
   man,
   util-linux,
@@ -32,7 +35,7 @@
 
 buildPythonPackage rec {
   pname = "xonsh";
-  version = "0.22.8";
+  version = "0.23.0";
   pyproject = true;
 
   # PyPI package ships incomplete tests
@@ -40,7 +43,7 @@ buildPythonPackage rec {
     owner = "xonsh";
     repo = "xonsh";
     tag = version;
-    hash = "sha256-NOQs21Ahp2oMx1Lw1ekvb2aqUWwIXw1WyC9ZE5V9wJI=";
+    hash = "sha256-hZMA1GMyzo2297iTrgOdRuqjqR55KughPsaL0EZWLWM=";
   };
 
   build-system = [
@@ -61,9 +64,14 @@ buildPythonPackage rec {
     pip
     pyte
     pytest-mock
+    pytest-rerunfailures
     pytest-subprocess
+    pytest-timeout
     pytestCheckHook
     requests
+
+    # required by test_xonsh_activator
+    virtualenv
   ]
   ++ lib.optionals (!stdenv.isDarwin) [
     # required by test_man_completion
@@ -74,16 +82,16 @@ buildPythonPackage rec {
   disabledTests = [
     # fails on sandbox
     "test_colorize_file"
-    "test_xonsh_activator"
+    "test_repath_HOME_PATH_itself"
+    "test_repath_HOME_PATH_var"
+    "test_repath_HOME_PATH_var_brace"
 
     # flaky tests in test_integrations.py
     "test_script"
     "test_catching_system_exit"
     "test_catching_exit_signal"
-    "test_alias_stability"
     "test_captured_subproc_is_not_affected_next_command"
     "test_spec_decorator_alias"
-    "test_alias_stability_exception"
 
     # flaky tests in test_python.py
     "test_complete_import"
@@ -112,18 +120,22 @@ buildPythonPackage rec {
     "test_on_command_not_found_replacement"
     "test_skipper_command"
     "test_xonsh_lexer_no_win"
+    "test_on_command_not_found_dict_without_env"
+  ];
+
+  disabledTestPaths = [
+    # don't run stress tests when building package
+    "tests/xintegration/test_stress.py"
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/248978
   dontWrapPythonPrograms = true;
 
-  env.LC_ALL = "en_US.UTF-8";
-
   postPatch = ''
     sed -i -e 's|/bin/ls|${lib.getExe' coreutils "ls"}|' tests/test_execer.py
-    sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/test_integrations.py
+    sed -i -e 's|SHELL=xonsh|SHELL=$out/bin/xonsh|' tests/xintegration/test_integrations.py
 
-    for script in tests/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
+    for script in tests/xintegration/test_integrations.py scripts/xon.sh $(find -name "*.xsh"); do
       sed -i -e 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
     done
     patchShebangs .
@@ -139,7 +151,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://xon.sh/";
-    description = "Python-ish, BASHwards-compatible shell";
+    description = "Python-powered shell";
     changelog = "https://github.com/xonsh/xonsh/blob/${version}/CHANGELOG.md";
     license = with lib.licenses; [ bsd3 ];
     mainProgram = "xonsh";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/xonsh/xonsh/releases/tag/0.23.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
