### PR TITLE
waysip: init at 0.6.1

### DIFF
--- a/pkgs/by-name/wa/waysip/package.nix
+++ b/pkgs/by-name/wa/waysip/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  glib,
+  fetchFromGitHub,
+  nix-update-script,
+  pango,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "waysip";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "waycrate";
+    repo = "waysip";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-QLXiQoL+S4T6RYe5vu2fSERUk/ZjEozXLg3rA3Dpn+Q=";
+  };
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    glib
+    pango
+  ];
+  cargoHash = "sha256-qhPXDeNnyYoH8h5CQvCZ/yHU+xzs+ZNEBVCRdIdguCM=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland native area selector for compositors implementing zwlr_layer_shell";
+    homepage = "https://github.com/waycrate/waysip";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      id3v1669
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "waysip";
+  };
+})


### PR DESCRIPTION
[Waysip](https://github.com/waycrate/waysip) - wayland native area selector for compositors implementing zwlr_layer_shell.
Can act as alternative to slurp.

## Things done
Initial packaging

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

