### PR TITLE
stalwart: 0.15.5 -> 0.16.0

### DIFF
--- a/pkgs/by-name/st/stalwart-cli/package.nix
+++ b/pkgs/by-name/st/stalwart-cli/package.nix
@@ -1,32 +1,41 @@
 {
   lib,
   rustPlatform,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
   versionCheckHook,
-  stalwart,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage {
-  inherit (stalwart) src version cargoDeps;
   pname = "stalwart-cli";
+  version = "1.0.0";
 
-  cargoBuildFlags = [
-    "--package"
-    "stalwart-cli"
-  ];
-  cargoTestFlags = [
-    "--package"
-    "stalwart-cli"
-  ];
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "cli";
+    tag = "v1.0.0";
+    hash = "sha256-xTxOYbPZ7zkweuuTJx3Alqig74KiD67i+TRzh1BZXa4=";
+  };
+
+  cargoHash = "sha256-Z5MDM5nJvjQJ9PpS07LbUc9FjVuwhRguchakjwypSDo=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = true;
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  # Prerelease reports incorrect version
-  dontVersionCheck = true;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    inherit (stalwart.meta) license homepage changelog;
     description = "Stalwart Mail Server CLI";
+    homepage = "https://github.com/stalwartlabs/cli";
+    changelog = "https://github.com/stalwartlabs/cli/blob/main/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
     mainProgram = "stalwart-cli";
     maintainers = with lib.maintainers; [
       giomf

--- a/pkgs/by-name/st/stalwart/0001-fix-missing-Duration-import.patch
+++ b/pkgs/by-name/st/stalwart/0001-fix-missing-Duration-import.patch
@@ -1,0 +1,45 @@
+--- a/crates/jmap/src/registry/get.rs	2026-04-22 14:58:54.693000885 +0200
++++ b/crates/jmap/src/registry/get.rs	2026-04-22 14:59:12.035883748 +0200
+@@ -347,6 +347,10 @@
+                 .await
+                 .map(|get| get.into_response()),
+             // SPDX-SnippetEnd
++            #[cfg(not(feature = "enterprise"))]
++            ObjectType::ArchivedItem | ObjectType::Metric | ObjectType::Trace => {
++                Ok(get.not_found_any().into_response())
++            }
+             ObjectType::SpamTrainingSample => {
+                 spam_sample_get(get).await.map(|get| get.into_response())
+             }
+--- a/crates/jmap/src/registry/set.rs	2026-04-22 14:58:54.698000851 +0200
++++ b/crates/jmap/src/registry/set.rs	2026-04-22 14:59:21.124822404 +0200
+@@ -681,6 +681,13 @@
+                 .await
+                 .map(|set| set.into_response()),
+             // SPDX-SnippetEnd
++            #[cfg(not(feature = "enterprise"))]
++            ObjectType::ArchivedItem => {
++                set.fail_all_create("Enterprise feature not available");
++                set.fail_all_update("Enterprise feature not available");
++                set.fail_all_destroy("Enterprise feature not available");
++                Ok(set.into_response())
++            }
+             ObjectType::SpamTrainingSample => {
+                 spam_sample_set(set).await.map(|set| set.into_response())
+             }
+--- a/crates/services/src/task_manager/scheduler.rs	2026-04-22 14:58:54.703000817 +0200
++++ b/crates/services/src/task_manager/scheduler.rs	2026-04-22 14:59:03.492941435 +0200
+@@ -4,12 +4,10 @@
+  * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-SEL
+  */
+
+-#[cfg(feature = "enterprise")]
+-use std::time::Duration;
+ use std::{
+     collections::BinaryHeap,
+     sync::Arc,
+-    time::{Instant, SystemTime},
++    time::{Duration, Instant, SystemTime},
+ };
+
+ use common::{

--- a/pkgs/by-name/st/stalwart/package.nix
+++ b/pkgs/by-name/st/stalwart/package.nix
@@ -21,16 +21,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stalwart" + (lib.optionalString stalwartEnterprise "-enterprise");
-  version = "0.15.5";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "stalwartlabs";
     repo = "stalwart";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-T7ft+GQLLPWgVFoo3m3pLDwgXRwa5idRFlhKjDLkQaw=";
+    hash = "sha256-ZGqm3mL7rgI83iK18J0W4TPcgsvPSKrOEgd1ydhcr1k=";
   };
 
-  cargoHash = "sha256-WneUROKV+uLX1d5TIOanO0jhHLsHHpFcXKUB6zdbSzA=";
+  cargoHash = "sha256-7qwZvWrrq5rSMkwu5x2l4FZoKnfd8mD1nosMsTg0+Bs=";
+
+  patches = [
+    ./0001-fix-missing-Duration-import.patch
+  ];
 
   depsBuildBuild = [
     pkg-config
@@ -173,6 +177,38 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # thread 'store::search_tests' (912386) panicked at tests/src/store/mod.rs:116:10:
     # Missing store type. Try running `STORE=<store_type> cargo test`: NotPresent
     "store::search_tests"
+    # Missing or invalid store type. Try running `STORE=<store_type> cargo test`: NotPresent
+    "automation::automation_tests"
+    "cluster::broadcast::cluster_tests"
+    "cluster::stress::stress_tests"
+    "directory::directory_tests"
+    "smtp::inbound::basic::basic_commands"
+    "smtp::inbound::ehlo::ehlo"
+    "smtp::inbound::limits::limits"
+    "smtp::inbound::mail::mail"
+    "smtp::inbound::milter::milter_session"
+    "smtp::inbound::milter::mta_hook_session"
+    "smtp::inbound::rcpt::rcpt"
+    "smtp::inbound::rewrite::address_rewrite"
+    "smtp::inbound::sign::sign_and_seal"
+    "smtp::inbound::throttle::throttle_inbound"
+    "smtp::lookup::expressions::expressions"
+    "smtp::lookup::utils::strategies"
+    "smtp::management::report::manage_reports"
+    "smtp::outbound::dane::dane_test"
+    "smtp::outbound::dane::dane_verify"
+    "smtp::outbound::fallback_relay::fallback_relay"
+    "smtp::outbound::ip_lookup::ip_lookup_strategy"
+    "smtp::outbound::mta_sts::mta_sts_verify"
+    "smtp::outbound::throttle::throttle_outbound"
+    "smtp::outbound::tls::starttls_optional"
+    "smtp::queue::dsn::generate_dsn"
+    "smtp::queue::manager::queue_due"
+    "smtp::reporting::dmarc::report_dmarc"
+    "smtp::reporting::scheduler::report_scheduler"
+    "smtp::reporting::tls::report_tls"
+    "system::system_tests"
+    "telemetry::telemetry_tests"
   ] (test: "--skip=${test}");
 
   doCheck = !(stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Update stalwart to the latest major version.

List of changes: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
