### PR TITLE
xyce: fix build

### DIFF
--- a/pkgs/by-name/xy/xyce/package.nix
+++ b/pkgs/by-name/xy/xyce/package.nix
@@ -2,6 +2,8 @@
   stdenv,
   fetchFromGitHub,
   fetchgit,
+  fetchpatch,
+  applyPatches,
   lib,
   bison,
   blas,
@@ -41,12 +43,21 @@ let
     hash = "sha256-8cvglBCykZVQk3BD7VE3riXfJ0PAEBwsoloqUsrMlBc=";
   };
 
-  regression_src = fetchFromGitHub {
-    name = "Xyce_Regression";
-    owner = "Xyce";
-    repo = "Xyce_Regression";
-    rev = "Release-${version}";
-    hash = "sha256-aA/4UpzSb+EeJ1RVkVwSKiNh7BDcLHxNDnKXZmnCBmI=";
+  regression_src = applyPatches {
+    src = fetchFromGitHub {
+      name = "Xyce_Regression";
+      owner = "Xyce";
+      repo = "Xyce_Regression";
+      rev = "Release-${version}";
+      hash = "sha256-aA/4UpzSb+EeJ1RVkVwSKiNh7BDcLHxNDnKXZmnCBmI=";
+    };
+    patches = [
+      # remove after next release
+      (fetchpatch {
+        url = "https://github.com/Xyce/Xyce_Regression/commit/a77e39e409d3ab2ae05d6dcbf08d9e42e3fd0f15.patch";
+        hash = "sha256-BJJO2qSwQf+u2HUWhdyBUwP3j4HbMPfXrAhgdzeTZgc=";
+      })
+    ];
   };
 in
 
@@ -80,7 +91,6 @@ stdenv.mkDerivation rec {
         koma-script
         optional
         framed
-        enumitem
         multirow
         newtx
         preprint
@@ -164,11 +174,14 @@ stdenv.mkDerivation rec {
     local docFiles=("doc/Users_Guide/Xyce_UG"
       "doc/Reference_Guide/Xyce_RG"
       "doc/Release_Notes/Release_Notes_${lib.versions.majorMinor version}/Release_Notes_${lib.versions.majorMinor version}")
+    # hotfix for: https://github.com/Xyce/Xyce/issues/177
+    substituteInPlace doc/Reference_Guide/Xyce_RG_macros.tex \
+      --replace-fail "\\def\\device{\\goodbreak" "\\def\\device{\\item[]\\goodbreak"
 
     # SANDIA LaTeX class and some organization logos are not publicly available see
     # https://groups.google.com/g/xyce-users/c/MxeViRo8CT4/m/ppCY7ePLEAAJ
     for img in "snllineblubrd" "snllineblk" "DOEbwlogo" "NNSA_logo"; do
-      sed -i -E "s/\\includegraphics\[height=(0.[1-9]in)\]\{$img\}/\\mbox\{\\rule\{0mm\}\{\1\}\}/" ''${docFiles[2]}.tex
+      sed -i -E "s/\\includegraphics\[height=(0.[1-9]in)\]\{$img\}/\\mbox\{\\\\rule\{0mm\}\{\1\}\}/" ''${docFiles[2]}.tex
     done
 
     install -d $doc/share/doc/${pname}-${version}/


### PR DESCRIPTION
https://hydra.nixos.org/build/326493760
https://hydra.nixos.org/build/326493756

```
Traceback (most recent call last):
  File "/home/wish/hydra/Xyce/build/../../Xyce_Regression/TestScripts/compareHomotopy.py", line 353, in <module>
    main()
    ~~~~^^
  File "/home/wish/hydra/Xyce/build/../../Xyce_Regression/TestScripts/compareHomotopy.py", line 338, in main
    interpgooddata,interptestdata, errors = computeErrors(gooddata, testdata, goodtags, goodStepRanges, testStepRanges, reltols, abstols, poptions)
                                            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wish/hydra/Xyce/build/../../Xyce_Regression/TestScripts/compareHomotopy.py", line 203, in computeErrors
    error = rhsErrorArc(outGood[0], outGood[1], outTest[0], outTest[1], reltol, abstol)
  File "/home/wish/hydra/Xyce/build/../../Xyce_Regression/TestScripts/compareHomotopy.py", line 93, in rhsErrorArc
    errorSum = numpy.trapz(differenceSq, arcX)
               ^^^^^^^^^^^
  File "/nix/store/v36j2786dqdcpa7q94l4angl30dw8l63-python3-3.13.12-env/lib/python3.13/site-packages/numpy/__init__.py", line 792, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
```

Applied an upstream commit for fix. Also added a hotfix for latex error.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
