### PR TITLE
stdenv: set meta.{position,license,teams,identifiers.cpeParts}

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -162,10 +162,23 @@ let
 
     // {
 
-      meta = {
-        description = "The default build environment for Unix packages in Nixpkgs";
-        platforms = lib.platforms.all;
-      };
+      meta =
+        let
+          pos = builtins.unsafeGetAttrPos "name" argsStdenv;
+        in
+        {
+          description = "The default build environment for Unix packages in Nixpkgs";
+          platforms = lib.platforms.all;
+          position = "${pos.file}:${toString pos.line}";
+          teams = [ lib.teams.stdenv ];
+          license = lib.licenses.mit;
+          identifiers.cpeParts = {
+            part = "a";
+            vendor = "nixos";
+            product = argsStdenv.name;
+            inherit version;
+          };
+        };
 
       inherit buildPlatform hostPlatform targetPlatform;
 


### PR DESCRIPTION
currently the sources button is missing:

<img width="763" height="367" alt="image" src="https://github.com/user-attachments/assets/0ca3ba0f-2ff3-4f05-a867-054939137ea7" />

### 

Maybe other meta attributes should be set like `license` (mit?), maintainers (stdenv team?), ...

Found that while trying to run a script that blindy tested `meta.broken` :upside_down_face: It seems that `check-meta` is not applied? 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
