### PR TITLE
xcodegen: fix changelog

### DIFF
--- a/pkgs/by-name/xc/xcodegen/package.nix
+++ b/pkgs/by-name/xc/xcodegen/package.nix
@@ -64,7 +64,7 @@ swiftPackages.stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Swift command line tool for generating your Xcode project";
     homepage = "https://github.com/yonaskolb/XcodeGen";
-    changelog = "https://github.com/XcodeGen/blob/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/yonaskolb/XcodeGen/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;
     maintainers = [ lib.maintainers.samasaur ];


### PR DESCRIPTION
added missing owner name in github changelog url.
- https://github.com/yonaskolb/XcodeGen/blob/2.44.1/CHANGELOG.md

Found with:
```nix
  # packagesWith borrowed from maintainers/scripts/check-hydra-by-maintainer.nix
  packages = packagesWith
    (
      name: pkg: (
        with builtins; (hasAttr "meta" pkg)
        && (hasAttr "position" pkg.meta)
        && (hasAttr "changelog" pkg.meta)
        && (hasAttr "src" pkg)
        && !(isNull pkg.src)
        && !(isPath pkg.src)
        && !(isString pkg.src)
        && !(isList pkg.src)
        && (hasAttr "gitRepoUrl" pkg.src)
        && (hasAttr "githubBase" pkg.src)
        && (
          with lib.strings; lib.isString pkg.meta.changelog
          && (hasPrefix "https://github.com" pkg.meta.changelog)
          && !(hasPrefix (toLower (removeSuffix ".git" pkg.src.gitRepoUrl)) (toLower pkg.meta.changelog))
        )
      )
    )
    ""
    pkgs;
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
