### PR TITLE
python3Packages.cuda-bindings: fix lib lookups

### DIFF
--- a/pkgs/development/python-modules/cuda-bindings/default.nix
+++ b/pkgs/development/python-modules/cuda-bindings/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   cudaPackages,
+  replaceVars,
   addDriverRunpath,
 
   # build-system
@@ -15,10 +16,9 @@
   symlinkJoin,
 
   # dependencies
-  cuda-pathfinder,
+  numpy,
 
   # tests
-  numpy,
   pytestCheckHook,
 
   # passthru
@@ -37,6 +37,21 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-uRv27h2b6wXC8oOf5k2KxZ0bUFNvNu6XO05FBbJcU1k=";
   };
+
+  # Apply patch relative to cuda_bindings
+  patchFlags = [ "-p2" ];
+
+  patches = [
+    (replaceVars ./patch-nvidia-libs-paths.patch {
+      libcudart = lib.getLib cudaPackages.cuda_cudart;
+      libcufile = lib.getLib cudaPackages.libcufile;
+      libnvfatbin = lib.getLib cudaPackages.libnvfatbin;
+      libnvjitlink = lib.getLib cudaPackages.libnvjitlink;
+      libnvml = addDriverRunpath.driverLink;
+      libnvrtc = lib.getLib cudaPackages.cuda_nvrtc;
+      libnvvm = "${cudaPackages.cuda_nvcc}/nvvm";
+    })
+  ];
 
   sourceRoot = "${finalAttrs.src.name}/cuda_bindings";
 
