### PR TITLE
cantata: 3.3.1 -> 3.4.0

### DIFF
--- a/pkgs/by-name/ca/cantata/package.nix
+++ b/pkgs/by-name/ca/cantata/package.nix
@@ -5,8 +5,8 @@
   cmake,
   pkg-config,
   qt6,
+  kdePackages,
   perl,
-  fetchpatch2,
 
   # Cantata doesn't build with cdparanoia enabled so we disable that
   # default for now until I (or someone else) figure it out.
@@ -163,13 +163,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cantata";
-  version = "3.3.1";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "nullobsi";
     repo = "cantata";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4lkfY+87lEE2A863JogG5PtO5SyGn7Hb8shQljSqq3Q=";
+    hash = "sha256-jwIsuNgsd1TFb1Zkyen/AulGQfVY2RWKfAJaWvg4WMI=";
   };
 
   patches = [
@@ -177,18 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
     # patchShebangs the playlists scripts, making that unnecessary (perl will
     # always be available because it's a dependency)
     ./dont-check-for-perl-in-PATH.diff
-
-    # remove following patches in next release
-    (fetchpatch2 {
-      name = "fix-build-with-qt-610-qfile-open.patch";
-      url = "https://github.com/nullobsi/cantata/pull/89.patch";
-      hash = "sha256-c7hdecX2oo9jTlLc6zd7LVjgZj4w89zN+eEw7ol/hmI=";
-    })
-    (fetchpatch2 {
-      name = "fix-build-with-qt-610-invalidateFilter-deprecated.patch";
-      url = "https://github.com/nullobsi/cantata/pull/90.patch";
-      hash = "sha256-dMxbC/p5mD/TQZEXORbvNON7Zzbvq0khaIR89lU5cO4=";
-    })
   ];
 
   postPatch = ''
@@ -199,6 +187,8 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtbase
     qt6.qtsvg
     qt6.qtwayland
+    kdePackages.karchive
+    kdePackages.kitemviews
     (perl.withPackages (ppkgs: with ppkgs; [ URI ]))
   ]
   ++ lib.flatten (builtins.catAttrs "pkgs" (builtins.filter (e: e.enable) options));


### PR DESCRIPTION
Changelog: https://github.com/nullobsi/cantata/releases/tag/v3.4.0

Resolves #512386

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test