### PR TITLE
irpf: 2026-1.0 -> 2026-1.1

### DIFF
--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -14,9 +14,6 @@
 let
   # The officially recommended version is Java 17
   java = jdk17;
-
-  # It's not clear yet if this version follows the app version, further updates will probably solve this question
-  pgd-updater-version = "1.0.0";
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
@@ -59,7 +56,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     cp --no-preserve=mode -r help lib lib-modulos "$BASEDIR"
 
-    install -Dm644 irpf.jar Leia-me.htm offline.png online.png pgd-updater-${pgd-updater-version}.jar "$BASEDIR"
+    install -Dm644 irpf.jar Leia-me.htm offline.png online.png pgd-updater-*.*.*.jar "$BASEDIR"
 
     # make xdg-open overrideable at runtime
     makeWrapper ${lib.getExe java} $out/bin/irpf \

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -17,7 +17,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
-  version = "2026-1.0";
+  version = "2026-1.1";
 
   # https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
   # Para outros sistemas operacionais -> Multi
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     in
     fetchzip {
       url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${finalAttrs.version}.zip";
-      hash = "sha256-hePdoDbFPOMjdSzsJqZWyFhHX138bMuocwCNpdOEkKA=";
+      hash = "sha256-/UB8mWB3yaT+mDa3mqGm2ULqDdNcmQu+cHKNdKQa/ug=";
     };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
