### PR TITLE
buildBazelPackage: support __structuredAttrs = true

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -86,6 +86,8 @@ let
       targetRunFlags ? [ ],
     }:
     lib.optionalString (targets != [ ]) ''
+      concatTo bazelFlagsArray bazelFlags
+
       # See footnote called [USER and BAZEL_USE_CPP_ONLY_TOOLCHAIN variables]
       BAZEL_USE_CPP_ONLY_TOOLCHAIN=1 \
       USER=homeless-shelter \
@@ -99,7 +101,7 @@ let
         "''${host_copts[@]}" \
         "''${linkopts[@]}" \
         "''${host_linkopts[@]}" \
-        $bazelFlags \
+        "''${bazelFlagsArray[@]}" \
         ${lib.strings.concatStringsSep " " additionalFlags} \
         ${lib.strings.concatStringsSep " " targets} \
         ${
@@ -239,13 +241,24 @@ stdenv.mkDerivation (
           );
 
         dontFixup = true;
-        allowedRequisites = [ ];
 
         inherit (lib.fetchers.normalizeHash { hashTypes = [ "sha256" ]; } fetchAttrs)
           outputHash
           outputHashAlgo
           ;
       }
+      // (
+        if fFetchAttrs.__structuredAttrs or false then
+          {
+            # With __structuredAttrs = true, the build always fails with “output $out is not allowed to refer to the following paths: $out”.
+            # This appears to be the same issue as in 283bca9648fc1afb01d3e4c3b5919251429da907.
+            outputChecks.out.allowedRequisites = [ "out" ];
+          }
+        else
+          {
+            allowedRequisites = [ ];
+          }
+      )
     );
 
     nativeBuildInputs = fBuildAttrs.nativeBuildInputs or [ ] ++ [

--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -73,6 +73,9 @@ buildBazelPackage rec {
 
   passthru.updateScript = nix-update-script { };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "Bazel/Build Analysis and Navigation Tool";
     homepage = "http://bant.build/";


### PR DESCRIPTION
Split from https://github.com/NixOS/nixpkgs/pull/510423

When using structured attributes, `bazelFlags` is an array. `$bazelFlags` then only returns the array's first item.

Instead we need to use `"${bazelFlags[@]}"` which correctly returns all array items with proper support for spaces in individual flags.

This remains compatible with the non-structured case by converting `bazelFlags` to an array in that case as well.

This is heavily inspired from 4caf9a61f94bd730bd178ec6f543b8972ee43552.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (subset of packages which failed in https://github.com/NixOS/nixpkgs/pull/510423#issuecomment-4282203553: bant mozc perf_data_converter protoc-gen-js verible veridian)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
