### PR TITLE
nodejs: provide fallback passthru values on the symlink variant

### DIFF
--- a/pkgs/development/web/nodejs/symlink.nix
+++ b/pkgs/development/web/nodejs/symlink.nix
@@ -3,7 +3,7 @@
   nodejs-slim,
   symlinkJoin,
 }:
-symlinkJoin {
+(symlinkJoin {
   pname = "nodejs";
   inherit (nodejs-slim) version passthru meta;
   paths = [
@@ -11,4 +11,40 @@ symlinkJoin {
     nodejs-slim.npm
   ]
   ++ lib.optional (builtins.hasAttr "corepack" nodejs-slim) nodejs-slim.corepack;
-}
+}).overrideAttrs
+  (nodejs: {
+    passthru =
+      (builtins.listToAttrs (
+        map
+          (name: {
+            inherit name;
+            value = lib.warn "Use nodejs-slim.${name} instead of nodejs.${name}" nodejs-slim.${name};
+          })
+          (
+            builtins.filter (
+              name:
+              !lib.strings.hasPrefix "__" name
+              && !(builtins.elem name [
+                "override"
+                "overrideAttrs"
+                "overrideDerivation"
+                "outputs"
+                "outputName"
+                "system"
+                "type"
+
+                # Filter out arguments of `getOutput`
+                "bin"
+                "dev"
+                "include"
+                "lib"
+                "man"
+                "out"
+                "static"
+              ])
+              && !(builtins.hasAttr name nodejs)
+            ) (builtins.attrNames nodejs-slim)
+          )
+      ))
+      // nodejs.passthru;
+  })


### PR DESCRIPTION
Follow-up on dbcb81f67b5f1b652931c2aa7925f6b4f6837204

Derivations are recommended to replace `nodejs` with `nodejs-slim`.

This PR was previously reviewed and merged as #503386, but was rolled back because it broke `release-checks`. This version excludes `outputName` from the warning. Verified with `nix-build nixos/release-small.nix -A nixpkgs.release-checks` that this is indeed sufficient to fix that check.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
