### PR TITLE
plover: fix crashes, move to `python3Packages`, and expose under pkgs/by-name

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -67,13 +67,16 @@
       pythonImportsCheck = [ "plover" ];
 
       meta = {
-        broken = stdenv.hostPlatform.isDarwin;
         description = "OpenSteno Plover stenography software";
+        homepage = "https://www.openstenoproject.org/plover/";
+        mainProgram = "plover";
         maintainers = with lib.maintainers; [
           twey
           kovirobi
         ];
         license = lib.licenses.gpl2Plus;
+        platforms = lib.platforms.unix;
+        broken = stdenv.hostPlatform.isDarwin;
       };
     }
   );

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -73,6 +73,7 @@
         maintainers = with lib.maintainers; [
           twey
           kovirobi
+          pandapip1
         ];
         license = lib.licenses.gpl2Plus;
         platforms = lib.platforms.unix;

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -73,7 +73,7 @@
           twey
           kovirobi
         ];
-        license = licenses.gpl2Plus;
+        license = lib.licenses.gpl2Plus;
       };
     }
   );

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -3,6 +3,7 @@
   config,
   stdenv,
   plover,
+  buildPythonPackage ? python3Packages.buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
   versionCheckHook,
@@ -32,79 +33,81 @@ let
     wrapQtAppsHook
     ;
 in
-{
-  dev = (
-    buildPythonPackage rec {
-      pname = "plover";
-      version = "4.0.2";
-      pyproject = true;
+buildPythonPackage rec {
+  pname = "plover";
+  version = "4.0.2";
+  pyproject = true;
 
-      src = fetchFromGitHub {
-        owner = "openstenoproject";
-        repo = "plover";
-        tag = "v${version}";
-        hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
-      };
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "plover";
+    tag = "v${version}";
+    hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
+  };
 
-      postPatch = ''
-        sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
-      '';
+  postPatch = ''
+    sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
+  '';
 
-      build-system = [
-        babel
-        setuptools
-        pyqt5
-        wheel
-      ];
-      dependencies = [
-        appdirs
-        evdev
-        pyqt5
-        pyserial
-        plover-stroke
-        rtf-tokenize
-        setuptools
-        wcwidth
-        xlib
-      ];
-      nativeBuildInputs = [
-        wrapQtAppsHook
-      ];
+  build-system = [
+    babel
+    setuptools
+    pyqt5
+    wheel
+  ];
+  dependencies = [
+    appdirs
+    evdev
+    pyqt5
+    pyserial
+    plover-stroke
+    rtf-tokenize
+    setuptools
+    wcwidth
+    xlib
+  ];
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
 
-      nativeCheckInputs = [
-        pytestCheckHook
-        versionCheckHook
-        pytest-qt
-        mock
-      ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+    pytest-qt
+    mock
+  ];
 
-      # Segfaults?!
-      disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
+  # Segfaults?!
+  disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
 
-      preFixup = ''
-        makeWrapperArgs+=("''${qtWrapperArgs[@]}")
-      '';
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
 
-      dontWrapQtApps = true;
+  dontWrapQtApps = true;
 
-      pythonImportsCheck = [ "plover" ];
+  pythonImportsCheck = [ "plover" ];
 
-      meta = {
-        description = "OpenSteno Plover stenography software";
-        homepage = "https://www.openstenoproject.org/plover/";
-        mainProgram = "plover";
-        maintainers = with lib.maintainers; [
-          twey
-          kovirobi
-          pandapip1
-        ];
-        license = lib.licenses.gpl2Plus;
-        platforms = lib.platforms.unix;
-        broken = stdenv.hostPlatform.isDarwin;
-      };
-    }
-  );
+  meta = {
+    description = "OpenSteno Plover stenography software";
+    homepage = "https://www.openstenoproject.org/plover/";
+    mainProgram = "plover";
+    maintainers = with lib.maintainers; [
+      twey
+      kovirobi
+      pandapip1
+    ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
 }
 // lib.optionalAttrs config.allowAliases {
-  stable = throw "plover.stable was removed because it used Python 2. Use plover.dev instead."; # added 2022-06-05
+  # TODO: After 26.05 branch-off, remove these aliases
+  dev =
+    if lib.versionOlder "25.05" lib.version then
+      throw "plover.dev was renamed. Use plover-dev instead." # added 2025-06-05`
+    else
+      plover;
+  stable = throw "plover.stable was renamed. Use plover instead."; # added 2022-06-05; updated 2025-06-27
 }

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -2,13 +2,36 @@
   lib,
   config,
   stdenv,
-  buildPythonPackage ? python3Packages.buildPythonPackage,
+  plover,
   fetchFromGitHub,
+  fetchpatch,
   versionCheckHook,
   python3Packages,
   libsForQt5,
 }:
 
