### PR TITLE
munge: split outputs, out -> out, dev, man

### DIFF
--- a/pkgs/by-name/mu/munge/package.nix
+++ b/pkgs/by-name/mu/munge/package.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-Hoaldm55E0HC3qqqBS5uZvlgcWepnVLyJNQMB2P/t9Q=";
   };
 
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     libgcrypt # provides libgcrypt.m4

--- a/pkgs/by-name/pm/pmix/package.nix
+++ b/pkgs/by-name/pm/pmix/package.nix
@@ -61,7 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-libevent=${lib.getDev libevent}"
     "--with-libevent-libdir=${lib.getLib libevent}/lib"
-    "--with-munge=${munge}"
+    "--with-munge=${lib.getDev munge}"
+    "--with-munge-libdir=${lib.getLib munge}/lib"
     "--with-hwloc=${lib.getDev hwloc}"
     "--with-hwloc-libdir=${lib.getLib hwloc}/lib"
   ];

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -126,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-json=${lib.getDev json_c}"
     "--with-jwt=${libjwt}"
     "--with-lz4=${lib.getDev lz4}"
-    "--with-munge=${munge}"
+    "--with-munge=${lib.getDev munge}"
     "--with-yaml=${lib.getDev libyaml}"
     "--with-ofed=${lib.getDev rdma-core}"
     "--sysconfdir=/etc/slurm"


### PR DESCRIPTION
Split the outputs to get a leaner runtime closure for slurm and other workload managers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
