### PR TITLE
pkgs-lib/formats: use go-toml instead of yj for toml.generate, go-toml: drop allowGoReference

### DIFF
--- a/pkgs/by-name/go/go-toml/package.nix
+++ b/pkgs/by-name/go/go-toml/package.nix
@@ -25,10 +25,6 @@ buildGoModule {
     "cmd/tomltestgen"
   ];
 
-  # allowGoReference adds the flag `-trimpath` which is also denoted by, go-toml's goreleaser config
-  #  <https://github.com/pelletier/go-toml/blob/a3d5a0bb530b5206c728eed9cb57323061922bcb/.goreleaser.yaml#L13>
-  allowGoReference = true;
-
   ldflags = [
     "-s"
     "-w"

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -461,16 +461,18 @@ optionalAttrs allowAliases aliases
       generate =
         name: value:
         pkgs.callPackage (
-          { runCommand, yj }:
+          { runCommand, go-toml }:
           runCommand name
             {
-              nativeBuildInputs = [ yj ];
+              nativeBuildInputs = [ go-toml ];
               value = builtins.toJSON value;
               passAsFile = [ "value" ];
               preferLocalBuild = true;
             }
+            # -use-json-number: preserve JSON ints as TOML ints
+            # (Go's json.Decoder defaults to float64 for all numbers)
             ''
-              yj -jt < "$valuePath" > "$out"
+              jsontoml -use-json-number < "$valuePath" > "$out"
             ''
         ) { };
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -695,16 +695,16 @@ runBuildTests {
       float = 3.141
       int = 10
       list = [1, 2]
-      str = "foo"
+      str = 'foo'
       true = true
 
       [attrs]
-      foo = "foo"
+      foo = 'foo'
 
       [level1]
       [level1.level2]
       [level1.level2.level3]
-      level4 = "deep"
+      level4 = 'deep'
     '';
   };
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -708,6 +708,41 @@ runBuildTests {
     '';
   };
 
+  # Regression test for https://github.com/NixOS/nixpkgs/issues/511970
+  # yj crashes on arrays mixing scalars and attrsets (heterogeneous arrays),
+  # e.g. Helix language-server configs like ["bash-ls", {name = "ts-ls"; ...}].
+  # TOML 1.0 allows mixed-type arrays; the converter must emit them as
+  # inline arrays with inline tables.
+  tomlHeterogeneousArray = shouldPass {
+    format = formats.toml { };
+    input = {
+      language-server = [
+        "bash-language-server"
+        {
+          name = "typescript-language-server";
+          except-features = [ "diagnostics" ];
+        }
+      ];
+    };
+    expected = ''
+      language-server = ['bash-language-server', {except-features = ['diagnostics'], name = 'typescript-language-server'}]
+    '';
+  };
+
+  # Regression test for https://github.com/sclevine/yj/issues/52
+  # yj truncates keys at the first comma because it stores TOML keys in Go
+  # struct tags, where commas are option separators.
+  # e.g. "stack(x,n)" is emitted as "stack(x" — silently losing data.
+  tomlCommaInKey = shouldPass {
+    format = formats.toml { };
+    input = {
+      "stack(x,n)" = "foobar";
+    };
+    expected = ''
+      'stack(x,n)' = 'foobar'
+    '';
+  };
+
   cdnAtoms = shouldPass {
     format = formats.cdn { };
     input = {


### PR DESCRIPTION
**This PR was produced with the help of LLMs**. All text here was written manually by me though.

We recently switched from `remarshal` to `yj` in https://github.com/NixOS/nixpkgs/pull/510585.

While this improved performance & closure size, it did introduce a few regressions: #511970 and #512271. (cc reporters @XYenon, @drupol)

We therefore switch from `yj` to `go-toml`, trading a small increase in closure size for even better performance, and, critically, correctness.

To verify the latter, regression tests are added.

Before this PR, `go-toml` had set `allowGoReference = true` and a comment added in https://github.com/NixOS/nixpkgs/commit/5a69b0b3c4a, that suggests the intention was to to *add* `-trimpath`, but the actual effect was the opposite. A third commit removes go from the run-time closure and reduces it's size from 263.6 MiB -> 8.6 MiB (on `x86_64-linux`) (cc @isabelroses who added it)

```
 NIX_SHOW_STATS=1 nix-instantiate -E '(pkgs.formats.toml{}).generate "x" {a.b=1;}'
 Best of 3.

                   cpuTime  nrFunctionCalls   nrThunks  drv-closure  closure
 remarshal          0.690s        634,117    1,184,499  2722 paths   202.3 MiB
 yq-go              0.743s        652,452    1,175,453  2470 paths    52.9 MiB
 yj                 0.302s        272,725      568,264  1481 paths     5.2 MiB
 go-toml            0.204s        158,842      287,465  1165 paths     8.6 MiB

 go-toml vs yj       -32%          -42%         -49%       -21%       +65%
 go-toml vs yq-go    -73%          -76%         -76%       -53%       -84%
 go-toml vs rem.     -70%          -75%         -76%       -57%       -96%
```

Fixes #511970, Fixes #512271. 

---

A note on string quoting & test update: Other than remarshal and yj, go-toml prefers TOML literal strings (`'foo'`) over basic strings (`"foo"`). This means every derivation built by `formats.toml` will see a rebuild. but the outputs should parse identical. Any TOML 1.0 compliant parser should read both forms the same way.

Literal strings are arguably safer since they don't interpret escape sequences (e.g. `C:\new` is emitted verbatim rather than needing `\\` escaping). go-toml doesn't expose an option to control quote style, so this isn't easy to avoid without either post-processing or yet another implementation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
