### PR TITLE
debian-devscripts: Add missing dependencies

### DIFF
--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -20,6 +20,8 @@
   help2man,
   nix-update-script,
   sendmailPath ? "/run/wrappers/bin/sendmail",
+  coreutils,
+  util-linux,
 }:
 
 let
@@ -49,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
+    substituteInPlace scripts/annotate-output.sh \
+      --replace-fail '/usr/bin/printf' '${lib.getExe' coreutils "printf"}'
     substituteInPlace scripts/debrebuild.pl \
       --replace-fail "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
     patchShebangs scripts
@@ -63,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     pkg-config
+    python3Packages.wrapPython
   ];
 
   buildInputs = [
@@ -92,7 +97,18 @@ stdenv.mkDerivation (finalAttrs: {
     FileDirList
     FileTouch
     IOString
+    StringShellQuote
+    YAMLLibYAML
   ]);
+
+  pythonPath = with python3Packages; [
+    junit-xml
+    magic
+    python-apt
+    python-debian
+    requests
+    unidiff
+  ];
 
   preConfigure = ''
     export PERL5LIB="$PERL5LIB''${PERL5LIB:+:}${dpkg}";
@@ -123,17 +139,29 @@ stdenv.mkDerivation (finalAttrs: {
     "PERLMOD_DIR=/share/devscripts"
   ];
 
-  postInstall = ''
+  preFixup = ''
+    buildPythonPath "$out ''${pythonPath[*]}"
+    patchPythonScript "$out/bin/deb-check-file-conflicts"
+    patchPythonScript "$out/bin/deb-janitor"
+    patchPythonScript "$out/bin/debbisect"
+    patchPythonScript "$out/bin/debdiff-apply"
+    patchPythonScript "$out/bin/debftbfs"
+    patchPythonScript "$out/bin/debootsnap"
+    patchPythonScript "$out/bin/reproducible-check"
+    patchPythonScript "$out/bin/sadt"
+    patchPythonScript "$out/bin/suspicious-source"
+    patchPythonScript "$out/bin/wrap-and-sort"
     sed -re 's@(^|[ !`"])/bin/bash@\1${stdenv.shell}@g' -i "$out/bin"/*
-    for i in "$out/bin"/*; do
-      wrapProgram "$i" \
+    ln -s debchange $out/bin/dch
+    ln -s deb2apptainer $out/bin/deb2singularity
+    ln -s pts-subscribe $out/bin/pts-unsubscribe
+    mv "$out/bin" "$out/.bin-wrapped"
+    for i in "$out/.bin-wrapped"/*; do
+      makeWrapper "$i" "$out/bin/''${i#$out/.bin-wrapped/}" \
         --prefix PERL5LIB : "$PERL5LIB" \
         --prefix PERL5LIB : "$out/share/devscripts" \
-        --prefix PYTHONPATH : "$out/${python.sitePackages}" \
-        --prefix PATH : "${dpkg}/bin"
+        --prefix PATH : "${curl}/bin:${dpkg}/bin:${gnupg}/bin:${util-linux}/bin"
     done
-    ln -s debchange $out/bin/dch
-    ln -s pts-subscribe $out/bin/pts-unsubscribe
   '';
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -20,6 +20,7 @@
   help2man,
   nix-update-script,
   sendmailPath ? "/run/wrappers/bin/sendmail",
+  runCommand,
   coreutils,
   util-linux,
 }:
@@ -176,6 +177,105 @@ stdenv.mkDerivation (finalAttrs: {
       "^v([0-9.]+)$"
     ];
   };
+
+  passthru.tests.helpVersion =
+    runCommand "debian-devscripts-test-help-version"
+      {
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+      }
+      ''
+        export HOME=/tmp
+
+        for cmd in ${finalAttrs.finalPackage}/bin/*; do
+            echo "Running $cmd"
+
+            case "''${cmd##*/}" in
+
+            # Fails with an error from python-apt
+            debootsnap | \
+            mk-origtargz | \
+            reproducible-check)
+                ! output=$("$cmd" --help 2>&1)
+                case "$output" in
+                *'
+        apt_pkg.Error: E:Unable to determine a suitable packaging system type')
+                    ;;
+                *)
+                    "$cmd" --help
+                    ;;
+                esac
+                ! "$cmd" --version
+                ;;
+
+            # Supports neither -h, --help, nor --version
+            add-patch | \
+            archpath | \
+            debrsign | \
+            dscextract | \
+            edit-patch | \
+            list-unreleased | \
+            namecheck | \
+            salsa | \
+            svnpath)
+                ! "$cmd" -h
+                ! "$cmd" --help
+                ! "$cmd" --version
+                ;;
+
+            # Supports -h but neither --help nor --version
+            deb2apptainer | \
+            deb2docker | \
+            deb2singularity)
+               "$cmd" -h
+               ! "$cmd" --help
+               ! "$cmd" --version
+               ;;
+
+            # Supports --help but not --version
+            annotate-output | \
+            dd-list | \
+            deb-check-file-conflicts | \
+            deb-janitor | \
+            debbisect | \
+            debcheckout | \
+            debdiff-apply | \
+            debftbfs | \
+            debrebuild | \
+            debrepro | \
+            hardening-check | \
+            ltnu | \
+            origtargz | \
+            sadt | \
+            suspicious-source | \
+            who-permits-upload | \
+            wrap-and-sort)
+                "$cmd" --help
+                ! "$cmd" --version
+                ;;
+
+            # Everything else supports --help and --version
+            *)
+                "$cmd" --help
+                output=$("$cmd" --version)
+                case "$output" in
+                *'version ${finalAttrs.version}
+        '* | *'version ${finalAttrs.version}.
+        '* | *'version
+        ${finalAttrs.version} '* | *'v. ${finalAttrs.version}
+        '* | *'devscripts ${finalAttrs.version}.'* | *'(devscripts ${finalAttrs.version})'*)
+                    ;;
+                *)
+                    echo "$cmd --version did not output the expected version ${finalAttrs.version}:" >&2
+                    "$cmd" --version
+                    false
+                esac
+                ;;
+
+            esac
+        done
+
+        : >"$out"
+      '';
 
   meta = {
     description = "Debian package maintenance scripts";

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -48,6 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/Debian/devscripts/pull/2/commits/c6a018e0ef50a1b0cb4962a2f96dae7c6f21f1d4.patch";
       hash = "sha256-UpS239JiAM1IYxNuJLdILq2h0xlR5t0Tzhj47xiMHww=";
     })
