### PR TITLE
css-variables-language-server: init at 2.8.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -911,6 +911,12 @@
     githubId = 4717906;
     name = "Jakub Skokan";
   };
+  aiwao = {
+    email = "aiwao@140.lol";
+    github = "aiwao";
+    githubId = 233898056;
+    name = "aiwao";
+  };
   aiyion = {
     email = "git@aiyionpri.me";
     github = "AiyionPrime";

--- a/pkgs/by-name/cs/css-variables-language-server/package.nix
+++ b/pkgs/by-name/cs/css-variables-language-server/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  libsecret,
+  nodejs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "css-variables-language-server";
+  version = "2.8.4";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vunguyentuan";
+    repo = "vscode-css-variables";
+    tag = "css-variables-language-server@${finalAttrs.version}";
+    hash = "sha256-NdacBF8sUOij6k4AkMim93LrBJi8JL43q/N8GryTXHA=";
+  };
+
+  npmDepsHash = "sha256-cgX/M05UGsx87QO/Ge0VCD2hQ9MkfJarJVNCj/IcnM0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libsecret
+  ];
+
+  preBuild = ''
+    patchShebangs .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/bin
+    cp -r node_modules $out/lib
+    cp -r packages $out/lib
+
+    makeWrapper ${nodejs}/bin/node $out/bin/index.js --add-flags "$out/lib/packages/css-variables-language-server/dist/index.js"
+
+    mv $out/bin/index.js $out/bin/css-variables-language-server
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CSS Variables Language Server in node";
+    changelog = "https://github.com/vunguyentuan/vscode-css-variables/releases/tag/css-variables-language-server@${finalAttrs.version}";
+    homepage = "https://github.com/vunguyentuan/vscode-css-variables";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aiwao ];
+    mainProgram = "css-variables-language-server";
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