+let
+  inherit (python3Packages)
+    buildPythonPackage
+    appdirs
+    babel
+    evdev
+    mock
+    pyqt5
+    pyserial
+    pytestCheckHook
+    pytest-qt
+    plover-stroke
+    rtf-tokenize
+    setuptools
+    wcwidth
+    wheel
+    xlib
+    ;
+  inherit (libsForQt5)
+    wrapQtAppsHook
+    ;
+in
 {
   dev = (
     buildPythonPackage rec {
@@ -27,13 +50,13 @@
         sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
       '';
 
-      build-system = with python3Packages; [
+      build-system = [
         babel
         setuptools
         pyqt5
         wheel
       ];
-      dependencies = with python3Packages; [
+      dependencies = [
         appdirs
         evdev
         pyqt5
@@ -44,11 +67,11 @@
         wcwidth
         xlib
       ];
-      nativeBuildInputs = with libsForQt5; [
+      nativeBuildInputs = [
         wrapQtAppsHook
       ];
 
-      nativeCheckInputs = with python3Packages; [
+      nativeCheckInputs = [
         pytestCheckHook
         versionCheckHook
         pytest-qt

--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -73,7 +73,7 @@
           twey
           kovirobi
         ];
-        license = lib.licenses.gpl2;
+        license = licenses.gpl2Plus;
       };
     }
   );

--- a/pkgs/by-name/pl/plover/package.nix
+++ b/pkgs/by-name/pl/plover/package.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  config,
+  python3Packages,
+  # For aliases
+  plover,
+}:
+python3Packages.toPythonApplication python3Packages.plover
+# Aliases to now-dropped plover.stable and plover.dev
+# Added 2026-04-22
+# TODO(@ShamrockLee): remove after Nixpkgs 25.11 EOL
+// lib.optionalAttrs (config.allowAliases && !(lib.oldestSupportedReleaseIsAtLeast 2605)) {
+  dev =
+    lib.throwIf (lib.oldestSupportedReleaseIsAtLeast 2511) "plover.dev was renamed. Use plover instead."
+      plover; # Added 2026-04-26
+  stable = throw "plover.stable was renamed. Use plover instead."; # Added 2022-06-05; updated 2026-04-26
+}

--- a/pkgs/by-name/pl/plover_4/package.nix
+++ b/pkgs/by-name/pl/plover_4/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.plover_4

--- a/pkgs/by-name/pl/plover_5/package.nix
+++ b/pkgs/by-name/pl/plover_5/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.plover_5

--- a/pkgs/development/python-modules/plover-stroke/default.nix
+++ b/pkgs/development/python-modules/plover-stroke/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  pytest-qt,
+  pyside6,
+  versionCheckHook,
+  which,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "plover-stroke";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "plover_stroke";
+    tag = finalAttrs.version;
+    hash = "sha256-A75OMzmEn0VmDAvmQCp6/7uptxzwWJTwsih3kWlYioA=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-qt
+    pyside6
+  ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    which
+  ];
+
+  versionCheckProgramArg = "${placeholder "out"}/${python.sitePackages}";
+
+  preInstallCheck = ''
+    versionCheckProgram="$(which ls)"
+  '';
+
+  pythonImportsCheck = [ "plover_stroke" ];
+
+  meta = {
+    description = "Helper class for working with steno strokes";
+    homepage = "https://github.com/openstenoproject/plover_stroke";
+    license = lib.licenses.gpl2Plus; # https://github.com/openstenoproject/plover_stroke/issues/4
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+})

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -3,36 +3,27 @@
   config,
   stdenv,
   plover,
-  buildPythonPackage ? python3Packages.buildPythonPackage,
+  buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
   versionCheckHook,
-  python3Packages,
-  libsForQt5,
+  appdirs,
+  babel,
+  evdev,
+  mock,
+  pyqt5,
+  pyserial,
+  pytestCheckHook,
+  pytest-qt,
+  plover-stroke,
+  rtf-tokenize,
+  setuptools,
+  wcwidth,
+  wheel,
+  xlib,
+  wrapQtAppsHook,
 }:
 
