### PR TITLE
python3Packages.litellm: 1.82.3 -> 1.83.7

### DIFF
--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -50,14 +50,14 @@
 
 buildPythonPackage rec {
   pname = "litellm";
-  version = "1.82.3";
+  version = "1.83.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BerriAI";
     repo = "litellm";
     tag = "v${version}-stable";
-    hash = "sha256-oeaK8Flt/oSX9nA7tFHyBp+hvsDeRK+w16zljyA9vdE=";
+    hash = "sha256-oVQ0FHZmXDY7HU4AMEQ9xcl10mIbqja9/j2mdunTWI4=";
   };
 
   build-system = [ poetry-core ];
@@ -122,8 +122,14 @@ buildPythonPackage rec {
     "litellm_enterprise"
   ];
 
-  # Relax dependency check on openai, may not be needed in the future
-  pythonRelaxDeps = [ "openai" ];
+  pythonRelaxDeps = [
+    "aiohttp"
+    "click"
+    "importlib-metadata"
+    "jsonschema"
+    "openai"
+    "python-dotenv"
+  ];
 
   # access network
   doCheck = false;


### PR DESCRIPTION
Diff: https://github.com/BerriAI/litellm/compare/v1.82.3-stable...v1.83.7-stable

Changelog: https://github.com/BerriAI/litellm/releases/tag/v1.83.7-stable

contains fixes for CVE-2026-35030, CVE-2026-35029, GHSA-69x8-hrgq-fjj8, GHSA-xqmj-j6mv-4862, GHSA-r75f-5x8p-qvmc, and GHSA-v4p8-mg3p-g94g
not sure if it contains a fix for https://github.com/NixOS/nixpkgs/issues/508886 (CVE-2026-40217)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
