### PR TITLE
pesde: init at 0.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28883,6 +28883,11 @@
     githubId = 7038383;
     name = "Vojta Káně";
   };
+  vokinn = {
+    github = "vokinn";
+    githubId = 113241287;
+    name = "vokin";
+  };
   volfyd = {
     email = "lb.nix@lisbethmail.com";
     github = "volfyd";

--- a/pkgs/by-name/pe/pesde/package.nix
+++ b/pkgs/by-name/pe/pesde/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  dbus,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "pesde";
+  version = "0.7.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pesde-pkg";
+    repo = "pesde";
+    rev = "e57b4c2db9eaf295c8af998212f427ea039ed46e";
+    hash = "sha256-+8SneWw3UQwXg1IV1zn0OM1ySAJpcvMqyoQd7eYAarE=";
+  };
+
+  cargoHash = "sha256-1k7bmH4ocF9JK15C7YonCmwDKVh639Nropuzm62roDA=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    openssl
+    dbus
+  ];
+  buildFeatures = [ "bin" ];
+
+  meta = {
+    description = "Package manager for the Luau programming language, supporting multiple runtimes including Roblox and Lune.";
+    homepage = "https://github.com/pesde-pkg/pesde";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vokinn ];
+    mainProgram = "pesde";
+  };
+}


### PR DESCRIPTION
Adds pesde, a package manager for the Luau programming language supporting multiple runtimes including Roblox and Lune.
Homepage: https://github.com/pesde-pkg/pesde

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
