### PR TITLE
wily: fix build with gcc15

### DIFF
--- a/pkgs/by-name/wi/wily/package.nix
+++ b/pkgs/by-name/wi/wily/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
   libx11,
   libxt,
 }:
@@ -20,7 +21,16 @@ stdenv.mkDerivation (finalAttrs: {
     libxt
   ];
 
-  patches = [ ./fix-gcc14-build.patch ];
+  patches = [
+    ./fix-gcc14-build.patch
+    (fetchDebianPatch {
+      pname = "wily";
+      version = "0.13.42";
+      debianRevision = "4";
+      patch = "gcc-15.patch";
+      hash = "sha256-PZZvn2G/1a4Hk0CMVdDK09vyIN9yQ3X4ToCENwYujFA=";
+    })
+  ];
 
   preInstall = ''
     mkdir -p $out/bin


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324354228

```
In file included from connect.c:13:
./../include/msg.h:6:20: error: cannot use keyword 'false' as enumeration constant
    6 | typedef enum Bool {false, true} Bool;
      |                    ^~~~~
./../include/msg.h:6:20: note: 'false' is a keyword with '-std=c23' onwards
connect.c: In function 'client_connect':
connect.c:109:9: warning: ignoring return value of 'tmpnam' declared with attribute 'warn_unused_result' [-Wunused-result]
  109 |         tmpnam(addr.sun_path);
      |         ^~~~~~~~~~~~~~~~~~~~~
```

Use debian patch from: https://sources.debian.org/patches/wily/0.13.42-4/gcc-15.patch/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
