### PR TITLE
boat-cli: init at 0.9.1

### DIFF
--- a/pkgs/by-name/bo/boat-cli/package.nix
+++ b/pkgs/by-name/bo/boat-cli/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  rustPlatform,
+  sqlite,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "boat-cli";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "coko7";
+    repo = "boat-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N7d/j6Wjz1Kf6CbvmtbNZhaR5OR7VAM8SwsH7jf+tPI=";
+  };
+
+  cargoHash = "sha256-PqRy3piwh0aK9YbGjlKcrk7MNBtw453nxdwztCaPaDY=";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Basic Opinionated Activity Tracker, a command line interface inspired by bartib.";
+    homepage = "https://github.com/coko7/boat-cli";
+    changelog = "https://github.com/coko7/boat-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tgi74 ];
+    mainProgram = "boat";
+  };
+})

--- a/pkgs/by-name/bo/boat-cli/package.nix
+++ b/pkgs/by-name/bo/boat-cli/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  rustPlatform,
+  sqlite,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "boat-cli";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "coko7";
+    repo = "boat-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+QhW7QWBoDzSNzkHotNLg/dnolSd3uK/IcDPnzVKBbI=";
+  };
+
+  cargoHash = "sha256-rfZbOeOoBWMp232vXVeKtQz3LP5IloIBZS0OWkN8Fys=";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Basic Opinionated Activity Tracker, a command line interface inspired by bartib.";
+    homepage = "https://github.com/coko7/boat-cli";
+    changelog = "https://github.com/coko7/boat-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tgi74 ];
+    mainProgram = "boat";
+  };
+})


### PR DESCRIPTION
Hello hello, this PR inits the package [boat-cli](https://github.com/coko7/boat-cli), a time-tracking CLI for everyday tasks.

`Basic Opinionated Activity Tracker, a command line interface inspired by bartib.`

You can test the tool with its main command: `boat`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
