### PR TITLE
virtualbox: 7.2.6 -> 7.2.8

### DIFF
--- a/nixos/modules/hardware/video/virtualbox.nix
+++ b/nixos/modules/hardware/video/virtualbox.nix
@@ -4,7 +4,18 @@ let
   inherit (config.services.xserver) videoDrivers;
 in
 {
-  boot.extraModulePackages = lib.mkIf (lib.elem "virtualbox" videoDrivers) [
-    kernelPackages.virtualboxGuestAdditions
-  ];
+  config = lib.mkIf (lib.elem "virtualbox" videoDrivers) {
+    assertions = [
+      {
+        assertion = lib.versionOlder kernelPackages.kernel.version "7.0";
+        message = ''
+          The `virtualbox` video driver provided by VirtualBox Guest Additions has been deprecated upstream for Linux kernel 7.0+.
+        '';
+      }
+    ];
+
+    boot.extraModulePackages = [
+      kernelPackages.virtualboxGuestAdditions
+    ];
+  };
 }

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -309,7 +309,11 @@ let
                     "echo 'Could not get IPv4 address for ${name}!' >&2; "
                     "exit 1"
                 )
-            ).strip()
+            )
+
+            ip = ip + '\n'
+            ip = ip[:ip.find('\n')]
+
             return ip
 
 

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -505,12 +505,12 @@ mapAttrs (mkVBoxTest { } vboxVMs) {
   simple-gui = ''
     # Home to select Tools, down to move to the VM, enter to start it.
     def send_vm_startup():
-        machine.send_key("home")
-        machine.send_key("down")
+        machine.send_key("ctrl-m")
         machine.send_key("ret")
 
 
     create_vm_simple()
+    machine.succeed(ru("VBoxManage setextradata global \"GUI/Input/SelectorShortcuts\" \"ToolsGlobalMachineManager=Ctrl+M\""))
     machine.succeed(ru("VirtualBox >&2 &"))
     machine.wait_until_succeeds(ru("xprop -name 'Oracle VirtualBox Manager'"))
     machine.sleep(5)

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -77,6 +77,8 @@ let
 
       virtualisation.virtualbox.guest.enable = true;
 
+      boot.initrd.systemd.enable = false;
+
       boot.initrd.kernelModules = [
         "af_packet"
         "vboxsf"

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -72,9 +72,9 @@ let
   buildType = "release";
   # Use maintainers/scripts/update.nix to update the version and all related hashes or
   # change the hashes in extpack.nix and guest-additions/default.nix as well manually.
-  virtualboxVersion = "7.2.6";
+  virtualboxVersion = "7.2.8";
   virtualboxSubVersion = "";
-  virtualboxSha256 = "c58443a0e6fcc7fc7e84c1011a10823b3540c6a2b8f2e27c4d8971272baf09f7";
+  virtualboxSha256 = "0642ed4a12b7204cd30c0abbc2c10c1cc7ad55ce1756a01e86a16d4b6b066592";
 
   kvmPatchVboxVersion = "7.2.6";
   kvmPatchVersion = "20260201";

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -5,7 +5,7 @@
 }:
 fetchurl rec {
   pname = "virtualbox-extpack";
-  version = "7.2.6";
+  version = "7.2.8";
   name = "Oracle_VirtualBox_Extension_Pack-${version}.vbox-extpack";
   url = "https://download.virtualbox.org/virtualbox/${version}/${name}";
   sha256 =
@@ -13,7 +13,7 @@ fetchurl rec {
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
     # Checksums can also be found at https://download.virtualbox.org/virtualbox/${version}/SHA256SUMS
     let
-      value = "d46449366b23417a626439785f23f7eaf06bfbfd2cb030713e1abfa5b03d4205";
+      value = "d7301435ee207ff96c5ad372939dc46d39e0f9db2bcce487cf1e8f739a2e845b";
     in
     assert (builtins.stringLength value) == 64;
     value;

--- a/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
@@ -5,7 +5,7 @@
 }:
 fetchurl {
   url = "http://download.virtualbox.org/virtualbox/${virtualboxVersion}/VBoxGuestAdditions_${virtualboxVersion}.iso";
-  sha256 = "740e9a729c944180a165188fd426f9a2e1a2581d654402a1b856f9755a1ffc97";
+  sha256 = "169acb9361ade42d32500f51b48ad366fdfdb094b5e3fb422d640c1416a6b216";
   meta = {
     description = "Guest additions ISO for VirtualBox";
     longDescription = ''

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -68,6 +68,8 @@ let
       pkg = libxt;
     }
   ];
+
+  hasVboxVideo = lib.versionOlder kernel.version "7.0";
 in
 stdenv.mkDerivation {
   pname = "VirtualBox-GuestAdditions";
@@ -133,7 +135,10 @@ stdenv.mkDerivation {
 
     # Install kernel modules.
     cd src/vboxguest-${virtualboxVersion}_NixOS
-    make install INSTALL_MOD_PATH=$out KBUILD_EXTRA_SYMBOLS=$PWD/vboxsf/Module.symvers
+
+    INSTALL_TARGETS=(install-vboxguest install-vboxsf ${lib.optionalString hasVboxVideo "install-vboxvideo"})
+    make INSTALL_MOD_PATH=$out KBUILD_EXTRA_SYMBOLS=$PWD/vboxsf/Module.symvers ''${INSTALL_TARGETS[@]}
+
     cd ../..
 
     # Install binaries

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -18,9 +18,9 @@
   libx11,
 }:
 let
-  virtualboxVersion = "7.2.6";
+  virtualboxVersion = "7.2.8";
   virtualboxSubVersion = "";
-  virtualboxSha256 = "c58443a0e6fcc7fc7e84c1011a10823b3540c6a2b8f2e27c4d8971272baf09f7";
+  virtualboxSha256 = "0642ed4a12b7204cd30c0abbc2c10c1cc7ad55ce1756a01e86a16d4b6b066592";
 
   platform =
     if stdenv.hostPlatform.isAarch64 then


### PR DESCRIPTION
Updates virtualbox to 7.2.8 with `nix-shell maintainers/scripts/update.nix --argstr package virtualbox`.

Fixes #491434.

Changelog: https://www.virtualbox.org/wiki/Changelog

### `vboxvideo` deprecation

> Linux Guest Additions: Deprecated vboxvideo kernel module for kernels 7.0 and newer; please consider using VMSVGA graphics or vboxvideo module which comes with Linux kernel or provided by your Linux distribution if guest running kernel 7.0+; vboxvideo will still be available for older kernels

Because the `vboxvideo` kernel module was deprecated for kernels 7.0 and newer, this PR also adds an assertion to fail early if `virtualbox` is specified in `services.xserver.videoDrivers` and the kernel is 7.0+.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
