### PR TITLE
rapina-cli: Init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2009,6 +2009,12 @@
     githubId = 25783780;
     name = "aos";
   };
+  apetrovic = {
+    email = "github.drapery867@simplelogin.com";
+    github = "apetrovic6";
+    githubId = 31852070;
+    name = "apetrovic";
+  };
   apeyroux = {
     email = "alex@px.io";
     github = "apeyroux";

--- a/pkgs/by-name/ra/rapina-cli/package.nix
+++ b/pkgs/by-name/ra/rapina-cli/package.nix
@@ -8,6 +8,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rapina-cli";
   version = "0.11.0";
 
+  __structuredAttrs = true;
+
   src = fetchCrate {
     inherit (finalAttrs) pname version;
     hash = "sha256-zdhyXJUSg8wU65YMXZBqDIkkGTh9DjSbc7b63pU2nuo=";
@@ -24,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://userapina.com";
     changelog = "https://github.com/rapina-rs/rapina/blob/master/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ apetrovic6 ];
+    maintainers = with lib.maintainers; [ apetrovic ];
     mainProgram = "rapina";
   };
 })

--- a/pkgs/by-name/ra/rapina-cli/package.nix
+++ b/pkgs/by-name/ra/rapina-cli/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rapina-cli";
+  version = "0.11.0";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-zdhyXJUSg8wU65YMXZBqDIkkGTh9DjSbc7b63pU2nuo=";
+  };
+
+  cargoHash = "sha256-wcYGBXs08I3E1/7Obx9E3BXmU5nFV0NBfWoALxHa4SI=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Rapina CLI is a command-line tool designed to streamline the process of generating and managing Rapina projects";
+    homepage = "https://userapina.com";
+    changelog = "https://github.com/rapina-rs/rapina/blob/master/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ apetrovic6 ];
+    mainProgram = "rapina";
+  };
+})

--- a/pkgs/by-name/ra/rapina-cli/package.nix
+++ b/pkgs/by-name/ra/rapina-cli/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rapina-cli";
+  version = "0.11.0";
+
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-zdhyXJUSg8wU65YMXZBqDIkkGTh9DjSbc7b63pU2nuo=";
+  };
+
+  cargoHash = "sha256-wcYGBXs08I3E1/7Obx9E3BXmU5nFV0NBfWoALxHa4SI=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Rapina CLI is a command-line tool designed to streamline the process of generating and managing Rapina projects";
+    homepage = "https://userapina.com";
+    changelog = "https://github.com/rapina-rs/rapina/blob/master/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ apetrovic ];
+    mainProgram = "rapina";
+  };
+})


### PR DESCRIPTION
Add Rapina cli tool for Rapina framework https://userapina.com.
The cli provides extra tooling for working with the framework.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
