### PR TITLE
xpar: 0.7 -> 1.0

### DIFF
--- a/pkgs/by-name/xp/xpar/package.nix
+++ b/pkgs/by-name/xp/xpar/package.nix
@@ -8,19 +8,26 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xpar";
-  version = "0.7";
+  version = "1.0";
 
   src = fetchFromGitHub {
-    owner = "kspalaiologos";
+    owner = "iczelia";
     repo = "xpar";
     rev = finalAttrs.version;
-    hash = "sha256-uZfOrhXEDBvALd+rCluzcMPDW/no9t8PqGBuoZm6MtA=";
+    hash = "sha256-FCYZl8tllGvgoIE/u9lpQJANOfB7phyOegXk82EOzzM=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [ nasm ];
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # for LTO
+    export AR="${stdenv.cc.targetPrefix}gcc-ar"
+    export NM="${stdenv.cc.targetPrefix}gcc-nm"
+    export RANLIB="${stdenv.cc.targetPrefix}gcc-ranlib"
+  '';
 
   configureFlags = [
     "--disable-arch-native"
@@ -31,8 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Error/erasure code system guarding data integrity";
-    homepage = "https://github.com/kspalaiologos/xpar";
-    changelog = "https://github.com/kspalaiologos/xpar/blob/${finalAttrs.version}/NEWS";
+    homepage = "https://github.com/iczelia/xpar";
+    changelog = "https://github.com/iczelia/xpar/blob/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ mrbenjadmin ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
Updated from 0.7 to 1.0, fixed LTO, and referred to the author's new username.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
