### PR TITLE
github: Serialize git worktree initialization

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -103,14 +103,14 @@ runs:
             await run('sudo', 'mount', '-t', 'tmpfs', 'tmpfs', 'nixpkgs')
           }
 
-          // Create all worktrees in parallel.
-          await Promise.all(
-            commits.map(async ({ sha, path }) => {
-              await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
-              await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
-              await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
-            })
-          )
+          // Git worktree setup can race when multiple worktrees are created and
+          // initialized at the same time against one repository. See #511286.
+          // Keep the setup sequential so shared repo config updates cannot contend.
+          for (const { sha, path } of commits) {
+            await run('git', 'worktree', 'add', join('nixpkgs', path), sha, '--no-checkout')
+            await run('git', '-C', join('nixpkgs', path), 'sparse-checkout', 'disable')
+            await run('git', '-C', join('nixpkgs', path), 'checkout', '--progress')
+          }
 
           // Apply pin bump to untrusted worktree
           if (pin_bump_sha) {


### PR DESCRIPTION
Fixes #511286


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
