### PR TITLE
brief: init at 0.6.0

### DIFF
--- a/pkgs/by-name/br/brief/package.nix
+++ b/pkgs/by-name/br/brief/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "brief";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "git-pkgs";
+    repo = "brief";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hmDtvHG51vK8s12Bh6hYkfEyLDauRUEEAIvE8n5XHuM=";
+  };
+  vendorHash = "sha256-9pxFAnvENcf1YJGrwrjO6ykknzCxXlc6P2UMsWxTjCA=";
+
+  ldflags = [
+    "-X github.com/git-pkgs/brief.Version=${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool that detects a software project's toolchain, configuration, and conventions";
+    homepage = "https://github.com/git-pkgs/brief";
+    changelog = "https://github.com/git-pkgs/brief/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ junestepp ];
+    mainProgram = "brief";
+  };
+})


### PR DESCRIPTION
Add brief, a CLI tool that detects a software project's toolchain, configuration, and conventions, then outputs a structured report. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.