### PR TITLE
various: remove duplicated `v` prefix in changelog url

### DIFF
--- a/pkgs/by-name/bt/btest/package.nix
+++ b/pkgs/by-name/bt/btest/package.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Bandwidth Test server and client";
     homepage = "https://github.com/manawenuz/btest-rs";
-    changelog = "https://github.com/manawenuz/btest-rs/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/manawenuz/btest-rs/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "btest";

--- a/pkgs/by-name/go/gonzo/package.nix
+++ b/pkgs/by-name/go/gonzo/package.nix
@@ -38,7 +38,7 @@ buildGoModule (finalAttrs: {
     description = "TUI log analysis tool";
     homepage = "https://gonzo.controltheory.com/";
     downloadPage = "https://github.com/control-theory/gonzo";
-    changelog = "https://github.com/control-theory/gonzo/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/control-theory/gonzo/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kpbaks ];
     mainProgram = "gonzo";

--- a/pkgs/by-name/jj/jj-pre-push/package.nix
+++ b/pkgs/by-name/jj/jj-pre-push/package.nix
@@ -51,7 +51,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Run pre-commit.com before `jj git push`";
     homepage = "https://github.com/acarapetis/jj-pre-push";
-    changelog = "https://github.com/acarapetis/jj-pre-push/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/acarapetis/jj-pre-push/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ xanderio ];
     mainProgram = "jj-pre-push";

--- a/pkgs/by-name/le/legitify/package.nix
+++ b/pkgs/by-name/le/legitify/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
   meta = {
     description = "Tool to detect and remediate misconfigurations and security risks of GitHub assets";
     homepage = "https://github.com/Legit-Labs/legitify";
-    changelog = "https://github.com/Legit-Labs/legitify/releases/tag/v${src.tag}";
+    changelog = "https://github.com/Legit-Labs/legitify/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "legitify";

--- a/pkgs/by-name/mx/mx-takeover/package.nix
+++ b/pkgs/by-name/mx/mx-takeover/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Tool to work with DNS MX records";
     homepage = "https://github.com/musana/mx-takeover";
-    changelog = "https://github.com/musana/mx-takeover/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/musana/mx-takeover/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "mx-takeover";

--- a/pkgs/by-name/ni/nile/package.nix
+++ b/pkgs/by-name/ni/nile/package.nix
@@ -47,7 +47,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Unofficial Amazon Games client";
     homepage = "https://github.com/imLinguin/nile";
-    changelog = "https://github.com/imLinguin/nile/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/imLinguin/nile/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     mainProgram = "nile";
     maintainers = [ ];

--- a/pkgs/by-name/re/regexploit/package.nix
+++ b/pkgs/by-name/re/regexploit/package.nix
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Tool to find regular expressions which are vulnerable to ReDoS";
     homepage = "https://github.com/doyensec/regexploit";
-    changelog = "https://github.com/doyensec/regexploit/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/doyensec/regexploit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/se/sequoia-sop/package.nix
+++ b/pkgs/by-name/se/sequoia-sop/package.nix
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Implementation of the Stateless OpenPGP Command Line Interface using Sequoia";
     homepage = "https://gitlab.com/sequoia-pgp/sequoia-sop";
-    changelog = "https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/v${finalAttrs.src.tag}/NEWS";
+    changelog = "https://gitlab.com/sequoia-pgp/sequoia-sop/-/blob/${finalAttrs.src.tag}/NEWS";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ doronbehar ];
     mainProgram = "sqop";

--- a/pkgs/by-name/st/statping-ng/package.nix
+++ b/pkgs/by-name/st/statping-ng/package.nix
@@ -93,7 +93,7 @@ buildGoModule rec {
   meta = {
     description = "Status Page for monitoring your websites and applications with beautiful graphs, analytics, and plugins";
     homepage = "https://github.com/statping-ng/statping-ng";
-    changelog = "https://github.com/statping-ng/statping-ng/releases/tag/v${src.tag}";
+    changelog = "https://github.com/statping-ng/statping-ng/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       FKouhai

--- a/pkgs/by-name/wa/wappalyzergo/package.nix
+++ b/pkgs/by-name/wa/wappalyzergo/package.nix
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Implementation of the Wappalyzer Technology Detection Library";
     homepage = "https://github.com/projectdiscovery/wappalyzergo";
-    changelog = "https://github.com/projectdiscovery/wappalyzergo/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/projectdiscovery/wappalyzergo/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "wappalyzergo";

--- a/pkgs/by-name/wt/wtcat/package.nix
+++ b/pkgs/by-name/wt/wtcat/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "WebTransport CLI";
     homepage = "https://github.com/pervrosen/wtcat";
-    changelog = "https://github.com/pervrosen/wtcat/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/pervrosen/wtcat/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "wtcat";

--- a/pkgs/by-name/za/zapper/package.nix
+++ b/pkgs/by-name/za/zapper/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Zaps arguments and environment from the process list";
     homepage = "https://github.com/hackerschoice/zapper";
-    changelog = "https://github.com/hackerschoice/zapper/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/hackerschoice/zapper/releases/tag/${finalAttrs.src.tag}";
     # https://github.com/hackerschoice/zapper/issues/4
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ fab ];

--- a/pkgs/by-name/zg/zgrab2/package.nix
+++ b/pkgs/by-name/zg/zgrab2/package.nix
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Fast Application Layer Scanner";
     homepage = "https://github.com/zmap/zgrab2";
-    changelog = "https://github.com/zmap/zgrab2/releases/tag/vv${finalAttrs.version}";
+    changelog = "https://github.com/zmap/zgrab2/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       isc

--- a/pkgs/development/python-modules/aiohttp-asgi-connector/default.nix
+++ b/pkgs/development/python-modules/aiohttp-asgi-connector/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "An AIOHTTP ClientSession connector for directly interacting with ASGI applications";
     homepage = "https://github.com/thearchitector/aiohttp-asgi-connector";
-    changelog = "https://github.com/thearchitector/aiohttp-asgi-connector/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/thearchitector/aiohttp-asgi-connector/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/aiopegelonline/default.nix
+++ b/pkgs/development/python-modules/aiopegelonline/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Library to retrieve data from PEGELONLINE";
     homepage = "https://github.com/mib1185/aiopegelonline";
-    changelog = "https://github.com/mib1185/aiopegelonline/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/mib1185/aiopegelonline/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/aiovlc/default.nix
+++ b/pkgs/development/python-modules/aiovlc/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python module to control VLC";
     homepage = "https://github.com/MartinHjelmare/aiovlc";
-    changelog = "https://github.com/MartinHjelmare/aiovlc/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/MartinHjelmare/aiovlc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/asgineer/default.nix
+++ b/pkgs/development/python-modules/asgineer/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   meta = {
     description = "Really thin ASGI web framework";
     homepage = "https://asgineer.readthedocs.io";
-    changelog = "https://github.com/almarklein/asgineer/releases/tag/v${src.tag}";
+    changelog = "https://github.com/almarklein/asgineer/releases/tag/${src.tag}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ matthiasbeyer ];
   };

--- a/pkgs/development/python-modules/asyncio-dgram/default.nix
+++ b/pkgs/development/python-modules/asyncio-dgram/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python support for higher level Datagram";
     homepage = "https://github.com/jsbronder/asyncio-dgram";
-    changelog = "https://github.com/jsbronder/asyncio-dgram/blob/v${finalAttrs.src.tag}/ChangeLog";
+    changelog = "https://github.com/jsbronder/asyncio-dgram/blob/${finalAttrs.src.tag}/ChangeLog";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/censys/default.nix
+++ b/pkgs/development/python-modules/censys/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python API wrapper for the Censys Search Engine (censys.io)";
     homepage = "https://github.com/censys/censys-python";
-    changelog = "https://github.com/censys/censys-python/releases/tag/v${src.tag}";
+    changelog = "https://github.com/censys/censys-python/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "censys";

--- a/pkgs/development/python-modules/container-inspector/default.nix
+++ b/pkgs/development/python-modules/container-inspector/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Suite of analysis utilities and command line tools for container images";
     homepage = "https://github.com/nexB/container-inspector";
-    changelog = "https://github.com/nexB/container-inspector/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/nexB/container-inspector/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/cwl-upgrader/default.nix
+++ b/pkgs/development/python-modules/cwl-upgrader/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Library to upgrade CWL syntax to a newer version";
     homepage = "https://github.com/common-workflow-language/cwl-upgrader";
-    changelog = "https://github.com/common-workflow-language/cwl-upgrader/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/common-workflow-language/cwl-upgrader/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "cwl-upgrader";

--- a/pkgs/development/python-modules/cwl-utils/default.nix
+++ b/pkgs/development/python-modules/cwl-utils/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Utilities for CWL";
     homepage = "https://github.com/common-workflow-language/cwl-utils";
-    changelog = "https://github.com/common-workflow-language/cwl-utils/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/common-workflow-language/cwl-utils/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/django-modeltranslation/default.nix
+++ b/pkgs/development/python-modules/django-modeltranslation/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   meta = {
     description = "Translates Django models using a registration approach";
     homepage = "https://github.com/deschler/django-modeltranslation";
-    changelog = "https://github.com/deschler/django-modeltranslation/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/deschler/django-modeltranslation/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ augustebaum ];
   };

--- a/pkgs/development/python-modules/dnsight/default.nix
+++ b/pkgs/development/python-modules/dnsight/default.nix
@@ -85,7 +85,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "SDK and CLI tool for DNS, email and web security hygiene";
     homepage = "https://github.com/dnsight/dnsight";
-    changelog = "https://github.com/dnsight/dnsight/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/dnsight/dnsight/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "dnsight";

--- a/pkgs/development/python-modules/dotwiz/default.nix
+++ b/pkgs/development/python-modules/dotwiz/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   meta = {
     description = "Dict subclass that supports dot access notation";
     homepage = "https://github.com/rnag/dotwiz";
-    changelog = "https://github.com/rnag/dotwiz/blob/v${src.tag}/HISTORY.rst";
+    changelog = "https://github.com/rnag/dotwiz/blob/${src.tag}/HISTORY.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/emoji-country-flag/default.nix
+++ b/pkgs/development/python-modules/emoji-country-flag/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
   meta = {
     description = "Flag emoji from country codes for Python";
     homepage = "https://github.com/cvzi/flag";
-    changelog = "https://github.com/cvzi/flag/releases/tag/v${src.tag}";
+    changelog = "https://github.com/cvzi/flag/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       skohtv

--- a/pkgs/development/python-modules/freebox-api/default.nix
+++ b/pkgs/development/python-modules/freebox-api/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python module to interact with the Freebox OS API";
     homepage = "https://github.com/hacf-fr/freebox-api";
-    changelog = "https://github.com/hacf-fr/freebox-api/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/hacf-fr/freebox-api/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "freebox_api";

--- a/pkgs/development/python-modules/heretic-llm/default.nix
+++ b/pkgs/development/python-modules/heretic-llm/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Tool to remove censorship removal for language models";
     homepage = "https://github.com/p-e-w/heretic";
-    changelog = "https://github.com/p-e-w/heretic/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/p-e-w/heretic/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [
       agpl3Only
       agpl3Plus

--- a/pkgs/development/python-modules/hier-config/default.nix
+++ b/pkgs/development/python-modules/hier-config/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Module to handle hierarchical configurations";
     homepage = "https://github.com/netdevops/hier_config";
-    changelog = "https://github.com/netdevops/hier_config/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/netdevops/hier_config/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/iaqualink/default.nix
+++ b/pkgs/development/python-modules/iaqualink/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for Jandy iAqualink";
     homepage = "https://github.com/flz/iaqualink-py";
-    changelog = "https://github.com/flz/iaqualink-py/releases/tag/v${src.tag}";
+    changelog = "https://github.com/flz/iaqualink-py/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/irisclient/default.nix
+++ b/pkgs/development/python-modules/irisclient/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python client for Iris REST api";
-    changelog = "https://github.com/houqp/iris-python-client/blob/v${src.tag}/HISTORY.rst";
+    changelog = "https://github.com/houqp/iris-python-client/blob/${src.tag}/HISTORY.rst";
     homepage = "https://github.com/houqp/iris-python-client";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ onny ];

--- a/pkgs/development/python-modules/juliandate/default.nix
+++ b/pkgs/development/python-modules/juliandate/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   meta = {
     description = "Conversions between Julian Dates and Julian/Gregorian calendar dates";
     homepage = "https://github.com/seanredmond/juliandate";
-    changelog = "https://github.com/seanredmond/juliandate/blob/v${src.tag}/HISTORY.MD";
+    changelog = "https://github.com/seanredmond/juliandate/blob/${src.tag}/HISTORY.MD";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/logurich/default.nix
+++ b/pkgs/development/python-modules/logurich/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Logger that combine loguru and rich";
     homepage = "https://github.com/PakitoSec/logurich";
-    changelog = "https://github.com/PakitoSec/logurich/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/PakitoSec/logurich/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/msoffcrypto-tool/default.nix
+++ b/pkgs/development/python-modules/msoffcrypto-tool/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python tool and library for decrypting MS Office files with passwords or other keys";
     homepage = "https://github.com/nolze/msoffcrypto-tool";
-    changelog = "https://github.com/nolze/msoffcrypto-tool/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/nolze/msoffcrypto-tool/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "msoffcrypto-tool";

--- a/pkgs/development/python-modules/pook/default.nix
+++ b/pkgs/development/python-modules/pook/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   meta = {
     description = "HTTP traffic mocking and testing";
     homepage = "https://github.com/h2non/pook";
-    changelog = "https://github.com/h2non/pook/blob/v${src.tag}/History.rst";
+    changelog = "https://github.com/h2non/pook/blob/${src.tag}/History.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/postgrest/default.nix
+++ b/pkgs/development/python-modules/postgrest/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/ppf-datamatrix/default.nix
+++ b/pkgs/development/python-modules/ppf-datamatrix/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/adrianschlatter/ppf.datamatrix";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kurogeek ];
-    changelog = "https://github.com/adrianschlatter/ppf.datamatrix/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/adrianschlatter/ppf.datamatrix/releases/tag/${finalAttrs.src.tag}";
   };
 })

--- a/pkgs/development/python-modules/pyjpegls/default.nix
+++ b/pkgs/development/python-modules/pyjpegls/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   meta = {
     description = "JPEG-LS for Python via CharLS C++ Library";
     homepage = "https://github.com/pydicom/pyjpegls";
-    changelog = "https://github.com/pydicom/pyjpegls/releases/tag/v${src.tag}";
+    changelog = "https://github.com/pydicom/pyjpegls/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };

--- a/pkgs/development/python-modules/pytest-insta/default.nix
+++ b/pkgs/development/python-modules/pytest-insta/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Pytest plugin for snapshot testing";
     homepage = "https://github.com/vberlier/pytest-insta";
-    changelog = "https://github.com/vberlier/pytest-insta/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/vberlier/pytest-insta/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/python-obfuscator/default.nix
+++ b/pkgs/development/python-modules/python-obfuscator/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Module to obfuscate code";
     homepage = "https://github.com/davidteather/python-obfuscator";
-    changelog = "https://github.com/davidteather/python-obfuscator/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/davidteather/python-obfuscator/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ siegema ];
   };

--- a/pkgs/development/python-modules/socid-extractor/default.nix
+++ b/pkgs/development/python-modules/socid-extractor/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python module to extract details from personal pages";
     homepage = "https://github.com/soxoj/socid-extractor";
-    changelog = "https://github.com/soxoj/socid-extractor/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/soxoj/socid-extractor/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "socid_extractor";

--- a/pkgs/development/python-modules/starlette-context/default.nix
+++ b/pkgs/development/python-modules/starlette-context/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Middleware for Starlette that allows you to store and access the context data of a request";
     homepage = "https://github.com/tomwojcik/starlette-context";
-    changelog = "https://github.com/tomwojcik/starlette-context/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/tomwojcik/starlette-context/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ siegema ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Auth";
     homepage = "https://github.com/supabase/supabase-py/";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ macbucheron ];
   };

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/python-modules/teamcity-messages/default.nix
+++ b/pkgs/development/python-modules/teamcity-messages/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python unit test reporting to TeamCity";
     homepage = "https://github.com/JetBrains/teamcity-messages";
-    changelog = "https://github.com/JetBrains/teamcity-messages/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/JetBrains/teamcity-messages/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/typst/default.nix
+++ b/pkgs/development/python-modules/typst/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python binding to typst";
     homepage = "https://github.com/messense/typst-py";
-    changelog = "https://github.com/messense/typst-py/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/messense/typst-py/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/whodap/default.nix
+++ b/pkgs/development/python-modules/whodap/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python RDAP utility for querying and parsing information about domain names";
     homepage = "https://github.com/pogzyb/whodap";
-    changelog = "https://github.com/pogzyb/whodap/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/pogzyb/whodap/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/yaxmldiff/default.nix
+++ b/pkgs/development/python-modules/yaxmldiff/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Yet Another XML Differ";
     homepage = "https://github.com/latk/yaxmldiff.py";
-    changelog = "https://https://github.com/latk/yaxmldiff.py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/latk/yaxmldiff.py/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ sigmanificient ];
   };


