### PR TITLE
killport: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/ki/killport/package.nix
+++ b/pkgs/by-name/ki/killport/package.nix
@@ -2,34 +2,47 @@
   lib,
   rustPlatform,
   fetchCrate,
+  stdenv,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "killport";
-  version = "1.1.0";
+  version = "2.0.0";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-7bENyg/KR4oI//jvG6bw+3UX3j9ITAXCMTpc+65VBZ8=";
+    hash = "sha256-I8GsTSCbWRItQ4Hzens2KlsHZNM/boipT392xYL4wmg=";
   };
 
-  cargoHash = "sha256-+PhaRVpsM/6GOnGkGDROoOGasrZsagK1LqBZTo9IbSI=";
+  cargoHash = "sha256-NOgt2WdS5JqTlCOI6qTOyBkTs/0qoA4qXoOHuZdRKvM=";
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
   checkFlags = [
-    # assertion failed: re.is_match(data)
+    # assertion failed: re.is_match(data) or blocked by sandbox
     "--skip=test_mode_option"
     "--skip=test_signal_handling"
+    "--skip=test_signal_sig"
+    "--skip=test_mode_short_flag"
+    "--skip=test_mode_process_finds_process"
+    "--skip=test_kill_udp_process"
+    "--skip=test_mode_auto_finds_process"
+    "--skip=test_kill_tcp_ipv4_process"
+    "--skip=test_dry_run_with_signal"
+    "--skip=test_combined_flags"
+    "--skip=test_dry_run_does_not_kill"
     "--skip=test_dry_run_option"
     "--skip=test_basic_kill_process"
+    "--skip=test_unix_process_kill_"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Command-line tool to easily kill processes running on a specified port";
     homepage = "https://github.com/jkfran/killport";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     mainProgram = "killport";
   };
 })


### PR DESCRIPTION
Update killport from 1.1.0 to 2.0.0

## Things done

  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
