### PR TITLE
eta: 1.0.1 -> 1.0.1-unstable-2026-01-04

### DIFF
--- a/pkgs/by-name/et/eta/package.nix
+++ b/pkgs/by-name/et/eta/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eta";
-  version = "1.0.1";
+  version = "1.0.1-unstable-2026-01-04";
 
   src = fetchFromGitHub {
     owner = "aioobe";
     repo = "eta";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-UQ8ZoxFAy5dKtXTLwPolPMd7YJeEjsK639RkGCMY6rU=";
+    rev = "7027a4012e7c697be1c9af1a9f21bfae1bd4913b";
+    hash = "sha256-18TOXDohyRGA0pmRyWgR9EPhKgZt+ZtkuTCFWbSnFlY=";
   };
 
   outputs = [


### PR DESCRIPTION
Fixes build for [GCC 15](https://github.com/NixOS/nixpkgs/issues/475479).
Diff: https://github.com/aioobe/eta/compare/v1.0.1...7027a4012e7c697be1c9af1a9f21bfae1bd4913b

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
