### PR TITLE
claude-usage-tracker: 3.0.3 -> 3.1.1

### DIFF
--- a/pkgs/by-name/cl/claude-usage-tracker/package.nix
+++ b/pkgs/by-name/cl/claude-usage-tracker/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "claude-usage-tracker";
-  version = "3.0.3";
+  version = "3.1.1";
 
   src = fetchzip {
     url = "https://github.com/hamed-elfayome/Claude-Usage-Tracker/releases/download/v${finalAttrs.version}/Claude-Usage.zip";
-    hash = "sha256-Yc4SukriyiLI/8U+rdhc3Jh/mD2V/0EF57rsVV0J3s4=";
+    hash = "";
     stripRoot = false;
   };
 
@@ -34,7 +34,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/hamed-elfayome/Claude-Usage-Tracker";
     changelog = "https://github.com/hamed-elfayome/Claude-Usage-Tracker/releases/tag/v${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    platforms = [ "aarch64-darwin" ];
+    platforms = [ 
+      "aarch64-darwin"
+      "x86_64-darwin" 
+    ];
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ myzel394 ];
   };


### PR DESCRIPTION
Update claude-usage-tracker from 3.0.3 to 3.1.1.

  https://github.com/hamed-elfayome/Claude-Usage-Tracker/blob/main/CHANGELOG.md

  Notable changes:

  v3.1.1:
  - Add Traditional Chinese (zh-Hant) localization (13 languages total)
  - Fix sign-in to always show fresh login page (proper Google SSO popup handling)
  - Fix cross-profile credential contamination
  - Fix menu bar items disappearing on config changes (stable autosave names)
  - Fix missing translations for multiprofile icon styles
  - UI improvements for credential entry views

  v3.1.0:
  - Right-click context menu on status bar icons
  - Per-element color customization for statusline
  - Weekly & extra usage segments in statusline
  - Active profile indicator
  - Nix installation option
  - Peak hours indicator
  - Multiple bug fixes

  Things done

  - Built on platform:
    - x86_64-linux
    - aarch64-linux
    - x86_64-darwin
    - aarch64-darwin
  - Tested, as applicable:
    - [NixOS tests] in [nixos/tests].
    - [Package tests] at passthru.tests.
    - Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
  - Tested basic functionality of all binary files, usually in ./result/bin/.
  - Nixpkgs Release Notes
    - Package update: when the change is major or breaking.
  - NixOS Release Notes
    - Module addition: when adding a new NixOS module.
    - Module update: when the change is significant.
  - Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.