### PR TITLE
ghost-complete: init at 0.9.1

### DIFF
--- a/pkgs/by-name/gh/ghost-complete/package.nix
+++ b/pkgs/by-name/gh/ghost-complete/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ghost-complete";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "StanMarek";
+    repo = "ghost-complete";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fsGrhQK28YFksI2pNiZ6fI6KjZOXxXxrhWjxOmBNk08=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-kiYdMczvnauhu/2ryO0NcK3PAI1P+xmYV8nRrIWaEB8=";
+
+  cargoBuildFlags = [ "--package=ghost-complete" ];
+
+  # Integration tests in crates/ghost-complete/tests/smoke.rs spawn a real
+  # PTY + shell and exercise terminal I/O, which isn't available in the
+  # Nix build sandbox.
+  doCheck = false;
+
+  # `ghost-complete install` imperatively copies these scripts into the
+  # user's `~/.config/ghost-complete/shell/` and edits `~/.zshrc` to source
+  # them. In a Nix world we instead expose them here so users can source
+  # them declaratively from their shell configuration (e.g. home-manager
+  # `programs.zsh.initContent` or NixOS `programs.zsh.interactiveShellInit`).
+  # The 709 completion specs are already embedded in the binary and used
+  # as an automatic fallback when no on-disk spec directory is present, so
+  # they don't need to be copied out.
+  postInstall = ''
+    install -Dm644 -t $out/share/ghost-complete/shell \
+      shell/init.zsh \
+      shell/ghost-complete.zsh \
+      shell/ghost-complete.bash \
+      shell/ghost-complete.fish
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal-native autocomplete engine using PTY proxying for macOS terminals";
+    homepage = "https://github.com/StanMarek/ghost-complete";
+    changelog = "https://github.com/StanMarek/ghost-complete/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ imcvampire ];
+    mainProgram = "ghost-complete";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Ghost Complete sits inside your terminal's data stream as a PTY proxy, intercepting I/O between your terminal emulator and your shell. When you type a command, it renders autocomplete suggestions as native ANSI popups — no macOS Accessibility API, no IME hacks, no Electron overlay. Just your terminal, your shell, and fast completions.

https://github.com/StanMarek/ghost-complete


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
