### PR TITLE
[Backport release-25.11] pdns: 4.9.8 -> 4.9.14

### DIFF
--- a/nixos/tests/powerdns.nix
+++ b/nixos/tests/powerdns.nix
@@ -30,7 +30,7 @@
 
       environment.systemPackages = with pkgs; [
         dnsutils
-        powerdns
+        pdns
         mariadb
       ];
     };
@@ -43,7 +43,7 @@
     with subtest("Loading the MySQL schema works"):
         server.succeed(
             "sudo -u pdns mysql -u pdns -D powerdns <"
-            "${pkgs.powerdns}/share/doc/pdns/schema.mysql.sql"
+            "${pkgs.pdns}/share/doc/pdns/schema.mysql.sql"
         )
 
     with subtest("PowerDNS server starts"):

--- a/pkgs/by-name/pd/pdns/package.nix
+++ b/pkgs/by-name/pd/pdns/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pdns";
-  version = "4.9.8";
+  version = "4.9.14";
 
   src = fetchurl {
     url = "https://downloads.powerdns.com/releases/pdns-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-GAtmrjMtMWaWjgE7/3y/bwxyhp1r5pfbdKAt86xuipE=";
+    hash = "sha256-4l9Qmv6Sx2HU6SUBl2TNXZ0W3zl7zzubmfhpVdvRN74=";
   };
   # redact configure flags from version output to reduce closure size
   patches = [ ./version.patch ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
