### PR TITLE
openvino: `aarch64-darwin` support

### DIFF
--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -15,6 +15,7 @@
   pkg-config,
   python3Packages,
   shellcheck,
+  darwin,
 
   # runtime
   flatbuffers,
@@ -71,16 +72,22 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    addDriverRunpath
-    autoPatchelfHook
     cmake
     git
     libarchive
-    patchelf
     pkg-config
     python
     scons'
     shellcheck
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    addDriverRunpath
+    autoPatchelfHook
+    patchelf
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.sigtool
+    darwin.autoSignDarwinBinariesHook
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_nvcc
@@ -106,9 +113,12 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "ENABLE_SAMPLES" false)
 
     # features
-    (cmakeBool "ENABLE_INTEL_CPU" stdenv.hostPlatform.isx86_64)
-    (cmakeBool "ENABLE_INTEL_GPU" true)
-    (cmakeBool "ENABLE_INTEL_NPU" stdenv.hostPlatform.isx86_64)
+    # On `aarch64-darwin`, we need `libopenvino_arm_cpu_plugin`.
+    # Without `openvino_intel_cpu_plugin`, it won't build.
+    # https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_cpu/CMakeLists.txt
+    (cmakeBool "ENABLE_INTEL_CPU" (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isDarwin))
+    (cmakeBool "ENABLE_INTEL_GPU" stdenv.hostPlatform.isLinux)
+    (cmakeBool "ENABLE_INTEL_NPU" (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform.isLinux))
     (cmakeBool "ENABLE_JS" false)
     (cmakeBool "ENABLE_LTO" true)
     (cmakeBool "ENABLE_ONEDNN_FOR_GPU" false)
@@ -123,6 +133,13 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "ENABLE_SYSTEM_PUGIXML" true)
     (cmakeBool "ENABLE_SYSTEM_SNAPPY" true)
     (cmakeBool "ENABLE_SYSTEM_TBB" true)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # dlopen fails without all that.
+    "-DCMAKE_MACOSX_RPATH=ON"
+    "-DCMAKE_INSTALL_NAME_DIR=@rpath"
+    "-DCMAKE_INSTALL_RPATH=@loader_path;@loader_path/../runtime/lib/arm64/Release"
+    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
   ];
 
   # src/graph/src/plugins/intel_gpu/src/graph/include/reorder_inst.h:24:8: error: type 'struct typed_program_node' violates the C++ One Definition Rule [-Werror=odr]
@@ -131,7 +148,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     flatbuffers
     gflags
-    level-zero
     libusb1
     libxml2
     ocl-icd
@@ -139,6 +155,9 @@ stdenv.mkDerivation (finalAttrs: {
     pugixml
     snappy
     onetbb
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    level-zero
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
@@ -152,7 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
     rmdir $out/python
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString stdenv.isLinux ''
     # Link to OpenCL
     find $out -type f \( -name '*.so' -or -name '*.so.*' \) | while read lib; do
       addDriverRunpath "$lib"
@@ -172,6 +191,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://docs.openvinotoolkit.org/";
     license = with lib.licenses; [ asl20 ];
     platforms = lib.platforms.all;
-    broken = stdenv.hostPlatform.isDarwin; # Cannot find macos sdk
   };
 })


### PR DESCRIPTION
## description

### the problem

openvino was marked as broken for macos, so i had to make a custom package for my project as follows

- download a prebuilt version from <https://storage.openvinotoolkit.org/repositories/openvino/packages/>
- fix rpath with `install_name_tool`
- `codesign`

since the prebuilt version exists, i think it's possible to build it in nixpkgs.

### how the solution was born

first, i simply removed the `broken` marker and tried building it. it failed because `level-zero` is for linux only, so i gated it behind platform flags, as well as some `nativeBuildInputs` for linux only

> side note: i don't remember having any issues like "cannot find macos sdk" or others (since mid 2025).

---

after that, openvino built just fine, but my rust app that uses [openvino bindings](https://github.com/intel/openvino-rs) failed to link dynamically because the dylibs were not signed properly. i tried manually signing everything, but then found `autoSignDarwinBinariesHook`.

---

after signing the binaries properly, dynamic linking still failed because it couldn't find the libraries.

seems like the issue was with the rpath

```bash
$ otool -L result/runtime/lib/arm64/Release/libopenvino_c.dylib

/nix/store/37bjf4025qm3iqzl2jb00gwzwywvwxgr-openvino-2026.1.0/lib/libopenvino_c.2610.dylib (compatibility version 2610.0.0, current version 2026.1.0)
/nix/store/37bjf4025qm3iqzl2jb00gwzwywvwxgr-openvino-2026.1.0/lib/libopenvino.2610.dylib (compatibility version 2610.0.0, current version 2026.1.0)
/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 2000.63.0)
/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
```

as seen, the path is `$out/lib/*.dylib` which is incorrect because all the dylibs are in `$out/runtime/lib/arm64/Release` (i have so many questions...)

i was told that instead of patching rpath manually, we can tell cmake to do it for us, so i added 4 more flags (currently gated behind the platform). after that, openvino finally linked dynamically

---

but it didn't run still :sob: 

i faced some `GENERAL_ERROR`s. after a bit of digging i realized it's because i had no available devices to run inference on, even though there should be just the cpu. it looks like you need a `libopenvino_arm_cpu_plugin` that only builds when you build the `openvino_intel_cpu_plugin`. somehow this fixed the problem. 

after all this, it worked properly

--- 

i avoided changing how it builds for linux because "if it works, don't touch it", so i didn't modify rpath for linux. my colleagues verified that on `x86_64-linux` it works as before. 

HOWEVER 💀 on `aarch64-linux` it fails to run for the same reason - no available devices. turning on the intel cpu plugin leads to linking errors like `undefined reference to vtable for arm_compute::TensorInfo'`. i haven't figured it out, so i'd suggest leaving it for future

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - ✅ x86_64-linux
  - ❌ aarch64-linux (see the end of summary)
  - ⚪ x86_64-darwin (didn't try; isn't it deprecated?)
  - ✅ aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
