### PR TITLE
nixos-test-driver: unbreak eval on macOS

### DIFF
--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -61,15 +61,15 @@ buildPythonApplication {
     util-linux
     vde2
   ]
+  ++ lib.optionals stdenv.isLinux [
+    vhost-device-vsock
+  ]
   ++ lib.optionals enableNspawn [
     systemd
   ]
   ++ lib.optionals enableOCR [
     imagemagick_light
     tesseract4
-  ]
-  ++ lib.optionals stdenv.isLinux [
-    vhost-device-vsock
   ];
 
   # containers test requires extra nix features that are not available in ofborg.

--- a/nixos/lib/test-driver/default.nix
+++ b/nixos/lib/test-driver/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
 
   buildPythonApplication,
   colorama,
@@ -59,7 +60,6 @@ buildPythonApplication {
     socat
     util-linux
     vde2
-    vhost-device-vsock
   ]
   ++ lib.optionals enableNspawn [
     systemd
@@ -67,6 +67,9 @@ buildPythonApplication {
   ++ lib.optionals enableOCR [
     imagemagick_light
     tesseract4
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    vhost-device-vsock
   ];
 
   # containers test requires extra nix features that are not available in ofborg.

--- a/nixos/lib/testing/driver-configuration.nix
+++ b/nixos/lib/testing/driver-configuration.nix
@@ -1,7 +1,7 @@
 {
   config,
   lib,
-  pkgs,
+  hostPkgs,
   ...
 }:
 let
@@ -75,9 +75,9 @@ in
         ) (lib.attrValues config.nodes ++ lib.attrValues config.containers)
       );
       global_timeout = config.globalTimeout;
-      test_script = pkgs.writeText "test-script" config.testScriptString;
+      test_script = hostPkgs.writeText "test-script" config.testScriptString;
       enable_ssh_backdoor = config.sshBackdoor.enable;
     };
-    driverConfigurationFile = pkgs.writers.writeJSON "driverConfiguration.json" config.driverConfiguration;
+    driverConfigurationFile = hostPkgs.writers.writeJSON "driverConfiguration.json" config.driverConfiguration;
   };
 }

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -9,6 +9,8 @@ let
 
   inherit (config) sshBackdoor;
 
+  inherit (hostPkgs.stdenv.hostPlatform) isLinux;
+
   # Reifies and correctly wraps the python test driver for
   # the respective qemu version and with or without ocr support
   testDriver = config.pythonTestDriverPackage.override {
@@ -251,7 +253,7 @@ in
         # depending on whether debugging is enabled.
         #
         # If needed, this can still be turned off.
-        virtualisation.qemu.enableSharedMemory = lib.mkDefault true;
+        virtualisation.qemu.enableSharedMemory = lib.mkDefault isLinux;
 
         assertions = [
           {


### PR DESCRIPTION
- driver-config.nix: use `hostPkgs` instead of `pkgs` when writing test_script and driver config file
- driver package: only depend on vsock stuff on linux, not macos 
- don't enable sharedMemory settings for qemu on macos

targetet at master branch as discussed in the staging chatroom.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
