### PR TITLE
switch-to-configuration-ng: Reload when ExecReload changes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -347,6 +347,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `switch-to-configuration` now reloads a service instead of restarting it when the only change to its unit is `ExecReload=`, and takes no action when `ExecReload=` is removed. Previously both cases triggered a restart.
+
 - [`hardware.nvidia.branch`](#opt-hardware.nvidia.branch) was added to select the NVIDIA driver branch; setting [`hardware.nvidia.package`](#opt-hardware.nvidia.package) overrides this.
 
 - The NixOS NVIDIA module wiring has been updated to match the new `nvidia-x11` output layout.

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -604,8 +604,10 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                         return UnitComparison::UnequalNeedsRestart;
                     }
                 }
-            } else if section_name == "Exec" && ini_cmp.len() == 1
-                && ini_cmp.contains_key("ExecReload") {
+            } else if section_name == "Exec"
+                && ini_cmp.len() == 1
+                && ini_cmp.contains_key("ExecReload")
+            {
                 ret = UnitComparison::UnequalNeedsReload;
                 continue;
             } else {
@@ -616,7 +618,9 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
 
     // A section was introduced that was missing in the previous unit
     if !section_cmp.is_empty() {
-        if section_cmp.keys().len() == 1 && (section_cmp.contains_key("Unit") || section_cmp.contains_key("Service")) {
+        if section_cmp.keys().len() == 1
+            && (section_cmp.contains_key("Unit") || section_cmp.contains_key("Service"))
+        {
             if let Some(new_unit_unit) = new_unit.get("Unit") {
                 for ini_key in new_unit_unit.keys() {
                     if !unit_section_ignores.contains_key(ini_key.as_str()) {
@@ -2646,10 +2650,7 @@ invalid
                     &HashMap::from([]),
                     &HashMap::from([(
                         "Service".to_string(),
-                        HashMap::from([(
-                            "ExecReload".to_string(),
-                            vec!["foobar".to_string()]
-                        )])
+                        HashMap::from([("ExecReload".to_string(), vec!["foobar".to_string()])])
                     )])
                 ) == super::UnitComparison::UnequalNeedsReload
             );
@@ -2658,17 +2659,11 @@ invalid
                 super::compare_units(
                     &HashMap::from([(
                         "Service".to_string(),
-                        HashMap::from([(
-                            "ExecReload".to_string(),
-                            vec!["foobar".to_string()]
-                        )])
+                        HashMap::from([("ExecReload".to_string(), vec!["foobar".to_string()])])
                     )]),
                     &HashMap::from([(
                         "Service".to_string(),
-                        HashMap::from([(
-                            "ExecReload".to_string(),
-                            vec!["barfoo".to_string()]
-                        )])
+                        HashMap::from([("ExecReload".to_string(), vec!["barfoo".to_string()])])
                     )])
                 ) == super::UnitComparison::UnequalNeedsReload
             );

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -604,7 +604,7 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                         return UnitComparison::UnequalNeedsRestart;
                     }
                 }
-            } else if section_name == "Exec"
+            } else if section_name == "Service"
                 && ini_cmp.len() == 1
                 && ini_cmp.contains_key("ExecReload")
             {
@@ -2665,6 +2665,23 @@ invalid
                         "Service".to_string(),
                         HashMap::from([("ExecReload".to_string(), vec!["barfoo".to_string()])])
                     )])
+                ) == super::UnitComparison::UnequalNeedsReload
+            );
+
+            // ExecReload added to an existing [Service] section
+            assert!(
+                super::compare_units(
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([("ExecStart".to_string(), vec!["x".to_string()])])
+                    )]),
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([
+                            ("ExecStart".to_string(), vec!["x".to_string()]),
+                            ("ExecReload".to_string(), vec!["y".to_string()]),
+                        ])
+                    )]),
                 ) == super::UnitComparison::UnequalNeedsReload
             );
 

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -532,6 +532,13 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                     }
                 }
                 continue; // check the next section
+            } else if section_name == "Service"
+                && section_val.len() == 1
+                && section_val.contains_key("ExecReload")
+            {
+                // Dropping ExecReload does not affect the running process and the
+                // new unit can no longer be reloaded, so there is nothing to do.
+                continue;
             } else {
                 return UnitComparison::UnequalNeedsRestart;
             }
