### PR TITLE
tcl.mkTclDerivation: use extendMkDerivation

### DIFF
--- a/doc/languages-frameworks/tcl.section.md
+++ b/doc/languages-frameworks/tcl.section.md
@@ -21,12 +21,12 @@ Here is a simple package example to be called with `tclPackages.callPackage`.
 ```
 { lib, fetchzip, mkTclDerivation, openssl }:
 
-mkTclDerivation rec {
+mkTclDerivation (finalAttrs: {
   pname = "tcltls";
   version = "1.7.22";
 
   src = fetchzip {
-    url = "https://core.tcl-lang.org/tcltls/uv/tcltls-${version}.tar.gz";
+    url = "https://core.tcl-lang.org/tcltls/uv/tcltls-${finalAttrs.version}.tar.gz";
     hash = "sha256-TOouWcQc3MNyJtaAGUGbaQoaCWVe6g3BPERct/V65vk=";
   };
 
@@ -43,7 +43,7 @@ mkTclDerivation rec {
     license = lib.licenses.tcltk;
     platforms = lib.platforms.unix;
   };
-}
+})
 ```
 
 All Tcl libraries are declared in `pkgs/top-level/tcl-packages.nix` and are defined in `pkgs/development/tcl-modules/`.

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -1,33 +1,9 @@
-# Generic builder for tcl packages/applications, generally based on mk-python-derivation.nix
+# Generic builder for tcl packages/applications
 {
   tcl,
   lib,
   makeWrapper,
-  runCommand,
-  writeScript,
 }:
-
-{
-  buildInputs ? [ ],
-  nativeBuildInputs ? [ ],
-  propagatedBuildInputs ? [ ],
-  checkInputs ? [ ],
-  nativeCheckInputs ? [ ],
-
-  # true if we should skip the configuration phase altogether
-  dontConfigure ? false,
-
-  # Extra flags passed to configure step
-  configureFlags ? [ ],
-
-  # Whether or not we should add common Tcl-related configure flags
-  addTclConfigureFlags ? true,
-
-  meta ? { },
-  passthru ? { },
-  doCheck ? true,
-  ...
-}@attrs:
 
 let
   inherit (tcl) stdenv;
@@ -41,20 +17,35 @@ let
     "--enable-stubs"
   ];
 
-  self = (
-    stdenv.mkDerivation (
-      (removeAttrs attrs [
-        "addTclConfigureFlags"
-        "checkPhase"
-        "checkInputs"
-        "nativeCheckInputs"
-        "doCheck"
-      ])
-      // {
+in
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
+    "addTclConfigureFlags"
+    "checkPhase"
+    "checkInputs"
+    "nativeCheckInputs"
+    "doCheck"
+  ];
+  extendDrvArgs =
+    finalAttrs:
+    args@{
+      # true if we should skip the configuration phase altogether
+      dontConfigure ? false,
 
-        buildInputs = buildInputs ++ [ tcl.tclPackageHook ];
+      # Extra flags passed to configure step
+      configureFlags ? [ ],
+
+      # Whether or not we should add common Tcl-related configure flags
+      addTclConfigureFlags ? true,
+      ...
+    }:
+    (
+      {
+        buildInputs = args.buildInputs or [ ] ++ [ tcl.tclPackageHook ];
+
         nativeBuildInputs =
-          nativeBuildInputs
+          args.nativeBuildInputs or [ ]
           ++ [
             makeWrapper
             tcl
@@ -62,18 +53,14 @@ let
           ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
             tcl.tclRequiresCheckHook
           ];
-        propagatedBuildInputs = propagatedBuildInputs ++ [ tcl ];
 
-        env = {
-          TCLSH = "${getBin tcl}/bin/tclsh";
-        }
-        // (attrs.env or { });
+        propagatedBuildInputs = args.propagatedBuildInputs or [ ] ++ [ tcl ];
 
         # Run tests after install, at which point we've done all TCLLIBPATH setup
         doCheck = false;
-        doInstallCheck = attrs.doCheck or (attrs.doInstallCheck or false);
-        installCheckInputs = checkInputs ++ (attrs.installCheckInputs or [ ]);
-        nativeInstallCheckInputs = nativeCheckInputs ++ (attrs.nativeInstallCheckInputs or [ ]);
+        doInstallCheck = args.doCheck or (args.doInstallCheck or false);
+        installCheckInputs = args.checkInputs or [ ] ++ args.installCheckInputs or [ ];
+        nativeInstallCheckInputs = args.nativeCheckInputs or [ ] ++ args.nativeInstallCheckInputs or [ ];
 
         # Add typical values expected by TEA for configureFlags
         configureFlags =
@@ -82,17 +69,19 @@ let
           else
             configureFlags;
 
+        env = {
+          TCLSH = "${getBin tcl}/bin/tclsh";
+        }
+        // args.env or { };
+
         meta = {
           platforms = tcl.meta.platforms;
         }
-        // meta;
+        // args.meta or { };
 
       }
-      // optionalAttrs (attrs ? checkPhase) {
-        installCheckPhase = attrs.checkPhase;
+      // optionalAttrs (args ? checkPhase) {
+        installCheckPhase = args.checkPhase;
       }
-    )
-  );
-
-in
-lib.extendDerivation true passthru self
+    );
+}


### PR DESCRIPTION
Should cause exactly ~~0 rebuilds~~ 1 rebuild: the manual

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
