### PR TITLE
darkstat: 3.0.721 -> 3.0.722

### DIFF
--- a/pkgs/by-name/da/darkstat/package.nix
+++ b/pkgs/by-name/da/darkstat/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "darkstat";
-  version = "3.0.721";
+  version = "3.0.722";
 
   src = fetchFromGitHub {
     owner = "emikulic";
     repo = "darkstat";
     tag = finalAttrs.version;
-    hash = "sha256-kKj4fCgphoe3lojJfARwpITxQh7E6ehUew9FVEW63uQ=";
+    hash = "sha256-WJjunJx9WjzRky1FL0k25h84Ypv273KXR5qT5YhHmbs=";
   };
 
   patches = [
@@ -54,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/emikulic/darkstat/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
     platforms = with lib.platforms; unix;
+    maintainers = with lib.maintainers; [ tbutter ];
     mainProgram = "darkstat";
   };
 })


### PR DESCRIPTION
Updating darkstat to 3.0.722

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.