### PR TITLE
zed-wakatime-ls: init at 0.1.10

### DIFF
--- a/pkgs/by-name/ze/zed-wakatime-ls/package.nix
+++ b/pkgs/by-name/ze/zed-wakatime-ls/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+# Usage:
+# Add "zed-wakatime-ls" to programs.zed-editor.extraPackages in home-manager
+# or just globally in home.packages or environment.systemPackages
+# to allow the WakaTime extension to find and run the language server
+# This will resolve https://github.com/wakatime/zed-wakatime/issues/55
+# without requiring nix-ld
+
+rustPlatform.buildRustPackage rec {
+  pname = "zed-wakatime-ls";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "wakatime";
+    repo = "zed-wakatime";
+    rev = "v${version}";
+    hash = "sha256-Jmm+eRHMNBkc6ZzadvkWrfsb+bwEBNM0fnXU4dJ0NgE=";
+  };
+
+  buildAndTestSubdir = "wakatime-ls";
+  doCheck = false; # No tests exist
+
+  cargoHash = "sha256-x2axmHinxYZ2VEddeCTqMJd8ok0KgAVdUhbWaOdRA30=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "WakatTime language server for Zed";
+    homepage = "https://github.com/wakatime/zed-wakatime";
+    changelog = "https://github.com/wakatime/zed-wakatime/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ krishnans2006 ];
+    mainProgram = "wakatime-ls";
+  };
+}

--- a/pkgs/by-name/ze/zed-wakatime-ls/package.nix
+++ b/pkgs/by-name/ze/zed-wakatime-ls/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zed-wakatime-ls";
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "wakatime";
+    repo = "zed-wakatime";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Jmm+eRHMNBkc6ZzadvkWrfsb+bwEBNM0fnXU4dJ0NgE=";
+  };
+
+  buildAndTestSubdir = "wakatime-ls";
+
+  cargoHash = "sha256-x2axmHinxYZ2VEddeCTqMJd8ok0KgAVdUhbWaOdRA30=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "WakaTime language server for Zed";
+    longDescription = ''
+      Usage: Add "zed-wakatime-ls" to programs.zed-editor.extraPackages in home-manager or globally
+      in home.packages or environment.systemPackages to allow the Zed WakaTime extension to find and
+      run the language server.
+    '';
+    homepage = "https://github.com/wakatime/zed-wakatime";
+    changelog = "https://github.com/wakatime/zed-wakatime/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ krishnans2006 ];
+    mainProgram = "wakatime-ls";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This packages the `wakatime-ls` subfolder of [wakatime/zed-wakatime](https://github.com/wakatime/zed-wakatime), which provides the `wakatime-ls` binary. This allows the WakaTime extension in Zed to successfully start when `nix-ld` is not enabled, by giving Zed a locally-installed executable to use instead of trying to auto-download one.

The auto-download will fail with this error (as noted [here](https://github.com/wakatime/zed-wakatime/issues/55)):

```nix
Language server wakatime:

initializing server wakatime, id 4
-- stderr--
Could not start dynamically linked executable: /home/haruki/.local/share/zed/extensions/work/wakatime/wakatime-ls-v0.1.9/wakatime-ls
NixOS cannot run dynamically linked executables intended for generic
linux environments out of the box. For more information, see:
https://nix.dev/permalink/stub-ld
```

This package follows a similar packaging style to [zed-discord-presence](https://github.com/bddvlpr/nixpkgs/blob/master/pkgs/by-name/ze/zed-discord-presence/package.nix), which also solves a similar problem.

A snippet of how this can be used can be found [here](https://github.com/krishnans2006/nixos-config/blob/cc30ed8023b22661caf9e4bbae388b3ae3b75f1d/modules/packages/zed-editor.nix#L24), and is also noted in the comments of the package source.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
