### PR TITLE
nixos/zapret2: init module

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -214,6 +214,24 @@
   "module-services-tdarr-server-only": [
     "index.html#module-services-tdarr-server-only"
   ],
+  "module-services-zapret2": [
+    "index.html#module-services-zapret2"
+  ],
+  "module-services-zapret2-configuration": [
+    "index.html#module-services-zapret2-configuration"
+  ],
+  "module-services-zapret2-configuration-firewall": [
+    "index.html#module-services-zapret2-configuration-firewall"
+  ],
+  "module-services-zapret2-configuration-lua-files": [
+    "index.html#module-services-zapret2-configuration-lua-files"
+  ],
+  "module-services-zapret2-configuration-profiles": [
+    "index.html#module-services-zapret2-configuration-profiles"
+  ],
+  "module-services-zapret2-quick-start": [
+    "index.html#module-services-zapret2-quick-start"
+  ],
   "module-virtualisation-xen": [
     "index.html#module-virtualisation-xen"
   ],

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -76,6 +76,8 @@
 
 - [Remark42](https://remark42.com/), a self-hosted comment engine. Available as [services.remark42](#opt-services.remark42.enable).
 
+- [Zapret2](https://github.com/bol-van/zapret2), an extensible DPI bypass program. Available as [services.zapret2](#opt-services.zapret2.enable).
+
 - [LibreChat](https://www.librechat.ai/), open-source self-hostable ChatGPT clone with Agents and RAG APIs. Available as [services.librechat](#opt-services.librechat.enable).
 
 - [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable)

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -56,6 +56,8 @@
 
 - [Koito](https://koito.io/), a modern, themeable scrobbler that you can use with any program that scrobbles to a custom ListenBrainz URL. Available as [services.koito](#opt-services.koito.enable).
 
+- [Zapret2](https://github.com/bol-van/zapret2), an extensible DPI bypass program. Available as [services.zapret2](#opt-services.zapret2.enable).
+
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
 - [gocron](https://github.com/flohoss/gocron), a task scheduler with web interface. Available as [services.gocron](#opt-services.gocron.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1462,6 +1462,7 @@
   ./services/networking/xrdp.nix
   ./services/networking/yggdrasil-jumper.nix
   ./services/networking/yggdrasil.nix
+  ./services/networking/zapret2.nix
   ./services/networking/zapret.nix
   ./services/networking/zenohd.nix
   ./services/networking/zerobin.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1498,6 +1498,7 @@
   ./services/networking/xrdp.nix
   ./services/networking/yggdrasil-jumper.nix
   ./services/networking/yggdrasil.nix
+  ./services/networking/zapret2.nix
   ./services/networking/zapret.nix
   ./services/networking/zenohd.nix
   ./services/networking/zerobin.nix

--- a/nixos/modules/services/networking/zapret2.md
+++ b/nixos/modules/services/networking/zapret2.md
@@ -1,0 +1,246 @@
+# Zapret2 {#module-services-zapret2}
+
+[Zapret2](https://github.com/bol-van/zapret2) is a service that enables
+bypassing DPI systems using extensible Lua filters that process outgoing
+network traffic.
+
+For details on which parameters are available and their usage, consult the
+[upstream documentation][1].
+
+## Quick Start {#module-services-zapret2-quick-start}
+
+A simple, minimal setup that includes only a single profile that applies two
+Lua [instances][2] to TLS ClientHello packets can be defined as follows:
+
+```nix
+{
+  services.zapret2 = {
+    enable = true;
+    profiles.default.parameters = [
+      "--filter-tcp=443"
+      "--payload=tls_client_hello"
+      "--lua-desync=fake:blob=fake_default_tls:tcp_ts=-1000:repeats=1"
+      "--lua-desync=fakedsplit:pos=1,midsld:tcp_ts=-1000"
+    ];
+  };
+}
+```
+
+## Configuration {#module-services-zapret2-configuration}
+
+The NixOS module for Zapret2 adds a small structured interface on top of the
+typical plain argument list that is passed to `nfqws2`. This allows e.g.
+profiles to be defined across multiple modules and merged correctly.
+
+### Profiles {#module-services-zapret2-configuration-profiles}
+
+Each Zapret2 profile is defined under the {option}`services.zapret2.profiles`
+option. Multiple profiles can be defined at once, however it's important to
+ensure that each profile can only match one category of traffic by using
+`--filter-*` parameters, because otherwise a profile will match all traffic,
+and since first match wins, no other profile can match it, even if it has a
+more specific filter:
+
+```nix
+{
+  services.zapret2.profiles = {
+    http.parameters = [
+      "--filter-tcp=80"
+      "--payload=http_req"
+      "--lua-desync=http_methodeol"
+    ];
+    https.parameters = [
+      "--filter-tcp=443"
+      "--payload=tls_client_hello"
+      "--lua-desync=multisplit:pos=1,sniext+1,host+1,midsld-2,midsld,midsld+2,endhost-1"
+    ];
+    stun.parameters = [
+      "--filter-udp=*"
+      "--payload=stun,discord_ip_discovery"
+      "--lua-desync=fake:blob=0x00000000000000000000000000000000:repeats=2"
+    ];
+  };
+}
+```
+
+Since profiles are matched on their order and first match wins, each profile
+also has a {option}`services.zapret2.profiles.‹name›.priority` option. Lower
+values will cause the profile to be ordered *before* others, higher values will
+cause the profile to be ordered *after* others. The default priority is `1000`.
+In other words, if you want to define a "fallback" profile that matches traffic
+not matched by any other profile, you should set the priority to a higher value
+such as `1500`.
+
+Each profile's parameters can have the typical filters such as `--filter-tcp=*`
+or `--filter-udp=*`, however for matching hostnames and IP addresses, there are
+a few options to make this more convenient:
+
+```nix
+{
+  services.zapret2.profiles.default = {
+    hosts = {
+      # Automatically keep track of which hosts need the DPI bypass and which
+      # don't. This works by Zapret2 checking if the connection would otherwise
+      # be matched by the profile, and if it is, it first bypasses it, however
+      # it monitors the connection to see if it gets denied (for example, if a
+      # TCP RST packet is received right after the TLS ClientHello is sent). If
+      # this happens, it will then add it to the auto host list (that is
+      # persisted on disk), so subsequent connections will succeed.
+      autodetect.enable = true;
+
+      # If you wish to change where the automatic hostlist file is saved, from
+      # the default location of `/var/lib/zapret2/‹name›-hosts.txt`, for
+      # example to share between multiple profiles:
+      autodetect.file = "/var/lib/zapret2/hosts.txt";
+
+      # Hardcoded list of DNS domains to include/exclude. Note that domains are
+      # matched including all their subdomains, so `nixos.org` also includes
+      # `cache.nixos.org` for example, and `ru` includes `gosuslugi.ru`. If you
+      # don't want this behaviour, you should add `^` to the beginning of the
+      # entry, e.g. `^example.com` will match `example.com` but not
+      # `www.example.com`.
+      include = [
+        "cachix.org"
+        "nixos.org"
+      ];
+      exclude = [ "ru" ];
+    };
+
+    ips = {
+      # Like with hostnames, hardcoded list of IP addresses or subnets in CIDR
+      # notation to include/exclude. Note that by default, the firewall already
+      # excludes local networks (as defined by RFC 1918), so they are not
+      # passed to Zapret2.
+      include = [ "213.59.192.0/18" ];
+      exclude = [ "173.245.48.0/20" ];
+    };
+  };
+}
+```
+
+If either an IP/host include list is defined, or {option}`hosts.autodetect` is
+enabled, the profile will enter a whitelist mode, where traffic by default
+won't be matched (except the special connection tracking case of the auto
+mode). If an IP/host exclude list is defined, traffic not on the exclude list
+is still matched by default, unless an include list is also defined.
+
+In addition to the options above, you may of course define `--ipset-*` or
+`--hostlist-*` options in the profile's parameters. This can be useful to e.g.
+maintain an externally updated list that is not hardcoded into the NixOS
+configuration. If you use these options, make sure the file paths are
+accessible by the user that Zapret2 runs as (by default, it runs as a dynamic
+user).
+
+### Lua Files {#module-services-zapret2-configuration-lua-files}
+
+By default, the module loads the `zapret-lib` and `zapret-antidpi` files from
+the package defined by {option}`services.zapret2.package`. The list of files to
+load can be customised using the {option}`services.zapret2.files` option, as
+follows:
+
+```nix
+{
+  services.zapret2.files = [
+    "zapret-lib"
+    "zapret-antidpi"
+    "zapret-obfs"
+    ./my-lib.lua
+    "/path/to/read/at/runtime/my-lib.lua"
+  ];
+}
+```
+
+Each entry in the list of files can either be a path value, an absolute string
+path (with the `.lua` extension), or the name of a [Zapret2 Lua library][3]
+(without the `.lua` extension). For example, `zapret-lib` gets resolved to
+`zapret-lib.lua` from the defined {option}`services.zapret2.package`. By
+default, `zapret-lib` and `zapret-antidpi` are already included, so for the
+simple case of DPI bypass using the standard libraries, configuring this option
+isn't needed.
+
+However, note that if you *do* customise this option, it overrides the default
+list of files completely. So, for example, if you are writing custom Lua desync
+functions, you will need to not only include your library's full path, but also
+any libraries that it depends on (typically `zapret-lib`).
+
+### Firewall {#module-services-zapret2-configuration-firewall}
+
+Options for the generated nftables firewall configuration can be customised
+under the {option}`services.zapret2.firewall` option. Since Zapret2 is a
+userspace program and all network traffic originates in the kernel, all
+matching network traffic has to be passed from kernel space to userspace. This
+is an expensive process that can slow down network traffic if too much traffic
+is processed. So, it is important to process as little traffic as possible to
+maintain high network throughput. The predefined firewall already excludes
+local IP ranges (as defined by RFC 1918), and the module includes a number of
+options to further reduce how much traffic is passed to Zapret2:
+
+```nix
+{
+  services.zapret2.firewall = {
+    # The maximum number of packets *per each connection* that is passed to
+    # Zapret2, where connection is defined by conntrack. So for the default
+    # value of 16, it will pass the first 16 packets of the connection to
+    # Zapret2 for processing. After 16 packets the firewall won't pass any
+    # packets, and the connection will completely bypass Zapret2. This is
+    # sufficient for most anti-DPI mangling. However if you are doing more
+    # complex processing, you may have to increase this. If you are doing
+    # obfuscation, you will want to set this to `null` so that every packet is
+    # passed. Otherwise obfuscation will only apply to the first 16 packets.
+    maxPackets = 16;
+
+    # The interfaces on which traffic will be passed to Zapret2 for processing.
+    # By default this is `null`, which matches every interface including e.g.
+    # loopback and VPN tunnels, which don't need processing. You should almost
+    # always set this to your actual outbound network interface(s) to prevent
+    # VPN traffic on the inside of the tunnel from getting mangled.
+    interfaces = [ "eth0" ];
+
+    # TCP and UDP ports routed to Zapret2 at the firewall level. Any ports not
+    # in these lists will bypass processing completely. No profile can ever
+    # match ports not on these lists, since they are not even passed to
+    # Zapret2. By default these are both `null`, meaning connections to all
+    # ports are passed.
+    tcpPorts = [
+      80
+      443
+    ];
+    udpPorts = [ 443 ];
+
+    # Internal parameters used by the firewall that mustn't be used by any
+    # other application, or in your own firewall configuration, for example if
+    # you are doing some kind of advanced setup on a router.
+    queue = 200;
+    desyncFwmark = "0x40000000";
+  };
+}
+```
+
+Since Zapret2 works using nfqueue, it's important that the queue number is not
+used by any other application on the system. If the default queue number of
+`200` is already used by another application, you should set the option
+{option}`services.zapret2.firewall.queue` to a queue number that isn't used.
+
+Likewise, it's also important that the desync mark used to mark
+already-processed packets is also not used by any other application. Otherwise,
+it may cause issues such as packet loops or some packets being ignored by the
+conflicting applications. If the default desync mark of `0x40000000` is used by
+another application (or within your firewall configuration), you should set the
+option {option}`services.zapret2.firewall.desyncFwmark` to a desync mark that
+isn't used. Note that the desync mark is expected to be a bitmask, i.e. it
+should be a single bit. As such, the option uses a string instead of a number,
+and the module checks that it only has a single bit set in it.
+
+The firewall configuration in the module only supports nftables, it does not
+support iptables. If you wish to use iptables, or otherwise want to define your
+own firewall configuration (for example, if you are running Zapret2 server-side
+instead of client-side), you can disable the built-in firewall configuration by
+setting {option}`services.zapret2.firewall.configureAutomatically` to `false`.
+Note that, even if the option is disabled, the module still uses the queue
+number and desync mark defined in the module's options, as they are passed as
+command-line arguments to Zapret2. None of the other firewall options are used.
+
+[1]: https://github.com/bol-van/zapret2/blob/master/docs/manual.en.md
+[2]: https://github.com/bol-van/zapret2/blob/master/docs/manual.en.md#traffic-processing-scheme
+[3]: https://github.com/bol-van/zapret2/tree/master/lua
+

--- a/nixos/modules/services/networking/zapret2.nix
+++ b/nixos/modules/services/networking/zapret2.nix
@@ -1,0 +1,555 @@
+{
+  utils,
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.zapret2;
+
+  profileSubmodule =
+    { config, name, ... }:
+    {
+      options = {
+        name = lib.mkOption {
+          type = lib.types.nonEmptyStr;
+          default = name;
+          defaultText = "‹name›";
+          description = "A unique string that identifies this profile.";
+        };
+
+        priority = lib.mkOption {
+          type = lib.types.int;
+          default = 1000;
+          example = 0;
+          description = ''
+            The priority for the profile when constructing the command-line
+            parameters. Lower priority values will cause the profile to be
+            ordered before others, meaning it will be matched before others.
+            Higher priority values will cause the profile to be ordered after
+            others, meaning it will be matched after others.
+          '';
+        };
+
+        ips = {
+          include = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "213.59.192.0/18"
+            ];
+            description = ''
+              An explicit list of IP addresses to include in the DPI bypass.
+              Each member is an IPv4 or IPv6 address, or a subnet in CIDR
+              notation.
+
+              If set to null (the default), no include list is set, meaning all
+              IP addresses are included in the DPI bypass. If set to an empty
+              list, the include list will be empty, and no IP address will be
+              included in the DPI bypass.
+            '';
+          };
+
+          exclude = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "173.245.48.0/20"
+              "103.21.244.0/22"
+              "103.22.200.0/22"
+              "103.31.4.0/22"
+              "141.101.64.0/18"
+              "108.162.192.0/18"
+              "190.93.240.0/20"
+              "188.114.96.0/20"
+              "197.234.240.0/22"
+              "198.41.128.0/17"
+              "162.158.0.0/15"
+              "104.16.0.0/13"
+              "104.24.0.0/14"
+              "172.64.0.0/13"
+              "131.0.72.0/22"
+            ];
+            description = ''
+              An explicit list of IP addresses to exclude from the DPI bypass.
+              Each member is an IPv4 or IPv6 address, or a subnet in CIDR
+              notation.
+
+              If set to null (the default) or an empty list, no exclude list is
+              set, meaning no IP addresses are excluded from the DPI bypass.
+            '';
+          };
+        };
+
+        hosts = {
+          include = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "youtube.com"
+              "chess.com"
+            ];
+            description = ''
+              An explicit list of hostnames to include in the DPI bypass. Each
+              member is a hostname, optionally prefixed with ^ to be a strict
+              match (by default all subdomains are matched).
+
+              If set to null (the default), no include list is set, meaning all
+              hostnames are included in the DPI bypass. If set to an empty
+              list, the include list will be empty, and no hostname will be
+              included in the DPI bypass.
+            '';
+          };
+
+          exclude = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "ru"
+              "yandex.net"
+              "yastatic.net"
+            ];
+            description = ''
+              An explicit list of hostnames to exclude from the DPI bypass.
+              Each member is a hostname, optionally prefixed with ^ to be a
+              strict match (by default all subdomains are matched).
+
+              If set to null (the default) or an empty list, no exclude list is
+              set, meaning no hostnames are excluded from the DPI bypass.
+            '';
+          };
+
+          auto = {
+            enable = lib.mkEnableOption ''
+              automatic tracking of which hosts the DPI bypass is necessary for
+            '';
+
+            file = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/zapret2/${config.name}-hosts.txt";
+              defaultText = "/var/lib/zapret2/‹name›-hosts.txt";
+              description = ''
+                The file where the automatic host list is saved. This path must
+                be writable by the user Zapret2 runs as (by default, it uses a
+                dynamic user, so it must be in {file}`/var/lib/zapret2`).
+              '';
+            };
+          };
+        };
+
+        parameters = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [
+            "--filter-tcp=443"
+            "--payload=tls_client_hello"
+            "--lua-desync=fake:blob=fake_default_tls:tcp_ts=-1000:repeats=1"
+            "--lua-desync=fakedsplit:pos=1,midsld:tcp_ts=-1000"
+          ];
+          description = ''
+            The parameters to use for this profile. Note that, when using
+            multiple profiles, a {option}`--filter-*` parameter MUST be defined,
+            otherwise the first profile will match everything and no other
+            profile will even be executed.
+
+            To obtain a list of suitable parameters, consider running the
+            `blockcheck2` program (part of the zapret2 package), searching the
+            [Zapret forums][1] for community solutions, or consulting the
+            [Zapret manual][2].
+
+            [1]: https://ntc.party/c/community-software/zapret-antidpi/
+            [2]: https://github.com/bol-van/zapret2/blob/master/docs/manual.md
+          '';
+        };
+      };
+
+      config.parameters = lib.mkMerge [
+        (lib.mkIf (config.ips.include != null) (
+          lib.mkBefore [
+            "--ipset=${pkgs.writeText "zapret2-ips-include.txt" (lib.concatLines config.ips.include)}"
+          ]
+        ))
+        (lib.mkIf (config.ips.exclude != null) (
+          lib.mkBefore [
+            "--ipset-exclude=${pkgs.writeText "zapret2-ips-exclude.txt" (lib.concatLines config.ips.exclude)}"
+          ]
+        ))
+        (lib.mkIf (config.hosts.include != null) (
+          lib.mkBefore [
+            "--hostlist=${pkgs.writeText "zapret2-hosts-include.txt" (lib.concatLines config.hosts.include)}"
+          ]
+        ))
+        (lib.mkIf (config.hosts.exclude != null) (
+          lib.mkBefore [
+            "--hostlist-exclude=${pkgs.writeText "zapret2-hosts-exclude.txt" (lib.concatLines config.hosts.exclude)}"
+          ]
+        ))
+        (lib.mkIf config.hosts.auto.enable (
+          lib.mkAfter [
+            "--hostlist-auto=${config.hosts.auto.file}"
+          ]
+        ))
+      ];
+    };
+
+  arguments =
+    let
+      fileOptions =
+        let
+          isAbsolute = x: builtins.isPath x || lib.hasPrefix "/" x;
+          toFile = x: if isAbsolute x then x else "${cfg.package}/share/zapret2/lua/${x}.lua";
+        in
+        map (x: "--lua-init=@${toFile x}") cfg.files;
+      profileOptions =
+        let
+          sorted = builtins.sort (a: b: a.priority < b.priority) (builtins.attrValues cfg.profiles);
+          toArgs = profile: [ "--name=${profile.name}" ] ++ profile.parameters;
+        in
+        builtins.foldl' (acc: p: acc ++ lib.optional (acc != [ ]) "--new" ++ toArgs p) [ ] sorted;
+    in
+    [
+      (lib.getExe cfg.package)
+      "--qnum=${toString cfg.firewall.queue}"
+      "--fwmark=${toString cfg.firewall.desyncMark}"
+    ]
+    ++ fileOptions
+    ++ profileOptions
+    ++ cfg.extraOptions;
+in
+
+{
+  options.services.zapret2 = {
+    enable = lib.mkEnableOption "zapret2, an extensible DPI bypass program";
+    package = lib.mkPackageOption pkgs "zapret2" { };
+
+    profiles = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule profileSubmodule);
+      default = { };
+      example = {
+        https.parameters = [
+          "--filter-tcp=443"
+          "--payload=tls_client_hello"
+          "--lua-desync=fake:blob=fake_default_tls:tcp_ts=-1000:repeats=1"
+          "--lua-desync=fakedsplit:pos=1,midsld:tcp_ts=-1000"
+        ];
+      };
+      description = ''
+        Defines DPI bypass profiles for Zapret2. For each item in the attrset,
+        the key will be used as the profile name, and the value will be the
+        command-line parameters passed to the profile.
+
+        Note that each profile should have a unique {option}`--filter-*`
+        option. By default, a profile matches all traffic, and when a profile
+        matches some traffic, no other profile is evaluated. Since profiles are
+        matched in order they are passed on the command line, the ordering of
+        profiles is important, and if a "fallback"/catch-all profile is
+        defined, it should be defined with a high priority to make sure it is
+        last in the list of profiles.
+
+        Each profile will be prepended with the {option}`--name` option to set
+        the name, and then joined together with {option}`--new` between
+        profiles to form the final command-line parameters that will be passed
+        to Zapret2. Therefore, neither {option}`--name` nor {option}`--new`
+        should be used in the values.
+      '';
+    };
+
+    extraOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--debug" ];
+      description = ''
+        Extra command line parameters to pass to Zapret2.
+
+        Profiles and desync strategies should not be set here, instead the
+        {option}`services.zapret2.profiles` option should be used instead,
+        which allows profiles to be defined and merged correctly across
+        multiple NixOS modules.
+
+        The {option}`--lua-init` parameters should not be included here, the
+        files to load should instead be set via the
+        {option}`services.zapret2.files` option.
+
+        Likewise, the {option}`--qnum` and {option}`--fwmark` parameters should
+        also not be included, instead the queue number and firewall desync mark
+        can be set using the {option}`services.zapret2.firewall.queue` and
+        {option}`services.zapret2.firewall.desyncMark` options respectively.
+      '';
+    };
+
+    files = lib.mkOption {
+      type = lib.types.listOf (lib.types.either lib.types.nonEmptyStr lib.types.path);
+      default = [
+        "zapret-lib"
+        "zapret-antidpi"
+      ];
+      example = [
+        "zapret-lib"
+        "zapret-obfs"
+        "/path/to/custom.lua"
+      ];
+      description = ''
+        List of Lua files that will be loaded and executed once on startup.
+        Each entry in the list can be either an absolute path (including the
+        .lua extension) or the name of a standard library file bundled with
+        zapret2 (without the .lua extension). In case of the latter, they
+        will be automatically resolved to the files in the configured zapret2
+        package.
+      '';
+    };
+
+    firewall = {
+      configureAutomatically = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Whether to automatically configure the firewall rules to apply the
+          DPI bypass to all outgoing non-local connections (using nftables).
+
+          If disabled, the only options that will be used are
+          {option}`firewall.queue` and {option}`firewall.desyncMark`, for the
+          {option}`--qnum` and {option}`--fwmark` parameters respectively.
+        '';
+      };
+
+      maxPackets = lib.mkOption {
+        type = lib.types.nullOr (lib.types.ints.between 2 65535);
+        default = 16;
+        example = 20;
+        description = ''
+          The number of packets in each connection to route via Zapret2. For
+          example, a value of 16 will only subject the first 16 packets in each
+          connection to anti-DPI measures. It's recommended to keep this value
+          low in order to avoid routing unnecessary traffic through userspace
+          if possible. However, if necessary, all traffic can be routed by
+            setting this option to null.
+        '';
+      };
+
+      interfaces = lib.mkOption {
+        type = lib.types.nullOr (lib.types.nonEmptyListOf lib.types.nonEmptyStr);
+        default = null;
+        example = [ "eth0" ];
+        description = ''
+          A filter for which interfaces to apply the DPI bypass to. Setting
+          this option to null (the default) means the DPI bypass applies to
+          all interfaces.
+        '';
+      };
+
+      allowedTCPPorts = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.port);
+        default = null;
+        example = [
+          80
+          443
+        ];
+        description = ''
+          A list of destination TCP ports to apply the DPI bypass to. Setting
+          this option to null (the default) means the DPI bypass applies to
+          all TCP connections. Setting this option to an empty list disables
+          applying the DPI bypass to any TCP connection.
+        '';
+      };
+
+      allowedUDPPorts = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.port);
+        default = null;
+        example = [ 443 ];
+        description = ''
+          A list of destination UDP ports to apply the DPI bypass to. Setting
+          this option to null (the default) means the DPI bypass applies to
+          all UDP connections. Setting this option to an empty list disables
+          applying the DPI bypass to any UDP connection.
+        '';
+      };
+
+      queue = lib.mkOption {
+        type = lib.types.ints.between 0 65535;
+        default = 200;
+        example = 400;
+        description = ''
+          The nfqueue queue number to use. This number must be unique between
+          all other programs using nfqueue.
+        '';
+      };
+
+      desyncMark = lib.mkOption {
+        type = lib.types.strMatching "0x(1|2|4|8)(0)*";
+        default = "0x40000000";
+        example = "0x10000000";
+        description = ''
+          The desync mark bitmask to use. This bitmask must contain only a
+          single bit, and must be unique between all other nftables rules.
+        '';
+        apply = lib.mapNullable lib.fromHexString;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # For the systemd nfqws@.service template unit
+    systemd.packages = [ cfg.package ];
+
+    systemd.services."nfqws2@default" = {
+      overrideStrategy = "asDropin";
+      aliases = [ "zapret2.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = lib.mkMerge [
+        {
+          ExecStart = [
+            ""
+            (utils.escapeSystemdExecArgs arguments)
+          ];
+        }
+        (lib.mkIf (builtins.any (p: p.hosts.auto.enable) (builtins.attrValues cfg.profiles)) {
+          StateDirectory = "zapret2";
+        })
+      ];
+    };
+
+    networking.nftables = lib.mkIf cfg.firewall.configureAutomatically {
+      enable = true;
+      tables.zapret2 = {
+        family = "inet";
+        content = ''
+          define DESYNC_MARK = ${toString cfg.firewall.desyncMark}
+          define QNUM = ${toString cfg.firewall.queue}
+          ${lib.optionalString (cfg.firewall.interfaces != null) ''
+            define WAN = { ${lib.concatMapStringsSep ", " (x: ''"${x}"'') cfg.firewall.interfaces} }
+          ''}
+          ${lib.optionalString (cfg.firewall.maxPackets != null) ''
+            define PKT = 1-${toString cfg.firewall.maxPackets}
+          ''}
+          ${lib.optionalString (cfg.firewall.allowedTCPPorts != null && cfg.firewall.allowedTCPPorts != [ ])
+            ''
+              define TCP_PORT = { ${lib.concatMapStringsSep ", " toString cfg.firewall.allowedTCPPorts} }
+            ''
+          }
+          ${lib.optionalString (cfg.firewall.allowedUDPPorts != null && cfg.firewall.allowedUDPPorts != [ ])
+            ''
+              define UDP_PORT = { ${lib.concatMapStringsSep ", " toString cfg.firewall.allowedUDPPorts} }
+            ''
+          }
+
+          set local4 {
+            type ipv4_addr
+            flags interval
+            elements = {
+              127.0.0.0/8,
+              10.0.0.0/8,
+              100.64.0.0/10,
+              172.16.0.0/12,
+              192.168.0.0/16,
+              169.254.0.0/16
+            }
+          }
+
+          set local6 {
+            type ipv6_addr
+            flags interval
+            elements = {
+              ::1/128,
+              fe80::/10,
+              fc00::/7,
+              ff00::/8
+            }
+          }
+
+          chain post {
+            type filter hook postrouting priority 101; policy accept;
+
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+              "ip daddr @local4 accept"
+            ]}
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+              "ip6 daddr @local6 accept"
+            ]}
+
+            ${lib.optionalString (cfg.firewall.allowedTCPPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto tcp"
+                (lib.optionalString (cfg.firewall.allowedTCPPorts != null) "tcp dport $TCP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction original")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct original packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+
+            ${lib.optionalString (cfg.firewall.allowedUDPPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto udp"
+                (lib.optionalString (cfg.firewall.allowedUDPPorts != null) "udp dport $UDP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction original")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct original packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+          }
+
+          chain pre {
+            type filter hook prerouting priority -101; policy accept;
+
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+              "ip saddr @local4 accept"
+            ]}
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+              "ip6 saddr @local6 accept"
+            ]}
+
+            ${lib.optionalString (cfg.firewall.allowedTCPPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto tcp"
+                (lib.optionalString (cfg.firewall.allowedTCPPorts != null) "tcp sport $TCP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction reply")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct reply packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+
+            ${lib.optionalString (cfg.firewall.allowedUDPPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto udp"
+                (lib.optionalString (cfg.firewall.allowedUDPPorts != null) "udp sport $UDP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction reply")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct reply packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+          }
+
+          chain predefrag {
+            type filter hook output priority -401; policy accept;
+            meta mark & $DESYNC_MARK != 0 notrack
+          }
+        '';
+      };
+    };
+
+    boot.kernel.sysctl = {
+      # From the zapret2 quickstart example commands, the RST packets that DPI
+      # systems inject can sometimes be dropped as invalid before they reach
+      # nfqueue. So relax the conntrack rules so that they aren't dropped.
+      "net.netfilter.nf_conntrack_tcp_be_liberal" = lib.mkDefault true;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    andre4ik3
+  ];
+}

