### PR TITLE
python3Packages.cohere: 5.21.1 -> 6.1.0

### DIFF
--- a/pkgs/development/python-modules/cohere/default.nix
+++ b/pkgs/development/python-modules/cohere/default.nix
@@ -9,13 +9,17 @@
   # dependencies
   fastavro,
   httpx,
-  httpx-sse,
   pydantic,
   pydantic-core,
   requests,
   tokenizers,
   types-requests,
   typing-extensions,
+
+  # optional-dependencies
+  aiohttp,
+  httpx-aiohttp,
+  oci,
 }:
 
 buildPythonPackage rec {
@@ -35,7 +39,6 @@ buildPythonPackage rec {
   dependencies = [
     fastavro
     httpx
-    httpx-sse
     pydantic
     pydantic-core
     requests
@@ -44,7 +47,13 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  pythonRelaxDeps = [ "httpx-sse" ];
+  optional-dependencies = {
+    aiohttp = [
+      aiohttp
+      httpx-aiohttp
+    ];
+    oci = [ oci ];
+  };
 
   # tests require CO_API_KEY
   doCheck = false;

--- a/pkgs/development/python-modules/cohere/default.nix
+++ b/pkgs/development/python-modules/cohere/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "cohere";
-  version = "5.21.1";
+  version = "6.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cohere-ai";
     repo = "cohere-python";
     tag = version;
-    hash = "sha256-RT4Sxk9fKunuyEXl2pvKgS6U82fPKjMPmSl9jwm+GBk=";
+    hash = "sha256-be6vhTGXnf1/iaD13VYjey/to+HX28VfmYlUPE2eFT4=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
Supersedes #508147.

Cohere 6.x introduced optional dependency groups (`aiohttp` and `oci`) in
`pyproject.toml` and dropped `httpx-sse` from core dependencies. This PR
exposes the new extras via `optional-dependencies` and removes the obsolete
`httpx-sse` dependency and its `pythonRelaxDeps` entry, addressing
@NickCao's review feedback on the original auto-update PR.

Changelog: https://github.com/cohere-ai/cohere-python/releases/tag/6.1.0

## Things done

- Built on NixOS
- `python3Packages.cohere` builds successfully; `pythonImportsCheck` passes
- `optional-dependencies` verified to expose `aiohttp` and `oci`