### PR TITLE
urx: init at 0.9.0

### DIFF
--- a/pkgs/by-name/ur/urx/package.nix
+++ b/pkgs/by-name/ur/urx/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  sqlite,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "urx";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "hahwul";
+    repo = "urx";
+    tag = finalAttrs.version;
+    hash = "sha256-NSPEAA+tD1CdCjRj3myQB8bPdMhT7H76qAIIWx2z++I=";
+  };
+
+  cargoHash = "sha256-nPm4ofmu03Rb12spjb+m36C6EauJIppgqTkX1oJF3uk=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ sqlite ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __structuredAttrs = true;
+
+  checkFlags = [
+    # Tests require network access
+    "--skip=providers"
+    "--skip=network::client::tests"
+  ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "--version" ];
+
+  meta = {
+    description = "Extracts URLs from OSINT Archives for Security Insights";
+    homepage = "https://github.com/hahwul/urx";
+    changelog = "https://github.com/hahwul/urx/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "urx";
+  };
+})


### PR DESCRIPTION
Extracts URLs from OSINT Archives for Security Insights

https://github.com/hahwul/urx

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
