### PR TITLE
usbvfiod: fix links for homepage and changelog

### DIFF
--- a/pkgs/by-name/us/usbvfiod/package.nix
+++ b/pkgs/by-name/us/usbvfiod/package.nix
@@ -29,9 +29,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   meta = {
-    homepage = "https://github.com/cloud-hypervisor/cloud-hypervisor";
+    homepage = "https://github.com/cyberus-technology/usbvfiod";
     description = "A tool for USB device pass-through using the vfio-user protocol.";
-    changelog = "https://github.com/cyberus-technology/usb/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/cyberus-technology/usbvfiod/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/us/usbvfiod/package.nix
+++ b/pkgs/by-name/us/usbvfiod/package.nix
@@ -39,6 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "usbvfiod";
     maintainers = with lib.maintainers; [
       lbeierlieb
+      snu
     ];
     platforms = [
       "aarch64-linux"


### PR DESCRIPTION
#509586 introduced usbvfiod to nixpkgs last week. @snue realized on [NixOS Search](https://search.nixos.org/packages?channel=unstable&include_modular_service_options=1&include_nixos_options=1&query=usbvfiod) that the homepage attribute still points to the github page of cloud-hypervisor (whose derivation I used as the template for usbvfiod's derivation).

This PR fixes the homepage and changelog attributes (there was also a typo in the changelog URL), and it adds @snue as a package maintainer ([his maintainer entry for reference](https://github.com/NixOS/nixpkgs/blob/ae3803233d8c8dcc524862ab39ac41723c3dd21b/maintainers/maintainer-list.nix#L25598)).

These changes do not affect the binary, only the meta field. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
