### PR TITLE
obsidianPlugins & obsidianThemes: init

### DIFF
--- a/pkgs/by-name/ob/obsidian/plugins/default.nix
+++ b/pkgs/by-name/ob/obsidian/plugins/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  callPackage,
+}:
+let
+  root = ./.;
+
+  assertManifestId =
+    name: pkg:
+    lib.trivial.warnIf (!(pkg ? manifestId))
+      "Plugin '${name}' is missing passthru.manifestId - plugins should define this to identify themselves"
+      pkg;
+in
+lib.pipe root [
+  builtins.readDir
+  (lib.filterAttrs (_: type: type == "directory"))
+  (builtins.mapAttrs (name: pkg: assertManifestId name (callPackage (root + "/${name}") { })))
+]

--- a/pkgs/by-name/ob/obsidian/themes/default.nix
+++ b/pkgs/by-name/ob/obsidian/themes/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  callPackage,
+}:
+let
+  root = ./.;
+
+  assertManifestId =
+    name: pkg:
+    lib.trivial.warnIf (!(pkg ? manifestId))
+      "Theme '${name}' is missing passthru.manifestId - themes should define this to identify themselves"
+      pkg;
+in
+lib.pipe root [
+  builtins.readDir
+  (lib.filterAttrs (_: type: type == "directory"))
+  (builtins.mapAttrs (name: pkg: assertManifestId name (callPackage (root + "/${name}") { })))
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12417,6 +12417,10 @@ with pkgs;
 
   radicle-node-unstable = callPackage ../by-name/ra/radicle-node/unstable.nix { };
 
+  obsidianPlugins = recurseIntoAttrs (callPackage ../by-name/ob/obsidian/plugins { });
+
+  obsidianThemes = recurseIntoAttrs (callPackage ../by-name/ob/obsidian/themes { });
+
   olivetin-3k = callPackage ../by-name/ol/olivetin/3k.nix { };
 
   newlib-nano = newlib.override {


### PR DESCRIPTION
Adding base structure to support further additions of obsidian plugins and themes. Each plugin/theme will be defined in its own directory. I don't think this can be further abstracted, since each project might use different build methods, e.g. NPM, Yarn.

I have manually tested building a theme and a plugin, which I will merge in further PRs if this one is accepted.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
