### PR TITLE
welle-io: fix permission error creating /Applications folder

### DIFF
--- a/pkgs/by-name/we/welle-io/package.nix
+++ b/pkgs/by-name/we/welle-io/package.nix
@@ -64,7 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DRTLSDR=true"
     "-DSOAPYSDR=true"
   ]
-  ++ lib.optional withFlac "-DFLAC=true";
+  ++ lib.optional withFlac "-DFLAC=true"
+  ++ lib.optional stdenv.hostPlatform.isDarwin "-DBUNDLE_INSTALL_DIR=${placeholder "out"}/Applications";
 
   meta = {
     description = "DAB/DAB+ Software Radio";


### PR DESCRIPTION
This pull request makes a small improvement to the build configuration for the `welle-io` package. The change ensures that, when building on macOS, the application bundle is installed in the correct directory.

- Added a CMake option to set the bundle install directory on macOS by appending `-DBUNDLE_INSTALL_DIR=${placeholder "out"}/Applications` when the build platform is Darwin.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
