### PR TITLE
 ibm-plex: use installFonts hook 

### DIFF
--- a/pkgs/by-name/ib/ibm-plex/package.nix
+++ b/pkgs/by-name/ib/ibm-plex/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  symlinkJoin,
+  installFonts,
   families ? [ ],
 }:
 let
@@ -18,22 +20,23 @@ stdenvNoCC.mkDerivation {
   pname = "ibm-plex";
   inherit version;
 
-  srcs = map (
-    family:
-    fetchzip {
-      url = "https://github.com/IBM/plex/releases/download/%40ibm%2Fplex-${family}%40${version}/ibm-plex-${family}.zip";
-      hash = availableFamilies.${family};
-    }
-  ) selectedFamilies;
+  src = symlinkJoin {
+    name = "ibm-plex-src";
+    paths = map (
+      family:
+      fetchzip {
+        url = "https://github.com/IBM/plex/releases/download/%40ibm%2Fplex-${family}%40${version}/ibm-plex-${family}.zip";
+        hash = availableFamilies.${family};
+      }
+    ) selectedFamilies;
+    postBuild = ''
+      find "$out" \( -name hinted -or -name unhinted -or -name split \) -exec rm -fr {} +
+    '';
+  };
 
-  dontUnpack = true;
   sourceRoot = ".";
 
-  installPhase = ''
-    runHook preInstall
-    find $srcs -type f -name '*.otf' -exec install -Dm644 {} -t $out/share/fonts/opentype \;
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/by-name/ib/ibm-plex/package.nix
+++ b/pkgs/by-name/ib/ibm-plex/package.nix
@@ -44,6 +44,7 @@ stdenvNoCC.mkDerivation {
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
+      ners
       romildo
       ryanccn
     ];

--- a/pkgs/by-name/ib/ibm-plex/package.nix
+++ b/pkgs/by-name/ib/ibm-plex/package.nix
@@ -38,6 +38,11 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [ installFonts ];
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   passthru.updateScript = ./update.sh;
 
   meta = {


### PR DESCRIPTION
The previous iteration of the package only installed the OTF files, and was not explicit about whether they were hinted, unhinted, or split.

This new version emits all the supported font types, as well as explicitly removes hinted, unhinted, and split files, as they have colliding names. `installFonts` helpfully errors out when colliding names are detected.