### PR TITLE
notesmd-cli: init at v0.3.5

### DIFF
--- a/pkgs/by-name/no/notesmd-cli/package.nix
+++ b/pkgs/by-name/no/notesmd-cli/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  notesmd-cli,
+}:
+
+buildGoModule rec {
+  pname = "notesmd-cli";
+  version = "v0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "Yakitrak";
+    repo = "notesmd-cli";
+    rev = "${version}";
+    hash = "sha256-uogfh0XK/kR5UrPDyMZicOkj/VuYrz4LzOkGRIfEWCI=";
+  };
+
+  vendorHash = null;
+  subPackages = [ "." ];
+
+  __structuredAttrs = true;
+
+  passthru.tests.version = testers.testVersion { package = notesmd-cli; };
+
+  meta = {
+    description = "Interact with an Obsidian vault from the terminal";
+    homepage = "https://github.com/Yakitrak/notesmd-cli";
+    license = lib.licenses.mit;
+    mainProgram = "notesmd-cli";
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.guilvareux ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