-let
-  inherit (python3Packages)
-    buildPythonPackage
-    appdirs
-    babel
-    evdev
-    mock
-    pyqt5
-    pyserial
-    pytestCheckHook
-    pytest-qt
-    plover-stroke
-    rtf-tokenize
-    setuptools
-    wcwidth
-    wheel
-    xlib
-    ;
-  inherit (libsForQt5)
-    wrapQtAppsHook
-    ;
-in
 buildPythonPackage rec {
   pname = "plover";
   version = "4.0.2";

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -86,6 +86,7 @@ buildPythonPackage (finalAttrs: {
       twey
       kovirobi
       pandapip1
+      ShamrockLee
     ];
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   versionCheckHook,
   appdirs,
   babel,
@@ -22,7 +21,9 @@
   wrapQtAppsHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "plover";
   version = "4.0.2";
   pyproject = true;
@@ -30,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "openstenoproject";
     repo = "plover";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
   };
 
@@ -90,4 +91,4 @@ buildPythonPackage rec {
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -1,8 +1,6 @@
 {
   lib,
-  config,
   stdenv,
-  plover,
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
@@ -92,13 +90,4 @@ buildPythonPackage rec {
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
-// lib.optionalAttrs config.allowAliases {
-  # TODO: After 26.05 branch-off, remove these aliases
-  dev =
-    if lib.versionOlder "25.05" lib.version then
-      throw "plover.dev was renamed. Use plover-dev instead." # added 2025-06-05`
-    else
-      plover;
-  stable = throw "plover.stable was renamed. Use plover instead."; # added 2022-06-05; updated 2025-06-27
 }

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  buildPackages,
   buildPythonPackage,
   fetchFromGitHub,
   versionCheckHook,
@@ -8,16 +9,24 @@
   babel,
   evdev,
   mock,
-  pyqt5,
+  packaging,
+  pkginfo,
+  psutil,
+  pygments,
   pyserial,
+  pyside6,
   pytestCheckHook,
   pytest-qt,
   plover-stroke,
+  readme-renderer,
+  requests-cache,
+  requests-futures,
   rtf-tokenize,
   setuptools,
   wcwidth,
   wheel,
   xlib,
+  qtbase,
   wrapQtAppsHook,
 }:
 
@@ -25,37 +34,61 @@ buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "plover";
-  version = "4.0.2";
+  version = "5.0.0.dev2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openstenoproject";
     repo = "plover";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
+    hash = "sha256-PZwxVrdQPhgbj+YmWZIUETngeJGs6IQty0hY43tLQO0=";
   };
 
+  # pythonRelaxDeps seemingly doesn't work here
   postPatch = ''
-    sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
+    sed -i 's/,<77//g' pyproject.toml
+    sed -i /PySide6-Essentials/d pyproject.toml
   '';
 
   build-system = [
     babel
     setuptools
-    pyqt5
+    pyside6
     wheel
+
+    # Replacement for missing pyside6-essentials tools,
+    # workaround for https://github.com/NixOS/nixpkgs/issues/277849.
+    # Ideally this would be solved in pyside6 itself but I spent four
+    # hours trying to untangle its build system before giving up. If
+    # anyone wants to spend the time fixing it feel free to request
+    # me (@Pandapip1) as a reviewer.
+    (buildPackages.writeShellScriptBin "pyside6-uic" ''
+      exec ${qtbase}/libexec/uic -g python "$@"
+    '')
+    (buildPackages.writeShellScriptBin "pyside6-rcc" ''
+      exec ${qtbase}/libexec/rcc -g python "$@"
+    '')
   ];
   dependencies = [
     appdirs
     evdev
-    pyqt5
+    packaging
+    pkginfo
+    psutil
+    pygments
     pyserial
+    pyside6
     plover-stroke
+    qtbase
+    readme-renderer
+    requests-cache
+    requests-futures
     rtf-tokenize
     setuptools
     wcwidth
     xlib
-  ];
+  ]
+  ++ readme-renderer.optional-dependencies.md;
   nativeBuildInputs = [
     wrapQtAppsHook
   ];

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  appdirs,
+  babel,
+  evdev,
+  mock,
+  pyqt5,
+  pyserial,
+  pytestCheckHook,
+  pytest-qt,
+  plover-stroke,
+  rtf-tokenize,
+  setuptools,
+  wcwidth,
+  wheel,
+  xlib,
+  wrapQtAppsHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "plover";
+  version = "4.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "plover";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";
+  };
+
+  postPatch = ''
+    sed -i 's/,<77//g' pyproject.toml # pythonRelaxDepsHook doesn't work for this for some reason
+  '';
+
+  build-system = [
+    babel
+    setuptools
+    pyqt5
+    wheel
+  ];
+  dependencies = [
+    appdirs
+    evdev
+    pyqt5
+    pyserial
+    plover-stroke
+    rtf-tokenize
+    setuptools
+    wcwidth
+    xlib
+  ];
+  nativeBuildInputs = [
+    wrapQtAppsHook
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+    pytest-qt
+    mock
+  ];
+
+  # Segfaults?!
+  disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  dontWrapQtApps = true;
+
+  pythonImportsCheck = [ "plover" ];
+
+  meta = {
+    description = "OpenSteno Plover stenography software";
+    homepage = "https://www.openstenoproject.org/plover/";
+    mainProgram = "plover";
+    maintainers = with lib.maintainers; [
+      twey
+      kovirobi
+      pandapip1
+      ShamrockLee
+    ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+})

