### PR TITLE
Reapply "nixos-test-driver: use info/error/debug log feature more"

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -346,7 +346,7 @@ class Driver:
         vlan_symbols = {
             f"vlan{v.nr}": self.vlans[idx] for idx, v in enumerate(self.vlans)
         }
-        print(
+        self.logger.debug(
             "additionally exposed symbols:\n    "
             + ", ".join(map(lambda m: m.name, self.machines))
             + ",\n    "

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -248,7 +248,7 @@ class TerminalLogger(AbstractLogger):
         tic = time.time()
         yield
         toc = time.time()
-        self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)", attributes)
+        self.info(f"(finished: {message}, in {toc - tic:.2f} seconds)", attributes)
 
     def debug(self, *args, **kwargs) -> None:
         if self._log_level <= LogLevel.DEBUG:
@@ -379,6 +379,6 @@ class XMLLogger(AbstractLogger):
         yield
         self.drain_log_queue()
         toc = time.time()
-        self.log(f"(finished: {message}, in {toc - tic:.2f} seconds)")
+        self.info(f"(finished: {message}, in {toc - tic:.2f} seconds)")
 
         self.xml.endElement("nest")

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -271,6 +271,18 @@ class BaseMachine(ABC):
         """
         self.logger.log(msg, {"machine": self.name})
 
+    def debug(self, msg: str) -> None:
+        """
+        Log a message to console with log level for debug.
+        """
+        self.logger.debug(msg, {"machine": self.name})
+
+    def error(self, msg: str) -> None:
+        """
+        Log a message to console with log level for error.
+        """
+        self.logger.error(msg, {"machine": self.name})
+
     def log_serial(self, msg: str) -> None:
         self.logger.log_serial(msg, self.name)
 
@@ -855,7 +867,7 @@ class QemuMachine(BaseMachine):
         def tty_matches(last_try: bool) -> bool:
             text = self.get_tty_text(tty)
             if last_try:
-                self.log(
+                self.debug(
                     f"Last chance to match /{regexp}/ on TTY{tty}, "
                     f"which currently contains: {text}"
                 )
@@ -1061,8 +1073,8 @@ class QemuMachine(BaseMachine):
 
             toc = time.time()
 
-            self.log("connected to guest root shell")
-            self.log(f"(connecting took {toc - tic:.2f} seconds)")
+            self.debug("connected to guest root shell")
+            self.debug(f"(connecting took {toc - tic:.2f} seconds)")
             self.connected = True
 
     @contextmanager
@@ -1225,7 +1237,7 @@ class QemuMachine(BaseMachine):
         if self.booted:
             return
 
-        self.log("starting vm")
+        self.debug("starting vm")
 
         def clear(path: Path) -> Path:
             if path.exists():
@@ -1299,7 +1311,7 @@ class QemuMachine(BaseMachine):
         self.pid = self.process.pid
         self.booted = True
 
-        self.log(f"QEMU running (pid {self.pid})")
+        self.debug(f"QEMU running (pid {self.pid})")
 
     def shutdown(self) -> None:
         """
@@ -1402,7 +1414,7 @@ class QemuMachine(BaseMachine):
     def release(self) -> None:
         if self.pid is None:
             return
-        self.logger.info(f"kill QemuMachine (pid {self.pid})")
+        self.logger.debug(f"kill QemuMachine (pid {self.pid})")
         assert self.process
         assert self.shell
         assert self.monitor
@@ -1492,7 +1504,7 @@ class NspawnMachine(BaseMachine):
         if self.machine_sock:
             self.machine_sock.close()
 
-        self.logger.info(f"kill NspawnMachine (pid {self.pid})")
+        self.logger.debug(f"kill NspawnMachine (pid {self.pid})")
         assert self.process is not None
         self.process.terminate()
         self.process = None
@@ -1610,7 +1622,7 @@ class NspawnMachine(BaseMachine):
         proc = self.process
 
         # 1. Wait for the directory to actually be created by the container
-        self.log(f"Waiting for journal at {journal_path}...")
+        self.debug(f"Waiting for journal at {journal_path}...")
         max_attempts = 10
         attempts = 0
         while not journal_path.exists() and attempts < max_attempts:
@@ -1647,7 +1659,7 @@ class NspawnMachine(BaseMachine):
                         if proc.poll() is not None:
                             break
                 except Exception as e:
-                    self.log(f"Error while reading journalctl output: {e}")
+                    self.error(f"Error while reading journalctl output: {e}")
                 finally:
                     log_proc.terminate()
                     log_proc.wait()
@@ -1685,7 +1697,7 @@ class NspawnMachine(BaseMachine):
 
         self.pid = self.process.pid
 
-        self.log(f"systemd-nspawn running (pid {self.pid})")
+        self.debug(f"systemd-nspawn running (pid {self.pid})")
 
         journal_thread = threading.Thread(target=self._stream_journal, daemon=True)
         journal_thread.start()


### PR DESCRIPTION
This reverts commit 4c907dbb68ff92ec570bedfc53ad58d67862e48b.

Accidentally pushed to staging-nixos before, reverted by me in https://github.com/NixOS/nixpkgs/commit/4c907dbb68ff92ec570bedfc53ad58d67862e48b.

@tfc I altered the commit to contain you as author of the re-apply. It felt wrong to have this a commit attributed to me :) 
As nixpkgs committer you should have the permission to push to this branch in my fork.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
