### PR TITLE
parallel: 20260322 -> 20260422

### DIFF
--- a/pkgs/by-name/pa/parallel/package.nix
+++ b/pkgs/by-name/pa/parallel/package.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "parallel";
-  version = "20260322";
+  version = "20260422";
 
   src = fetchurl {
     url = "mirror://gnu/parallel/parallel-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-dkaA6TL00NIc8DKb2fnu1lmJXeFoNgAfZJFTO4Ir7+A=";
+    hash = "sha256-ZkzxZdZuohey9JzZanhl7PkMnQYWWZzCq6jK1IHZB7s=";
   };
 
   outputs = [
@@ -56,6 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
       }"
   '';
 
+  # Force run `check` instead of the `tests` target, because the `test` target depends on a private testsuite.
+  # The reason `check` isn't used by default is due to it failing when selecting the target to run. (due to stdenv not overriding the Makefiles SHELL variable from `/bin/bash`).
+  #
+  # See:
+  #   https://github.com/NixOS/nixpkgs/blob/ef4f672aa2be8b268a4280e8e2a68cd97a4cf67b/pkgs/stdenv/generic/setup.sh#L1541
+  #   https://github.com/NixOS/nixpkgs/blob/ef4f672aa2be8b268a4280e8e2a68cd97a4cf67b/pkgs/stdenv/generic/setup.sh#L1555
+  checkTarget = "check";
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
Changelog: https://savannah.gnu.org/news/?id=10886
Diff: https://cgit.git.savannah.gnu.org/cgit/parallel.git/diff/?id=20260422&id2=20260322

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
