### PR TITLE
httrack: 3.49.2 -> 3.49.6

### DIFF
--- a/pkgs/by-name/ht/httrack/package.nix
+++ b/pkgs/by-name/ht/httrack/package.nix
@@ -1,19 +1,23 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   zlib,
   openssl,
   libiconv,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.49.2";
+  version = "3.49.6";
   pname = "httrack";
 
-  src = fetchurl {
-    url = "https://mirror.httrack.com/httrack-${finalAttrs.version}.tar.gz";
-    sha256 = "09a0gm67nml86qby1k1gh7rdxamnrnzwr6l9r5iiq94favjs0xrl";
+  src = fetchFromGitHub {
+    owner = "xroche";
+    repo = "httrack";
+    # 3.49.6 is not tagged, but corresponds to this rev.
+    rev = "748c35de7858ead963daf1393ad023d75b7820c2";
+    hash = "sha256-Iaeo6lB84I0amr2C8iZ+kQ6F8AXqyyARV6FiwpBshvA=";
+    fetchSubmodules = true;
   };
 
   buildInputs = [
@@ -22,12 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  enableParallelBuilding = true;
-
   meta = {
     description = "Easy-to-use offline browser / website mirroring utility";
-    homepage = "http://www.httrack.com";
+    homepage = "https://www.httrack.com";
     license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = with lib.platforms; unix;
   };
 })


### PR DESCRIPTION
Update httrack 3.49.2 to 3.39.6

Fetch from github.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
