### PR TITLE
qmk-udev-rules: 0.27.13 -> 0.1.20

### DIFF
--- a/pkgs/by-name/qm/qmk-udev-rules/package.nix
+++ b/pkgs/by-name/qm/qmk-udev-rules/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qmk-udev-rules";
-  version = "0.27.13";
+  version = "0.1.20";
 
   src = fetchFromGitHub {
     owner = "qmk";
-    repo = "qmk_firmware";
-    tag = finalAttrs.version;
-    hash = "sha256-Zs508OQ0RYCg0f9wqR+VXUmVvhP/jCA3piwRq2ZpR84=";
+    repo = "qmk_udev";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sxwvyMniEXTnmHEs8ldsBjwReKUT5FlqYxcUULV0cpI=";
   };
 
   dontBuild = true;
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -D util/udev/50-qmk.rules $out/lib/udev/rules.d/50-qmk.rules
+    install -D 50-qmk.rules $out/lib/udev/rules.d/50-qmk.rules
 
     runHook postInstall
   '';


### PR DESCRIPTION
https://github.com/qmk/qmk_udev/releases/tag/v0.1.20

Despite the version number decrement, this is an update. The udev rules were
just moved to a separate repo with different versioning.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
