### PR TITLE
nixos/test-driver: add `shell_interact()` support for nspawn containers

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -41,14 +41,17 @@ back into the test driver command line upon its completion. This allows
 you to inspect the state of the VMs after the test (e.g. to debug the
 test script).
 
-## Shell access to VMs in interactive mode {#sec-nixos-test-shell-access}
+## Shell access in interactive mode {#sec-nixos-test-shell-access}
 
 The function `<yourmachine>.shell_interact()` grants access to a shell running
-inside a virtual machine. To use it, replace `<yourmachine>` with the name of a
-virtual machine defined in the test, for example: `machine.shell_interact()`.
+inside a virtual machine or container. To use it, replace `<yourmachine>` with
+the name of a machine defined in the test, for example: `machine.shell_interact()`.
 Keep in mind that this shell may not display everything correctly as it is
-running within an interactive Python REPL, and logging output from the virtual
-machine may overwrite input and output from the guest shell:
+running within an interactive Python REPL, and logging output from the machine
+may overwrite input and output from the guest shell.
+
+For QEMU machines, `shell_interact()` connects to the guest's backdoor shell
+via `socat`:
 
 ```py
 >>> machine.shell_interact()
@@ -73,6 +76,37 @@ using:
 
 Once the connection is established, you can enter commands in the socat terminal
 where socat is running.
+
+For `systemd-nspawn` container machines, `shell_interact()` uses `nsenter` to
+enter the container's namespaces directly via a PTY:
+
+```py
+>>> container.shell_interact()
+container: Terminal is ready:
+sh-5.3# hostname
+container
+```
+
+## VM vs. container interactive capabilities {#sec-nixos-test-interactive-capabilities}
+
+Not all interactive features are available for both machine backends.
+The following table summarizes the differences:
+
+| Feature | QEMU VMs | nspawn containers |
+|---|---|---|
+| `shell_interact()` | yes (via backdoor socket) | yes (via `nsenter`) |
+| `get_tty_text()` | yes | yes |
+| `wait_until_tty_matches()` | yes | yes |
+| `dump_tty_contents()` | yes | yes |
+| `screenshot()` | yes | no |
+| `get_screen_text()` (OCR) | yes | no |
+| `send_key()` / `send_chars()` | yes | no |
+| `console_interact()` | yes | no |
+| `forward_port()` | yes | no |
+| SSH backdoor | yes | yes (via `systemd-ssh-proxy`) |
+
+Graphical display features (`screenshot`, OCR, keyboard input) rely on
+QEMU's monitor protocol and are not available for containers.
 
 ## SSH Access for test VMs {#sec-nixos-test-ssh-access}
 

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -41,14 +41,22 @@ back into the test driver command line upon its completion. This allows
 you to inspect the state of the VMs after the test (e.g. to debug the
 test script).
 
-## Shell access to VMs in interactive mode {#sec-nixos-test-shell-access}
+## Shell access in interactive mode {#sec-nixos-test-shell-access}
+
+::: {.warning}
+`shell_interact()` is intended for use in interactive test runs, and in nspawn
+containers in fact are only available in interactive settings.
+:::
 
 The function `<yourmachine>.shell_interact()` grants access to a shell running
-inside a virtual machine. To use it, replace `<yourmachine>` with the name of a
-virtual machine defined in the test, for example: `machine.shell_interact()`.
+inside a virtual machine or container. To use it, replace `<yourmachine>` with
+the name of a machine defined in the test, for example: `machine.shell_interact()`.
 Keep in mind that this shell may not display everything correctly as it is
-running within an interactive Python REPL, and logging output from the virtual
-machine may overwrite input and output from the guest shell:
+running within an interactive Python REPL, and logging output from the machine
+may overwrite input and output from the guest shell.
+
+For QEMU machines, `shell_interact()` connects to the guest's backdoor shell
+via `socat`:
 
 ```py
 >>> machine.shell_interact()
@@ -73,6 +81,16 @@ using:
 
 Once the connection is established, you can enter commands in the socat terminal
 where socat is running.
+
+For `systemd-nspawn` container machines, `shell_interact()` uses `nsenter` to
+enter the container's namespaces directly via a PTY:
+
+```py
+>>> container.shell_interact()
+container: Terminal is ready:
+sh-5.3# hostname
+container
+```
 
 ## SSH Access for test VMs {#sec-nixos-test-ssh-access}
 

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -2288,6 +2288,9 @@
   "sec-nixos-test-shell-access": [
     "index.html#sec-nixos-test-shell-access"
   ],
