### PR TITLE
veroroute: Use qt6 instead of qt5 + VM test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1743,6 +1743,7 @@ in
   vector = import ./vector { inherit runTest; };
   velocity = runTest ./velocity.nix;
   vengi-tools = runTest ./vengi-tools.nix;
+  veroroute = runTest ./veroroute.nix;
   victorialogs = import ./victorialogs { inherit runTest; };
   victoriametrics = import ./victoriametrics { inherit runTest; };
   victoriatraces = import ./victoriatraces { inherit runTest; };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1742,6 +1742,7 @@ in
   vector = import ./vector { inherit runTest; };
   velocity = runTest ./velocity.nix;
   vengi-tools = runTest ./vengi-tools.nix;
+  veroroute = runTest ./veroroute.nix;
   victorialogs = import ./victorialogs { inherit runTest; };
   victoriametrics = import ./victoriametrics { inherit runTest; };
   victoriatraces = import ./victoriatraces { inherit runTest; };

--- a/nixos/tests/veroroute.nix
+++ b/nixos/tests/veroroute.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+{
+  name = "veroroute";
+  meta.maintainers = with pkgs.lib.maintainers; [ nh2 ];
+
+  enableOCR = true;
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        ./common/x11.nix
+      ];
+
+      services.xserver.enable = true;
+      environment.systemPackages = [
+        pkgs.veroroute
+        pkgs.xdotool
+      ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_x()
+
+    machine.execute("veroroute >&2 &")
+    machine.wait_until_succeeds("xdotool search --pid $(pidof veroroute)")
+    machine.wait_for_text("File")  # menu entry renders correctly
+    machine.screenshot("screen")
+  '';
+}

--- a/nixos/tests/veroroute.nix
+++ b/nixos/tests/veroroute.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+{
+  name = "veroroute";
+  meta.maintainers = with pkgs.lib.maintainers; [ nh2 ];
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [
+        ./common/x11.nix
+      ];
+
+      services.xserver.enable = true;
+      environment.systemPackages = [
+        pkgs.veroroute
+        pkgs.xdotool
+      ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_x()
+
+    machine.execute("veroroute >&2 &")
+    machine.wait_until_succeeds("xdotool search --pid $(pidof veroroute)")
+    machine.screenshot("screen")
+  '';
+}

--- a/pkgs/by-name/ve/veroroute/package.nix
+++ b/pkgs/by-name/ve/veroroute/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  libsForQt5,
+  qt6,
   nixosTests,
 }:
 
@@ -16,11 +16,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    libsForQt5.qmake
-    libsForQt5.wrapQtAppsHook
+    qt6.qmake
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
-    libsForQt5.qtbase
+    qt6.qtbase
   ];
 
   preConfigure = ''

--- a/pkgs/by-name/ve/veroroute/package.nix
+++ b/pkgs/by-name/ve/veroroute/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   libsForQt5,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -25,6 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
   preConfigure = ''
     cd Src/
   '';
+
+  passthru.tests = {
+    veroroute = nixosTests.veroroute;
+  };
 
   meta = {
     description = "Qt based Veroboard/Perfboard/PCB layout and routing application";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
