### PR TITLE
pumpkin: init at 0-unstable-2026-03-05

### DIFF
--- a/pkgs/by-name/pu/pumpkin/package.nix
+++ b/pkgs/by-name/pu/pumpkin/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pumpkin";
+  version = "0-unstable-2026-03-05";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Pumpkin-MC";
+    repo = "Pumpkin";
+    rev = "fbe13bbacd1a6573aef9e23ad9b92e1c03a603c8";
+    hash = "sha256-OYufs3WDL2yHk0tn+G249tfd8PmEr5exKPCRNflRS6Q=";
+  };
+
+  cargoHash = "sha256-gjMUqkb7yq0Sn8uokP5UV1vqdyaoI3Sv2Nb7yGNKgZ0=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  cargoBuildFlags = [
+    "-p"
+    "pumpkin"
+  ];
+
+  meta = {
+    description = "Modern OSS Minecraft server in Rust";
+    longDescription = ''
+      Pumpkin is a server built from the ground-up. Its plugin system uses WebAssembly
+      as a sandboxed plugin runtime. Unlike traditional JVM-based servers such as Vanilla, Spigot, or Paper,
+      Pumpkin compiles to a single native executable with no Java runtime
+      dependency, achieving startup times around 5 milliseconds, idle memory
+      usage around 100MB, and near-zero CPU overhead at idle. It is fully
+      multi-threaded, supports both Java Edition and Bedrock Edition clients
+      natively, and is free and open source software licensed under the GNU
+      General Public License.
+    '';
+    homepage = "https://pumpkinmc.org/";
+    changelog = "https://github.com/Pumpkin-MC/Pumpkin/commit/${finalAttrs.src.rev}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "pumpkin";
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/pu/pumpkin/package.nix
+++ b/pkgs/by-name/pu/pumpkin/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pumpkin";
+  version = "0-unstable-2026-06-02";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Pumpkin-MC";
+    repo = "Pumpkin";
+    rev = "24e3b597121eda31cf25cc94e42cc4d823a94123";
+    hash = "sha256-SQpsYI2YZ93xsDMr69vnuGwH+GsXMeEtZFacDmWsSHY=";
+  };
+
+  cargoHash = "sha256-9C90MdGbFEhminPvrZIqQ0o6nJPdO42Lqrxpl/sKUbs=";
+
+  meta = {
+    description = "Modern OSS Minecraft server in Rust";
+    longDescription = ''
+      Pumpkin is a server built from the ground-up. Its plugin system uses WebAssembly
+      as a sandboxed plugin runtime. Unlike traditional JVM-based servers such as Vanilla, Spigot, or Paper,
+      Pumpkin compiles to a single native executable with no Java runtime
+      dependency, achieving startup times around 5 milliseconds, idle memory
+      usage around 100MB, and near-zero CPU overhead at idle. It is fully
+      multi-threaded, and supports both Java Edition and Bedrock Edition clients
+      natively.
+    '';
+    homepage = "https://pumpkinmc.org/";
+    changelog = "https://github.com/Pumpkin-MC/Pumpkin/commit/${finalAttrs.src.rev}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "pumpkin";
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
