### PR TITLE
release-checks: fix eval error

### DIFF
--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -17,7 +17,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/av/AvailabilityVersions/package.nix
+++ b/pkgs/os-specific/darwin/by-name/av/AvailabilityVersions/package.nix
@@ -11,7 +11,11 @@ let
   inherit (buildPackages) gnused python3;
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/bo/bootstrap_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/bo/bootstrap_cmds/package.nix
@@ -14,7 +14,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/di/diskdev_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/di/diskdev_cmds/package.nix
@@ -10,7 +10,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/do/doc_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/do/doc_cmds/package.nix
@@ -11,7 +11,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/dy/dyld/package.nix
+++ b/pkgs/os-specific/darwin/by-name/dy/dyld/package.nix
@@ -22,7 +22,11 @@ let
 
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/fi/file_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/fi/file_cmds/package.nix
@@ -19,7 +19,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/io/IOKitTools/package.nix
+++ b/pkgs/os-specific/darwin/by-name/io/IOKitTools/package.nix
@@ -10,7 +10,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/po/PowerManagement/package.nix
+++ b/pkgs/os-specific/darwin/by-name/po/PowerManagement/package.nix
@@ -7,7 +7,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/sh/shell_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/sh/shell_cmds/package.nix
@@ -15,7 +15,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/te/text_cmds/package.nix
+++ b/pkgs/os-specific/darwin/by-name/te/text_cmds/package.nix
@@ -18,7 +18,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;

--- a/pkgs/os-specific/darwin/by-name/to/top/package.nix
+++ b/pkgs/os-specific/darwin/by-name/to/top/package.nix
@@ -9,7 +9,11 @@
 let
   f =
     pkgs: prev:
-    if !pkgs.stdenv.hostPlatform.isDarwin || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin" then
+    if
+      !pkgs.stdenv.hostPlatform.isDarwin
+      || pkgs.stdenv.name == "bootstrap-stage0-stdenv-darwin"
+      || !(pkgs.stdenv ? __bootPackages)
+    then
       prev.darwin.sourceRelease
     else
       f pkgs.stdenv.__bootPackages pkgs;


### PR DESCRIPTION
Attempt to fix eval error on Hydra. See: https://hydra.nixos.org/build/326752376.

These checks don’t fail from me locally. My hope is the added conditional makes whatever is breaking Hydra work again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
