### PR TITLE
cudaPackages.cuda_crt: patch math_functions.h signatures, python3Packages.deep-ep: cleanup, fix build on CUDA>=13.0

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_crt.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_crt.nix
@@ -1,9 +1,38 @@
-{ backendStdenv, buildRedist }:
+{
+  lib,
+  backendStdenv,
+  buildRedist,
+  glibc,
+}:
 buildRedist {
   redistName = "cuda";
   pname = "cuda_crt";
 
   outputs = [ "out" ];
+
+  # Fix compatibility with glibc 2.42:
+  # CUDA >= 13.0 fixed sinpi/cospi (using __NV_IEC_60559_FUNCS_EXCEPTION_SPECIFIER), but
+  # rsqrt/rsqrtf in math_functions.h still lack noexcept, conflicting with glibc 2.42's
+  # declarations.
+  postInstall = lib.optionalString (lib.versionAtLeast glibc.version "2.42") ''
+    nixLog "Patching math_functions.h rsqrt signatures to match glibc's ones"
+    substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.h" \
+      --replace-fail \
+        "rsqrt(double x);" \
+        "rsqrt(double x) noexcept (true);" \
+      --replace-fail \
+        "rsqrtf(float x);" \
+        "rsqrtf(float x) noexcept (true);"
+
+    nixLog "Patching math_functions.hpp rsqrt signatures to match glibc's ones"
+    substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.hpp" \
+      --replace-fail \
+        "__func__(double rsqrt(const double a))" \
+        "__func__(double rsqrt(const double a) throw())" \
+      --replace-fail \
+        "__func__(float rsqrtf(const float a))" \
+        "__func__(float rsqrtf(const float a) throw())"
+  '';
 
   brokenAssertions = [
     # TODO(@connorbaker): Build fails on x86 when using pkgsLLVM.

--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -168,6 +168,11 @@ buildRedist (finalAttrs: {
       # The cospi|sinpi|rsqrt function signatures in include/common/math_functions.h do not match
       # glibc 2.42's.
       # Indeed, there they are declared with noexcept(true) which is not the case in cuda_nvcc.
+      # - In CUDA < 13.0, sinpi/cospi/rsqrt all lack exception specifiers.
+      # - In CUDA >= 13.0, NVIDIA fixed sinpi/cospi (using __NV_IEC_60559_FUNCS_EXCEPTION_SPECIFIER)
+      #   but rsqrt/rsqrtf still lack noexcept, so we only patch those.
+      #   As the CRT headers (including math_functions.h) moved to the cuda_crt package, the glibc
+      #   2.42 compatibility patch is applied there instead.
       + lib.optionalString (cudaOlder "13.0" && lib.versionAtLeast glibc.version "2.42") ''
         nixLog "Patching math_functions.h signatures to match glibc's ones"
         substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.h" \
@@ -213,6 +218,7 @@ buildRedist (finalAttrs: {
             "__func__(float cospif(const float a))" \
             "__func__(float cospif(const float a) throw())"
       ''
+
       # Fix clang CUDA compilation: host_defines.h redefines __noinline__ as
       # __attribute__((noinline)), which conflicts with libstdc++ >=12 using
       # __attribute__((__noinline__)) — the macro expands to

--- a/pkgs/development/python-modules/deep-ep/default.nix
+++ b/pkgs/development/python-modules/deep-ep/default.nix
@@ -8,7 +8,6 @@
   setuptools,
 
   # env
-  symlinkJoin,
   cudaPackages,
 
   # buildInputs
@@ -20,11 +19,6 @@
   cudaSupport ? config.cudaSupport,
 }:
 let
-  inherit (lib)
-    getBin
-    getInclude
-    ;
-
   minSupportedCudaCapability = "8.0"; # build fails with 7.5
 
   minCudaCapability = builtins.head (
@@ -66,31 +60,34 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
       DISABLE_SM90_FEATURES = if disableSm90Features then "1" else "0";
 
-      CUDA_HOME = symlinkJoin {
-        name = "cuda-redist";
-        paths = with cudaPackages; [
-          (getBin cuda_nvcc)
-
-          (getInclude cuda_cccl) # <nv/target>
-          (getInclude cuda_cudart) # cuda_runtime.h
-          (getInclude libcublas) # cublas_v2.h
-          (getInclude libcusolver) # cusolverDn.h
-          (getInclude libcusparse) # cusparse.h
-        ];
-      };
+      CUDA_HOME = (lib.getBin cudaPackages.cuda_nvcc).outPath;
     }
 
     # nvshmem must be disabled (unsetting NVSHMEM_DIR) when supporting <9.0 capabilities
     # https://github.com/deepseek-ai/DeepEP/blob/v1.2.1/setup.py#L65
     // lib.optionalAttrs (!disableSm90Features) {
-      NVSHMEM_DIR = (getInclude cudaPackages.libnvshmem).outPath;
+      NVSHMEM_DIR = (lib.getInclude cudaPackages.libnvshmem).outPath;
     }
   );
 
   buildInputs = [
     pybind11
     rdma-core
-  ];
+  ]
+  ++ lib.optionals cudaSupport (
+    with cudaPackages;
+    [
+      cuda_cccl # <nv/target>
+      cuda_cudart # cuda_runtime.h
+      libcublas # cublas_v2.h
+      libcusolver # cusolverDn.h
+      libcusparse # cusparse.h
+    ]
+    # On CUDA >=13.0, crt/host_config.h is shipped in cudaPackages.cuda_crt
+    ++ lib.optionals cuda_crt.meta.available [
+      cuda_crt # crt/host_config.h
+    ]
+  );
 
   pythonImportsCheck = [ "deep_ep" ];
 


### PR DESCRIPTION
## Things done

This PR addresses the mismatch in function declarations between glibc and cuda CRT.

The issue was already addressed for CUDA<13.0 (#484031), but is still relevant with CUDA>=13.0.
Indeed, the patch already targeted all CUDA versions, before realizing that it failed to apply on CUDA>=13.0.
Thus, it was removed in #488738, assuming it was not needed however.
Yet, while some functions are now fine (`sinpi`, `cospi`), `rsqrt`and `rsqrtf` still need to be patched.
They are not declared in `cuda_nvcc` anymore, but in `cuda_crt`.

cc @NixOS/cuda-maintainers 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
