### PR TITLE
[Staging 25.11] systemd: 258.5 -> 258.7

### DIFF
--- a/pkgs/by-name/li/libgudev/package.nix
+++ b/pkgs/by-name/li/libgudev/package.nix
@@ -74,6 +74,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
   ];
 
+  # https://gitlab.gnome.org/GNOME/libgudev/-/issues/10
+  preCheck = ''
+    mesonCheckFlagsArray=( $(meson test --list | grep -v test-gudevdevice) )
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libgudev";

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -207,13 +207,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "258.5";
+  version = "258.7";
 
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3xz8q0R0gMAwRDV2QmYO0r/0Fw+9LOyR3O3XuMrTpgY=";
+    hash = "sha256-ehxf7szijCJGZ1lqZsvoDrahGp8P3IgWH6mUJ2Yx9S0=";
   };
 
   # On major changes, or when otherwise required, you *must* :


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/508870 / CVE-2026-40225

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
