### PR TITLE
icinga2: 2.15.1 -> 2.16.2

### DIFF
--- a/pkgs/by-name/ic/icinga2-agent/package.nix
+++ b/pkgs/by-name/ic/icinga2-agent/package.nix
@@ -5,4 +5,5 @@ icinga2.override {
   withNotification = false;
   withIcingadb = false;
   withPerfdata = false;
+  withOtel = false;
 }

--- a/pkgs/by-name/ic/icinga2/package.nix
+++ b/pkgs/by-name/ic/icinga2/package.nix
@@ -13,7 +13,9 @@
   patchelf,
   mariadb-connector-c,
   libpq,
+  protobuf,
   zlib,
+  ctestCheckHook,
   tzdata,
   # Databases
   withMysql ? true,
@@ -25,18 +27,19 @@
   withNotification ? true,
   withPerfdata ? true,
   withIcingadb ? true,
+  withOtel ? true,
   nameSuffix ? "",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "icinga2${nameSuffix}";
-  version = "2.15.1";
+  version = "2.16.0";
 
   src = fetchFromGitHub {
     owner = "icinga";
     repo = "icinga2";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-w/eD07yzBm3x4G74OuGwkmpBzj63UoklmcKxVi5lx8E=";
+    hash = "sha256-Znpm7wMrTfth1VmZM1gQFCUV0bIS747lLK4PHYOzCRs=";
   };
 
   patches = [
@@ -68,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
       (mkFeatureFlag "NOTIFICATION" withNotification)
       (mkFeatureFlag "PERFDATA" withPerfdata)
       (mkFeatureFlag "ICINGADB" withIcingadb)
+      (mkFeatureFlag "OPENTELEMETRY" withOtel)
       # Misc.
       "-DICINGA2_USER=icinga2"
       "-DICINGA2_GROUP=icinga2"
@@ -86,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     systemd
   ]
+  ++ lib.optional withOtel protobuf
   ++ lib.optional withPostgresql libpq;
 
   nativeBuildInputs = [
@@ -96,7 +101,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
-  nativeCheckInputs = [ tzdata ]; # legacytimeperiod/dst needs this
+
+  # https://github.com/Icinga/icinga2/issues/10722#issuecomment-4178294982
+  ctestFlags = [
+    "-LE"
+    "network"
+  ];
+
+  nativeCheckInputs = [
+    ctestCheckHook # ctestFlags needs this
+    tzdata # legacytimeperiod/dst needs this
+  ];
 
   postFixup = ''
     rm -r $out/etc/logrotate.d $out/etc/sysconfig $out/lib/icinga2/prepare-dirs
@@ -126,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Open source monitoring system";
     homepage = "https://www.icinga.com";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       das_j

--- a/pkgs/by-name/ic/icinga2/package.nix
+++ b/pkgs/by-name/ic/icinga2/package.nix
@@ -7,13 +7,15 @@
   flex,
   bison,
   systemd,
-  boost186,
+  boost,
   libedit,
   openssl,
   patchelf,
   mariadb-connector-c,
   libpq,
+  protobuf,
   zlib,
+  ctestCheckHook,
   tzdata,
   # Databases
   withMysql ? true,
@@ -25,18 +27,19 @@
   withNotification ? true,
   withPerfdata ? true,
   withIcingadb ? true,
+  withOtel ? true,
   nameSuffix ? "",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "icinga2${nameSuffix}";
-  version = "2.15.1";
+  version = "2.16.2";
 
   src = fetchFromGitHub {
     owner = "icinga";
     repo = "icinga2";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-w/eD07yzBm3x4G74OuGwkmpBzj63UoklmcKxVi5lx8E=";
+    hash = "sha256-+9NveqbvOsw9ipoWCk5HA0ykVZS8WxBTuOzdoSb8HH8=";
   };
 
   patches = [
@@ -68,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
       (mkFeatureFlag "NOTIFICATION" withNotification)
       (mkFeatureFlag "PERFDATA" withPerfdata)
       (mkFeatureFlag "ICINGADB" withIcingadb)
+      (mkFeatureFlag "OPENTELEMETRY" withOtel)
       # Misc.
       "-DICINGA2_USER=icinga2"
       "-DICINGA2_GROUP=icinga2"
@@ -81,11 +85,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost186
+    boost
     libedit
     openssl
     systemd
   ]
+  ++ lib.optional withOtel protobuf
   ++ lib.optional withPostgresql libpq;
 
   nativeBuildInputs = [
@@ -96,7 +101,17 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
-  nativeCheckInputs = [ tzdata ]; # legacytimeperiod/dst needs this
+
+  # https://github.com/Icinga/icinga2/issues/10722#issuecomment-4178294982
+  ctestFlags = [
+    "-LE"
+    "network"
+  ];
+
+  nativeCheckInputs = [
+    ctestCheckHook # ctestFlags needs this
+    tzdata # legacytimeperiod/dst needs this
+  ];
 
   postFixup = ''
     rm -r $out/etc/logrotate.d $out/etc/sysconfig $out/lib/icinga2/prepare-dirs
@@ -126,7 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Open source monitoring system";
     homepage = "https://www.icinga.com";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       das_j


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes #485061
closes #485063

CC @oxzi
CC https://github.com/Icinga/icinga2/issues/10778

Release notes (latest first):
   - https://github.com/Icinga/icinga2/releases/tag/v2.16.2
   - https://github.com/Icinga/icinga2/releases/tag/v2.16.1
   - https://github.com/Icinga/icinga2/releases/tag/v2.16.0

   GitHub security advisories (worse first):
   - https://github.com/Icinga/icinga2/security/advisories/GHSA-vj39-ww8j-vvx5
   - https://github.com/Icinga/icinga2/security/advisories/GHSA-jgqj-x5j9-vgcm
   - https://github.com/Icinga/icinga2/security/advisories/GHSA-wh38-wg57-5w7g

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
