### PR TITLE
fishPlugins.fish-scripting: init at 0-unstable-2024-09-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28264,6 +28264,11 @@
     githubId = 12422133;
     name = "Chromo-residuum-opec";
   };
+  ui-1 = {
+    name = "ui-1";
+    github = "ui-1";
+    githubId = 134524800;
+  };
   uku3lig = {
     name = "uku";
     email = "hi@uku.moe";

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -38,6 +38,8 @@ lib.makeScope newScope (
 
     fish-bd = callPackage ./fish-bd.nix { };
 
+    fish-scripting = callPackage ./fish-scripting.nix { };
+
     # Fishtape 2.x and 3.x aren't compatible,
     # but both versions are used in the tests of different other plugins.
     fishtape = callPackage ./fishtape.nix { };

--- a/pkgs/shells/fish/plugins/fish-scripting.nix
+++ b/pkgs/shells/fish/plugins/fish-scripting.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+}:
+buildFishPlugin {
+  pname = "fish-scripting";
+  version = "0-unstable-2024-09-19";
+
+  src = fetchFromGitHub {
+    owner = "lewisacidic";
+    repo = "fish-scripting";
+    rev = "4da565fde4ea4b9159a64768181269e26398a283";
+    hash = "sha256-4HGQW05+Y/2Psb1Iw+3N6MaNurpbkQrSK66W+5wGQbQ=";
+  };
+
+  meta = {
+    description = "Fish abbreviations for some scripting commands";
+    homepage = "https://github.com/lewisacidic/fish-scripting";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ui-1 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
