### PR TITLE
[Backport release-25.11] nuclei: 3.5.1 -> 3.8.0

### DIFF
--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "nuclei";
-  version = "3.5.1";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
     tag = "v${version}";
-    hash = "sha256-85gGcNDuARc7sMJcl3yVwuTYG0laQ5/Uk7qxcXFeViQ=";
+    hash = "sha256-jZInWfXHUuntdEKdaFV46/A7NTcCB77bLYaFSL9w+Os=";
   };
 
-  vendorHash = "sha256-VKszu2WNLL2gSkgyAoA80HkYGD6kRdfj5fGLErjL86A=";
+  vendorHash = "sha256-jw6DhUCFz7dnWX3tMsj2fMX36YA5RwkQlONVQHg37dY=";
 
   proxyVendor = true; # hash mismatch between Linux and Darwin
 

--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "nuclei";
-  version = "3.6.0";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
     tag = "v${version}";
-    hash = "sha256-jZInWfXHUuntdEKdaFV46/A7NTcCB77bLYaFSL9w+Os=";
+    hash = "sha256-CuR/8vTNnHsD4yuc39SF4kjh6SCH7VTVgicU7HekYhI=";
   };
 
-  vendorHash = "sha256-jw6DhUCFz7dnWX3tMsj2fMX36YA5RwkQlONVQHg37dY=";
+  vendorHash = "sha256-j5+PpCAYV5NsXQHbyXg7Of6MmEmGDbLZBsXBSKCBo+8=";
 
   proxyVendor = true; # hash mismatch between Linux and Darwin
 

--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "nuclei";
-  version = "3.6.1";
+  version = "3.6.2";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
     tag = "v${version}";
-    hash = "sha256-CuR/8vTNnHsD4yuc39SF4kjh6SCH7VTVgicU7HekYhI=";
+    hash = "sha256-cWfX1W9foaCmqH17RDNHq38SYbl9enzZmyYZKkHz36k=";
   };
 
-  vendorHash = "sha256-j5+PpCAYV5NsXQHbyXg7Of6MmEmGDbLZBsXBSKCBo+8=";
+  vendorHash = "sha256-yXXjYsLO3jQI0fS7f5LG/KTVpRg+ROc0DPUVYdNOW8I=";
 
   proxyVendor = true; # hash mismatch between Linux and Darwin
 

--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -5,14 +5,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "nuclei";
   version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-MAOyMpcJsw4O+oC3IhEBF1XR6KSLBHhYZDnmNnwX4mo=";
   };
 
@@ -46,7 +46,7 @@ buildGoModule rec {
       CVEs across targets that are known and easily detectable.
     '';
     homepage = "https://github.com/projectdiscovery/nuclei";
-    changelog = "https://github.com/projectdiscovery/nuclei/releases/tag/v${version}";
+    changelog = "https://github.com/projectdiscovery/nuclei/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab
@@ -54,4 +54,4 @@ buildGoModule rec {
     ];
     mainProgram = "nuclei";
   };
-}
+})

--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "nuclei";
-  version = "3.6.2";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
     tag = "v${version}";
-    hash = "sha256-cWfX1W9foaCmqH17RDNHq38SYbl9enzZmyYZKkHz36k=";
+    hash = "sha256-MAOyMpcJsw4O+oC3IhEBF1XR6KSLBHhYZDnmNnwX4mo=";
   };
 
-  vendorHash = "sha256-yXXjYsLO3jQI0fS7f5LG/KTVpRg+ROc0DPUVYdNOW8I=";
+  vendorHash = "sha256-XaRcVKFgsQnPngqmp7QIcx2jV7h51EafNlZjSd9lUIE=";
 
   proxyVendor = true; # hash mismatch between Linux and Darwin
 

--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "nuclei";
-  version = "3.7.1";
+  version = "3.8.0";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PiuFlEIEQNsVLLwHVDi+b/ABPyrp4+hnO6JjLGHxWc0=";
+    hash = "sha256-jzXV9QBpeH26nrViHdKR6Id7Dkdl0Ob1r71RhorCJvM=";
   };
 
-  vendorHash = "sha256-eevywU57QoA2K/Fl4XQZwaiyGCiGDrkvAdco6khcInc=";
+  vendorHash = "sha256-dxyyaletTVud6p81QzOsitw7m4yAZG3r1ZoEb2vQqOY=";
 
   proxyVendor = true; # hash mismatch between Linux and Darwin
 

--- a/pkgs/by-name/nu/nuclei/package.nix
+++ b/pkgs/by-name/nu/nuclei/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "nuclei";
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "nuclei";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MAOyMpcJsw4O+oC3IhEBF1XR6KSLBHhYZDnmNnwX4mo=";
+    hash = "sha256-PiuFlEIEQNsVLLwHVDi+b/ABPyrp4+hnO6JjLGHxWc0=";
   };
 
-  vendorHash = "sha256-XaRcVKFgsQnPngqmp7QIcx2jV7h51EafNlZjSd9lUIE=";
+  vendorHash = "sha256-eevywU57QoA2K/Fl4XQZwaiyGCiGDrkvAdco6khcInc=";
 
   proxyVendor = true; # hash mismatch between Linux and Darwin
 


### PR DESCRIPTION
Fix #512401

cherry picked from commits:

- c606d3555462 nuclei: 3.5.1 -> 3.6.0
- 702569c30425 nuclei: 3.6.0 -> 3.6.1
- fbf9c4385361 nuclei: 3.6.1 -> 3.6.2
- 9bc15022cbc4 nuclei: 3.6.2 -> 3.7.0
- 1605a32568aa nuclei: migrate to finalAttrs
- c98c02a94e6e nuclei: 3.7.0 -> 3.7.1
- 7b762fd2541b nuclei: 3.7.1 -> 3.8.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
