### PR TITLE
dracut: 059 -> 111

### DIFF
--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -5,7 +5,7 @@
   gitUpdater,
   makeBinaryWrapper,
   pkg-config,
-  asciidoc,
+  asciidoctor,
   libxslt,
   docbook_xsl,
   bash,
@@ -29,16 +29,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dracut";
-  version = "059";
+  version = "110";
 
   src = fetchFromGitHub {
-    owner = "dracutdevs";
-    repo = "dracut";
-    rev = finalAttrs.version;
-    hash = "sha256-zSyC2SnSQkmS/mDpBXG2DtVVanRRI9COKQJqYZZCPJM=";
+    owner = "dracut-ng";
+    repo = "dracut-ng";
+    tag = finalAttrs.version;
+    hash = "sha256-BSH8mTuYPYzycbuENHfi7I030JrNilksVbvntoOwlx8=";
   };
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   buildInputs = [
     bash
@@ -48,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
     pkg-config
-    asciidoc
+    asciidoctor
     libxslt
     docbook_xsl
   ];
@@ -110,10 +111,10 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater { };
 
   meta = {
-    homepage = "https://github.com/dracutdevs/dracut/wiki";
+    homepage = "https://dracut-ng.github.io/";
     description = "Event driven initramfs infrastructure";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -5,7 +5,7 @@
   gitUpdater,
   makeBinaryWrapper,
   pkg-config,
-  asciidoc,
+  asciidoctor,
   libxslt,
   docbook_xsl,
   bash,
@@ -29,16 +29,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dracut";
-  version = "059";
+  version = "111";
 
   src = fetchFromGitHub {
-    owner = "dracutdevs";
-    repo = "dracut";
-    rev = finalAttrs.version;
-    hash = "sha256-zSyC2SnSQkmS/mDpBXG2DtVVanRRI9COKQJqYZZCPJM=";
+    owner = "dracut-ng";
+    repo = "dracut-ng";
+    tag = finalAttrs.version;
+    hash = "sha256-2jdS7/LGuLSBBXv1R/o8yjgwdXl2l2wNbZWxq01wSb0";
   };
 
   strictDeps = true;
+  __structuredAttrs = true;
 
   buildInputs = [
     bash
@@ -48,16 +49,17 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
     pkg-config
-    asciidoc
+    asciidoctor
     libxslt
     docbook_xsl
   ];
 
   postPatch = ''
     substituteInPlace dracut.sh \
-      --replace 'dracutbasedir="$dracutsysrootdir"/usr/lib/dracut' 'dracutbasedir="$dracutsysrootdir"'"$out/lib/dracut"
+      --replace-fail "dracutbasedir=\"$""{dracutsysrootdir-}\"/usr/lib/dracut" \
+        "if [ -n \"$""{dracutsysrootdir:-}\" ]; then dracutbasedir=\"$""{dracutsysrootdir}/usr/lib/dracut\" ; else dracutbasedir=\"$out/lib/dracut\" ; fi"
     substituteInPlace lsinitrd.sh \
-      --replace 'dracutbasedir=/usr/lib/dracut' "dracutbasedir=$out/lib/dracut"
+      --replace-fail 'dracutbasedir=/usr/lib/dracut' "dracutbasedir=$out/lib/dracut"
 
     echo 'DRACUT_VERSION=${finalAttrs.version}' >dracut-version.sh
   '';
@@ -110,10 +112,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater { };
 
   meta = {
-    homepage = "https://github.com/dracutdevs/dracut/wiki";
+    homepage = "https://dracut-ng.github.io/";
+    changelog = "https://github.com/dracut-ng/dracut/blob/${finalAttrs.src.tag}/NEWS.md";
     description = "Event driven initramfs infrastructure";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Update dracut 059 to 110

Previously linked homepage https://github.com/dracutdevs/dracut/wiki states "Dracut development has moved to https://github.com/dracut-ng/dracut-ng .". The new repo is a continuation and now at version 110.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
