### PR TITLE
mruby: 3.3.0 -> 4.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19899,6 +19899,12 @@
     name = "Alessio Caiazza";
     matrix = "@alessio:caiazza.info";
   };
+  nomadium = {
+    email = "miguel@miguel.cc";
+    github = "nomadium";
+    githubId = 79817;
+    name = "Miguel Landaeta";
+  };
   nomaterials = {
     email = "nomaterials@gmail.com";
     github = "no-materials";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19766,6 +19766,12 @@
     name = "Alessio Caiazza";
     matrix = "@alessio:caiazza.info";
   };
+  nomadium = {
+    email = "miguel@miguel.cc";
+    github = "nomadium";
+    githubId = 79817;
+    name = "Miguel Landaeta";
+  };
   nomaterials = {
     email = "nomaterials@gmail.com";
     github = "no-materials";

--- a/pkgs/by-name/mr/mruby/package.nix
+++ b/pkgs/by-name/mr/mruby/package.nix
@@ -10,22 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mruby";
-  version = "3.3.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "mruby";
     repo = "mruby";
     rev = finalAttrs.version;
-    sha256 = "sha256-rCoEC1ioX6bOocPoPi+Lsn4PM8gY0DjKja1/MJvJ1n8=";
+    sha256 = "sha256-7CDTRQncpjY0HO0S1lM57aUvV6ZseEp+/nxXp4ZuuQs=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2025-7207.patch";
-      url = "https://github.com/mruby/mruby/commit/1fdd96104180cc0fb5d3cb086b05ab6458911bb9.patch";
-      hash = "sha256-wtSlLydofkp2brk/pRiJqt4NhkGRdzsx7JpTmWu2B7I=";
-    })
-  ];
 
   nativeBuildInputs = [ rake ];
 
@@ -53,7 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Embeddable implementation of the Ruby language";
     homepage = "https://mruby.org";
-    maintainers = with lib.maintainers; [ nicknovitski ];
+    maintainers = with lib.maintainers; [
+      nicknovitski
+      nomadium
+    ];
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     mainProgram = "mruby";

--- a/pkgs/by-name/mr/mruby/package.nix
+++ b/pkgs/by-name/mr/mruby/package.nix
@@ -10,22 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mruby";
-  version = "3.3.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "mruby";
     repo = "mruby";
     rev = finalAttrs.version;
-    sha256 = "sha256-rCoEC1ioX6bOocPoPi+Lsn4PM8gY0DjKja1/MJvJ1n8=";
+    sha256 = "sha256-7CDTRQncpjY0HO0S1lM57aUvV6ZseEp+/nxXp4ZuuQs=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2025-7207.patch";
-      url = "https://github.com/mruby/mruby/commit/1fdd96104180cc0fb5d3cb086b05ab6458911bb9.patch";
-      hash = "sha256-wtSlLydofkp2brk/pRiJqt4NhkGRdzsx7JpTmWu2B7I=";
-    })
-  ];
 
   nativeBuildInputs = [ rake ];
 
@@ -53,9 +45,13 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Embeddable implementation of the Ruby language";
     homepage = "https://mruby.org";
-    maintainers = with lib.maintainers; [ nicknovitski ];
+    maintainers = with lib.maintainers; [
+      nicknovitski
+      nomadium
+    ];
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     mainProgram = "mruby";
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
Diff: https://github.com/mruby/mruby/compare/3.3.0...4.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
