### PR TITLE
python3Packages.django-health-check: 3.20.8 -> 4.4.1; add optional-dependencies

### DIFF
--- a/pkgs/development/python-modules/django-health-check/default.nix
+++ b/pkgs/development/python-modules/django-health-check/default.nix
@@ -1,32 +1,29 @@
 {
   lib,
-  boto3,
+  stdenv,
   buildPythonPackage,
-  celery,
-  django-storages,
-  django,
   fetchFromGitHub,
   flit-core,
   flit-scm,
-  gitMinimal,
-  mock,
   pytest-cov-stub,
   pytest-django,
   pytestCheckHook,
-  redis,
-  sphinx,
+  psutil,
+  dnspython,
+  pytest-asyncio,
+  libredirect,
 }:
 
 buildPythonPackage rec {
   pname = "django-health-check";
-  version = "3.20.8";
+  version = "4.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "KristianOellegaard";
+    owner = "codingjoe";
     repo = "django-health-check";
     tag = version;
-    hash = "sha256-voB3shugfM/nO0vPd9yA4NOUB+E9aVcFnqG1mtfRYFc=";
+    hash = "sha256-XHautU7asnlm5Pxddf9+UD20v75rbc9Uo7hLjDYt/SU=";
   };
 
   build-system = [
@@ -34,35 +31,42 @@ buildPythonPackage rec {
     flit-scm
   ];
 
-  buildInputs = [
-    sphinx
-    django
+  dependencies = [
+    dnspython
   ];
 
-  nativeBuildInputs = [ gitMinimal ];
-
   nativeCheckInputs = [
-    boto3
-    django-storages
     pytest-cov-stub
     pytest-django
     pytestCheckHook
-    mock
-    celery
-    redis
+    psutil
+    pytest-asyncio
+    libredirect.hook
   ];
 
   disabledTests = [
-    # commandline output mismatch
-    "test_command_with_non_existence_subset"
+    # require online DNS resolution
+    "test_run_check__dns_working"
+    "test_check_status__nonexistent_hostname"
+    "test_check_status__no_answer"
   ];
 
   pythonImportsCheck = [ "health_check" ];
 
+  preCheck = lib.optionalString stdenv.hostPlatform.isLinux ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/resolv.conf=$(realpath resolv.conf)
+  '';
+
+  preInstallCheck = ''
+    export PYTHONPATH=$PWD:$PYTHONPATH
+    export DJANGO_SETTINGS_MODULE=tests.testapp.settings
+  '';
+
   meta = {
     description = "Pluggable app that runs a full check on the deployment";
-    homepage = "https://github.com/KristianOellegaard/django-health-check";
-    changelog = "https://github.com/revsys/django-health-check/releases/tag/${src.tag}";
+    homepage = "https://github.com/codingjoe/django-health-check";
+    changelog = "https://github.com/codingjoe/django-health-check/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onny ];
   };

--- a/pkgs/development/python-modules/django-health-check/default.nix
+++ b/pkgs/development/python-modules/django-health-check/default.nix
@@ -87,6 +87,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/codingjoe/django-health-check";
     changelog = "https://github.com/codingjoe/django-health-check/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ onny ];
+    maintainers = with lib.maintainers; [
+      onny
+      dav-wolff
+    ];
   };
 }

--- a/pkgs/development/python-modules/django-health-check/default.nix
+++ b/pkgs/development/python-modules/django-health-check/default.nix
@@ -2,16 +2,22 @@
   lib,
   stdenv,
   buildPythonPackage,
+  celery,
   fetchFromGitHub,
   flit-core,
   flit-scm,
   pytest-cov-stub,
   pytest-django,
   pytestCheckHook,
+  redis,
   psutil,
   dnspython,
   pytest-asyncio,
   libredirect,
