### PR TITLE
Squawker-vpn: init at 0.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16547,6 +16547,12 @@
     githubId = 93316844;
     name = "Manaiki Laut";
   };
+  mandar1jn = {
+    email = "marijnkneppers@gmail.com";
+    github = "mandar1jn";
+    githubId = 49076509;
+    name = "Marijn Kneppers";
+  };
   mandos = {
     email = "marek.maksimczyk@mandos.net.pl";
     github = "mandos";

--- a/pkgs/by-name/sq/squawker-vpn/package.nix
+++ b/pkgs/by-name/sq/squawker-vpn/package.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   unpackCmd = "dpkg -x $curSrc source";
 
+  __structuredAttrs = true;
+  strictDeps = true;
   nativeBuildInputs = [
     dpkg
   ];

--- a/pkgs/by-name/sq/squawker-vpn/package.nix
+++ b/pkgs/by-name/sq/squawker-vpn/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "squawker-vpn";
+  version = "0.10.1";
+
+  src = fetchurl {
+    url = "https://squawker-vpn.vm.tryhackme.com/latest/squawker-vpn_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-vs8Dcb6JVqD09TP2OqLewLRq742l88pue4CFSoGw+Ec=";
+  };
+
+  unpackCmd = "dpkg -x $curSrc source";
+
+  nativeBuildInputs = [
+    dpkg
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r ./{usr,lib} $out/
+
+    mkdir -p $out/bin
+    mv $out/usr/bin/squawker-vpn $out/bin/
+    substituteInPlace $out/usr/share/applications/squawker-vpn.desktop --replace "/usr/bin/squawker-vpn" "$out/bin/squawker-vpn"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://tryhackme.com/manage-account/access";
+    description = "Squawker VPN is a VPN application that helps you connect to THM VPN";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ mandar1jn ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add squawker vpn at version 0.10.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
