### PR TITLE
kubeshark: 52.10.3 -> 53.2.3

### DIFF
--- a/pkgs/by-name/ku/kubeshark/package.nix
+++ b/pkgs/by-name/ku/kubeshark/package.nix
@@ -75,6 +75,7 @@ buildGoModule (finalAttrs: {
     '';
     maintainers = with lib.maintainers; [
       qjoly
+      miniharinn
     ];
   };
 })

--- a/pkgs/by-name/ku/kubeshark/package.nix
+++ b/pkgs/by-name/ku/kubeshark/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "kubeshark";
-  version = "52.10.3";
+  version = "53.2.3";
 
   src = fetchFromGitHub {
     owner = "kubeshark";
     repo = "kubeshark";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-n7AYUms6fn25UinLd5xFG2DfcpJU0/pR4JF3i1VY1hM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ey40GmwM7UdMNZIYLF1AFeJAwnT2f2xqHB6lG/uM+ds=";
   };
 
   vendorHash = "sha256-4s1gxJo2w5BibZ9CJP7Jl9Z8Zzo8WpBokBnRN+zp8b4=";
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
     [
       "-s"
       "-w"
-      "-X ${t}/misc.GitCommitHash=${finalAttrs.src.rev}"
+      "-X ${t}/misc.GitCommitHash=${finalAttrs.src.tag}"
       "-X ${t}/misc.Branch=master"
       "-X ${t}/misc.BuildTimestamp=0"
       "-X ${t}/misc.Platform=unknown"
@@ -42,6 +42,9 @@ buildGoModule (finalAttrs: {
     go test ./...
   '';
   doCheck = true;
+
+  # Tests bind loopback sockets via httptest.
+  __darwinAllowLocalNetworking = true;
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd kubeshark \


### PR DESCRIPTION
Changelog: https://github.com/kubeshark/kubeshark/releases/tag/v53.2.3

I've also added myself to maintainers.

Supersedes #473623

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test