### PR TITLE
iterm2: 3.6.6 -> 3.6.10

### DIFF
--- a/pkgs/by-name/it/iterm2/package.nix
+++ b/pkgs/by-name/it/iterm2/package.nix
@@ -15,13 +15,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "iterm2";
-  version = "3.6.6";
+  version = "3.6.10";
 
   src = fetchzip {
     url = "https://iterm2.com/downloads/stable/iTerm2-${
       lib.replaceStrings [ "." ] [ "_" ] version
     }.zip";
-    hash = "sha256-n3VoRxMOBQK/8mbVbORSBz73tsuKAUMG7dFZIbaqdHU=";
+    hash = "sha256-igdExoh3d8EZBuKkqyNqF087jUISax07rSWG3eenUbw=";
   };
 
   dontFixup = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates iTerm2 to [v3.6.10](https://github.com/gnachman/iTerm2/releases/tag/v3.6.10), bringing in gnachman/iTerm2@eeeefb9475877b861ad8d12502dcbcbe539f9328 which is a release backport of the commit gnachman/iTerm2@a9e745993c2e2cbb30b884a16617cd5495899f86 that fixes the security bug described in the blog post [MAD Bugs: "cat readme.txt" is not safe in iTerm2](https://blog.calif.io/p/mad-bugs-even-cat-readmetxt-is-not), which [reached the front page of Hacker News last week](https://news.ycombinator.com/item?id=47809190).

<details>
<summary>Expand for commands to run in the iTerm2 repo showing that this security fix commit was absent in earlier 3.6.x releases.</summary>

```sh
git merge-base --is-ancestor eeeefb9475877b861ad8d12502dcbcbe539f9328 v3.6.6 ; echo $?
```

```sh
git merge-base --is-ancestor eeeefb9475877b861ad8d12502dcbcbe539f9328 v3.6.9 ; echo $?
```

```sh
git merge-base --is-ancestor eeeefb9475877b861ad8d12502dcbcbe539f9328 v3.6.10 ; echo $?
```

</details>

I used the update script from #457938 as follows:

```sh
nix-shell maintainers/scripts/update.nix --argstr package iterm2
```

@emaiax I'm concerned about the fact that @r-ryantm did not automatically open PRs to update iTerm2 after you added this update script, despite the fact that [v3.6.7](https://github.com/gnachman/iTerm2/releases/tag/v3.6.7) was released over two months ago; do you happen to know why? Does the bot only automatically update Linux packages?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
