### PR TITLE
nixos/hydra: fix args for createdb

### DIFF
--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -360,7 +360,7 @@ in
         ${lib.optionalString haveLocalDB ''
           if ! [ -e ${baseDir}/.db-created ]; then
             runuser -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createuser hydra
-            runuser -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createdb -- -O hydra hydra
+            runuser -u ${config.services.postgresql.superUser} ${config.services.postgresql.package}/bin/createdb -O hydra hydra
             touch ${baseDir}/.db-created
           fi
           echo "create extension if not exists pg_trgm" | runuser -u ${config.services.postgresql.superUser} -- ${config.services.postgresql.package}/bin/psql hydra


### PR DESCRIPTION
> createdb: error: too many command-line arguments (first is "hydra")

reproducible with the hydra nixosTest on master.

```
systemd[1]: Starting hydra-init.service...
runuser[1464]: pam_unix(runuser:session): session opened for user postgres(uid=71) by (uid=0)
runuser[1464]: pam_unix(runuser:session): session closed for user postgres
runuser[1467]: pam_unix(runuser:session): session opened for user postgres(uid=71) by (uid=0)
hydra-init-pre-start[1468]: createdb: error: too many command-line arguments (first is "hydra")
hydra-init-pre-start[1468]: createdb: hint: Try "createdb --help" for more information.
runuser[1467]: pam_unix(runuser:session): session closed for user postgres
systemd[1]: hydra-init.service: Control process exited, code=exited, status=1/FAILURE
systemd[1]: hydra-init.service: Failed with result 'exit-code'.
systemd[1]: Failed to start hydra-init.service.
systemd[1]: Dependency failed for hydra-queue-runner.service.
systemd[1]: hydra-queue-runner.service: Job hydra-queue-runner.service/start failed with result 'dependency'.
systemd[1]: Dependency failed for hydra-notify.service.
systemd[1]: hydra-notify.service: Job hydra-notify.service/start failed with result 'dependency'.
systemd[1]: Dependency failed for hydra-evaluator.service.
systemd[1]: hydra-evaluator.service: Job hydra-evaluator.service/start failed with result 'dependency'.
systemd[1]: Dependency failed for hydra-server.service.
systemd[1]: hydra-server.service: Job hydra-server.service/start failed with result 'dependency'.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
