### PR TITLE
phosh: 0.51.0 -> 0.54.0

### DIFF
--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -40,6 +40,10 @@
   nixosTests,
   gmobile,
   appstream,
+  qrcodegen,
+  gobject-introspection,
+  docutils,
+  gi-docgen,
 }:
 
 let
@@ -51,6 +55,8 @@ let
     repo = "libcall-ui";
     tag = "v0.1.5";
     hash = "sha256-4lSTwSRZditK51N/4s3tmIOgffe5+WyKxVq2IGqWRn4=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 
   # Derived from subprojects/gvc.wrap
@@ -58,13 +64,15 @@ let
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "libgnome-volume-control";
-    rev = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6";
-    hash = "sha256-gdgTnxzH8BeYQAsvv++Yq/8wHi7ISk2LTBfU8hk12NM=";
+    rev = "d2442f455844e5292cb4a74ffc66ecc8d7595a9f";
+    hash = "sha256-10n441b7m/mvQRdrmEsxGxqjKUWzjGvnzJy256NZN5s=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "phosh";
-  version = "0.51.0";
+  version = "0.54.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -72,7 +80,9 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Phosh";
     repo = "phosh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bM1eKa5/aBjAHOFYyqjs6pLmr3R/WoK3590yGiLVNM4=";
+    hash = "sha256-gByZRyUe17JY5imgtRdubJl1VH1JxlzmDQkHOtEIvj8=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 
   nativeBuildInputs = [
@@ -83,6 +93,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     wayland-scanner
     wrapGAppsHook4
+    docutils
+    gi-docgen
   ];
 
   buildInputs = [
@@ -111,6 +123,8 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     feedbackd
     appstream
+    qrcodegen
+    gobject-introspection
   ];
 
   nativeCheckInputs = [
@@ -131,6 +145,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Save some time building if tests are disabled
     "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-Dc_args=-I${glib.dev}/include/gio-unix-2.0/"
+    "-Dsearchd=true"
+    "-Dbindings-lib=true"
+    "-Dgtk_doc=true"
+    "-Dman=true"
   ];
 
   checkPhase = ''
@@ -157,7 +175,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    description = "Pure Wayland shell prototype for GNOME on mobile devices";
+    description = "Pure Wayland shell for mobile devices";
     homepage = "https://gitlab.gnome.org/World/Phosh/phosh";
     changelog = "https://gitlab.gnome.org/World/Phosh/phosh/-/blob/v${finalAttrs.version}/debian/changelog";
     license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -28,16 +28,21 @@
   libyaml,
   mobile-broadband-provider-info,
   modemmanager,
