### PR TITLE
gitlab-duo: fix build

### DIFF
--- a/pkgs/by-name/gi/gitlab-duo/package.nix
+++ b/pkgs/by-name/gi/gitlab-duo/package.nix
@@ -30,9 +30,19 @@ buildNpmPackage (finalAttrs: {
     ./missing-hashes.patch
   ];
 
-  # PATCH: Only build for the current platform, not all targets
+  # PATCH:
+  # 1. Only build for the current platform, not all targets.
+  # 2. Compile from pre-bundled dist instead of raw source, to work around a Bun
+  #    bundler issue where re-bundling produces code in turn cannot be parsed:
+  #
+  #        SyntaxError: Cannot declare a function that shadows a let/const/class/function variable '_init'.
+  #              at <parse> (/$bunfs/root/duo-darwin-arm64:323006:1)
+  #              at native:11:43
   postPatch = ''
-    sed -i 's/SUPPORTED_TARGETS=".\+"/SUPPORTED_TARGETS="bun-$TARGET"/' packages/cli/scripts/compile_executables.sh
+    sed -i \
+      -e 's/SUPPORTED_TARGETS=".\+"/SUPPORTED_TARGETS="bun-$TARGET"/' \
+      -e 's|SOURCE_FILE="./src/index.tsx"|SOURCE_FILE="./dist/index.js"|' \
+      packages/cli/scripts/compile_executables.sh
   '';
 
   npmFlags = [ "--install-links" ];
@@ -69,7 +79,6 @@ buildNpmPackage (finalAttrs: {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     changelog = "https://gitlab.com/gitlab-org/editor-extensions/gitlab-lsp/-/blob/main/CHANGELOG.md";
     description = "CLI for GitLab AI assistant";
     downloadPage = "https://gitlab.com/gitlab-org/editor-extensions/gitlab-lsp";


### PR DESCRIPTION
Currently fails to build on Linux and is marked as broken on Darwin; now builds on both.

<details>
<summary>Current failing build log</summary>

```console
$ nix build github:NixOS/nixpkgs#gitlab-duo
error: Cannot build '/nix/store/7gz2i8v3fvki5im94pm8aq816bhhkkqp-gitlab-duo-8.67.0.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/hmai362411rb7xad3n5njsz3lapmryb8-gitlab-duo-8.67.0
       Last 25 log lines:
       >   [17ms] compile  ./bin/duo-linux-arm64
       > ===> Successfully built: ./bin/duo-linux-arm64
       > ===> All builds completed successfully!
       > Finished npmBuildHook
       > Running phase: installPhase
       > Running phase: fixupPhase
       > shrinking RPATHs of ELF executables and libraries in /nix/store/hmai362411rb7xad3n5njsz3lapmryb8-gitlab-duo-8.67.0
       > shrinking /nix/store/hmai362411rb7xad3n5njsz3lapmryb8-gitlab-duo-8.67.0/bin/duo
       > checking for references to /nix/var/nix/builds/nix-1677-2890067205/ in /nix/store/hmai362411rb7xad3n5njsz3lapmryb8-gitlab-duo-8.67.0...
       > patching script interpreter paths in /nix/store/hmai362411rb7xad3n5njsz3lapmryb8-gitlab-duo-8.67.0
       > Running phase: installCheckPhase
       > Executing versionCheckPhase
       > Did not find version 8.67.0 in the output of the command /nix/store/hmai362411rb7xad3n5njsz3lapmryb8-gitlab-duo-8.67.0/bin/duo --version
       > 323003 |   }
       > 323004 |   enhanceDscWithOpenTelemetryRootSpanName(client);
       > 323005 |   setupEventContextTrace(client);
       > 323006 |   return client;
       > 323007 | }
       > 323008 | function validateOpenTelemetrySetup() {
       >          ^
       > SyntaxError: Cannot declare a function that shadows a let/const/class/function variable '_init'.
       >       at <parse> (/$bunfs/root/duo-linux-arm64:323008:1)
       >       at native:11:43
       >
       > Bun v1.3.11 (Linux arm64)
       For full logs, run:
         nix log /nix/store/7gz2i8v3fvki5im94pm8aq816bhhkkqp-gitlab-duo-8.67.0.drv
$
```

</details>

This looks like a bug in Bun's bundling; by building from the dist instead of source it Just Works™.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
