### PR TITLE
sdrangel: fix macOS linker flag for flac

### DIFF
--- a/pkgs/by-name/sd/sdrangel/package.nix
+++ b/pkgs/by-name/sd/sdrangel/package.nix
@@ -101,7 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6Packages.qtspeech
     qt6Packages.qttools
     qt6Packages.qtwebsockets
-    qt6Packages.qtwebengine
     rtl-sdr
     serialdv
     sgp4
@@ -109,7 +108,13 @@ stdenv.mkDerivation (finalAttrs: {
     uhd
     zlib
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ qt6Packages.qtwayland ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    qt6Packages.qtwayland
+  ]
+  # FIX: Conditionally include WebEngine only on non-Darwin systems
+  ++ lib.optionals (!stdenv.isDarwin) [
+    qt6Packages.qtwebengine
+  ]
   ++ lib.optionals withSDRplay [ sdrplay ];
 
   cmakeFlags = [
@@ -120,6 +125,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-Wno-dev"
     "-DENABLE_QT6=ON"
   ];
+
+  # FIX: Force macOS linker to globally resolve FLAC symbols for all compiled plugins
+  NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lFLAC";
 
   meta = {
     description = "Software defined radio (SDR) software";


### PR DESCRIPTION
This pull request makes a targeted fix to the `sdrangel` package build on macOS. The main change is to ensure that the FLAC library is correctly linked, which is necessary for all compiled plugins to resolve FLAC symbols globally.

Build and linker fixes:

Added a conditional linker flag (`-lFLAC`) for macOS builds to force global resolution of FLAC symbols for all compiled plugins.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