+  gobject-introspection,
+  appstream,
+  gst_all_1,
 }:
 
 let
   # Derived from subprojects/gvc.wrap
   gvc = fetchFromGitLab {
     domain = "gitlab.gnome.org";
-    owner = "GNOME";
+    owner = "guidog";
     repo = "libgnome-volume-control";
-    rev = "5f9768a2eac29c1ed56f1fbb449a77a3523683b6";
-    hash = "sha256-gdgTnxzH8BeYQAsvv++Yq/8wHi7ISk2LTBfU8hk12NM=";
+    rev = "d2442f455844e5292cb4a74ffc66ecc8d7595a9f";
+    hash = "sha256-10n441b7m/mvQRdrmEsxGxqjKUWzjGvnzJy256NZN5s=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
   # Derived from subprojects/glibcellbroadcast.wrap
   libcellbroadcast = fetchFromGitLab {
@@ -46,6 +51,8 @@ let
     repo = "cellbroadcastd";
     tag = "v0.0.2";
     hash = "sha256-rs9MoC54sVrs3HK0cbX4msYWA63y+DlDOZ5LboVtW9Y=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
   # Derived from subprojects/libcellbroadcast/subprojects/gvdb.wrap
   gvdb = fetchFromGitLab {
@@ -54,11 +61,13 @@ let
     repo = "gvdb";
     rev = "4758f6fb7f889e074e13df3f914328f3eecb1fd3";
     hash = "sha256-4mqoHPlrMPenoGPwDqbtv4/rJ/uq9Skcm82pRvOxNIk=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 in
 stdenv.mkDerivation rec {
   pname = "phosh-mobile-settings";
-  version = "0.51.0";
+  version = "0.54.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -66,7 +75,9 @@ stdenv.mkDerivation rec {
     owner = "Phosh";
     repo = "phosh-mobile-settings";
     rev = "v${version}";
-    hash = "sha256-eIRhxhU+u4cocqyw7ab5BefTp9om5UaiqrJWwN+RtoQ=";
+    hash = "sha256-TuwxzzalNhNJwPmmPJmxsHebzksPYv8jV6K0vYntQIw=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 
   nativeBuildInputs = [
@@ -77,6 +88,8 @@ stdenv.mkDerivation rec {
     wayland-scanner
     wrapGAppsHook4
     glib.dev
+    gobject-introspection
+    appstream
   ];
 
   buildInputs = [
@@ -97,6 +110,7 @@ stdenv.mkDerivation rec {
     libyaml
     mobile-broadband-provider-info
     modemmanager
+    gst_all_1.gst-plugins-base
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -36,11 +36,13 @@ let
     repo = "gvdb";
     rev = "4758f6fb7f889e074e13df3f914328f3eecb1fd3";
     hash = "sha256-4mqoHPlrMPenoGPwDqbtv4/rJ/uq9Skcm82pRvOxNIk=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "phoc";
-  version = "0.53.0";
+  version = "0.54.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -48,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Phosh";
     repo = "phoc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qBeOsHxdcJjAx/KGJEQKuqkexp1lGWeEaJPBjAy1Yxw=";
+    hash = "sha256-P81D3gCC4Q1JQPUlAtLbMZdlVOPpJJ1/rLX7zijFcc0=";
     # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
     forceFetchGit = true;
   };

--- a/pkgs/by-name/qr/qrcodegen/package.nix
+++ b/pkgs/by-name/qr/qrcodegen/package.nix
@@ -38,6 +38,12 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dt $out/lib/ libqrcodegen.a
     install -Dt $out/include/qrcodegen/ qrcodegen.h
 
+    mkdir -p $out/lib/pkgconfig
+    substitute ${./qrcodegen.pc} $out/lib/pkgconfig/qrcodegen.pc \
+      --subst-var out \
+      --subst-var pname \
+      --subst-var version
+
     runHook postInstall
   '';
 

--- a/pkgs/by-name/qr/qrcodegen/qrcodegen.pc
+++ b/pkgs/by-name/qr/qrcodegen/qrcodegen.pc
@@ -1,0 +1,9 @@
+prefix=@out@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @pname@
+Description: High-quality QR Code generator library in many languages
+Version: @version@
+Cflags: -I${includedir}/qrcodegen
+Libs: -L${libdir} -lqrcodegen

--- a/pkgs/by-name/st/stevia/package.nix
+++ b/pkgs/by-name/st/stevia/package.nix
@@ -22,17 +22,20 @@
   libxkbcommon,
   systemd,
   nix-update-script,
+  dconf,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "stevia";
-  version = "0.52.1";
+  version = "0.54.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World/Phosh";
     repo = "stevia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GdAKy7F8SRGtfmN6as6AAg6p/WJrcDPp338OHUXoORM=";
+    hash = "sha256-eCM2PSn0sDnL7iDbgt6phQsGmdeBfkVjOkxt42WxyXo=";
+    # Workaround for https://github.com/NixOS/nixpkgs/issues/485701
+    forceFetchGit = true;
   };
 
   mesonFlags = [
@@ -67,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     libhandy
     libxkbcommon
     systemd
+    dconf
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Just smalls updates to the Phosh DE.

Notable changes:

- Added `forceFetchGit = true;` for every `fetchFromGitLab` because of #485701 
- Added a pkg-config .pc file for qrcodegen because it is now a dependency of Phosh, and there is no .pc file for it to simplify the linking process.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
