### PR TITLE
labar: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1578,6 +1578,12 @@
     githubId = 5149377;
     name = "Amine Chikhaoui";
   };
+  amodio = {
+    name = "Jacques Boscq";
+    github = "Amodio";
+    githubId = 2722398;
+    email = "jacques@boscq.fr";
+  };
   amozeo = {
     email = "wroclaw223@outlook.com";
     github = "amozeo";

--- a/pkgs/by-name/la/labar/package.nix
+++ b/pkgs/by-name/la/labar/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  wayland-scanner,
+
+  # buildInputs
+  cairo,
+  librsvg,
+  alsa-lib,
+  gtk4,
+  wayland,
+  wayland-protocols,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "labar";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Amodio";
+    repo = "${finalAttrs.pname}";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-eXizGL7etaBBp8gO2FCruDqbMh+jpUlPrYbzhSJEJh0=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    cairo
+    librsvg
+    alsa-lib
+    gtk4
+    wayland
+    wayland-protocols
+  ];
+
+  mesonBuildType = "release";
+
+  mesonFlags = [
+    "-Db_sanitize=none"
+  ];
+
+  meta = {
+    homepage = "https://github.com/Amodio/labar";
+    description = "Launch bar for Wayland";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "${finalAttrs.pname}";
+    inherit (wayland.meta) platforms;
+    maintainers = with lib.maintainers; [ amodio ];
+  };
+})


### PR DESCRIPTION
Launch bar for Wayland

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test