### PR TITLE
tansu: init at 0.6.0

### DIFF
--- a/pkgs/by-name/ta/tansu/package.nix
+++ b/pkgs/by-name/ta/tansu/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  # tansu-client's tests::tcp_client_server binds 127.0.0.1; darwin sandbox blocks it without this.
+  __darwinAllowLocalNetworking = true;
+
+  pname = "tansu";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "tansu-io";
+    repo = "tansu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8mk3PQInvnqLQaChiBFDXjEqu5vWT/RbApQr71/zqFs=";
+  };
+
+  cargoHash = "sha256-E1eR9U3Qa4pBtiovflqgMWBoWUP8mCxqT7Fb99yBqvI=";
+
+  buildFeatures = [
+    "dynostore"
+    "libsql"
+    "slatedb"
+    "turso"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Drop-in replacement for Apache Kafka";
+    homepage = "https://tansu.io";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jonhermansen ];
+    mainProgram = "tansu";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds tansu, a Kafka-compatible broker. Binary exposes broker, proxy, topic CLI, traffic generator, and a perf tool.

Currently evaluating this as a tiny drop-in replacement for Kafka in local development.

https://tansu.io/

https://github.com/tansu-io/tansu

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
