### PR TITLE
citrix-workspace: fix hdx webcam/mic, 25.08.10 -> 26.01.0

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -145,6 +145,8 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
   dontConfigure = true;
+  strictDeps = true;
+  __structuredAttrs = true;
   sourceRoot = ".";
   preferLocalBuild = true;
   passthru.icaroot = "${placeholder "out"}/opt/citrix-icaclient";
@@ -243,19 +245,36 @@ stdenv.mkDerivation rec {
         program:
         if (builtins.match "selfservice(.*)" program) != null then
           "--icaroot"
-        else if (builtins.match "wfica(.*)" program != null) then
+        else if (builtins.match "wfica(.*)" program) != null then
           null
         else
           "-icaroot";
+
+      ldLibraryPath =
+        program:
+        lib.concatStringsSep ":" (
+          lib.optional (builtins.match "wfica(.*)" program != null) "$ICAInstDir"
+          ++ [
+            "$ICAInstDir/lib"
+            "$ICAInstDir/usr/lib/x86_64-linux-gnu"
+            "$ICAInstDir/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/injected-bundle"
+          ]
+        );
+
+      # Only the ICA engine needs the top-level client directory on the library
+      # path. Leaving it enabled for UI helpers exposes Citrix's session-only
+      # libproxy.so to the embedded web stack, which then fails to resolve CGP
+      # symbols.
       wrap = program: ''
         wrapProgram $out/opt/citrix-icaclient/${program} \
           ${lib.optionalString (icaFlag program != null) ''--add-flags "${icaFlag program} $ICAInstDir"''} \
           --set ICAROOT "$ICAInstDir" \
           --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
-          --prefix LD_LIBRARY_PATH : "$ICAInstDir:$ICAInstDir/lib:$ICAInstDir/usr/lib/x86_64-linux-gnu:$ICAInstDir/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/injected-bundle" \
+          --prefix LD_LIBRARY_PATH : "${ldLibraryPath program}" \
           --set LD_PRELOAD "${libredirect}/lib/libredirect.so ${lib.getLib pcsclite}/lib/libpcsclite.so" \
           --set NIX_REDIRECTS "/usr/share/zoneinfo=${tzdata}/share/zoneinfo:/etc/zoneinfo=${tzdata}/share/zoneinfo:/etc/timezone=$ICAInstDir/timezone:/usr/lib/x86_64-linux-gnu=$ICAInstDir/usr/lib/x86_64-linux-gnu"
       '';
+
       wrapLink = program: ''
         ${wrap program}
         ln -sf $out/opt/citrix-icaclient/${program} $out/bin/${baseNameOf program}
@@ -283,9 +302,22 @@ stdenv.mkDerivation rec {
       export HOME=$(mktemp -d)
 
       # Run upstream installer in the store-path.
-      sed -i -e 's,^ANSWER="",ANSWER="$INSTALLER_YES",g' -e 's,/bin/true,true,g' -e 's, -C / , -C . ,g' ./linuxx64/hinst
+      sed -i \
+        -e 's,^ANSWER="",ANSWER="$INSTALLER_YES",g' \
+        -e 's,/bin/true,true,g' \
+        -e 's, -C / , -C . ,g' \
+        -e 's,^[[:space:]]*install_deviceTrust "\$ICAInstDir",      :,' \
+        -e 's,^[[:space:]]*install_EPA_with_prompt "\$ICAInstDir",      :,' \
+        -e 's,^[[:space:]]*install_fido2Service "\$CDSourceDir" "\$ICAInstDir",  :,' \
+        ./linuxx64/hinst
       source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
       faketime -f "$source_date" ${stdenv.shell} linuxx64/hinst CDROM "$(pwd)"
+
+      mkdir -p "$ICAInstDir/usr"
+      tar -xzf ./linuxx64/linuxx64.cor/Webkit2gtk4.0/webkit2gtk-4.0.tar.gz \
+        --strip-components=2 \
+        -C "$ICAInstDir/usr" \
+        webkit2gtk-4.0-package/usr/lib
 
       if [ -f "$ICAInstDir/util/setlog" ]; then
         chmod +x "$ICAInstDir/util/setlog"
@@ -362,6 +394,9 @@ stdenv.mkDerivation rec {
     ${lib.getExe perl} -0777 -pi -e 's{/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/injected-bundle/}{"\0" x length($&)}e' \
       $out/opt/citrix-icaclient/usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.0.so.37.56.4
 
+    addAutoPatchelfSearchPath --no-recurse "$out/opt/citrix-icaclient/usr/lib/x86_64-linux-gnu"
+    addAutoPatchelfSearchPath "$out/opt/citrix-icaclient/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/injected-bundle"
+    addAutoPatchelfSearchPath "$out/opt/citrix-icaclient/lib"
     autoPatchelf -- "$out"
 
     $out/opt/citrix-icaclient/util/ctx_rehash

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -277,6 +277,9 @@ stdenv.mkDerivation rec {
             "$ICAInstDir/lib"
             "$ICAInstDir/usr/lib/x86_64-linux-gnu"
             "$ICAInstDir/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/injected-bundle"
+            # HdxRtcEngine loads libpulse.so.0 with dlopen, so autoPatchelf
+            # cannot discover it from ELF dependencies.
+            "${lib.getLib libpulseaudio}/lib"
           ]
         );
 

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -19,6 +19,7 @@
   glib,
   glib-networking,
   gnome2,
+  gst_all_1,
   gtk2,
   gtk2-x11,
   gtk3,
@@ -77,6 +78,7 @@
   xprop,
   xdpyinfo,
   libxcb,
+  x264,
   zlib,
 
   homepage,
@@ -87,6 +89,18 @@
 }:
 
 let
+  gstPackages = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-vaapi
+  ];
+
+  gstPluginPath = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gstPackages;
+
   fuse3' = symlinkJoin {
     name = "fuse3-backwards-compat";
     paths = [ (lib.getLib fuse3) ];
