### PR TITLE
guitarix-vst: init at 0.5

### DIFF
--- a/pkgs/by-name/gu/guitarix-vst/package.nix
+++ b/pkgs/by-name/gu/guitarix-vst/package.nix
@@ -1,0 +1,76 @@
+{
+  alsa-lib,
+  avahi,
+  boost,
+  curl,
+  fetchFromGitHub,
+  fftwFloat,
+  freetype,
+  glib,
+  glibmm,
+  lib,
+  libsndfile,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+  lilv,
+  ncurses,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "guitarix-vst";
+  version = "0.5";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = "guitarix.vst";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SuKPTdYt9sFAZGFsf5P6nl4lzTOirOTOeRoCJEMH76w=";
+    fetchSubmodules = true;
+  };
+
+  postPatch = ''
+    substituteInPlace Builds/LinuxMakefile/Makefile \
+      --replace-fail '$(shell arch)' '${stdenv.hostPlatform.uname.processor}'
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    ncurses
+  ];
+
+  buildInputs = [
+    alsa-lib
+    avahi
+    boost
+    curl
+    fftwFloat
+    freetype
+    glib
+    glibmm
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+    lilv
+    libsndfile
+  ];
+
+  installFlags = [ "JUCE_VST3DESTDIR=${placeholder "out"}/lib/vst3" ];
+
+  meta = {
+    description = "Versatile (guitar) amplifier VST3 plugin";
+    homepage = "https://github.com/brummer10/guitarix.vst";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.eymeric ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add the guitarix-vst package, heavily based on the AUR one.

## Things done

<img width="1110" height="938" alt="image" src="https://github.com/user-attachments/assets/a91f8b76-f9ba-4c21-831f-35ef6ddec1fb" />

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
