### PR TITLE
treewide: update radicle domains

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -920,14 +920,14 @@ respectively. Otherwise, the fetcher uses `fetchzip`.
 
 This is used with Radicle repositories. The arguments expected are similar to `fetchgit`.
 
-Requires a `seed` argument (e.g. `seed.radicle.xyz` or `rosa.radicle.xyz`) and a `repo` argument
+Requires a `seed` argument (e.g. `seed.radicle.dev` or `rosa.radicle.network`) and a `repo` argument
 (the repository id *without* the `rad:` prefix). Also accepts an optional `node` argument which
 contains the id of the node from which to fetch the specified ref. If `node` is `null` (the
 default), a canonical ref is fetched instead.
 
 ```nix
 fetchFromRadicle {
-  seed = "seed.radicle.xyz";
+  seed = "seed.radicle.dev";
   repo = "z3gqcJUoA1n9HaHKufZs5FCSGazv5"; # heartwood
   tag = "releases/1.3.0";
   hash = "sha256-4o88BWKGGOjCIQy7anvzbA/kPOO+ZsLMzXJhE61odjw=";
@@ -942,7 +942,7 @@ contains the full revision id of the Radicle patch to fetch.
 
 ```nix
 fetchRadiclePatch {
-  seed = "rosa.radicle.xyz";
+  seed = "rosa.radicle.network";
   repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5"; # radicle-explorer
   revision = "d97d872386c70607beda2fb3fc2e60449e0f4ce4"; # patch: d77e064
   hash = "sha256-ttnNqj0lhlSP6BGzEhhUOejKkkPruM9yMwA5p9Di4bk=";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -139,7 +139,7 @@
 
 - [`pay-respects`](https://codeberg.org/iff/pay-respects), a terminal command correction program, alternative to `thefuck`, written in Rust. Available as [programs.pay-respects](options.html#opt-programs.pay-respects).
 
-- [Radicle](https://radicle.xyz), an open source, peer-to-peer code collaboration stack built on Git. Available as [services.radicle](#opt-services.radicle.enable).
+- [Radicle](https://radicle.dev), an open source, peer-to-peer code collaboration stack built on Git. Available as [services.radicle](#opt-services.radicle.enable).
 
 - [Ordinal](https://github.com/snu-sf/Ordinal), A library for ordinal numbers in the Coq proof assistant.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -149,9 +149,9 @@
 
 - [qBittorrent](https://www.qbittorrent.org/), a bittorrent client programmed in C++ / Qt that uses libtorrent by Arvid Norberg. Available as [services.qbittorrent](#opt-services.qbittorrent.enable).
 
-- [radicle-ci-broker](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), a tool for running CI for repositories in the local [Radicle](https://radicle.xyz/) node. Available as [services.radicle.ci.broker.enable](#opt-services.radicle.ci.broker.enable).
+- [radicle-ci-broker](https://radicle.network/nodes/seed.radicle.dev/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), a tool for running CI for repositories in the local [Radicle](https://radicle.dev/) node. Available as [services.radicle.ci.broker.enable](#opt-services.radicle.ci.broker.enable).
 
-- [radicle-native-ci](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE), an adapter for the [Radicle CI broker](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), for performing CI runs locally. Available as [services.radicle.ci.adapters.native](#opt-services.radicle.ci.adapters.native.instances).
+- [radicle-native-ci](https://radicle.network/nodes/seed.radicle.dev/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE), an adapter for the [Radicle CI broker](https://radicle.network/nodes/seed.radicle.dev/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), for performing CI runs locally. Available as [services.radicle.ci.adapters.native](#opt-services.radicle.ci.adapters.native.instances).
 
 - [rauc](https://rauc.io/) (the Robust Auto-Update Controller), a daemon that allows reliable and secure software updates in embedded Linux systems. Available at [services.rauc](#opt-services.rauc.enable).
 

--- a/nixos/modules/services/continuous-integration/radicle/adapters/native.nix
+++ b/nixos/modules/services/continuous-integration/radicle/adapters/native.nix
@@ -81,7 +81,7 @@ in
                 };
                 description = ''
                   Configuration of radicle-native-ci.
-                  See <https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE#configuration> for more information.
+                  See <https://radicle.network/nodes/seed.radicle.dev/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE#configuration> for more information.
                 '';
                 default = { };
               };

--- a/nixos/modules/services/continuous-integration/radicle/ci-broker.nix
+++ b/nixos/modules/services/continuous-integration/radicle/ci-broker.nix
@@ -135,7 +135,7 @@ in
       };
       description = ''
         Configuration of radicle-ci-broker.
-        See <https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8/tree/doc/userguide.md#configuration> for more information.
+        See <https://radicle.network/nodes/seed.radicle.dev/rad:zwTxygwuz5LDGBq255RA2CbNGrz8/tree/doc/userguide.md#configuration> for more information.
       '';
       default = { };
       example = lib.literalExpression ''

--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -41,7 +41,7 @@ let
       pkgs.gitMinimal
     ];
     documentation = [
-      "https://docs.radicle.xyz/guides/seeder"
+      "https://radicle.dev/guides/seeder"
     ];
     after = [
       "network.target"
@@ -225,7 +225,7 @@ in
         };
       settings = lib.mkOption {
         description = ''
-          See <https://app.radicle.xyz/nodes/seed.radicle.garden/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/radicle/src/node/config.rs#L275>
+          See <https://radicle.network/nodes/iris.radicle.network/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/radicle/src/node/config.rs#L275>
         '';
         default = { };
         example = lib.literalExpression ''

--- a/pkgs/by-name/ra/radicle-ci-broker/package.nix
+++ b/pkgs/by-name/ra/radicle-ci-broker/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.27.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "zwTxygwuz5LDGBq255RA2CbNGrz8";
     node = "z6MkgEMYod7Hxfy9qCvDv5hYHkZ4ciWmLFgfvm3Wn1b2w2FV";
     tag = "v${finalAttrs.version}";
@@ -66,8 +66,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle CI broker";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8/tree/NEWS.md";
+    homepage = "https://radicle.network/nodes/seed.radicle.dev/rad:zwTxygwuz5LDGBq255RA2CbNGrz8";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:zwTxygwuz5LDGBq255RA2CbNGrz8/tree/NEWS.md";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ra/radicle-desktop/package.nix
+++ b/pkgs/by-name/ra/radicle-desktop/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.9.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "z4D5UCArafTzTQpDZNQRuqswh3ury";
     tag = "releases/${finalAttrs.version}";
     hash = "sha256-ruBHhJ0JvbtXd0GonL5rNp733mulVSQJsVzkikQKCK0=";
@@ -125,8 +125,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle desktop app";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4D5UCArafTzTQpDZNQRuqswh3ury";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4D5UCArafTzTQpDZNQRuqswh3ury/tree/CHANGELOG.md";
+    homepage = "https://radicle.network/nodes/seed.radicle.dev/rad:z4D5UCArafTzTQpDZNQRuqswh3ury";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z4D5UCArafTzTQpDZNQRuqswh3ury/tree/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
     teams = [ lib.teams.radicle ];

--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -108,7 +108,7 @@ lib.fix (
           server.
         '';
 
-        homepage = "https://radicle.xyz";
+        homepage = "https://radicle.dev";
         license = lib.licenses.gpl3;
 
         teams = [ lib.teams.radicle ];

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # You must update the radicle-explorer source hash when changing this.
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
     tag = "releases/${finalAttrs.version}";
     sparseCheckout = [ "radicle-httpd" ];
@@ -77,8 +77,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       A Radicle HTTP daemon exposing a JSON HTTP API that allows someone to browse local
       repositories on a Radicle node via their web browser.
     '';
-    homepage = "https://radicle.xyz";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/radicle-httpd/CHANGELOG.md";
+    homepage = "https://radicle.dev";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/radicle-httpd/CHANGELOG.md";
     # cargo.toml says MIT and asl20, LICENSE file says GPL3
     license = with lib.licenses; [
       gpl3Only

--- a/pkgs/by-name/ra/radicle-job/package.nix
+++ b/pkgs/by-name/ra/radicle-job/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.2";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "z2UcCU1LgMshWvXj6hXSDDrwB8q8M";
     tag = "releases/v${finalAttrs.version}";
     hash = "sha256-kFlSig0eiUdw6GHwacNHtuGkuW14CkHkc3okN2ZeTns=";
@@ -32,8 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Create, update, and query Radicle Job Collaborative Objects";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z2UcCU1LgMshWvXj6hXSDDrwB8q8M";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z2UcCU1LgMshWvXj6hXSDDrwB8q8M/tree/CHANGELOG.md";
+    homepage = "https://radicle.network/nodes/seed.radicle.dev/rad:z2UcCU1LgMshWvXj6hXSDDrwB8q8M";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z2UcCU1LgMshWvXj6hXSDDrwB8q8M/tree/CHANGELOG.md";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ra/radicle-native-ci/package.nix
+++ b/pkgs/by-name/ra/radicle-native-ci/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.14.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "z3qg5TKmN83afz2fj9z3fQjU8vaYE";
     node = "z6MkgEMYod7Hxfy9qCvDv5hYHkZ4ciWmLFgfvm3Wn1b2w2FV";
     tag = "v${finalAttrs.version}";
@@ -40,8 +40,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle CI adapter for native CI";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE/tree/NEWS.md";
+    homepage = "https://radicle.network/nodes/seed.radicle.dev/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE/tree/NEWS.md";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radicle-node";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "z3gqcJUoA1n9HaHKufZs5FCSGazv5";
     tag = "releases/${finalAttrs.version}";
     hash = srcHash;
@@ -164,8 +164,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Unlike centralized code hosting platforms, there is no single entity controlling the network.
       Repositories are replicated across peers in a decentralized manner, and users are in full control of their data and workflow.
     '';
-    homepage = "https://radicle.xyz";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/CHANGELOG.md";
+    homepage = "https://radicle.dev";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
+    seed = "seed.radicle.dev";
     repo = "z39mP9rQAaGmERfUMPULfPUi473tY";
     tag = "releases/${finalAttrs.version}";
     hash = "sha256-2/pLlhilJyrZl9eLFWIh4YxlJwBbzjmb1Cg1xFSSl5k=";
@@ -66,8 +66,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle terminal user interface";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z39mP9rQAaGmERfUMPULfPUi473tY";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z39mP9rQAaGmERfUMPULfPUi473tY/tree/CHANGELOG.md";
+    homepage = "https://radicle.network/nodes/seed.radicle.dev/rad:z39mP9rQAaGmERfUMPULfPUi473tY";
+    changelog = "https://radicle.network/nodes/seed.radicle.dev/rad:z39mP9rQAaGmERfUMPULfPUi473tY/tree/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or
       mit

--- a/pkgs/by-name/se/selfci/package.nix
+++ b/pkgs/by-name/se/selfci/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Minimalistic local-first Unix-philosophy-abiding CI";
-    homepage = "https://app.radicle.xyz/nodes/radicle.dpc.pw/rad%3Az2tDzYbAXxTQEKTGFVwiJPajkbeDU";
+    homepage = "https://radicle.network/nodes/radicle.dpc.pw/rad%3Az2tDzYbAXxTQEKTGFVwiJPajkbeDU";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       dvn0


### PR DESCRIPTION
https://radicle.dev/2026/04/23/domain-move

generated using the following nushell script:

```nushell
rg -l radicle | lines | do {
  sd -F seed.radicle.xyz seed.radicle.dev ...$in

  sd -F iris.radicle.xyz iris.radicle.network ...$in
  sd -F seed.radicle.garden iris.radicle.network ...$in

  sd -F rosa.radicle.xyz rosa.radicle.network ...$in
  sd -F ash.radicle.garden rosa.radicle.network ...$in

  sd -F app.radicle.xyz radicle.network ...$in

  sd -F docs.radicle.xyz radicle.dev ...$in
  sd -F radicle.xyz radicle.dev ...$in
}
```

and manually reverted the change in `pkgs/by-name/ty/typst/typst-packages-from-universe.toml`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