### PR DESCRIPTION
- inspired by https://github.com/NixOS/nixpkgs/pull/512354

Automated with the following script. Only `sammcj/gollama` had a legitimate `vv` combo in the changelog.

```nix
{ pkgs }:

let
  # Borrowed from maintainers/scripts/check-hydra-by-maintainer.nix
  inherit (pkgs) lib;

  packagesWith =
    cond: return: prefix: set:
    (lib.flatten (
      lib.mapAttrsToList (
        name: pkg:
        let
          result = builtins.tryEval (
            if lib.isDerivation pkg && cond name pkg then
              [ (return pkg "${prefix}${name}") ]
            else if
              pkg.recurseForDerivations or false || pkg.recurseForRelease or false
            then
              packagesWith cond return "${name}." pkg
            else
              [ ]
          );
        in
        if result.success then result.value else [ ]
      ) set
    ));

  packages = packagesWith
      (
        name: pkg:
        (
          builtins.hasAttr "meta" pkg
          && builtins.hasAttr "changelog" pkg.meta
          && lib.isString pkg.meta.changelog
          && lib.strings.hasInfix "/vv" pkg.meta.changelog
        )
      )
      (pkg: name: {
        inherit name;
        inherit (pkg.meta) changelog position;
      })
      ""
      pkgs;

in packages
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
