### PR TITLE
rstudio: revert 201ccf894a7665098b49d031503ec7d1a79251ba

### DIFF
--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -17,7 +17,7 @@
   git,
   jdk,
   makeWrapper,
-  nodejs-slim,
+  nodejs,
   npmHooks,
   xcbuild,
   yarn,
@@ -135,7 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     ant
     jdk
 
-    nodejs-slim
+    nodejs
     yarn
     yarnConfigHook
     zip
@@ -145,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (!server) [
     makeWrapper
-    (nodejs-slim.python.withPackages (ps: [ ps.setuptools ]))
+    (nodejs.python.withPackages (ps: [ ps.setuptools ]))
     npmHooks.npmConfigHook
   ];
 
@@ -289,8 +289,8 @@ stdenv.mkDerivation (finalAttrs: {
     RSTUDIO_INSTALLED_NODE_VERSION="22.21.1"
 
     mkdir -p dependencies/common/node
-    ln -s ${nodejs-slim} dependencies/common/node/$RSTUDIO_NODE_VERSION
-    ln -s ${nodejs-slim} dependencies/common/node/$RSTUDIO_INSTALLED_NODE_VERSION-installed
+    ln -s ${nodejs} dependencies/common/node/$RSTUDIO_NODE_VERSION
+    ln -s ${nodejs} dependencies/common/node/$RSTUDIO_INSTALLED_NODE_VERSION-installed
 
   ''
   + lib.optionalString (!server) ''


### PR DESCRIPTION
Revert 201ccf894a7665098b49d031503ec7d1a79251ba which broke the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
