### PR TITLE
lvm2: 2.03.38 -> 2.03.39

### DIFF
--- a/pkgs/os-specific/linux/lvm2/2_03.nix
+++ b/pkgs/os-specific/linux/lvm2/2_03.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "2.03.38";
-  hash = "sha256-Mi1Ev0DeMY5ua1LFaZmq64axbIJnGHrC4BpE1NxSaWA=";
+  version = "2.03.39";
+  hash = "sha256-I7yQZ+KP4NN7PMRB8oZbngIs48Ykur4ikYuN2QwDHug=";
 }

--- a/pkgs/os-specific/linux/lvm2/fix-blkdeactivate.patch
+++ b/pkgs/os-specific/linux/lvm2/fix-blkdeactivate.patch
@@ -1,5 +1,3 @@
-diff --git a/scripts/blkdeactivate.sh.in b/scripts/blkdeactivate.sh.in
-index 7c517b87b..e51a33778 100644
 --- a/scripts/blkdeactivate.sh.in
 +++ b/scripts/blkdeactivate.sh.in
 @@ -34,11 +34,11 @@ TOOL=blkdeactivate
@@ -7,7 +5,7 @@ index 7c517b87b..e51a33778 100644
  SYS_BLK_DIR="/sys/block"
  
 -MDADM="/sbin/mdadm"
--MOUNTPOINT="/bin/mountpoint"
+-MOUNTPOINT="/usr/bin/mountpoint"
 -MPATHD="/sbin/multipathd"
 -UMOUNT="/bin/umount"
 -VDO="/bin/vdo"


### PR DESCRIPTION
## Things done
https://github.com/lvmteam/lvm2/releases/tag/v2_03_39

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
