### PR TITLE
librewolf-unwrapped: 149.0.2-2 -> 150.0-1

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
@@ -32,6 +32,10 @@ rec {
 
     sed -i '/# This must remain last./i gkrust_features += ["glean_disable_upload"]\'$'\n' toolkit/library/rust/gkrust-features.mozbuild
 
+    # Temporary fix used with patches/rust-build.patch
+    sed -i 's/9456ca46168ef86c98399a2536f577ef7be3cdde90c0c51392d8ac48519d3fae/b9432f9ed39742015f4bb4c3e75c89a2b9a9eef943dd0fd7cd889fddd1e6d39c/g' third_party/rust/encoding_rs/.cargo-checksum.json
+
+
     cp ${source}/patches/pref-pane/category-librewolf.svg browser/themes/shared/preferences
     cp ${source}/patches/pref-pane/librewolf.css browser/themes/shared/preferences
     cp ${source}/patches/pref-pane/librewolf.inc.xhtml browser/components/preferences

--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "149.0.2-2",
+  "packageVersion": "150.0-1",
   "source": {
-    "rev": "149.0.2-2",
-    "hash": "sha256-rnDL98f3vwpcRmWfNuTcp2SDk6CKiOPEZFYnNsVDUa0="
+    "rev": "150.0-1",
+    "hash": "sha256-udoXrll3sQnG8Jp6AZtd9V2vela4Uej9SKy7wP7YiUc="
   },
   "firefox": {
-    "version": "149.0.2",
-    "hash": "sha512-hEpG7gaOzcZrcifQiaBXrT9JRRFP6iyygNXio4PQoCL8ZiitV8Bo6jTPFZRy9jxQ6n7RKLwRoLJ/Frt7Z9fzzw=="
+    "version": "150.0",
+    "hash": "sha512-d+jq6G57F8M5M/3qbTtfvnPmYTlJ5iwT2e0+WT57oLUHAfqX/H1WoniWHS4c2ykCJEwwoQIHkAkbCuLwyxtOcQ=="
   }
 }


### PR DESCRIPTION
diff: https://codeberg.org/librewolf/source/compare/149.0.2-2...150.0-1
mfsa: https://www.mozilla.org/en-US/security/advisories/mfsa2026-30

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
