### PR TITLE
xfr: 0.9.6 -> 0.9.9

### DIFF
--- a/pkgs/by-name/xf/xfr/package.nix
+++ b/pkgs/by-name/xf/xfr/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xfr";
-  version = "0.9.6";
+  version = "0.9.9";
 
   src = fetchFromGitHub {
     owner = "lance0";
     repo = "xfr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wYhwDSL9C4rtWgkhaXimk3u03c9UHj2O9eEe8pRlj6c=";
+    hash = "sha256-AY+hNVywXWXgpLS0W/mtgfQWH/b647WLzjJCY3HrABM=";
   };
 
-  cargoHash = "sha256-f8m5vFNk62iXyK1Sh3Dda0pV6rUNErymS6QxiCuZ8DA=";
+  cargoHash = "sha256-8iW5OSGpoLfa2RWJJigOSwk6Eiv6m4WNUEWyoAqkl0M=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
## Release Notes:

- https://github.com/lance0/xfr/releases/tag/v0.9.9
- https://github.com/lance0/xfr/releases/tag/v0.9.8
- https://github.com/lance0/xfr/releases/tag/v0.9.7

Not quite sure why the bumps weren't proposed by the bot automatically.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
