### PR TITLE
nixos/livekit-ingress: allow port -1 to disable WHIP/RTMP

### DIFF
--- a/nixos/modules/services/networking/livekit-ingress.nix
+++ b/nixos/modules/services/networking/livekit-ingress.nix
@@ -10,6 +10,20 @@ let
   format = pkgs.formats.yaml { };
   settings = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
 
+  optionalPort = (lib.types.ints.between (-1) 65535);
+
+  normalisePort =
+    defaultPort: configValue:
+    if configValue == -1 then
+      null
+    else if configValue == 0 then
+      defaultPort
+    else
+      configValue;
+
+  actualRTMPPort = normalisePort 1935 cfg.settings.rtmp_port;
+  actualWHIPPort = normalisePort 8080 cfg.settings.whip_port;
+
   isLocallyDistributed = config.services.livekit.enable;
 in
 {
@@ -43,15 +57,15 @@ in
         freeformType = format.type;
         options = {
           rtmp_port = lib.mkOption {
-            type = lib.types.port;
+            type = optionalPort;
             default = 1935;
-            description = "TCP port for RTMP connections";
+            description = "TCP port for RTMP connections. -1 to disable";
           };
 
           whip_port = lib.mkOption {
-            type = lib.types.port;
+            type = optionalPort;
             default = 8080;
-            description = "TCP port for WHIP connections";
+            description = "TCP port for WHIP connections. -1 to disable";
           };
 
           redis = {
@@ -120,10 +134,21 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.openFirewall.rtmp -> actualRTMPPort != null;
+        message = "services.livekit-ingress: configured to open RTMP port, but the RTMP service is disabled";
+      }
+      {
+        assertion = cfg.openFirewall.whip -> actualWHIPPort != null;
+        message = "services.livekit-ingress: configured to open WHIP port, but the WHIP service is disabled";
+      }
+    ];
+
     networking.firewall = {
       allowedTCPPorts = lib.mkMerge [
-        (lib.mkIf cfg.openFirewall.rtmp [ cfg.settings.rtmp_port ])
-        (lib.mkIf cfg.openFirewall.whip [ cfg.settings.whip_port ])
+        (lib.mkIf cfg.openFirewall.rtmp [ actualRTMPPort ])
+        (lib.mkIf cfg.openFirewall.whip [ actualWHIPPort ])
       ];
       allowedUDPPortRanges = lib.mkIf cfg.openFirewall.rtc [
         {


### PR DESCRIPTION
LiveKit Ingress allows disabling these services by setting their ports to -1 in the configuration file. Expose that in the NixOS module interface.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
