### PR TITLE
wingedit: init at 3.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28336,6 +28336,11 @@
     githubId = 29992205;
     keys = [ { fingerprint = "6684 4E7D D213 C75D 8828  6215 C714 A58B 6C1E 0F52"; } ];
   };
+  undyingsoul = {
+    name = "Undying Soul";
+    github = "UndyingSoul";
+    githubId = 31867988;
+  };
   ungeskriptet = {
     name = "David Wronek";
     email = "nix@david-w.eu";

--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -79,6 +79,9 @@ stdenv.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ magnetophon ];
+    maintainers = with lib.maintainers; [
+      magnetophon
+      undyingsoul
+    ];
   };
 })

--- a/pkgs/applications/audio/midas/wingedit.nix
+++ b/pkgs/applications/audio/midas/wingedit.nix
@@ -1,0 +1,20 @@
+{ lib, callPackage, ... }@args:
+
+callPackage ./generic.nix (
+  args
+  // rec {
+    brand = "Behringer";
+    type = "WING";
+    version = "3.3.2";
+    url =
+      let
+        lower = lib.strings.toLower type;
+        cap =
+          (lib.strings.toUpper (builtins.substring 0 1 lower))
+          + (builtins.substring 1 (builtins.stringLength lower - 1) lower);
+      in
+      "https://cdn-media.empowertribe.com/54ca5aa1529e442b977a9b77bc81c458/${cap}-Edit_LINUX_${version}.tar.gz";
+    hash = "sha256-MAhYfjErJTDwJKt3JN7J1w2e3QAy1fmgwGIJwtNETkE=";
+    homepage = "https://www.behringer.com/en/products/0603-afc";
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10795,6 +10795,8 @@ with pkgs;
 
   x32edit = callPackage ../applications/audio/midas/x32edit.nix { };
 
+  wingedit = callPackage ../applications/audio/midas/wingedit.nix { };
+
   kodiPackages = recurseIntoAttrs (kodi.packages);
 
   kodi = callPackage ../applications/video/kodi {


### PR DESCRIPTION
Added initial package for Behringer WING Edit 3.3.2. Also willing to help maintain x32edit and m32edit and the new wingedit software packages, as I use them often. Largely based off of x32edit and m32edit pkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
