### PR TITLE
nixos/facter: enable amd-pstate for amd cpus

### DIFF
--- a/nixos/modules/hardware/facter/amd-cpu.nix
+++ b/nixos/modules/hardware/facter/amd-cpu.nix
@@ -1,0 +1,24 @@
+{ lib, config, ... }:
+let
+  facterLib = import ./lib.nix lib;
+
+  inherit (config.hardware.facter) report;
+  isBaremetal = config.hardware.facter.detected.virtualisation.none.enable;
+  hasAmdCpu = facterLib.hasAmdCpu report;
+
+  kver = config.boot.kernelPackages.kernel.version;
+in
+lib.mkIf (config.hardware.facter.enable && isBaremetal && hasAmdCpu) {
+  boot = lib.mkMerge [
+    (lib.mkIf ((lib.versionAtLeast kver "5.17") && (lib.versionOlder kver "6.1")) {
+      kernelParams = [ "initcall_blacklist=acpi_cpufreq_init" ];
+      kernelModules = [ "amd-pstate" ];
+    })
+    (lib.mkIf ((lib.versionAtLeast kver "6.1") && (lib.versionOlder kver "6.3")) {
+      kernelParams = [ "amd_pstate=passive" ];
+    })
+    (lib.mkIf (lib.versionAtLeast kver "6.3") {
+      kernelParams = [ "amd_pstate=active" ];
+    })
+  ];
+}

--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -5,6 +5,7 @@
 }:
 {
   imports = [
+    ./amd-cpu.nix
     ./boot.nix
     ./bluetooth.nix
     ./camera


### PR DESCRIPTION
Like the title says. mostly a copy of what nixos-hardware does.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