+    # Write to stdout and exit 0 for --help, --version
+    # https://salsa.debian.org/debian/devscripts/-/merge_requests/637
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/devscripts/-/commit/dbb258ea17749e2d102d4d181fe2709bda5584e7.patch";
+      hash = "sha256-+/E1UhxKk4PYD1bO1kI0qjfBpcMoFbo3xiY45IQ/FWU=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -195,16 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
             debootsnap | \
             mk-origtargz | \
             reproducible-check)
-                ! output=$("$cmd" --help 2>&1)
-                case "$output" in
-                *'
-        apt_pkg.Error: E:Unable to determine a suitable packaging system type')
-                    ;;
-                *)
-                    "$cmd" --help
-                    ;;
-                esac
-                ! "$cmd" --version
                 ;;
 
             # Supports neither -h, --help, nor --version
@@ -217,9 +207,6 @@ stdenv.mkDerivation (finalAttrs: {
             namecheck | \
             salsa | \
             svnpath)
-                ! "$cmd" -h
-                ! "$cmd" --help
-                ! "$cmd" --version
                 ;;
 
             # Supports -h but neither --help nor --version
@@ -227,8 +214,6 @@ stdenv.mkDerivation (finalAttrs: {
             deb2docker | \
             deb2singularity)
                "$cmd" -h
-               ! "$cmd" --help
-               ! "$cmd" --version
                ;;
 
             # Supports --help but not --version
@@ -250,7 +235,6 @@ stdenv.mkDerivation (finalAttrs: {
             who-permits-upload | \
             wrap-and-sort)
                 "$cmd" --help
-                ! "$cmd" --version
                 ;;
 
             # Everything else supports --help and --version


### PR DESCRIPTION
Fix many problems like this, and add a test to catch them more easily in the future:

```console
$ uscan --help
Can't locate YAML/XS.pm in @INC (you may need to install the YAML::XS module) (@INC entries checked: /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/share/devscripts /nix/store/44rkdj2i577vnqagmvmdfs7q1ynf0svd-dpkg-1.23.7/lib/perl5/site_perl /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/site_perl/5.42.0 /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/site_perl /nix/store/0zy7ij0s1w0pj5hcvzgxlzcfyp7gaqxn-perl5.42.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/0zy7ij0s1w0pj5hcvzgxlzcfyp7gaqxn-perl5.42.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl/5.42.0 /nix/store/0zy7ij0s1w0pj5hcvzgxlzcfyp7gaqxn-perl5.42.0-Crypt-SSLeay-0.73_06/lib/perl5/site_perl /nix/store/dp4rcklvmch783hvsxc1g9dwzgvnib0d-perl5.42.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/dp4rcklvmch783hvsxc1g9dwzgvnib0d-perl5.42.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl/5.42.0 /nix/store/dp4rcklvmch783hvsxc1g9dwzgvnib0d-perl5.42.0-Bytes-Random-Secure-0.29/lib/perl5/site_perl /nix/store/0sm05q0vfqv8g26syk9f1p9fhfp2pzfi-perl5.42.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/0sm05q0vfqv8g26syk9f1p9fhfp2pzfi-perl5.42.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl/5.42.0 /nix/store/0sm05q0vfqv8g26syk9f1p9fhfp2pzfi-perl5.42.0-Crypt-Random-Seed-0.03/lib/perl5/site_perl /nix/store/fziqk7757v2pbpw43yddp2sbzmp8rdms-perl5.42.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/fziqk7757v2pbpw43yddp2sbzmp8rdms-perl5.42.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl/5.42.0 /nix/store/fziqk7757v2pbpw43yddp2sbzmp8rdms-perl5.42.0-Crypt-Random-TESHA2-0.01/lib/perl5/site_perl /nix/store/4apvr044zkzrlgd2njfmhwnm137h5grc-perl5.42.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/4apvr044zkzrlgd2njfmhwnm137h5grc-perl5.42.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl/5.42.0 /nix/store/4apvr044zkzrlgd2njfmhwnm137h5grc-perl5.42.0-Math-Random-ISAAC-1.004/lib/perl5/site_perl /nix/store/qfqb79y0lx039dzwr2sj6w4c0gmxy41d-perl5.42.0-LWP-Protocol-https-6.11/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/qfqb79y0lx039dzwr2sj6w4c0gmxy41d-perl5.42.0-LWP-Protocol-https-6.11/lib/perl5/site_perl/5.42.0 /nix/store/qfqb79y0lx039dzwr2sj6w4c0gmxy41d-perl5.42.0-LWP-Protocol-https-6.11/lib/perl5/site_perl /nix/store/zw83cdwazlgyin27sxp6b7r4pkrvzxyf-perl5.42.0-IO-Socket-SSL-2.083/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/zw83cdwazlgyin27sxp6b7r4pkrvzxyf-perl5.42.0-IO-Socket-SSL-2.083/lib/perl5/site_perl/5.42.0 /nix/store/zw83cdwazlgyin27sxp6b7r4pkrvzxyf-perl5.42.0-IO-Socket-SSL-2.083/lib/perl5/site_perl /nix/store/82si3xnlrcpmpvrcv8ladpaka7yry52p-perl5.42.0-Mozilla-CA-20230821/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/82si3xnlrcpmpvrcv8ladpaka7yry52p-perl5.42.0-Mozilla-CA-20230821/lib/perl5/site_perl/5.42.0 /nix/store/82si3xnlrcpmpvrcv8ladpaka7yry52p-perl5.42.0-Mozilla-CA-20230821/lib/perl5/site_perl /nix/store/rmxa83whbaf8i8wyaa5gw8ii4ygkdg1r-perl5.42.0-Net-SSLeay-1.92/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/rmxa83whbaf8i8wyaa5gw8ii4ygkdg1r-perl5.42.0-Net-SSLeay-1.92/lib/perl5/site_perl/5.42.0 /nix/store/rmxa83whbaf8i8wyaa5gw8ii4ygkdg1r-perl5.42.0-Net-SSLeay-1.92/lib/perl5/site_perl /nix/store/xq5xj979jbifdbnck57nci15xjmx08ny-perl5.42.0-libwww-perl-6.72/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/xq5xj979jbifdbnck57nci15xjmx08ny-perl5.42.0-libwww-perl-6.72/lib/perl5/site_perl/5.42.0 /nix/store/xq5xj979jbifdbnck57nci15xjmx08ny-perl5.42.0-libwww-perl-6.72/lib/perl5/site_perl /nix/store/z4a5wck37pjm6wjsdczgq50vgbx05lv3-perl5.42.0-File-Listing-6.16/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/z4a5wck37pjm6wjsdczgq50vgbx05lv3-perl5.42.0-File-Listing-6.16/lib/perl5/site_perl/5.42.0 /nix/store/z4a5wck37pjm6wjsdczgq50vgbx05lv3-perl5.42.0-File-Listing-6.16/lib/perl5/site_perl /nix/store/qpcckqhjfpa7syidqannxx0ak0y01s0b-perl5.42.0-HTTP-Date-6.06/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/qpcckqhjfpa7syidqannxx0ak0y01s0b-perl5.42.0-HTTP-Date-6.06/lib/perl5/site_perl/5.42.0 /nix/store/qpcckqhjfpa7syidqannxx0ak0y01s0b-perl5.42.0-HTTP-Date-6.06/lib/perl5/site_perl /nix/store/lavzd9b8g9wb67jfvsyk36jdf3rn7f9v-perl5.42.0-TimeDate-2.33/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/lavzd9b8g9wb67jfvsyk36jdf3rn7f9v-perl5.42.0-TimeDate-2.33/lib/perl5/site_perl/5.42.0 /nix/store/lavzd9b8g9wb67jfvsyk36jdf3rn7f9v-perl5.42.0-TimeDate-2.33/lib/perl5/site_perl /nix/store/yprhvifdy49akv0k1zpnylmz03n7xa8m-perl5.42.0-HTML-Parser-3.81/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/yprhvifdy49akv0k1zpnylmz03n7xa8m-perl5.42.0-HTML-Parser-3.81/lib/perl5/site_perl/5.42.0 /nix/store/yprhvifdy49akv0k1zpnylmz03n7xa8m-perl5.42.0-HTML-Parser-3.81/lib/perl5/site_perl /nix/store/qzfplr3a838gvwgpdpnsmx9byqx998vb-perl5.42.0-HTML-Tagset-3.20/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/qzfplr3a838gvwgpdpnsmx9byqx998vb-perl5.42.0-HTML-Tagset-3.20/lib/perl5/site_perl/5.42.0 /nix/store/qzfplr3a838gvwgpdpnsmx9byqx998vb-perl5.42.0-HTML-Tagset-3.20/lib/perl5/site_perl /nix/store/k6xlk3z6ig125sl66ivsjn0l0clwckh9-perl5.42.0-HTTP-Message-6.45/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/k6xlk3z6ig125sl66ivsjn0l0clwckh9-perl5.42.0-HTTP-Message-6.45/lib/perl5/site_perl/5.42.0 /nix/store/k6xlk3z6ig125sl66ivsjn0l0clwckh9-perl5.42.0-HTTP-Message-6.45/lib/perl5/site_perl /nix/store/7hrgvxzk5la51bgmarqmckw8sirpf7jd-perl5.42.0-Clone-0.46/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/7hrgvxzk5la51bgmarqmckw8sirpf7jd-perl5.42.0-Clone-0.46/lib/perl5/site_perl/5.42.0 /nix/store/7hrgvxzk5la51bgmarqmckw8sirpf7jd-perl5.42.0-Clone-0.46/lib/perl5/site_perl /nix/store/l7pxln6szhh7rjkj4pykfmhf1193j5g9-perl5.42.0-Encode-Locale-1.05/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/l7pxln6szhh7rjkj4pykfmhf1193j5g9-perl5.42.0-Encode-Locale-1.05/lib/perl5/site_perl/5.42.0 /nix/store/l7pxln6szhh7rjkj4pykfmhf1193j5g9-perl5.42.0-Encode-Locale-1.05/lib/perl5/site_perl /nix/store/cyv2n2s0w7kf99m2jhvzr9798d9ycr4n-perl5.42.0-IO-HTML-1.004/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/cyv2n2s0w7kf99m2jhvzr9798d9ycr4n-perl5.42.0-IO-HTML-1.004/lib/perl5/site_perl/5.42.0 /nix/store/cyv2n2s0w7kf99m2jhvzr9798d9ycr4n-perl5.42.0-IO-HTML-1.004/lib/perl5/site_perl /nix/store/z7h43yv038l8r8j2mvxbckqh59wyf4jz-perl5.42.0-LWP-MediaTypes-6.04/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/z7h43yv038l8r8j2mvxbckqh59wyf4jz-perl5.42.0-LWP-MediaTypes-6.04/lib/perl5/site_perl/5.42.0 /nix/store/z7h43yv038l8r8j2mvxbckqh59wyf4jz-perl5.42.0-LWP-MediaTypes-6.04/lib/perl5/site_perl /nix/store/lgmnihkfcc48jxj9d09bj5505yxlnjk2-perl5.42.0-URI-5.21/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/lgmnihkfcc48jxj9d09bj5505yxlnjk2-perl5.42.0-URI-5.21/lib/perl5/site_perl/5.42.0 /nix/store/lgmnihkfcc48jxj9d09bj5505yxlnjk2-perl5.42.0-URI-5.21/lib/perl5/site_perl /nix/store/5j71fc9jiap48q0ch376d1cb5hbsa2df-perl5.42.0-HTTP-Cookies-6.10/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/5j71fc9jiap48q0ch376d1cb5hbsa2df-perl5.42.0-HTTP-Cookies-6.10/lib/perl5/site_perl/5.42.0 /nix/store/5j71fc9jiap48q0ch376d1cb5hbsa2df-perl5.42.0-HTTP-Cookies-6.10/lib/perl5/site_perl /nix/store/9mw8m1jz0il3jrz0kvm51mhyrydgmq45-perl5.42.0-HTTP-CookieJar-0.014/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/9mw8m1jz0il3jrz0kvm51mhyrydgmq45-perl5.42.0-HTTP-CookieJar-0.014/lib/perl5/site_perl/5.42.0 /nix/store/9mw8m1jz0il3jrz0kvm51mhyrydgmq45-perl5.42.0-HTTP-CookieJar-0.014/lib/perl5/site_perl /nix/store/0298s83dc0xhg2fh3252975b676cabak-perl5.42.0-HTTP-Negotiate-6.01/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/0298s83dc0xhg2fh3252975b676cabak-perl5.42.0-HTTP-Negotiate-6.01/lib/perl5/site_perl/5.42.0 /nix/store/0298s83dc0xhg2fh3252975b676cabak-perl5.42.0-HTTP-Negotiate-6.01/lib/perl5/site_perl /nix/store/y5ri5ddnjrlynxd7zhy66hql9rcs18g8-perl5.42.0-Net-HTTP-6.23/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/y5ri5ddnjrlynxd7zhy66hql9rcs18g8-perl5.42.0-Net-HTTP-6.23/lib/perl5/site_perl/5.42.0 /nix/store/y5ri5ddnjrlynxd7zhy66hql9rcs18g8-perl5.42.0-Net-HTTP-6.23/lib/perl5/site_perl /nix/store/684msv6gqfcwwl8b1g3rzimdz0j5cmy2-perl5.42.0-Try-Tiny-0.31/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/684msv6gqfcwwl8b1g3rzimdz0j5cmy2-perl5.42.0-Try-Tiny-0.31/lib/perl5/site_perl/5.42.0 /nix/store/684msv6gqfcwwl8b1g3rzimdz0j5cmy2-perl5.42.0-Try-Tiny-0.31/lib/perl5/site_perl /nix/store/7hcyn89m0q78ilwaa0q3yia6d69w57kk-perl5.42.0-WWW-RobotRules-6.02/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/7hcyn89m0q78ilwaa0q3yia6d69w57kk-perl5.42.0-WWW-RobotRules-6.02/lib/perl5/site_perl/5.42.0 /nix/store/7hcyn89m0q78ilwaa0q3yia6d69w57kk-perl5.42.0-WWW-RobotRules-6.02/lib/perl5/site_perl /nix/store/wp19ij354vy51f1pvdq8dradhawnkr5j-perl5.42.0-DB_File-1.859/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/wp19ij354vy51f1pvdq8dradhawnkr5j-perl5.42.0-DB_File-1.859/lib/perl5/site_perl/5.42.0 /nix/store/wp19ij354vy51f1pvdq8dradhawnkr5j-perl5.42.0-DB_File-1.859/lib/perl5/site_perl /nix/store/9cfhrq5bjf0pq35vw2apgmg4vj0990xr-perl5.42.0-File-DesktopEntry-0.22/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/9cfhrq5bjf0pq35vw2apgmg4vj0990xr-perl5.42.0-File-DesktopEntry-0.22/lib/perl5/site_perl/5.42.0 /nix/store/9cfhrq5bjf0pq35vw2apgmg4vj0990xr-perl5.42.0-File-DesktopEntry-0.22/lib/perl5/site_perl /nix/store/8l3g2ni2vpaaygdkqgqd7i8fs9fvng6b-perl5.42.0-File-BaseDir-0.09/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/8l3g2ni2vpaaygdkqgqd7i8fs9fvng6b-perl5.42.0-File-BaseDir-0.09/lib/perl5/site_perl/5.42.0 /nix/store/8l3g2ni2vpaaygdkqgqd7i8fs9fvng6b-perl5.42.0-File-BaseDir-0.09/lib/perl5/site_perl /nix/store/fz6fwyvrkaf5chc11cr3fbp2fp6l9qi9-perl5.42.0-IPC-System-Simple-1.30/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/fz6fwyvrkaf5chc11cr3fbp2fp6l9qi9-perl5.42.0-IPC-System-Simple-1.30/lib/perl5/site_perl/5.42.0 /nix/store/fz6fwyvrkaf5chc11cr3fbp2fp6l9qi9-perl5.42.0-IPC-System-Simple-1.30/lib/perl5/site_perl /nix/store/lypx2cv4d5q3zki8kg030ql83i9cwlll-perl5.42.0-Parse-DebControl-2.005/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/lypx2cv4d5q3zki8kg030ql83i9cwlll-perl5.42.0-Parse-DebControl-2.005/lib/perl5/site_perl/5.42.0 /nix/store/lypx2cv4d5q3zki8kg030ql83i9cwlll-perl5.42.0-Parse-DebControl-2.005/lib/perl5/site_perl /nix/store/7ncdrrc4bpjs60x98c3rdhxryjw4c0ic-perl5.42.0-IO-Stringy-2.113/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/7ncdrrc4bpjs60x98c3rdhxryjw4c0ic-perl5.42.0-IO-Stringy-2.113/lib/perl5/site_perl/5.42.0 /nix/store/7ncdrrc4bpjs60x98c3rdhxryjw4c0ic-perl5.42.0-IO-Stringy-2.113/lib/perl5/site_perl /nix/store/9mbmmdfpwyzdzwvf1rz40yfxcw90l2hn-perl5.42.0-Moo-2.005005/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/9mbmmdfpwyzdzwvf1rz40yfxcw90l2hn-perl5.42.0-Moo-2.005005/lib/perl5/site_perl/5.42.0 /nix/store/9mbmmdfpwyzdzwvf1rz40yfxcw90l2hn-perl5.42.0-Moo-2.005005/lib/perl5/site_perl /nix/store/f4b69bill44jnrpa0bk51r77919l1yvm-perl5.42.0-Class-Method-Modifiers-2.15/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/f4b69bill44jnrpa0bk51r77919l1yvm-perl5.42.0-Class-Method-Modifiers-2.15/lib/perl5/site_perl/5.42.0 /nix/store/f4b69bill44jnrpa0bk51r77919l1yvm-perl5.42.0-Class-Method-Modifiers-2.15/lib/perl5/site_perl /nix/store/c1hi36492xn2q6kzdxdkn4s4f69digf2-perl5.42.0-Module-Runtime-0.016/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/c1hi36492xn2q6kzdxdkn4s4f69digf2-perl5.42.0-Module-Runtime-0.016/lib/perl5/site_perl/5.42.0 /nix/store/c1hi36492xn2q6kzdxdkn4s4f69digf2-perl5.42.0-Module-Runtime-0.016/lib/perl5/site_perl /nix/store/80k29qd7y4pawmx3jbv11w3r12mlcfl3-perl5.42.0-Role-Tiny-2.002004/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/80k29qd7y4pawmx3jbv11w3r12mlcfl3-perl5.42.0-Role-Tiny-2.002004/lib/perl5/site_perl/5.42.0 /nix/store/80k29qd7y4pawmx3jbv11w3r12mlcfl3-perl5.42.0-Role-Tiny-2.002004/lib/perl5/site_perl /nix/store/hgdwk4ijgvvykwz9gyfz33bl56bybjm3-perl5.42.0-Sub-Quote-2.006008/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/hgdwk4ijgvvykwz9gyfz33bl56bybjm3-perl5.42.0-Sub-Quote-2.006008/lib/perl5/site_perl/5.42.0 /nix/store/hgdwk4ijgvvykwz9gyfz33bl56bybjm3-perl5.42.0-Sub-Quote-2.006008/lib/perl5/site_perl /nix/store/726fpsibidvpa194imfjn6rgv9zcx2wd-perl5.42.0-File-HomeDir-1.006/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/726fpsibidvpa194imfjn6rgv9zcx2wd-perl5.42.0-File-HomeDir-1.006/lib/perl5/site_perl/5.42.0 /nix/store/726fpsibidvpa194imfjn6rgv9zcx2wd-perl5.42.0-File-HomeDir-1.006/lib/perl5/site_perl /nix/store/5whqs3bq26hrgy5fky389wlksz1j9dmj-perl5.42.0-File-Which-1.27/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/5whqs3bq26hrgy5fky389wlksz1j9dmj-perl5.42.0-File-Which-1.27/lib/perl5/site_perl/5.42.0 /nix/store/5whqs3bq26hrgy5fky389wlksz1j9dmj-perl5.42.0-File-Which-1.27/lib/perl5/site_perl /nix/store/hb6rfmj6x2i2ndhqbpn6b9nzzcafvq8p-perl5.42.0-IPC-Run-20231003.0/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/hb6rfmj6x2i2ndhqbpn6b9nzzcafvq8p-perl5.42.0-IPC-Run-20231003.0/lib/perl5/site_perl/5.42.0 /nix/store/hb6rfmj6x2i2ndhqbpn6b9nzzcafvq8p-perl5.42.0-IPC-Run-20231003.0/lib/perl5/site_perl /nix/store/78phldmycj8f2jx99hy4adxgw982kb84-perl5.42.0-IO-Tty-1.20/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/78phldmycj8f2jx99hy4adxgw982kb84-perl5.42.0-IO-Tty-1.20/lib/perl5/site_perl/5.42.0 /nix/store/78phldmycj8f2jx99hy4adxgw982kb84-perl5.42.0-IO-Tty-1.20/lib/perl5/site_perl /nix/store/98hdyvfw64nizmlp2lzf99mmpncaprj8-perl5.42.0-File-DirList-0.05/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/98hdyvfw64nizmlp2lzf99mmpncaprj8-perl5.42.0-File-DirList-0.05/lib/perl5/site_perl/5.42.0 /nix/store/98hdyvfw64nizmlp2lzf99mmpncaprj8-perl5.42.0-File-DirList-0.05/lib/perl5/site_perl /nix/store/kqipqdrkzpvw78if442wmcf0rg8prk4j-perl5.42.0-File-Touch-0.12/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/kqipqdrkzpvw78if442wmcf0rg8prk4j-perl5.42.0-File-Touch-0.12/lib/perl5/site_perl/5.42.0 /nix/store/kqipqdrkzpvw78if442wmcf0rg8prk4j-perl5.42.0-File-Touch-0.12/lib/perl5/site_perl /nix/store/6h7gxm0z1nlczdk10xvk85nzm0kanxra-perl5.42.0-IO-String-1.08/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/6h7gxm0z1nlczdk10xvk85nzm0kanxra-perl5.42.0-IO-String-1.08/lib/perl5/site_perl/5.42.0 /nix/store/6h7gxm0z1nlczdk10xvk85nzm0kanxra-perl5.42.0-IO-String-1.08/lib/perl5/site_perl /nix/store/44rkdj2i577vnqagmvmdfs7q1ynf0svd-dpkg-1.23.7 /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/site_perl/5.42.0/x86_64-linux-thread-multi /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/site_perl/5.42.0 /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/5.42.0/x86_64-linux-thread-multi /nix/store/phnk1lwy8xs0yrbrcs6l2mb9yr9c2knp-perl-5.42.0/lib/perl5/5.42.0) at /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/share/devscripts/Devscripts/Uscan/FindFiles.pm line 58.
BEGIN failed--compilation aborted at /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/share/devscripts/Devscripts/Uscan/FindFiles.pm line 58.
Compilation failed in require at /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/share/devscripts/Devscripts/Uscan.pm line 8.
BEGIN failed--compilation aborted at /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/share/devscripts/Devscripts/Uscan.pm line 8.
Compilation failed in require at /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/bin/.uscan-wrapped line 880.
BEGIN failed--compilation aborted at /nix/store/mslzpvcysf7ybddnhgza3wicnh16hahp-debian-devscripts-2.26.7/bin/.uscan-wrapped line 880.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
