### PR TITLE
[Backport release-25.11] psysh: unbreak, 0.12.7 -> 0.12.22

### DIFF
--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -6,13 +6,13 @@
 }:
 php.buildComposerProject2 (finalAttrs: {
   pname = "psysh";
-  version = "0.12.21";
+  version = "0.12.22";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/qY7o7gsO0SdDzf9sfWFDpO/fjX3tSAoKsTeSGQ65HM=";
+    hash = "sha256-mcK7s/CmXTvQMNXY4bAtwWudY1aOJdt0XkOKUVhIVHQ=";
     forceFetchGit = true;
     postFetch = ''
       cp $out/build/composer.json $out/
@@ -20,7 +20,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-4vRTUmlSSuUmOLPgIrdz56FFzDRrhJ68cCNIMbAa/4s=";
+  vendorHash = "sha256-cJT4E9gRwtuY1cziGyw5a3HsGdHc7FiRtmJWbXj2f+4=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -47,6 +47,7 @@ php.buildComposerProject2 (finalAttrs: {
     changelog = "https://github.com/bobthecow/psysh/releases/tag/v${finalAttrs.version}";
     description = "PsySH is a runtime developer console, interactive debugger and REPL for PHP";
     mainProgram = "psysh";
+    maintainers = [ lib.maintainers.piotrkwiecinski ];
     license = lib.licenses.mit;
     homepage = "https://psysh.org/";
   };

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -6,13 +6,13 @@
 }:
 php.buildComposerProject2 (finalAttrs: {
   pname = "psysh";
-  version = "0.12.20";
+  version = "0.12.21";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YTKViaWBCUxerYklo22mNzrFp8M/RE3VLHrqhXuYkes=";
+    hash = "sha256-/qY7o7gsO0SdDzf9sfWFDpO/fjX3tSAoKsTeSGQ65HM=";
     forceFetchGit = true;
     postFetch = ''
       cp $out/build/composer.json $out/
@@ -20,7 +20,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-2RgV+1tq+quvjDHLE+DYsi99RUJoeXjYQiR1PTLTfOw=";
+  vendorHash = "sha256-4vRTUmlSSuUmOLPgIrdz56FFzDRrhJ68cCNIMbAa/4s=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -6,13 +6,13 @@
 }:
 php.buildComposerProject2 (finalAttrs: {
   pname = "psysh";
-  version = "0.12.19";
+  version = "0.12.20";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j2AcpbptbsdK/GOIuglMBwklTZSAEa8oD7g/H9oibUo=";
+    hash = "sha256-YTKViaWBCUxerYklo22mNzrFp8M/RE3VLHrqhXuYkes=";
     forceFetchGit = true;
     postFetch = ''
       cp $out/build/composer.json $out/
@@ -20,7 +20,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-REcymcAZoTZcSSrMcjIe14pICwSIw1WR4nHWgYFILzI=";
+  vendorHash = "sha256-2RgV+1tq+quvjDHLE+DYsi99RUJoeXjYQiR1PTLTfOw=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -40,12 +40,12 @@ php.buildComposerProject2 (finalAttrs: {
 
     preBuild = ''
       composer config platform.php 7.4
-      composer require --no-update symfony/polyfill-iconv:1.31 symfony/polyfill-mbstring:1.31
-      composer require --no-update --dev roave/security-advisories:dev-latest
-      composer update --lock --no-install
+      composer require --no-cache --no-update symfony/polyfill-iconv:1.31 symfony/polyfill-mbstring:1.31
+      composer require --no-cache --no-update --dev roave/security-advisories:dev-latest
+      composer update --no-cache --lock --no-install
     '';
 
-    vendorHash = "sha256-8l5bQ+VnLOtPUspMN1f+iXo7LldPTuYqyrAeW2aVoH8=";
+    vendorHash = "sha256-jKQyQSg08uDTO2RzQCQlKzNiYtXyqiHNdjO+TwIjeUY=";
   };
 
   doInstallCheck = true;
@@ -58,7 +58,5 @@ php.buildComposerProject2 (finalAttrs: {
     mainProgram = "psysh";
     license = lib.licenses.mit;
     homepage = "https://psysh.org/";
-    # `composerVendor` doesn't build
-    broken = true;
   };
 })

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -4,40 +4,23 @@
   php,
   versionCheckHook,
 }:
-
-let
+php.buildComposerProject2 (finalAttrs: {
   pname = "psysh";
   version = "0.12.19";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
-    tag = "v${version}";
-    hash = "sha256-Gdye6+fdqqxgHqq79XJgSkywP1IMMAIVexh0kEol0Jw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j2AcpbptbsdK/GOIuglMBwklTZSAEa8oD7g/H9oibUo=";
     forceFetchGit = true;
-  };
-in
-php.buildComposerProject2 (finalAttrs: {
-  inherit
-    pname
-    version
-    src
-    ;
-
-  composerVendor = php.mkComposerVendor {
-    inherit
-      src
-      version
-      pname
-      ;
-
-    preConfigure = ''
-      cp build/composer.json .
-      cp build/composer.lock .
+    postFetch = ''
+      cp $out/build/composer.json $out/
+      cp $out/build/composer.lock $out/
     '';
-
-    vendorHash = "sha256-REcymcAZoTZcSSrMcjIe14pICwSIw1WR4nHWgYFILzI=";
   };
+
+  vendorHash = "sha256-REcymcAZoTZcSSrMcjIe14pICwSIw1WR4nHWgYFILzI=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitHub,
-  fetchurl,
   lib,
   php,
   versionCheckHook,
@@ -8,19 +7,14 @@
 
 let
   pname = "psysh";
-  version = "0.12.7";
+  version = "0.12.19";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
     tag = "v${version}";
-    hash = "sha256-dgMUz7lB1XoJ08UvF9XMZGVXYcFK9sNnSb+pcwfeoqQ=";
-  };
-
-  composerLock = fetchurl {
-    name = "composer.lock";
-    url = "https://github.com/bobthecow/psysh/releases/download/v${version}/composer-v${version}.lock";
-    hash = "sha256-JYJksHKyKKhU248hLPaNXFCh3X+5QiT8iNKzeGc1ZPw=";
+    hash = "sha256-Gdye6+fdqqxgHqq79XJgSkywP1IMMAIVexh0kEol0Jw=";
+    forceFetchGit = true;
   };
 in
 php.buildComposerProject2 (finalAttrs: {
@@ -35,17 +29,14 @@ php.buildComposerProject2 (finalAttrs: {
       src
       version
       pname
-      composerLock
       ;
 
-    preBuild = ''
-      composer config platform.php 7.4
-      composer require --no-cache --no-update symfony/polyfill-iconv:1.31 symfony/polyfill-mbstring:1.31
-      composer require --no-cache --no-update --dev roave/security-advisories:dev-latest
-      composer update --no-cache --lock --no-install
+    preConfigure = ''
+      cp build/composer.json .
+      cp build/composer.lock .
     '';
 
-    vendorHash = "sha256-jKQyQSg08uDTO2RzQCQlKzNiYtXyqiHNdjO+TwIjeUY=";
+    vendorHash = "sha256-REcymcAZoTZcSSrMcjIe14pICwSIw1WR4nHWgYFILzI=";
   };
 
   doInstallCheck = true;


### PR DESCRIPTION
Hashes should be different than on master due to changes to buildComposerProject2.

Backport of:
- #459254 (partial)
- #488301
- #488986
- #491276
- #499364
- #504882

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
