### PR TITLE
wiiload: fix build with gcc15

### DIFF
--- a/pkgs/by-name/wi/wiiload/fix-gcc15.patch
+++ b/pkgs/by-name/wi/wiiload/fix-gcc15.patch
@@ -1,0 +1,21 @@
+diff --git a/source/main.c b/source/main.c
+index 2d817e5..9dfeb3d 100644
+--- a/source/main.c
++++ b/source/main.c
+@@ -28,6 +28,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <libgen.h>
++#include <stdbool.h>
+ #ifndef _WIN32
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+@@ -62,8 +63,6 @@ typedef signed short s16;
+ typedef signed int s32;
+ typedef signed long long s64;
+
+-typedef enum { false, true } bool;
+-
+ #ifndef __WIN32__
+ static const char *desc_export = "export";
+ #ifndef __APPLE__

--- a/pkgs/by-name/wi/wiiload/package.nix
+++ b/pkgs/by-name/wi/wiiload/package.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-pZdZzCAPfAVucuiV/q/ROY3cz/wxQWep6dCTGNn2fSo=";
   };
 
+  patches = [
+    # https://github.com/devkitPro/wiiload/pull/4
+    ./fix-gcc15.patch
+  ];
+
   preConfigure = "./autogen.sh";
 
   meta = {


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324354199

```
source/main.c:65:16: error: cannot use keyword 'false' as enumeration constant
   65 | typedef enum { false, true } bool;
      |                ^~~~~
source/main.c:65:16: note: 'false' is a keyword with '-std=c23' onwards
source/main.c:65:30: error: expected ';', identifier or '(' before 'bool'
   65 | typedef enum { false, true } bool;
      |                              ^~~~
source/main.c:65:30: warning: useless type name in empty declaration
```

Vendored an upstream pull request. Only tested compilation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
