### PR TITLE
buildRustCrate: add extraRustcOptsForProcMacro

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -871,6 +871,19 @@ general. A number of other parameters can be overridden:
   (hello { }).override { extraRustcOpts = "-Z debuginfo=2"; }
   ```
 
+- Extra arguments to be passed to `rustc` when this crate is a
+  proc-macro. Proc-macro crates are compiled as host dylibs that
+  `rustc` loads at compile time; flags such as `-Zsanitizer=address`,
+  `-Cpasses=sancov-module`, or `-Cinstrument-coverage` leave
+  unresolved runtime symbols in the dylib and break the build. Set
+  this attribute (e.g. to `[ ]`) to opt the proc-macro out while
+  still passing those flags via `extraRustcOpts` to other crates.
+  When `null` (the default), inherits `extraRustcOpts`:
+
+  ```nix
+  (myProcMacro { }).override { extraRustcOptsForProcMacro = [ ]; }
+  ```
+
 - The lint level cap passed to `rustc`. Defaults to `null`, which
   auto-resolves to `"allow"` (silences all lints) when `lints` is
   empty, or `"forbid"` (no cap) when `lints` is set. Because `rustc`

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -871,6 +871,15 @@ general. A number of other parameters can be overridden:
   (hello { }).override { extraRustcOpts = "-Z debuginfo=2"; }
   ```
 
+- Extra arguments passed to `rustc` when the crate is a proc-macro,
+  replacing `extraRustcOpts`. Useful to keep instrumentation flags
+  (sanitizers, coverage) off host dylibs. Defaults to `null`, which
+  inherits `extraRustcOpts`:
+
+  ```nix
+  (myProcMacro { }).override { extraRustcOptsForProcMacro = [ ]; }
+  ```
+
 - The lint level cap passed to `rustc`. Defaults to `null`, which
   auto-resolves to `"allow"` (silences all lints) when `lints` is
   empty, or `"forbid"` (no cap) when `lints` is set. Because `rustc`

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -255,6 +255,21 @@ lib.makeOverridable
       # Example: [ "-Z debuginfo=2" ]
       # Default: []
       extraRustcOptsForBuildRs,
+      # A list of extra options to pass to rustc when this crate is a
+      # proc-macro. Proc-macro crates are compiled as host dylibs that
+      # rustc loads via `dlopen`; flags that emit references to a
+      # sanitizer or coverage runtime (e.g. `-Zsanitizer=address`,
+      # `-Cpasses=sancov-module`, `-Cinstrument-coverage`) will leave
+      # unresolved symbols in the dylib and break compilation. Cargo
+      # avoids this by not applying `RUSTFLAGS` to host artifacts;
+      # this attribute provides the same opt-out for buildRustCrate.
+      #
+      # When `null`, falls back to `extraRustcOpts` so that existing
+      # callers see no behaviour change.
+      #
+      # Example: [ ]  # opt the proc-macro out of all extraRustcOpts
+      # Default: null (inherit `extraRustcOpts`)
+      extraRustcOptsForProcMacro,
       # The lint level cap passed to rustc via `--cap-lints`.
       # See <https://doc.rust-lang.org/rustc/lints/levels.html#capping-lints>.
       #
@@ -352,7 +367,12 @@ lib.makeOverridable
       buildInputs_ = buildInputs;
       extraRustcOpts_ = extraRustcOpts;
       extraRustcOptsForBuildRs_ = extraRustcOptsForBuildRs;
+      extraRustcOptsForProcMacro_ = extraRustcOptsForProcMacro;
       buildTests_ = buildTests;
+      procMacro = lib.attrByPath [ "procMacro" ] false crate;
+      # When neither the override nor the crate sets a proc-macro-specific
+      # list, keep today's behaviour (proc-macros receive `extraRustcOpts`).
+      hasProcMacroOpts = extraRustcOptsForProcMacro_ != null || crate ? extraRustcOptsForProcMacro;
       resolvedLints = crate.lints or lints;
       lintFlags = lintsToRustcFlags resolvedLints;
       resolvedCapLints =
@@ -474,7 +494,7 @@ lib.makeOverridable
         crateRustVersion = crate.rust-version or "";
         crateVersion = crate.version;
         crateType =
-          if lib.attrByPath [ "procMacro" ] false crate then
+          if procMacro then
             [ "proc-macro" ]
           else if lib.attrByPath [ "plugin" ] false crate then
             [ "dylib" ]
