### PR TITLE
structorizer: 3.32-34 -> 3.32-35

### DIFF
--- a/pkgs/by-name/st/structorizer/package.nix
+++ b/pkgs/by-name/st/structorizer/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "structorizer";
-  version = "3.32-34";
+  version = "3.32-35";
 
   src = fetchFromGitHub {
     owner = "fesch";
     repo = "Structorizer.Desktop";
     rev = version;
-    hash = "sha256-oTh45xoJYrJL0BbV5hdPfvv7wz49gExpvN3G5AOk3R0=";
+    hash = "sha256-ur00Vq+bl+R5MBpmGQO8nX9rEVNMgih1OzWlpY0RDIk=";
   };
 
   patches = [
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ jdk11 ];
 
   postPatch = ''
+    substituteInPlace structorizer.sh --replace "\$DIR/Structorizer.app/Contents/Java/Structorizer.jar" "$out/share/java/structorizer.jar"
+
     chmod +x makeStructorizer
     chmod +x makeBigJar
 
@@ -58,9 +60,10 @@ stdenv.mkDerivation rec {
 
     install -d $out/bin $out/share/mime/packages $out/share/applications
 
-    install -D ${pname}.jar -t $out/share/java/
-      makeWrapper ${jdk11}/bin/java $out/bin/${pname} \
-      --add-flags "-jar $out/share/java/${pname}.jar" \
+    install -D structorizer.jar -t $out/share/java/
+    cp structorizer.sh $out/bin/structorizer
+    wrapProgram $out/bin/structorizer \
+      --prefix PATH : ${lib.makeBinPath [ jdk11 ]} \
       --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp" \
       ''${gappsWrapperArgs[@]}
 
@@ -69,7 +72,7 @@ stdenv.mkDerivation rec {
 
     cd src/lu/fisch/${pname}/gui
     install -vD icons/000_${pname}.png $out/share/icons/hicolor/16x16/apps/${pname}.png
-    for icon_width in 24 32 48 64 128 256; do
+    for icon_width in 20 24 32 48 64 128 256; do
       install -vD icons_"$icon_width"/000_${pname}.png $out/share/icons/hicolor/"$icon_width"x"$icon_width"/apps/${pname}.png
     done
 


### PR DESCRIPTION
updated to 3.32-35 including adding the new 20px icon and the --non-reparenting option

this PR makes structorizer start via a patched version of their structorizer.sh where they parse the --non-reparenting option (and perhaps more in the future). maybe this makes it slightly more maintainable.

They also added a new 20px icon that this also adds to the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
