### PR TITLE
python3Packages.netbox-qrcode: fix build failure

### DIFF
--- a/pkgs/development/python-modules/netbox-qrcode/default.nix
+++ b/pkgs/development/python-modules/netbox-qrcode/default.nix
@@ -9,7 +9,7 @@
   # dependencies
   pillow,
   qrcode,
-  psycopg,
+  psycopg2,
 
   # nativeCheckInputs
   django,
@@ -40,7 +40,7 @@ buildPythonPackage (finalAttrs: {
     django
     netaddr
     netbox
-    psycopg # not specified in pyproject.toml, but required at import time
+    psycopg2 # not specified in pyproject.toml, but required at import time
   ];
 
   preFixup = ''


### PR DESCRIPTION
Saw the build failure on [nfd.1l.is](https://nfd.1l.is/?selected=m8c)

`netbox-qrcode` depends on `psycopg2`, not the latest `psycopg`.

<details>
  <summary>
  Build failure logs
  </summary>

```
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 759, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "/nix/store/4q3izh0xr2ymxy02fxl56qsvk8zk9h0a-python3.14-netbox-qrcode-0.0.20/lib/python3.14/site-packages/netbox_qrcode/__init__.py", line 1, in <module>
    from netbox.plugins import PluginConfig
  File "/nix/store/xms630b8d023myp2hmxv2q03d56ck4hm-netbox-4.5.7/opt/netbox/netbox/netbox/plugins/__init__.py", line 14, in <module>
    from .navigation import *
  File "/nix/store/xms630b8d023myp2hmxv2q03d56ck4hm-netbox-4.5.7/opt/netbox/netbox/netbox/plugins/navigation.py", line 5, in <module>
    from netbox.choices import ButtonColorChoices
  File "/nix/store/xms630b8d023myp2hmxv2q03d56ck4hm-netbox-4.5.7/opt/netbox/netbox/netbox/choices.py", line 3, in <module>
    from utilities.choices import ChoiceSet
  File "/nix/store/xms630b8d023myp2hmxv2q03d56ck4hm-netbox-4.5.7/opt/netbox/netbox/utilities/choices.py", line 6, in <module>
    from utilities.data import get_config_value_ci
  File "/nix/store/xms630b8d023myp2hmxv2q03d56ck4hm-netbox-4.5.7/opt/netbox/netbox/utilities/data.py", line 4, in <module>
    from django.db.backends.postgresql.psycopg_any import NumericRange
  File "/nix/store/5ghrw44w2cx1373dix3d33r56nl5g22p-python3.14-django-5.2.12/lib/python3.14/site-packages/django/db/backends/postgresql/psycopg_any.py", line 77, in <module>
    from psycopg2 import errors, extensions, sql  # NOQA
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'psycopg2'
error: builder for '/nix/store/inn5i41s470avkrjr3q66phjwkdxa27v-python3.14-netbox-qrcode-0.0.20.drv' failed with exit code 1
```
</details>


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
