### PR TITLE
nixos-rebuild-ng: fix test_upgrade_channels in aarch64-darwin

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -726,7 +726,11 @@ def switch_to_configuration(
     )
 
 
-def upgrade_channels(all_channels: bool = False, sudo: bool = False) -> None:
+def upgrade_channels(
+    all_channels: bool = False,
+    sudo: bool = False,
+    channels_dir: Path = Path("/nix/var/nix/profiles/per-user/root/channels/"),
+) -> None:
     """Upgrade channels for classic Nix.
 
     It will either upgrade just the `nixos` channel (including any channel
@@ -739,7 +743,7 @@ def upgrade_channels(all_channels: bool = False, sudo: bool = False) -> None:
         )
 
     channel_updated = False
-    for channel_path in Path("/nix/var/nix/profiles/per-user/root/channels/").glob("*"):
+    for channel_path in channels_dir.glob("*"):
         if channel_path.is_dir() and (
             all_channels
             or channel_path.name == "nixos"

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -892,11 +892,13 @@ def test_switch_to_configuration_with_systemd_run(
     ],
 )
 @patch("pathlib.Path.is_dir", autospec=True, return_value=True)
+@patch("pathlib.Path.exists", autospec=True, return_value=False)
 @patch("os.geteuid", autospec=True, return_value=1000)
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_upgrade_channels(
     mock_run: Mock,
     mock_geteuid: Mock,
+    mock_exists: Mock,
     mock_is_dir: Mock,
     mock_glob: Mock,
 ) -> None:
@@ -912,7 +914,11 @@ def test_upgrade_channels(
         ["nix-channel", "--update", "nixos"], check=False, sudo=True
     )
 
+    # root check
     mock_geteuid.return_value = 0
+    # (channel_path / ".update-on-nixos-rebuild").exists()
+    mock_exists.return_value = True
+
     n.upgrade_channels(all_channels=True, sudo=False)
     mock_run.assert_has_calls(
         [

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -882,50 +882,61 @@ def test_switch_to_configuration_with_systemd_run(
     )
 
 
-@patch(
-    "pathlib.Path.glob",
-    autospec=True,
-    return_value=[
-        Path("/nix/var/nix/profiles/per-user/root/channels/nixos"),
-        Path("/nix/var/nix/profiles/per-user/root/channels/nixos-hardware"),
-        Path("/nix/var/nix/profiles/per-user/root/channels/home-manager"),
-    ],
-)
-@patch("pathlib.Path.is_dir", autospec=True, return_value=True)
-@patch("pathlib.Path.exists", autospec=True, return_value=False)
 @patch("os.geteuid", autospec=True, return_value=1000)
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_upgrade_channels(
-    mock_run: Mock,
-    mock_geteuid: Mock,
-    mock_exists: Mock,
-    mock_is_dir: Mock,
-    mock_glob: Mock,
-) -> None:
+def test_upgrade_channels(mock_run: Mock, mock_geteuid: Mock, tmpdir: Path) -> None:
+    tmp_path = Path(tmpdir)
+
     with pytest.raises(m.NixOSRebuildError) as e:
-        n.upgrade_channels(all_channels=False, sudo=False)
+        n.upgrade_channels(all_channels=False, sudo=False, channels_dir=tmp_path)
     assert str(e.value) == (
         "error: if you pass the '--upgrade' or '--upgrade-all' flag, you must "
         "also pass '--sudo' or run the command as root (e.g., with sudo)"
     )
 
-    n.upgrade_channels(all_channels=False, sudo=True)
-    mock_run.assert_called_once_with(
-        ["nix-channel", "--update", "nixos"], check=False, sudo=True
+    (tmp_path / "nixos").mkdir()
+    (tmp_path / "nixos-hardware").mkdir()
+    (tmp_path / "nixos-hardware" / ".update-on-nixos-rebuild").touch()
+    (tmp_path / "home-manager").mkdir()
+
+    # should work because we are passing sudo=True even with os.geteuid == 1000
+    n.upgrade_channels(all_channels=False, sudo=True, channels_dir=tmp_path)
+    mock_run.assert_has_calls(
+        [
+            call(
+                ["nix-channel", "--update", "nixos-hardware"],
+                check=False,
+                sudo=True,
+            ),
+            call(
+                ["nix-channel", "--update", "nixos"],
+                check=False,
+                sudo=True,
+            ),
+        ]
     )
+    mock_run.reset_mock()
 
     # root check
     mock_geteuid.return_value = 0
-    # (channel_path / ".update-on-nixos-rebuild").exists()
-    mock_exists.return_value = True
 
-    n.upgrade_channels(all_channels=True, sudo=False)
+    n.upgrade_channels(all_channels=True, sudo=False, channels_dir=tmp_path)
     mock_run.assert_has_calls(
         [
-            call(["nix-channel", "--update", "nixos"], check=False, sudo=False),
             call(
-                ["nix-channel", "--update", "nixos-hardware"], check=False, sudo=False
+                ["nix-channel", "--update", "home-manager"],
+                check=False,
+                sudo=False,
             ),
-            call(["nix-channel", "--update", "home-manager"], check=False, sudo=False),
+            call(
+                ["nix-channel", "--update", "nixos-hardware"],
+                check=False,
+                sudo=False,
+            ),
+            call(
+                ["nix-channel", "--update", "nixos"],
+                check=False,
+                sudo=False,
+            ),
         ]
     )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This should avoid an issue where the sandbox is causing a read failure in the `.update-on-nixos-rebuild` file inside the `test_upgrafe_channels`.

Seems to be an issue in a particular setup in `aarch64-darwin` at least, but I can't reproduce.

Also refactor the same test to use a temporary directory instead of mocking `pathlib.Path`. Should be more robust.

Fix: #511860.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