--- a/pkgs/development/python-modules/rtf-tokenize/default.nix
+++ b/pkgs/development/python-modules/rtf-tokenize/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  versionCheckHook,
+  which,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "rtf-tokenize";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "openstenoproject";
+    repo = "rtf_tokenize";
+    tag = finalAttrs.version;
+    hash = "sha256-zwD2sRYTY1Kmm/Ag2hps9VRdUyQoi4zKtDPR+F52t9A=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    which
+  ];
+
+  versionCheckProgramArg = "${placeholder "out"}/${python.sitePackages}";
+
+  preInstallCheck = ''
+    versionCheckProgram="$(which ls)"
+  '';
+
+  pythonImportsCheck = [ "rtf_tokenize" ];
+
+  meta = {
+    description = "Simple RTF tokenizer package for Python";
+    homepage = "https://github.com/openstenoproject/rtf_tokenize";
+    license = lib.licenses.gpl2Plus; # https://github.com/openstenoproject/rtf_tokenize/issues/1
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10132,8 +10132,6 @@ with pkgs;
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
 
-  plover = callPackage ../applications/misc/plover { };
-
   # perhaps there are better apps for this task? It's how I had configured my previous system.
   # And I don't want to rewrite all rules
   profanity = callPackage ../applications/networking/instant-messengers/profanity (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10132,7 +10132,7 @@ with pkgs;
 
   plex-mpv-shim = python3Packages.callPackage ../applications/video/plex-mpv-shim { };
 
-  plover = recurseIntoAttrs (libsForQt5.callPackage ../applications/misc/plover { });
+  plover = callPackage ../applications/misc/plover { };
 
   # perhaps there are better apps for this task? It's how I had configured my previous system.
   # And I don't want to rewrite all rules

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12664,6 +12664,14 @@ self: super: with self; {
 
   plotpy = callPackage ../development/python-modules/plotpy { };
 
+  # Plover 5 moves from PyQt5 to PySide6,
+  # which is a backward-incompatible change to praphical plugins.
+  # Use Plover 4 for now (2026-04-26),
+  # as the upstream still warns about this in every Plover 5 release,
+  # List of unsupported plugins:
+  # https://github.com/opensteno/plover_plugins_registry/blob/master/unsupported.json
+  plover = plover_4;
+
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
   plover_4 = callPackage ../development/python-modules/plover/4.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12666,6 +12666,10 @@ self: super: with self; {
 
   plover-stroke = callPackage ../development/python-modules/plover-stroke { };
 
+  plover_4 = callPackage ../development/python-modules/plover/4.nix {
+    inherit (pkgs.libsForQt5) wrapQtAppsHook;
+  };
+
   pluggy = callPackage ../development/python-modules/pluggy { };
 
   pluginbase = callPackage ../development/python-modules/pluginbase { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17157,6 +17157,8 @@ self: super: with self; {
 
   rtb-data = callPackage ../development/python-modules/rtb-data { };
 
+  rtf-tokenize = callPackage ../development/python-modules/rtf-tokenize { };
+
   rtfde = callPackage ../development/python-modules/rtfde { };
 
   rtfunicode = callPackage ../development/python-modules/rtfunicode { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12664,6 +12664,8 @@ self: super: with self; {
 
   plotpy = callPackage ../development/python-modules/plotpy { };
 
+  plover-stroke = callPackage ../development/python-modules/plover-stroke { };
+
   pluggy = callPackage ../development/python-modules/pluggy { };
 
   pluginbase = callPackage ../development/python-modules/pluginbase { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12678,6 +12678,10 @@ self: super: with self; {
     inherit (pkgs.libsForQt5) wrapQtAppsHook;
   };
 
+  plover_5 = callPackage ../development/python-modules/plover/5.nix {
+    inherit (pkgs.qt6) qtbase wrapQtAppsHook;
+  };
+
   pluggy = callPackage ../development/python-modules/pluggy { };
 
   pluginbase = callPackage ../development/python-modules/pluginbase { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR ships with Gavin (@Pandapip1)'s work to prevent the Plover package from crashing on startup, at least on some "Plover-friendly" platforms and desktop environments.

This PR also includes the following renaming and updates:
- Rename Plover 4 package from `plover.dev` to `python3Packages.plover_4` and expose its corresponding Python application to `pkgs/by-name` as `plover_4`.
- Add Plover 5 as `python3Packages.plover_5` and expose as `plover_5`.
- Define `python3Packages.plover` referencing `python3Packages.plover_4` for better plugin backward-compatibility, exposing as `plover` with aliases to `plover.stable` and `plover.dev` that throws error messages to inform users about the renaming.

This PR is the successor of PR #419593
- #419593

Fixes #419420
Fixes #141797
- #419420
- #141797

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
