### PR TITLE
nomachine-client: 9.2.18_3 -> 9.4.14_1

### DIFF
--- a/pkgs/by-name/no/nomachine-client/package.nix
+++ b/pkgs/by-name/no/nomachine-client/package.nix
@@ -9,10 +9,10 @@
   libpulseaudio,
 }:
 let
-  versionMajor = "9.2";
-  versionMinor = "18";
-  versionBuild_x86_64 = "3";
-  versionBuild_i686 = "3";
+  versionMajor = "9.4";
+  versionMinor = "14";
+  versionBuild_x86_64 = "1";
+  versionBuild_i686 = "1";
 in
 stdenv.mkDerivation rec {
   pname = "nomachine-client";
@@ -22,12 +22,12 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
-        sha256 = "sha256-/ElNG6zIOdE3Qwf/si9fKXMLxM81ZmRZmvbc6rw/M0c=";
+        sha256 = "sha256-tLL8l/UgTiVzGs+mwJeRUlVA8lH72JVogBOEpaSr2AY=";
       }
     else if stdenv.hostPlatform.system == "i686-linux" then
       fetchurl {
         url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
-        sha256 = "sha256-uLkBprPjYyWN0jwB6rJwG1sLbIg/jAjx57joLBhVwr0=";
+        sha256 = "sha256-pPvg8MCrpCsQiiglRxHHl9wVyndI9JTluX/mwah3wwQ=";
       }
     else
       throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";
@@ -99,8 +99,8 @@ stdenv.mkDerivation rec {
     mainProgram = "nxplayer";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = {
-      fullName = "NoMachine 7 End-User License Agreement";
-      url = "https://www.nomachine.com/licensing-7";
+      fullName = "NoMachine End User License Agreement, version 9";
+      url = "https://www.nomachine.com/licensing/nomachine-end-user-license-agreement";
       free = false;
     };
     maintainers = with lib.maintainers; [ talyz ];


### PR DESCRIPTION
- Updates to [latest version](https://kb.nomachine.com/SU03X00271)
- Fixes https://github.com/NixOS/nixpkgs/issues/509902
- Fixes https://github.com/NixOS/nixpkgs/issues/509904
- Fixes https://github.com/NixOS/nixpkgs/issues/509910

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test