### PR TITLE
emacsPackages.ghostel: build zig module

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ghostel/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  fetchFromGitHub,
+  melpaBuild,
+  nix-update-script,
+  stdenv,
+  zig_0_15,
+  emacs,
+}:
+
+let
+  zig = zig_0_15;
+
+  pname = "ghostel";
+
+  version = "0.18.1-unstable-2026-04-24";
+
+  src = fetchFromGitHub {
+    owner = "dakra";
+    repo = "ghostel";
+    rev = "fdfb68f70ca6f43277ef8a0ba4103631857e4ad4";
+    hash = "sha256-u3zUj5uUHqFEP7mjmADNB6n6n/LmGR6ne0ylalop8WI=";
+  };
+
+  module = stdenv.mkDerivation (finalAttrs: {
+    inherit pname version src;
+
+    deps = zig.fetchDeps {
+      inherit (finalAttrs) src pname version;
+      fetchAll = true;
+      hash = "sha256-ghN/UMACgkFQQEr4nH5gbbJbt/+2bz6tL2bJpbw9mGE=";
+    };
+
+    nativeBuildInputs = [ zig ];
+
+    env.EMACS_INCLUDE_DIR = "${emacs}/include";
+
+    postConfigure = ''
+      cp -rLT ${finalAttrs.deps} "$ZIG_GLOBAL_CACHE_DIR/p"
+      chmod -R u+w "$ZIG_GLOBAL_CACHE_DIR/p"
+    '';
+  });
+
+  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+in
+melpaBuild {
+  inherit pname version src;
+
+  files = ''
+    (:defaults "etc" "ghostel-module${libExt}")
+  '';
+
+  preBuild = ''
+    install ${module}/lib/libghostel-module${libExt} ghostel-module${libExt}
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=branch=main" ]; };
+
+    inherit module;
+  };
+
+  meta = {
+    homepage = "https://github.com/dakra/ghostel";
+    description = "Terminal emulator powered by libghostty";
+    maintainers = with lib.maintainers; [ vonfry ];
+    license = lib.licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Build ghostel zig module in nix.

~~Update issue: zig deps are locked. emacs-ovelay update/migration needs a manual hash update.~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
