### PR TITLE
bazel: 9.0.1 -> 9.1.0

### DIFF
--- a/pkgs/by-name/ba/bazel_9/examples.nix
+++ b/pkgs/by-name/ba/bazel_9/examples.nix
@@ -62,10 +62,10 @@ in
     bazelVendorDepsFOD = {
       outputHash =
         {
-          aarch64-darwin = "sha256-MRm+Pm5mDXys8erQLKHRSClFzxWIYU7Y/otKxl5sJQg=";
-          aarch64-linux = "sha256-cJuNZapJ8LvfPRdv5V9iuy0xxCxLFI5uWTLtAa6bE/w=";
-          x86_64-darwin = "sha256-fOLRQIiRq7BATULy7W90bQ/DrW3Fn7vLut6fKFSoQDA=";
-          x86_64-linux = "sha256-nSe0ywhsTJz6ycqTZaUKfnOvpJOmwip8hYXck9HtW2Q=";
+          aarch64-darwin = "sha256-Jth981+r20azC/CqoWN3LK5USm8zUIpL9Xt88+TcL1o=";
+          aarch64-linux = "sha256-4E/QCSOXTN/dW65xz/n47tXW0PlHUOP1UP+TwJfMueI=";
+          x86_64-darwin = "sha256-t4JP4o3O9C9BehidQPVu4EATnUZodhFh1/ctITxD6JA=";
+          x86_64-linux = "sha256-HzgFpbEBZ8efA5pwUsGZjt9bKiAXslB17OZQcm3cspc=";
         }
         .${stdenv.hostPlatform.system};
       outputHashAlgo = "sha256";
@@ -100,10 +100,10 @@ in
     bazelRepoCacheFOD = {
       outputHash =
         {
-          aarch64-darwin = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
-          aarch64-linux = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
-          x86_64-darwin = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
-          x86_64-linux = "sha256-Yk+Y3XxlmE48RCYqmSfeBtElCGlVVdJvqRtuIMWbxrk=";
+          aarch64-darwin = "sha256-CbA4Kcn6656xnK6DkN4TZ7u1/mizA49Im9hRCU86TGs=";
+          aarch64-linux = "sha256-CbA4Kcn6656xnK6DkN4TZ7u1/mizA49Im9hRCU86TGs=";
+          x86_64-darwin = "sha256-CbA4Kcn6656xnK6DkN4TZ7u1/mizA49Im9hRCU86TGs=";
+          x86_64-linux = "sha256-CbA4Kcn6656xnK6DkN4TZ7u1/mizA49Im9hRCU86TGs=";
         }
         .${stdenv.hostPlatform.system};
       outputHashAlgo = "sha256";
@@ -139,10 +139,10 @@ in
     bazelVendorDepsFOD = {
       outputHash =
         {
-          aarch64-darwin = "sha256-6rUV8UMjFZXA053BXIruK8+OEturmtz+YeAlkivePdA=";
-          aarch64-linux = "sha256-/mv7HVsx97RLzYl12WwsI2gYf0qBr+78B5NiEpTRyrc=";
-          x86_64-darwin = "sha256-BpQFhalV5AfYSjWQp+9lxOnfbaD/NADtvrNMqznEojM=";
-          x86_64-linux = "sha256-uutDUAHYecqDYmS90jZfZ8IrhSzpWB6WgcsZPlRJVaM=";
+          aarch64-darwin = "sha256-uUl7PpR3jAKvj6VWspPE3IR4Gr/V2VrBv1MlTzOIZJs=";
+          aarch64-linux = "sha256-uhcIwDk8NAZDBynzxWk+0fLP/2XadKQRl5BlFPjf4/8=";
+          x86_64-darwin = "sha256-vi3+/ps+dhDjqYHxWSnWOXhh1jWJWwb5ifUUhN4vxrg=";
+          x86_64-linux = "sha256-YURF8Zjueq3BN5GfEx5L+C4hGmr5qfJc7OngqZ17384=";
         }
         .${stdenv.hostPlatform.system};
       outputHashAlgo = "sha256";

--- a/pkgs/by-name/ba/bazel_9/package.nix
+++ b/pkgs/by-name/ba/bazel_9/package.nix
@@ -29,7 +29,7 @@
   cctools,
   # Allow to independently override the jdks used to build and run respectively
   jdk_headless,
-  version ? "9.0.1",
+  version ? "9.1.0",
 }:
 
 let
@@ -89,7 +89,7 @@ let
 
   src = fetchzip {
     url = "https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip";
-    hash = "sha256-tdrSgtIXi8Xd03BgxLRWhw1bB1Zhuo0E2pWMCskBDG8=";
+    hash = "sha256-RbRM9HxcBij5gbd0aeArslc/IyjvycM5v7zOnaDT3cU=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/ba/bazel_9/patches/default_bash.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/default_bash.patch
@@ -1,22 +1,26 @@
 diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
-index a982b782e1..d49b047074 100644
+index 8ac0c2bb97..4233eccf19 100644
 --- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
 +++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
-@@ -89,13 +89,13 @@ public class BazelRuleClassProvider {
+@@ -87,16 +87,16 @@ public class BazelRuleClassProvider {
      public boolean useStrictActionEnv;
    }
  
 -  private static final PathFragment FALLBACK_SHELL = PathFragment.create("/bin/bash");
 +  private static final PathFragment FALLBACK_SHELL = PathFragment.create("@defaultBash@");
  
-   public static final ImmutableMap<OS, PathFragment> SHELL_EXECUTABLE =
+   @VisibleForTesting
+   public static final ImmutableMap<OS, PathFragment> SHELL_EXECUTABLES =
        ImmutableMap.<OS, PathFragment>builder()
            .put(OS.WINDOWS, PathFragment.create("c:/msys64/usr/bin/bash.exe"))
 -          .put(OS.FREEBSD, PathFragment.create("/usr/local/bin/bash"))
 -          .put(OS.OPENBSD, PathFragment.create("/usr/local/bin/bash"))
+-          .put(OS.LINUX, PathFragment.create("/bin/bash"))
+-          .put(OS.DARWIN, PathFragment.create("/bin/bash"))
 +          .put(OS.FREEBSD, PathFragment.create("@defaultBash@"))
 +          .put(OS.OPENBSD, PathFragment.create("@defaultBash@"))
++          .put(OS.LINUX, PathFragment.create("@defaultBash@"))
++          .put(OS.DARWIN, PathFragment.create("@defaultBash@"))
            .put(OS.UNKNOWN, FALLBACK_SHELL)
            .buildOrThrow();
  
-

--- a/pkgs/by-name/ba/bazel_9/patches/deps_patches.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/deps_patches.patch
@@ -1,5 +1,5 @@
 diff --git a/MODULE.bazel b/MODULE.bazel
-index d845a0e98d..be0aa7bd7c 100644
+index 8b49dac324..13e24c9f5c 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
 @@ -22,16 +22,30 @@ bazel_dep(name = "googleapis", version = "0.0.0-20250604-de157ca3")
@@ -15,7 +15,7 @@ index d845a0e98d..be0aa7bd7c 100644
  bazel_dep(name = "protobuf", version = "33.4", repo_name = "com_google_protobuf")
  bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
  bazel_dep(name = "rules_graalvm", version = "0.11.1")
- bazel_dep(name = "rules_java", version = "9.0.3")
+ bazel_dep(name = "rules_java", version = "9.1.0")
 +single_version_override(
 +    module_name = "rules_java",
 +    patches = ["//third_party:rules_java.patch"],
@@ -33,7 +33,7 @@ index d845a0e98d..be0aa7bd7c 100644
  bazel_dep(name = "rules_shell", version = "0.6.1")
  bazel_dep(name = "rules_testing", version = "0.9.0")
  bazel_dep(name = "stardoc", version = "0.8.0", repo_name = "io_bazel_skydoc")
-@@ -42,6 +56,11 @@ bazel_dep(name = "zstd-jni", version = "1.5.6-9")
+@@ -42,6 +56,12 @@ bazel_dep(name = "zstd-jni", version = "1.5.6-9")
  # Depend on apple_support second after rules_cc so that the Xcode toolchain
  # from apple_support does not win over the generic Unix toolchain from rules_cc.
  bazel_dep(name = "rules_cc", version = "0.2.17")
@@ -42,6 +42,7 @@ index d845a0e98d..be0aa7bd7c 100644
 +    patches = ["//third_party:rules_cc.patch"],
 +    patch_strip = 1,
 +)
++
  bazel_dep(name = "apple_support", version = "1.24.5")
  
  # The starlark rules in @rules_cc are hidden behind macros but docgen needs to

--- a/pkgs/by-name/ba/bazel_9/patches/strict_action_env.patch
+++ b/pkgs/by-name/ba/bazel_9/patches/strict_action_env.patch
@@ -1,13 +1,13 @@
 diff --git a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
-index a70b5559bc..10bdffe961 100644
+index 8ac0c2bb97..2925991b51 100644
 --- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
 +++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java
-@@ -466,7 +466,7 @@ public class BazelRuleClassProvider {
-       // Note that --action_env does not propagate to the host config, so it is not a viable
-       // workaround when a genrule is itself built in the host config (e.g. nested genrules). See
+@@ -357,7 +357,7 @@ public class BazelRuleClassProvider {
+       // Note that --action_env does not propagate to the exec config, so it is not a viable
+       // workaround when a genrule is itself built in the exec config (e.g. nested genrules). See
        // #8536.
 -      return "/bin:/usr/bin:/usr/local/bin";
 +      return "@strictActionEnvPatch@";
      }
-
+ 
      String newPath = "";


### PR DESCRIPTION
Update to latest [9.1.0 release](https://github.com/bazelbuild/bazel/releases/tag/9.1.0)

Update 9.0.1 patches to apply cleanly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
