### PR TITLE
uif2iso: fix build with gcc15, fix version

### DIFF
--- a/pkgs/by-name/ui/uif2iso/package.nix
+++ b/pkgs/by-name/ui/uif2iso/package.nix
@@ -2,18 +2,29 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   unzip,
   zlib,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation {
   pname = "uif2iso";
-  version = "0.1.7";
+  version = "0.1.7c";
 
   src = fetchurl {
     url = "https://aluigi.altervista.org/mytoolz/uif2iso.zip";
     sha256 = "1v18fmlzhkkhv8xdc9dyvl8vamwg3ka4dsrg7vvmk1f2iczdx3dp";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-cdr/uif2iso/files/uif2iso-0.1.7c-fix_c23.patch?id=80ed6e7c6b7b628e80f9f76d614c49f583ed5152";
+      hash = "sha256-8b18Q6gGVd2pjQzRf17jhrYuaz86crHH26gOJy/krqk=";
+      stripLen = 2;
+      extraPrefix = "";
+    })
+  ];
 
   nativeBuildInputs = [ unzip ];
   buildInputs = [ zlib ];
@@ -21,6 +32,9 @@ stdenv.mkDerivation {
   installPhase = ''
     make -C . prefix="$out" install;
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Tool for converting single/multi part UIF image files to ISO";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324350367

```
loki91.c: In function 'enloki':
loki91.c:210:18: error: too many arguments to function 'f'; expected 0, have 2
  210 |             L ^= f (R, loki_subkeys[i]);
      |                  ^  ~
loki91.c:142:17: note: declared here
  142 | static Long     f();                    /* declare LOKI function f */
      |                 ^
```

Applied a gentoo patch. Also fixed the version (missing "c" suffix) and added versionCheckHook.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
