### PR TITLE
rspamd: use vendored doctest to fix build

### DIFF
--- a/pkgs/by-name/rs/rspamd/package.nix
+++ b/pkgs/by-name/rs/rspamd/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitHub,
   cmake,
-  doctest,
+  # doctest,
   fmt,
   perl,
   glib,
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    doctest
+    # doctest
     fmt
     glib
     openssl
@@ -94,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DENABLE_BLAS=${if withBlas then "ON" else "OFF"}"
     "-DENABLE_FASTTEXT=ON"
     "-DENABLE_JEMALLOC=ON"
-    "-DSYSTEM_DOCTEST=ON"
+    "-DSYSTEM_DOCTEST=OFF" # https://github.com/rspamd/rspamd/issues/5994
     "-DSYSTEM_FMT=ON"
     "-DSYSTEM_XXHASH=ON"
     "-DSYSTEM_ZSTD=ON"


### PR DESCRIPTION
build was broken by doctest 2.5.0 upgrade, I was not able to fix that myself, and upstream seems like they don't care, so let's fallback to vendored 2.4.11 for now.

cc @yuyuyureka

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