@@ -216,8 +230,10 @@ stdenv.mkDerivation rec {
     libxaw
     libxmu
     libxtst
+    x264
     zlib
-  ];
+  ]
+  ++ gstPackages;
 
   runtimeDependencies = [
     glib
@@ -241,11 +257,14 @@ stdenv.mkDerivation rec {
 
   installPhase =
     let
+      isSelfservice = program: (builtins.match "selfservice(.*)" program) != null;
+      isWfica = program: (builtins.match "wfica(.*)" program) != null;
+
       icaFlag =
         program:
-        if (builtins.match "selfservice(.*)" program) != null then
+        if isSelfservice program then
           "--icaroot"
-        else if (builtins.match "wfica(.*)" program) != null then
+        else if isWfica program then
           null
         else
           "-icaroot";
@@ -253,7 +272,7 @@ stdenv.mkDerivation rec {
       ldLibraryPath =
         program:
         lib.concatStringsSep ":" (
-          lib.optional (builtins.match "wfica(.*)" program != null) "$ICAInstDir"
+          lib.optional (isWfica program) "$ICAInstDir"
           ++ [
             "$ICAInstDir/lib"
             "$ICAInstDir/usr/lib/x86_64-linux-gnu"
@@ -265,19 +284,33 @@ stdenv.mkDerivation rec {
       # path. Leaving it enabled for UI helpers exposes Citrix's session-only
       # libproxy.so to the embedded web stack, which then fails to resolve CGP
       # symbols.
+      wrapperArgs =
+        program:
+        lib.concatStringsSep " \\\n          " (
+          lib.optional (icaFlag program != null) ''--add-flags "${icaFlag program} $ICAInstDir"''
+          ++ [
+            ''--set ICAROOT "$ICAInstDir"''
+            ''--prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"''
+            ''--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${gstPluginPath}"''
+            ''--prefix LD_LIBRARY_PATH : "${ldLibraryPath program}"''
+            ''--set LD_PRELOAD "${libredirect}/lib/libredirect.so ${lib.getLib pcsclite}/lib/libpcsclite.so"''
+            ''--set NIX_REDIRECTS "/usr/share/zoneinfo=${tzdata}/share/zoneinfo:/etc/zoneinfo=${tzdata}/share/zoneinfo:/etc/timezone=$ICAInstDir/timezone:/usr/lib/x86_64-linux-gnu=$ICAInstDir/usr/lib/x86_64-linux-gnu"''
+          ]
+        );
+
       wrap = program: ''
         wrapProgram $out/opt/citrix-icaclient/${program} \
-          ${lib.optionalString (icaFlag program != null) ''--add-flags "${icaFlag program} $ICAInstDir"''} \
-          --set ICAROOT "$ICAInstDir" \
-          --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
-          --prefix LD_LIBRARY_PATH : "${ldLibraryPath program}" \
-          --set LD_PRELOAD "${libredirect}/lib/libredirect.so ${lib.getLib pcsclite}/lib/libpcsclite.so" \
-          --set NIX_REDIRECTS "/usr/share/zoneinfo=${tzdata}/share/zoneinfo:/etc/zoneinfo=${tzdata}/share/zoneinfo:/etc/timezone=$ICAInstDir/timezone:/usr/lib/x86_64-linux-gnu=$ICAInstDir/usr/lib/x86_64-linux-gnu"
+          ${wrapperArgs program}
       '';
 
       wrapLink = program: ''
         ${wrap program}
         ln -sf $out/opt/citrix-icaclient/${program} $out/bin/${baseNameOf program}
+      '';
+
+      makeBinWrapper = program: wrapperName: ''
+        makeWrapper $out/opt/citrix-icaclient/${program} $out/bin/${wrapperName} \
+          ${wrapperArgs program}
       '';
 
       copyCert = path: ''
@@ -324,6 +357,7 @@ stdenv.mkDerivation rec {
         ln -sf "$ICAInstDir/util/setlog" "$out/bin/citrix-setlog"
       fi
       ${mkWrappers wrapLink toWrap}
+      ${makeBinWrapper "wfica" "wfica"}
       ${mkWrappers wrap [
         "PrimaryAuthManager"
         "ServiceRecord"
@@ -346,6 +380,9 @@ stdenv.mkDerivation rec {
       rm $ICAInstDir/util/{gst_aud_{play,read},gst_*0.10,libgstflatstm0.10.so} || true
       ln -sf $ICAInstDir/util/gst_play1.0 $ICAInstDir/util/gst_play
       ln -sf $ICAInstDir/util/gst_read1.0 $ICAInstDir/util/gst_read
+      # `hinst` disables multimedia when it cannot link into FHS plugin
+      # directories. In Nix we provide the plugin path via wrappers instead.
+      sed -i 's/^MultiMedia=Off$/MultiMedia=On/' "$ICAInstDir/config/module.ini"
 
       echo "We arbitrarily set the timezone to UTC. No known consequences at this point."
       echo UTC > "$ICAInstDir/timezone"

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -268,7 +268,7 @@ stdenv.mkDerivation rec {
       mkWrappers = lib.concatMapStringsSep "\n";
 
       toWrap = [
-        "wfica"
+        "adapter"
         "selfservice"
         "util/configmgr"
         "util/conncenter"
@@ -320,6 +320,33 @@ stdenv.mkDerivation rec {
 
       echo "Copy .desktop files."
       cp $out/opt/citrix-icaclient/desktop/* $out/share/applications/
+      for desktop in $out/share/applications/*.desktop; do
+        sed -i \
+          -e "s#/opt/Citrix/ICAClient#$ICAInstDir#g" \
+          -e "s#$ICAInstDir/util/ctxwebhelper#ctxwebhelper#g" \
+          "$desktop"
+
+        case "$(basename "$desktop")" in
+          citrixapp.desktop)
+            sed -i \
+              -e 's#^TryExec=.*#TryExec=selfservice#' \
+              -e 's#^Exec=.*#Exec=selfservice %u#' \
+              "$desktop"
+            ;;
+          selfservice.desktop)
+            sed -i \
+              -e 's#^TryExec=.*#TryExec=selfservice#' \
+              -e 's#^Exec=.*#Exec=selfservice#' \
+              "$desktop"
+            ;;
+          wfica.desktop)
+            sed -i \
+              -e 's#^TryExec=.*#TryExec=adapter#' \
+              -e 's#^Exec=.*#Exec=adapter %f#' \
+              "$desktop"
+            ;;
+        esac
+      done
 
       # We introduce a dependency on the source file so that it need not be redownloaded everytime
       echo $src >> "$out/share/workspace_dependencies.pin"

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -21,6 +21,15 @@ let
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
   supportedVersions = lib.mapAttrs mkVersionInfo {
+    "26.01.0" = {
+      major = "26";
+      minor = "01";
+      patch = "0";
+      hash = "0avrf9jpqhijvp6w4jgs7xgp4gg1q2mdzak9h9klkqrbsgrvjr3p";
+      suffix = "150";
+      homepage = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
+    };
+
     "25.08.10" = {
       major = "25";
       minor = "08";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1963,9 +1963,10 @@ with pkgs;
   };
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
+    citrix_workspace_26_01_0
     citrix_workspace_25_08_10
     ;
-  citrix_workspace = citrix_workspace_25_08_10;
+  citrix_workspace = citrix_workspace_26_01_0;
 
   colord-gtk4 = colord-gtk.override { withGtk4 = true; };
 


### PR DESCRIPTION
Rewrite the generated desktop entries to call the wrapped commands from $out/bin instead of the upstream install paths. Keep selfservice as the launcher target for menu and citrixapp URI handling, and keep adapter as the ICA file handler entrypoint.

Unpack the vendor-bundled WebKit 4.0 runtime, skip optional EPA, device
trust, and FIDO installer steps, and make 26.01 the default Citrix Workspace package.

Add the GStreamer plugin stack that Citrix documents for Linux webcam redirection and propagate GST_PLUGIN_SYSTEM_PATH_1_0 through the wrapped entrypoints so the client can discover those plugins at runtime.


NOTE: Did not go through setting up EPA new feature. Just wanted to get webcam/mic/usb working. Finally got the webcam/mic working and wanted to PR this before I continue trying to figure out what's happening with usb redirection. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