+  "sec-nixos-test-interactive-capabilities": [
+    "index.html#sec-nixos-test-interactive-capabilities"
+  ],
   "sec-nixos-test-ssh-access": [
     "index.html#sec-nixos-test-ssh-access"
   ],

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -580,6 +580,37 @@ class BaseMachine(ABC):
         """
         return self.systemctl(f"stop {jobname}", user)
 
+    def get_tty_text(self, tty: str) -> str:
+        """
+        Get the output printed to a given TTY.
+        """
+        status, output = self.execute(
+            f"fold -w$(stty -F /dev/tty{tty} size | awk '{{print $2}}') /dev/vcs{tty}"
+        )
+        return output
+
+    def wait_until_tty_matches(self, tty: str, regexp: str, timeout: int = 900) -> None:
+        """Wait until the visible output on the chosen TTY matches regular
+        expression. Throws an exception on timeout.
+        """
+        matcher = re.compile(regexp)
+
+        def tty_matches(last_try: bool) -> bool:
+            text = self.get_tty_text(tty)
+            if last_try:
+                self.log(
+                    f"Last chance to match /{regexp}/ on TTY{tty}, "
+                    f"which currently contains: {text}"
+                )
+            return len(matcher.findall(text)) > 0
+
+        with self.nested(f"waiting for {regexp} to appear on tty {tty}"):
+            retry(tty_matches, timeout)
+
+    def dump_tty_contents(self, tty: str) -> None:
+        """Debugging: Dump the contents of the TTY<n>"""
+        self.execute(f"fold -w 80 /dev/vcs{tty} | systemd-cat")
+
     def execute(
         self,
         command: str,
@@ -836,37 +867,6 @@ class QemuMachine(BaseMachine):
             if decoded[-1] == "\n":
                 break
         return "".join(output_buffer)
-
-    def get_tty_text(self, tty: str) -> str:
-        """
-        Get the output printed to a given TTY.
-        """
-        status, output = self.execute(
-            f"fold -w$(stty -F /dev/tty{tty} size | awk '{{print $2}}') /dev/vcs{tty}"
-        )
-        return output
-
-    def wait_until_tty_matches(self, tty: str, regexp: str, timeout: int = 900) -> None:
-        """Wait until the visible output on the chosen TTY matches regular
-        expression. Throws an exception on timeout.
-        """
-        matcher = re.compile(regexp)
-
-        def tty_matches(last_try: bool) -> bool:
-            text = self.get_tty_text(tty)
-            if last_try:
-                self.log(
-                    f"Last chance to match /{regexp}/ on TTY{tty}, "
-                    f"which currently contains: {text}"
-                )
-            return len(matcher.findall(text)) > 0
-
-        with self.nested(f"waiting for {regexp} to appear on tty {tty}"):
-            retry(tty_matches, timeout)
-
-    def dump_tty_contents(self, tty: str) -> None:
-        """Debugging: Dump the contents of the TTY<n>"""
-        self.execute(f"fold -w 80 /dev/vcs{tty} | systemd-cat")
 
     def _execute(
         self,
@@ -1600,6 +1600,43 @@ class NspawnMachine(BaseMachine):
             text=True,
         )
         return (cp.returncode, cp.stdout)
+
+    def shell_interact(self) -> None:
+        """
+        Allows you to directly interact with the container shell
+        via ``nsenter``. This should only be used during test development,
+        not in production tests.
+        Killing the interactive session with ``Ctrl-d`` or ``Ctrl-c``
+        returns to the test driver.
+        """
+        import pty
+
+        self.start()
+
+        container_pid = self.get_systemd_process
+        nsenter_path = shutil.which("nsenter")
+        assert nsenter_path is not None
+
+        self.log("Terminal is ready:")
+        try:
+            pty.spawn(
+                [
+                    nsenter_path,
+                    "--target",
+                    str(container_pid),
+                    "--mount",
+                    "--uts",
+                    "--ipc",
+                    "--net",
+                    "--pid",
+                    "--cgroup",
+                    "--",
+                    "/bin/sh",
+                    "-l",
+                ]
+            )
+        except KeyboardInterrupt:
+            pass
 
     def _stream_journal(self) -> None:
         assert self.process is not None, "Container not started"

--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1615,6 +1615,43 @@ class NspawnMachine(BaseMachine):
         )
         return (cp.returncode, cp.stdout)
 
+    def shell_interact(self) -> None:
+        """
+        Allows you to directly interact with the container shell
+        via ``nsenter``. This should only be used during test development,
+        not in production tests.
+        Killing the interactive session with ``Ctrl-d`` or ``Ctrl-c``
+        returns to the test driver.
+        """
+        import pty
+
+        self.start()
+
+        container_pid = self.get_systemd_process
+        nsenter_path = shutil.which("nsenter")
+        assert nsenter_path is not None
+
+        self.log("Terminal is ready:")
+        try:
+            pty.spawn(
+                [
+                    nsenter_path,
+                    "--target",
+                    str(container_pid),
+                    "--mount",
+                    "--uts",
+                    "--ipc",
+                    "--net",
+                    "--pid",
+                    "--cgroup",
+                    "--",
+                    "/bin/sh",
+                    "-l",
+                ]
+            )
+        except KeyboardInterrupt:
+            pass
+
     def _stream_journal(self) -> None:
         assert self.process is not None, "Container not started"
         journal_path = self.state_dir / "var/log/journal"


### PR DESCRIPTION
Move `get_tty_text`, `wait_until_tty_matches`, and `dump_tty_contents` from `QemuMachine` to `BaseMachine` so they are available on `NspawnMachine` as well. These methods only use `self.execute()`, which both machine types implement.

Add `shell_interact()` to `NspawnMachine`, using `pty.spawn` with `nsenter` to give users an interactive shell inside the container during interactive test sessions.

Update the manual to reflect that `shell_interact()` works for both VMs and containers.

Disclaimer: i used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
