### PR TITLE
re-appintentsmetadataprocessor,re-intentbuilderc,re-derq: init mac build tools

### DIFF
--- a/pkgs/by-name/re/re-appintentsmetadataprocessor/package.nix
+++ b/pkgs/by-name/re/re-appintentsmetadataprocessor/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromCodeberg,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "re-appintentsmetadataprocessor";
+  version = "1.0.0";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "viraptor";
+    repo = "re-appintentsmetadataprocessor";
+    tag = finalAttrs.version;
+    hash = "sha256-yZZd1j1V9hNFg1zZmXoNwDi9aueoEIqnptS+NityGlg=";
+  };
+
+  cargoHash = "sha256-mkev7O6eO2ddFoP3Gm6r+2kllnz2c9HiYADjFZXQIHo=";
+
+  meta = {
+    mainProgram = "appintentsmetadataprocessor";
+    description = "Open reimplementation of Apple's appintentsmetadataprocessor";
+    homepage = "https://codeberg.org/viraptor/re-appintentsmetadataprocessor";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ viraptor ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/re/re-derq/package.nix
+++ b/pkgs/by-name/re/re-derq/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromCodeberg,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "re-derq";
+  version = "1.0.1";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "viraptor";
+    repo = "re-derq";
+    tag = finalAttrs.version;
+    hash = "sha256-dnkxHEuFCn/QVMdTNhWtv5fh54Gald0YQCO0/LoQtCI=";
+  };
+
+  cargoHash = "sha256-KnH8jJb2rLn2LAgno+QbBg5K5NQErlvGDbhxEthwryM=";
+
+  meta = {
+    mainProgram = "derq";
+    description = "Open reimplementation of Apple's derq";
+    homepage = "https://codeberg.org/viraptor/re-derq";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ viraptor ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/re/re-intentbuilderc/package.nix
+++ b/pkgs/by-name/re/re-intentbuilderc/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromCodeberg,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "re-intentbuilderc";
+  version = "1.0.2";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "viraptor";
+    repo = "re-intentbuilderc";
+    tag = finalAttrs.version;
+    hash = "sha256-MucaZ+5MfwMj2nxMcKONxlVXaeHJnN1KVvP2961dQIY=";
+  };
+
+  cargoHash = "sha256-9PmIoXngNuWUXYa1f4CS5JS1yh+/9E8GBfjndIFEqTk=";
+
+  meta = {
+    mainProgram = "intentbuilderc";
+    description = "Open reimplementation of Apple's intentbuilderc";
+    homepage = "https://codeberg.com/viraptor/re-intentbuilderc";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ viraptor ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Tools required for building xcode-style projects. Part of the larger effort https://github.com/NixOS/nixpkgs/issues/512622

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
