### PR TITLE
vowpal-wabbit: 9.10.0 -> 9.11.2

### DIFF
--- a/pkgs/by-name/vo/vowpal-wabbit/add-missing-includes.patch
+++ b/pkgs/by-name/vo/vowpal-wabbit/add-missing-includes.patch
@@ -1,0 +1,36 @@
+diff --git a/vowpalwabbit/config/include/vw/config/option.h b/vowpalwabbit/config/include/vw/config/option.h
+index fa584b15..97d7d92f 100644
+--- a/vowpalwabbit/config/include/vw/config/option.h
++++ b/vowpalwabbit/config/include/vw/config/option.h
+@@ -7,6 +7,7 @@
+ #include "vw/common/vw_exception.h"
+ #include "vw/common/vw_throw.h"
+ 
++#include <cstdint>
+ #include <memory>
+ #include <set>
+ #include <sstream>
+diff --git a/vowpalwabbit/core/include/vw/core/feature_group.h b/vowpalwabbit/core/include/vw/core/feature_group.h
+index 569c54ca..6e390565 100644
+--- a/vowpalwabbit/core/include/vw/core/feature_group.h
++++ b/vowpalwabbit/core/include/vw/core/feature_group.h
+@@ -10,6 +10,7 @@
+ 
+ #include <algorithm>
+ #include <cstddef>
++#include <cstdint>
+ #include <iterator>
+ #include <memory>
+ #include <numeric>
+diff --git a/vowpalwabbit/io/include/vw/io/io_adapter.h b/vowpalwabbit/io/include/vw/io/io_adapter.h
+index f5131085..9c57a449 100644
+--- a/vowpalwabbit/io/include/vw/io/io_adapter.h
++++ b/vowpalwabbit/io/include/vw/io/io_adapter.h
+@@ -4,6 +4,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <functional>
+ #include <memory>
+ #include <string>

--- a/pkgs/by-name/vo/vowpal-wabbit/package.nix
+++ b/pkgs/by-name/vo/vowpal-wabbit/package.nix
@@ -5,6 +5,8 @@
   cmake,
   boost,
   eigen,
+  gtest,
+  help2man,
   rapidjson,
   spdlog,
   zlib,
@@ -12,25 +14,31 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vowpal-wabbit";
-  version = "9.10.0";
+  version = "9.11.2";
 
   src = fetchFromGitHub {
     owner = "VowpalWabbit";
     repo = "vowpal_wabbit";
     tag = finalAttrs.version;
-    hash = "sha256-HKxhEB4ph2tOWgvYngYTcv0OCMISj3KqZpP2zsEUPs0=";
+    hash = "sha256-A1Eqj843QidqVlADi6qEKFuw+T0h1FxkRwJ9oRTZgeU=";
     fetchSubmodules = true;
   };
 
+  patches = [
+    # https://github.com/VowpalWabbit/vowpal_wabbit/pull/4916
+    ./add-missing-includes.patch
+  ];
+
   postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "set(VW_CXX_STANDARD 11)" "set(VW_CXX_STANDARD 14)"
     # Avoid duplicate add RapidJSON
     substituteInPlace ext_libs/ext_libs.cmake \
       --replace-fail "add_library(RapidJSON INTERFACE)" ""
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    help2man
+  ];
 
   buildInputs = [
     boost
@@ -41,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    "-DUSE_LATEST_STD=ON"
     "-DVW_INSTALL=ON"
     "-DBUILD_JAVA=OFF"
     "-DBUILD_PYTHON=OFF"
@@ -49,7 +58,17 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSPDLOG_SYS_DEP=ON"
     "-DVW_BOOST_MATH_SYS_DEP=ON"
     "-DVW_EIGEN_SYS_DEP=ON"
+    "-DVW_GTEST_SYS_DEP=ON"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DCMAKE_CTEST_ARGUMENTS=-E;SpanningTreeTest"
   ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  doCheck = true;
 
   meta = {
     description = "Machine learning system focused on online reinforcement learning";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324352526
- Release note: https://github.com/VowpalWabbit/vowpal_wabbit/releases/tag/9.11.2
- Diff: https://github.com/VowpalWabbit/vowpal_wabbit/compare/9.10.0...9.11.2

Fixes the compilation error with gcc15:

```
In file included from /build/source/vowpalwabbit/config/include/vw/config/options.h:7,
                 from /build/source/vowpalwabbit/config/src/cli_help_formatter.cc:8:
/build/source/vowpalwabbit/config/include/vw/config/option.h:28:35: error: 'uint32_t' was not declared in this scope
   28 |   virtual void visit(typed_option<uint32_t>& /*option*/){};
      |                                   ^~~~~~~~
/build/source/vowpalwabbit/config/include/vw/config/option.h:12:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   11 | #include <set>
  +++ |+#include <cstdint>
   12 | #include <sstream>
...
```

Enabled basic unit tests. Our packaged `gtest` now requires C++17, which in combination with this project's default C++14 setting will cause ABI incompatibility issues in the bundled `string-view-lite` library. Changed to "-DUSE_LATEST_STD=ON" for more future proof.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
