### PR TITLE
tidal-for-mac: Add native macOS Tidal client

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16203,6 +16203,12 @@
     githubId = 7910815;
     name = "Alex McGrath";
   };
+  lykaz = {
+    name = "Lukas";
+    matrix = "@luki63:matrix.org";
+    github = "lykaz";
+    githubId = 57544489;
+  };
   lykos153 = {
     email = "silvio.ankermann@cloudandheat.com";
     github = "Lykos153";

--- a/pkgs/by-name/ti/tidal-for-mac/package.nix
+++ b/pkgs/by-name/ti/tidal-for-mac/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchzip,
+  stdenvNoCC,
+  writeShellApplication,
+  curl,
+  jq,
+  common-updater-scripts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tidal-for-mac";
+  version = "2.41.3";
+
+  src = fetchzip {
+    url = "https://download.tidal.com/desktop/mac/TIDAL.arm64.${finalAttrs.version}.zip";
+    hash = "sha256-hkaxCWIIyEOl9dg9SkkRQUL3UA8+OcBPV9ICQOWTi+w=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Tidal.app"
+    cp -R Contents "$out/Applications/Tidal.app/"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "tidal-update-script";
+    runtimeInputs = [
+      curl
+      jq
+      common-updater-scripts
+    ];
+    text = ''
+      version=$(curl -s "https://formulae.brew.sh/api/cask/tidal.json" | jq -r '.version')
+      update-source-version tidal-for-mac "$version" --file=./pkgs/by-name/ti/tidal-for-mac/package.nix
+    '';
+  });
+
+  meta = {
+    description = "Native desktop client for Tidal";
+    homepage = "https://tidal.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "aarch64-darwin" ];
+    maintainers = with lib.maintainers; [ lykaz ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Added the native Tidal desktop app to nixpks, included an updater script to update. Referenced from [whatsapp-for-mac](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/wh/whatsapp-for-mac/package.nix)

Tried to follow whatsapp-for-mac as closely as possible, however fetchzip unzipped .app also therefore "reverted" to fetchurl. Also added myself to maintainers.

If something is missing, please point it out, and I will fix it immediately. I tried do follow [CONTRIBUTING.md] as closely as possible, but do to the sheer size I feel like I have missed something. 

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. 
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
