### PR TITLE
kissfft: 131.1.0 -> 0-unstable-2026-03-07

### DIFF
--- a/pkgs/by-name/ki/kissfft/package.nix
+++ b/pkgs/by-name/ki/kissfft/package.nix
@@ -15,9 +15,9 @@
   llvmPackages,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "kissfft-${datatype}${lib.optionalString enableOpenmp "-openmp"}";
-  version = "131.1.0";
+  version = "0-unstable-2026-03-07";
 
   outputs = [
     "bin"
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "mborgerding";
     repo = "kissfft";
-    rev = finalAttrs.version;
-    hash = "sha256-ukikTVnmKomKXTo6zc+PhpZzEkzXN2imFwZOYlfR3Pk=";
+    rev = "1e56ac81667d53363a8483a9e53afdbdf49ddfab";
+    hash = "sha256-7Jvt77w/hp/g+BtSIxEbZyAQHxDU11hbpKUq0BfuKrA=";
   };
 
   patches = [
@@ -83,4 +83,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-})
+}


### PR DESCRIPTION
kissfft 131.2.0 released October 22, 2025, which is almost two years ago, but had a failing test.
The test was fixed in a follow up commit without a new release.

There's a few small fixes and general maintenance since 131.1.0, so this updates to the latest commit, which is just fixes on top of 131.2.0.

Changes: <https://github.com/mborgerding/kissfft/compare/131.1.0...1e56ac8>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
