### PR TITLE
roswell: 24.10.115 -> 26.02.116

### DIFF
--- a/pkgs/by-name/ro/roswell/package.nix
+++ b/pkgs/by-name/ro/roswell/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "roswell";
-  version = "24.10.115";
+  version = "26.02.116";
 
   src = fetchFromGitHub {
     owner = "roswell";
     repo = "roswell";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-2aYA1AzRPXaM82Sh+dMiQJcOAD0rzwV09VyLy0oS6as=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-saKCLr1Nmzl+zcPbYSXt7o82hh6vYhACCfUUzEs/31E=";
   };
 
   patches = [
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ hiro98 ];
     platforms = lib.platforms.unix;
     homepage = "https://github.com/roswell/roswell";
-    changelog = "https://github.com/roswell/roswell/blob/v${finalAttrs.version}/ChangeLog";
+    changelog = "https://github.com/roswell/roswell/blob/${finalAttrs.src.tag}/ChangeLog";
     mainProgram = "ros";
   };
 })


### PR DESCRIPTION
Tracking: #511329

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
