### PR TITLE
libgda5: fix C23 md5c.c build

### DIFF
--- a/pkgs/by-name/li/libgda5/0002-c23-md5c.patch
+++ b/pkgs/by-name/li/libgda5/0002-c23-md5c.patch
@@ -1,0 +1,54 @@
+--- a/libgda/md5c.c
++++ b/libgda/md5c.c
+@@ -99,2 +99,2 @@
+-void MD5Init (context)
+-MD5_CTX *context;                                        /* context */
++void
++MD5Init (MD5_CTX *context)
+@@ -116,4 +116,2 @@
+-void MD5Update (context, input, inputLen)
+-MD5_CTX *context;                                        /* context */
+-unsigned char *input;                                /* input block */
+-unsigned int inputLen;                     /* length of input block */
++void
++MD5Update (MD5_CTX *context, unsigned char *input, unsigned int inputLen)
+@@ -158,3 +156,2 @@
+-void MD5Final (digest, context)
+-unsigned char digest[16];                         /* message digest */
+-MD5_CTX *context;                                       /* context */
++void
++MD5Final (unsigned char digest[16], MD5_CTX *context)
+@@ -187,3 +184,2 @@
+-static void MD5Transform (state, block)
+-UINT4 state[4];
+-unsigned char block[64];
++static void
++MD5Transform (UINT4 state[4], unsigned char block[64])
+@@ -280,4 +276,2 @@
+-static void Encode (output, input, len)
+-unsigned char *output;
+-UINT4 *input;
+-unsigned int len;
++static void
++Encode (unsigned char *output, UINT4 *input, unsigned int len)
+@@ -298,4 +292,2 @@
+-static void Decode (output, input, len)
+-UINT4 *output;
+-unsigned char *input;
+-unsigned int len;
++static void
++Decode (UINT4 *output, unsigned char *input, unsigned int len)
+@@ -312,4 +304,2 @@
+-static void MD5_memcpy (output, input, len)
+-POINTER output;
+-POINTER input;
+-unsigned int len;
++static void
++MD5_memcpy (POINTER output, POINTER input, unsigned int len)
+@@ -325,4 +315,2 @@
+-static void MD5_memset (output, value, len)
+-POINTER output;
+-int value;
+-unsigned int len;
++static void
++MD5_memset (POINTER output, int value, unsigned int len)

--- a/pkgs/by-name/li/libgda5/package.nix
+++ b/pkgs/by-name/li/libgda5/package.nix
@@ -48,6 +48,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix configure detection of features with c99.
     ./0001-gcc14-fix.patch
 
+    # Fix K&R-style MD5 definitions that fail under C23.
+    ./0002-c23-md5c.patch
+
     # Fix build with gettext 0.25
     (fetchpatch {
       url = "https://src.fedoraproject.org/rpms/libgda5/raw/945495e5c6cdd98a5360eff77245421876a97a57/f/gettext.patch";


### PR DESCRIPTION
Tracking: #511329

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
