### PR TITLE
folly: disable flaky AsyncFileWriter.discard test

### DIFF
--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -174,6 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     "singleton_thread_local_test.SingletonThreadLocalDeathTest.Overload"
 
     # very strict timing constraints, will fail under load
+    "logging_async_file_writer_test.AsyncFileWriter.discard"
     "io_async_hh_wheel_timer_test.HHWheelTimerTest.CancelTimeout"
     "io_async_hh_wheel_timer_test.HHWheelTimerTest.DefaultTimeout"
     "io_async_hh_wheel_timer_test.HHWheelTimerTest.DeleteWheelInTimeout"


### PR DESCRIPTION
Resolves #512186

[![](https://hydra-banner.harinn.dev/build/326608210)](https://hydra.nixos.org/build/326608210)

Not reproduced locally; based on Hydra's log.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test