### PR TITLE
tiddlywiki: 5.3.8 -> 5.4.0

### DIFF
--- a/pkgs/by-name/ti/tiddlywiki/package.nix
+++ b/pkgs/by-name/ti/tiddlywiki/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tiddlywiki";
-  version = "5.3.8";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "tiddlywiki";
     repo = "tiddlywiki5";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nBBjD9JB4tliRJ5N1aK3pc9PzCHG1fByj7vWtKnNEzI=";
+    hash = "sha256-MvX10TwSRQxB8qqLtnlxCelDL6CDlSHGWccv4Xh630I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog: https://tiddlywiki.com/static/Release%25205.4.0.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test