### PR TITLE
stdenv: remove `foundMakefile` variable

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1503,14 +1503,17 @@ configurePhase() {
 }
 
 
+noMakefile() {
+    [[ -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]
+}
+
+
 buildPhase() {
     runHook preBuild
 
-    if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]; then
+    if [[ -z "${makeFlags-}" ]] && noMakefile; then
         echo "no Makefile or custom buildPhase, doing nothing"
     else
-        foundMakefile=1
-
         # shellcheck disable=SC2086
         local flagsArray=(
             ${enableParallelBuilding:+-j${NIX_BUILD_CORES}}
@@ -1530,7 +1533,7 @@ buildPhase() {
 checkPhase() {
     runHook preCheck
 
-    if [[ -z "${foundMakefile:-}" ]]; then
+    if noMakefile; then
         echo "no Makefile or custom checkPhase, doing nothing"
         runHook postCheck
         return
@@ -1570,13 +1573,10 @@ checkPhase() {
 installPhase() {
     runHook preInstall
 
-    # Dont reuse 'foundMakefile' set in buildPhase, a makefile may have been created in buildPhase
-    if [[ -z "${makeFlags-}" && -z "${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ]]; then
+    if [[ -z "${makeFlags-}" ]] && noMakefile; then
         echo "no Makefile or custom installPhase, doing nothing"
         runHook postInstall
         return
-    else
-        foundMakefile=1
     fi
 
     if [ -n "$prefix" ]; then
@@ -1657,7 +1657,7 @@ fixupPhase() {
 installCheckPhase() {
     runHook preInstallCheck
 
-    if [[ -z "${foundMakefile:-}" ]]; then
+    if [[ -z "${makeFlags-}" ]] && noMakefile; then
         echo "no Makefile or custom installCheckPhase, doing nothing"
     #TODO(@oxij): should flagsArray influence make -n?
     elif [[ -z "${installCheckTarget:-}" ]] \


### PR DESCRIPTION
This variable creates an unnecessary interdependency between the various phases, which `nix develop` currently has to accomodate by manually setting it when run with a `--phase`. This is ugly and requires nix to have awareness of a low-level implementation detail of stdenv. See: https://github.com/NixOS/nix/blob/15d583f3eae76c87758f005b0b4d167089521f84/src/nix/develop.cc#L605-L607

This is part of the effort to move much of the `nix develop` logic into stdenv itself, I'm branching it off into its own PR because it causes a mass-rebuild.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
