### PR TITLE
pmix: ensure build info pointing to dev outputs is removed

### DIFF
--- a/pkgs/by-name/pm/pmix/package.nix
+++ b/pkgs/by-name/pm/pmix/package.nix
@@ -37,6 +37,20 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --build ./config
     patchShebangs --build ./contrib
     patchShebangs --build ./src/util/convert-help.py
+
+  ''
+  # 1. Remove the build information (options to configure and the CC path)
+  # These are hardcoded in the library and create an unwanted dependency
+  # on *.dev inputs.
+  # 2. Remove the reference to the pmix include directories, which are
+  # also hardcoded into the library (would be a cyclic reference).
+  + ''
+    substituteInPlace ./src/runtime/pmix_info_support.c \
+      --replace-fail 'PMIX_CONFIGURE_CLI' '""' \
+      --replace-fail 'PMIX_CC_ABSOLUTE' '""'
+
+    substituteInPlace ./src/mca/pinstalldirs/config/pinstall_dirs.h.in \
+      --replace-fail '@includedir@' ""
   '';
 
   nativeBuildInputs = [
@@ -90,10 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = lib.optionalString (lib.elem "dev" finalAttrs.outputs) ''
-    # The build info (parameters to ./configure) are hardcoded
-    # into the library. This clears all references to $dev/include.
-    remove-references-to -t "''${!outputDev}" $(readlink -f $out/lib/libpmix.so)
-
     # The path to the pmixcc-wrapper-data.txt is hard coded and
     # points to $out instead of dev. Use wrapper to fix paths.
     wrapProgram "''${!outputDev}"/bin/pmixcc \


### PR DESCRIPTION
Configure flags are recorded and hardcoded into library as human readable build information. This pulls in all dev inputs and gcc.

reduces the pmix runtime enclosure size: 394M -> 44M
reduces the openmpi runtime enclosure size: 592M -> 256M




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
