### PR TITLE
tlf: 1.4.1 -> 1.4.1-unstable-2026-03-27

### DIFF
--- a/pkgs/by-name/tl/tlf/package.nix
+++ b/pkgs/by-name/tl/tlf/package.nix
@@ -9,33 +9,25 @@
   pkg-config,
   glib,
   perl,
+  python3Packages,
   ncurses5,
   hamlib,
   xmlrpc_c,
+  pythonPluginSupport ? true,
+  python3,
+  cmocka,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tlf";
-  version = "1.4.1";
+  version = "1.4.1-unstable-2026-03-27";
 
   src = fetchFromGitHub {
-    owner = "tlf";
+    owner = "Tlf";
     repo = "tlf";
-    rev = "tlf-${finalAttrs.version}";
-    sha256 = "1xpgs4k27pjd9mianfknknp6mf34365bcp96wrv5xh4dhph573rj";
+    rev = "e6385f88ad793043d874b89d56d29bea5dac4e26";
+    hash = "sha256-XYj0vUqxnc6SuH+fV0EWgVBV3W1W2yhMCK/zcEWrMQ4=";
   };
-
-  patches = [
-    # Pull upstream fix for ncurses-6.3:
-    #   https://github.com/Tlf/tlf/pull/282
-    # We use Debian's patch as upstream fixes don't apply as is due to
-    # related code changes. The change will be a part of 1.4.2 release.
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://salsa.debian.org/debian-hamradio-team/tlf/-/raw/5a2d79fc35bde97f653b1373fd970d41fe01a3ec/debian/patches/warnings-as-errors.patch?inline=false";
-      sha256 = "1zi1dd4vqkgl2pg29lnhj91ralqg58gmkzq9fkcx0dyakbjm6070";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -43,18 +35,31 @@ stdenv.mkDerivation (finalAttrs: {
     automake
     pkg-config
     perl
+    python3Packages.pexpect
   ];
+
   buildInputs = [
     glib
     ncurses5
     hamlib
     xmlrpc_c
+  ]
+  ++ lib.optionals pythonPluginSupport [
+    python3
   ];
 
   configureFlags = [
-    "--enable-hamlib"
     "--enable-fldigi-xmlrpc"
+  ]
+  ++ lib.optionals pythonPluginSupport [
+    "--enable-python-plugin"
   ];
+
+  nativeCheckInputs = [
+    cmocka
+  ];
+
+  doCheck = true;
 
   postInstall = ''
     mkdir -p $out/lib


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324339522

Actively developed but did not have a release for long time, thus updated to latest commit.
Removed the obsolete "--enable-hamlib" flag. Added python plugin support. Enabled tests.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
