### PR TITLE
Add Windsurf-Next as a package

### DIFF
--- a/pkgs/by-name/wi/windsurf-next/info.json
+++ b/pkgs/by-name/wi/windsurf-next/info.json
@@ -1,0 +1,20 @@
+{
+  "aarch64-darwin": {
+    "version": "2.0.1067+next.08b5de9bae",
+    "vscodeVersion": "1.110.1",
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-arm64/next/08b5de9bae1728a5ad46386c9b8903192a125c51/Windsurf-darwin-arm64-2.0.1067+next.08b5de9bae.zip",
+    "sha256": "fbef22f36cec2bc6086c5ff3b7750ec190652e1755d2ae2a6d7332f77b5f9d16"
+  },
+  "x86_64-darwin": {
+    "version": "2.0.1067+next.08b5de9bae",
+    "vscodeVersion": "1.110.1",
+    "url": "https://windsurf-stable.codeiumdata.com/darwin-x64/next/08b5de9bae1728a5ad46386c9b8903192a125c51/Windsurf-darwin-x64-2.0.1067+next.08b5de9bae.zip",
+    "sha256": "5d449094e2a2121059c45f38dba7901b0768fda12f2b8e1a492dd8d76af6f50e"
+  },
+  "x86_64-linux": {
+    "version": "2.0.1067+next.08b5de9bae",
+    "vscodeVersion": "1.110.1",
+    "url": "https://windsurf-stable.codeiumdata.com/linux-x64/next/08b5de9bae1728a5ad46386c9b8903192a125c51/Windsurf-linux-x64-2.0.1067+next.08b5de9bae.tar.gz",
+    "sha256": "9f04433ef536baadef12ed9d25d52f49da00214724fb0afc5971fa48b15fa2d1"
+  }
+}

--- a/pkgs/by-name/wi/windsurf-next/package.nix
+++ b/pkgs/by-name/wi/windsurf-next/package.nix
@@ -58,9 +58,11 @@ in
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
 }).overrideAttrs (oldAttrs: {
-  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-    # Windsurf Next uses code-next.png instead of code.png
-    cp $out/lib/windsurf-next/resources/app/resources/linux/code-next.png \
-       $out/lib/windsurf-next/resources/app/resources/linux/code.png
-  '' + oldAttrs.postInstall or "";
+  installPhase = if stdenv.hostPlatform.isLinux then
+    (builtins.replaceStrings
+      [ ''icon_file="$out/lib/windsurf-next/resources/app/resources/linux/code.png"'' ]
+      [ ''icon_file="$out/lib/windsurf-next/resources/app/resources/linux/code-next.png"'' ]
+      oldAttrs.installPhase)
+  else
+    oldAttrs.installPhase;
 })

--- a/pkgs/by-name/wi/windsurf-next/package.nix
+++ b/pkgs/by-name/wi/windsurf-next/package.nix
@@ -12,7 +12,7 @@ let
     (lib.importJSON ./info.json)."${stdenv.hostPlatform.system}"
       or (throw "windsurf-next: unsupported system ${stdenv.hostPlatform.system}");
 in
-buildVscode {
+(buildVscode {
   inherit commandLineArgs useVSCodeRipgrep;
 
   inherit (info) version vscodeVersion;
@@ -57,4 +57,10 @@ buildVscode {
     ];
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
-}
+}).overrideAttrs (oldAttrs: {
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # Windsurf Next uses code-next.png instead of code.png
+    cp $out/lib/windsurf-next/resources/app/resources/linux/code-next.png \
+       $out/lib/windsurf-next/resources/app/resources/linux/code.png
+  '' + oldAttrs.postInstall or "";
+})

--- a/pkgs/by-name/wi/windsurf-next/package.nix
+++ b/pkgs/by-name/wi/windsurf-next/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  buildVscode,
+  fetchurl,
+  nixosTests,
+  commandLineArgs ? "",
+  useVSCodeRipgrep ? stdenv.hostPlatform.isDarwin,
+}:
+let
+  info =
+    (lib.importJSON ./info.json)."${stdenv.hostPlatform.system}"
+      or (throw "windsurf-next: unsupported system ${stdenv.hostPlatform.system}");
+in
+buildVscode {
+  inherit commandLineArgs useVSCodeRipgrep;
+
+  inherit (info) version vscodeVersion;
+  pname = "windsurf-next";
+
+  executableName = "windsurf-next";
+  longName = "Windsurf Next";
+  shortName = "windsurf-next";
+  libraryName = "windsurf-next";
+  iconName = "windsurf-next";
+
+  sourceRoot = if stdenv.hostPlatform.isDarwin then "Windsurf - Next.app" else "Windsurf";
+  sourceExecutableName = if stdenv.hostPlatform.isDarwin then "Windsurf - Next" else "windsurf-next";
+
+  src = fetchurl { inherit (info) url sha256; };
+
+  tests = nixosTests.vscodium;
+
+  updateScript = ./update/update.mts;
+
+  # Editing the `codium` binary (and shell scripts) within the app bundle causes the bundle's signature
+  # to be invalidated, which prevents launching starting with macOS Ventura, because VSCodium is notarized.
+  # See https://eclecticlight.co/2022/06/17/app-security-changes-coming-in-ventura/ for more information.
+  dontFixup = stdenv.hostPlatform.isDarwin;
+
+  meta = {
+    description = "Agentic IDE powered by AI Flow paradigm";
+    longDescription = ''
+      The first agentic IDE, and then some.
+      The Windsurf Editor is where the work of developers and AI truly flow together, allowing for a coding experience that feels like literal magic.
+    '';
+    homepage = "https://windsurf.com";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      sarahec
+      xiaoxiangmoe
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+  };
+}

