### PR TITLE
androidenv: fix platform-tools 37.0.0 darwin hash mismatch

### DIFF
--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -27683,8 +27683,8 @@
           {
             "arch": "all",
             "os": "macosx",
-            "sha1": "ff8facde137e57994112672a0d0f411a3ca7b201",
-            "size": 16442198,
+            "sha1": "8c4c926d0ca192376b2a04b0318484724319e67c",
+            "size": 16442240,
             "url": "https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip"
           },
           {


### PR DESCRIPTION
## Description

Fixes hash mismatch error for `platform-tools_r37.0.0-darwin.zip` on macOS.

Google updated the platform-tools file on their servers without changing the version number or URL, causing Nix builds to fail with:

```
error: hash mismatch in fixed-output derivation
         specified: sha1-/4+s3hN+V5lBEmcqDQ9BGjynsgE=
            got:    sha1-jEySbQyhkjdrKgSwMYSEckMZ5nw=
```

## Changes

- Updated SHA1 hash in `pkgs/development/mobile/androidenv/repo.json`
- Old hash: `ff8facde137e57994112672a0d0f411a3ca7b201`
- New hash: `8c4c926d0ca192376b2a04b0318484724319e67c`

## Verification

Downloaded the file and verified the hash:
```bash
$ curl -L https://dl.google.com/android/repository/platform-tools_r37.0.0-darwin.zip -o platform-tools_r37.0.0-darwin.zip
$ shasum platform-tools_r37.0.0-darwin.zip
8c4c926d0ca192376b2a04b0318484724319e67c  platform-tools_r37.0.0-darwin.zip
```

Tested with:
```bash
nix build .#androidenv.androidPkgs.androidsdk
```

## Context

This is a recurring issue with Android SDK packages where Google updates files at stable URLs. Similar fixes: #317057, #391715, #507124

Affects: `aarch64-darwin`, `x86_64-darwin`