### PR TITLE
wml: 2.32.0 -> 2.32.0-unstable-2025-12-23

### DIFF
--- a/pkgs/by-name/wm/wml/package.nix
+++ b/pkgs/by-name/wm/wml/package.nix
@@ -31,22 +31,16 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wml";
-  version = "2.32.0";
+  version = "2.32.0-unstable-2025-12-23";
 
   src = fetchFromGitHub {
     owner = "thewml";
     repo = "website-meta-language";
-    tag = "releases/wml-${finalAttrs.version}";
-    hash = "sha256-9ZiMGm0W2qS/7nL8NsmGBsuB5sNJvWuJaxE7CTdWo6s=";
+    rev = "de200ecef0b2a64553799b1d83dfa65580d0bc16";
+    hash = "sha256-okeDaCX4Pp5qVFfHmaz+keagX6vgzFTtGoiim/pW6IA=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
-
-  # https://github.com/thewml/website-meta-language/commit/727806494dcb9d334ffb324aedbf6076e4796299
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'CMAKE_MINIMUM_REQUIRED(VERSION 3.0)' 'CMAKE_MINIMUM_REQUIRED(VERSION 3.15)'
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -77,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Offline HTML preprocessor";
     homepage = "https://www.shlomifish.org/open-source/projects/website-meta-language/";
     downloadPage = "https://github.com/thewml/website-meta-language/releases";
-    changelog = "https://github.com/thewml/website-meta-language/blob/${finalAttrs.src.tag}/src/ChangeLog";
+    changelog = "https://github.com/thewml/website-meta-language/blob/${finalAttrs.src.rev}/src/ChangeLog";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ prince213 ];
     mainProgram = "wml";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324354458

```
/build/source/src/wml_backend/p3_eperl/eperl_sys.c:34:8: error: conflicting types for 'getenv'; have 'char *(void)'
   34 | char * getenv ();
      |        ^~~~~~
In file included from /build/source/src/wml_backend/p3_eperl/eperl_config.h:47,
                 from /build/source/src/wml_backend/p3_eperl/eperl_sys.c:30:
/nix/store/h0ip0h6qp7kc2wm7mwjaglkxxbzmjri4-glibc-2.42-51-dev/include/stdlib.h:773:14: note: previous declaration of 'getenv' with type 'char *(const char *)'
  773 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^~~~~~
/build/source/src/wml_backend/p3_eperl/eperl_sys.c: In function 'mytmpfile':
/build/source/src/wml_backend/p3_eperl/eperl_sys.c:209:26: error: too many arguments to function 'getenv'; expected 0, have 1
  209 |     const char *tmpdir = getenv ("TMPDIR");
      |                          ^~~~~~  ~~~~~~~~
/build/source/src/wml_backend/p3_eperl/eperl_sys.c:34:8: note: declared here
   34 | char * getenv ();
      |        ^~~~~~
```

Updated to latest git commit to fix various compilation problems.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