--- a/pkgs/by-name/wi/windsurf-next/update/.gitignore
+++ b/pkgs/by-name/wi/windsurf-next/update/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/pkgs/by-name/wi/windsurf-next/update/package.json
+++ b/pkgs/by-name/wi/windsurf-next/update/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "windsurf-scripts",
+  "version": "1.0.0",
+  "scripts": {
+    "update": "node update.mts"
+  },
+  "dependencies": {
+    "@types/node": "^22.13.1",
+    "prettier": "^3.4.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/pkgs/by-name/wi/windsurf-next/update/tsconfig.json
+++ b/pkgs/by-name/wi/windsurf-next/update/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "NodeNext",
+    "noEmit": true,
+    "strict": true
+  }
+}

--- a/pkgs/by-name/wi/windsurf-next/update/update.mts
+++ b/pkgs/by-name/wi/windsurf-next/update/update.mts
@@ -1,0 +1,84 @@
+#!/usr/bin/env nix-shell
+/*
+#!nix-shell -i node --pure --packages cacert nodejs_latest
+*/
+import * as assert from "node:assert/strict";
+import * as fsPromises from "node:fs/promises";
+import * as path from "node:path";
+import * as process from "node:process";
+
+const __dirname = import.meta.dirname;
+const __filename = import.meta.filename;
+
+interface LatestInfo {
+  readonly url: string;
+  readonly sha256hash: string;
+  readonly windsurfVersion: string;
+  readonly productVersion: string;
+}
+
+const platforms = ["aarch64-darwin", "x86_64-darwin", "x86_64-linux"] as const;
+type Platform = (typeof platforms)[number];
+type InfoMap = Record<
+  Platform,
+  {
+    readonly version: string;
+    readonly vscodeVersion: string;
+    readonly url: string;
+    readonly sha256: string;
+  }
+>;
+
+async function getInfo(
+  targetSystem: "darwin-arm64" | "darwin-x64" | "linux-x64",
+) {
+  const url =
+    `https://windsurf-next.codeium.com/api/update/${targetSystem}/stable/latest` as const;
+
+  const response = await fetch(url);
+  assert.ok(response.ok, `Failed to fetch ${url}`);
+
+  const latestInfo: LatestInfo = JSON.parse(await response.text());
+  assert.ok(latestInfo.sha256hash, "sha256hash is required");
+  assert.ok(latestInfo.url, "url is required");
+  assert.ok(latestInfo.windsurfVersion, "windsurfVersion is required");
+  assert.ok(latestInfo.productVersion, "productVersion is required");
+  return {
+    version: latestInfo.windsurfVersion,
+    vscodeVersion: latestInfo.productVersion,
+    url: latestInfo.url,
+    sha256: latestInfo.sha256hash,
+  };
+}
+
+async function main() {
+  const filePath = path.join(__dirname, "../info.json");
+  const oldInfo = JSON.parse(
+    await fsPromises.readFile(filePath, { encoding: "utf-8" }),
+  );
+
+  const info: InfoMap = {
+    "aarch64-darwin": await getInfo("darwin-arm64"),
+    "x86_64-darwin": await getInfo("darwin-x64"),
+    "x86_64-linux": await getInfo("linux-x64"),
+  };
+  if (JSON.stringify(oldInfo) === JSON.stringify(info)) {
+    console.log("[update] No updates found");
+    return;
+  }
+  for (const platform of platforms) {
+    console.log(
+      `[update] Updating Windsurf - Next ${platform} ${oldInfo[platform].version} -> ${info[platform].version}`,
+    );
+  }
+  await fsPromises.writeFile(
+    filePath,
+    JSON.stringify(info, null, 2) + "\n",
+    "utf-8",
+  );
+  console.log("[update] Updating Windsurf - Next complete");
+}
+
+if (process.argv[1] === __filename) {
+  main();
+}


### PR DESCRIPTION
I've copied the existing Windsurf flow and added support for Windsurf-next (which has experimental features).

Also, for some reason, Windsurf changes the code.png to code-next.png on linux, which breaks buildVscode's generix.nix's build step.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
