### PR TITLE
nanomq: 0.24.11 → 0.25.6

### DIFF
--- a/pkgs/by-name/na/nanomq/package.nix
+++ b/pkgs/by-name/na/nanomq/package.nix
@@ -50,13 +50,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nanomq";
-  version = "0.24.11";
+  version = "0.24.13";
 
   src = fetchFromGitHub {
     owner = "emqx";
     repo = "nanomq";
     tag = finalAttrs.version;
-    hash = "sha256-I2SLc/KbkBvqbbWuLr8ARmmg4DeE7ZbTqcM1tw8WhwQ=";
+    hash = "sha256-qkLKVpTEMXKQKZhDOukJpVZx3pY/DBqRIP45rZVHPmU=";
     fetchSubmodules = true;
   };
 
@@ -135,9 +135,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sikmir ];
     platforms = lib.platforms.unix;
-    knownVulnerabilities = [
-      "CVE-2026-22040"
-      "CVE-2025-68699"
-    ];
   };
 })

--- a/pkgs/by-name/na/nanomq/package.nix
+++ b/pkgs/by-name/na/nanomq/package.nix
@@ -50,13 +50,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nanomq";
-  version = "0.24.11";
+  version = "0.25.6";
 
   src = fetchFromGitHub {
-    owner = "emqx";
+    owner = "nanomq";
     repo = "nanomq";
     tag = finalAttrs.version;
-    hash = "sha256-I2SLc/KbkBvqbbWuLr8ARmmg4DeE7ZbTqcM1tw8WhwQ=";
+    hash = "sha256-Ym57iLZFnmR7NErX8qE8I9ApNPC08Z437b3tWTeqcIw=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2026-22040 - Affected versions: 0.24.6
https://nvd.nist.gov/vuln/detail/CVE-2025-68699 - Affected versions: 0.24.6

Resolves #512405: CVE-2026-32135 - Versions prior to 0.24.11

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
