### PR TITLE
dopamine: build from source

### DIFF
--- a/pkgs/by-name/do/dopamine/package.nix
+++ b/pkgs/by-name/do/dopamine/package.nix
@@ -1,39 +1,121 @@
 {
   lib,
-  fetchurl,
-  appimageTools,
-  nix-update-script,
-  makeWrapper,
+  stdenv,
+  fetchFromGitHub,
+  buildNpmPackage,
+  electron_39,
+  python3,
+  xcodebuild,
 }:
-appimageTools.wrapType2 rec {
+buildNpmPackage (finalAttrs: {
   pname = "dopamine";
   version = "3.0.4";
 
-  src = fetchurl {
-    url = "https://github.com/digimezzo/dopamine/releases/download/v${version}/Dopamine-${version}.AppImage";
-    hash = "sha256-sm8/ZzSqa1CsQJ7XfQ67yAKX5rR9E8J/Z6v1rLVhNwI=";
+  src = fetchFromGitHub {
+    owner = "digimezzo";
+    repo = "dopamine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/qgzlbaV0JdKD3UT9Kr5QD3RPMF0ZvO3VIdHokGAFic=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  npmDepsHash = "sha256-7qRKecY/w7s0zd/TpIRku8wfFE8FwEXPTr8Xz6nusic=";
 
-  extraInstallCommands =
-    let
-      contents = appimageTools.extract { inherit pname version src; };
-    in
-    ''
-      wrapProgram $out/bin/${pname} \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+  patches = [
+    # register-scheme contains install scripts, but has no lockfile
+    ./remove-register-scheme.patch
 
-      install -Dm644 ${contents}/dopamine.desktop $out/share/applications/dopamine.desktop
-      substituteInPlace $out/share/applications/dopamine.desktop \
-        --replace-fail 'Exec=AppRun' 'Exec=dopamine'
-      cp -r ${contents}/usr/share/icons $out/share
-    '';
+    # fixes node-addon-api errors with aarch64-darwin
+    ./update-node-addon-api.patch
+  ];
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };
+  nativeBuildInputs = [
+    (python3.withPackages (ps: with ps; [ distutils ]))
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcodebuild ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  buildPhase = ''
+    runHook preBuild
+
+    # needed for better-sqlite3 rebuild
+    export npm_config_nodedir="${electron_39.headers}"
+    export npm_config_target="${electron_39.version}"
+
+    npm rebuild --verbose --no-progress --offline
+
+    # reduce better-sqlite3 size
+    pushd node_modules/better-sqlite3
+    rm -rf src deps build/{deps,Release/{.deps,obj,obj.target,test_extension.node}}
+    popd
+
+    npm run build:prod
+
+    # otherwise angular uses up ~150MB space
+    rm -rf .angular
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          cp -r ${electron_39.dist}/Electron.app ./
+          find ./Electron.app -name 'Info.plist' -exec chmod +rw {} \;
+
+          npm exec electron-builder -- \
+            --dir \
+            -c.npmRebuild=false \
+            -c.mac.identity=null \
+            -c.electronDist=./ \
+            -c.electronVersion=${electron_39.version} \
+            -c.extraMetadata.version=v${finalAttrs.version} \
+            --config electron-builder.config.js
+        ''
+      else
+        ''
+          npm exec electron-builder -- \
+            --dir \
+            -c.npmRebuild=false \
+            -c.electronDist=${electron_39.dist} \
+            -c.electronVersion=${electron_39.version} \
+            -c.extraMetadata.version=v${finalAttrs.version} \
+            --config electron-builder.config.js
+        ''
+    }
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir -p $out/{Applications,bin}
+          cp -r release/mac*/Dopamine.app $out/Applications
+          makeWrapper $out/Applications/Dopamine.app/Contents/MacOS/Dopamine $out/bin/dopamine
+        ''
+      else
+        ''
+          mkdir -p $out/share/dopamine
+          cp -r release/linux*unpacked/{locales,resources{,.pak}} $out/share/dopamine
+
+          makeWrapper ${lib.getExe electron_39} $out/bin/dopamine \
+            --add-flags $out/share/dopamine/resources/app.asar \
+            --inherit-argv0
+
+          for size in 16 24 32 48 64 96 128 256 512; do
+            install -Dm644 "build/icons/"$size"x"$size".png" "$out/share/icons/hicolor/"$size"x"$size"/apps/dopamine.png"
+          done
+
+          install -Dm644 deployment/AUR/dopamine.desktop $out/share/applications/dopamine.desktop
+        ''
+    }
+
+    runHook postInstall
+  '';
 
   meta = {
-    changelog = "https://github.com/digimezzo/dopamine/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/digimezzo/dopamine/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Audio player that keeps it simple";
     homepage = "https://github.com/digimezzo/dopamine";
     license = lib.licenses.gpl3Only;
@@ -42,7 +124,6 @@ appimageTools.wrapType2 rec {
       Guanran928
       ern775
     ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/do/dopamine/package.nix
+++ b/pkgs/by-name/do/dopamine/package.nix
@@ -1,39 +1,121 @@
 {
   lib,
-  fetchurl,
-  appimageTools,
-  nix-update-script,
-  makeWrapper,
+  stdenv,
+  fetchFromGitHub,
+  buildNpmPackage,
+  electron_40,
+  python3,
+  xcodebuild,
 }:
-appimageTools.wrapType2 rec {
+buildNpmPackage (finalAttrs: {
   pname = "dopamine";
-  version = "3.0.4";
+  version = "3.0.6";
 
-  src = fetchurl {
-    url = "https://github.com/digimezzo/dopamine/releases/download/v${version}/Dopamine-${version}.AppImage";
-    hash = "sha256-sm8/ZzSqa1CsQJ7XfQ67yAKX5rR9E8J/Z6v1rLVhNwI=";
+  src = fetchFromGitHub {
+    owner = "digimezzo";
+    repo = "dopamine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HTPWejm5Wi6yGJyS/f1RhjIluTz01ue8lAsnAcQY3IY=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  npmDepsHash = "sha256-JkGS0YmjsdUiOD48HcGXy/fPTP33JQAtJui0mQWicmc=";
 
-  extraInstallCommands =
-    let
-      contents = appimageTools.extract { inherit pname version src; };
-    in
-    ''
-      wrapProgram $out/bin/${pname} \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+  patches = [
+    # register-scheme contains install scripts, but has no lockfile
+    ./remove-register-scheme.patch
 
-      install -Dm644 ${contents}/dopamine.desktop $out/share/applications/dopamine.desktop
-      substituteInPlace $out/share/applications/dopamine.desktop \
-        --replace-fail 'Exec=AppRun' 'Exec=dopamine'
-      cp -r ${contents}/usr/share/icons $out/share
-    '';
+    # fixes node-addon-api errors with aarch64-darwin
+    ./update-node-addon-api.patch
+  ];
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };
+  nativeBuildInputs = [
+    (python3.withPackages (ps: with ps; [ distutils ]))
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcodebuild ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  buildPhase = ''
+    runHook preBuild
+
+    # needed for better-sqlite3 rebuild
+    export npm_config_nodedir="${electron_40.headers}"
+    export npm_config_target="${electron_40.version}"
+
+    npm rebuild --verbose --no-progress --offline
+
+    # reduce better-sqlite3 size
+    pushd node_modules/better-sqlite3
+    rm -rf src deps build/{deps,Release/{.deps,obj,obj.target,test_extension.node}}
+    popd
+
+    npm run build:prod
+
+    # otherwise angular uses up ~150MB space
+    rm -rf .angular
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          cp -r ${electron_40.dist}/Electron.app ./
+          find ./Electron.app -name 'Info.plist' -exec chmod +rw {} \;
+
+          npm exec electron-builder -- \
+            --dir \
+            -c.npmRebuild=false \
+            -c.mac.identity=null \
+            -c.electronDist=./ \
+            -c.electronVersion=${electron_40.version} \
+            -c.extraMetadata.version=v${finalAttrs.version} \
+            --config electron-builder.config.js
+        ''
+      else
+        ''
+          npm exec electron-builder -- \
+            --dir \
+            -c.npmRebuild=false \
+            -c.electronDist=${electron_40.dist} \
+            -c.electronVersion=${electron_40.version} \
+            -c.extraMetadata.version=v${finalAttrs.version} \
+            --config electron-builder.config.js
+        ''
+    }
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir -p $out/{Applications,bin}
+          cp -r release/mac*/Dopamine.app $out/Applications
+          makeWrapper $out/Applications/Dopamine.app/Contents/MacOS/Dopamine $out/bin/dopamine
+        ''
+      else
+        ''
+          mkdir -p $out/share/dopamine
+          cp -r release/linux*unpacked/{locales,resources{,.pak}} $out/share/dopamine
+
+          makeWrapper ${lib.getExe electron_40} $out/bin/dopamine \
+            --add-flags $out/share/dopamine/resources/app.asar \
+            --inherit-argv0
+
+          for size in 16 24 32 48 64 96 128 256 512; do
+            install -Dm644 "build/icons/"$size"x"$size".png" "$out/share/icons/hicolor/"$size"x"$size"/apps/dopamine.png"
+          done
+
+          install -Dm644 deployment/AUR/Dopamine.desktop $out/share/applications/dopamine.desktop
+        ''
+    }
+
+    runHook postInstall
+  '';
 
   meta = {
-    changelog = "https://github.com/digimezzo/dopamine/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/digimezzo/dopamine/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Audio player that keeps it simple";
     homepage = "https://github.com/digimezzo/dopamine";
     license = lib.licenses.gpl3Only;
@@ -42,7 +124,6 @@ appimageTools.wrapType2 rec {
       Guanran928
       ern775
     ];
-    platforms = [ "x86_64-linux" ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/do/dopamine/remove-register-scheme.patch
+++ b/pkgs/by-name/do/dopamine/remove-register-scheme.patch
@@ -1,0 +1,32 @@
+diff --git a/package-lock.json b/package-lock.json
+index c0db8fd5..a060c1cc 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -12156,9 +12156,6 @@
+             "dependencies": {
+                 "node-fetch": "^2.6.1",
+                 "ws": "^7.3.1"
+-            },
+-            "optionalDependencies": {
+-                "register-scheme": "github:devsnek/node-register-scheme"
+             }
+         },
+         "node_modules/dmg-builder": {
+@@ -21476,17 +21473,6 @@
+                 "node": ">=4"
+             }
+         },
+-        "node_modules/register-scheme": {
+-            "version": "0.0.2",
+-            "resolved": "git+ssh://git@github.com/devsnek/node-register-scheme.git#e7cc9a63a1f512565da44cb57316d9fb10750e17",
+-            "hasInstallScript": true,
+-            "license": "MIT",
+-            "optional": true,
+-            "dependencies": {
+-                "bindings": "^1.3.0",
+-                "node-addon-api": "^1.3.0"
+-            }
+-        },
+         "node_modules/regjsgen": {
+             "version": "0.8.0",
+             "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",

--- a/pkgs/by-name/do/dopamine/update-node-addon-api.patch
+++ b/pkgs/by-name/do/dopamine/update-node-addon-api.patch
@@ -1,0 +1,39 @@
+diff --git a/package-lock.json b/package-lock.json
+index c0db8fd5..d98f8cfe 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -18303,12 +18303,15 @@
+             }
+         },
+         "node_modules/nice-napi/node_modules/node-addon-api": {
+-            "version": "3.2.1",
+-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+-            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
++            "version": "8.7.0",
++            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
++            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+             "dev": true,
+             "license": "MIT",
+-            "optional": true
++            "optional": true,
++            "engines": {
++                "node": "^18 || ^20 || >= 21"
++            }
+         },
+         "node_modules/nice-try": {
+             "version": "1.0.5",
+diff --git a/package.json b/package.json
+index 2eecf247..94a0cf8d 100644
+--- a/package.json
++++ b/package.json
+@@ -116,5 +116,10 @@
+         "tinycolor2": "1.6.0",
+         "tslib": "2.0.0",
+         "uuid": "9.0.0"
++    },
++    "overrides": {
++        "nice-napi": {
++            "node-addon-api": "^8.0.0"
++        }
+     }
+ }


### PR DESCRIPTION
Changed dopamine to building from source.
I tried to explain all the steps as best as I can, all of them should be necessary but I'm open to questions about anything.

This also adds support for platforms:
- aarch64-linux
- x86_64-darwin
- aarch64-darwin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
