### PR TITLE
openshell: 0.0.22 -> 0.0.34

### DIFF
--- a/pkgs/by-name/op/openshell/package.nix
+++ b/pkgs/by-name/op/openshell/package.nix
@@ -6,20 +6,29 @@
   versionCheckHook,
   cacert,
   gitMinimal,
+  pkg-config,
+  z3,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "openshell";
-  version = "0.0.22";
+  version = "0.0.34";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "OpenShell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-98wmBhj1Bqkod9DWh4qhkT3287c56ZKRDf/Z3QCYf4Q=";
+    hash = "sha256-wchygUeSYbHXVgq5mR3nObPiEygREgvIk579gnPVMvM=";
   };
 
-  cargoHash = "sha256-lzS8V8e+wMX8KUfgrftNLdbyivoj0wtRWOThBRS1IdM=";
+  cargoHash = "sha256-ovg7IZL022wsj5EUjySCWsf0KrUCZLwQrjvvWld8Owo=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [ z3 ];
 
   nativeCheckInputs = [
     cacert


### PR DESCRIPTION
Changelog: https://github.com/NVIDIA/OpenShell/releases/tag/v0.0.34

Upstream added a z3-sys dependency (SMT-based policy evaluation), which pulls in z3 and requires bindgen. 
Added `rustPlatform.bindgenHook`, `pkg-config`, and `z3`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test