### PR TITLE
lib/modules: expanded error message when no options defined

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -360,7 +360,11 @@ let
               throw ''
                 ${baseMsg}
 
-                It seems as if you're trying to declare an option by placing it into `config' rather than `options'!
+                It seems that your are providing `config` definitions in a module when no options are declared!
+
+                To resolve this, verify that:
+                - The option is declared in `options' (as options.${showOption (prefix ++ firstDef.prefix)})
+                - All modules that declare the option are included in `imports'.
               ''
             else
               throw ''

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -204,9 +204,9 @@ checkConfigOutput '"ok"' config.result ./specialArgs-lib.nix
 
 # https://github.com/NixOS/nixpkgs/pull/131205
 # We currently throw this error already in `config`, but throwing in `config.wrong1` would be acceptable.
-checkConfigError 'It seems as if you.re trying to declare an option by placing it into .config. rather than .options.' config.wrong1 ./error-mkOption-in-config.nix
+checkConfigError 'It seems that your are providing `config` definitions in a module when no options are declared!' config.wrong1 ./error-mkOption-in-config.nix
 # We currently throw this error already in `config`, but throwing in `config.nest.wrong2` would be acceptable.
-checkConfigError 'It seems as if you.re trying to declare an option by placing it into .config. rather than .options.' config.nest.wrong2 ./error-mkOption-in-config.nix
+checkConfigError 'It seems that your are providing `config` definitions in a module when no options are declared!' config.nest.wrong2 ./error-mkOption-in-config.nix
 checkConfigError 'The option .sub.wrong2. does not exist. Definition values:' config.sub ./error-mkOption-in-submodule-config.nix
 checkConfigError '.*This can happen if you e.g. declared your options in .types.submodule.' config.sub ./error-mkOption-in-submodule-config.nix
 checkConfigError '.*A definition for option .bad. is not of type .non-empty .list of .submodule...\.' config.bad ./error-nonEmptyListOf-submodule.nix


### PR DESCRIPTION
There are three likely cases for this to display:
- option is being defined in config erroneously
- config is being defined before defining its option
- config is being defined before importing the module with its option definition

The first case was handled in the error message, now the other two are as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
