### PR TITLE
open-webui: 0.8.12 -> 0.9.1

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.8.12";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-ynWv/X4IBKO09+ira+NUwbzw51MK9aEvGkeaHzCngd0=";
+    hash = "sha256-INUxpLGN+Jn2oYggA9kkp1zGY+LPQNXuRop4DaOi9Ps=";
   };
 
   frontend = buildNpmPackage rec {
@@ -32,7 +32,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-UeoU7UGQ+0ViEIjK/Ze7KazB/JCyFYljHyTmxuza4v8=";
+    npmDepsHash = "sha256-tn76LGDLRaR87VM0pHgkutsbg4X4Kco04HwgGSS8Uug=";
 
     # See https://github.com/open-webui/open-webui/issues/15880
     npmFlags = [
@@ -92,12 +92,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
       aiocache
       aiofiles
       aiohttp
+      aiosqlite
       alembic
       anthropic
       apscheduler
       argon2-cffi
       asgiref
       async-timeout
+      asyncpg
       authlib
       azure-ai-documentintelligence
       azure-identity
@@ -155,7 +157,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
       pandas
       peewee
       peewee-migrate
-      pgvector
       pillow
       psutil
       pyarrow
@@ -187,7 +188,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
       starsessions
       tiktoken
       transformers
-      unstructured
       uvicorn
       validators
       xlrd
@@ -204,6 +204,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
     mariadb = [
       mariadb
+    ];
+
+    unstructured = [
+      unstructured
     ];
 
     all = [
@@ -223,6 +227,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     ]
     ++ finalAttrs.passthru.optional-dependencies.mariadb
     ++ finalAttrs.passthru.optional-dependencies.postgres
+    ++ finalAttrs.passthru.optional-dependencies.unstructured
     ++ moto.optional-dependencies.s3;
   };
 


### PR DESCRIPTION
Diff: https://github.com/open-webui/open-webui/compare/v0.8.12...v0.9.1

Changelog: https://github.com/open-webui/open-webui/blob/v0.9.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
