### PR TITLE
sway: prefer systemd user bus over spawning a session dbus-daemon

### DIFF
--- a/pkgs/by-name/sw/sway/package.nix
+++ b/pkgs/by-name/sw/sway/package.nix
@@ -41,6 +41,11 @@ let
     if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
       export DBUS_SESSION_BUS_ADDRESS
       exec ${getExe sway} "$@"
+    elif [ -n "$XDG_RUNTIME_DIR" ] && [ -S "$XDG_RUNTIME_DIR/bus" ]; then
+      # Prefer the systemd --user bus (dbus-daemon or dbus-broker) over
+      # spawning a redundant session bus via dbus-run-session.
+      export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+      exec ${getExe sway} "$@"
     else
       exec ${optionalString dbusSupport "${dbus}/bin/dbus-run-session"} ${getExe sway} "$@"
     fi


### PR DESCRIPTION
Closes #512058.

## Summary

The `sway` base wrapper spawns a fresh session bus via `dbus-run-session` when `DBUS_SESSION_BUS_ADDRESS` is unset. `dbus-run-session` hardcodes `dbus-daemon` (reference impl) and ignores the per-user bus already provided by `systemd --user` at `$XDG_RUNTIME_DIR/bus`.

On NixOS this splits the session:

- Under `services.dbus.implementation = "broker"`, sway descendants bypass the broker user bus and land on a separate `dbus-daemon`.
- Even under the reference impl, a redundant second `dbus-daemon` runs for the sway session alongside the existing user bus.

This PR prefers the existing user bus when available, keeping `dbus-run-session` only as the last-resort fallback for environments without a `systemd --user` instance (containers, minimal CI).

## Diff

```diff
     if [ "$DBUS_SESSION_BUS_ADDRESS" ]; then
       export DBUS_SESSION_BUS_ADDRESS
       exec sway "$@"
+    elif [ -n "$XDG_RUNTIME_DIR" ] && [ -S "$XDG_RUNTIME_DIR/bus" ]; then
+      export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+      exec sway "$@"
     else
       exec dbus-run-session sway "$@"
     fi
```

## Things done

- [x] Built on platform(s): x86_64-linux (`nix-build -A sway`)
- [x] Inspected generated wrapper script — branches emit as expected.
- [ ] For packages with a release notes entry: not applicable.
- [x] (If applicable) Relevant documentation in the source code updated (wrapper comment added).
- [x] Tested, as applicable:
  - Wrapper rebuild succeeds.
  - Manual branch inspection: wrapper now resolves `$XDG_RUNTIME_DIR/bus` before falling back to `dbus-run-session`.

`swayfx` inherits this wrapper via `sway.override`, so no separate change is needed for it.

## Test plan

- [ ] Launch `sway` from TTY on a system with `systemd --user` active.
- [ ] Verify `DBUS_SESSION_BUS_ADDRESS` inside the session points at `unix:path=/run/user/$UID/bus`.
- [ ] Verify no extra `dbus-daemon --session` process is spawned for the session (`pgrep -a dbus-daemon`).
- [ ] Verify under `services.dbus.implementation = "broker"` sway descendants use the broker user bus.
- [ ] Verify container/minimal environments without `$XDG_RUNTIME_DIR/bus` still fall through to `dbus-run-session`.

## Priorities and Process

Add `a:1` label if the issue affects you.

- [x] I have read the [Contributing guide](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] I have read the relevant sections of the [Nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#chap-contributing).
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) and the [review guidelines](https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions).