### PR TITLE
heroic{,-unwrapped}: 2.20.1 -> 2.21.0; heroic-unwrapped.legendary: 0.20.42 -> 0.20.43

### DIFF
--- a/pkgs/by-name/he/heroic-unwrapped/legendary.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/legendary.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "legendary-heroic";
-  version = "0.20.42";
+  version = "0.20.43";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "legendary";
     tag = finalAttrs.version;
-    hash = "sha256-ZnOQhIGAgUvZVdPpxdothKzPElp/hdvUJA0mTpXLyIM=";
+    hash = "sha256-EQBrj+GOmVD0ZEArOk1Me4LLKbs6Ezl1lTzD0k5uUsQ=";
   };
 
   build-system = with python3Packages; [
@@ -25,6 +25,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     requests
     requests-futures
     filelock
+    pycryptodomex
   ];
 
   pythonImportsCheck = [ "legendary" ];

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -12,7 +12,7 @@
   makeWrapper,
   # Electron updates can break Heroic, so try to use same version as upstream.
   # If the used electron version is higher than upstream's then the node-abi package might need to be updated
-  electron_39,
+  electron,
   vulkan-helper,
   gogdl,
   nile,
@@ -22,7 +22,6 @@
 
 let
   pnpm = pnpm_10_29_2;
-  electron = electron_39;
 
   legendary = callPackage ./legendary.nix { };
   epic-integration = callPackage ./epic-integration.nix { };
@@ -30,13 +29,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
-  version = "2.20.1";
+  version = "2.21.0";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nXDQxctzXI/kB6o1ShhrhiloWnpYObG66nMAwxijFto=";
+    hash = "sha256-rgLmm9krjPYjSn/wGAYbnFw7kqvuu9IBipb4ibOClOw=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -48,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-3SkCLoH4ZQzKZIdCkWOfBHt83vjxbpTpMvhMZPCysyI=";
+    hash = "sha256-O3QQsk8pvF9U5QvuMebCsy/iYz1oZIMkPeMtWohqW3w=";
   };
 
   nativeBuildInputs = [
@@ -120,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -D "flatpak/com.heroicgameslauncher.hgl.desktop" "$out/share/applications/com.heroicgameslauncher.hgl.desktop"
     install -D "src/frontend/assets/heroic-icon.svg" "$out/share/icons/hicolor/scalable/apps/com.heroicgameslauncher.hgl.svg"
     substituteInPlace "$out/share/applications/com.heroicgameslauncher.hgl.desktop" \
-      --replace-fail "Exec=heroic-run --ozone-platform-hint=auto" "Exec=heroic"
+      --replace-fail "Exec=heroic-run" "Exec=heroic"
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v2.21.0
Diff: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/compare/v2.20.1...v2.21.0

## Things done

- Bumped heroic and legendary to latest

Some notes: 
- As far as I've tested, no lost or broken functionality. Some minor log messages, but doesn't seem to affect anything:

```
(node:278245) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `electron --trace-deprecation ...` to show where the warning was created)
(17:20:39) [WARNING]: [Backend]:         Failed to register protocol with OS.
```
- Other components [did not receive updates](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/blob/38d09ff2f34dab121a73adf97f1d209e29e60f3f/meta/downloadHelperBinaries.ts#L17)
- Unpinned Electron as there is no version for [v41.1.1](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5467). The nixpkgs Electron is newer than this, so please report any issues.
- New 'fullscreen mode' looks great!

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/7a1c03cb-ab58-4257-960c-7c32d25d8b24" />

If I missed anything, please let me know.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
