### PR TITLE
tauon: 8.2.2 -> 9.1.3, python3Packages.pysdl3: 0.9.8b9 -> 0.9.11b0

### DIFF
--- a/pkgs/by-name/ta/tauon/package.nix
+++ b/pkgs/by-name/ta/tauon/package.nix
@@ -48,14 +48,14 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "tauon";
-  version = "8.2.2";
+  version = "9.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Taiko2k";
     repo = "Tauon";
     tag = "v${version}";
-    hash = "sha256-d7bEC68ZJthJE/AlcUqBSNM4L4YAjwHXTiWDCtKf598=";
+    hash = "sha256-Z/+8UCtwvY9000b1Y+HaTIehK8axzyR+eeeBPhllS4U=";
   };
 
   postUnpack = ''
@@ -74,6 +74,8 @@ python3Packages.buildPythonApplication rec {
   pythonRemoveDeps = [
     "opencc"
     "tekore"
+    # Whether or not it is enabled (withDiscordRPC), it isn't present during build.
+    "pypresence"
   ];
 
   nativeBuildInputs = [
@@ -101,6 +103,7 @@ python3Packages.buildPythonApplication rec {
     opusfile
     pango
     pipewire
+    python3Packages.pyopengl
     wavpack
   ];
 
@@ -121,6 +124,7 @@ python3Packages.buildPythonApplication rec {
       pychromecast
       pylast
       pygobject3
+      pyopengl
       pysdl3
       requests
       send2trash

--- a/pkgs/development/python-modules/pysdl3/default.nix
+++ b/pkgs/development/python-modules/pysdl3/default.nix
@@ -19,18 +19,18 @@
 let
   dochash =
     if stdenv.hostPlatform.isLinux then
-      "sha256-d2YQUBWRlDROwiDMJ5mQAR9o+cYsbv1jiulsr1SAaik="
+      "sha256-ldx6r0KKNl1mkohTkaEG4rawf4VjHeJvNUdPkmrAkYA="
     else if stdenv.hostPlatform.isDarwin then
-      "sha256-eIzTsn4wYz7TEyWN8QssM7fxpMfz/ENlxDVUMz0Cm4c="
+      "sha256-ga0ebb9zIPI5+Qza8APs0kbCxUIxqCmXRO/R8uWASOg="
     else if stdenv.hostPlatform.isWindows then
-      "sha256-+iagR5jvpHi8WDh4/DO+GDP6jajEpZ6G1ROhM+zkSiw="
+      "sha256-bBwETA9/ph0zXVNad9zMkQvfq1MmFJ08tCV+mUPwlXQ="
     else
       throw "PySDL3 does not support ${stdenv.hostPlatform.uname.system}";
   lib_ext = stdenv.hostPlatform.extensions.sharedLibrary;
 in
 buildPythonPackage rec {
   pname = "pysdl3";
-  version = "0.9.8b9";
+  version = "0.9.11b0";
   pyproject = true;
 
   pythonImportsCheck = [ "sdl3" ];
@@ -39,12 +39,12 @@ buildPythonPackage rec {
     owner = "Aermoss";
     repo = "PySDL3";
     tag = "v${version}";
-    hash = "sha256-TpfMpp8CGb8lYALCWlMtyucxObDg1VYEvBW+mVHN9JM=";
+    hash = "sha256-lUnQ5YDM6HXarZUSy+x95lStBXDQlvG5JL6hFdHg6z0=";
   };
 
   docfile = fetchurl {
     url = "https://github.com/Aermoss/PySDL3/releases/download/v${version}/${stdenv.hostPlatform.uname.system}-Docs.py";
-    hash = "${dochash}";
+    hash = dochash;
   };
 
   postUnpack = ''
@@ -83,6 +83,13 @@ buildPythonPackage rec {
     SDL_AUDIODRIVER = "dummy";
     SDL_RENDER_DRIVER = "software";
     PYTHONFAULTHANDLER = "1";
+
+    # For import checks, duplicated from setup hook.
+    SDL_CHECK_BINARY_VERSION = 0;
+    SDL_DISABLE_METADATA = 1;
+    # Checks for __doc__.py next to the file being executed.
+    # It's very fragile, and doesn't work during the import check.
+    SDL_DOC_GENERATOR = 0;
   };
 
   meta = {

--- a/pkgs/development/python-modules/pysdl3/setup-hook.sh
+++ b/pkgs/development/python-modules/pysdl3/setup-hook.sh
@@ -2,7 +2,7 @@
 # https://pysdl3.readthedocs.io/en/latest/install.html#the-environment-variable-method
 
 # Don't check Pypi for new PySDL3 releases at runtime
-export SDL_CHECK_VERSION=0
+export SDL_CHECK_BINARY_VERSION=0
 # Don't try to download SDL binaries at runtime
 export SDL_DOWNLOAD_BINARIES=0
 # Nixpkgs does not provide a metadata.json. Instead we want PySDL3 to find the


### PR DESCRIPTION
Updated tauon to the latest version, and the dependency pysdl3, which is only used by tauon.

I didn't go through the process of enabling the new visualiser features, but that's probably worth doing in the future.

I set some env vars for the build as well as in the setup hook, since not having them causes a bunch of failed internet connections in the import check (although it does still build).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Maintainer: @jansol
Commits: <https://github.com/Taiko2k/Tauon/compare/v8.2.2...v9.1.3>
Release Changelogs: <https://github.com/Taiko2k/Tauon/releases>

I'm up to adding myself as a maintainer if you would like.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
   - [x] run again after pysdl3 is no longer trying to reach out to network
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
   - Have not tested that doc hints work correctly.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
