### PR TITLE
cudaPackages.libcuobjclient: init at 1.0.0.26

### DIFF
--- a/pkgs/development/cuda-modules/packages/libcuobjclient.nix
+++ b/pkgs/development/cuda-modules/packages/libcuobjclient.nix
@@ -1,0 +1,31 @@
+{
+  buildRedist,
+  libcufile,
+  numactl,
+}:
+buildRedist {
+  redistName = "cuda";
+  pname = "libcuobjclient";
+
+  outputs = [
+    "out"
+    "dev"
+    "include"
+    "lib"
+  ];
+
+  buildInputs = [
+    libcufile
+    numactl
+  ];
+
+  meta = {
+    description = "CUDA cuObject Client";
+    longDescription = ''
+      High-performance suite of libraries designed to enable direct data transfers between GPU
+      memory or system memory and object storage (S3-compatible) solution via RDMA.
+    '';
+    homepage = "https://docs.nvidia.com/gpudirect-storage/cuobject/";
+    changelog = "https://docs.nvidia.com/gpudirect-storage/cuobject/";
+  };
+}


### PR DESCRIPTION
## Things done

Add [libcuobjclient](https://docs.nvidia.com/gpudirect-storage/cuobject/cuobject-client-release-notes/index.html), _a high-performance suite of libraries designed to enable direct data transfers between GPU memory or system memory and object storage (S3-compatible) solution via RDMA_.

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
