### PR TITLE
 mangowc: 0.12.3 -> 0.12.8 

### DIFF
--- a/pkgs/by-name/ma/mangowc/package.nix
+++ b/pkgs/by-name/ma/mangowc/package.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.12.3";
 
   src = fetchFromGitHub {
-    owner = "DreamMaoMao";
-    repo = "mangowc";
+    owner = "mangowm";
+    repo = "mango";
     tag = finalAttrs.version;
     hash = "sha256-cuOOgfufbGv0QIrRD6bAzaHiYXt32wxwt2Tzi+jAmwg=";
   };
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     mainProgram = "mango";
     description = "Lightweight and feature-rich Wayland compositor based on dwl";
-    homepage = "https://github.com/DreamMaoMao/mangowc";
+    homepage = "https://github.com/mangowm/mango";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ hustlerone ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ma/mangowc/package.nix
+++ b/pkgs/by-name/ma/mangowc/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "mangowc";
-  version = "0.12.3";
+  version = "0.12.8";
 
   src = fetchFromGitHub {
     owner = "mangowm";
     repo = "mango";
     tag = finalAttrs.version;
-    hash = "sha256-cuOOgfufbGv0QIrRD6bAzaHiYXt32wxwt2Tzi+jAmwg=";
+    hash = "sha256-k9qFn9I+eeAq1kBfw6QRLRMDb6sIV+pgd5zpKNoc1ck=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ma/mangowc/package.nix
+++ b/pkgs/by-name/ma/mangowc/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     mainProgram = "mango";
     description = "Lightweight and feature-rich Wayland compositor based on dwl";
-    homepage = "https://github.com/mangowm/mango";
+    homepage = "https://mangowm.github.io";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ hustlerone ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Updates the mangowc package and its GitHub repository and homepage

https://github.com/mangowm/mango/releases/tag/0.12.8
https://github.com/mangowm/mango/releases/tag/0.12.7 <-- new website
https://github.com/mangowm/mango/releases/tag/0.12.6
https://github.com/mangowm/mango/releases/tag/0.12.5 <-- highlights that the repository was moved to `mangowm/mango`
https://github.com/mangowm/mango/releases/tag/0.12.4

Nothing else in these release notes look relevant from a nixpkgs perspective

#494922 was automatically opened but doesn't contain any of the meta/repo changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
