### PR TITLE
ci/parse.nix: Fail on warning

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -184,9 +184,10 @@ rec {
     nix = pkgs.nixVersions.latest;
   };
   parse = pkgs.lib.recurseIntoAttrs {
-    latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
-    lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
+    nix_latest = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.latest; };
     nix_2_28 = pkgs.callPackage ./parse.nix { nix = pkgs.nixVersions.nix_2_28; };
+    lix = pkgs.callPackage ./parse.nix { nix = pkgs.lix; };
+    lix_latest = pkgs.callPackage ./parse.nix { nix = pkgs.lixPackageSets.latest.lix; };
   };
   shell = import ../shell.nix { inherit nixpkgs system; };
   tarball = import ../pkgs/top-level/make-tarball.nix {

--- a/ci/parse.nix
+++ b/ci/parse.nix
@@ -28,7 +28,14 @@ runCommand "nix-parse-${nix.name}"
     # the other CI jobs will report in more detail. This job is about checking parsing
     # across different implementations / versions, not about providing the best DX.
     # Returning all parse errors requires significantly more resources.
-    find . -type f -iname '*.nix' | xargs -P $(nproc) nix-instantiate --parse >/dev/null
+
+    find . -type f -iname '*.nix' | xargs -P $(nproc) nix-instantiate --parse 2>&1 >/dev/null | {
+      # Also fail on (deprecation) warnings printed to stderr.
+      if grep "warning"; then
+        echo "Failing due to warnings in stderr" >&2
+        exit 1
+      fi
+    }
 
     touch $out
   ''


### PR DESCRIPTION
Lix simply emits all warnings to stderr. All warnings it emits are deprecation warnings which we would like to turn into hard errors in the future, but are still too widespread in use, including in Nixpkgs. If we don't hard-error on these too, then regressions will continue being introduced and we will never be able to turn these into hard errors.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
