### PR TITLE
ruby_4_0: 4.0.2 -> 4.0.3

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -407,8 +407,8 @@ in
   };
 
   ruby_4_0 = generic {
-    version = rubyVersion "4" "0" "2" "";
-    hash = "sha256-UVArJrULaN9JYzNspB42jN6SySj6+RZU3kxMF5H4Kqw=";
+    version = rubyVersion "4" "0" "3" "";
+    hash = "sha256-d5ZKzDcNXIN1uVAuW6bBPAPvkaueufUhyE+0K5yaaw8=";
     cargoHash = "sha256-z7NwWc4TaR042hNx0xgRkh/BQEpEJtE53cfrN0qNiE0=";
   };
 


### PR DESCRIPTION
Updates Ruby 4.0 to 4.0.3.
Release notes: https://github.com/ruby/ruby/releases/tag/v4.0.3

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] lib/tests
- [ ] Ran `nixpkgs-review`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md and relevant READMEs.
