### PR TITLE
Firefox: 149.0.2 -> 150.0; 140.9.1esr -> 140.10.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -155,7 +155,7 @@ stdenv.mkDerivation {
   };
 
   meta = {
-    changelog = "https://www.mozilla.org/en-US/firefox/${version}/releasenotes/";
+    changelog = "https://www.firefox.com/en-US/firefox/${version}/releasenotes/";
     description = "Mozilla Firefox, free web browser (binary package)";
     homepage = "https://www.mozilla.org/firefox/";
     license = {

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "149.0.2";
+  version = "150.0";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ach/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ach/firefox-150.0.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "915f7154b19a8824f38c6d8d9ef9fd7dfa0d584e132dc5168d883f2d91637578";
+      sha256 = "6fda3549eeb58d2c0abee981f03cec5abdf0a99031d82be368ab11268791cf28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/af/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/af/firefox-150.0.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "82fb2ab67e9580f2d00d9648a93273d886257c6451c2afc8b8f0d87edcd650eb";
+      sha256 = "2f564c698f6d287b2574d00380886119ba3ec088f622ebccc08e83799ecdbcaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/an/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/an/firefox-150.0.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "34a77b8d91792b0e39b8486451e8ceee38c24707c3468532f2526d6247bb3c93";
+      sha256 = "d91484977a311430e8d883b2de04338d07b166ba1244b215e5a7e3c4381a9e08";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ar/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ar/firefox-150.0.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "0b49c7a9f71c9cced01dd808e89177daf49f39f70e410a91cb3218dbbaff5d92";
+      sha256 = "069c5001055811f1c6e26c80d1b6b94b0d1944d29774ce294863a075bc30610f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ast/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ast/firefox-150.0.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "39df917e8faeb5d72b8f44dd0a0174e169cbbc7f29f280144cdc021a56a76878";
+      sha256 = "46c58edf509744ae7b2b66fa8b9ccc35b596bb46b19fe36d72c0cfd5df147ecd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/az/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/az/firefox-150.0.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "233ef08032f7ac8acb355d6d3564c64671f5285354a357adff5ccb98d28ed85d";
+      sha256 = "aee9472480d653b17ca70a27bd02d5809c686eea855c083707f4f97e20fa9e04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/be/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/be/firefox-150.0.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "bcc477d83ae12cce815bfc23ac063ec2c2fa114384094688f5def74326c25e45";
+      sha256 = "f337bbece77ab7a80a2379d7d937f4b07c33143f33c067586b6b8b9a7a036bcd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/bg/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/bg/firefox-150.0.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "792a7bc598d48e13b90a38c29fe7b64a2bcca0c0b5d7f0d04f381b7b58dd9d76";
+      sha256 = "bc93a3c89dd4ddaeca71ab29f60fb0f03d4c575829fb6f008d5d3f768c822483";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/bn/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/bn/firefox-150.0.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "d73127cf9823ef87e2477141129c631c1eb0611281dd649970c09dec3d040eb9";
+      sha256 = "5498489c48848ae28416d859951faed4ab176a2f7c1578f28b3d2d59631e6c53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/br/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/br/firefox-150.0.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e65aefabcd888eb8c24d81722626b785b511cb6b487c5c62344868306ac1f76b";
+      sha256 = "e37a97e0235c36028bd43e4358bc50a8c64819ea9d28b889dd550afab6f06396";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/bs/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/bs/firefox-150.0.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "143e57ec8a7806e621ab536ed2f8e05d33dd6fb42b906f4894cfbe21db8508c1";
+      sha256 = "6e8b7aa778e3423c10c26de2eacddc5fd1adb50f97c90ba5fda3379a1ed74f92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ca-valencia/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ca-valencia/firefox-150.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "f135ca51047e3999e8e65187d557784ed9c68783549098a4e9eb0fbdb29c8bcb";
+      sha256 = "26fb6c5c4018bb318e65ce8545dd1470a76f5865d42b341c7009ec7961f1170a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ca/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ca/firefox-150.0.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "68a244f947e7a5d4df8d37e29fc0b78a2578a4988bd94da331a610d8d49d8ec1";
+      sha256 = "fa1688801bd1fd16771bd31d457c70b02b15d493f709e37dc947e26f642d7f75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/cak/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/cak/firefox-150.0.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "985cdf7d4c7e485ba6c313c454d9e3fd63026a99beab47fd3f867226e4731203";
+      sha256 = "5334bc92c4912b4500311c8ddcb149abed21ab74a8bb7a91213a3690c43a130a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/cs/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/cs/firefox-150.0.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "486bcae2a7319009d6e1eecf93f2cb7c54c4a175725783c8110ce082fc4b81d7";
+      sha256 = "0deaf31785fec9f5212a81ca7908525283205783b3670c41fc669e1288006eb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/cy/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/cy/firefox-150.0.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "682fc6666b78bc0c267ed38356685b1bd33994b2c81b5957597706426ed39d82";
+      sha256 = "b19fd410e899ce9e2ed41667e0ea7500d9c6a3eb20579a45563bd7bc7afad21a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/da/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/da/firefox-150.0.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "59ca679a369dbdb829de61d539d521b253be65749ee18a6d8327d93e04e4ada4";
+      sha256 = "bc609f518235a115c6b64c67e3cbc805098cc2a4c4b19352e951c8e60316e733";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/de/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/de/firefox-150.0.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "66f368c13d8601a439c14247a655ae5a922d40c2407cb046338f9722336917be";
+      sha256 = "5991544d554bdad4e1d485fba3e3d1bd86909bacf42afe2c794bb7cedf5192de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/dsb/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/dsb/firefox-150.0.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2c858b39e5698db1c5ad372dcdeded25d67af095c48baa2e0a0da52a2fc56749";
+      sha256 = "0925ac61578aff7ada7c5d4ce94e4bee685a4487b3930e55817325f1b21c38a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/el/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/el/firefox-150.0.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "9f98aa8e6ba4ffe8c807b85d9de0d1eebacc4e5edc692232f546618f9ce6623f";
+      sha256 = "ce06c587a2b86fa73e7e8cd93427a74498fbec28ee2603bfbf048c9962931cd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/en-CA/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/en-CA/firefox-150.0.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "9041c4d4c5263c12c0b79d29af5293db73d49b2a702f8778b39b7e0ce3ed46fc";
+      sha256 = "7187c727aacc8b462c340bc3d68d4e2c78c53a0db6e92efdf1d3a3eb770bcdd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/en-GB/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/en-GB/firefox-150.0.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "d86c5bf2302d4b63cb40493764c37853a1e701eaf4d40098e5d32bcb2fb2faea";
+      sha256 = "04802f87d51633e593682c3a67ffe5ad2278d8aefba0a7a963b1aadaf78bb2f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/en-US/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/en-US/firefox-150.0.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "814e872b969a4a33b6d44d27a2ab2f4b2c81692560cadb5855c0a3ae269e20e8";
+      sha256 = "2ff987e94bfa6ed51f53d6b4baa7f0f8ec3fc26c4c47bd9f86c70d11aa0fbd60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/eo/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/eo/firefox-150.0.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "f055f5fc14b0bc1abab6b35d8324a464ecf282d9938a77cc292f78cf1b998813";
+      sha256 = "1983fb4d167646ec7a9c9320de1b37e4f0042fd24c890848b84a304df13e0e68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/es-AR/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-AR/firefox-150.0.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "0d6adfb55a6e1a0da7698550b6f4fa223edd63d8ae5f071cb6cd9c9afe742c34";
+      sha256 = "bc2e4b24152c6a2f9b2a29e9a4c7dae698f803ba2cc841a39e318a4e04f95575";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/es-CL/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-CL/firefox-150.0.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "159404339059544d27204b041637a720591d45514bdf5401ba1b5a2a417ef0d2";
+      sha256 = "0f11ee090d0927239847c22de8e4e8fde5426cb0f48ab5c40bb4819a6d0dfa9b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/es-ES/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-ES/firefox-150.0.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "35a000d479dac8ac487bf54aad540bc65695dc0343d899194f8a57350e58d41b";
+      sha256 = "cd604a866aa7f8e6086d70690671281f975d20206edbfde19f1c153d82d52081";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/es-MX/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-MX/firefox-150.0.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "4a8affb9046887265a41bf9eff242e53ee0dbe47050aab103bc1ecc60582e306";
+      sha256 = "00250676a87308cf1cb0260fd300c3d3abaebbaa01bb58952bced085496bb94b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/et/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/et/firefox-150.0.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "7315fde254ff4b8ab2f78e3140ac15078013df47e2d8e9ab38d7cdf494532852";
+      sha256 = "e6effc06ee1998a7842e3459ef87d0eb41813239df1a638b19e25cee690f4545";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/eu/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/eu/firefox-150.0.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "9ec326a2301f7508dafb10dd20caa2a042dbcea87ab3ec13f495eb6994c45cbd";
+      sha256 = "b55c891191869c9b38cc8abdacc73fa46f6f400571247fda0e11351d4eecb8e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/fa/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fa/firefox-150.0.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8b8f78d26d47d45c22d1eac3291ac63e2f6b43fa3ac1fc7155ffa905bc4dffe7";
+      sha256 = "8565e9302d61fe53db0aa93b54c77c2e5fa01668a0749f2180d4a2877bd436da";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ff/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ff/firefox-150.0.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "394bb50c5887421d77c732b2561b164f9d1b7a6cf0f5ba4ddce768415f348dc8";
+      sha256 = "9cdf2a235b2900f5773abeff59d929a787576fc76e8b0f8bfbf199d8d3493c86";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/fi/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fi/firefox-150.0.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "c841f5b2bc0a3649c28ed6d0dc0eb565882c8fea7d73450d8c6dec76435a06da";
+      sha256 = "ff8901eb6714133cbbcf8cc0cac83b253686d82e9dbff693538d10a577dbbe17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/fr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fr/firefox-150.0.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "6f4ecf12fec4d8ee6897193587f78c0faf51a270d4e2fc764c814a2843d76ce7";
+      sha256 = "e5993ec9c373df0e3e738f00e3914fdf727b00e3b15a0ed4892e5d1416f30eff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/fur/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fur/firefox-150.0.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "8b74a36a1f64ec42b73bd2fa654eef4fab7fdc6fc04668a63b4ba5094ebaaf32";
+      sha256 = "25dec1f12105b87d9ec64847b97b3d66610ca10bfdefa1b0d6c9e94ccd5f1e06";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/fy-NL/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fy-NL/firefox-150.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "78a39d20a6c034a7aea1821fa64bd9d0fa466b78ddde260acef0249bbe59f166";
+      sha256 = "13bd01d13edc2a63d334d184adff5b5f58014e50e97c5dfc747f7c22865f67a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ga-IE/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ga-IE/firefox-150.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "d714e00209d4f6caa79d6677639a63c3cbb8e3ee3a875050e981c08f8cae4eca";
+      sha256 = "fc08eb3c9f3e0554a8b449502a91b53562b9a1b90e9bbbe3f5ec7a69835a075c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/gd/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gd/firefox-150.0.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "88d6d3c4a250e295c486c0066a7fce19a9c7cfcb5cc9ea5aebba19b68aea7730";
+      sha256 = "f93f7c51e96248b8f4bc342f887e698c2a8300c635dc188e243a92344bf9a40c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/gl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gl/firefox-150.0.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "8c68f7e5fb5560e82eaf91f156aa3b1da93eb76041a617a9e67c56f24fff17b0";
+      sha256 = "94df516061208f827856132baab2f21a3e3099066ca324358586c5de2b8d64d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/gn/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gn/firefox-150.0.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "ab45890636a88ccef67e5e33d2e1d9713f09036f7832a8353a4f263dc147d1ae";
+      sha256 = "fcdd1c0a2ea34e49c82e71b15ff6246fcc94c0a822ec857d20d84ed1194a2426";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/gu-IN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gu-IN/firefox-150.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "e9194c82f2596fbffcd7625fa3ee0818282a4fdf9071b901e58ee4b2cd272c6b";
+      sha256 = "9aa1360317b7a730c5bfbaca9fd4271170299ae7d86d01352a0fe90fd6af7567";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/he/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/he/firefox-150.0.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "b64db02a5d699e16d5a17138716daa5708e538ef3147cab9a4ed6743bbafa08c";
+      sha256 = "96b935a94a0e57cef008b0fc72de9fa46328ad47aa12eb1f348a51b684588c4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/hi-IN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hi-IN/firefox-150.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "a8459a9463d0c83c1015053fa32281773ef0a9ed5c0cf0d31967b2f7bab35f19";
+      sha256 = "ab8d3295c74c407cb923035f070b3dd8a8f102e7968b0786010b31c105f0ff61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/hr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hr/firefox-150.0.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "75f876906cc65bac1a337e8371922f046035e107f261bdaf60af7fbd224ce44e";
+      sha256 = "c07894fc729efd289a16c75bd9791bf9b45da02582aa6b16b1575f215c87baa3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/hsb/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hsb/firefox-150.0.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "60230563672a58abea8da1c42a6c8d702d23039f52b1ed2630ab1a2020dcbd3a";
+      sha256 = "7639cb516533ce99038691116edc6ef571192e74f1458850de438c1cd6591239";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/hu/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hu/firefox-150.0.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bcdfd2865640c831c12b2e977d3bf5e11d66b5da8186deba9904405b8e0e8145";
+      sha256 = "9b8a83bef86262ecaa8f0c52cd8f6ea24c37307aa4e757b4e467039cbb91ec6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/hy-AM/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hy-AM/firefox-150.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "0901387338816ad318365b4cc5d9192ce60d16852baaa485db5639de8ee58e5a";
+      sha256 = "034f14b74c65117fe19191da9a48862cfb4b43dc3d96bccba7c52c413af72b82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ia/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ia/firefox-150.0.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a1f0c7ba3c67841613264c350ea854504d64eef50402bbc2387311a3cdb065dd";
+      sha256 = "0c99d8783d83621cd75d74ec91b1917aaa7649030c94848af74eeca85fba4f95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/id/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/id/firefox-150.0.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "b92d59e8dbfd364ce0e2dc876f588e7f4dc3568563053045edb7eba982c52e1e";
+      sha256 = "7836898dd1569518d1e11f872e90b161072f786b0df1ef0a6e561066e48e4fba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/is/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/is/firefox-150.0.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "eec89ed0cdf6e267b2400a5596feb0a80c31698b930f7b80c54409d530e345ff";
+      sha256 = "9a3425105dc9cae3c61c9c66099d8db45ebdafca3b24ba61a6ae3d9a8367aabc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/it/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/it/firefox-150.0.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "69d4c0b751ec442d7b3b5f3dc90509a0ac4ade2adeea4119f635561ba410dce5";
+      sha256 = "c46f185b9357b62d4ed2d5f1fd4abc3d88174c72b97846eae87d8a7e0ac149e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ja/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ja/firefox-150.0.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ea3ec0bcbf915edf5e567885f9e7357fc0787e73137c8d2c6a7923e941fe3d89";
+      sha256 = "86f16a1bc7e8dd1e54ff4abac9684c4380eab88ef55c45b056107aad33c197ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ka/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ka/firefox-150.0.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "fe0623dc0db3b562dab67af245cc7f53b53c2d1127eec06af092969bff4c1940";
+      sha256 = "711bf219c8271cebbadf735510e06f64732f96a3e82e9f02031c1b4c45210473";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/kab/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/kab/firefox-150.0.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "0b25f77246af6c02331d996932aa749d02d733a3b9285612a41ec11a2fdaaa2b";
+      sha256 = "9e808d0b0433fcaeca0f046bf3504d174afdcb51ca7fcce13cf8d5445dafaeb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/kk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/kk/firefox-150.0.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "28d0d8d7eadb06b986e7a92c0fb957f75da019fed48c0d0becf80f648e7d70d8";
+      sha256 = "e39c684b53088922e06f291e36360d8b7668854e7ccb090897e3c4d6afea2120";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/km/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/km/firefox-150.0.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "7578b68b26ec9f315d3a3c465ad8b31b3b3b761a17110c43d5d730c35d208c47";
+      sha256 = "27755aaf765e65cbc3813aa780390586db75d0a54e0bf30d9b39c5457efece30";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/kn/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/kn/firefox-150.0.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "88c60c67e3baaf9e0ec0b9ee6daee5a5cda17cbf3020c1ac85e8da8c2b3d3ac2";
+      sha256 = "59365d692e939a83ee409db0c593200ca5721f3c0c37dc15fd305ff9f4cad8a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ko/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ko/firefox-150.0.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "1cad5371b3d59bdb9be3c1e27fa5566b6096e86ad2db0f6d87f8d7479f616668";
+      sha256 = "f9b40208d5d782d823caf658b3527778fd569c4beffceebeac0e593fd72ea846";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/lij/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/lij/firefox-150.0.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "fa6dd32729bef1a39e28fdaaf4e5b464d823e72f9772b428b5f6684f8c6acab0";
+      sha256 = "8d92d909dcf6fb2096cdf174c38fd22343b735bd406f1bd7b70ebe2ace40780b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/lt/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/lt/firefox-150.0.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "312fbd4ec659235b62de9e9a548ca46b78517fb08e98154bc4db1f1176a0e438";
+      sha256 = "2ed3230c2989218674b5c5c454e6be6db02aa53a51171f80b710a8854364ea4b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/lv/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/lv/firefox-150.0.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "1464cd0d552e02604d0cb27b7b689a71208b02d2d1293b46aed8755fb855c9a9";
+      sha256 = "3cae4a5fee6856fc8d26f9f331e6209c92e368e7d8e0cca116493da5257d1e88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/mk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/mk/firefox-150.0.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "9dfe7cd867786a7f4b35ef3d733541b88896400c455cbd9e2576e257127655b3";
+      sha256 = "4e983c39616f2a0a903f18c7b9c724d3ee30e284b91a2197346d5ef9b89333c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/mr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/mr/firefox-150.0.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "69fbff9f816d53670f762975e7011874fffa2ad3e240845185176d7e9dcb326b";
+      sha256 = "018c79ec6dd8d80aaf025260ee1f0fa436d1f273a0450401b5582d325d15e808";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ms/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ms/firefox-150.0.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "15523ef65f7983db03d70593e6f5600505e51bfef685ae65c611680e66455f81";
+      sha256 = "fd6e53060243b54d02cf15f83ae6b6a1fd74387e32c3a872e06287e4e67e7214";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/my/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/my/firefox-150.0.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "914884ecf867b875ad097308ab50e1b6e1784ad91ff3a1641b4f862147aee64f";
+      sha256 = "66be74d223804ea70759e21f67388c506459b1e5dabcb99ea4c6940d8437bd5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/nb-NO/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/nb-NO/firefox-150.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "e48a5b90acd1534a28a83185ac37f9eac437b88785ba71e091f4a89197b8cf68";
+      sha256 = "881700e587a36b40c3a363e721b7a8b6bc8525bfac3ef0bc0bd32c4ae55eadb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ne-NP/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ne-NP/firefox-150.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "f4d87eb31eeb041307a8461330f6df4145e93a650a4e99367fa776dcf5cf1efb";
+      sha256 = "612e84a33109f3be70ebf5806d23aa82abfb1e2ee1be26be8871dcc834ef5e90";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/nl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/nl/firefox-150.0.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "2e2ca657fbae7d91d3b877660f69717ca2ddbe2ee2246373b364f2099837e4d9";
+      sha256 = "8cf72e25578ef232d111fde5dc233be761467b3ccf9089d356724a202a4af507";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/nn-NO/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/nn-NO/firefox-150.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "80f9d57ee5cb2a72205bbd8f8f5c7264f12527cb73eb8af7fe7ea22a3fdf0160";
+      sha256 = "d8b7b4c09f69d8b4f72bf65efb38c1a6fd2cbb7a5e1d628c7747d53f1b752cd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/oc/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/oc/firefox-150.0.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "211a109b976fbfa73230d2745c79481995e14a6f962f07adfbd14e58c9efd06f";
+      sha256 = "d85c3edbdb601e4b2f185da27dd87a5c991edd57d7093eae0ea504e8c895014b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/pa-IN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pa-IN/firefox-150.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "c2dee5536a44b2abc679f1f814e865a328398b49c1379c3945ecb86608688766";
+      sha256 = "0b1606b64d0b712a7844cd98f51c271400c409a02875fced5830407cf6e24eb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/pl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pl/firefox-150.0.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "2c6d858db7d0a8e09709ab84d0520b00c6293c674ac1575159a4fc74bb1392c7";
+      sha256 = "e2e48642bcf8b73ae19be2212f4c5faecea12d90ab03467f9ce778a02ac54f92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/pt-BR/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pt-BR/firefox-150.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "4ea72d7749441ae7d3e45ab4e65da83aec2754c8c60ba622b20a2fc841052cf9";
+      sha256 = "d2c9dc14be5395be1e99782644a0dd69cd381bd0558ba905e59842baf2d9fd77";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/pt-PT/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pt-PT/firefox-150.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "ff8b3fdfe7671a971acfed5c972f6c216f6729788b5c87cadba7722dc28494e0";
+      sha256 = "78ca0c4486fd2b5f36e74fb75de94be6be3ae9863283fc40c098dde7bd056ae5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/rm/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/rm/firefox-150.0.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9fa742995a0c409bb0555a5ba2ce89610657a8f3859eb507d3b6291fac028619";
+      sha256 = "5fdcc6ea08da8d9539bdb6b058370880b8387d8b724663e692ac69a70ae1688d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ro/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ro/firefox-150.0.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ba044b182198710e868b5ddc4727d9dacacbc74a7a0950485ed6d5097c95de1b";
+      sha256 = "ccbd22c2e0a5b42b0a7385e5d18f1f4318f9aee45db45e979f66606b5b38cde1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ru/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ru/firefox-150.0.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "9c9ed2eaacc96376dbece319028e6c43f89fb55a5ecf623b045858ef8d954b9b";
+      sha256 = "12fa20208db2048f35cda8c868103dcee372fec4fa111fa46e135aaab7d4a556";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sat/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sat/firefox-150.0.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "ea1ce3c5b12c7318d606c929f5b8bca495bf293da5ac212da89a426eb95c5c7e";
+      sha256 = "719e550ad69aced566f63f2863f5f8f1fd2dd5e7f1bb31606eeee830d151760e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sc/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sc/firefox-150.0.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "5d0024f6ee9eae87cbb4ab9dd250134ae1290738dc8085d3f281d52e12f3147b";
+      sha256 = "cd215721dba4cf36b00eaf5a3bf29af623c7f86b21e6f4abe54b0f00f6a52214";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sco/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sco/firefox-150.0.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "1cf505e51e189d84deb66e3010dc55cb04df7c685066f4343a1ab873bc48470a";
+      sha256 = "434a248ede9771a58f7315585609b659287dacfd2f077b3b7726f17d3f32817b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/si/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/si/firefox-150.0.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "4b954316fe56917dfd0b0c1627d609d343cb9395209b39f1f9b7441af6620871";
+      sha256 = "9eea0ae86f75db6996f5bd2030f5edff11e9071f294ff4bac39cbf1405cab6bd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sk/firefox-150.0.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "23acdf86a812134334f33d464a7a7b283f97aa114b1e2e65a9a935a67d6a2af2";
+      sha256 = "76393f918ffbf5697ac29eb5548545ac3f81d26d1fd126d434eef22037525c9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/skr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/skr/firefox-150.0.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "3f1fc4f859875736b16b835c2dd091763dc6010e62e63cb11c60d4df84eb4eee";
+      sha256 = "47b2a99f38081ecaebd470c9c92c3764dc22a0d5e8a5b5d1ebd3ef8a5778c6ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sl/firefox-150.0.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "f559fe15e1d2bc5b2681135267ab95ad93aacfc9dfba2ab82e77eafc9bc4199b";
+      sha256 = "58fb7c5d61b347c1ecb6273f95345fc45adf3cc82951faa3a6704fe0d97475db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/son/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/son/firefox-150.0.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "33f0c513c128695d4aa43555c2e1c0fad7a01955aa22f333d75c2c8125f146e5";
+      sha256 = "d3eff42279227c045c0c5deeecc2955c316639a1c624d2f431be9eb8dc208981";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sq/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sq/firefox-150.0.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "106ebc1bacf954f306751be2fe53f40bf564ff77013f50c6c1e70d0de652d920";
+      sha256 = "01223c61da469892fee98effddd3d8c862f2037e1fe0f9a063c0f8d54ca45f66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sr/firefox-150.0.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "1969da9eac822fc0c31dc2092b3fce1cbba93fce2aa3df43343a2a6625a3fb0e";
+      sha256 = "7341c99e41b96ae73b3eca82aaed9a53d9d7f93148511598a340f2df2c5f1bd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/sv-SE/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sv-SE/firefox-150.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "58ce9b69e1be44987248f2ce04334b5e4d39285cac9a5e3140ae06b59a6cd790";
+      sha256 = "534c40d3b5187ea53514457b74c84e9221fe0e59b7a9c7a543ebb00f2c6b0ebc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/szl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/szl/firefox-150.0.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "e87a23d50e4ef459f705c61da357d703e388b23d7c72fbb48b0b29b3fc56a2fd";
+      sha256 = "89059713ba528500e256bf36b59b3b29b518e2fe6a1cce387765b5668d377899";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ta/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ta/firefox-150.0.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "80396a5bbe37acb7922d5053b596d99012cd335c6e0b624b660321b6af2ef9b0";
+      sha256 = "819e223804e6bf19269556a603f5e1de22864973aeb6c02b07dbf5883bddec65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/te/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/te/firefox-150.0.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "af905da16cb6706220b07589d4f72bb0034d2bcc7d511f1eeded441462a2c913";
+      sha256 = "d0d619885daa8b580cceb419267b213bcb428f240cf33b5cddbb56a371b7b5a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/tg/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/tg/firefox-150.0.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "953fec2761acbacf81c16853eddc71c5bfe807fd674c180bae070a71c63297af";
+      sha256 = "de0a569e50ea10f2581292f91c87b6c9e589c8eaaa925a9154d3c99ef2970fa2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/th/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/th/firefox-150.0.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "892a39bc5fd4cb4eaf16108757230ca3854b29cec72f2eefd2588cfb8386943e";
+      sha256 = "e24b9a1c30995b3edcea1c62eeaa16d24fe51a917dfd5d77bbb4f28a88298316";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/tl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/tl/firefox-150.0.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "ca50b4d6ef4aece6eabcbba9ce9b6215768f81f8eb9fc2b3126301fad0fcfe1f";
+      sha256 = "572e70a6f3f5095c00ef5c5381f4ed3d686f0cda2b754dd80b2b7f475e36b882";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/tr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/tr/firefox-150.0.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "07f4b3b9dd524bc8d11b2924235322cd2b75f0709385e58e9d5db7d7ea0fedd1";
+      sha256 = "491929752bf6aad4637418779679e09fd4c11831c5c9ae8e5ebe54ec07524bac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/trs/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/trs/firefox-150.0.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "1a5411192e84fac6dd78e81e48dfdfe9a9d920139d8b3bb35f0cfa7606452caa";
+      sha256 = "38ff7c7e4e0296a8774c2fd51b68c966f9c0a9d2b80cb66f3ece90f0b9f3c2b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/uk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/uk/firefox-150.0.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "6039649e183299cb75328a430425722bdd9cc57fa26ab0a1cff68b4d1b05cd19";
+      sha256 = "477afc4e02ce89b72e999237d36f2088e89abdb9a6e6afb199e1a4ede58d48ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/ur/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ur/firefox-150.0.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "67dcc7c629b18569ecccfffcc0b7a2e08b8c671ebeef87aa3c3790a60f6a0f40";
+      sha256 = "ff286564a782108c772c8b050464499f08b97e40c108ebbde703de5c539b240e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/uz/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/uz/firefox-150.0.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "3c540aac04885882bc2edce25319ba8e25cc22d81e6d58f5550311c7afbe7770";
+      sha256 = "88178214e9aa0e4e00b6c7bab3651efe4bf9fbc552b2e3a5fe6374aa4d9c3f79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/vi/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/vi/firefox-150.0.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "3216080fdb0c255978aac7927279702baf4f516c635aade3ea8a72c564aa12f0";
+      sha256 = "7f8823ed0456189dc3ee7e42ecc605c3445fdab99a82aacb9ce6d7ed5ad9d15b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/xh/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/xh/firefox-150.0.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "f576dc2ae4d94612de4824871ec7c42522e1deb3ba3df61882123f9da647ffc2";
+      sha256 = "8988a0e5547a5039bdafd01193e3159d96757a36630420f7d5f2ee6e350df329";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/zh-CN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/zh-CN/firefox-150.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "712eba43675e1c3a849fb0d4ce1ab8783123e732a396872c4feccbd36628fefc";
+      sha256 = "c4ec491f484bf7ee35e91f89e297a943b785ab2d657de3e1352320b7de967b01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-x86_64/zh-TW/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/zh-TW/firefox-150.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "749c6075189a957405ee7fe59e2a3ec6cbea15186b26f924eb5870bb5461fb55";
+      sha256 = "dd81e74e904f74b72247f56d92b180bfe8fecec5732f76d3650ebbd5d8051944";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ach/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ach/firefox-150.0.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "eeb2e072049ef3cfd9e2f3ef0454486d81c6d012f9a442f3a73b66bbfadf668c";
+      sha256 = "bfb5d97c838501a93f4a8148ecc00de102a51f8d2bfb2019da7e331ea9fbd7b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/af/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/af/firefox-150.0.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "fcc8668dc790bbe870cae3511c188d62745b1acdc76ad180536a7ea8cac0bfbb";
+      sha256 = "f2e2444bce5853d147ebfd62b6663b626207964a3cb34558865a27aa9a499cc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/an/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/an/firefox-150.0.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "a00d9f30ead0e81e43f41faf6e981f8cd71ad7a939a2dc8331c1be46d51d68fd";
+      sha256 = "773d7793172b12ca5ef9931bfdfe45527332b8214a47aa8cce7cec056b9e5ba5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ar/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ar/firefox-150.0.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "f2a53d0f89910a0e8879f72ba7c9bdb473cc4774e3ee621b1524f1a9edb58844";
+      sha256 = "fe2c2721d91dfbf210b2f965abd49ffa0853a9f3ffb7245e09d4b5c432977608";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ast/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ast/firefox-150.0.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "88c48fc67663b8d01754e42c3c1dc5d4e5e47b6f5d39ff711e2428a0efc144de";
+      sha256 = "3d2a9d32b4b65c9d820c7369acf38abd7601fafb2762c8450666bf14cb60fb62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/az/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/az/firefox-150.0.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "7a5c74b6310ac7ef80d2a609fbb84bd9864d0f0f61d85c920d0a81f94226151d";
+      sha256 = "d85d3df76c17e39520f81fbeb763c73ed5f8208a40d91aec2fe73e4b4ef8bd73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/be/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/be/firefox-150.0.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "413de9b35e4a1b4674c0be51db53134e5f10f70416a4271bef6e7ee0a648cf44";
+      sha256 = "ff61b2f17609e9088765a8c2c27c73aefe679ab364178be923e9bd79e7e82c64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/bg/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/bg/firefox-150.0.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "b72219f4fe77c7dec63d128cc63c2204126fdf28de3851601d62031def30b871";
+      sha256 = "24d052f7057bd679445abdadf3594ee298913b25d7b6d037c46a4a3d817c2580";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/bn/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/bn/firefox-150.0.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "35d50919e8c8846b72b4218bbe8bbf5aeb8ff0a4b2b7994656a7f2960ad2151d";
+      sha256 = "d6753fb7c487243faa6767c30d459c69a2c5b922f0b448efe31e17a0f7228050";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/br/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/br/firefox-150.0.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "58d73ec73834881f99901c94dd8d454b791bd81e0c4c74b3299957ebfd99b3aa";
+      sha256 = "01c695d79b76c7b688dbdce4c7be454562b048900a6170ce1831f644cdb2649d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/bs/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/bs/firefox-150.0.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "87089e8d1a90a32da3137d3ac8de42f83ff164fee5d657693bcad16f2fac5c0c";
+      sha256 = "53ef34e6bde6bd751dfca50e833ce7662cbd916c1202885f560cf0880fb05d4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ca-valencia/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ca-valencia/firefox-150.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "e41b3098f8af0e04982f2d3feaf1038067d0a11a74af1ca50406afb493440a18";
+      sha256 = "169695d4ac628ff56655e37dfce77dafb7f4d52f02f76dfd9791b2ceacf5faff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ca/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ca/firefox-150.0.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "aff532d9d0886dd0ae177966b0c0590b37b73cc3e2b99165ab230da13ca471ab";
+      sha256 = "54ecf88b598f7a0ff1f75a575b09ab6ce210eaf606b85be137282c301fc9a0e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/cak/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/cak/firefox-150.0.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "377e4501b1fe9f1fe336264af9f93c753357de0cdc5ea861c948fc884c09b2fb";
+      sha256 = "7d68e7c8307f72b14f588f35f7ea8d4570d28e07c1a779c025be01a8b54a7ab5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/cs/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/cs/firefox-150.0.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "78c2f0b558483d539cf4640816bca8eae9ed43c70b6202c9d1bc2975098ca652";
+      sha256 = "1d0d62000802d037a2386f5375bfcb924ec7830c9822390ccf18097dde958a99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/cy/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/cy/firefox-150.0.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "e4bc09affe615c56270b6dffb8cd20af7059df47d5c2707b33a27c318ed9b5fe";
+      sha256 = "96afc930c806785ef41a37bd6fe1c52746289efb311eaba17af187c76e8aaf88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/da/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/da/firefox-150.0.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "d15e1aae2d3d02de17174fc9b4bcaab85ffb30bccfd71794a54586e96550756f";
+      sha256 = "0519613f94868e1a0a6e07d646c0ff0ca606a6b1d7c850d7f4496f774fa86353";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/de/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/de/firefox-150.0.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "162f10d54fb04e1aa3f794847c07112626a1b6edadc1aad1f28ac452dea70db0";
+      sha256 = "f6cc63dee1b96ed41d60934e002a44a4a16da79f15c06297fba10f13abcc7d13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/dsb/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/dsb/firefox-150.0.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "ae1f74f16f7c0abe1f623952ae43c8b07cc7be387547c58a7621798bae05a64d";
+      sha256 = "692524f3a8df532855c2880ac2e4bba10637d79cfec3e687664afc285d919c20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/el/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/el/firefox-150.0.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "b2dd8b410d910878f79aff1a3c9ef118dd17bd3842a4fe002319feeb3a7a5d85";
+      sha256 = "8c33b155683938adb80db55ea6a6db6df233382d38c75f99288653c2a00fe2c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/en-CA/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/en-CA/firefox-150.0.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "ab048a1cd63ca60ac62da96e8cf8d0ce644e81517b19cb5d6c704917bedbf656";
+      sha256 = "df7400d44670569befe8695660885e42ffb31a4eaee7e3c822bf01ddcdcce39d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/en-GB/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/en-GB/firefox-150.0.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "032232aea59c9727bcd993f631a1b0b10bdc4f98272256f3046451fbb4508774";
+      sha256 = "ab5c228fea3531abaaa5f80b25cae5fddb56e8f94f795d44985319e1510625aa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/en-US/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/en-US/firefox-150.0.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "b6c4c861dcb3ccaadadb77959f7de028f8543ecd8bc6a0b9f420752cf07c47b2";
+      sha256 = "9e6e2974ddfa840544caf26efda765c4988931bf2ada85c6b107500cd916cee7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/eo/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/eo/firefox-150.0.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "aa8b822112446df2e2915eb0c60961e066919acefede1b9e180afcb3f44497f0";
+      sha256 = "c70bd558e0566d7c42467a7c950ff3df8a8db4d7ebedcc987464d48fa56def5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/es-AR/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-AR/firefox-150.0.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "48c7a5e5f79e90e3ac7b488f2082490124e7ef6c3ec28792cb34d65f4b10dddc";
+      sha256 = "967de64c73a667ac467fa94a821f50c0cf18993353a1882cf6f297a9d894d5ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/es-CL/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-CL/firefox-150.0.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "ca420775f1ccbd40905cabccd0bd86014347e3a4b2324c8726b279f3d6bfe316";
+      sha256 = "30bcbb562ff20cf4d6d69a22507efe1882e6afb76580cd73c770b41df81cf996";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/es-ES/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-ES/firefox-150.0.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "4c8aaa0577d4609ba2377251a0eb038b2f5e6b41e8219dcc878b729eecddeae4";
+      sha256 = "95b6502bb5c79a86790444e9047ebfbcc0da1bfd4a139b1118af9a3d6034c803";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/es-MX/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-MX/firefox-150.0.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "bcbe32653720db53eb3b7f30fa613037ab2f20adcb5b7c92f1865564fcf47b36";
+      sha256 = "d14341b9dbdf69bd26f7020aea990e7b1260798b2126edb12f26130112ec676f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/et/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/et/firefox-150.0.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "5933fccc6575e717daf5d3c52e33312628767edf1dc0649bf41898ac40961a1e";
+      sha256 = "090fdb54b57196bfe50d95703fd891fc45e5b61a71f01d9f387a4ea090cf185b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/eu/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/eu/firefox-150.0.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "5aa5f710161f42821deb1b12e3ccd423ccead6d0eb45386ea7523a913540ffae";
+      sha256 = "17f09f54c040a86218503a963871e9009ec91ff808cb83544de76978b74e32a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/fa/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fa/firefox-150.0.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "692f413ec30eb824d3137e1a1ed06ebe2459b4c114fea25349da53d72f3f8ef0";
+      sha256 = "2ba0a879cb17e11cdd40f4db120b6c4ce96ef3534427603055224600f3e0eea4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ff/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ff/firefox-150.0.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "bfe66a8163621436fefdc026a10b61596882da726ee7a9e933b5697344fe5f65";
+      sha256 = "968a570398cd970f1884b49e17aa2ed245f59b70f9c7d3c807ec7f75259d5e43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/fi/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fi/firefox-150.0.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "a39bbeb218e966da2173febe6e133910de9c261d20e269f74db3ad7ff204693a";
+      sha256 = "e7f8a50883183b11cdbbee3ec3f31b8efa72571a0e5235a13ced94a756d98ff5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/fr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fr/firefox-150.0.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "8a6209f97093f753c2583bc569e048926a84e8b318273cb936c0852ed21856ad";
+      sha256 = "b8abb61dd340aff2d0812e3fe22b128ccacaba4acc8e2c670df99627af5c09b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/fur/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fur/firefox-150.0.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "f275edbe5cf069e61ad9e0827948750ddcdbfb750e49fd0bfd1ed94c89aa00ab";
+      sha256 = "37877b40446d443941f174d26735b50c8b3680e33fac023e97632c056533f586";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/fy-NL/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fy-NL/firefox-150.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "67ab08451f2c43928621862f51dc9e1304f42a6cd543beb216705f63810d78e1";
+      sha256 = "15e36db60b6b31648163dc8f740c6fc91373daa8d39ce573bb3c51bd22aa86db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ga-IE/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ga-IE/firefox-150.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "93e4ade1793e4cdfbb72c1f9c36bafa8f03b5e1a3d8caad1079f3a5d7a2fad4d";
+      sha256 = "80e113f41aba04d445315c3d27766e107e27b01598451eb7f293b7f1a176adb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/gd/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gd/firefox-150.0.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "8533131ac994622e3bab03b6f51856b760fe6ad5c9bd91d1cfce5f4ceaf0705b";
+      sha256 = "50e0a2530aae063cd0928e6d1123eefb275c722b81b29649cdae2a2a9f5f59f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/gl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gl/firefox-150.0.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "b1f53bed7e4ae75616697ef65f210a7a1bf8fdfb7953a3dfb2c3772300bc2eb4";
+      sha256 = "35f9737a3576583e0c3f70df8d7deb96918648b35722bc87e82eae86054ddf25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/gn/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gn/firefox-150.0.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "a92b49821f2c1424a934e155967e298a9c30313fae163ef504f76dcca76fe019";
+      sha256 = "beed54e00bef3e35625583175a338d652e09764df312752403a7b3d7402c1d33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/gu-IN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gu-IN/firefox-150.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "e124252bfd105d14d1fcaaeca567cce5f32250a0df8cb05afd7c9bb444b545fb";
+      sha256 = "b85e6dddf1c4d854502724c6f661da6dc28c2f15504ff0509299ae75feae97fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/he/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/he/firefox-150.0.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "9ca964e267e60246ff2069e0d17877e797cd5f17aa8e93dade658f8e53794bb3";
+      sha256 = "815f9e01499dbb83df62380bee2ed0b5a6bee368f00a51cb14e178465135e3a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/hi-IN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hi-IN/firefox-150.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "ffcd48b625ca40847c5e6ae957afeebce96205deebf3a61eba76b4c2719313d7";
+      sha256 = "ccb8169a407e548ec662e2149bcd848fc19b8bb6fb7559afff412456c3fb1596";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/hr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hr/firefox-150.0.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "eea045a952e125ba804a7b6e08a39e9e532719b24b6cbea500cc69c6313ec03c";
+      sha256 = "66e17b54c9ca0275dcc0dc17a57b64eac0360587f4d80caaf5a8f904bd9f3fbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/hsb/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hsb/firefox-150.0.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "67fb434b8cb9665c32dca1a1172e7088393ecd9692a6435d5bb9749d4e3d2a65";
+      sha256 = "001ab0ccbfe3fdbc6b057664d02929dc3ebc4e9567684749f05f483cb3ebf369";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/hu/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hu/firefox-150.0.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "d81cf206ba390121475076d648e2127d12b117e210b0452bdfa4c4820401004b";
+      sha256 = "16babc87894317efe88d6234762b6f0c14db62323b20987abcb95d9f639f32bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/hy-AM/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hy-AM/firefox-150.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "26ecfcf4e5b35a748729c616aab70b2c02d25284a91936857a9ba0ececacf54f";
+      sha256 = "419d551fca7fc4066303b980e7fff9585f7115270fbbadab3f487b559e88170a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ia/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ia/firefox-150.0.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "db711a01b26a061ac2bf58f83be9738478f57227e7bcb870de8a3349bb505fd7";
+      sha256 = "d6bddb0e06ebb26dad4fbec0589c550c0a4644133ae915a801419b8c5083e5dd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/id/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/id/firefox-150.0.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "c6d05c134c5417c1c49db45e2238f4de64e09566f6f276790459d35db2229e9c";
+      sha256 = "02da44560c02c186417906254dd427213aac0f923c17499a89cdb169832069e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/is/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/is/firefox-150.0.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "60fdb608f979a773bc895a8e0bb74fa194d70e4a24de639336410900704ddc6a";
+      sha256 = "acc08d39f248b5b799aa5f2631eaea6a0778157887fb5c0926ff42e7b1145b8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/it/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/it/firefox-150.0.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "27d1cdad67e8fc9fb849dcb203005ef92ebcd64b6841b0e5f509788f6691ca50";
+      sha256 = "96f389427893b009b4b00c0426d7c1e44f4edfe4f85c954665798273dd24cf6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ja/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ja/firefox-150.0.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "4887f17ddcbf952734c18dae24f217b07bdd8a52ff4dbb75e6977e606302d7e2";
+      sha256 = "a28a5dc44c81b8d7bbb36e8529ec12b9eb93a4dbbb315e510591f57df70e431d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ka/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ka/firefox-150.0.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "f497ae93110a598ffd67994274bc58d97e203d287658220ef7bd1921def5eb90";
+      sha256 = "e749135cafc5505f32832b36053a7c1179d3b10ecd00bf22856855e1aa595385";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/kab/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/kab/firefox-150.0.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "22f3d3fc6328d09e2d9b44650a5fc154ec88c75e65e5fe3a8eae414e4bbc54ed";
+      sha256 = "56289ea469839fb14e1755b807c8590fdfec417e3ba3e167977d0a775d47ddfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/kk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/kk/firefox-150.0.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "b85bc13ed4f3fd1bdaf3ea49d381b43bbf076396cd2817e6f69ca4c96cb31c8f";
+      sha256 = "cf264d6c21e67632ee81eb808a52b624a3a994c6b6075aa93be0fc8cf8867d5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/km/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/km/firefox-150.0.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "b76e5cc3eded3fd1770a94d1e0fbc590d6152873b091bdad590c885980ed72bf";
+      sha256 = "fd96e17527b863213e311ee9e3221b64c6dc44db4465d926afc17cde37970f37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/kn/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/kn/firefox-150.0.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "97b527d80a8b0e13520647cc91da8c5f3cadf79f94e8ee388fa6b08a47434c4b";
+      sha256 = "7a47e0e8cf8917bc9626dc0ba59ef7425be9cbcdf54e2b31954402d1cc3988d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ko/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ko/firefox-150.0.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "a00d8029f4e270704cd463355266bf0510ec8737c9285c4e24e352b20960b3ba";
+      sha256 = "a90d9216e1112bb9639f536e6752e8a7f0afc5f19748e4544140096b4b7d1bee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/lij/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/lij/firefox-150.0.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "be756699e4d405af72d3953c5dbda14939d59f45955c594734755e3f6755c6b2";
+      sha256 = "c9868c2d93656facbef63bd0267870ca145efb0860063870b13c011debcc0570";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/lt/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/lt/firefox-150.0.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "87dea4df9b699533df5f4fe11c5118484710a49c708d78cbcd19f7299ab6948b";
+      sha256 = "8fc2b840950ad2593876794170575af91c04ad334552404f5460a5d006e9d594";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/lv/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/lv/firefox-150.0.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "ea07864f49875d3fe354c6ab412fecf1f7014be3dd60ef7b7b370eb3b61dbd13";
+      sha256 = "a534d5e8e12e57a3b288ca1b12be61fb270da791f6ccd33938233eb1c0f3fc07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/mk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/mk/firefox-150.0.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "db67fc34f89568c54c06c5a428df1a71ed0a5a77580e43b5c109738f05b2b8d2";
+      sha256 = "101f937a0a64cc4aeb71ecc0b76334bdcf3c4bc41bc2923a845df89e1b1e4475";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/mr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/mr/firefox-150.0.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "4dabf57482f6294f6eb83131928329a1b41ae9040e1f0b1da63ab21acd650bcf";
+      sha256 = "e9f8226415d5aa07faf0a9493d247c98f20ac1cfd64ad45dffa5b101470f266c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ms/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ms/firefox-150.0.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "ba08818ea28bbad067cdd89a2947ba712d72b0abf6d369840c045675c1b94eed";
+      sha256 = "4860eaef1ffcc84c776645d46d09d05f792b5c939447b5e5cae5015080cba254";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/my/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/my/firefox-150.0.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "4c809668d64609ee2046e449592003bf9d0d0439461b2ea41bb531fe3b47d948";
+      sha256 = "365b05ab1bb379d6fe3a7d47f4cad780fd06e8e4cf2d97be8b454e557b549f5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/nb-NO/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/nb-NO/firefox-150.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "4b28ffbb8559b7a43f86d38edf51558e319a80c5f03077c211496592747aa8e3";
+      sha256 = "26da7d07de34b248bf31b46456be7db188819782de4be81c3102936ce7a7c147";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ne-NP/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ne-NP/firefox-150.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "4ba080b6c33d927bfb9a1baa468172cf3e612ef69606b32913ffcbd40b4326d1";
+      sha256 = "f18c403279ab4355f3c3af7df37917ddee15cf12d5702ee3631416094e34e29e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/nl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/nl/firefox-150.0.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "843f41e8371ab6c4eeabd0b871f67bb31ab8a71b92d0da9e889dc743e63d705d";
+      sha256 = "3af9e6a79b151deb9edbe20637b484763682ce129e19c62bf64d75c1c8b3e3b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/nn-NO/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/nn-NO/firefox-150.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "3f858528676b612305728a690f5595c770fe36241837a503d775c48b87bda28b";
+      sha256 = "ced05bce994800f362e23305269324bff93363f6971a6fb3dcd50fd6695b46a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/oc/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/oc/firefox-150.0.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "be0c18de40c22f922aefcd60f88c1eb5af917f0596ae467e7ba5adb704a5a1e1";
+      sha256 = "001a3236dc3221693f00ccf7d3ef9a772a9f85e956086113f2d5ec00097764be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/pa-IN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pa-IN/firefox-150.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "53844254d8d25e8828c7b168f4607b88b74212cb92055c51c74331139c51ff0e";
+      sha256 = "ed8e49b3bad3263620c3335079c72bd01c12b5ec19bf5d2a3ee2501cc9bdfc3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/pl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pl/firefox-150.0.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "895711187cb83b17d80cd005fa31db62a5c96ee681383c9ed94083b14b39e939";
+      sha256 = "3b1518027b323cfdfdc4bb95f66bd75dc43ce387a75fade39f8cdcd789483f55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/pt-BR/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pt-BR/firefox-150.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "dc8bc0f3a3c35091a62154a7599ff824dbd42fe318901bab3d9bbcaee4d32af6";
+      sha256 = "07decb7d696a9cecf4130352c77bdacf23fd0c7b486889fa40f5cf1faff22b5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/pt-PT/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pt-PT/firefox-150.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "975ab649fe829e6ee5924fda3e93820d527a6fdd9f9e0756bf6a911378cdc378";
+      sha256 = "cb011d2ba53d7eaf9d8065fbcf8a0a599ebd46d63a140af48aa68be90e2e89b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/rm/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/rm/firefox-150.0.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "1b76bbb0bd18dc08907c7c7bf606e2e317ba46790b9bf64bf746d2b7b9d6d042";
+      sha256 = "059036333a669b2e332bd1c91f8462f8f2c9197dd200686c93e8bc9c98d9a3e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ro/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ro/firefox-150.0.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "06de2bce30216bc5025ea7d8fd80f1ea9da3f741548f2f921078deeede2ce35b";
+      sha256 = "dc0424e5288f25cf15e9dde77d21ee8b4819f2f3efcfb1a7f9759db38de69435";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ru/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ru/firefox-150.0.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "2d082bd94239e898a90cd668aae6678489e277cd280cf20af7cec4bb634e9d61";
+      sha256 = "acc30078a9be326d58972b4ec86abde7d829309915f573ff930d07453497bde0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sat/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sat/firefox-150.0.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "d241a923bac592d25715192ea45e87c64130688aa1f203d768dddb5a7bf8f296";
+      sha256 = "64fe33329ccf4e46a7c83eba9ace506fb0f1eaa77f84e4fe0fe2a4b79adafe04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sc/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sc/firefox-150.0.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "2407c3733feabd510ac982a423d88615fa06fecc6b49521f92d85695d6384dc7";
+      sha256 = "6865e09f8ac77bcb4f07f9adbb6d8db55d265d60bddd589c8fffd74fe08b88c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sco/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sco/firefox-150.0.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "52520becf02ead01f4cbc7e0e311e2e1e492b7bee3af893f5ff5164fd706cfd1";
+      sha256 = "aa391d7766f94b938e70c1b25c6a94e37c89d0ff9dae04b194aa9f9cb05c6bce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/si/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/si/firefox-150.0.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "acba0375ebd634fbd61e5c37498fef4d2c4b3772f3ae8fb6756bb82917f11758";
+      sha256 = "6724d82646c653cefeadf1170ed0e137541631536d282a7e11ccfd0066f17dbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sk/firefox-150.0.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "4e055de2c05a0a6cba4aeb3c150e6d0d76ff82ba731b70d7fbfbfbb82be40307";
+      sha256 = "c660a9a3fc60a8dec171931f8dc42eab78f2e8eac052ad38b234f27c1cdaaf69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/skr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/skr/firefox-150.0.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "29d57674ec57f2f290f583139ca189f9c1cbc40d6eeb5d0aa926d743a288c589";
+      sha256 = "c4c02f3a144f70bd0ee2e9ad112e523bd5962253afbf72b7c672cbacb09f7f69";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sl/firefox-150.0.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "b12961bbfeea5c1e542bb90a97cd9983d8ce940ac6a7d772feeb8a76560e9764";
+      sha256 = "5734549558ace1c969ed2e2b4375a08f8869b25ab560d706bb60ddb4193590c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/son/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/son/firefox-150.0.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "6d010d064a4def1c7efd65762f0c6ea25166394f568afb315fb4763bdcd8e4ef";
+      sha256 = "a5d560cea663dc82152ab9bcf7d2733396254c02dd7308709d74264553e1ae15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sq/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sq/firefox-150.0.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "d6bc6cd25d1afa24305b25ab00540ae3a0d89ae0e7b94bf5053e636907143643";
+      sha256 = "3eb5c4b583205380c13eb99c13df361db7adb46324ab37e4405b892f5c923d21";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sr/firefox-150.0.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "73f077937baa63edc36f18064c8cb8fe5673d61701731d76367af1ce9fc43494";
+      sha256 = "83b9a7cc9b19d82771f29f2fc2f20e76b04c0778d51644a3ab38223d46c51c2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/sv-SE/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sv-SE/firefox-150.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "85b6d4620d322fb944f1725206c8f3bf0070da23c02dc1e0131ee0b4280211c3";
+      sha256 = "d60f17565af94a7bac9b4188a036844b170a2183d1adb9323cc0e297121007d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/szl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/szl/firefox-150.0.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "9f6ec16f3e0fe79249a78ea7f0b46ed78c176452548bb1b30029f0afddcb8cae";
+      sha256 = "0ab6422102620f7a2f8a3109e4a1ad7cefcba8692c3ab561cc218b71134fbe16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ta/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ta/firefox-150.0.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "146477087ba0896de262dd726b756fac1f1dddfda224ee217a7f29876236209c";
+      sha256 = "7e6b81fe4bf32f20d6d63b624cfbbdc4534ad39908b9057ee7ec18d90fa0f006";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/te/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/te/firefox-150.0.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "d77ba2802ba5f7fb932f63f278e73601b11619878bf7ae13acfa6916cdf19686";
+      sha256 = "5c66682d957e02c9f93eb248bdec5787a2397099b1ec63d5bfe62e15fee8a616";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/tg/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/tg/firefox-150.0.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "70339d076e2c5f430af37f59708dd51b8f4db5c1fdcd53de29dec99f1f46cff9";
+      sha256 = "6151d4822fb5085e2743ace099c3fb5b06b11b10e9aaf48cd100da19e452701e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/th/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/th/firefox-150.0.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "07667686c80f8d94a5429a9a24b666e478babb66bff8b7508a0c385a8850fafe";
+      sha256 = "de1cccee3e3f2734e011dde3aa4c564fefa43a493fa682b631c4f7a81c15260a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/tl/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/tl/firefox-150.0.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "9b82b93df9a8768831bab5d5dc9746e3b95fa9011eb365b67fd1a3996e74104f";
+      sha256 = "816f2620046c878db2f2d91ba859b8db6657dfab0f48bf12f9956247edb43ced";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/tr/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/tr/firefox-150.0.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "b595fe4b615f9b40d210e4ecc3baaad705b9060dcfdbfaa5bd6093503ca5feb8";
+      sha256 = "c3e21bed21f1d8ded7b8f67fb6a5b971aaedf982358cc2adaa1d22830cd3d4b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/trs/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/trs/firefox-150.0.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "ed01de73c7a77f850b0187ea20a7f5b9f8897d701510e0bbaf50ff3960299305";
+      sha256 = "2e34b768fb5ade0ded463a23278e779f726dc8a98ba50640b4c11d1dd9f439cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/uk/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/uk/firefox-150.0.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "d8af8ff2e70b9db81c1b53e8f3376c5e884ee917ff77370f097a8bdb7db2cc40";
+      sha256 = "2d3668f7dd2250b87d3568ea9a24fd9d56eece1087f0933bb41754f39f1d563e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/ur/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ur/firefox-150.0.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "730f9a84efb8b2c7ce173a659ee9e12edb9abd241067706ca7d6394531be2157";
+      sha256 = "f5b1c24d9d01ad2aa80d83312cb5a149bbb60aa08213ab53cafbb6c5c816055d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/uz/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/uz/firefox-150.0.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "c913c5730a42f084aa973e41ac2a05b4f1a93e625f5616be41c38fe1609e2bb9";
+      sha256 = "6185d107063cb3d37dd57b9931cbd7880c6119bf85c381aa90115fa2b4c69d6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/vi/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/vi/firefox-150.0.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "c76b6d0f2219538cb2195e08398dedd96935b2af78fd551a0494bf2df0aaafc2";
+      sha256 = "97a3ec310672fcb164205418b4a5d253a7e8b7c45798022233f4296c24f77e5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/xh/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/xh/firefox-150.0.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "e75b9b4fb0ae49fd9b5847a244a73b8465ff66d7c726d1f69d133fdd10085dc9";
+      sha256 = "04ff21fad2cbf864fe975706f955f98bed94a731aefa9c50e04804471ba961b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/zh-CN/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/zh-CN/firefox-150.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "15a34006972313c317d355d92b668f4d3e3b6bcd467e510fdf25240a8138898b";
+      sha256 = "b2c97b5d0b1c84fd75f52c7480b262c2f6ce9a951ad30f8ce6c985f6f78b91d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/linux-aarch64/zh-TW/firefox-149.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/zh-TW/firefox-150.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "49a3ac3bebd410a3fcd832911e5b7aa76273a7779ca25d7448b590b3eb49c317";
+      sha256 = "91ed18bc6d5d9d9422f07f51b0c2e5e231431facb2871d413b5da61cc4119fa6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ach/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ach/Firefox%20150.0.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "17458617c6225363376666de5f773ce0e996a66e7725ff1b8555c8c6123993b5";
+      sha256 = "e2f99ffde15698e329db9e7fc0ba6cf50179f5b4246b0af824c694e861c8859d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/af/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/af/Firefox%20150.0.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "bf13fa2de1f85d5d3b000449f67e92bde6c56e5f763e0ed3b17939e46d6ebdd8";
+      sha256 = "f36f2dd4c98d0cad0edd619c2e7aec22f7a86893f79407e96fd49b9b309f1a8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/an/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/an/Firefox%20150.0.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "a3e5b7383c5298a0527a300a50f24fe4df1b94f74c2e663e5fe5a217819a752f";
+      sha256 = "dfa35cf323f25d1eb7ee8e95fd4ce1a28d1201e1082af5782ee53a6e2831472f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ar/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ar/Firefox%20150.0.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "2fd7fd5d1145c47e9949f9e479dc00b980221cbd0a09882bf8ad59d744320128";
+      sha256 = "afeec7930073b35949ed52303b3efcb0874f7ece39c697f89aaa78d4c36bad82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ast/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ast/Firefox%20150.0.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "de5be8997fb4e8749f3f8c04f2e7767bc1a4e913bcd930ba3b93ea69893fdcf7";
+      sha256 = "59611ab660fd04204462ecd7c0f5378539cb32ea65ad9bf009837a52a79c742f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/az/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/az/Firefox%20150.0.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "8bd9bff878e7223ca9bffba1592d80ff6ae0b584b5402393f078db2178fb619b";
+      sha256 = "ad3573544a5856de13c62b2fe44351d6dd72f7d4a620492d6d5095fa495fca31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/be/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/be/Firefox%20150.0.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "2371584571ea965ec3b147af15ac8e91224809e42d41284dbd134d6a36c823ed";
+      sha256 = "2745f823e387caa1a511a0e4a9480ad00413eb97ca1ff775113f4f0cf4da4d15";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/bg/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/bg/Firefox%20150.0.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "8a6337a3b4ccb266470f15fa52611fd469d316256b0c6ae0322ec40fcf96bc01";
+      sha256 = "1566dfe0d417ea0b5fe474454f6ace8a30e673d61f940bb4e2f522e77ec21e64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/bn/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/bn/Firefox%20150.0.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "401b530b2101b38b2bd06fa17c25c9e038d70aee86aa42e2da8e509e32007ddf";
+      sha256 = "509e9b7f2a205bdc985413e963aca3d56e32fceff571e1d290fc47d218838b91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/br/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/br/Firefox%20150.0.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "f158c662da66d41b7a75c810a31cb4fa71b779f44813f49fe99dc8cff6258dbb";
+      sha256 = "3046278dcc38b3454e8946797669d742b845f435fbed655309205dca6d4bcfb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/bs/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/bs/Firefox%20150.0.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "556375a5e72e9bfa95454db2ee06be5d5cd344dc32d8c60f84d9f32d9a799ab9";
+      sha256 = "05e4a787bf8a8778035b9ada4a31fcf3bd03bb6178592ce47782baa7caa876ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ca-valencia/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ca-valencia/Firefox%20150.0.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "debfc27c246e0ceb7c20eb37ff344634d575915d35a06aebefa47d583b057b12";
+      sha256 = "913bcc960aebfb8bec9553308cb2e016bb9c1fe01a82f5440425480844f49717";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ca/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ca/Firefox%20150.0.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "408c5c150cb6a5977d46d878e70d1e5d71683fec0ad6d5c3242efc8b7353dca4";
+      sha256 = "a7efad433f593638bf2c8c9e72fb1f8bf57850ae2349638bbdec0c4180bbce3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/cak/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/cak/Firefox%20150.0.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "734f3688fcfc8c21827e1966b545d7b2c52d4575bfe87c3e9f83786c9c72911a";
+      sha256 = "318b0df6f127c4f064304f3b26a708592d1c47a03c61d20f66661eba747eb2b6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/cs/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/cs/Firefox%20150.0.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "ef85a1014e78d60006d341709827a35bd8a0702191630f73c88678a90851be15";
+      sha256 = "071bf4034d1e1a7a1dccb90bec227ee4789a58500db939990c984e823a3c73a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/cy/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/cy/Firefox%20150.0.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "04cd64e4dbdab63149a9cace466acc92a1ac78bd06beb4484dad669bf80784ad";
+      sha256 = "f62445587949d8e6d0ffbbc13d16be51be48b1bd1cbd947f05b7b73e94d1cbda";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/da/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/da/Firefox%20150.0.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "3c598a4f371ae5b86a396bbcafd3706a8b7f4604b678eae50dbe5617287f177b";
+      sha256 = "0bba3653fa7789ea14f51d16152fc9289b9a12ecb0a375da18fa2cbc738471c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/de/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/de/Firefox%20150.0.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "57acb06f41b93834199dc7a0711fc3919ea327b55c3d5856b774408fea50046e";
+      sha256 = "ab4a318fc950826e7e2d174c42c36f4d5f7311199dbebdc48ee5a0e0f8e2354d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/dsb/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/dsb/Firefox%20150.0.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "12c381cce912dc4069fc377a0a343b664445710ee8b8e9755a783eee15076cff";
+      sha256 = "2945d491b0aaf17f86e4b6e63a28d089246cb2cd0b0fa900cda1a73b1ed92837";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/el/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/el/Firefox%20150.0.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "8400c1760d435a87212a85548cbd7812d69833f03adbcb4703e1d027d8786d35";
+      sha256 = "3bcb364362142750d764812c2d86077cf87b592c4a72baccbb1a18e8de6c09c0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/en-CA/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/en-CA/Firefox%20150.0.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "90ad15659be49d6d8a4884c6c951dac3d6f668aa0e43bcc27ae44dcace698dda";
+      sha256 = "088bdd837a5771b4aed7686f2e847867a5a1534bbcb983eac6ffac954ec1c079";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/en-GB/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/en-GB/Firefox%20150.0.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "e4fec96ba9d5e899513e55199c3de77387833f2bc0ae593e6467ddcdb8dfd306";
+      sha256 = "59ce8018013a9a647c91bffa9c0637821524b677ceb78542b983d6bc88c41649";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/en-US/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/en-US/Firefox%20150.0.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "3c4f90c4d8e52ded2ab3c173323d57c9f2943b448d05cb68f938760bb56d524f";
+      sha256 = "203667ff6b0920f89973d477b1394d99b4b78807a613914c97bb1b3200e6da1b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/eo/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/eo/Firefox%20150.0.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "da848459fae17021589249f6d39c4d7d39ff5732ce4fe3572700b90b1c5deec3";
+      sha256 = "e6fec1759803d73fc22797cf99334f1eac4da522dbae4ec8b06abe6747880d34";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/es-AR/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-AR/Firefox%20150.0.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "2e19ade06bef4b08298b5346802d291a21121f44eac5a728cd35e791fe08935a";
+      sha256 = "8752226080d09bdc42bfd8b91ed7e694159401837b5aa3218fd595872d3dd926";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/es-CL/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-CL/Firefox%20150.0.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "0c8d9b31596b944983cbfde9fa6db894f8101f3efcecff25e9ccbeefbb85efcc";
+      sha256 = "406bfe67e7d92a3b365a314bfce1453c937d950cce47924eff577e924e28557c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/es-ES/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-ES/Firefox%20150.0.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "e3803389c75d884c11cfd4c0ea453b363e2a3e96c67c34a6603b78de4770e8ce";
+      sha256 = "0a14361560e5393d41f805bbcbac2dc24c3da16d218a18ca042d7913a552c679";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/es-MX/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-MX/Firefox%20150.0.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "8a0b78333eb98edaa6f947f616d5ef037e53152fbd0485e163be741f6fff4c0c";
+      sha256 = "4a6b627fc6804ed5a6fa4d797cf203690461d9cdb7faa6671ec11314114e867f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/et/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/et/Firefox%20150.0.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "dc9c52ba1101578895c5eb1cf5f928288dbc73ebb038544b1899299194a5bdac";
+      sha256 = "bd970085f5a9825ec8f4d96c9370a7b89a098f3812e8de27498ba497ea687499";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/eu/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/eu/Firefox%20150.0.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "af48ade7023f7bf28c401617127fc83959ee8dfd47e8815a50ba79e042b3fd00";
+      sha256 = "520f5732ca766b542c43e8fe520ce5b9e709b66b60d3cf71d36c5565a7f0a9f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/fa/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fa/Firefox%20150.0.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "a877c020de276a13278af602605eefac02f95c0e92c8258fe15c95c3fffdfdbe";
+      sha256 = "6d082bca5b04d9951d9bacc89b1b33f08758c695058a8adc3814c1a362f9520b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ff/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ff/Firefox%20150.0.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "0ee7906713ee776093901eb4746bf79eefe1df2ae2e0810fdbaf53742cbd5c4e";
+      sha256 = "16bb5c8740943579fdb32e82d5ff2b8498fde6251afd2778acfca74a8fe74b45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/fi/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fi/Firefox%20150.0.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "8e44d9f9a9dc7c3c676e35526226374f80c98bc1a6a5976143b58c4cf3f3dbb1";
+      sha256 = "4119a5949a8602cd3d472342f63b0d9aeb0707e509b07db6aca8ec01aae09220";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/fr/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fr/Firefox%20150.0.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "113dde158c2528e34a1c52ef96e69965e12d666b5914b0295e9d277e90faee00";
+      sha256 = "cdacb332809c8c1862ccb1623031a296357ba6a53d288403445be93ca319a62f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/fur/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fur/Firefox%20150.0.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "a715cbdb3dab942165f561513444edaf1ab8e8ac6a986870af1838593dc9dabc";
+      sha256 = "82f6933e7e04e434904d7e7bc473097200ef071b8c1f59456c0f9f01afa9bef9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/fy-NL/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fy-NL/Firefox%20150.0.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "7191bb2bbc26638c8a86ab5d8a7b36f2e99d49f5cf0fbdffb1a6d756b1b4e4db";
+      sha256 = "dfc61dba9a4cd772be21c656e04da55ff6eed85adfe38d7cd752d139de7d813e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ga-IE/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ga-IE/Firefox%20150.0.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "8924594c360ebc68a68d7fefb80710221db783edce0fc72017532a37c95279e8";
+      sha256 = "5ac1ec34a95244839f896b5d9e9f3b89b4276a5ef660880f7ccdf5466938dbfb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/gd/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gd/Firefox%20150.0.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "830557c158734e70e4c19a5dbc7e15757618a73bc7d1a8dfd969f97735b6d35e";
+      sha256 = "a5fe8008b3406793d673100d7d0ec6785a8c878015c11e9c064496547013c204";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/gl/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gl/Firefox%20150.0.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "b7564959fe6feb69749e5f81748d82f6b4ee90f6033f73aa2e797b52c94cf80f";
+      sha256 = "7a2fa34d2526f047b3649b480e0d5046a46a8fdbdfe05a393bcd3b513ec416d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/gn/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gn/Firefox%20150.0.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "6316e287c5974a052ffd2dfd789473f75316e47f4949501498e7c87169ad5930";
+      sha256 = "b6d7bc020d2551632c0063528a35bd9c71dceaf437703f25676663b34e5a9030";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/gu-IN/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gu-IN/Firefox%20150.0.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "ed4112472ca95520805b0a788259b60d30571c59ef13f6176f6b600aca0aae14";
+      sha256 = "deced77571f57a83661c4ebe430bb945ad5135a3137524bee7cdfb39c9837150";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/he/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/he/Firefox%20150.0.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "0e89db2578b9b27175b09f52b552907f44d323bf94f2fb34de513397b24945e7";
+      sha256 = "147b97dbe732977acbc792956f82cc954d5891ba22717a533fc429f3061c1a07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/hi-IN/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hi-IN/Firefox%20150.0.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "3f7c928c9dd1caffb3504dd368daade3c54fcdc14a10975484b50552f678740a";
+      sha256 = "2625dc7f5959adbc72391e20abd839f6f0bd12b1a0a9d6775e0d270dd43f5f03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/hr/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hr/Firefox%20150.0.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "2788dc0bb77fa461748d1d4648a1a98cc5302302cfc441046f0fd875e7363cb1";
+      sha256 = "7d1bcc51e2660c132fb880dc2678cc7c4342ec891177f25dc33206e1bf78182a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/hsb/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hsb/Firefox%20150.0.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "4b84658f914efbccfe8f930e419ad1654faddae02daf7ee7ddd1083383f14345";
+      sha256 = "b63fc4a6ce0bfb1af6d7698b0ecd0dedbb3f79b4cbb5b4037b04eaf566a41aab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/hu/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hu/Firefox%20150.0.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "478b013d7f867f25058f1a9c4d3d4b50f8f2b930905f3ac008f16f7c652a15a6";
+      sha256 = "48629e9ae8212e03f2d9aa7c6d9bfc531218db350076161ae99808b9abf9069f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/hy-AM/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hy-AM/Firefox%20150.0.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "b44702c2dd7e817f32a7d434489f1f0795a525ecc22b540d91e100660d71a3f8";
+      sha256 = "249bc6e8fa8e2a46e00d13552d0ea4be0117a608f8d2a70578cbd2372465da22";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ia/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ia/Firefox%20150.0.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "3c1caf4c17dc9a9cf24fee9e544ad43029a9d1d15e1e2444083705d687ce3100";
+      sha256 = "8f223ce9c7f32ca477bb9f1bc340e572ea2310f97ca0a04c02cbb811c17ec2b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/id/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/id/Firefox%20150.0.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "9431e6dda26af4262b70b80dffaa4c80e3d017d7bd66895be4280ba032108165";
+      sha256 = "bcb61e41d888ab6de6854086cbe1bbe3701a8709a48b84170264ab6576aebb73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/is/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/is/Firefox%20150.0.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "a7d33dbf78360b504bdc46e7b43bdbe09de735ee31d82a47834aa49f94cd2398";
+      sha256 = "79becad3d33edd9beb8ea1bf7dd20320b359020815fb41f07181a3e11c95fb20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/it/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/it/Firefox%20150.0.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "52fb87adef3276d6975a2b95017712b675ee3a592720b55f1c1b8a52c1e199ab";
+      sha256 = "6ef5871c8951a69ff4f013f6c69d360d613fa01563318b08d98f079b7070b461";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ja-JP-mac/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ja-JP-mac/Firefox%20150.0.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "62ed2d1ec4ba95c70932d530fb5bb900e40ea7cca7943f6ed85e29d706e0cf5c";
+      sha256 = "48d16cfd50ac3101e248c6c3a61d029a5573284bf47baea329427e7338b54685";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ka/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ka/Firefox%20150.0.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "0ac6bcf3cc43961d0d9139658a91e4393c2d94c1d20075d01504a7109b353705";
+      sha256 = "e0b956a354597d8f4e258f12193476bda64d3e3853528c9a28e3e3573abe64f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/kab/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/kab/Firefox%20150.0.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "d35c0502704d43f348cf8959237e830ba4e65243bcbd9d2f0e7a420856e66cb2";
+      sha256 = "975021e54d958973ed42c9f51067f083885534b44701c4f27d671bfbffd929b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/kk/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/kk/Firefox%20150.0.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "c5715dc85386553eb2428c05263001e86690d6f541b589b88e1ee2f0b6bd8d00";
+      sha256 = "832e6b87e2543d88ca3fa737e12cee984572eddba6dbd9a641a1452809259c84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/km/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/km/Firefox%20150.0.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "79d67bf1dab004140ec0f443c47e06c12d006a0329c3fee3a6020fa9c29f0e84";
+      sha256 = "bd9ebf1c384f0f50738eae6a2eea9fed6dc4f9044ac040a01acf6e9a7f7e6b85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/kn/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/kn/Firefox%20150.0.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "bdae4800346cb39ef25fdbc96fc262e54b92ca11b5c99c144c1271e9490a07a7";
+      sha256 = "2223200b5fd4e96bef71c619255e4431f0162782ce71f4dfc7e0969d6273be10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ko/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ko/Firefox%20150.0.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "307dbb2455208cc55c6e0ee467bfee681e4d4917b02c615ce0944bba0ba945ae";
+      sha256 = "78e4bf62066f0608a218baf53ab0eae7e0c9214f335e7cb1a38072afb567513d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/lij/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/lij/Firefox%20150.0.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "2ef684e1b06b1e918236e973ea033ae43ccf29849fd4dee961e1e29132da37d6";
+      sha256 = "ac4a69804ac2938a4756774180f0cf56d4587757cef872b8d825502d2f1965fb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/lt/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/lt/Firefox%20150.0.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "511321df070ad398340285376c7e6ea6f2e5a69cf6fffa13292f8f77d691809d";
+      sha256 = "60a74fcf7a1d7ba9f7eb1cd27360ec32c45016c9c0c9c70dd8d73ceb5fe1d994";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/lv/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/lv/Firefox%20150.0.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "cd1cd39573da46fd0d513788ab3cc2cca4d7a08f804d3ffa848c7ba354c462d6";
+      sha256 = "aadbaab1bd91fbd442b8827591250ef5cff9040c21fd97d4285ba5d81d4457d8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/mk/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/mk/Firefox%20150.0.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "18e1d16e36b79070de63c5707639a631bd716e7d866afabcecd3c606026f6b9a";
+      sha256 = "cee675f21a7d2ebf2f402270aee057ed8f0ce0092da12ae7cdd0fc85e3b18758";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/mr/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/mr/Firefox%20150.0.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "447d278b00fe53125241a3c5d6255fff8fe1ecb36a571545825d77076828c4c0";
+      sha256 = "8868a5d395347301c55c5f78f697a1bb52de47253b7245589f34fe464c9a1c40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ms/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ms/Firefox%20150.0.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "2c43f9348400f3a96faa61aafe6e6de2a5bb87aea6d615eb3c4af178540a49f1";
+      sha256 = "750bc64c2ab827826aed35b6da9cca647399e3294df2cf630f5cc636d5da61bf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/my/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/my/Firefox%20150.0.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "e371d65ebf9d91b69a5058f93d8abe15698df93372070bc19a5d1013de54134e";
+      sha256 = "038b6bcbb2721c70cfd33cdf879e83f8e5fb307c7c9cbec8ce907fb6e617730d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/nb-NO/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/nb-NO/Firefox%20150.0.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "ccaeb9afec6b7654b80fad8ac56c5f597afedf90835793067882157917c79518";
+      sha256 = "bc8935903eeea49bd45e8275f03e9e740c592e5a8169dce577dba14c1d1732a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ne-NP/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ne-NP/Firefox%20150.0.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "c2c6aa0d1711ae72a789b042310b87c8106e267b063024956148262c4870b319";
+      sha256 = "811c118292c752ad5fe1d1f253c47ed2d7f25c23d82eaaa4b20d19b5d0ced135";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/nl/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/nl/Firefox%20150.0.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "f593ef8ee7b2a2b117731c81dbf7e54a8921f3dd9d4dfcb916114ab98543cf3a";
+      sha256 = "41c818ea0b92df3e600c3c645f818645aa2e456f40734663fd9281b0732c4c51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/nn-NO/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/nn-NO/Firefox%20150.0.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "e503702b7d13dd94fcb32fc23e63ea94cdb74ff0a34ef2103cda74c26936642d";
+      sha256 = "3184e233f39b648dd7580262ef66591180a92ce9e1596989f195ab5e4e2cda61";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/oc/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/oc/Firefox%20150.0.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "5aa3e7639db665021ea0f438fe248870ef9c74b2b7f7bf10e47a0c826a738f4d";
+      sha256 = "c53ccceb610e24be9130fdbf4f603d7010a9dac35e5d914842ea4f676ddc3e74";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/pa-IN/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pa-IN/Firefox%20150.0.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "e9eca004c9ffb34d100da9cc20958c03d1a46eac6e599890d8b7f7cb2b9d85f0";
+      sha256 = "0b99e9868f1a8881fddc1cba7e22ed997edc2df4d719a3dc5641cbcab0def7ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/pl/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pl/Firefox%20150.0.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "9d6594eb2bb66586c22549d59f5db55b5f6279a4d3b5bf081dd8629f11af16cb";
+      sha256 = "02d38b35d439946e1cc06e341b82206a36face5a98d699ef4d525aa43ceb782a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/pt-BR/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pt-BR/Firefox%20150.0.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "0eb9e5126674e8050f5e17362d06a28fe8736ed8f2d512206557bdacc370afe3";
+      sha256 = "ee872bc7eccb06694ebb40dac937c56968b25a33d11ffffe9b1792fb304dc4f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/pt-PT/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pt-PT/Firefox%20150.0.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "ca26005a77491953bdc7ec7928f3178815f67ddf6ad6292ec6a7d8efdc351322";
+      sha256 = "8d44bb2dd36833035935bb29fd2006da070dd61b3017e1db3da950908eeeabfb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/rm/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/rm/Firefox%20150.0.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "7093779b74769b1730a873d887e12faab722d10e93fd0a17d2e3b7543516be87";
+      sha256 = "ecec9f55bfd0f42466eab33a9dacfa936188e82418a38ad41becf76ec26f4190";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ro/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ro/Firefox%20150.0.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "568070d89a2a0554da44fafee975886c4c082206e04cc690ca101362734992b2";
+      sha256 = "e6ca0b18792b55afd20aba6014cd2678fc091d6e772760a2ff14e2d39e1f6ab3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ru/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ru/Firefox%20150.0.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "d63292b9119faf59578599c6280133feafef1830857b777501e2b38b0f71d730";
+      sha256 = "f009ae9bfd40cb6cf6a52ea952cd63c363acd1133fa80bb2536aff48412709fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sat/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sat/Firefox%20150.0.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "ec0b0068818987c5347ea3d9a067da75d133d200fe21eae63a542c9082b5e14e";
+      sha256 = "c6e6eed4908b8ee44d8c9d5726c93b19ed6a4c9d931b4a9caae9de842ff899b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sc/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sc/Firefox%20150.0.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "dd2243fe40ce6433273f9831a787882d9f20893fd7aa6e032839ddc5380546d5";
+      sha256 = "451744f61ac1bfd93fd3faf09f7a7570ee828a70191ab5290717cc28ae1e2c37";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sco/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sco/Firefox%20150.0.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "ee678e23150f6ddb20d868c7c832ee5f59463d604c4ea33c60c0df7d28860ddd";
+      sha256 = "3f7dd6d01c68ca4cae050e44ede5b870341e66e5ff90156ff9ab083edb5605cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/si/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/si/Firefox%20150.0.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "dfe5b4b143cbf1c55ac5db17f78864274882416c089035b20a4f126bc22ebf96";
+      sha256 = "ddab892764e2019cfe657a794188808f6167bff7c32357a671a057aa0dc63e8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sk/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sk/Firefox%20150.0.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "870076b37afe4ee7876801704678d57f6f00622932b5997908ba16edfcbbbd36";
+      sha256 = "afccb64c6be439428912bb49f880c3491bd8666cfecd7ad26fcd2d410fdf1a24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/skr/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/skr/Firefox%20150.0.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "f223485dd713ccd6e2ee5006ae9167fde722441c40292381628844dd5ed796b6";
+      sha256 = "e765f6c3844f21111f249a79610837d56237b99419bba3ee17c9b145ec35d396";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sl/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sl/Firefox%20150.0.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "d5951f27f4c9d1564331ee9be099f94acc2a31a304e7d9c8bcd9b40465592e50";
+      sha256 = "f621e3fd3e525d52758a4f43537176e740e1fd90207da8eab0215fecb01600d5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/son/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/son/Firefox%20150.0.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "7acffca79e8d45c06b74134eade5af48e523ba04c780439b0631291abade95f7";
+      sha256 = "b2ae31affc04473ee6174b7cb08d49bda96e968d2918e363ea9c3ecdcdfcc420";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sq/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sq/Firefox%20150.0.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "4e2039176fc6fd9155220c86348f6825f3ca9d2da6fd66146f5452d87f677ed6";
+      sha256 = "5d921780265bf24a565fee901b2c41aecedc87ad53f7410dd14265c5cae9fb9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sr/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sr/Firefox%20150.0.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "8fe5d0dad4918ca5e1c7dc45ad500b7a10be7a3d6c4b2fb93bea923ededc8ddc";
+      sha256 = "8c867b4e486d8b9753b4201f8a939c31710fc6bb315eacc5a079d89f2626d4ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/sv-SE/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sv-SE/Firefox%20150.0.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "708620552991829c81a13ab2f71cf4f2b0daa0eec9ef7e1f7ddf0f71db015920";
+      sha256 = "c70e230922d4ae6ae8f4ab5e73d4b38a11c74c6fccb14782d58ba19ae1bd5e4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/szl/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/szl/Firefox%20150.0.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "fe71a57e63fe57337ca52e973944cef4686e106b9dae6983ff009c1b1c90c27b";
+      sha256 = "3b33c959100bf3856ed18c3985e39fc044376c1eb8d96a8313a3813468810574";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ta/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ta/Firefox%20150.0.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "4ec31cf605fcbe4f9440000f14247bede9dab17a3850d4f023090f0cae42c9c5";
+      sha256 = "db395f1b99caa216113dbc504a109c4e4b8c59e644d7652c54064aced8bd4735";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/te/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/te/Firefox%20150.0.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "77ebdd18be9680ec5642df5d113b8569a51b33ab831e0e4463984358ff27e8fd";
+      sha256 = "800c86a587c6414d0e102d92dcd2e9e41919c6ce6fccc9a63cf0e02edf72b2d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/tg/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/tg/Firefox%20150.0.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "3fe67b7101ef95dcb6a8fb5620a1de9c69ce142830ccb0f3c217c376cfe3ff12";
+      sha256 = "756a3e76cdba1e34455b7ac3c637020232f7099918b804bce489258d0a621dfe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/th/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/th/Firefox%20150.0.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "d40026556974703ac4416af86a60200eca370695f9fe2c2512a6253c6ebaa2d8";
+      sha256 = "dad99883df22810004a23231b3c0bf261742de0ae8300a5a347334c295c59303";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/tl/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/tl/Firefox%20150.0.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "d8d37b5664f7298579e030f06451a2903198a6d4b214db0aa58c19a03c43d5fc";
+      sha256 = "afc55a8ec60c36b98d4729a99567af1e9174088c9e886b8c1699395ef94840f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/tr/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/tr/Firefox%20150.0.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "849f7044a82bfb91b9e7176c010c2390d0739ddd9719128da75e794daba7cd77";
+      sha256 = "567a203a8372b78ee0b8d1a8a2ae38834bd5bc33ff0c75a547dd3d766588c6e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/trs/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/trs/Firefox%20150.0.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "d199b9b43bd5fd419a0bb25cddf01902f27b303a01fa14c6081a04bd2434bdaf";
+      sha256 = "7fbb43a8fc8830a3de6618c36861cd4ae31263df065663be4b3de78720911636";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/uk/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/uk/Firefox%20150.0.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "109ce1cacd861d1bb9e6f16c2ec168a2fbc505926ad4afe72f0c5f257459c355";
+      sha256 = "a1e99a73327e9cc5dc910a85f859d4a8d17ee56db837926195432832936bf338";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/ur/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ur/Firefox%20150.0.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "cd4a29cf182344ab765c26639564eb2c362ef00ad46c5c28e999054058cd6c36";
+      sha256 = "dea1ca0d4db9cf690a0fc0cd09e54d61c3348331edb6b53708993ce7c9c33c41";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/uz/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/uz/Firefox%20150.0.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "fe7514078842333b9bb07b704bc250d5bbe030db84dc1b28cc2ce70bc65291d9";
+      sha256 = "1a711465583bec0d94dad20da45d3c78b068b117bfa5602e3b69dc9c6da25a96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/vi/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/vi/Firefox%20150.0.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "2b36dea774e92328d1d4eadb51eea8cc2db8b510d15adab0ab4afed95cababfd";
+      sha256 = "22c6a53d890f66b01e47965f9ce9a0db22c71c0d722ad336bcf5dce930a4600d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/xh/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/xh/Firefox%20150.0.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "dac74d35bfeb606e535a178bc8cb5431d4ac5f3fc457a5f6a688f119bbcf831c";
+      sha256 = "253552c147b314f419c6a7ada0512e357b91b69331f817709d57849d543acffb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/zh-CN/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/zh-CN/Firefox%20150.0.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "514c3fe4d728f64bf53bb612521d81d8ea75f558a8cf7ae4b3da07f1558b7681";
+      sha256 = "858c6f75ed5c40e062dac3267d2e7b559af6f0618206a1f9b3be841bee6f4882";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/149.0.2/mac/zh-TW/Firefox%20149.0.2.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/zh-TW/Firefox%20150.0.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "9d2c88564d5ef81285e8465eb18b11ea4ca7f3d853da6bc1159386e57c0057d2";
+      sha256 = "45360816b33a3e30eac95e845e9aa5bcb9f012f19fbae2aca3a8b80b74c2d4ae";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-140.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-140.nix
@@ -9,15 +9,15 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "140.9.1esr";
+  version = "140.10.0esr";
   applicationName = "Firefox ESR";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "119a4e4e536fd4534adcc4a546a988e553285f9326bf16e9771854ec2dc7d039a729aedc5925623e172260a5e154172c56a011f131068736eb2a89a8de611840";
+    sha512 = "56b274df21d0a908e826af6dda89a42b77fb0f597b75542b0330d448ae22be07a3636a3187ff1b488e466cc8c5264a8a75f79901354a49e35a3e99dcb0852514";
   };
 
   meta = {
-    changelog = "https://www.mozilla.org/en-US/firefox/${lib.removeSuffix "esr" version}/releasenotes/";
+    changelog = "https://www.firefox.com/en-US/firefox/${lib.removeSuffix "esr" version}/releasenotes/";
     description = "Web browser built from Firefox source tree";
     homepage = "http://www.mozilla.com/en-US/firefox/";
     maintainers = with lib.maintainers; [ hexa ];

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,14 +9,14 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "149.0.2";
+  version = "150.0";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "844a46ee068ecdc66b7227d089a057ad3f4945114fea2cb280d5e2a383d0a022fc6628ad57c068ea34cf159472f63c50ea7ed128bc11a0b27f16bb7b67d7f3cf";
+    sha512 = "77e8eae86e7b17c33933fdea6d3b5fbe73e6613949e62c13d9ed3e593e7ba0b50701fa97fc7d56a278961d2e1cdb2902244c30a1020790091b0ae2f0cb1b4e71";
   };
 
   meta = {
-    changelog = "https://www.mozilla.org/en-US/firefox/${version}/releasenotes/";
+    changelog = "https://www.firefox.com/en-US/firefox/${version}/releasenotes/";
     description = "Web browser built from Firefox source tree";
     homepage = "http://www.mozilla.com/en-US/firefox/";
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/150.0/releasenotes/
https://www.firefox.com/en-US/firefox/140.10.0/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
