### PR TITLE
Maintain material black colors - rename pkg to material black colors icons

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3480,6 +3480,12 @@
     githubId = 28444296;
     name = "Benjamin Hougland";
   };
+  bigboggle = {
+    email = "zekeboggs10@gmail.com";
+    github = "BigBoggle";
+    githubId = 94147496;
+    name = "Zeke Boggs";
+  };
   billewanick = {
     email = "bill@ewanick.com";
     github = "billewanick";

--- a/pkgs/by-name/ma/material-black-colors-icons/package.nix
+++ b/pkgs/by-name/ma/material-black-colors-icons/package.nix
@@ -2,12 +2,12 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  colorVariants ? [ ], # default: install all icons
+  iconColorVariants ? [ ], # default: install all icons
 }:
 
 let
-  pname = "material-black-colors";
-  colorVariantList = [
+  pname = "material-black-colors-icons";
+  iconColorVariantList = [
     "MB-Blueberry-Suru-GLOW"
     "MB-Cherry-Suru-GLOW"
     "MB-Lime-Suru-GLOW"
@@ -35,7 +35,7 @@ let
   ];
 
 in
-lib.checkListOfEnum "${pname}: color variants" colorVariantList colorVariants
+lib.checkListOfEnum "${pname}: color variants" iconColorVariantList iconColorVariants
 
   stdenvNoCC.mkDerivation
   {
@@ -53,7 +53,9 @@ lib.checkListOfEnum "${pname}: color variants" colorVariantList colorVariants
       runHook preInstall
       mkdir -p $out/share/icons
       cp -r ${
-        lib.concatStringsSep " " (if colorVariants != [ ] then colorVariants else colorVariantList)
+        lib.concatStringsSep " " (
+          if iconColorVariants != [ ] then iconColorVariants else iconColorVariantList
+        )
       } $out/share/icons/
       runHook postInstall
     '';
@@ -61,7 +63,7 @@ lib.checkListOfEnum "${pname}: color variants" colorVariantList colorVariants
     dontFixup = true;
 
     meta = {
-      description = "Material Black Colors icons";
+      description = "Material Black Colors Icons";
       homepage = "https://github.com/rtlewis88/rtl88-Themes/tree/material-black-COLORS";
       maintainers = with lib.maintainers; [
         bigboggle

--- a/pkgs/by-name/ma/material-black-colors/package.nix
+++ b/pkgs/by-name/ma/material-black-colors/package.nix
@@ -63,7 +63,9 @@ lib.checkListOfEnum "${pname}: color variants" colorVariantList colorVariants
     meta = {
       description = "Material Black Colors icons";
       homepage = "https://github.com/rtlewis88/rtl88-Themes/tree/material-black-COLORS";
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [
+        bigboggle
+      ];
       platforms = lib.platforms.all;
       license = with lib.licenses; [
         gpl3Plus


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.


-->
Added myself as a maintainer to material-black-colors.

Updated package name to improve naming conventions, as the old one didn't indicate the upstream also included a gtk theme of a similar name. This package only contains an icon set from the repo.  
Renamed the existing variables in the existing package to reflect this. 

The new name is material-black-colors-icons.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
