### PR TITLE
ucblogo: 6.2.4 -> 6.2.5

### DIFF
--- a/pkgs/by-name/uc/ucblogo/package.nix
+++ b/pkgs/by-name/uc/ucblogo/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ucblogo-code";
-  version = "6.2.4";
+  version = "6.2.5";
 
   src = fetchFromGitHub {
     owner = "jrincayc";
     repo = "ucblogo-code";
-    rev = "ca23b30a62eaaf03ea203ae71d00dc45a046514e";
-    hash = "sha256-BVNKkT0YUqI/z5W6Y/u3WbrHmaw7Z165vFt/mlzjd+8=";
+    tag = "version_${finalAttrs.version}";
+    hash = "sha256-QofC7G6IS5TNxwRm23uhuThLou05etGuG/S3Wm29yUI=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326623356
- Release note: https://github.com/jrincayc/ucblogo-code/releases/tag/version_6.2.5
- Diff: https://github.com/jrincayc/ucblogo-code/compare/version_6.2.4...version_6.2.5

```
coms.c: In function 'lshell':
coms.c:547:18: error: conflicting types for 'popen'; have 'FILE *(void)'
  547 |     extern FILE *popen();
      |                  ^~~~~
In file included from logo.h:84,
                 from coms.c:31:
/nix/store/h0ip0h6qp7kc2wm7mwjaglkxxbzmjri4-glibc-2.42-51-dev/include/stdio.h:893:14: note: previous declaration of 'popen' with type 'FILE *(const char *, const char *)'
  893 | extern FILE *popen (const char *__command, const char *__modes)
      |              ^~~~~
coms.c:564:12: error: too many arguments to function 'popen'; expected 0, have 2
  564 |     strm = popen(cmdbuf,"r");
      |            ^~~~~ ~~~~~~
coms.c:547:18: note: declared here
  547 |     extern FILE *popen();
      |                  ^~~~~
coms.c:575:33: error: passing argument 5 of 'make_strnode' from incompatible pointer type [-Wincompatible-pointer-types]
  575 |                         STRING, strnzcpy);
      |                                 ^~~~~~~~
      |                                 |
      |                                 char * (*)(char *, char *, int)
In file included from coms.c:32:
globals.h:65:38: note: expected 'char * (*)(void)' but argument is of type 'char * (*)(char *, char *, int)'
   65 |                           NODETYPES, char *(*)());
      |                                      ^~~~~~~~~~~
globals.h:52:14: note: 'strnzcpy' declared here
   52 | extern char *strnzcpy(char *, char *, int);
      |              ^~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
