### PR TITLE
Revert "nixos/prometheus-exporters: add socketOpts and use for node-exporter & postfix-exporter"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -318,8 +318,6 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - [hardware.xpadneo](#opt-hardware.xpadneo.enable) now supports configuring kernel module parameters via a freeform [settings](#opt-hardware.xpadneo.settings) option, with convenience options for [rumble attenuation](#opt-hardware.xpadneo.rumbleAttenuation) and [controller quirks](#opt-hardware.xpadneo.quirks).
 
-- The `services.prometheus.exporters` module interface now accepts an optional `socketOpts` attribute, allowing individual exporter modules to describe an accompanying `systemd.sockets.prometheus-${name}-exporter` unit alongside their service, enabling socket activation support.
-
 - Wine has been updated to the 11.0 branch. Please check the [upstream announcement](https://gitlab.winehq.org/wine/wine/-/releases/wine-11.0) for more details.
 
 - `security.acme` now defaults to a dynamic renewal duration, if

--- a/nixos/modules/services/monitoring/prometheus/exporters.md
+++ b/nixos/modules/services/monitoring/prometheus/exporters.md
@@ -138,22 +138,11 @@ example:
           DynamicUser = false;
           ExecStart = ''
             ${pkgs.prometheus-postfix-exporter}/bin/postfix_exporter \
-              --web.systemd-socket \
+              --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
               --web.telemetry-path ${cfg.telemetryPath} \
               ${lib.concatStringsSep " \\\n  " cfg.extraFlags}
           '';
         };
-      };
-
-      # `socketOpts` is an optional attribute set describing a
-      # `systemd.sockets.prometheus-${name}-exporter` unit that
-      # accompanies the exporter's service. When set, it is merged
-      # with a default definition that includes
-      # `wantedBy = [ "sockets.target" ]`, enabling socket activation
-      # for exporters that support it.
-      # Note that this attribute is optional.
-      socketOpts = {
-        socketConfig.ListenStream = "${cfg.listenAddress}:${toString cfg.port}";
       };
     }
     ```

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -36,15 +36,10 @@ let
   #   - extraOpts   (types.attrs): extra configuration options to
   #                                configure the exporter with, which
   #                                are appended to the default options
-  #   - socketOpts  (types.attrs): optional config that is merged with
-  #                                the default definition of the
-  #                                exporter's systemd socket unit. When
-  #                                set, a `prometheus-${name}-exporter.socket`
-  #                                unit is created, enabling socket activation.
   #
-  #  Note that `extraOpts` and `socketOpts` are optional, but a script
-  #  for the exporter's systemd service must be provided by specifying
-  #  either `serviceOpts.script` or `serviceOpts.serviceConfig.ExecStart`
+  #  Note that `extraOpts` is optional, but a script for the exporter's
+  #  systemd service must be provided by specifying either
+  #  `serviceOpts.script` or `serviceOpts.serviceConfig.ExecStart`
 
   exporterOpts =
     (genAttrs
@@ -316,7 +311,6 @@ let
       name,
       conf,
       serviceOpts,
-      socketOpts,
     }:
     let
       enableDynamicUser = serviceOpts.serviceConfig.DynamicUser or true;
@@ -374,12 +368,6 @@ let
         "-m comment --comment ${name}-exporter -j nixos-fw-accept"
       ]);
       networking.firewall.extraInputRules = mkIf (conf.openFirewall && nftables) conf.firewallRules;
-      systemd.sockets."prometheus-${name}-exporter" = mkIf (socketOpts != null) (mkMerge [
-        {
-          wantedBy = [ "sockets.target" ];
-        }
-        socketOpts
-      ]);
       systemd.services."prometheus-${name}-exporter" = mkMerge [
         {
           wantedBy = [ "multi-user.target" ];
@@ -615,7 +603,6 @@ in
       mkExporterConf {
         inherit name;
         inherit (conf) serviceOpts;
-        socketOpts = conf.socketOpts or null;
         conf = cfg.${name};
       }
     ) exporterOpts)

--- a/nixos/modules/services/monitoring/prometheus/exporters/node.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/node.nix
@@ -39,7 +39,6 @@ in
       '';
     };
   };
-
   serviceOpts = {
     serviceConfig = {
       DynamicUser = false;
@@ -48,7 +47,7 @@ in
         ${pkgs.prometheus-node-exporter}/bin/node_exporter \
           ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
           ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
-          --web.systemd-socket ${concatStringsSep " " cfg.extraFlags}
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} ${concatStringsSep " " cfg.extraFlags}
       '';
       RestrictAddressFamilies =
         optionals (collectorIsEnabled "logind" || collectorIsEnabled "systemd") [
@@ -67,9 +66,5 @@ in
       # Allow space monitoring under /home
       ProtectHome = true;
     };
-  };
-
-  socketOpts = {
-    socketConfig.ListenStream = "${cfg.listenAddress}:${toString cfg.port}";
   };
 }

--- a/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
@@ -85,7 +85,6 @@ in
       };
     };
   };
-
   serviceOpts = {
     after = mkIf cfg.systemd.enable [ cfg.systemd.unit ];
     serviceConfig = {
@@ -96,7 +95,7 @@ in
       SupplementaryGroups = mkIf cfg.systemd.enable [ "systemd-journal" ];
       ExecStart = ''
         ${lib.getExe cfg.package} \
-          --web.systemd-socket \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
           --web.telemetry-path ${cfg.telemetryPath} \
           --postfix.showq_path ${escapeShellArg cfg.showqPath} \
           ${concatStringsSep " \\\n  " (
@@ -115,9 +114,5 @@ in
           )}
       '';
     };
-  };
-
-  socketOpts = {
-    socketConfig.ListenStream = "${cfg.listenAddress}:${toString cfg.port}";
   };
 }


### PR DESCRIPTION
Users have reported breakages, see comments in the original PR: NixOS/nixpkgs#510391

Reverts NixOS/nixpkgs#510391