@@ -90,15 +105,25 @@ buildPythonPackage (finalAttrs: {
     cudaPackages.libcufile # cufile.h
   ];
 
+  pythonRemoveDeps = [
+    # We circumvent cuda_pathfinder to localize nvidia libs with patches
+    "cuda-pathfinder"
+  ];
   dependencies = [
-    cuda-pathfinder
+    # Not explicitly listed as a dependency, but is required at import time
+    numpy
   ];
 
   pythonImportsCheck = [
     "cuda"
-    "cuda.cuda"
-    "cuda.cudart"
-    "cuda.nvrtc"
+    "cuda.bindings.cufile"
+    "cuda.bindings.driver"
+    "cuda.bindings.nvfatbin"
+    "cuda.bindings.nvjitlink"
+    "cuda.bindings.nvml"
+    "cuda.bindings.nvrtc"
+    "cuda.bindings.nvvm"
+    "cuda.bindings.runtime"
   ];
 
   preCheck = ''
@@ -106,7 +131,6 @@ buildPythonPackage (finalAttrs: {
   '';
 
   nativeCheckInputs = [
-    numpy
     pytestCheckHook
   ];
 
@@ -121,6 +145,24 @@ buildPythonPackage (finalAttrs: {
     #
     # Ideally, we should transition to cuda 13 across the whole nixpkgs tree.
     "tests/test_nvjitlink.py"
+  ];
+
+  disabledTests = [
+    # sysfs cpu topology is not available in the sandbox, causing:
+    #   cuda.bindings.nvml.UnknownError: Unknown Error
+    #   hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.
+    "test_device_get_cpu_affinity_within_scope"
+    "test_device_get_memory_affinity"
+
+    # Requires the nvidia_fs kernel module (GPUDirect Storage), causing:
+    #   cuda.bindings.cufile.cuFileError: NVFS_SETUP_ERROR (5033): NVFS driver initialization error
+    "test_buf_register_already_registered"
+    "test_buf_register_host_memory"
+    "test_buf_register_invalid_flags"
+    "test_buf_register_large_buffer"
+    "test_buf_register_multiple_buffers"
+    "test_buf_register_simple"
+    "test_driver_open"
   ];
 
   # Tests need access to a GPU

--- a/pkgs/development/python-modules/cuda-bindings/patch-nvidia-libs-paths.patch
+++ b/pkgs/development/python-modules/cuda-bindings/patch-nvidia-libs-paths.patch
@@ -1,0 +1,178 @@
+diff --git a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+index f684be6870..9437de642b 100644
+--- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
++++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
+@@ -8,7 +8,7 @@ cimport cuda.bindings._lib.windll as windll
+ {{else}}
+ cimport cuda.bindings._lib.dlfcn as dlfcn
+ {{endif}}
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ 
+@@ -47,7 +47,7 @@ cdef int _cuPythonInit() except -1 nogil:
+     # Load library
+     with gil, __symbol_lock:
+         {{if 'Windows' == platform.system()}}
+-        handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
++        handle = CDLL("@libnvrtc@/lib/libnvrtc.so")._handle
+ 
+         # Load function
+         {{if 'nvrtcGetErrorString' in found_functions}}
+@@ -156,7 +156,7 @@ cdef int _cuPythonInit() except -1 nogil:
+         {{endif}}
+ 
+         {{else}}
+-        handle = <void*><uintptr_t>(load_nvidia_dynamic_lib("nvrtc")._handle_uint)
++        handle = <void*><uintptr_t>(CDLL("@libnvrtc@/lib/libnvrtc.so")._handle)
+ 
+         # Load function
+         {{if 'nvrtcGetErrorString' in found_functions}}
+diff --git a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+index 78ea77b283..0b875a6cd3 100644
+--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+@@ -9,7 +9,7 @@ import threading
+ 
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ import cython
+ 
+@@ -95,7 +95,7 @@ cdef void* __cuFileSetParameterString = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("cufile")._handle_uint
++    cdef uintptr_t handle = CDLL("@libcufile@/lib/libcufile.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
+index f5a9bbd218..8271f7aa20 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -73,7 +73,7 @@ cdef void* __nvFatbinAddTileIR = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvfatbin")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvfatbin@/lib/libnvfatbin.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+index d676aac372..ed3c000566 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -76,7 +76,7 @@ cdef void* __nvJitLinkVersion = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvJitLink")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvjitlink@/lib/libnvJitLink.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
+index 28f0919423..852f75e46d 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
+@@ -10,7 +10,7 @@ import threading
+ 
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -406,7 +406,7 @@ cdef void* __nvmlDeviceSetRusdSettings_v1 = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvml")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvml@/lib/libnvidia-ml.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+index 8a84834a9a..a3ced66807 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -75,7 +75,7 @@ cdef void* __nvvmGetProgramLog = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvvm")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvvm@/lib/libnvvm.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/cyruntime.pyx.in b/cuda_bindings/cuda/bindings/cyruntime.pyx.in
+index 5cd65fbd96..fbbcffbbb7 100644
+--- a/cuda_bindings/cuda/bindings/cyruntime.pyx.in
++++ b/cuda_bindings/cuda/bindings/cyruntime.pyx.in
+@@ -1874,7 +1874,7 @@ cdef cudaError_t cudaGraphicsVDPAURegisterOutputSurface(cudaGraphicsResource** r
+ {{if True}}
+ 
+ from libc.stdint cimport uintptr_t
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ {{if 'Windows' == platform.system()}}
+ cimport cuda.bindings._lib.windll as windll
+ {{else}}
+@@ -1884,11 +1884,11 @@ cimport cuda.bindings._lib.dlfcn as dlfcn
+ cdef cudaError_t getLocalRuntimeVersion(int* runtimeVersion) except ?cudaErrorCallRequiresNewerDriver nogil:
+     # Load
+     with gil:
+-        loaded_dl = load_nvidia_dynamic_lib("cudart")
++        loaded_dl = CDLL("@libcudart@/lib/libcudart.so")
+         {{if 'Windows' == platform.system()}}
+-        handle = <uintptr_t>loaded_dl._handle_uint
++        handle = <uintptr_t>loaded_dl._handle
+         {{else}}
+-        handle = <void *><uintptr_t>loaded_dl._handle_uint
++        handle = <void *><uintptr_t>loaded_dl._handle
+         {{endif}}
+ 
+     {{if 'Windows' == platform.system()}}
+diff --git a/cuda_bindings/cuda/bindings/nvml.pyx b/cuda_bindings/cuda/bindings/nvml.pyx
+index 42c9fdcc87..0661379a68 100644
+--- a/cuda_bindings/cuda/bindings/nvml.pyx
++++ b/cuda_bindings/cuda/bindings/nvml.pyx
+@@ -27471,4 +27471,3 @@ cpdef str vgpu_type_get_name(unsigned int vgpu_type_id):
+         __status__ = nvmlVgpuTypeGetName(<nvmlVgpuTypeId_t>vgpu_type_id, vgpu_type_name, <unsigned int*>size)
+     check_status(__status__)
+     return cpython.PyUnicode_FromStringAndSize(vgpu_type_name, size[0])
+-


### PR DESCRIPTION
## Things done

I love this...

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
