### PR TITLE
nixl: init at 1.0.1

### DIFF
--- a/pkgs/by-name/ni/nixl/package.nix
+++ b/pkgs/by-name/ni/nixl/package.nix
@@ -1,0 +1,151 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  gitMinimal,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+
+  # buildInputs
+  abseil-cpp,
+  asio,
+  aws-sdk-cpp,
+  hwloc,
+  libaio,
+  libfabric,
+  liburing,
+  numactl,
+  python3Packages,
+  taskflow,
+  ucx,
+
+  # passthru
+  nix-update-script,
+
+  config,
+  cudaPackages,
+  cudaSupport ? config.cudaSupport,
+}:
+let
+  effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
+in
+effectiveStdenv.mkDerivation (finalAttrs: {
+  pname = "nixl";
+  version = "1.0.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ai-dynamo";
+    repo = "nixl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mDpDqwUwI0baIDDpt9/wgIP3saBWY8yWKgwzHgrzJiU=";
+  };
+
+  postPatch =
+    # Fix deprecated abseil-cpp Mutex API (Lock/Unlock/ReaderLock/ReaderUnlock
+    # replaced by lock/unlock/lock_shared/unlock_shared in abseil 20260107)
+    ''
+      substituteInPlace src/core/sync.h \
+        --replace-fail 'm.Lock()' 'm.lock()' \
+        --replace-fail 'm.Unlock()' 'm.unlock()' \
+        --replace-fail 'm.ReaderLock()' 'm.lock_shared()' \
+        --replace-fail 'm.ReaderUnlock()' 'm.unlock_shared()'
+    ''
+    # Fix asio::io_context::post() removed in asio 1.36+
+    # Use the free function asio::post(io_context, handler) instead
+    + ''
+      substituteInPlace src/plugins/ucx/ucx_backend.cpp \
+        --replace-fail 'io_->post(' 'asio::post(*io_, '
+    ''
+    # Fix UB: explicit destructor call on lock_guard (GCC 15 -Werror=maybe-uninitialized)
+    # Replace lock_guard + manual destructor with unique_lock + unlock()
+    + ''
+      substituteInPlace src/plugins/libfabric/libfabric_backend.cpp \
+        --replace-fail \
+          'std::lock_guard<std::mutex> lock(connection_state_mutex_);' \
+          'std::unique_lock<std::mutex> lock(connection_state_mutex_);' \
+        --replace-fail \
+          'lock.~lock_guard();' \
+          'lock.unlock();'
+    ''
+    # Fix GDS plugin: Nix uses lib/ not lib64/
+    + ''
+      substituteInPlace src/plugins/cuda_gds/meson.build src/plugins/gds_mt/meson.build \
+        --replace-fail "'/lib64'" "'/lib'"
+    '';
+
+  nativeBuildInputs = [
+    cmake
+    gitMinimal
+    meson
+    ninja
+    pkg-config
+    python3
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+  ];
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    abseil-cpp
+    asio
+    aws-sdk-cpp
+    hwloc
+    libaio
+    libfabric
+    liburing
+    numactl
+    taskflow
+    ucx
+
+    python3Packages.python
+    # Using C++ header files, not Python import
+    python3Packages.pybind11
+  ]
+  ++ lib.optionals cudaSupport (
+    with cudaPackages;
+    [
+      cuda_cudart
+      cuda_nvcc # crt/host_config.h; even though we include this in nativeBuildInputs, it's needed here too
+      libcufile # cufile.h
+    ]
+    # libcuobjclient is only available on cuda>=13.1
+    ++ lib.optionals (libcuobjclient.meta.available or false) [
+      libcuobjclient
+    ]
+  );
+
+  mesonFlags = [
+    (lib.mesonOption "cudapath_lib" "${lib.getLib cudaPackages.cuda_cudart}/lib")
+    (lib.mesonOption "gds_path" (lib.getInclude cudaPackages.cuda_cudart).outPath)
+
+    # Override C++17 -> C++20: taskflow 4.0 headers require C++20 features
+    # (std::bit_ceil, std::atomic::wait/notify, std::atomic_flag::test, etc.)
+    (lib.mesonOption "cpp_std" "c++20")
+
+    # Disable -Werror to prevent false positives from stricter GCC 15 -Wmaybe-uninitialized
+    (lib.mesonOption "werror" "false")
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "NVIDIA Inference Xfer Library";
+    homepage = "https://github.com/ai-dynamo/nixl";
+    changelog = "https://github.com/ai-dynamo/nixl/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+    broken = !cudaSupport;
+  };
+})

--- a/pkgs/by-name/ni/nixl/package.nix
+++ b/pkgs/by-name/ni/nixl/package.nix
@@ -137,6 +137,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+
+    # propagate the stdenv so that the python API can consume it directly
+    stdenv = effectiveStdenv;
+
+    pythonPackage = python3Packages.nixl;
   };
 
   meta = {

--- a/pkgs/development/python-modules/nixl/default.nix
+++ b/pkgs/development/python-modules/nixl/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildPythonPackage,
+  python,
+  nixl,
+
+  # build-system
+  build,
+  meson-python,
+  pybind11,
+  pytest,
+  pyyaml,
+  setuptools,
+  types-pyyaml,
+
+  # dependencies
+  numpy,
+  torch,
+
+  config,
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
+}:
+
+buildPythonPackage.override { inherit (nixl) stdenv; } (finalAttrs: {
+  inherit (nixl)
+    pname
+    version
+    src
+    __structuredAttrs
+    strictDeps
+    nativeBuildInputs
+    dontUseCmakeConfigure
+    buildInputs
+    mesonFlags
+    ;
+  pyproject = true;
+
+  postPatch = (nixl.postPatch or "") + ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        '"patchelf",' \
+        ""
+  '';
+
+  build-system = [
+    build
+    meson-python
+    pybind11
+    pytest
+    pyyaml
+    setuptools
+    types-pyyaml
+  ];
+  dontUseMesonConfigure = true;
+
+  dependencies = [
+    numpy
+    torch
+  ];
+
+  # Install the `nixl` shim module (re-exports nixl_cu{12,13}).
+  # Upstream builds this as a separate wheel via `uv build` (nixl-meta), but that doesn't work in
+  # the sandbox.
+  postInstall = ''
+    install -Dm644 \
+      src/bindings/python/nixl-meta/nixl/__init__.py \
+      "$out/${python.sitePackages}/nixl/__init__.py"
+  '';
+
+  pythonImportsCheck = [
+    "nixl"
+  ]
+  ++ lib.optionals cudaSupport [
+    "nixl_cu${cudaPackages.cudaMajorVersion}"
+  ];
+
+  # No tests we can run in the sandbox
+  doCheck = false;
+
+  meta = nixl.meta // {
+    description = "Python API for nixl";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11132,6 +11132,8 @@ self: super: with self; {
 
   nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
 
+  nixl = callPackage ../development/python-modules/nixl { inherit (pkgs) nixl; };
+
   nixpkgs-plugin-update = callPackage ../development/python-modules/nixpkgs-plugin-update { };
 
   nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };


### PR DESCRIPTION
## Things done

Add [nixl](https://github.com/ai-dynamo/nixl), aka NVIDIA Inference Xfer Library.
- **nixl: init at 1.0.1**
- **python3Packages.nixl: init at 1.0.1**

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
