### PR TITLE
vsmartcard-vpcd: add missing wrapPythonPrograms

### DIFF
--- a/pkgs/by-name/vs/vsmartcard-vpcd/package.nix
+++ b/pkgs/by-name/vs/vsmartcard-vpcd/package.nix
@@ -8,6 +8,7 @@
   pcsclite,
   qrencode,
   python3,
+  python3Packages,
   help2man,
 }:
 
@@ -28,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     libtool
     pkg-config
+    python3Packages.wrapPython
     help2man
   ];
 
@@ -46,6 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = lib.optional stdenv.hostPlatform.isDarwin "--enable-infoplist";
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
 
   meta = {
     description = "Emulates a smart card and makes it accessible through PC/SC";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes this issue:

```
$ vicc
Traceback (most recent call last):
  File "/run/current-system/sw/bin/vicc", line 116, in <module>
    from virtualsmartcard.VirtualSmartcard import VirtualICC
ModuleNotFoundError: No module named 'virtualsmartcard'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
