### PR TITLE
nixos/pam: allow disabling entirely

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1842,6 +1842,17 @@ in
 
   options = {
 
+    security.pam.enable = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+
+      description = ''
+        Whether to enable PAM, or entirely disable it.
+
+        Unless you're building a container image, you probably don't want to disable PAM.
+      '';
+    };
+
     security.pam.package = lib.mkPackageOption pkgs "pam" { };
 
     security.pam.loginLimits = lib.mkOption {
@@ -2463,200 +2474,207 @@ in
 
   ###### implementation
 
-  config = {
-    assertions = [
-      {
-        assertion = config.users.motd == "" || config.users.motdFile == null;
-        message = ''
-          Only one of users.motd and users.motdFile can be set.
-        '';
-      }
-      {
-        assertion = config.security.pam.zfs.enable -> config.boot.zfs.enabled;
-        message = ''
-          `security.pam.zfs.enable` requires enabling ZFS (`boot.zfs.enabled`).
-        '';
-      }
-      {
-        assertion = with config.security.pam.sshAgentAuth; enable -> authorizedKeysFiles != [ ];
-        message = ''
-          `security.pam.enableSSHAgentAuth` requires `services.openssh.authorizedKeysFiles` to be a non-empty list.
-          Did you forget to set `services.openssh.enable` ?
-        '';
-      }
-      {
-        assertion =
-          with config.security.pam.rssh;
-          enable
-          -> (settings.auth_key_file or null != null || settings.authorized_keys_command or null != null);
-        message = ''
-          security.pam.rssh.enable requires either security.pam.rssh.settings.auth_key_file or
-          security.pam.rssh.settings.authorized_keys_command to be set.
-        '';
-      }
-    ];
+  config = lib.mkMerge [
+    {
+      warnings = lib.optional (
+        !config.security.pam.enable && !config.boot.isContainer
+      ) "PAM disabled but boot.isContainer is not set.";
+    }
+    (lib.mkIf config.security.pam.enable {
+      assertions = [
+        {
+          assertion = config.users.motd == "" || config.users.motdFile == null;
+          message = ''
+            Only one of users.motd and users.motdFile can be set.
+          '';
+        }
+        {
+          assertion = config.security.pam.zfs.enable -> config.boot.zfs.enabled;
+          message = ''
+            `security.pam.zfs.enable` requires enabling ZFS (`boot.zfs.enabled`).
+          '';
+        }
+        {
+          assertion = with config.security.pam.sshAgentAuth; enable -> authorizedKeysFiles != [ ];
+          message = ''
+            `security.pam.enableSSHAgentAuth` requires `services.openssh.authorizedKeysFiles` to be a non-empty list.
+            Did you forget to set `services.openssh.enable` ?
+          '';
+        }
+        {
+          assertion =
+            with config.security.pam.rssh;
+            enable
+            -> (settings.auth_key_file or null != null || settings.authorized_keys_command or null != null);
+          message = ''
+            security.pam.rssh.enable requires either security.pam.rssh.settings.auth_key_file or
+            security.pam.rssh.settings.authorized_keys_command to be set.
+          '';
+        }
+      ];
 
-    warnings =
-      lib.optional
-        (
-          with config.security.pam.sshAgentAuth;
-          enable && lib.any (s: lib.hasPrefix "%h" s || lib.hasPrefix "~" s) authorizedKeysFiles
-        )
-        ''
-          security.pam.sshAgentAuth.authorizedKeysFiles contains files in the user's home directory.
-
-          Specifying user-writeable files there result in an insecure configuration:
-          a malicious process can then edit such an authorized_keys file and bypass the ssh-agent-based authentication.
-          See https://github.com/NixOS/nixpkgs/issues/31611
-        ''
-      ++
+      warnings =
         lib.optional
           (
-            with config.security.pam.rssh;
-            enable && settings.auth_key_file or null != null && settings.authorized_keys_command or null != null
+            with config.security.pam.sshAgentAuth;
+            enable && lib.any (s: lib.hasPrefix "%h" s || lib.hasPrefix "~" s) authorizedKeysFiles
           )
           ''
-            security.pam.rssh.settings.auth_key_file will be ignored as
-            security.pam.rssh.settings.authorized_keys_command has been specified.
-            Explictly set the former to null to silence this warning.
-          '';
+            security.pam.sshAgentAuth.authorizedKeysFiles contains files in the user's home directory.
 
-    environment.systemPackages =
-      # Include the PAM modules in the system path mostly for the manpages.
-      [ package ]
-      ++ lib.optional config.users.ldap.enable pam_ldap
-      ++ lib.optional config.services.kanidm.unix.enable config.services.kanidm.package
-      ++ lib.optional config.services.sssd.enable pkgs.sssd
-      ++ lib.optionals config.security.pam.krb5.enable [
-        pam_krb5
-        pam_ccreds
-      ]
-      ++ lib.optionals config.security.pam.enableOTPW [ pkgs.otpw ]
-      ++ lib.optionals config.security.pam.oath.enable [ pkgs.oath-toolkit ]
-      ++ lib.optionals config.security.pam.p11.enable [ pkgs.pam_p11 ]
-      ++ lib.optionals config.security.pam.enableFscrypt [ pkgs.fscrypt-experimental ]
-      ++ lib.optionals config.security.pam.u2f.enable [ pkgs.pam_u2f ];
+            Specifying user-writeable files there result in an insecure configuration:
+            a malicious process can then edit such an authorized_keys file and bypass the ssh-agent-based authentication.
+            See https://github.com/NixOS/nixpkgs/issues/31611
+          ''
+        ++
+          lib.optional
+            (
+              with config.security.pam.rssh;
+              enable && settings.auth_key_file or null != null && settings.authorized_keys_command or null != null
+            )
+            ''
+              security.pam.rssh.settings.auth_key_file will be ignored as
+              security.pam.rssh.settings.authorized_keys_command has been specified.
+              Explictly set the former to null to silence this warning.
+            '';
 
-    security.wrappers = {
-      unix_chkpwd = {
-        setuid = true;
-        owner = "root";
-        group = "root";
-        source = "${package}/bin/unix_chkpwd";
+      environment.systemPackages =
+        # Include the PAM modules in the system path mostly for the manpages.
+        [ package ]
+        ++ lib.optional config.users.ldap.enable pam_ldap
+        ++ lib.optional config.services.kanidm.unix.enable config.services.kanidm.package
+        ++ lib.optional config.services.sssd.enable pkgs.sssd
+        ++ lib.optionals config.security.pam.krb5.enable [
+          pam_krb5
+          pam_ccreds
+        ]
+        ++ lib.optionals config.security.pam.enableOTPW [ pkgs.otpw ]
+        ++ lib.optionals config.security.pam.oath.enable [ pkgs.oath-toolkit ]
+        ++ lib.optionals config.security.pam.p11.enable [ pkgs.pam_p11 ]
+        ++ lib.optionals config.security.pam.enableFscrypt [ pkgs.fscrypt-experimental ]
+        ++ lib.optionals config.security.pam.u2f.enable [ pkgs.pam_u2f ];
+
+      security.wrappers = {
+        unix_chkpwd = {
+          setuid = true;
+          owner = "root";
+          group = "root";
+          source = "${package}/bin/unix_chkpwd";
+        };
       };
-    };
 
-    environment.etc = lib.mapAttrs' makePAMService enabledServices;
+      environment.etc = lib.mapAttrs' makePAMService enabledServices;
 
-    systemd =
-      lib.mkIf (lib.any (service: service.updateWtmp) (lib.attrValues config.security.pam.services))
-        {
-          tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
-          services.lastlog2-import = {
-            enable = true;
-            wantedBy = [ "default.target" ];
-            after = [
-              "local-fs.target"
-              "systemd-tmpfiles-setup.service"
-            ];
-            # TODO: ${pkgs.util-linux.lastlog}/lib/systemd/system/lastlog2-import.service
-            # uses unpatched /usr/bin/mv, needs to be fixed on staging
-            # in the meantime, use a service drop-in here
-            serviceConfig.ExecStartPost = [
-              ""
-              "${lib.getExe' pkgs.coreutils "mv"} /var/log/lastlog /var/log/lastlog.migrated"
-            ];
+      systemd =
+        lib.mkIf (lib.any (service: service.updateWtmp) (lib.attrValues config.security.pam.services))
+          {
+            tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
+            services.lastlog2-import = {
+              enable = true;
+              wantedBy = [ "default.target" ];
+              after = [
+                "local-fs.target"
+                "systemd-tmpfiles-setup.service"
+              ];
+              # TODO: ${pkgs.util-linux.lastlog}/lib/systemd/system/lastlog2-import.service
+              # uses unpatched /usr/bin/mv, needs to be fixed on staging
+              # in the meantime, use a service drop-in here
+              serviceConfig.ExecStartPost = [
+                ""
+                "${lib.getExe' pkgs.coreutils "mv"} /var/log/lastlog /var/log/lastlog.migrated"
+              ];
+            };
+            packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
           };
-          packages = [ pkgs.util-linux.lastlog ]; # lib/systemd/system/lastlog2-import.service
+
+      security.pam.services = {
+        other = {
+          useDefaultRules = false;
+          rules =
+            let
+              rules = utils.pam.autoOrderRules [
+                {
+                  name = "warn";
+                  control = "required";
+                  modulePath = "${package}/lib/security/pam_warn.so";
+                }
+                {
+                  name = "deny";
+                  control = "required";
+                  modulePath = "${package}/lib/security/pam_deny.so";
+                }
+              ];
+            in
+            {
+              auth = rules;
+              account = rules;
+              password = rules;
+              session = rules;
+            };
         };
 
-    security.pam.services = {
-      other = {
-        useDefaultRules = false;
-        rules =
-          let
-            rules = utils.pam.autoOrderRules [
-              {
-                name = "warn";
-                control = "required";
-                modulePath = "${package}/lib/security/pam_warn.so";
-              }
-              {
-                name = "deny";
-                control = "required";
-                modulePath = "${package}/lib/security/pam_deny.so";
-              }
-            ];
-          in
-          {
-            auth = rules;
-            account = rules;
-            password = rules;
-            session = rules;
-          };
+        # Most of these should be moved to specific modules.
+        i3lock.enable = lib.mkDefault config.programs.i3lock.enable;
+        i3lock-color.enable = lib.mkDefault config.programs.i3lock.enable;
+        vlock.enable = lib.mkDefault config.console.enable;
+        xlock.enable = lib.mkDefault config.services.xserver.enable;
+        xscreensaver.enable = lib.mkDefault config.services.xscreensaver.enable;
+
+        runuser = {
+          rootOK = true;
+          unixAuth = false;
+          setEnvironment = false;
+        };
+
+        /*
+          FIXME: should runuser -l start a systemd session? Currently
+          it complains "Cannot create session: Already running in a
+          session".
+        */
+        runuser-l = {
+          rootOK = true;
+          unixAuth = false;
+        };
+      }
+      // lib.optionalAttrs (config.security.pam.enableFscrypt) {
+        # Allow fscrypt to verify login passphrase
+        fscrypt = { };
       };
 
-      # Most of these should be moved to specific modules.
-      i3lock.enable = lib.mkDefault config.programs.i3lock.enable;
-      i3lock-color.enable = lib.mkDefault config.programs.i3lock.enable;
-      vlock.enable = lib.mkDefault config.console.enable;
-      xlock.enable = lib.mkDefault config.services.xserver.enable;
-      xscreensaver.enable = lib.mkDefault config.services.xscreensaver.enable;
+      security.apparmor.includes."abstractions/pam" =
+        lib.concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
+          lib.attrNames enabledServices
+        )
+        + (
+          with lib;
+          pipe enabledServices [
+            lib.attrValues
+            (catAttrs "rules")
+            (lib.concatMap lib.attrValues)
+            (lib.concatMap lib.attrValues)
+            (lib.filter (rule: rule.enable))
+            (lib.filter (
+              rule:
+              !builtins.elem rule.control [
+                "include"
+                "substack"
+              ]
+            ))
+            (lib.catAttrs "modulePath")
+            (map (
+              modulePath:
+              lib.throwIfNot (lib.hasPrefix "/" modulePath)
+                ''non-absolute PAM modulePath "${modulePath}" is unsupported by apparmor''
+                modulePath
+            ))
+            lib.unique
+            (map (module: "mr ${module},"))
+            concatLines
+          ]
+        );
 
-      runuser = {
-        rootOK = true;
-        unixAuth = false;
-        setEnvironment = false;
-      };
-
-      /*
-        FIXME: should runuser -l start a systemd session? Currently
-        it complains "Cannot create session: Already running in a
-        session".
-      */
-      runuser-l = {
-        rootOK = true;
-        unixAuth = false;
-      };
-    }
-    // lib.optionalAttrs (config.security.pam.enableFscrypt) {
-      # Allow fscrypt to verify login passphrase
-      fscrypt = { };
-    };
-
-    security.apparmor.includes."abstractions/pam" =
-      lib.concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
-        lib.attrNames enabledServices
-      )
-      + (
-        with lib;
-        pipe enabledServices [
-          lib.attrValues
-          (catAttrs "rules")
-          (lib.concatMap lib.attrValues)
-          (lib.concatMap lib.attrValues)
-          (lib.filter (rule: rule.enable))
-          (lib.filter (
-            rule:
-            !builtins.elem rule.control [
-              "include"
-              "substack"
-            ]
-          ))
-          (lib.catAttrs "modulePath")
-          (map (
-            modulePath:
-            lib.throwIfNot (lib.hasPrefix "/" modulePath)
-              ''non-absolute PAM modulePath "${modulePath}" is unsupported by apparmor''
-              modulePath
-          ))
-          lib.unique
-          (map (module: "mr ${module},"))
-          concatLines
-        ]
-      );
-
-    security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;
-    security.sudo-rs.extraConfig = optionalSudoConfigForSSHAgentAuth;
-  };
+      security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;
+      security.sudo-rs.extraConfig = optionalSudoConfigForSSHAgentAuth;
+    })
+  ];
 }

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1854,6 +1854,17 @@ in
 
   options = {
 
+    security.pam.enable = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+
+      description = ''
+        Whether to enable PAM, or entirely disable it.
+
+        Unless you're building a container image, you probably don't want to disable PAM.
+      '';
+    };
+
     security.pam.package = lib.mkPackageOption pkgs "pam" { };
 
     security.pam.loginLimits = lib.mkOption {
@@ -2475,7 +2486,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = lib.mkIf config.security.pam.enable {
     assertions = [
       {
         assertion = config.users.motd == "" || config.users.motdFile == null;


### PR DESCRIPTION
In containers, it can be reasonable to have no interactive logins at all  and to run the container entirely 'lights out'. In this setting, PAM is  dead weight, and adds considerably to container image size (mostly by  bringing other things in to the closure). However, presently, there's no  way to get rid of it.

This change adds the coarse tool of entirely disabling PAM. Because  other settings (desktops and servers) likely don't want to be twiddling  this, a warning is added. That _could_ be an assertion, but I reasoned  that there might be odd cases where it's desired - and not having PAM is  not something that entirely disables the system, so a hard assertion  feels wrong. I am also trying not to get sucked in to the morass of  reforming pam.nix more broadly to make it less cumbersome, hence the  coarsity of the setting.

The diff is slightly annoying to read due to a formatting change caused by the extra layers of wrapping, but there aren't any semantic changes in the config payload.

I don't know how to predict if this ought to be targetting master or staging-nixos. I'm happy to retarget if master is wrong!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
