### PR TITLE
turm: init at 0.14.0

### DIFF
--- a/pkgs/by-name/tu/turm/package.nix
+++ b/pkgs/by-name/tu/turm/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "turm";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "karimknaebel";
+    repo = "turm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-K83jfPQORE0MQiyeHfWxtp1BhVAS15o3sbd5Vp75GCU=";
+  };
+
+  cargoHash = "sha256-G9CeueyNB+jJ1veAb80m3uRBHhJ15jc0y4rxO2Rvuhs=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI for the Slurm Workload Manager";
+    homepage = "https://github.com/karimknaebel/turm";
+    changelog = "https://github.com/karimknaebel/turm/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nemeott ];
+    mainProgram = "turm";
+  };
+})


### PR DESCRIPTION
Add `turm`, a TUI for SLURM. Seems useful for HPC users that use SLURM. [https://github.com/karimknaebel/turm](https://github.com/karimknaebel/turm).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
