### PR TITLE
python3Packages.pelican: 4.11.0 -> 4.12.0

### DIFF
--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "pelican";
-  version = "4.11.0";
+  version = "4.12.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "getpelican";
     repo = "pelican";
     tag = version;
-    hash = "sha256-SrzHAqDX+DCeaWMmlG8tgA1RKLDnICkvDIE/kUQZN+s=";
+    hash = "sha256-g/wm4ZA4KBMnvpe58ZQ7lTUBF6PywC4IivmBBco4F00=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     postFetch = ''
@@ -53,7 +53,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pelican/tests/test_pelican.py \
-      --replace "'git'" "'${git}/bin/git'"
+      --replace-fail "\"git\"" "'${git}/bin/git'"
   '';
 
   build-system = [ pdm-backend ];
@@ -88,6 +88,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     beautifulsoup4
+    git
     lxml
     mock
     pandoc
@@ -95,23 +96,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlags = [
-    # DeprecationWarning: 'jinja2.Markup' is deprecated and...
-    "-Wignore::DeprecationWarning"
-    # PendingDeprecationWarning: `Publisher.set_components()` will be removed in ...
-    "-Wignore::PendingDeprecationWarning"
-  ];
-
   disabledTests = [
     # AssertionError
     "test_basic_generation_works"
     "test_custom_generation_works"
     "test_custom_locale_generation_works"
-    "test_deprecated_attribute"
-    # AttributeError
-    "test_wp_custpost_true_dirpage_false"
-    "test_can_toggle_raw_html_code_parsing"
-    "test_dirpage_directive_for_page_kind"
   ];
 
   env.LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