@@ -485,8 +505,13 @@ lib.makeOverridable
         edition = crate.edition or null;
         codegenUnits = if crate ? codegenUnits then crate.codegenUnits else defaultCodegenUnits;
         extraRustcOpts =
-          lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
-          ++ extraRustcOpts_
+          (
+            if procMacro && hasProcMacroOpts then
+              (crate.extraRustcOptsForProcMacro or [ ])
+              ++ lib.optionals (extraRustcOptsForProcMacro_ != null) extraRustcOptsForProcMacro_
+            else
+              lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts ++ extraRustcOpts_
+          )
           ++ lintFlags
           ++ (lib.optional (edition != null) "--edition ${edition}");
         extraRustcOptsForBuildRs =
@@ -586,6 +611,7 @@ lib.makeOverridable
     verbose = crate_.verbose or true;
     extraRustcOpts = [ ];
     extraRustcOptsForBuildRs = [ ];
+    extraRustcOptsForProcMacro = null;
     capLints = null;
     lints = { };
     features = [ ];

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -255,6 +255,12 @@ lib.makeOverridable
       # Example: [ "-Z debuginfo=2" ]
       # Default: []
       extraRustcOptsForBuildRs,
+      # Extra rustc options for proc-macro crates, replacing
+      # `extraRustcOpts`. Lets callers keep instrumentation flags
+      # (sanitizers, coverage) off host dylibs, mirroring Cargo's
+      # behaviour of not applying RUSTFLAGS to host artifacts.
+      # Default: null (inherit `extraRustcOpts`)
+      extraRustcOptsForProcMacro,
       # The lint level cap passed to rustc via `--cap-lints`.
       # See <https://doc.rust-lang.org/rustc/lints/levels.html#capping-lints>.
       #
@@ -352,7 +358,21 @@ lib.makeOverridable
       buildInputs_ = buildInputs;
       extraRustcOpts_ = extraRustcOpts;
       extraRustcOptsForBuildRs_ = extraRustcOptsForBuildRs;
+      extraRustcOptsForProcMacro_ = extraRustcOptsForProcMacro;
       buildTests_ = buildTests;
+      procMacro = lib.attrByPath [ "procMacro" ] false crate;
+      # For proc-macros, prefer the *ForProcMacro variant at each level
+      # (crate attr, override arg) and fall back to extraRustcOpts.
+      crateExtraRustcOpts =
+        if procMacro && crate ? extraRustcOptsForProcMacro then
+          crate.extraRustcOptsForProcMacro
+        else
+          crate.extraRustcOpts or [ ];
+      overrideExtraRustcOpts =
+        if procMacro && extraRustcOptsForProcMacro_ != null then
+          extraRustcOptsForProcMacro_
+        else
+          extraRustcOpts_;
       resolvedLints = crate.lints or lints;
       lintFlags = lintsToRustcFlags resolvedLints;
       resolvedCapLints =
@@ -474,7 +494,7 @@ lib.makeOverridable
         crateRustVersion = crate.rust-version or "";
         crateVersion = crate.version;
         crateType =
-          if lib.attrByPath [ "procMacro" ] false crate then
+          if procMacro then
             [ "proc-macro" ]
           else if lib.attrByPath [ "plugin" ] false crate then
             [ "dylib" ]
@@ -485,8 +505,8 @@ lib.makeOverridable
         edition = crate.edition or null;
         codegenUnits = if crate ? codegenUnits then crate.codegenUnits else defaultCodegenUnits;
         extraRustcOpts =
-          lib.optionals (crate ? extraRustcOpts) crate.extraRustcOpts
-          ++ extraRustcOpts_
+          crateExtraRustcOpts
+          ++ overrideExtraRustcOpts
           ++ lintFlags
           ++ (lib.optional (edition != null) "--edition ${edition}");
         extraRustcOptsForBuildRs =
@@ -586,6 +606,7 @@ lib.makeOverridable
     verbose = crate_.verbose or true;
     extraRustcOpts = [ ];
     extraRustcOptsForBuildRs = [ ];
+    extraRustcOptsForProcMacro = null;
     capLints = null;
     lints = { };
     features = [ ];

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -836,6 +836,40 @@ rec {
             ];
           };
         };
