### PR TITLE
papers: adds darwin app bundle integration

### DIFF
--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -122,6 +122,20 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     substituteInPlace $out/share/thumbnailers/papers.thumbnailer \
       --replace-fail '=papers-thumbnailer' "=$out/bin/papers-thumbnailer"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    appDir="$out/Applications/Papers.app/Contents"
+
+    mkdir -p "$appDir"/{MacOS,Resources}
+
+    install -Dm444 "$NIX_BUILD_TOP/$sourceRoot/build-aux/macos/Info.plist" "$appDir/Info.plist"
+    install -Dm444 "$NIX_BUILD_TOP/$sourceRoot/build-aux/macos/Papers.icns" "$appDir/Resources/Papers.icns"
+
+    substituteInPlace "$appDir/Info.plist" \
+      --replace-fail "<string>1.0</string>" "<string>${finalAttrs.version}</string>" \
+      --replace-fail "<string>1</string>" "<string>${finalAttrs.version}</string>"
+
+    ln -s "$out/bin/papers" "$appDir/MacOS/Papers"
   '';
 
   preFixup = ''

--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -102,13 +102,10 @@ stdenv.mkDerivation (finalAttrs: {
     nautilus
   ];
 
-  mesonFlags =
-    lib.optionals (!withLibsecret) [
-      "-Dkeyring=disabled"
-    ]
-    ++ lib.optionals (!supportNautilus) [
-      "-Dnautilus=false"
-    ];
+  mesonFlags = [
+    (lib.mesonEnable "keyring" withLibsecret)
+    (lib.mesonBool "nautilus" supportNautilus)
+  ];
 
   # For https://gitlab.gnome.org/GNOME/papers/-/blob/5efed8638dd4a2d5c36f59eb9a22158d69632e0b/shell/src/meson.build#L36
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Wraps paper in a macOS app bundle! Prior, papers was only accessible on the Command Line for Darwin users. This brings it to a dedicated app bundle state, that users can open and use like any other app on their desktop. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
