### PR TITLE
python3Packages.otter-grader: init at 6.1.6; python3Packages.fica: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/fica/default.nix
+++ b/pkgs/development/python-modules/fica/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  docutils,
+  pyyaml,
+  sphinx,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fica";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chrispyles";
+    repo = "fica";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A13xC8BGsPddsk8ZN2DeMCYc0phy/B4JD9shuoorOwg=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    docutils
+    pyyaml
+    sphinx
+  ];
+
+  pythonImportsCheck = [
+    "fica"
+  ];
+
+  meta = {
+    description = "Library for managing and documenting user configurations";
+    homepage = "https://github.com/chrispyles/fica";
+    changelog = "https://github.com/chrispyles/fica/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hhr2020 ];
+  };
+})

--- a/pkgs/development/python-modules/fica/default.nix
+++ b/pkgs/development/python-modules/fica/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  docutils,
+  pyyaml,
+  sphinx,
+  pytestCheckHook,
+  numpy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fica";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chrispyles";
+    repo = "fica";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A13xC8BGsPddsk8ZN2DeMCYc0phy/B4JD9shuoorOwg=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    docutils
+    pyyaml
+    sphinx
+  ];
+
+  pythonImportsCheck = [
+    "fica"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+  ];
+
+  meta = {
+    description = "Library for managing and documenting user configurations";
+    homepage = "https://github.com/chrispyles/fica";
+    changelog = "https://github.com/chrispyles/fica/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hhr2020 ];
+  };
+})

--- a/pkgs/development/python-modules/otter-grader/default.nix
+++ b/pkgs/development/python-modules/otter-grader/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  click,
+  dill,
+  fica,
+  ipylab,
+  ipython,
+  ipywidgets,
+  jinja2,
+  jupytext,
+  nbconvert,
+  nbformat,
+  pandas,
+  python-on-whales,
+  pyyaml,
+  requests,
+  wrapt,
+  ipykernel,
+  jupyter-client,
+  pypdf,
+  google-api-python-client,
+  google-auth-oauthlib,
+  gspread,
+  six,
+  rpy2,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "otter-grader";
+  version = "6.1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ucbds-infra";
+    repo = "otter-grader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bqBwDbxnvRm7W9r87YK9vwi3sSyoyqbdnqVs5HxOzsg=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    click
+    dill
+    fica
+    ipylab
+    ipython
+    ipywidgets
+    jinja2
+    jupytext
+    nbconvert
+    nbformat
+    pandas
+    python-on-whales
+    pyyaml
+    requests
+    wrapt
+  ];
+
+  optional-dependencies = {
+    grading = [
+      ipykernel
+      jupyter-client
+      pypdf
+    ];
+    plugins = [
+      google-api-python-client
+      google-auth-oauthlib
+      gspread
+      six
+    ];
+    r = [
+      rpy2
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "fica"
+  ];
+
+  pythonImportsCheck = [
+    "otter"
+  ];
+
+  meta = {
+    description = "Python and R autograder";
+    homepage = "https://github.com/ucbds-infra/otter-grader";
+    changelog = "https://github.com/ucbds-infra/otter-grader/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ hhr2020 ];
+  };
+})

--- a/pkgs/development/python-modules/otter-grader/default.nix
+++ b/pkgs/development/python-modules/otter-grader/default.nix
@@ -1,0 +1,153 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  click,
+  dill,
+  fica,
+  ipylab,
+  ipython,
+  ipywidgets,
+  jinja2,
+  jupytext,
+  nbconvert,
+  nbformat,
+  pandas,
+  python-on-whales,
+  pyyaml,
+  requests,
+  wrapt,
+  ipykernel,
+  jupyter-client,
+  pypdf,
+  google-api-python-client,
+  google-auth-oauthlib,
+  gspread,
+  six,
+  rpy2,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  pytest-html,
+  matplotlib,
+  tqdm,
+  R,
+  rPackages,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "otter-grader";
+  version = "6.1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ucbds-infra";
+    repo = "otter-grader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bqBwDbxnvRm7W9r87YK9vwi3sSyoyqbdnqVs5HxOzsg=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    click
+    dill
+    fica
+    ipylab
+    ipython
+    ipywidgets
+    jinja2
+    jupytext
+    nbconvert
+    nbformat
+    pandas
+    python-on-whales
+    pyyaml
+    requests
+    wrapt
+  ];
+
+  optional-dependencies = {
+    grading = [
+      ipykernel
+      jupyter-client
+      pypdf
+    ];
+    plugins = [
+      google-api-python-client
+      google-auth-oauthlib
+      gspread
+      six
+    ];
+    r = [
+      rpy2
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "fica"
+  ];
+
+  pythonImportsCheck = [
+    "otter"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+    pytest-html
+    matplotlib
+    tqdm
+    R
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  checkInputs = [
+    rPackages.knitr
+    rPackages.ottr
+  ];
+
+  disabledTests = [
+    # requires Docker
+    "test_timeout_some_notebooks_finish"
+    "test_timeout_no_notebooks_finish"
+    "test_network"
+    "test_notebooks_with_pdfs"
+    "test_config_overrides_integration"
+    "test_queue"
+    # testthat 3.x assertion message format differs from the expected results in
+    # this R Markdown test, causing a partial credit output mismatch
+    "test_rmd"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # socket.bind() fails under macOS sandbox
+    "test_otter_example"
+    "test_jupyterlite"
+    "test_require_no_pdf_ack"
+    "test_require_no_pdf_ack_with_message"
+    "test_otter_check_script"
+    "test_otter_check_notebook"
+    "test_kernel_override"
+    "test_log_execution"
+    "test_results_load_failure_handling"
+    "test_notebook"
+    "test_pdf_generation_failure"
+    "test_use_submission_pdf"
+    "test_force_public_test_summary"
+    "test_script"
+    "test_assignment_name"
+    "test_token_sanitization"
+    "test_pdf_via_html"
+  ];
+
+  meta = {
+    description = "Python and R autograder";
+    homepage = "https://github.com/ucbds-infra/otter-grader";
+    changelog = "https://github.com/ucbds-infra/otter-grader/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ hhr2020 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5497,6 +5497,8 @@ self: super: with self; {
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };
 
+  fica = callPackage ../development/python-modules/fica { };
+
   fickling = callPackage ../development/python-modules/fickling { };
 
   fido2 = callPackage ../development/python-modules/fido2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11979,6 +11979,8 @@ self: super: with self; {
 
   ots-python = callPackage ../development/python-modules/ots-python { };
 
+  otter-grader = callPackage ../development/python-modules/otter-grader { };
+
   otxv2 = callPackage ../development/python-modules/otxv2 { };
 
   ourgroceries = callPackage ../development/python-modules/ourgroceries { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5507,6 +5507,8 @@ self: super: with self; {
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };
 
+  fica = callPackage ../development/python-modules/fica { };
+
   fickling = callPackage ../development/python-modules/fickling { };
 
   fido2 = callPackage ../development/python-modules/fido2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11985,6 +11985,8 @@ self: super: with self; {
 
   ots-python = callPackage ../development/python-modules/ots-python { };
 
+  otter-grader = callPackage ../development/python-modules/otter-grader { };
+
   otxv2 = callPackage ../development/python-modules/otxv2 { };
 
   ourgroceries = callPackage ../development/python-modules/ourgroceries { };


### PR DESCRIPTION
Added `python3Packages.otter-grader`, a Python and R autograder.
Added `python3Packages.fica`, which is a dependency of `otter-grader`

https://github.com/ucbds-infra/otter-grader
https://github.com/chrispyles/fica

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
