### PR TITLE
python3Packages.python-multipart: 0.0.22 -> 0.0.29

### DIFF
--- a/pkgs/development/python-modules/asgi-csrf/default.nix
+++ b/pkgs/development/python-modules/asgi-csrf/default.nix
@@ -49,6 +49,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "asgi_csrf" ];
 
   meta = {
+    # https://github.com/simonw/asgi-csrf/issues/38
+    broken = lib.versionAtLeast python-multipart.version "0.0.26";
     description = "ASGI middleware for protecting against CSRF attacks";
     license = lib.licenses.asl20;
     homepage = "https://github.com/simonw/asgi-csrf";

--- a/pkgs/development/python-modules/frictionless/default.nix
+++ b/pkgs/development/python-modules/frictionless/default.nix
@@ -195,7 +195,8 @@ buildPythonPackage rec {
     openpyxl
     xlrd
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  # datasette is transitively broken by asgi-csrf
+  ++ lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "datasette" ]);
 
   disabledTestPaths = [
     # Requires optional dependencies that have not been packaged (commented out above)

--- a/pkgs/development/python-modules/python-multipart/default.nix
+++ b/pkgs/development/python-modules/python-multipart/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   hatchling,
   pytestCheckHook,
-  mock,
   pyyaml,
 
   # for passthru.tests
@@ -17,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-multipart";
-  version = "0.0.22";
+  version = "0.0.26";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Kludex";
     repo = "python-multipart";
     tag = finalAttrs.version;
-    hash = "sha256-UegnwGxiXQalbp18t1dl2JOQH6BY975cpBa9uo3SOuk=";
+    hash = "sha256-RBRHSpOWLENfrT42/NLhMXb/g5RAcWzbsgPQGN4XZG0=";
   };
 
   build-system = [ hatchling ];
@@ -33,7 +32,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
-    mock
     pyyaml
   ];
 

--- a/pkgs/development/python-modules/python-multipart/default.nix
+++ b/pkgs/development/python-modules/python-multipart/default.nix
@@ -2,10 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   hatchling,
   pytestCheckHook,
-  mock,
   pyyaml,
 
   # for passthru.tests
@@ -18,24 +16,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-multipart";
-  version = "0.0.22";
+  version = "0.0.29";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Kludex";
     repo = "python-multipart";
     tag = finalAttrs.version;
-    hash = "sha256-UegnwGxiXQalbp18t1dl2JOQH6BY975cpBa9uo3SOuk=";
+    hash = "sha256-1aV7gWLuulINesm3L8Wm3+prmeD9+OY/ihm36rtQPRs=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2026-40347-part-1.patch";
-      url = "https://github.com/Kludex/python-multipart/commit/6a7b76dd2653d99d8e5981d7ff09a4a047750b37.patch";
-      hash = "sha256-W1nyYMMoaf+lsNze3ppPeAXN+swG1dScDibazePSt+k=";
-    })
-    ./CVE-2026-40347-part-2.patch
-  ];
 
   build-system = [ hatchling ];
 
@@ -43,7 +32,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
-    mock
     pyyaml
   ];
 


### PR DESCRIPTION
Diff: https://github.com/Kludex/python-multipart/compare/0.0.22...0.0.29

Changelog: https://github.com/Kludex/python-multipart/blob/0.0.29/CHANGELOG.md

fixes https://github.com/NixOS/nixpkgs/issues/512408
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
