### PR TITLE
duckdb: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/by-name/du/duckdb/versions.json
+++ b/pkgs/by-name/du/duckdb/versions.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.5.1",
-  "rev": "7dbb2e646fea939a89f10a55aa98c474cbb0c098",
-  "hash": "sha256-FygBpfhvezvUbI969Dta+vZOPt6BnSW2d5gO4I4oB2A=",
-  "python_hash": "sha256-ZB+Zcxg5VjBzfTkQk7TxoP9pw+hvOXpB2qqnqqmjhxM="
+  "version": "1.5.2",
+  "rev": "8a5851971fae891f292c2714d86046ee018e9737",
+  "hash": "sha256-FWoVF7s/n28NN1HtnO0Cr3YyoIDgJcWBtBiO7vWiSOU=",
+  "python_hash": "sha256-B14dXW5pPnToiKbSD9ACzNksIhBG+ui1P9l67Qyke8o="
 }


### PR DESCRIPTION
used `update.sh` (nice!).

see: https://github.com/duckdb/duckdb/releases/tag/v1.5.2
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
