### PR TITLE
prometheus: Include TestFsType patch

### DIFF
--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -63,6 +63,8 @@ let
 
     env.CI = true;
 
+    __darwinAllowLocalNetworking = true;
+
     doCheck = true;
     checkPhase = ''
       runHook preCheck

--- a/pkgs/by-name/pr/prometheus/package.nix
+++ b/pkgs/by-name/pr/prometheus/package.nix
@@ -92,6 +92,10 @@ buildGoModule (finalAttrs: {
 
   proxyVendor = true;
 
+  patches = [
+    ./prometheus-pr18519-fix-TestFsType.patch
+  ];
+
   outputs = [
     "out"
     "doc"

--- a/pkgs/by-name/pr/prometheus/prometheus-pr18519-fix-TestFsType.patch
+++ b/pkgs/by-name/pr/prometheus/prometheus-pr18519-fix-TestFsType.patch
@@ -1,0 +1,25 @@
+--- a/util/runtime/statfs_unix_test.go
++++ b/util/runtime/statfs_unix_test.go
+@@ -19,20 +19,18 @@ import (
+ 	"os"
+ 	"testing"
+
+-	"github.com/grafana/regexp"
+ 	"github.com/stretchr/testify/require"
+ )
+
+-var regexpFsType = regexp.MustCompile("^[A-Z][A-Z0-9_]*_MAGIC$")
+-
+ func TestFsType(t *testing.T) {
+ 	var fsType string
+
+ 	path, err := os.Getwd()
+ 	require.NoError(t, err)
+
++	// A real path must yield a non-zero filesystem type.
+ 	fsType = FsType(path)
+-	require.Regexp(t, regexpFsType, fsType)
++	require.NotEqual(t, "0", fsType)
+
+ 	fsType = FsType("/no/where/to/be/found")
+ 	require.Equal(t, "0", fsType)


### PR DESCRIPTION
Include the patch from https://github.com/prometheus/prometheus/pull/18519

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
