### PR TITLE
translatelocally: fix build with gcc15

### DIFF
--- a/pkgs/by-name/tr/translatelocally/add_missing_include.patch
+++ b/pkgs/by-name/tr/translatelocally/add_missing_include.patch
@@ -1,0 +1,12 @@
+diff --git a/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h b/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h
+index 87de194..85e85a1 100755
+--- a/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h
++++ b/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h
+@@ -5,6 +5,7 @@
+ #include <unordered_set>
+ #include <vector>
+ #include <set>
++#include <cstdint>
+ 
+ namespace marian {
+ 

--- a/pkgs/by-name/tr/translatelocally/gcc15_compat_vnd_marian_missing_include.patch
+++ b/pkgs/by-name/tr/translatelocally/gcc15_compat_vnd_marian_missing_include.patch
@@ -1,0 +1,12 @@
+diff --git a/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h b/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h
+index 87de194..85e85a1 100755
+--- a/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h
++++ b/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h
+@@ -5,6 +5,7 @@
+ #include <unordered_set>
+ #include <vector>
+ #include <set>
++#include <cstdint>
+ 
+ namespace marian {
+ 

--- a/pkgs/by-name/tr/translatelocally/package.nix
+++ b/pkgs/by-name/tr/translatelocally/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./version_without_git.patch
+    ./add_missing_include.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/tr/translatelocally/package.nix
+++ b/pkgs/by-name/tr/translatelocally/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./version_without_git.patch
+    ./gcc15_compat_vnd_marian_missing_include.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
- #475479 
- #516381
- https://hydra.nixos.org/build/324340019

```
In file included from /build/source/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.cpp:1:
/build/source/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h:18:9: error: 'uint32_t' does not name a type
   18 | typedef uint32_t IndexType;
      |         ^~~~~~~~
/build/source/3rd_party/bergamot-translator/3rd_party/marian-dev/src/microsoft/quicksand.h:8:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    7 | #include <set>
  +++ |+#include <cstdint>
    8 | 
...
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
