### PR TITLE
speedscope: 1.24.0 -> 1.25.0

### DIFF
--- a/pkgs/by-name/sp/speedscope/package.nix
+++ b/pkgs/by-name/sp/speedscope/package.nix
@@ -5,14 +5,14 @@
   versionCheckHook,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "speedscope";
   version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "jlfwong";
     repo = "speedscope";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2kBgOMWSr3XEkcfzetA4njIE2co+mHoPPUFmKn0tMVk=";
 
     # scripts/prepack.sh wants to extract the git commit from .git
@@ -50,4 +50,4 @@ buildNpmPackage rec {
     mainProgram = "speedscope";
     maintainers = with lib.maintainers; [ thomasjm ];
   };
-}
+})

--- a/pkgs/by-name/sp/speedscope/package.nix
+++ b/pkgs/by-name/sp/speedscope/package.nix
@@ -7,13 +7,13 @@
 
 buildNpmPackage rec {
   pname = "speedscope";
-  version = "1.24.0";
+  version = "1.25.0";
 
   src = fetchFromGitHub {
     owner = "jlfwong";
     repo = "speedscope";
     tag = "v${version}";
-    hash = "sha256-QL+Hm3ujfZeKHMoNgQdxYStgWOIbxjDmXMHKnWddTfs=";
+    hash = "sha256-2kBgOMWSr3XEkcfzetA4njIE2co+mHoPPUFmKn0tMVk=";
 
     # scripts/prepack.sh wants to extract the git commit from .git
     # We don't want to keep .git for reproducibility reasons, so save the commit
@@ -25,7 +25,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-MgCIiVeq9w5XRPIsZ/9AbZpVwRQdzZgK7VC5Gl7cn78=";
+  npmDepsHash = "sha256-hgvO5iU9lerTa9FJRHq9lm67lgrFSM5AR02GShsM3P8=";
 
   patches = [
     ./fix-shebang.patch
@@ -36,11 +36,6 @@ buildNpmPackage rec {
   '';
 
   dontNpmBuild = true;
-
-  postFixup = ''
-    # Remove some dangling symlinks
-    rm $out/lib/node_modules/speedscope/node_modules/.bin/sshpk*
-  '';
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Changelog: https://github.com/jlfwong/speedscope/releases/tag/v1.25.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
