### PR TITLE
syncdown: init at 0.2.0

### DIFF
--- a/pkgs/by-name/sy/syncdown/package.nix
+++ b/pkgs/by-name/sy/syncdown/package.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, bun, cacert, fetchFromGitHub, writeShellScriptBin
+, autoPatchelfHook, }:
+let
+  pname = "syncdown";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "hjinco";
+    repo = "syncdown";
+    rev = "cf7ef40af6c8a5f7b46a1798d3b367d6ddb1a108";
+    hash = "sha256-J9OccGQeWPxs/OC4iDvr9yyZC2WrTofW9SZ5XDb4MIU=";
+  };
+
+  srcWithDeps = stdenv.mkDerivation {
+    name = "syncdown-src-with-deps";
+    inherit src;
+    nativeBuildInputs = [ bun cacert ];
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-JuDE6Df6cue3hQz9aAXr7nq377eNIzb9z2S9RldrR0I=";
+    buildPhase = ''
+      export HOME=$(mktemp -d)
+      bun install --frozen-lockfile --ignore-scripts
+    '';
+    installPhase = "cp -r . $out";
+  };
+in writeShellScriptBin "syncdown" ''
+  exec ${bun}/bin/bun run ${srcWithDeps}/apps/cli/src/bin.ts "$@"
+''


### PR DESCRIPTION
Adds syncdown cli tool via bun build compile.

syncdown pulls content from external services and saves it as local Markdown files on your filesystem. 

Many AI workflows talk to tools like Notion, Gmail, or Google Calendar directly through MCP or provider APIs. That is flexible, but repeated remote reads are often slower and more token-expensive than working from local files.

syncdown is designed for people who want their notes and messages outside the browser: in a local folder they can search, back up, sync, feed into another tool, or index with local search tooling such as [qmd](https://github.com/tobi/qmd). It also gives them one place to manage information that would otherwise stay scattered across multiple services.

Author: @hhhjin
https://github.com/hjinco/syncdown
https://syncdown.dev/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. (not applicable)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality. (not applicable)
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (not applicable)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking. (not applicable)
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module. (not applicable)
  - [ ] Module update: when the change is significant. (not applicable)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
