### PR TITLE
home-assistant-custom-components.auth_oidc: 0.6.5-alpha -> 1.0.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/auth_oidc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/auth_oidc/package.nix
@@ -4,34 +4,40 @@
   fetchFromGitHub,
   fetchNpmDeps,
   aiofiles,
-  bcrypt,
   jinja2,
   joserfc,
   nodejs,
   npmHooks,
-  python-jose,
+  pytestCheckHook,
+  pytest-homeassistant-custom-component,
+  pytest-cov-stub,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "christaangoossens";
   domain = "auth_oidc";
-  version = "0.6.5-alpha";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "christiaangoossens";
     repo = "hass-oidc-auth";
     tag = "v${version}";
-    hash = "sha256-nclrSO6KmPnwXRPuuFwR6iYHsyfqcelPRGERWVJpdyk=";
+    hash = "sha256-ZYJD0PVh2E07cdY1a7uxSxdooAMz78HwJpwr4uWofZM=";
   };
 
   postPatch = ''
-    rm custom_components/auth_oidc/static/style.css
+    # Tests import directly from auth_oidc, but the component is installed
+    # under custom_components.auth_oidc
+    for f in tests/test_hass_webserver.py tests/test_state_store.py; do
+      substituteInPlace "$f" \
+        --replace-fail "from auth_oidc" "from custom_components.auth_oidc"
+    done
   '';
 
   env.npmDeps = fetchNpmDeps {
     name = "${domain}-npm-deps";
     inherit src;
-    hash = "sha256-i75YeCZVSMFDWzaiDJRTYqQee5I15n9ll0YYX1PXYbA=";
+    hash = "sha256-R5i4o2VnaXwgX72r6cBJULxSKadkU22vriMMWoMc5As=";
   };
 
   nativeBuildInputs = [
@@ -41,15 +47,19 @@ buildHomeAssistantComponent rec {
 
   dependencies = [
     aiofiles
-    bcrypt
     jinja2
     joserfc
-    python-jose
   ];
 
   postBuild = ''
     npm run css
   '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-homeassistant-custom-component
+    pytest-cov-stub
+  ];
 
   meta = {
     changelog = "https://github.com/christiaangoossens/hass-oidc-auth/releases/tag/v${version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/christiaangoossens/hass-oidc-auth/releases/tag/v1.0.2
Diff: https://github.com/christiaangoossens/hass-oidc-auth/compare/v0.6.5-alpha...v1.0.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