@@ -560,6 +567,11 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                 // If the key is missing in the new unit, they are different unless the key that is
                 // now missing is one of the ignored keys
                 if section_name == "Unit" && unit_section_ignores.contains_key(ini_key.as_str()) {
+                    continue;
+                }
+                // Dropping ExecReload does not affect the running process and the
+                // new unit can no longer be reloaded, so there is nothing to do.
+                if section_name == "Service" && ini_key == "ExecReload" {
                     continue;
                 }
                 return UnitComparison::UnequalNeedsRestart;
@@ -2708,6 +2720,33 @@ invalid
                         ),
                     ]),
                 ) == super::UnitComparison::UnequalNeedsReload
+            );
+
+            // ExecReload removed: running process is unaffected and the new
+            // unit cannot be reloaded, so no action is needed.
+            assert!(
+                super::compare_units(
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([
+                            ("ExecStart".to_string(), vec!["x".to_string()]),
+                            ("ExecReload".to_string(), vec!["y".to_string()]),
+                        ])
+                    )]),
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([("ExecStart".to_string(), vec!["x".to_string()])])
+                    )]),
+                ) == super::UnitComparison::Equal
+            );
+            assert!(
+                super::compare_units(
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([("ExecReload".to_string(), vec!["y".to_string()])])
+                    )]),
+                    &HashMap::from([]),
+                ) == super::UnitComparison::Equal
             );
 
             // ExecReload added to an existing [Service] section

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -618,22 +618,25 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
 
     // A section was introduced that was missing in the previous unit
     if !section_cmp.is_empty() {
-        if section_cmp.keys().len() == 1
-            && (section_cmp.contains_key("Unit") || section_cmp.contains_key("Service"))
-        {
-            if let Some(new_unit_unit) = new_unit.get("Unit") {
-                for ini_key in new_unit_unit.keys() {
-                    if !unit_section_ignores.contains_key(ini_key.as_str()) {
-                        return UnitComparison::UnequalNeedsRestart;
-                    } else if ini_key == "X-Reload-Triggers" {
-                        ret = UnitComparison::UnequalNeedsReload;
+        if section_cmp.keys().len() == 1 {
+            // Dispatch on which section is actually new.
+            if section_cmp.contains_key("Unit") {
+                if let Some(new_unit_unit) = new_unit.get("Unit") {
+                    for ini_key in new_unit_unit.keys() {
+                        if !unit_section_ignores.contains_key(ini_key.as_str()) {
+                            return UnitComparison::UnequalNeedsRestart;
+                        } else if ini_key == "X-Reload-Triggers" {
+                            ret = UnitComparison::UnequalNeedsReload;
+                        }
                     }
                 }
-            } else if let Some(new_unit_service) = new_unit.get("Service") {
-                if new_unit_service.len() == 1 && new_unit_service.contains_key("ExecReload") {
-                    ret = UnitComparison::UnequalNeedsReload;
-                } else {
-                    return UnitComparison::UnequalNeedsRestart;
+            } else if section_cmp.contains_key("Service") {
+                if let Some(new_unit_service) = new_unit.get("Service") {
+                    if new_unit_service.len() == 1 && new_unit_service.contains_key("ExecReload") {
+                        ret = UnitComparison::UnequalNeedsReload;
+                    } else {
+                        return UnitComparison::UnequalNeedsRestart;
+                    }
                 }
             } else {
                 return UnitComparison::UnequalNeedsRestart;
@@ -2665,6 +2668,45 @@ invalid
                         "Service".to_string(),
                         HashMap::from([("ExecReload".to_string(), vec!["barfoo".to_string()])])
                     )])
+                ) == super::UnitComparison::UnequalNeedsReload
+            );
+
+            // New [Service] section while [Unit] already existed: must inspect
+            // the [Service] section, not the (unchanged) [Unit] one.
+            assert!(
+                super::compare_units(
+                    &HashMap::from([(
+                        "Unit".to_string(),
+                        HashMap::from([("Description".to_string(), vec!["x".to_string()])])
+                    )]),
+                    &HashMap::from([
+                        (
+                            "Unit".to_string(),
+                            HashMap::from([("Description".to_string(), vec!["x".to_string()])])
+                        ),
+                        (
+                            "Service".to_string(),
+                            HashMap::from([("ExecStart".to_string(), vec!["y".to_string()])])
+                        ),
+                    ]),
+                ) == super::UnitComparison::UnequalNeedsRestart
+            );
+            assert!(
+                super::compare_units(
+                    &HashMap::from([(
+                        "Unit".to_string(),
+                        HashMap::from([("Description".to_string(), vec!["x".to_string()])])
+                    )]),
+                    &HashMap::from([
+                        (
+                            "Unit".to_string(),
+                            HashMap::from([("Description".to_string(), vec!["x".to_string()])])
+                        ),
+                        (
+                            "Service".to_string(),
+                            HashMap::from([("ExecReload".to_string(), vec!["y".to_string()])])
+                        ),
+                    ]),
                 ) == super::UnitComparison::UnequalNeedsReload
             );
 

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -489,9 +489,10 @@ enum UnitComparison {
 
 // Compare the contents of two unit files and return whether the unit needs to be restarted or
 // reloaded. If the units differ, the service is restarted unless the only difference is
-// `X-Reload-Triggers` in the `Unit` section. If this is the only modification, the unit is
-// reloaded instead of restarted. If the only difference is `Options` in the `[Mount]` section, the
-// unit is reloaded rather than restarted.
+// `X-Reload-Triggers` in the `[Unit]` section, `Options` in the `[Mount]` section, or `ExecReload`
+// in the `[Service]` section, in which case the unit is reloaded rather than restarted. Removing
+// `ExecReload` is treated as a no-op since the running process is unaffected and the new unit can
+// no longer be reloaded.
 fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison {
     let mut ret = UnitComparison::Equal;
 

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -576,6 +576,12 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                     }
                 }
 
+                // If this is a service unit, check if it was only `ExecReload`
+                if section_name == "Service" && ini_key == "ExecReload" {
+                    ret = UnitComparison::UnequalNeedsReload;
+                    continue;
+                }
+
                 // If this is a mount unit, check if it was only `Options`
                 if section_name == "Mount" && ini_key == "Options" {
                     ret = UnitComparison::UnequalNeedsReload;
@@ -598,6 +604,10 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                         return UnitComparison::UnequalNeedsRestart;
                     }
                 }
+            } else if section_name == "Exec" && ini_cmp.len() == 1
+                && ini_cmp.contains_key("ExecReload") {
+                ret = UnitComparison::UnequalNeedsReload;
+                continue;
             } else {
                 return UnitComparison::UnequalNeedsRestart;
             }
@@ -606,7 +616,7 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
 
     // A section was introduced that was missing in the previous unit
     if !section_cmp.is_empty() {
-        if section_cmp.keys().len() == 1 && section_cmp.contains_key("Unit") {
+        if section_cmp.keys().len() == 1 && (section_cmp.contains_key("Unit") || section_cmp.contains_key("Service")) {
             if let Some(new_unit_unit) = new_unit.get("Unit") {
                 for ini_key in new_unit_unit.keys() {
                     if !unit_section_ignores.contains_key(ini_key.as_str()) {
@@ -615,6 +625,14 @@ fn compare_units(current_unit: &UnitInfo, new_unit: &UnitInfo) -> UnitComparison
                         ret = UnitComparison::UnequalNeedsReload;
                     }
                 }
+            } else if let Some(new_unit_service) = new_unit.get("Service") {
+                if new_unit_service.len() == 1 && new_unit_service.contains_key("ExecReload") {
+                    ret = UnitComparison::UnequalNeedsReload;
+                } else {
+                    return UnitComparison::UnequalNeedsRestart;
+                }
+            } else {
+                return UnitComparison::UnequalNeedsRestart;
             }
         } else {
             return UnitComparison::UnequalNeedsRestart;
@@ -2617,6 +2635,38 @@ invalid
                         "Unit".to_string(),
                         HashMap::from([(
                             "X-Reload-Triggers".to_string(),
+                            vec!["barfoo".to_string()]
+                        )])
+                    )])
+                ) == super::UnitComparison::UnequalNeedsReload
+            );
+
+            assert!(
+                super::compare_units(
+                    &HashMap::from([]),
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([(
+                            "ExecReload".to_string(),
+                            vec!["foobar".to_string()]
+                        )])
+                    )])
+                ) == super::UnitComparison::UnequalNeedsReload
+            );
+
+            assert!(
+                super::compare_units(
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([(
+                            "ExecReload".to_string(),
+                            vec!["foobar".to_string()]
+                        )])
+                    )]),
+                    &HashMap::from([(
+                        "Service".to_string(),
+                        HashMap::from([(
+                            "ExecReload".to_string(),
                             vec!["barfoo".to_string()]
                         )])
                     )])


### PR DESCRIPTION
Part of breaking up #216025

Instead of triggering a restart when the reload script changes, signal that the unit only needs to be reloaded instead. This is an important optimisation for systemd-nspawn containers where the reload script can house the container's config activation script and we want to explicitly avoid restarting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
