### PR TITLE
ingress2gateway: 0.5.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/in/ingress2gateway/package.nix
+++ b/pkgs/by-name/in/ingress2gateway/package.nix
@@ -6,21 +6,25 @@
 
 buildGoModule (finalAttrs: {
   pname = "ingress2gateway";
-  version = "0.5.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "ingress2gateway";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-pX/4WFqYkBPnaEki3q3CahBCePUvKQzVulT+oMtUXQc=";
+    hash = "sha256-rnSkJMME0BOQYlMv8tN8CywivVOwEek6eJ46jHY7ho0=";
   };
 
-  vendorHash = "sha256-NlQbjKU5EoNY70ziDs98394LSxSIyTGsGgP1S22ynDA=";
+  vendorHash = "sha256-9YV4T7sDhb/1ZgpjrIm4AWFx1OoZbY9u3jpGlCM4edc=";
 
   ldflags = [
     "-s"
     "-w"
+    "-X"
+    "github.com/kubernetes-sigs/ingress2gateway/pkg/i2gw.Version=v${finalAttrs.version}"
   ];
+
+  excludedPackages = [ "e2e" ];
 
   meta = {
     description = "Convert Ingress resources to Gateway API resources";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/kubernetes-sigs/ingress2gateway/releases/tag/v1.0.0

* skips building and running the new e2e test suite, as it requires access to a kubernetes cluster or container runtime
* sets the version so that `ingress2gateway version` no longer reports `dev` to be the version

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
