### PR TITLE
intel-llvm: disable __structuredAttrs on symlinkJoin

### DIFF
--- a/pkgs/by-name/in/intel-llvm/package.nix
+++ b/pkgs/by-name/in/intel-llvm/package.nix
@@ -118,7 +118,10 @@ let
       inherit (self.unwrapped) pname version meta;
 
       strictDeps = true;
-      __structuredAttrs = true;
+      # Currently broken for symlinkJoin, can be removed once the following
+      # reaches branch master:
+      # https://github.com/NixOS/nixpkgs/pull/510526
+      __structuredAttrs = false;
 
       paths = with self; [
         # Order is important, we want files from the wrappers to take precedence


### PR DESCRIPTION
Follow-up to #470035

`symlinkJoin` is currently broken with `__structuredAttrs = true` (see #510434), producing an empty `$out`. Setting it to `__structuredAttrs = false` in this PR until that's fixed globally. (After that, this should be safe to revert)

The bug slipped past me in the original PR because I used an out-of-tree setup for testing, which only replicated changes in `unwrapped.nix`.

The CI Vet will yell at this PR, but since this is exclusively a workaround for a bug, imo the CI failure can be ignored.

cc @doronbehar

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
