### PR TITLE
inngest: init at 1.17.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6070,6 +6070,11 @@
     github = "darkyzhou";
     githubId = 7220778;
   };
+  darwin67 = {
+    name = "Darwin D Wu";
+    github = "darwin67";
+    githubId = 5746693;
+  };
   daru-san = {
     name = "Daru";
     email = "zadarumaka@proton.me";

--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nix-update-script,
+}:
+
+let
+  sources = {
+    x86_64-linux = {
+      os = "linux";
+      arch = "amd64";
+      hash = "sha256-Vh9uCOBNzdKfZngrhupWjntWMJvNBzYg/sGPGaBoOeI=";
+    };
+    aarch64-linux = {
+      os = "linux";
+      arch = "arm64";
+      hash = "sha256-iM6sackbdmz6Sbge2Xjx8kNlZ6uyUToE2NiojlSn82s=";
+    };
+    x86_64-darwin = {
+      os = "darwin";
+      arch = "amd64";
+      hash = "sha256-9gbox1f9nABWf/KP7QIJDBqWk6VR+sosJuY7HmwHC9g=";
+    };
+    aarch64-darwin = {
+      os = "darwin";
+      arch = "arm64";
+      hash = "sha256-uk4e0/gOVEJFAr1Z2eVzCf8abR8IPHbYadQKmH5Y97w=";
+    };
+  };
+
+  source =
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "inngest";
+  version = "1.17.9";
+
+  src = fetchurl {
+    url = "https://github.com/inngest/inngest/releases/download/v${finalAttrs.version}/inngest_${finalAttrs.version}_${source.os}_${source.arch}.tar.gz";
+    inherit (source) hash;
+  };
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 inngest $out/bin/inngest
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI and dev server for Inngest durable workflows";
+    homepage = "https://github.com/inngest/inngest";
+    changelog = "https://github.com/inngest/inngest/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.sspl;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "inngest";
+    platforms = lib.attrNames sources;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -69,6 +69,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "inngest";
     platforms = lib.attrNames sources;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ darwin67 ];
   };
 })


### PR DESCRIPTION
Adds `inngest`, the CLI and dev server for Inngest durable workflows.

Homepage: https://github.com/inngest/inngest

Packaging notes:
- Uses the official upstream GitHub release binaries rather than building from source.
- Packages Linux and Darwin release tarballs for both `amd64` and `arm64`.
- Hashes are derived from the upstream `checksums.txt` release manifest.
- Adds `passthru.updateScript = nix-update-script { };` so nixpkgs-update can follow future GitHub releases.

Verified on `x86_64-linux`:
- `NIXPKGS_ALLOW_UNFREE=1 nix-build -A inngest`
- `./result/bin/inngest version`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
