### PR TITLE
nixos/dbus: switch default implementation to dbus-broker

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -42,6 +42,15 @@
 
 - The default kernel package has been updated from 6.12 to 6.18. All supported kernels remain available.
 
+- The default D-Bus implementation has been switched from `dbus` to `dbus-broker`. dbus-broker provides
+  higher performance and reliability while maintaining compatibility with the D-Bus reference implementation.
+
+  Note that changing `services.dbus.implementation` is a **switch inhibitor**: switching between
+  implementations requires a reboot rather than just `nixos-rebuild switch`, because restarting D-Bus
+  mid-session is unsafe.
+
+  Users who wish to keep the classic daemon can set: `services.dbus.implementation = "dbus";`
+
 ## New Modules {#sec-release-26.05-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -68,7 +68,7 @@ in
           "dbus"
           "broker"
         ];
-        default = "dbus";
+        default = "broker";
         description = ''
           The implementation to use for the message bus defined by the D-Bus specification.
           Can be either the classic dbus daemon or dbus-broker, which aims to provide high


### PR DESCRIPTION
dbus-broker provides higher performance and reliability compared to the classic dbus-daemon. The prerequisite PR #477800 has been merged, making this switch safe.

Note that services.dbus.implementation is a switch inhibitor: changing the D-Bus implementation between generations requires a reboot rather than nixos-rebuild switch, since restarting D-Bus mid-session is unsafe.

Fixes #299476


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
