### PR TITLE
nixos/test-driver: fix duplicate names in type check

### DIFF
--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -36,7 +36,7 @@ let
   theOnlyMachine =
     let
       exactlyOneMachine = lib.length (lib.attrValues config.nodes) == 1;
-      allMachineNames = map (c: c.system.name) (lib.attrValues config.allMachines);
+      allMachineNames = lib.attrNames config.allMachines;
     in
     lib.optional (exactlyOneMachine && !lib.elem "machine" allMachineNames) "machine";
 


### PR DESCRIPTION
This pr aims to fix duplicate entries of `machine` existing in `pythonizedVmNames` to avoid failing the mypy check phase.

This occurs when having a `nodes.machine` with a `networking.hostName` set to a value that is not the default `"machine"` - eg. The `nixosTest.goupile` test [is failing](https://hydra.nixos.org/build/326657238/log) on master due to this.

It is very rarely the case where the node name and the `hostName` are different. But this fix allows overriding the `networking.hostName` in nixos tests. (It was working previously but started failing recently, I have bisected the change which broke it to f1bcb61731224bd8440510fc620d3c51f3e51c85 in https://github.com/NixOS/nixpkgs/commit/f1bcb61731224bd8440510fc620d3c51f3e51c85#diff-34359c3e76b24c2a56212dd2020e937a8cccd26a5b7fc5d502ad7fda005e3632L38-R34)

With this change we no longer use `hostName` but the node's name instead for the type hints.