### PR TITLE
[Backport release-25.11] zvm: 0.8.8 -> 0.8.14

### DIFF
--- a/pkgs/by-name/zv/zvm/package.nix
+++ b/pkgs/by-name/zv/zvm/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "zvm";
-  version = "0.8.8";
+  version = "0.8.10";
 
   src = fetchFromGitHub {
     owner = "tristanisham";
     repo = "zvm";
     tag = "v${version}";
-    hash = "sha256-M1xpE2Lq6XZgvH9J0c2Xj1BJNN+4TTGwp4iluVyVAJs=";
+    hash = "sha256-n6V6fMfE7yBSta+RLkQbTFjQUOs4VuonEu6ecWQIFUc=";
   };
 
-  vendorHash = "sha256-wo+vA9AYXIjv6SGb7hNY6ZIVMyJ5enMd8gpQ6u3F7To=";
+  vendorHash = "sha256-yk1n0mW4WIKHTg9xgr+1IKbUpZWIaBaYrA6FwNBjVKc=";
 
   doInstallCheck = true;
   versionCheckProgramArg = "--version";

--- a/pkgs/by-name/zv/zvm/package.nix
+++ b/pkgs/by-name/zv/zvm/package.nix
@@ -1,23 +1,23 @@
 {
   lib,
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
 }:
 
-buildGoModule rec {
+buildGo126Module rec {
   pname = "zvm";
-  version = "0.8.11";
+  version = "0.8.14";
 
   src = fetchFromGitHub {
     owner = "tristanisham";
     repo = "zvm";
     tag = "v${version}";
-    hash = "sha256-RMXF69zqqNK3tifbeDM7dxkiHMws7n+PeeHvCUK7/OU=";
+    hash = "sha256-MAE7zs60DFIicYRtMhstzsOiS2flVv+dyPJVmcyAEio=";
   };
 
-  vendorHash = "sha256-dM9FiUucSBkk8L93HfzoHQ1EyyRmAZjfedvOyRBDFBA=";
+  vendorHash = "sha256-29hFuQnLPdLkAG4x5QWqXqBIGtppi/rj3OuTfMBgTAI=";
 
   doInstallCheck = true;
   versionCheckProgramArg = "--version";

--- a/pkgs/by-name/zv/zvm/package.nix
+++ b/pkgs/by-name/zv/zvm/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "zvm";
-  version = "0.8.10";
+  version = "0.8.11";
 
   src = fetchFromGitHub {
     owner = "tristanisham";
     repo = "zvm";
     tag = "v${version}";
-    hash = "sha256-n6V6fMfE7yBSta+RLkQbTFjQUOs4VuonEu6ecWQIFUc=";
+    hash = "sha256-RMXF69zqqNK3tifbeDM7dxkiHMws7n+PeeHvCUK7/OU=";
   };
 
-  vendorHash = "sha256-yk1n0mW4WIKHTg9xgr+1IKbUpZWIaBaYrA6FwNBjVKc=";
+  vendorHash = "sha256-dM9FiUucSBkk8L93HfzoHQ1EyyRmAZjfedvOyRBDFBA=";
 
   doInstallCheck = true;
   versionCheckProgramArg = "--version";


### PR DESCRIPTION
Backport of:
* #461803
* #475741 (security fix)
* #504073

Release notes: https://github.com/tristanisham/zvm/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