--- a/nixos/modules/services/networking/zapret2.nix
+++ b/nixos/modules/services/networking/zapret2.nix
@@ -1,0 +1,563 @@
+{
+  utils,
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.zapret2;
+
+  profileSubmodule =
+    { config, name, ... }:
+    {
+      options = {
+        name = lib.mkOption {
+          type = lib.types.nonEmptyStr;
+          default = name;
+          defaultText = "‹name›";
+          description = "A unique string that identifies this profile.";
+        };
+
+        priority = lib.mkOption {
+          type = lib.types.int;
+          default = 1000;
+          example = 0;
+          description = ''
+            The priority for the profile when constructing the command-line
+            parameters. Lower priority values will cause the profile to be
+            ordered before others, meaning it will be matched before others.
+            Higher priority values will cause the profile to be ordered after
+            others, meaning it will be matched after others.
+          '';
+        };
+
+        ips = {
+          include = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "213.59.192.0/18"
+            ];
+            description = ''
+              An explicit list of IP addresses to include in the DPI bypass.
+              Each member is an IPv4 or IPv6 address, or a subnet in CIDR
+              notation.
+
+              If set to null (the default), no include list is set, meaning all
+              IP addresses are included in the DPI bypass. If set to an empty
+              list, the include list will be empty, and no IP address will be
+              included in the DPI bypass.
+            '';
+          };
+
+          exclude = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "173.245.48.0/20"
+              "103.21.244.0/22"
+              "103.22.200.0/22"
+              "103.31.4.0/22"
+              "141.101.64.0/18"
+              "108.162.192.0/18"
+              "190.93.240.0/20"
+              "188.114.96.0/20"
+              "197.234.240.0/22"
+              "198.41.128.0/17"
+              "162.158.0.0/15"
+              "104.16.0.0/13"
+              "104.24.0.0/14"
+              "172.64.0.0/13"
+              "131.0.72.0/22"
+            ];
+            description = ''
+              An explicit list of IP addresses to exclude from the DPI bypass.
+              Each member is an IPv4 or IPv6 address, or a subnet in CIDR
+              notation.
+
+              If set to null (the default) or an empty list, no exclude list is
+              set, meaning no IP addresses are excluded from the DPI bypass.
+            '';
+          };
+        };
+
+        hosts = {
+          include = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "youtube.com"
+              "chess.com"
+            ];
+            description = ''
+              An explicit list of hostnames to include in the DPI bypass. Each
+              member is a hostname, optionally prefixed with ^ to be a strict
+              match (by default all subdomains are matched).
+
+              If set to null (the default), no include list is set, meaning all
+              hostnames are included in the DPI bypass. If set to an empty
+              list, the include list will be empty, and no hostname will be
+              included in the DPI bypass.
+            '';
+          };
+
+          exclude = lib.mkOption {
+            type = lib.types.nullOr (lib.types.uniq (lib.types.listOf lib.types.nonEmptyStr));
+            default = null;
+            example = [
+              "ru"
+              "yandex.net"
+              "yastatic.net"
+            ];
+            description = ''
+              An explicit list of hostnames to exclude from the DPI bypass.
+              Each member is a hostname, optionally prefixed with ^ to be a
+              strict match (by default all subdomains are matched).
+
+              If set to null (the default) or an empty list, no exclude list is
+              set, meaning no hostnames are excluded from the DPI bypass.
+            '';
+          };
+
+          autodetect = {
+            enable = lib.mkEnableOption ''
+              automatic tracking of which hosts the DPI bypass is necessary for
+            '';
+
+            file = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/zapret2/${config.name}-hosts.txt";
+              defaultText = "/var/lib/zapret2/‹name›-hosts.txt";
+              description = ''
+                The file where the automatic host list is saved. This path must
+                be writable by the user Zapret2 runs as (by default, it uses a
+                dynamic user, so it should generally be in
+                {file}`/var/lib/zapret2`).
+              '';
+            };
+          };
+        };
+
+        parameters = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [
+            "--filter-tcp=443"
+            "--payload=tls_client_hello"
+            "--lua-desync=fake:blob=fake_default_tls:tcp_ts=-1000:repeats=1"
+            "--lua-desync=fakedsplit:pos=1,midsld:tcp_ts=-1000"
+          ];
+          description = ''
+            The parameters to use for this profile. Note that, when using
+            multiple profiles, a {option}`--filter-*` parameter MUST be defined,
+            otherwise the first profile will match everything and no other
+            profile will even be executed.
+
+            To obtain a list of suitable parameters, consider running the
+            `blockcheck2` program (part of the zapret2 package), searching the
+            [Zapret forums][1] for community solutions, or consulting the
+            [Zapret manual][2].
+
+            [1]: https://ntc.party/c/community-software/zapret-antidpi/
+            [2]: https://github.com/bol-van/zapret2/blob/master/docs/manual.en.md
+          '';
+        };
+      };
+
+      config.parameters = lib.mkMerge [
+        (lib.mkIf (config.ips.include != null) (
+          lib.mkBefore [
+            "--ipset=${pkgs.writeText "zapret2-ips-include.txt" (lib.concatLines config.ips.include)}"
+          ]
+        ))
+        (lib.mkIf (config.ips.exclude != null) (
+          lib.mkBefore [
+            "--ipset-exclude=${pkgs.writeText "zapret2-ips-exclude.txt" (lib.concatLines config.ips.exclude)}"
+          ]
+        ))
+        (lib.mkIf (config.hosts.include != null) (
+          lib.mkBefore [
+            "--hostlist=${pkgs.writeText "zapret2-hosts-include.txt" (lib.concatLines config.hosts.include)}"
+          ]
+        ))
+        (lib.mkIf (config.hosts.exclude != null) (
+          lib.mkBefore [
+            "--hostlist-exclude=${pkgs.writeText "zapret2-hosts-exclude.txt" (lib.concatLines config.hosts.exclude)}"
+          ]
+        ))
+        (lib.mkIf config.hosts.autodetect.enable (
+          lib.mkAfter [
+            "--hostlist-auto=${config.hosts.autodetect.file}"
+          ]
+        ))
+      ];
+    };
+
+  arguments =
+    let
+      fileOptions =
+        let
+          isAbsolute = x: builtins.isPath x || lib.hasPrefix "/" x;
+          toFile = x: if isAbsolute x then x else "${cfg.package}/share/zapret2/lua/${x}.lua";
+        in
+        map (x: "--lua-init=@${toFile x}") cfg.files;
+      profileOptions =
+        let
+          sorted = builtins.sort (a: b: a.priority < b.priority) (builtins.attrValues cfg.profiles);
+          toArgs = profile: [ "--name=${profile.name}" ] ++ profile.parameters;
+        in
+        builtins.foldl' (acc: p: acc ++ lib.optional (acc != [ ]) "--new" ++ toArgs p) [ ] sorted;
+    in
+    [
+      (lib.getExe cfg.package)
+      "--qnum=${toString cfg.firewall.queue}"
+      "--fwmark=${cfg.firewall.desyncFwmark}"
+    ]
+    ++ fileOptions
+    ++ profileOptions
+    ++ cfg.extraOptions;
+in
+
+{
+  options.services.zapret2 = {
+    enable = lib.mkEnableOption "zapret2, an extensible DPI bypass program";
+    package = lib.mkPackageOption pkgs "zapret2" { };
+
+    profiles = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule profileSubmodule);
+      default = { };
+      example = {
+        https.parameters = [
+          "--filter-tcp=443"
+          "--payload=tls_client_hello"
+          "--lua-desync=fake:blob=fake_default_tls:tcp_ts=-1000:repeats=1"
+          "--lua-desync=fakedsplit:pos=1,midsld:tcp_ts=-1000"
+        ];
+      };
+      description = ''
+        Defines DPI bypass profiles for Zapret2.
+
+        Note that each profile should have a unique {option}`--filter-*`
+        option. By default, a profile matches all traffic, and when a profile
+        matches some traffic, no other profile is evaluated. Since profiles are
+        matched in order they are passed on the command line, the ordering of
+        profiles is important, and if a "fallback"/catch-all profile is
+        defined, it should be defined with a high priority to make sure it is
+        last in the list of profiles.
+
+        Each profile will be prepended with the {option}`--name` option to set
+        the name, and then joined together with {option}`--new` between
+        profiles to form the final command-line parameters that will be passed
+        to Zapret2. Therefore, neither {option}`--name` nor {option}`--new`
+        should be used in the values.
+      '';
+    };
+
+    extraOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--debug" ];
+      description = ''
+        Extra command line parameters to pass to Zapret2.
+
+        Profiles and desync strategies should not be set here, instead the
+        {option}`services.zapret2.profiles` option should be used instead,
+        which allows profiles to be defined and merged correctly across
+        multiple NixOS modules.
+
+        The {option}`--lua-init` parameters should not be included here, the
+        files to load should instead be set via the
+        {option}`services.zapret2.files` option.
+
+        Likewise, the {option}`--qnum` and {option}`--fwmark` parameters should
+        also not be included, instead the queue number and firewall desync mark
+        can be set using the {option}`services.zapret2.firewall.queue` and
+        {option}`services.zapret2.firewall.desyncFwmark` options respectively.
+      '';
+    };
+
+    files = lib.mkOption {
+      type = lib.types.listOf (lib.types.either lib.types.nonEmptyStr lib.types.path);
+      default = [
+        "zapret-lib"
+        "zapret-antidpi"
+      ];
+      example = [
+        "zapret-lib"
+        "zapret-obfs"
+        "/path/to/custom.lua"
+      ];
+      description = ''
+        List of Lua files that will be loaded and executed once on startup.
+        Each entry in the list can be either an absolute path (including the
+        .lua extension) or the name of a standard library file bundled with
+        zapret2 (without the .lua extension). In case of the latter, they
+        will be automatically resolved to the files in the configured zapret2
+        package.
+      '';
+    };
+
+    firewall = {
+      configureAutomatically = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        example = false;
+        description = ''
+          Whether to automatically configure the firewall rules to apply the
+          DPI bypass to all outgoing non-local connections (using nftables).
+
+          If disabled, the only options that will be used are
+          {option}`firewall.queue` and {option}`firewall.desyncFwmark`, for the
+          {option}`--qnum` and {option}`--fwmark` parameters respectively.
+        '';
+      };
+
+      maxPackets = lib.mkOption {
+        type = lib.types.nullOr (lib.types.ints.between 2 65535);
+        default = 16;
+        example = 20;
+        description = ''
+          The number of packets in each connection to route via Zapret2. For
+          example, a value of 16 will only subject the first 16 packets in each
+          connection to anti-DPI measures. It's recommended to keep this value
+          low in order to avoid routing unnecessary traffic through userspace
+          if possible. However, if necessary, all traffic can be routed by
+          setting this option to null.
+        '';
+      };
+
+      interfaces = lib.mkOption {
+        type = lib.types.nullOr (lib.types.nonEmptyListOf lib.types.nonEmptyStr);
+        default = null;
+        example = [ "eth0" ];
+        description = ''
+          A filter for which interfaces to apply the DPI bypass to. Setting
+          this option to null (the default) means the DPI bypass applies to
+          all interfaces.
+        '';
+      };
+
+      tcpPorts = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.port);
+        default = null;
+        example = [
+          80
+          443
+        ];
+        description = ''
+          A list of destination TCP ports that are routed to Zapret2 at the
+          firewall level. Setting this option to null (the default) means all
+          TCP connections are routed to Zapret2. Setting this option to an
+          empty list disables routing to Zapret2 for any TCP connection.
+        '';
+      };
+
+      udpPorts = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.port);
+        default = null;
+        example = [ 443 ];
+        description = ''
+          A list of destination UDP ports that are routed to Zapret2 at the
+          firewall level. Setting this option to null (the default) means all
+          UDP connections are routed to Zapret2. Setting this option to an
+          empty list disables routing to Zapret2 for any UDP connection.
+        '';
+      };
+
+      queue = lib.mkOption {
+        type = lib.types.ints.between 0 65535;
+        default = 200;
+        example = 400;
+        description = ''
+          The nfqueue queue number to use. This number must be unique between
+          all other programs using nfqueue.
+        '';
+      };
+
+      desyncFwmark = lib.mkOption {
+        type = lib.types.strMatching "0x(1|2|4|8)(0){0,7}";
+        default = "0x40000000";
+        example = "0x10000000";
+        description = ''
+          The desync mark bitmask to use. This bitmask must contain only a
+          single bit, and must be unique among all other nftables rules.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.firewall.configureAutomatically -> config.networking.nftables.enable;
+        message = "When Zapret2 is set to configure the firewall automatically (services.zapret2.firewall.configureAutomatically), nftables must be enabled (networking.nftables.enable must be true).";
+      }
+    ];
+
+    # For the systemd nfqws@.service template unit
+    systemd.packages = [ cfg.package ];
+
+    systemd.services."nfqws2@default" = {
+      overrideStrategy = "asDropin";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = lib.mkMerge [
+        {
+          ExecStart = [
+            ""
+            (utils.escapeSystemdExecArgs arguments)
+          ];
+          CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_RAW";
+          AmbientCapabilities = "CAP_NET_ADMIN CAP_NET_RAW";
+          NoNewPrivileges = true;
+          ProtectSystem = "full";
+          DynamicUser = true;
+          SystemCallFilter = "@system-service";
+          SystemCallArchitectures = "native";
+        }
+        (lib.mkIf (builtins.any (p: p.hosts.autodetect.enable) (builtins.attrValues cfg.profiles)) {
+          StateDirectory = "zapret2";
+        })
+      ];
+    };
+
+    networking.nftables = lib.mkIf cfg.firewall.configureAutomatically {
+      enable = lib.mkDefault true;
+      tables.zapret2 = {
+        family = "inet";
+        content = ''
+          define DESYNC_MARK = ${cfg.firewall.desyncFwmark}
+          define QNUM = ${toString cfg.firewall.queue}
+          ${lib.optionalString (cfg.firewall.interfaces != null) ''
+            define WAN = { ${lib.concatMapStringsSep ", " (x: ''"${x}"'') cfg.firewall.interfaces} }
+          ''}
+          ${lib.optionalString (cfg.firewall.maxPackets != null) ''
+            define PKT = 1-${toString cfg.firewall.maxPackets}
+          ''}
+          ${lib.optionalString (cfg.firewall.tcpPorts != null && cfg.firewall.tcpPorts != [ ]) ''
+            define TCP_PORT = { ${lib.concatMapStringsSep ", " toString cfg.firewall.tcpPorts} }
+          ''}
+          ${lib.optionalString (cfg.firewall.udpPorts != null && cfg.firewall.udpPorts != [ ]) ''
+            define UDP_PORT = { ${lib.concatMapStringsSep ", " toString cfg.firewall.udpPorts} }
+          ''}
+
+          set local4 {
+            type ipv4_addr
+            flags interval
+            elements = {
+              127.0.0.0/8,
+              10.0.0.0/8,
+              100.64.0.0/10,
+              172.16.0.0/12,
+              192.168.0.0/16,
+              169.254.0.0/16
+            }
+          }
+
+          set local6 {
+            type ipv6_addr
+            flags interval
+            elements = {
+              ::1/128,
+              fe80::/10,
+              fc00::/7,
+              ff00::/8
+            }
+          }
+
+          chain post {
+            type filter hook postrouting priority 101; policy accept;
+
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+              "ip daddr @local4 accept"
+            ]}
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+              "ip6 daddr @local6 accept"
+            ]}
+
+            ${lib.optionalString (cfg.firewall.tcpPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto tcp"
+                (lib.optionalString (cfg.firewall.tcpPorts != null) "tcp dport $TCP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction original")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct original packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+
+            ${lib.optionalString (cfg.firewall.udpPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "oifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto udp"
+                (lib.optionalString (cfg.firewall.udpPorts != null) "udp dport $UDP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction original")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct original packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+          }
+
+          chain pre {
+            type filter hook prerouting priority -101; policy accept;
+
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+              "ip saddr @local4 accept"
+            ]}
+            ${lib.concatStringsSep " " [
+              (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+              "ip6 saddr @local6 accept"
+            ]}
+
+            ${lib.optionalString (cfg.firewall.tcpPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto tcp"
+                (lib.optionalString (cfg.firewall.tcpPorts != null) "tcp sport $TCP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction reply")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct reply packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+
+            ${lib.optionalString (cfg.firewall.udpPorts != [ ]) ''
+              ${lib.concatStringsSep " " [
+                (lib.optionalString (cfg.firewall.interfaces != null) "iifname $WAN")
+                "meta mark & $DESYNC_MARK == 0"
+                "meta l4proto udp"
+                (lib.optionalString (cfg.firewall.udpPorts != null) "udp sport $UDP_PORT")
+                (lib.optionalString (cfg.firewall.maxPackets == null) "ct direction reply")
+                (lib.optionalString (cfg.firewall.maxPackets != null) "ct reply packets $PKT")
+                "queue num $QNUM bypass"
+              ]}
+            ''}
+          }
+
+          chain predefrag {
+            type filter hook output priority -401; policy accept;
+            meta mark & $DESYNC_MARK != 0 notrack
+          }
+        '';
+      };
+    };
+
+    boot.kernel.sysctl = {
+      # From the zapret2 quickstart example commands, the RST packets that DPI
+      # systems inject can sometimes be dropped as invalid before they reach
+      # nfqueue. So relax the conntrack rules so that they aren't dropped.
+      "net.netfilter.nf_conntrack_tcp_be_liberal" = lib.mkDefault true;
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+    doc = ./zapret2.md;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1924,6 +1924,7 @@ in
   yggdrasil = runTest ./yggdrasil.nix;
   your_spotify = runTest ./your_spotify.nix;
   zammad = runTest ./zammad.nix;
+  zapret2 = runTest ./zapret2.nix;
   zenohd = runTest ./zenohd.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;
   zfs = import ./zfs.nix { inherit system pkgs runTest; };

--- a/nixos/tests/zapret2.nix
+++ b/nixos/tests/zapret2.nix
@@ -1,0 +1,153 @@
+{ pkgs, lib, ... }:
+
+let
+  serverIP = "203.0.113.1";
+  clientIP = "203.0.113.2";
+
+  mkInterface = address: {
+    ipv4.addresses = lib.singleton {
+      inherit address;
+      prefixLength = 24;
+    };
+  };
+
+  # naive DPI to block any TCP stream with "acme.test"
+  suricataRules = pkgs.writeText "suricata.rules" ''
+    drop tcp-pkt any any -> any any (msg:"Block acme.test"; flow:established,to_server; content:"acme.test"; nocase; sid:1000001; rev:1;)
+  '';
+in
+
+{
+  name = "zapret2";
+  meta.maintainers = with lib.maintainers; [ andre4ik3 ];
+
+  nodes = {
+    router = {
+      virtualisation.vlans = [
+        1
+        2
+      ];
+      networking = {
+        useDHCP = false;
+        interfaces = {
+          eth1.ipv4.addresses = lib.mkForce [ ];
+          eth2.ipv4.addresses = lib.mkForce [ ];
+        };
+      };
+
+      # disable suricata-update because this requires an Internet connection
+      systemd.services.suricata-update.enable = false;
+
+      services.suricata = {
+        enable = true;
+        settings = {
+          outputs = lib.singleton {
+            fast.enabled = true;
+          };
+
+          af-packet = [
+            {
+              interface = "eth1";
+              threads = 1;
+              defrag = false;
+              cluster-type = "cluster_flow";
+              cluster-id = 98;
+              copy-mode = "ips";
+              copy-iface = "eth2";
+              buffer-size = 64535;
+            }
+            {
+              interface = "eth2";
+              threads = 1;
+              cluster-id = 97;
+              defrag = false;
+              cluster-type = "cluster_flow";
+              copy-mode = "ips";
+              copy-iface = "eth1";
+              buffer-size = 64535;
+            }
+          ];
+
+          classification-file = "${pkgs.suricata}/etc/suricata/classification.config";
+        };
+      };
+
+      systemd.tmpfiles.rules = [
+        "C /var/lib/suricata/rules/suricata.rules - - - - ${suricataRules}"
+        "z /var/lib/suricata/rules/suricata.rules 644 suricata suricata -"
+      ];
+    };
+
+    server = {
+      virtualisation.vlans = [ 1 ];
+      networking = {
+        useDHCP = false;
+        interfaces.eth1 = mkInterface serverIP;
+        firewall.allowedTCPPorts = [ 443 ];
+      };
+
+      security.pki.certificates = lib.singleton (builtins.readFile ./common/acme/server/ca.cert.pem);
+
+      services.nginx = {
+        enable = true;
+        virtualHosts."acme.test" = {
+          onlySSL = true;
+          reuseport = true;
+          sslCertificate = ./common/acme/server/acme.test.cert.pem;
+          sslCertificateKey = ./common/acme/server/acme.test.key.pem;
+          root = lib.mkForce (
+            pkgs.runCommandLocal "testdir" { } ''
+              mkdir "$out"
+              cat > "$out/index.html" <<EOF
+              <html><body>Hello World!</body></html>
+              EOF
+            ''
+          );
+        };
+      };
+    };
+
+    client = {
+      virtualisation.vlans = [ 2 ];
+      networking = {
+        useDHCP = false;
+        interfaces.eth1 = mkInterface clientIP;
+      };
+
+      security.pki.certificates = lib.singleton (builtins.readFile ./common/acme/server/ca.cert.pem);
+
+      services.zapret2 = {
+        enable = true;
+        firewall.interfaces = [ "eth1" ];
+        profiles.default.parameters = [
+          "--filter-tcp=443"
+          "--payload=tls_client_hello"
+          "--lua-desync=multisplit:pos=host+1,midsld,endhost-1"
+        ];
+      };
+
+      networking.extraHosts = ''
+        ${serverIP} acme.test
+      '';
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    for machine in [client, router, server]:
+      machine.wait_for_unit("multi-user.target")
+
+    server.wait_for_unit("nginx.service")
+    router.wait_for_unit("suricata.service")
+
+    # with nfqws2 running, the request should succeed
+    client.wait_for_unit("nfqws2@default.service")
+    client.sleep(5)
+    client.succeed("curl -s --max-time 5 https://acme.test | grep -F 'Hello World!'")
+
+    # with nfqws2 stopped, the DPI should block it
+    client.stop_job("nfqws2@default.service")
+    client.fail("curl -s --max-time 5 https://acme.test")
+  '';
+}

--- a/pkgs/by-name/za/zapret2/package.nix
+++ b/pkgs/by-name/za/zapret2/package.nix
@@ -16,6 +16,7 @@
   libnetfilter_queue,
   systemdLibs,
   zlib,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -130,6 +131,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.tests = { inherit (nixosTests) zapret2; };
 
   meta = {
     description = "Anti-DPI software for bypassing DPI systems";


### PR DESCRIPTION
[Zapret2](https://github.com/bol-van/zapret2) is a service that enables bypassing DPI systems using extensible Lua filters that process outgoing network traffic.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
