### PR TITLE
pvetui: init at 1.3.2

### DIFF
--- a/pkgs/by-name/pv/pvetui/package.nix
+++ b/pkgs/by-name/pv/pvetui/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pvetui";
+  version = "1.3.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "devnullvoid";
+    repo = "pvetui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PgxhfDFP0DBrihtkIWFYEOTbXUvp/WuB47iNPHJGr1Q=";
+  };
+
+  vendorHash = "sha256-gGhEW9owJYjI+59X/yJ+tta9AQh9hoBdOBaO5Rojdy8=";
+
+  subPackages = [ "cmd/pvetui" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/devnullvoid/pvetui/internal/version.version=${finalAttrs.version}"
+    "-X github.com/devnullvoid/pvetui/internal/version.commit=${finalAttrs.src.tag}"
+    "-X github.com/devnullvoid/pvetui/internal/version.buildDate=1970-01-01T00:00:00Z"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal UI for Proxmox Virtual Environment";
+    homepage = "https://pvetui.org/";
+    changelog = "https://github.com/devnullvoid/pvetui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ miniharinn ];
+    mainProgram = "pvetui";
+  };
+})


### PR DESCRIPTION
This PR adds pvetui, a terminal UI for Proxmox Virtual Environment.

Init at version 1.3.2: https://github.com/devnullvoid/pvetui/releases/tag/v1.3.2

Upstream GitHub: https://github.com/devnullvoid/pvetui
Homepage: https://pvetui.org/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
