### PR TITLE
packagekit: 1.3.3 -> 1.3.5

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -10,6 +10,8 @@
   sqlite,
   gobject-introspection,
   vala,
+  jansson,
+  docbook_xsl_ns,
   gtk-doc,
   boost,
   meson,
@@ -30,7 +32,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "packagekit";
-  version = "1.3.3";
+  version = "1.3.5";
 
   outputs = [
     "out"
@@ -42,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "PackageKit";
     repo = "PackageKit";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-BgVfM2EtuvV9qTFSy+WW5Ny1QrHIj3t2Royrn7ZHAA8=";
+    hash = "sha256-aKucwqwNyZWyHfNu9ntzSwD+eQy8KjCt6RVMjjjZmZg=";
   };
 
   buildInputs = [
@@ -52,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gtk3
+    jansson
     sqlite
     boost
   ]
@@ -97,6 +100,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "install_dir: join_paths(get_option('sysconfdir'), 'PackageKit')" "install_dir: join_paths('$out', 'etc', 'PackageKit')"
     substituteInPlace data/meson.build \
       --replace-fail "install_dir: join_paths(get_option('localstatedir'), 'lib', 'PackageKit')," "install_dir: join_paths('$out', 'var', 'lib', 'PackageKit'),"
+    substituteInPlace client/meson.build \
+      --replace-fail http://docbook.sourceforge.net/release/xsl-ns/current ${docbook_xsl_ns}/share/xml/docbook-xsl-ns
+
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Fixes high severity GHSA-f55j-vvr9-69xv

https://github.com/PackageKit/PackageKit/blob/36c89f22add88f6c051d85f2fda9abbec830d5ab/NEWS#L1-L87

See https://www.openwall.com/lists/oss-security/2026/04/22/6

https://github.com/PackageKit/PackageKit/compare/v1.3.3...v1.3.5


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
