### PR TITLE
goshs: 2.0.1 -> 2.0.3

### DIFF
--- a/pkgs/by-name/go/goshs/package.nix
+++ b/pkgs/by-name/go/goshs/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   stdenv,
   lib,
+  fetchpatch,
   testers,
 
   # passthru
@@ -11,16 +12,24 @@
 
 buildGoModule (finalAttrs: {
   pname = "goshs";
-  version = "2.0.1";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "patrickhener";
     repo = "goshs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Lh4jUz6dtbAwC9ErQrHe5FtxjHLL2gBRTSqLtj33GTc=";
+    hash = "sha256-DdGzX1qVz8mA+T9l+V2n7r6ngtV1moypT3sLO7f4OcY=";
   };
 
-  vendorHash = "sha256-wn+t6xY4zUK6NE5kZSefHYGpMq5whFZ644ij5bDs50I=";
+  patches = [
+    # Fixes the build for 2.0.3
+    (fetchpatch {
+      url = "https://github.com/patrickhener/goshs/commit/dc4a86e846b5a2e6f7cc97a29a73367dea26f91a.patch";
+      hash = "sha256-yXVBxOAp37yVdI5JlFMzSuSwiUaF2gWOfy4GfBVkGSI=";
+    })
+  ];
+
+  vendorHash = "sha256-R0U/cytan8U9nE/qYHmDUlUfIYhZAcjV2v/uIlZPTCs=";
 
   ldflags = [
     "-s"
@@ -42,12 +51,11 @@ buildGoModule (finalAttrs: {
     "-skip=^TestGetIPv4Addr$"
   ];
 
-  # Disabled until https://github.com/patrickhener/goshs/issues/137 is resolved
-  # passthru.tests.version = testers.testVersion {
-  #   package = goshs;
-  #   command = "goshs -v";
-  #   version = "goshs ${finalAttrs.version}";
-  # };
+  passthru.tests.version = testers.testVersion {
+    package = goshs;
+    command = "goshs -v";
+    version = "goshs ${finalAttrs.version}";
+  };
 
   meta = {
     description = "Simple, yet feature-rich web server written in Go";


### PR DESCRIPTION
Currently the tests here are failing, that issue [is reported upstream](https://github.com/patrickhener/goshs/issues/148).

This update may fix

- https://github.com/NixOS/nixpkgs/issues/512423
- https://github.com/NixOS/nixpkgs/issues/508896
- https://github.com/NixOS/nixpkgs/issues/512417
- https://github.com/NixOS/nixpkgs/issues/508903

(I have not checked)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
