### PR TITLE
claudeline: init at 0.23.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9196,6 +9196,12 @@
     githubId = 26125115;
     name = "Frédéric Christ";
   };
+  fredrikaverpil = {
+    email = "fredrik.averpil@gmail.com";
+    github = "fredrikaverpil";
+    githubId = 994357;
+    name = "Fredrik Averpil";
+  };
   Freed-Wu = {
     email = "wuzhenyu@ustc.edu";
     github = "Freed-Wu";

--- a/pkgs/by-name/cl/claudeline/package.nix
+++ b/pkgs/by-name/cl/claudeline/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "claudeline";
+  version = "0.23.0";
+
+  src = fetchFromGitHub {
+    owner = "fredrikaverpil";
+    repo = "claudeline";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-VogE3MAc/EGdokvm/bThqH/gJ/sJXV9FR8JBWjgF7LE=";
+  };
+
+  vendorHash = null;
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minimalistic Claude Code status line";
+    homepage = "https://github.com/fredrikaverpil/claudeline";
+    changelog = "https://github.com/fredrikaverpil/claudeline/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fredrikaverpil ];
+    mainProgram = "claudeline";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [claudeline](https://github.com/fredrikaverpil/claudeline) — a minimalistic Claude Code status line written in Go (stdlib only, no external dependencies).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test