### PR TITLE
neovim: check for pnames when asserting if two treesitters are installed

### DIFF
--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -218,6 +218,8 @@ let
             paths = allGrammars;
           };
 
+          allAndOptPluginNames = map (plugin: plugin.pname) (allPlugins ++ opt);
+
           packdirStart = vimFarm "pack/${packageName}/start" "packdir-start" (
             if allGrammars != [ ] then allPlugins ++ [ allGrammarsSymlinked ] else allPlugins
           );
@@ -234,8 +236,8 @@ let
 
         assert
           (
-            builtins.elem vimPlugins.nvim-treesitter (opt ++ allPlugins)
-            && builtins.elem vimPlugins.nvim-treesitter-legacy (opt ++ allPlugins)
+            builtins.elem "nvim-treesitter" allAndOptPluginNames
+            && builtins.elem "nvim-treesitter-legacy" allAndOptPluginNames
           )
           -> throw "You cannot include two different versions of nvim-treesitter, perhaps you included a legacy plugin together with a new one?";
 


### PR DESCRIPTION
Previously it evaluated `nvim-treesitter-legacy` derivation, which now results in a warning. Checking for pname shouldn't raise this warning, since now only plugins that are installed get evaluated.

Pointed out in https://github.com/NixOS/nixpkgs/pull/510623#issuecomment-4289158985 (CC @r-vdp)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
