### PR TITLE
easyeffects: override speexdsp to disable fftw in build

### DIFF
--- a/pkgs/by-name/ea/easyeffects/package.nix
+++ b/pkgs/by-name/ea/easyeffects/package.nix
@@ -55,6 +55,7 @@ let
     kirigami-addons
     qqc2-desktop-style
     ;
+  speexdsp' = speexdsp.override { withFftw3 = false; };
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -109,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
     rnnoise
     rubberband
     soundtouch
-    speexdsp
+    speexdsp'
     onetbb
     webrtc-audio-processing
     zita-convolver


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
So when the Speexdsp package was created, it included building with fftw3 for whatever reason (Most repositories don't do this) and as a result of this, the Speexdsp plugin can cause Easyeffects to crash. To fix this, an optional flag was created and the EE definition was overriden to disable this flag (https://github.com/NixOS/nixpkgs/pull/257996).

Later when the package was moved to the by-name structure, this override was refactored into the package (https://github.com/NixOS/nixpkgs/pull/322534). 

However much later on, this override was removed due to the PR author supposedly being unable to reproduce it (https://github.com/NixOS/nixpkgs/pull/460185).

Recently, I started experiencing crashing and couldn't find a definitive cause. I opened a PR upstream (https://github.com/wwmm/easyeffects/issues/4978) and after a lot of discussion and testing, I've come to the conclusion that this flag/override being removed is the cause. I've tested it with the override returned and I've yet to experience any issues.

I'm still not sure why there was such a long time between the override being removed and the crashes coming back but it's possible that some changes upstream prevented these crashes and a newer update unintentionally allowed them to happen again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
