### PR TITLE
Automatically configure `amd_pstate` using nixos-facter report

### DIFF
--- a/nixos/modules/hardware/cpu/amd-pstate.nix
+++ b/nixos/modules/hardware/cpu/amd-pstate.nix
@@ -1,0 +1,48 @@
+{ lib, config, ... }:
+let
+  inherit (lib) types;
+  cfg = config.hardware.cpu.amd.pstate;
+  kver = config.boot.kernelPackages.kernel.version;
+
+  kernel6_1To6_3 = (lib.versionAtLeast kver "6.1") && (lib.versionOlder kver "6.3");
+  kernel6_3OrLater = lib.versionAtLeast kver "6.3";
+in
+{
+  options.hardware.cpu.amd.pstate = {
+    enable = lib.mkEnableOption "AMD CPU performance control";
+
+    mode = lib.mkOption {
+      type = types.nullOr (
+        types.enum [
+          "active"
+          "passive"
+          "guided"
+        ]
+      );
+      default =
+        if kernel6_3OrLater then
+          "active"
+        else if kernel6_1To6_3 then
+          "passive"
+        else
+          null;
+
+      defaultText = "Dependent on the Linux kernel version";
+      description = ''
+        The different performance characteristics of `amd_pstate` modes are described here: https://www.kernel.org/doc/html/latest/admin-guide/pm/amd-pstate.html#amd-pstate-driver-operation-modes
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot = lib.mkMerge [
+      (lib.mkIf (cfg.mode == null) {
+        kernelParams = [ "initcall_blacklist=acpi_cpufreq_init" ];
+        kernelModules = [ "amd-pstate" ];
+      })
+      (lib.mkIf (cfg.mode != null) {
+        kernelParams = [ "amd_pstate=${cfg.mode}" ];
+      })
+    ];
+  };
+}

--- a/nixos/modules/hardware/facter/cpu.nix
+++ b/nixos/modules/hardware/facter/cpu.nix
@@ -1,0 +1,23 @@
+{ lib, config, ... }:
+let
+  facterLib = import ./lib.nix lib;
+
+  cfg = config.hardware.facter;
+in
+{
+  options.hardware.facter.detected.cpu.amd = {
+    enable = lib.mkEnableOption "Enable the Facter AMD CPU module" // {
+      default = lib.hasAttrByPath [ "hardware" "cpu" ] cfg.report -> facterLib.hasAmdCpu cfg.report;
+      defaultText = "Enabled if the CPU vendor is `AuthenticAMD`.";
+    };
+
+    cppc = lib.mkEnableOption "Collaborative Processor Performance Control" // {
+      default = lib.all (cpu: lib.elem "cppc" cpu.features) cfg.report.hardware.cpu;
+      defaultText = "Enabled if the cpu supports Collaborative Processor Performance Control (`cppc`).";
+    };
+  };
+
+  config.hardware.cpu.amd = lib.mkIf cfg.detected.cpu.amd.enable {
+    pstate.enable = lib.mkDefault cfg.detected.cpu.amd.cppc;
+  };
+}

--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -8,6 +8,7 @@
     ./boot.nix
     ./bluetooth.nix
     ./camera
+    ./cpu.nix
     ./debug.nix
     ./disk.nix
     ./fingerprint

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -58,6 +58,7 @@
   ./hardware/coral.nix
   ./hardware/corectrl.nix
   ./hardware/cpu/amd-microcode.nix
+  ./hardware/cpu/amd-pstate.nix
   ./hardware/cpu/amd-ryzen-smu.nix
   ./hardware/cpu/amd-sev.nix
   ./hardware/cpu/intel-microcode.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've moved from nixos-hardware to using factor for configuring the hardware of my systems and I noticed that `amd_pstate` was not automatically configured. I've made a quick implementation based on the [one in nixos-hardware](https://github.com/NixOS/nixos-hardware/blob/72674a6b5599e844c045ae7449ba91f803d44ebc/common/cpu/amd/pstate.nix#L16) and configured it to be enabled if the required feature is detected by facter.

I've tested it on my own machine where it works as expected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
