### PR TITLE
various packages: drop markuskowa as maintainer

### DIFF
--- a/pkgs/by-name/gp/gpredict/package.nix
+++ b/pkgs/by-name/gp/gpredict/package.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     homepage = "http://gpredict.oz9aec.net/";
     maintainers = with lib.maintainers; [
-      markuskowa
       cmcdragonkai
       pandapip1
     ];

--- a/pkgs/by-name/qg/qgit/package.nix
+++ b/pkgs/by-name/qg/qgit/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Graphical front-end to Git";
     maintainers = with lib.maintainers; [
       peterhoeg
-      markuskowa
     ];
     inherit (qt6.qtbase.meta) platforms;
     mainProgram = "qgit";

--- a/pkgs/by-name/sn/snapper/package.nix
+++ b/pkgs/by-name/sn/snapper/package.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://snapper.io";
     license = lib.licenses.gpl2Only;
     mainProgram = "snapper";
-    maintainers = with lib.maintainers; [ markuskowa ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/te/texmaker/package.nix
+++ b/pkgs/by-name/te/texmaker/package.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       cfouche
-      markuskowa
     ];
     mainProgram = "texmaker";
   };


### PR DESCRIPTION
Some spring cleaning. I no longer use these packages. My time is more limited these days, and I need to reduce  my maintainer load.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
