### PR TITLE
envoy: fix deps fetch by pinning go and providing hashes

### DIFF
--- a/pkgs/by-name/en/envoy/0005-nixpkgs-pin-go-sdk-downloads.patch
+++ b/pkgs/by-name/en/envoy/0005-nixpkgs-pin-go-sdk-downloads.patch
@@ -1,0 +1,79 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Daniel Baker <dan@djacu.dev>
+Date: Thu, 30 Apr 2026 08:42:44 -0700
+Subject: [PATCH] nixpkgs: pin Go SDK downloads
+
+Pin Go SDK downloads to avoid fetching the mutable version listing from
+https://go.dev/dl/?mode=json&include=all. Without explicit sdks, each
+go_download_sdk call downloads that listing (which changes with every Go
+release) and caches it in repository_cache, causing the deps hash to
+drift. See: io_bazel_rules_go/go/private/sdk.bzl lines 74-93 (rules_go
+v0.50.0)
+
+Signed-off-by: Daniel Baker <dan@djacu.dev>
+---
+ bazel/dependency_imports.bzl | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/bazel/dependency_imports.bzl b/bazel/dependency_imports.bzl
+index 90e49d5ceb0024b57481b816518990f58fc2ad5f..26091a877ea3951bfe69944ab8580857e787bb64 100644
+--- a/bazel/dependency_imports.bzl
++++ b/bazel/dependency_imports.bzl
+@@ -27,6 +27,18 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
+ # go version for rules_go
+ GO_VERSION = "1.24.6"
+ 
++# Pin Go SDK downloads to avoid fetching the mutable version listing from
++# https://go.dev/dl/?mode=json&include=all. Without explicit sdks, each
++# go_download_sdk call downloads that listing (which changes with every Go
++# release) and caches it in repository_cache, causing the deps hash to drift.
++# See: io_bazel_rules_go/go/private/sdk.bzl lines 74-93 (rules_go v0.50.0)
++_GO_SDKS = {
++    "linux_amd64": ["go" + GO_VERSION + ".linux-amd64.tar.gz", "bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712"],
++    "linux_arm64": ["go" + GO_VERSION + ".linux-arm64.tar.gz", "124ea6033a8bf98aa9fbab53e58d134905262d45a022af3a90b73320f3c3afd5"],
++    "darwin_amd64": ["go" + GO_VERSION + ".darwin-amd64.tar.gz", "4a8d7a32052f223e71faab424a69430455b27b3fff5f4e651f9d97c3e51a8746"],
++    "darwin_arm64": ["go" + GO_VERSION + ".darwin-arm64.tar.gz", "4e29202c49573b953be7cc3500e1f8d9e66ddd12faa8cf0939a4951411e09a2a"],
++}
++
+ JQ_VERSION = "1.7"
+ YQ_VERSION = "4.24.4"
+ 
+@@ -46,7 +58,8 @@ def envoy_dependency_imports(
+         register_preinstalled_tools=True,  # use host tools (default)
+     )
+     go_rules_dependencies()
+-    go_register_toolchains(go_version)
++    go_download_sdk(name = "go_sdk", version = go_version, sdks = _GO_SDKS)
++    go_register_toolchains()
+     if go_version != "host":
+         envoy_download_go_sdks(go_version)
+     gazelle_dependencies(go_sdk = "go_sdk")
+@@ -218,24 +231,28 @@ def envoy_download_go_sdks(go_version):
+         goos = "linux",
+         goarch = "amd64",
+         version = go_version,
++        sdks = _GO_SDKS,
+     )
+     go_download_sdk(
+         name = "go_linux_arm64",
+         goos = "linux",
+         goarch = "arm64",
+         version = go_version,
++        sdks = _GO_SDKS,
+     )
+     go_download_sdk(
+         name = "go_darwin_amd64",
+         goos = "darwin",
+         goarch = "amd64",
+         version = go_version,
++        sdks = _GO_SDKS,
+     )
+     go_download_sdk(
+         name = "go_darwin_arm64",
+         goos = "darwin",
+         goarch = "arm64",
+         version = go_version,
++        sdks = _GO_SDKS,
+     )
+ 
+ def crates_repositories():

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -43,14 +43,19 @@ let
     hash = "sha256-dT6ehfmW/huuyitqIlYAlEzUE6WrVA39sDKxatkZGaY=";
   };
 
+  # When GO_VERSION changes upstream, update the four sha256 hex strings in the
+  # _GO_SDKS dict in 0005-nixpkgs-pin-go-sdk-downloads.patch using output from
+  # this command (set the version literal in `select` to match GO_VERSION):
+  #   curl -s 'https://go.dev/dl/?mode=json&include=all' | jq -r '.[] | select(.version == "go1.24.6") | .files[] | select(.kind == "archive" and (.os == "linux" or .os == "darwin") and (.arch == "amd64" or .arch == "arm64")) | "\(.os)_\(.arch): \(.sha256)"'
+
   # these need to be updated for any changes to fetchAttrs
   depsHash' =
     if depsHash != null then
       depsHash
     else
       {
-        x86_64-linux = "sha256-dQpkB4jRfJOB14AO5ynoL3VObI1af7nTI3vbMr5N6/g=";
-        aarch64-linux = "sha256-59sY+bpGsKMDthcj+jw00WhN+vsP5MOTXy0m8HJxebM=";
+        x86_64-linux = "sha256-+oEQV3VfZu+p/f6Sif9pj2AkaA9+u0M8k+czdlcDLXI=";
+        aarch64-linux = "sha256-FcZfRinOd5KO6VnO9cx6ZQxJJ+KCFfB3Nk2k7zMuVU4";
       }
       .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 
@@ -80,6 +85,9 @@ buildBazelPackage rec {
 
       # bump rules_rust to support newer Rust
       ./0004-nixpkgs-bump-rules_rust-to-0.60.0.patch
+
+      # pin Go SDK downloads so the deps hash doesn't drift on every Go release
+      ./0005-nixpkgs-pin-go-sdk-downloads.patch
     ];
     postPatch = ''
       chmod -R +w .


### PR DESCRIPTION
Pin Go SDK downloads to avoid fetching the mutable version listing from https://go.dev/dl/?mode=json&include=all. Without explicit sdks, each go_download_sdk call downloads that listing (which changes with every Go release) and caches it in repository_cache, causing the deps hash to drift. See: io_bazel_rules_go/go/private/sdk.bzl lines 74-93 (rules_go v0.50.0)

fixes https://github.com/NixOS/nixpkgs/issues/438433

Need help getting the hash and verifying build for `aarch64-linux`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
