### PR TITLE
pkgs-lib/formats: use `yq-go` instead of `yj` for `toml.generate`

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -461,16 +461,16 @@ optionalAttrs allowAliases aliases
       generate =
         name: value:
         pkgs.callPackage (
-          { runCommand, yj }:
+          { runCommand, yq-go }:
           runCommand name
             {
-              nativeBuildInputs = [ yj ];
+              nativeBuildInputs = [ yq-go ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
               preferLocalBuild = true;
             }
             ''
-              yj -jt < "$valuePath" > "$out"
+              ${lib.getExe yq-go} -p=json -o=toml < "$valuePath" > "$out"
             ''
         ) { };
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -689,22 +689,18 @@ runBuildTests {
         2
       ];
       level1.level2.level3.level4 = "deep";
+      "x(y,z)" = "special key";
     };
     expected = ''
+      attrs = { foo = "foo" }
       false = false
       float = 3.141
       int = 10
+      level1 = { level2 = { level3 = { level4 = "deep" } } }
       list = [1, 2]
       str = "foo"
       true = true
-
-      [attrs]
-      foo = "foo"
-
-      [level1]
-      [level1.level2]
-      [level1.level2.level3]
-      level4 = "deep"
+      x(y,z) = "special key"
     '';
   };
 


### PR DESCRIPTION
Hello,

This PR is a potential fix for https://github.com/NixOS/nixpkgs/pull/510585 and https://github.com/NixOS/nixpkgs/issues/511970

An issue has also been opened at `yj` to report the issue: https://github.com/sclevine/yj/issues/52 and I really hope it will be fixed upstream at some point because this change comes at a price:

```
❯ nix build nixpkgs#yq-go
❯ nix path-info -Sh ./result
/nix/store/b72l95minifsrvdmrwwjzdl1fn7spfdf-yq-go-4.52.5          52.9 MiB
❯ nix build nixpkgs#yj
❯ nix path-info -Sh ./result
/nix/store/waza2z71mgp748q06j07xdidkrfa3hb7-yj-5.1.0       5.2 MiB
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
