### PR TITLE
logic2-automation: init at 1.0.11

### DIFF
--- a/pkgs/development/python-modules/logic2-automation/default.nix
+++ b/pkgs/development/python-modules/logic2-automation/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build
+  hatchling,
+
+  # dependencies
+  grpcio,
+  grpcio-tools,
+  protobuf,
+}:
+
+buildPythonPackage rec {
+  pname = "logic2-automation";
+  version = "1.0.11";
+
+  src = fetchFromGitHub {
+    owner = "saleae";
+    repo = "logic2-automation";
+    rev = "v${version}";
+    hash = "sha256-e0UvRwUs+rKFF3ky8bnHV22ZA9sU+AoghcMui2pIzQ0=";
+  };
+
+  # The proto files are in ./proto, the pyproject.toml is in ./python
+  sourceRoot = "source/python";
+
+  # See python/build.sh in the original repository
+  preBuild = "./build.sh";
+
+  pyproject = true;
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    grpcio
+    grpcio-tools
+    protobuf
+  ];
+
+  # Tests require the unfree saleae-logic-2 package, plus gRPC server
+  # This is very hard to package so it's skipped for now
+  doCheck = false;
+
+  pythonImportsCheck = [ "saleae.automation" ];
+
+  meta = {
+    description = "Automation interface for Saleae Logic 2 software";
+    homepage = "https://github.com/saleae/logic2-automation";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ krishnans2006 ];
+  };
+}

--- a/pkgs/development/python-modules/logic2-automation/default.nix
+++ b/pkgs/development/python-modules/logic2-automation/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build
+  hatchling,
+
+  # dependencies
+  grpcio,
+  grpcio-tools,
+  protobuf,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "logic2-automation";
+  version = "1.0.11";
+
+  src = fetchFromGitHub {
+    owner = "saleae";
+    repo = "logic2-automation";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e0UvRwUs+rKFF3ky8bnHV22ZA9sU+AoghcMui2pIzQ0=";
+  };
+
+  sourceRoot = "source/python";
+
+  preBuild = "./build.sh";
+
+  pyproject = true;
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    grpcio
+    grpcio-tools
+    protobuf
+  ];
+
+  # Tests require the unfree saleae-logic-2 package, plus gRPC server which is not packaged, yet.
+  doCheck = false;
+
+  pythonImportsCheck = [ "saleae.automation" ];
+
+  meta = {
+    description = "Automation interface for Saleae Logic 2 software";
+    homepage = "https://github.com/saleae/logic2-automation";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ krishnans2006 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9299,6 +9299,8 @@ self: super: with self; {
 
   logging-tree = callPackage ../development/python-modules/logging-tree { };
 
+  logic2-automation = callPackage ../development/python-modules/logic2-automation { };
+
   logical-unification = callPackage ../development/python-modules/logical-unification { };
 
   logilab-common = callPackage ../development/python-modules/logilab/common.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9450,6 +9450,8 @@ self: super: with self; {
 
   logging-tree = callPackage ../development/python-modules/logging-tree { };
 
+  logic2-automation = callPackage ../development/python-modules/logic2-automation { };
+
   logical-unification = callPackage ../development/python-modules/logical-unification { };
 
   logilab-common = callPackage ../development/python-modules/logilab/common.nix {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This packages [logic2-automation](https://github.com/saleae/logic2-automation), a Python API that allows scripts to interface with the [Saleae Logic 2](https://github.com/NixOS/nixpkgs/blob/162f04bf3dd222187388bc990a8678170d594419/pkgs/by-name/sa/saleae-logic-2/package.nix) desktop application. This allows automatic triggering and analysis for many logic analyzers.

For examples of the package being used, see [here](https://github.com/sigpwny/2025-csaw-esc/tree/main/challenges/set1).

Tests are disabled, since all tests require communicating via gRPC with the actual Logic 2 application (which is difficult to set up, and unfree). I was able to get around the unfree test input issue using `passthru.tests` (creating a new derivation), but was not able to get gRPC communication working between `logic2-automation` and `saleae-logic-2` in the test context.

As a simple manual test, I installed this package with a dev shell and the script [here](https://saleae.github.io/logic2-automation/getting_started.html#using-the-python-automation-api) worked perfectly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
