### PR TITLE
{hister,nixos/hister,nixosTests.hister}: init at 0.17.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -247,3 +247,5 @@
 - `trilium-desktop` and `trilium-server` have been updated to 0.104.0. This release includes security hardening fixes that may break functionality. [See upstream release note for details](https://github.com/TriliumNext/Trilium/releases/tag/v0.104.0).
 
 - `nix` now supports running in "daemonless" mode by setting `nix.daemon.enable = false`. Under this mode all store operations must go through the [local store type](https://nix.dev/manual/nix/latest/store/types/local-store), which typically requires root permissions.
+
+- [Hister](https://github.com/asciimoo/hister), a web history service offering blazing fast, content-based search across visited websites. Available as [services.hister](#opt-services.hister.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1715,6 +1715,7 @@
   ./services/web-apps/haven.nix
   ./services/web-apps/healthchecks.nix
   ./services/web-apps/hedgedoc.nix
+  ./services/web-apps/hister.nix
   ./services/web-apps/hledger-web.nix
   ./services/web-apps/homebox.nix
   ./services/web-apps/homer.nix

--- a/nixos/modules/services/web-apps/hister.nix
+++ b/nixos/modules/services/web-apps/hister.nix
@@ -1,0 +1,224 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.hister;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+  dataDir = if cfg.dataDir != null then cfg.dataDir else "/var/lib/hister";
+  generatedConfig = yamlFormat.generate "hister-config.yml" cfg.settings;
+  hasConfig = cfg.configPath != null || cfg.settings != { };
+  runtimeConfigSource = if cfg.settings != { } then generatedConfig else cfg.configPath;
+  runtimeConfig = "/run/hister/config.yml";
+
+  histerEnv =
+    lib.optionalAttrs (cfg.port != null) {
+      HISTER_PORT = toString cfg.port;
+    }
+    // lib.optionalAttrs hasConfig {
+      HISTER_CONFIG = runtimeConfig;
+    }
+    // {
+      HISTER_DATA_DIR = dataDir;
+    };
+
+  privilegedPort = cfg.port != null && cfg.port < 1024;
+in
+{
+  meta.maintainers = with lib.maintainers; [ _4evy ];
+
+  options.services.hister = {
+    enable = lib.mkEnableOption "Hister, a web history service with content-based search";
+
+    package = lib.mkPackageOption pkgs "hister" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "hister";
+      description = "User account under which Hister runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "hister";
+      description = "Group under which Hister runs.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/var/lib/hister";
+      description = ''
+        Directory where Hister stores its data. When `null` (the default), the
+        service is isolated under `/var/lib/hister` via systemd's
+        `StateDirectory=`. When set to an explicit path, that path is created
+        with `systemd-tmpfiles` and granted via `ReadWritePaths=` instead.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.nullOr lib.types.port;
+      default = null;
+      example = 4433;
+      description = ''
+        Port on which Hister listens. When set, this overrides the port in
+        `server.address` from the configuration file via the `HISTER_PORT`
+        environment variable.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open {option}`services.hister.port` in the firewall. Has no
+        effect if `port` is `null`.
+      '';
+    };
+
+    configPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/etc/hister/config.yml";
+      description = ''
+        Path to an existing Hister configuration file mounted read-only into
+        the service runtime directory and passed via `HISTER_CONFIG`. Mutually
+        exclusive with {option}`services.hister.settings`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/hister.env";
+      description = ''
+        Path to an environment file (read at service start) used to inject
+        secrets such as `HISTER__APP__ACCESS_TOKEN` without placing them in the
+        world-readable Nix store.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Hister configuration rendered to YAML and passed via `HISTER_CONFIG`.
+        Accepts any structure the server accepts: see the `app`, `server`,
+        `indexer`, `crawler`, `hotkeys`, `extractors`, `semantic_search`, and
+        `sensitive_content_patterns` blocks documented upstream.
+      '';
+      example = lib.literalExpression ''
+        {
+          app = {
+            search_url = "https://google.com/search?q={query}";
+            log_level = "info";
+          };
+          server = {
+            address = "127.0.0.1:4433";
+            database = "db.sqlite3";
+          };
+          hotkeys.web = {
+            "/" = "focus_search_input";
+            "enter" = "open_result";
+          };
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.configPath != null && cfg.settings != { });
+        message = "Only one of services.hister.configPath and services.hister.settings can be set";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    users.users = lib.mkIf (cfg.user == "hister") {
+      hister = {
+        description = "Hister web history service";
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "hister") {
+      hister = { };
+    };
+
+    systemd.tmpfiles.settings."10-hister"."${dataDir}".d = lib.mkIf (cfg.dataDir != null) {
+      user = cfg.user;
+      group = cfg.group;
+      mode = "0750";
+    };
+
+    systemd.services.hister = {
+      description = "Hister web history service";
+      after = [
+        "network.target"
+        "systemd-tmpfiles-setup.service"
+        "systemd-tmpfiles-resetup.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = histerEnv;
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} listen";
+        Restart = "on-failure";
+        User = cfg.user;
+        Group = cfg.group;
+        RuntimeDirectory = lib.mkIf hasConfig "hister";
+        RuntimeDirectoryMode = lib.mkIf hasConfig "0750";
+        BindReadOnlyPaths = lib.mkIf hasConfig [ "${runtimeConfigSource}:${runtimeConfig}" ];
+        StateDirectory = lib.mkIf (cfg.dataDir == null) "hister";
+        StateDirectoryMode = lib.mkIf (cfg.dataDir == null) "0750";
+        ReadWritePaths = lib.mkIf (cfg.dataDir != null) [ cfg.dataDir ];
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+
+        AmbientCapabilities = lib.mkIf privilegedPort [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = if privilegedPort then [ "CAP_NET_BIND_SERVICE" ] else [ "" ];
+
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        LockPersonality = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        MemoryDenyWriteExecute = true;
+        UMask = "0077";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.openFirewall && cfg.port != null) [ cfg.port ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -793,6 +793,7 @@ in
   hibernate-systemd-stage-1 = handleTestOn [ "x86_64-linux" ] ./hibernate.nix {
     systemdStage1 = true;
   };
+  hister = runTest ./hister.nix;
   hitch = handleTest ./hitch { };
   hledger-web = runTest ./hledger-web.nix;
   hockeypuck = runTest ./hockeypuck.nix;

--- a/nixos/tests/hister.nix
+++ b/nixos/tests/hister.nix
@@ -1,0 +1,146 @@
+{ lib, pkgs, ... }:
+let
+  configPathConfig = pkgs.writeText "hister-config.yml" ''
+    app:
+      title: NixOS Hister Config Path
+      search_url: https://config.example.invalid/?q={query}
+    hotkeys:
+      web:
+        alt+c: open_query_in_search_engine
+  '';
+in
+{
+  name = "hister";
+
+  meta = {
+    maintainers = with lib.maintainers; [ _4evy ];
+  };
+
+  nodes.machine = {
+    environment.systemPackages = [ pkgs.jq ];
+
+    systemd.tmpfiles.settings."10-hister-env"."/run/hister.env"."f" = {
+      mode = "0600";
+      user = "root";
+      group = "root";
+      argument = "HISTER__APP__ACCESS_TOKEN=test-token";
+    };
+
+    specialisation = {
+      inline_settings.configuration.services.hister = {
+        enable = true;
+        port = 4433;
+        environmentFile = "/run/hister.env";
+        settings = {
+          app = {
+            log_level = "debug";
+            title = "NixOS Hister";
+            search_url = "https://search.example.invalid/?q={query}";
+            open_results_on_new_tab = true;
+          };
+          hotkeys.web."alt+n" = "open_query_in_search_engine";
+        };
+      };
+
+      config_file.configuration.services.hister = {
+        enable = true;
+        port = 4434;
+        configPath = configPathConfig;
+      };
+
+      custom_data_dir.configuration.services.hister = {
+        enable = true;
+        port = 4435;
+        dataDir = "/srv/hister-data";
+        settings.app.title = "NixOS Hister Custom Data";
+      };
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      switchTo =
+        name:
+        "${nodes.machine.system.build.toplevel}/specialisation/${name}/bin/switch-to-configuration test";
+    in
+    ''
+      start_all()
+
+      with subtest("inline settings"):
+        machine.succeed("${switchTo "inline_settings"}")
+        machine.systemctl("restart hister.service")
+        machine.wait_for_unit("hister.service")
+        machine.wait_for_open_port(4433)
+        machine.succeed("curl -fsS http://localhost:4433/ | grep -F '<title>Hister</title>'")
+        machine.succeed("test $(stat -c %a /var/lib/hister) = 750")
+        machine.succeed("test $(stat -c %a /run/hister) = 750")
+        machine.succeed("test -s /run/hister/tui.yaml")
+        machine.succeed("test -s /var/lib/hister/db.sqlite3")
+        machine.succeed("test -s /var/lib/hister/.secret_key")
+        machine.succeed("test -s /var/lib/hister/rules.json")
+        machine.succeed(
+            "curl -fsS http://localhost:4433/api/config"
+            + " | jq -e "
+            + "'"
+            + '.baseUrl == "http://127.0.0.1:4433"'
+            + ' and .title == "NixOS Hister"'
+            + ' and .searchUrl == "https://search.example.invalid/?q={query}"'
+            + ' and .openResultsOnNewTab == true'
+            + ' and .hotkeys."alt+n" == "open_query_in_search_engine"'
+            + ' and .authMode == "token"'
+            + "'"
+        )
+        machine.fail("journalctl -u hister.service | grep -F 'Failed to create tui.yaml'")
+
+      with subtest("configPath"):
+        machine.succeed("${switchTo "config_file"}")
+        machine.systemctl("restart hister.service")
+        machine.wait_for_unit("hister.service")
+        machine.wait_for_open_port(4434)
+        machine.succeed("curl -fsS http://localhost:4434/ >/dev/null")
+        machine.succeed("test $(stat -c %a /run/hister) = 750")
+        machine.succeed("test -s /run/hister/tui.yaml")
+        machine.succeed("test -s /var/lib/hister/db.sqlite3")
+        machine.succeed("test -s /var/lib/hister/.secret_key")
+        machine.succeed("test -s /var/lib/hister/rules.json")
+        machine.succeed(
+            "curl -fsS http://localhost:4434/api/config"
+            + " | jq -e "
+            + "'"
+            + '.baseUrl == "http://127.0.0.1:4434"'
+            + ' and .title == "NixOS Hister Config Path"'
+            + ' and .searchUrl == "https://config.example.invalid/?q={query}"'
+            + ' and .hotkeys."alt+c" == "open_query_in_search_engine"'
+            + ' and .authMode == "none"'
+            + "'"
+        )
+        machine.fail("journalctl -u hister.service | grep -F 'Failed to create tui.yaml'")
+
+      with subtest("custom dataDir"):
+        machine.systemctl("stop hister.service")
+        machine.succeed("rm -rf /var/lib/hister")
+        machine.succeed("${switchTo "custom_data_dir"}")
+        machine.systemctl("restart hister.service")
+        machine.wait_for_unit("hister.service")
+        machine.wait_for_open_port(4435)
+        machine.succeed("curl -fsS http://localhost:4435/ >/dev/null")
+        machine.succeed("test $(stat -c %U:%G:%a /srv/hister-data) = hister:hister:750")
+        machine.succeed("test $(stat -c %a /run/hister) = 750")
+        machine.succeed("test -s /run/hister/tui.yaml")
+        machine.succeed("test -s /srv/hister-data/db.sqlite3")
+        machine.succeed("test -s /srv/hister-data/.secret_key")
+        machine.succeed("test -s /srv/hister-data/rules.json")
+        machine.succeed("test ! -e /var/lib/hister")
+        machine.succeed(
+            "curl -fsS http://localhost:4435/api/config"
+            + " | jq -e "
+            + "'"
+            + '.baseUrl == "http://127.0.0.1:4435"'
+            + ' and .title == "NixOS Hister Custom Data"'
+            + ' and .authMode == "none"'
+            + "'"
+        )
+        machine.fail("journalctl -u hister.service | grep -F 'Failed to create tui.yaml'")
+    '';
+}

--- a/pkgs/by-name/hi/hister/package.nix
+++ b/pkgs/by-name/hi/hister/package.nix
@@ -10,6 +10,7 @@
   nix-update-script,
   pkg-config,
   versionCheckHook,
+  nixosTests,
 }:
 buildGoModule (finalAttrs: {
   pname = "hister";
@@ -87,6 +88,7 @@ buildGoModule (finalAttrs: {
         "frontend"
       ];
     };
+    tests = { inherit (nixosTests) hister; };
   };
 
   meta = {

--- a/pkgs/by-name/hi/hister/package.nix
+++ b/pkgs/by-name/hi/hister/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_22,
+  sqlite,
+  yt-dlp-light,
+  makeBinaryWrapper,
+  nix-update-script,
+  pkg-config,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "hister";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "asciimoo";
+    repo = "hister";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UIKQVs2hbzalDeRL1ILUgfMQnues5IFrzWn9Eg5sm30=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  vendorHash = "sha256-ozTULKnUrzBy+tK/eSq7exPVjXp43mSzg4EOWG+r1No=";
+  proxyVendor = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+  ];
+  buildInputs = [ sqlite ];
+
+  tags = [ "libsqlite3" ];
+
+  preBuild = ''
+    mkdir -p server/static/app
+    cp -r ${finalAttrs.passthru.frontend}/* server/static/app/
+  '';
+
+  ldflags = [
+    "-s"
+  ];
+
+  subPackages = [ "." ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hister \
+      --prefix PATH : ${lib.makeBinPath [ yt-dlp-light ]}
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    frontend = (buildNpmPackage.override { nodejs = nodejs_22; }) {
+      pname = "${finalAttrs.pname}-frontend";
+      inherit (finalAttrs) version src;
+
+      strictDeps = true;
+
+      npmWorkspace = "webui/app";
+      npmDepsFetcherVersion = 2;
+      npmDepsHash = "sha256-ueGtZYMrmQeYsJXmA5RRV5GHCEH5Ui+6PDiQ/Nd1quM=";
+
+      # vite 8's rolldown pipeline does a dns.lookup('localhost') during `vite build`
+      # which fails in darwin's relaxed sandbox without loopback access
+      __darwinAllowLocalNetworking = true;
+
+      preBuild = ''
+        patchShebangs webui
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"
+        cp -r webui/app/build/* "$out/"
+        runHook postInstall
+      '';
+    };
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "frontend"
+      ];
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/asciimoo/hister/releases/tag/v${finalAttrs.version}";
+    description = "Web history on steroids - blazing fast, content-based search for visited websites";
+    homepage = "https://github.com/asciimoo/hister";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "hister";
+    maintainers = with lib.maintainers; [ _4evy ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
[Hister](https://github.com/asciimoo/hister) is a self-hostable web history
service: it indexes the pages you visit and offers blazing-fast, content-based
search across them

I added the package, a NixOS module (freeform YAML `settings`, mutually
exclusive with `configPath`, hardened systemd unit, optional `environmentFile`
for secrets), and a VM test that boots the service and curls the root endpoint


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
