### PR TITLE
kdePackages.spectacle: fix OCR runtime loading

### DIFF
--- a/pkgs/kde/plasma/spectacle/default.nix
+++ b/pkgs/kde/plasma/spectacle/default.nix
@@ -1,19 +1,29 @@
 {
-  lib,
+  fetchpatch,
   mkKdeDerivation,
+  pkg-config,
   qtwayland,
   qtmultimedia,
   opencv,
   tesseractLanguages ? [ ],
   tesseract5,
 }:
-let
-  tesseract = tesseract5.override { enableLanguages = tesseractLanguages; };
-in
 mkKdeDerivation {
   pname = "spectacle";
 
+  # Backport the upstream switch from runtime QLibrary loading to direct
+  # linking so Spectacle OCR can find Tesseract reliably on NixOS.
+  patches = [
+    (fetchpatch {
+      url = "https://invent.kde.org/graphics/spectacle/-/commit/13b0be099e7abe9bbb17b90e62c2e83afb248db7.patch";
+      hash = "sha256-HEgHsuajaF+WVMiRp0YKRmi+/NsIy5s8frwMJRIdDY8=";
+    })
+  ];
+
+  extraNativeBuildInputs = [ pkg-config ];
+
   extraBuildInputs = [
+    (tesseract5.override { enableLanguages = tesseractLanguages; })
     qtwayland
     qtmultimedia
     (opencv.override {
@@ -25,11 +35,6 @@ mkKdeDerivation {
       runAccuracyTests = false; # tests will fail because of missing plugins but that's okay
     })
   ];
-
-  # no point adding the dependency when we have no language packs
-  preFixup = lib.optionalString (tesseractLanguages != [ ]) ''
-    patchelf --add-needed libtesseract.so.5 --add-rpath ${tesseract}/lib $out/bin/spectacle
-  '';
 
   meta.mainProgram = "spectacle";
 }


### PR DESCRIPTION
Spectacle already injects `libtesseract.so.5` into the binary closure when `tesseractLanguages` is enabled, but OCR still fails on NixOS because Spectacle also does a separate `QLibrary("tesseract")` runtime lookup.

This patch keeps the existing `preFixup` ELF dependency injection and additionally patches `src/TesseractRuntimeLoader.cpp` so Spectacle first tries the absolute Nix store path to `libtesseract.so.5`, then falls back to the generic `tesseract` name. That makes the runtime loader work in non-FHS environments like NixOS while keeping the change local to the package and conditional on OCR being enabled.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test