### PR TITLE
nixos/test-driver: drop `/dev/net/tun` requirement for vm <-> container communication

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests.section.md
@@ -50,15 +50,3 @@ See the documentation of the settings
 [`uid-range`](https://nix.dev/manual/nix/stable/command-ref/conf-file.html?highlight=uid-range#conf-system-features), and
 [`cgroups`](https://nix.dev/manual/nix/stable/development/experimental-features#xp-feature-cgroups)
 for more information.
-
-If the test uses both `systemd-nspawn` [`containers`](#test-opt-containers) and QEMU virtual machine [`nodes`](#test-opt-nodes)
-and requires them share a common VLAN,
-`/dev/net` must be present in the sandbox.
-This allows them to be bridged over a TAP interface.
-To make this path available, set the following option:
-
-```nix
-{
-  nix.settings.sandbox-paths = [ "/dev/net" ];
-}
-```

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -14,6 +14,7 @@
   ruff,
   ty,
 
+  iproute2,
   netpbm,
   vhost-device-vsock,
   nixosTests,
@@ -25,6 +26,7 @@
   tesseract4,
   util-linux,
   vde2,
+  vde_plug2tapless,
 
   enableNspawn ? false,
   enableOCR ? false,
@@ -59,6 +61,8 @@ buildPythonApplication {
     socat
     util-linux
     vde2
+    iproute2
+    vde_plug2tapless
     vhost-device-vsock
   ]
   ++ lib.optionals enableNspawn [

--- a/nixos/lib/test-driver/src/test_driver/vlan.py
+++ b/nixos/lib/test-driver/src/test_driver/vlan.py
@@ -69,7 +69,7 @@ class VLan:
     def __init__(self, nr: int, tmp_dir: Path, logger: AbstractLogger):
         self.nr = nr
         self.socket_dir = tmp_dir / f"vde{self.nr}.ctl"
-        self.tap_name = f"vde-tap{self.nr}"
+        bridge_name = f"br{self.nr}"
         self.logger = logger
 
         # TODO: don't side-effect environment here
@@ -136,11 +136,13 @@ class VLan:
         )
         self._stdout_thread.start()
 
-        # This is needed to allow systemd-nspawn containers to communicate
+        # TODO: Only do this if necessary (it fails if we don't have pid 0 inside the sandbox).
+        #       refs: <https://github.com/NixOS/nixpkgs/pull/511413#discussion_r3108252527>
+        # This allows systemd-nspawn containers to communicate
         # with VMs connected to the VLAN.
-        self.logger.debug(f"creating tap interface {self.tap_name}")
+        self._create_bridge(bridge_name)
         self.plug_process = subprocess.Popen(
-            ["vde_plug2tap", "-s", self.socket_dir, self.tap_name],
+            ["vde_plug2tapless", self.socket_dir, bridge_name],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -149,7 +151,7 @@ class VLan:
         assert self.plug_process.stdout is not None
         self._plug_stdout_thread = threading.Thread(
             target=self._log_stream,
-            args=(self.plug_process.stdout, f"vde_plug2tap[{self.nr}]"),
+            args=(self.plug_process.stdout, f"vde_plug2tapless[{self.nr}]"),
             daemon=True,
         )
         self._plug_stdout_thread.start()
@@ -164,3 +166,17 @@ class VLan:
             self.plug_process.terminate()
             self.plug_process.wait()
         self.process.terminate()
+
+    def _create_bridge(self, bridge_name) -> None:
+        self.logger.debug(f"creating bridge {bridge_name}")
+        subprocess.run(["ip", "link", "add", bridge_name, "type", "bridge"], check=True)
+        subprocess.run(["ip", "link", "set", bridge_name, "up"], check=True)
+        # The bridge won't actually appear up until it has a member interface
+        # that is up. Creating a dummy interface is one way to make that happen.
+        # We need the interface to be up for `vde_plug2tapless` to work.
+        dummy_name = f"dummy{self.nr}"
+        subprocess.run(["ip", "link", "add", dummy_name, "type", "dummy"], check=True)
+        subprocess.run(
+            ["ip", "link", "set", dummy_name, "master", bridge_name], check=True
+        )
+        subprocess.run(["ip", "link", "set", dummy_name, "up"], check=True)

--- a/nixos/lib/test-driver/src/test_driver/vlan.py
+++ b/nixos/lib/test-driver/src/test_driver/vlan.py
@@ -35,6 +35,9 @@ def readline_with_timeout(
             # works if the file descriptor is in non-blocking mode!
             while line := readable.readline():
                 yield line
+            else:
+                raise Exception("no lines found. perhaps the process has died?")
+
     finally:
         fcntl.fcntl(fd, fcntl.F_SETFL, og_flags)
 
@@ -120,6 +123,7 @@ class VLan:
         for line in readline_with_timeout(
             self.process.stdout, timeout=dt.timedelta(seconds=5)
         ):
+            self.logger.debug(f"vde_switch[{self.nr}]: {line.rstrip()}")
             if "1000 Success" in line:
                 break
 

--- a/nixos/lib/test-driver/src/test_driver/vlan.py
+++ b/nixos/lib/test-driver/src/test_driver/vlan.py
@@ -127,6 +127,8 @@ class VLan:
             if "1000 Success" in line:
                 break
 
+        assert (self.socket_dir / "ctl").exists(), "cannot start vde_switch"
+
         self._stdout_thread = threading.Thread(
             target=self._log_stream,
             args=(self.process.stdout, f"vde_switch[{self.nr}]"),
@@ -151,8 +153,6 @@ class VLan:
             daemon=True,
         )
         self._plug_stdout_thread.start()
-
-        assert (self.socket_dir / "ctl").exists(), "cannot start vde_switch"
 
         self.logger.debug(f"running vlan (pid {self.pid}; ctl {self.socket_dir})")
 

--- a/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
+++ b/nixos/modules/virtualisation/nspawn-container/run-nspawn/src/run_nspawn/__init__.py
@@ -1,6 +1,8 @@
 import contextlib
 import dataclasses
 import fcntl
+import ipaddress
+import json
 import logging
 import os
 import signal
@@ -22,11 +24,14 @@ class Netns:
     path: Path
 
 
-def run_ip(*args: str) -> None:
-    subprocess.run(
+def run_ip(*args: str) -> str:
+    cp = subprocess.run(
         ["@ip@", *args],
         check=True,
+        text=True,
+        stdout=subprocess.PIPE,
     )
+    return cp.stdout
 
 
 @contextlib.contextmanager
@@ -54,6 +59,21 @@ def vlan_lock(vlan: int) -> typing.Generator[None, None, None]:
             fcntl.flock(f, fcntl.LOCK_UN)
 
 
+IpInterface = ipaddress.IPv4Interface | ipaddress.IPv6Interface
+
+
+def get_ip_interfaces(intf_name: str) -> list[IpInterface]:
+    intfs_info = json.loads(run_ip("--json", "address", "show", "dev", intf_name))
+    (intf_info,) = intfs_info
+
+    def parse_addr_info(addr_info: dict[str, typing.Any]) -> IpInterface:
+        local: str = addr_info["local"]
+        prefixlen: int = addr_info["prefixlen"]
+        return ipaddress.ip_interface(f"{local}/{prefixlen}")
+
+    return [parse_addr_info(addr_info) for addr_info in intf_info["addr_info"]]
+
+
 @contextlib.contextmanager
 def ensure_vlan_bridge(vlan: int) -> typing.Generator[str, None, None]:
     """
@@ -64,13 +84,11 @@ def ensure_vlan_bridge(vlan: int) -> typing.Generator[str, None, None]:
     """
     # These IP addresses correspond to the static IP assignment logic in
     # <nixos/lib/testing/network.nix>.
-    ipv4_addr = f"192.168.{vlan}.254/24"
-    ipv6_addr = f"2001:db8:{vlan}::fe/64"
+    ipv4_ip_intf = ipaddress.ip_interface(f"192.168.{vlan}.254/24")
+    ipv6_ip_intf = ipaddress.ip_interface(f"2001:db8:{vlan}::fe/64")
 
     bridge_name = f"br{vlan}"
-    tap_name = f"vde-tap{vlan}"
     bridge_path = Path("/sys/class/net") / bridge_name
-    tap_path = Path("/sys/class/net") / tap_name
     try:
         # To avoid racing against other nspawn containers that also
         # need this vlan, grab an exclusive lock.
@@ -79,21 +97,13 @@ def ensure_vlan_bridge(vlan: int) -> typing.Generator[str, None, None]:
                 logger.info("creating bridge %s", bridge_name)
                 run_ip("link", "add", bridge_name, "type", "bridge")
                 run_ip("link", "set", bridge_name, "up")
-                run_ip("addr", "add", ipv4_addr, "dev", bridge_name)
-                run_ip("addr", "add", ipv6_addr, "dev", bridge_name)
 
-            if tap_path.exists():
-                logger.info(f"attaching {tap_name} to {bridge_name}")
-                run_ip("link", "set", tap_name, "master", bridge_name)
-                run_ip("link", "set", tap_name, "up")
-            else:
-                logger.warning(
-                    f"TAP {tap_name} not found; container will be isolated from VDE"
-                )
-                if not Path("/dev/net").exists():
-                    logger.warning(
-                        "A common reason for this is that /dev/net is not available in the Nix sandbox. Try adding /dev/net to extra-sandbox-paths."
-                    )
+            bridge_ip_intfs = get_ip_interfaces(bridge_name)
+            if ipv4_ip_intf not in bridge_ip_intfs:
+                run_ip("addr", "add", str(ipv4_ip_intf), "dev", bridge_name)
+
+            if ipv6_ip_intf not in bridge_ip_intfs:
+                run_ip("addr", "add", str(ipv6_ip_intf), "dev", bridge_name)
 
         yield bridge_name
     finally:

--- a/pkgs/by-name/vd/vde_plug2tapless/package.nix
+++ b/pkgs/by-name/vd/vde_plug2tapless/package.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  vde2,
+  python3,
+  writeShellApplication,
+}:
+writeShellApplication {
+  name = "vde_plug2tapless";
+  runtimeInputs = [ vde2 ];
+  text = ''
+    if [ $# -ne 2 ]; then
+        echo "Usage: $0 [vde_socket_dir] [intf]" >&2
+        echo "Example: $0 /tmp/vde1.ctl/ br0" >&2
+        exit 1
+    fi
+
+    vde_socket_dir=$1
+    intf=$2
+
+    exec dpipe vde_plug "$vde_socket_dir" = ${lib.getExe python3} ${./vde_plugee.py} "$intf"
+  '';
+}

--- a/pkgs/by-name/vd/vde_plug2tapless/vde_plugee.py
+++ b/pkgs/by-name/vd/vde_plug2tapless/vde_plugee.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+# This is a proof of concept alternative to `vde_plug2tap`.
+# Unlike `vde_plug2tap`, it doesn't require a tap interface, it operates on raw sockets.
+# This doesn't actually integrate directly with VDE, it's built to be used with `vde_plug`:
+#
+# $ dpipe vde_plug /tmp/vde1.ctl/ = ./vde_plugee.py
+#
+# TODO: Reach out to [vde-2] and see if this might be in scope for the project.
+#       If they are, port to C and send it to them.
+#
+# [vde-2]: https://github.com/virtualsquare/vde-2
+
+import threading
+import sys
+import struct
+import argparse
+import socket
+from typing import BinaryIO
+
+# From netpacket/packet.h
+PACKET_ADD_MEMBERSHIP = 1
+PACKET_DROP_MEMBERSHIP = 2
+PACKET_MR_PROMISC = 1
+
+# From bits/socket.h
+SOL_PACKET = 263
+
+# 65,536 is larger than any number on <https://en.wikipedia.org/wiki/Jumbo_frame>.
+MTU = 2**16
+
+# Inspired by <https://github.com/secdev/scapy/blob/v2.7.0/scapy/arch/linux/__init__.py#L143-L151>
+def set_promisc(s: socket.socket, intf: str, on: bool):
+    intf_index = socket.if_nametoindex(intf)
+    mreq = struct.pack("IHH8s", intf_index, PACKET_MR_PROMISC, 0, b"")
+    if on:
+        cmd = PACKET_ADD_MEMBERSHIP
+    else:
+        cmd = PACKET_DROP_MEMBERSHIP
+    s.setsockopt(SOL_PACKET, cmd, mreq)
+
+
+def shovel_vde_to_bridge(recv_vde: BinaryIO, bridge_socket: socket.socket, debug: bool):
+    print("vde -> bridge: shoveling", file=sys.stderr)
+
+    while True:
+        # Read frame.
+        # The format doesn't seem to be documented anywhere.
+        # First, it's the size in 2 octets (network byte order),
+        # followed by the raw data.
+        # https://github.com/virtualsquare/vde-2/blob/v2.3.3/src/lib/libvdeplug.c#L663-L664
+        frame_len_buf = recv_vde.read(2)
+        if len(frame_len_buf) == 0:
+            print("vde switch seems to have gone away", file=sys.stderr)
+            return
+        (frame_len,) = struct.unpack("!H", frame_len_buf)
+        if debug:
+            print(f"vde -> bridge: reading a frame of size {frame_len}", file=sys.stderr)
+        raw_frame = recv_vde.read(frame_len)
+
+        # Send frame.
+        size = bridge_socket.send(raw_frame)
+        if debug:
+            print(f"vde -> bridge: send frame of size {size}", file=sys.stderr)
+
+def shovel_bridge_to_vde(bridge_socket: socket.socket, send_vde: BinaryIO, debug: bool):
+    print("bridge -> vde: shoveling", file=sys.stderr)
+
+    while True:
+        # Read frame.
+        raw_frame, _ancdata, flags, _addr = bridge_socket.recvmsg(MTU)
+        if flags & socket.MSG_TRUNC:
+            assert False, "Ethernet frame was truncated. This shouldn't happen."
+        size = len(raw_frame)
+        if debug:
+            print(f"bridge -> vde: read a frame of size {size}", file=sys.stderr)
+
+        # Send frame.
+        send_vde.write(struct.pack("!H", size))
+        send_vde.write(raw_frame)
+        send_vde.flush()
+        if debug:
+            print(f"bridge -> vde: wrote a frame of size {size}", file=sys.stderr)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("intf")
+    parser.add_argument("--debug", type=bool, default=False)
+    args = parser.parse_args()
+
+    bridge_interface = args.intf
+    bridge_socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(socket.ETH_P_ALL))
+    set_promisc(bridge_socket, bridge_interface, on=True)
+    bridge_socket.bind((bridge_interface, 0))
+
+    # TODO: Fail faster. Right now, if any of these threads crash, the program keeps running.
+    #       Simplest approach is probably to get rid of threads and do asyncio.
+    #       Figure out if you're porting this to C first, though.
+    threads = [
+        # daemon=True ensures that this process actually exits when we get a SIGINT,
+        # but we do tend to crash with a SIGBART:
+        #
+        # > Fatal Python error: _enter_buffered_busy: could not acquire lock for <_io.BufferedReader name='<stdin>'> at interpreter shutdown, possibly due to daemon threads
+        # > Python runtime state: finalizing (tstate=0x00007f733fe2bde8)
+        # >
+        # > Current thread 0x00007f733ff1c780 (most recent call first):
+        # >   <no Python frame>
+        #
+        # The cleanest solution might be to rewrite this to be async rather than using threads.
+        threading.Thread(target=lambda: shovel_bridge_to_vde(bridge_socket, sys.stdout.buffer, debug=args.debug), daemon=True),
+        threading.Thread(target=lambda: shovel_vde_to_bridge(sys.stdin.buffer, bridge_socket, debug=args.debug), daemon=True),
+    ]
+
+    for t in threads:
+        t.start()
+
+    for t in threads:
+        t.join()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a POC: just looking for high level feedback right now.

With these changes, I am able to run `nix-build -A nixosTests.nixos-test-driver.containers` *without* exposing `/dev/net/tun` in my nix sandbox.

<hr />

`vde_plug2tap` allows communication between our QEMU VMs (connected via `vde_switch`) and our systemd-nspawn containers (connected via Linux bridge interfaces). Unfortunately, it requires `/dev/net/tun` to create a TAP interface to hook into the bridge interfaces. `/dev/net/tun` is not normally present in the nix build sandbox, and folks have raised security concerns about making it available. TODO: citation needed, all I have right now is [this](https://github.com/NixOS/infra/issues/987#issuecomment-4261612652).

Here I've put together a proof of concept of an alternate implementation of `vde_plug2tap` that uses raw sockets instead of TAP interfaces. I haven't been able to find an existing project that does this, probably because it's unusual to be in a situation where you can create raw sockets (which requires root), but you cannot create TAP interfaces. From [Universal TUN/TAP device driver]:

> There’s no harm in allowing the device [`/dev/net/tun`] to be
> accessible by non-root users, since CAP_NET_ADMIN is required for
> creating network devices or for connecting to network devices which
> aren’t owned by the user in question.

[Universal TUN/TAP device driver]: https://www.kernel.org/doc/html/latest/networking/tuntap.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
