### PR TITLE
bigquery-emulator: fix changelog

### DIFF
--- a/pkgs/by-name/bi/bigquery-emulator/package.nix
+++ b/pkgs/by-name/bi/bigquery-emulator/package.nix
@@ -34,7 +34,7 @@ buildGoModule.override
     meta = {
       description = "BigQuery emulator server implemented in Go";
       homepage = "https://github.com/goccy/bigquery-emulator";
-      changelog = "https://github.com/goccy/pname/releases/tag/v${finalAttrs.version}";
+      changelog = "https://github.com/goccy/bigquery-emulator/releases/tag/v${finalAttrs.version}";
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ tarantoj ];
       mainProgram = "bigquery-emulator";


### PR DESCRIPTION
Fixed `pname` -> `${pname}` (as hardcoded string)

Found with:
```nix
  # packagesWith borrowed from maintainers/scripts/check-hydra-by-maintainer.nix
  packages = packagesWith
    (
      name: pkg: (
        with builtins; (hasAttr "meta" pkg)
        && (hasAttr "position" pkg.meta)
        && (hasAttr "changelog" pkg.meta)
        && (hasAttr "src" pkg)
        && !(isNull pkg.src)
        && !(isPath pkg.src)
        && !(isString pkg.src)
        && !(isList pkg.src)
        && (hasAttr "gitRepoUrl" pkg.src)
        && (hasAttr "githubBase" pkg.src)
        && (
          with lib.strings; lib.isString pkg.meta.changelog
          && (hasPrefix "https://github.com" pkg.meta.changelog)
          && !(hasPrefix (toLower (removeSuffix ".git" pkg.src.gitRepoUrl)) (toLower pkg.meta.changelog))
        )
      )
    )
    ""
    pkgs;
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