+  confluent-kafka,
+  aio-pika,
+  httpx,
+  feedparser,
 }:
 
 buildPythonPackage rec {
@@ -34,6 +40,19 @@ buildPythonPackage rec {
   dependencies = [
     dnspython
   ];
+
+  optional-dependencies = {
+    psutil = [ psutil ];
+    celery = [ celery ];
+    kafka = [ confluent-kafka ];
+    rabbitmq = [ aio-pika ];
+    redis = [ redis ];
+    rss = [
+      httpx
+      feedparser
+    ];
+    atlassian = [ httpx ];
+  };
 
   nativeCheckInputs = [
     pytest-cov-stub

--- a/pkgs/development/python-modules/django-health-check/default.nix
+++ b/pkgs/development/python-modules/django-health-check/default.nix
@@ -1,32 +1,29 @@
 {
   lib,
-  boto3,
+  stdenv,
   buildPythonPackage,
-  celery,
-  django-storages,
-  django,
   fetchFromGitHub,
   flit-core,
   flit-scm,
-  gitMinimal,
-  mock,
   pytest-cov-stub,
   pytest-django,
   pytestCheckHook,
-  redis,
-  sphinx,
+  psutil,
+  dnspython,
+  pytest-asyncio,
+  libredirect,
 }:
 
 buildPythonPackage rec {
   pname = "django-health-check";
-  version = "3.20.8";
+  version = "4.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "KristianOellegaard";
+    owner = "codingjoe";
     repo = "django-health-check";
     tag = version;
-    hash = "sha256-voB3shugfM/nO0vPd9yA4NOUB+E9aVcFnqG1mtfRYFc=";
+    hash = "sha256-ijlkgE1ZxlBPUadTeZcwIKYocZo51ZidQyQqFHOnEv4=";
   };
 
   build-system = [
@@ -34,35 +31,50 @@ buildPythonPackage rec {
     flit-scm
   ];
 
-  buildInputs = [
-    sphinx
-    django
+  dependencies = [
+    dnspython
   ];
 
-  nativeBuildInputs = [ gitMinimal ];
-
   nativeCheckInputs = [
-    boto3
-    django-storages
     pytest-cov-stub
     pytest-django
     pytestCheckHook
-    mock
-    celery
-    redis
+    psutil
+    pytest-asyncio
+    libredirect.hook
   ];
 
   disabledTests = [
-    # commandline output mismatch
-    "test_command_with_non_existence_subset"
+    # require online DNS resolution
+    "test_run_check__dns_working"
+    "test_check_status__nonexistent_hostname"
+    "test_check_status__no_answer"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # sensors_temperatures is not available on darwin: https://psutil.readthedocs.io/stable/index.html#psutil.sensors_temperatures
+    "TestTemperature"
+    # some metrics aren't available on darwin: https://psutil.readthedocs.io/stable/index.html#psutil.virtual_memory
+    "TestMemory"
+    # live_server not working on darwin
+    "TestHealthCheckCommand"
   ];
 
   pythonImportsCheck = [ "health_check" ];
 
+  preCheck = ''
+    echo "nameserver 127.0.0.1" > resolv.conf
+    export NIX_REDIRECTS=/etc/resolv.conf=$(realpath resolv.conf)
+  '';
+
+  preInstallCheck = ''
+    export PYTHONPATH=$PWD:$PYTHONPATH
+    export DJANGO_SETTINGS_MODULE=tests.testapp.settings
+  '';
+
   meta = {
     description = "Pluggable app that runs a full check on the deployment";
-    homepage = "https://github.com/KristianOellegaard/django-health-check";
-    changelog = "https://github.com/revsys/django-health-check/releases/tag/${src.tag}";
+    homepage = "https://github.com/codingjoe/django-health-check";
+    changelog = "https://github.com/codingjoe/django-health-check/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onny ];
   };

--- a/pkgs/development/python-modules/django-health-check/default.nix
+++ b/pkgs/development/python-modules/django-health-check/default.nix
@@ -95,6 +95,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/codingjoe/django-health-check";
     changelog = "https://github.com/codingjoe/django-health-check/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ onny ];
+    maintainers = with lib.maintainers; [
+      onny
+      dav-wolff
+    ];
   };
 }


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/509938
Changelog: https://github.com/codingjoe/django-health-check/releases

I changed the github link to reflect what is linked on pypi (https://pypi.org/project/django-health-check/).  
Both of the previous links (https://github.com/KristianOellegaard/django-health-check & https://github.com/revsys/django-health-check) redirect to this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