+        # `extraRustcOptsForProcMacro` defaults to `null`, meaning
+        # proc-macro crates inherit `extraRustcOpts`. This case sets only
+        # `extraRustcOpts` and the source requires `--cfg=target_only` to
+        # compile, so it succeeds iff the inherited list reaches rustc.
+        procMacroExtraOptsInherit = {
+          procMacro = true;
+          edition = "2018";
+          extraRustcOpts = [ "--cfg=target_only" ];
+          src = mkFile "src/lib.rs" ''
+            #[cfg(not(target_only))]
+            compile_error!("extraRustcOpts not inherited by proc-macro");
+            use proc_macro as _;
+          '';
+        };
+        # When `extraRustcOptsForProcMacro` is set, it REPLACES
+        # `extraRustcOpts` for proc-macro crates. This is the cargo-like
+        # opt-out for instrumentation flags (sanitizers, sancov,
+        # `-Cinstrument-coverage`) that would otherwise leave unresolved
+        # runtime symbols in the host dylib. The source fails if either
+        # the target-only flag leaks through or the proc-macro flag is
+        # absent.
+        procMacroExtraOptsOverride = {
+          procMacro = true;
+          edition = "2018";
+          extraRustcOpts = [ "--cfg=target_only" ];
+          extraRustcOptsForProcMacro = [ "--cfg=host_only" ];
+          src = mkFile "src/lib.rs" ''
+            #[cfg(target_only)]
+            compile_error!("extraRustcOpts leaked into proc-macro");
+            #[cfg(not(host_only))]
+            compile_error!("extraRustcOptsForProcMacro not applied");
+            use proc_macro as _;
+          '';
+        };
         # The `lints` attr mirrors Cargo.toml's `[lints]` table and is
         # translated to rustc `-A`/`-W`/`-D`/`-F` flags. Lower-priority
         # entries are emitted first so that higher-priority specific lints

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -836,6 +836,32 @@ rec {
             ];
           };
         };
+        # Default (null) inherits extraRustcOpts for proc-macros.
+        procMacroExtraOptsInherit = {
+          procMacro = true;
+          edition = "2018";
+          extraRustcOpts = [ "--cfg=target_only" ];
+          src = mkFile "src/lib.rs" ''
+            #[cfg(not(target_only))]
+            compile_error!("extraRustcOpts not inherited by proc-macro");
+            use proc_macro as _;
+          '';
+        };
+        # When set, extraRustcOptsForProcMacro replaces extraRustcOpts
+        # for proc-macro crates.
+        procMacroExtraOptsOverride = {
+          procMacro = true;
+          edition = "2018";
+          extraRustcOpts = [ "--cfg=target_only" ];
+          extraRustcOptsForProcMacro = [ "--cfg=host_only" ];
+          src = mkFile "src/lib.rs" ''
+            #[cfg(target_only)]
+            compile_error!("extraRustcOpts leaked into proc-macro");
+            #[cfg(not(host_only))]
+            compile_error!("extraRustcOptsForProcMacro not applied");
+            use proc_macro as _;
+          '';
+        };
         # The `lints` attr mirrors Cargo.toml's `[lints]` table and is
         # translated to rustc `-A`/`-W`/`-D`/`-F` flags. Lower-priority
         # entries are emitted first so that higher-priority specific lints


### PR DESCRIPTION
Proc-macro crates are compiled as host dylibs that rustc loads via dlopen. When callers pass instrumentation flags through `extraRustcOpts` (e.g. `-Zsanitizer=address`, `-Cpasses=sancov-module`, `-Cinstrument-coverage`), the proc-macro dylib ends up with unresolved references to the corresponding runtime and fails to link or load.

Cargo avoids this by not applying `RUSTFLAGS` to host artifacts (build scripts, proc-macros, build-dependencies). buildRustCrate already exposes a separate `extraRustcOptsForBuildRs` for the build-script case; this adds the analogous knob for proc-macros.

The new attribute defaults to `null`, which falls back to `extraRustcOpts` so existing callers see no change. Setting it to `[]` is the typical opt-out when applying sanitizer/coverage flags tree-wide via `crateOverrides`.

Out of scope: build-dependency crates that are also linked into a build.rs binary. Since buildRustCrate compiles each crate once with a single flag set, a crate that appears in both the target and build-dep graphs cannot have different flags per role; addressing that needs a host/target compile split at the dependency-graph level (crate2nix or similar).

## Things done

- [x] Added two test cases (`procMacroExtraOptsInherit`, `procMacroExtraOptsOverride`) under `tests.buildRustCrate`
- [x] Verified existing test drv hashes unchanged (no behavior change for callers not setting the new attr)
- [x] Updated `doc/languages-frameworks/rust.section.md`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)