### PR TITLE
klipper: fix cross runtime behavior

### DIFF
--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -9,7 +9,9 @@
   makeWrapper,
   writeShellScript,
 }:
-
+let
+  isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
+in
 stdenv.mkDerivation rec {
   pname = "klipper";
   version = "0.13.0-unstable-2026-03-21";
@@ -46,10 +48,30 @@ stdenv.mkDerivation rec {
     ))
   ];
 
-  # we need to run this to prebuild the chelper.
-  postBuild = ''
-    python ./chelper/__init__.py
+  # we need to run this to prebuild the chelper .so. However when cross
+  # compiling, a patch is temporarily required during the build process to
+  # prevent the build process from using dlopen() on this .so which has been
+  # built for a foreign architecture. We then place the unpatched __init__.py
+  # back, as this dlopen() call is required at runtime
+  postBuild =
+    if isCross then
+      ''
+        python ./chelper/__init__.py
+        mv ./chelper/__init__unpatched.py ./chelper/__init__.py
+      ''
+    else
+      ''
+        python ./chelper/__init__.py
+      '';
+
+  prePatch = lib.optionalString isCross ''
+    cp ./chelper/__init__.py ./chelper/__init__unpatched.py
   '';
+
+  patches = lib.optionals isCross [
+    # https://github.com/Klipper3d/klipper/pull/7254
+    ./cross-ffi.patch
+  ];
 
   # Python 3 is already supported but shebangs aren't updated yet
   postPatch = ''
@@ -59,14 +81,9 @@ stdenv.mkDerivation rec {
     done
 
     # needed for cross compilation
-    substituteInPlace ./chelper/__init__.py \
+    substituteInPlace ./chelper/__init__*.py \
       --replace 'GCC_CMD = "gcc"' 'GCC_CMD = "${stdenv.cc.targetPrefix}cc"'
   '';
-
-  patches = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    # https://github.com/Klipper3d/klipper/pull/7254
-    ./cross-ffi.patch
-  ];
 
   pythonInterpreter =
     (python3.withPackages (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

continuation of https://github.com/NixOS/nixpkgs/pull/511549

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
