### PR TITLE
minc_tools: migrate to by-name

### DIFF
--- a/pkgs/by-name/mi/minc_tools/package.nix
+++ b/pkgs/by-name/mi/minc_tools/package.nix
@@ -6,13 +6,16 @@
   makeWrapper,
   flex,
   bison,
-  perl,
-  TextFormat,
+  perlPackages,
   libminc,
   libjpeg,
   nifticlib,
   zlib,
 }:
+
+let
+  inherit (perlPackages) perl TextFormat;
+in
 
 stdenv.mkDerivation {
   pname = "minc-tools";
@@ -30,6 +33,16 @@ stdenv.mkDerivation {
   # Upstream issue: https://github.com/BIC-MNI/minc-tools/issues/123
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace-fail "SET CMP0026 OLD" "SET CMP0026 NEW"
+
+    # FIX: Rename the colliding NAN token to MINC_NAN in the flex/bison parser files
+    sed -i 's/\bNAN\b/MINC_NAN/g' progs/minccalc/gram.y progs/minccalc/lex.l
+
+    # FIX: Rename the colliding fdiv function to avoid glibc 2.42 <math.h> conflicts
+    sed -i 's/\bfdiv\b/minc_fdiv/g' progs/mincblob/mincblob.c
+
+    # FIX: Remove legacy unprototyped C declarations that break under GCC 15 strictness
+    sed -i 's/, \*mat_create()//g' conversion/minctoecat/ecat_write.c
+    sed -i 's/\*fopen(), //g' conversion/minctoecat/ecat_write.c
   '';
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11398,10 +11398,6 @@ with pkgs;
     useRx3d = true;
   };
 
-  minc_tools = callPackage ../applications/science/biology/minc-tools {
-    inherit (perlPackages) perl TextFormat;
-  };
-
   raxml-mpi = raxml.override { useMpi = true; };
 
   ### SCIENCE/MACHINE LEARNING


### PR DESCRIPTION
This pull request refactors the packaging of `minc-tools` by moving its Nix expression to a new location and updating its dependencies and build process for better compatibility and maintainability. The changes include improvements to how Perl dependencies are handled, as well as several important patches to the build scripts to resolve compatibility issues with newer toolchains.

Key changes:

**Refactoring and Dependency Management:**
* Moved the `minc-tools` package definition from `pkgs/applications/science/biology/minc-tools/default.nix` to `pkgs/by-name/mi/minc_tools/package.nix`, and updated dependency handling to use `perlPackages` for `perl` and `TextFormat` instead of referencing them directly.

**Build and Compatibility Fixes:**
* Added patches in the `postPatch` phase to:
  - Rename the colliding `NAN` token to `MINC_NAN` in Flex/Bison parser files to avoid macro conflicts.
  - Rename the `fdiv` function to `minc_fdiv` in `mincblob.c` to prevent conflicts with glibc 2.42's `<math.h>`.
  - Remove legacy unprototyped C declarations in `ecat_write.c` to fix build failures under GCC 15 strictness.

**Top-level Package List Cleanup:**
* Removed the old reference to `minc_tools` from `pkgs/top-level/all-packages.nix`, reflecting the migration to the new package location and dependency style.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
