### PR TITLE
surge: add darwin support

### DIFF
--- a/pkgs/by-name/su/surge/package.nix
+++ b/pkgs/by-name/su/surge/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/3wrsA7aG7Jb4ehhnKRJ6hAH0Ir5EAvCypRbcKhBG/M=";
   };
 
-  patches = [
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
     # Fix build error due to newer glibc version by upgrading lib "catch 2"
     # Issue: https://github.com/surge-synthesizer/surge/pull/4843
     # Patch: https://github.com/surge-synthesizer/surge/pull/4845
@@ -57,40 +57,48 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  buildInputs = [
-    cairo
-    libsndfile
-    libxcb
-    libxkbcommon
-    libxcb-util
-    libxcb-cursor
-    libxcb-keysyms
-    zenity
-    curl
-    rsync
-  ];
+  buildInputs =
+    [
+      cairo
+      libsndfile
+      curl
+      rsync
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libxcb
+      libxkbcommon
+      libxcb-util
+      libxcb-cursor
+      libxcb-keysyms
+      zenity
+    ];
 
   # Fix build with gcc 15
   env.NIX_CFLAGS_COMPILE = "-Wno-deprecated";
 
-  postPatch = ''
-    substituteInPlace src/common/SurgeStorage.cpp \
-      --replace "/usr/share/Surge" "$out/share/surge"
-    substituteInPlace src/linux/UserInteractionsLinux.cpp \
-      --replace '"zenity' '"${zenity}/bin/zenity'
-    patchShebangs scripts/linux/
-    cp -r $extraContent/Skins/ resources/data/skins
+  postPatch =
+    ''
+      substituteInPlace src/common/SurgeStorage.cpp \
+        --replace "/usr/share/Surge" "$out/share/surge"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace src/linux/UserInteractionsLinux.cpp \
+        --replace '"zenity' '"${zenity}/bin/zenity'
+      patchShebangs scripts/linux/
+    ''
+    + ''
+      cp -r $extraContent/Skins/ resources/data/skins
 
-    substituteInPlace libs/libsamplerate/CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 3.1..3.18)" "cmake_minimum_required(VERSION 3.10)"
-  '';
+      substituteInPlace libs/libsamplerate/CMakeLists.txt \
+        --replace-fail "cmake_minimum_required(VERSION 3.1..3.18)" "cmake_minimum_required(VERSION 3.10)"
+    '';
 
   installPhase = ''
     cd ..
     cmake --build build --config Release --target install-everything-global
   '';
 
-  doInstallCheck = true;
+  doInstallCheck = stdenv.hostPlatform.isLinux;
 
   installCheckPhase = ''
     export HOME=$(mktemp -d)
@@ -105,7 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://surge-synthesizer.github.io";
     license = lib.licenses.gpl3;
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [
       magnetophon
     ];


### PR DESCRIPTION
## Summary

The `surge` synthesizer (1.9.0) builds and runs correctly on `aarch64-darwin` and other Darwin platforms, but `meta.platforms` was restricted to `[ "x86_64-linux" ]`, causing evaluation to refuse building it on macOS.

Changes:
- `meta.platforms`: `[ "x86_64-linux" ]` → `lib.platforms.linux ++ lib.platforms.darwin`
- `buildInputs`: X11 libraries (`libxcb`, `libxkbcommon`, `libxcb-util`, `libxcb-cursor`, `libxcb-keysyms`) and `zenity` are now Linux-only via `lib.optionals stdenv.hostPlatform.isLinux`
- `patches`: the glibc/catch2 fix is Linux-only (glibc is not present on Darwin)
- `postPatch`: zenity path substitution and `patchShebangs scripts/linux/` are wrapped in `lib.optionalString stdenv.hostPlatform.isLinux`
- `doInstallCheck`: set to `stdenv.hostPlatform.isLinux` — the `surge-headless` binary is only built on Linux

The darwin cmake build uses the macOS SDK frameworks (CoreAudio, CoreMIDI, Cocoa, etc.) which are found automatically by cmake via the Darwin stdenv; no additional explicit framework dependencies are needed.

## Test plan

- [x] `nix-instantiate -A surge` evaluates successfully on `aarch64-darwin` (no "not available on hostPlatform" error)
- [x] `surge.meta.platforms` now includes `aarch64-darwin`
- [ ] Full build on `aarch64-darwin` (tested locally by reporter — package builds and runs)
- [ ] Existing `x86_64-linux` build unaffected (only additive changes for Linux)