### PR TITLE
nixosTests.command-not-found: init

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -61,7 +61,14 @@ in
   config = lib.mkMerge [
     {
       programs.command-not-found = {
-        enable = lib.mkDefault (builtins.pathExists cfg.dbPath);
+        /*
+          - command-not-found itself defaults to false (priority 1500).
+          - Minimal profile uses mkDefault (priority 1000).
+
+          We want this option to take precedence over command-not-found's option default (<1500),
+          and minimal profile to take precedence over this (>1000).
+        */
+        enable = lib.mkOverride 1100 (builtins.pathExists cfg.dbPath);
         dbPath = pkgs.path + "/programs.sqlite";
       };
     }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -375,6 +375,7 @@ in
   coder = runTest ./coder.nix;
   collectd = runTest ./collectd.nix;
   commafeed = runTest ./commafeed.nix;
+  command-not-found = runTest ./command-not-found;
   connman = runTest ./connman.nix;
   console-xkb-and-i18n = runTest ./console-xkb-and-i18n.nix;
   consul = runTest ./consul.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -380,6 +380,7 @@ in
   coder = runTest ./coder.nix;
   collectd = runTest ./collectd.nix;
   commafeed = runTest ./commafeed.nix;
+  command-not-found = runTest ./command-not-found;
   connman = runTest ./connman.nix;
   console = runTest ./console.nix;
   console-xkb-and-i18n = runTest ./console-xkb-and-i18n.nix;

--- a/nixos/tests/command-not-found/default.nix
+++ b/nixos/tests/command-not-found/default.nix
@@ -1,0 +1,39 @@
+{
+  name = "command-not-found";
+
+  nodes.machine =
+    { lib, ... }:
+    {
+      programs.command-not-found = {
+        dbPath = lib.mkForce (lib.toFile "fake-db" "");
+      };
+    };
+
+  nodes.machineWithoutCommandNotFound = { };
+
+  nodes.machineMinimalProfile =
+    { lib, modulesPath, ... }:
+    {
+      imports = [ (modulesPath + "/profiles/minimal.nix") ];
+      programs.command-not-found = {
+        dbPath = lib.mkForce (lib.toFile "fake-db" "");
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      cfg = nodes.machine.programs.command-not-found;
+    in
+
+    # Check auto-enable config priority.
+    assert cfg.enable;
+    assert !nodes.machineWithoutCommandNotFound.programs.command-not-found.enable;
+    assert !nodes.machineMinimalProfile.programs.command-not-found.enable;
+
+    /* python */ ''
+      machine.start()
+      stdout = machine.fail("command-not-found 2>&1 this-command-doesnt-exist")
+      assert "this-command-doesnt-exist: command not found" in stdout
+    '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done

Add test to make sure command-not-found option is enabled with a priority that doesn't conflict with well-known profiles. Evaluates correctly with `--option allow-import-from-derivation false`.

Related to #512102

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
