### PR TITLE
nixseparatedebuginfod2: 1.0.1 -> 2.0.0

### DIFF
--- a/nixos/modules/services/development/nixseparatedebuginfod2.nix
+++ b/nixos/modules/services/development/nixseparatedebuginfod2.nix
@@ -7,7 +7,7 @@
 }:
 let
   cfg = config.services.nixseparatedebuginfod2;
-  url = "127.0.0.1:${toString cfg.port}";
+  address = "127.0.0.1:${toString cfg.port}";
 in
 {
   imports = [
@@ -40,16 +40,16 @@ in
     };
   };
   config = lib.mkIf cfg.enable {
-    systemd.services.nixseparatedebuginfod2 = {
+    systemd.sockets.nixseparatedebuginfod2 = {
       wantedBy = [ "multi-user.target" ];
-      path = [ config.nix.package ];
+      socketConfig.ListenStream = [ address ];
+    };
+    systemd.services.nixseparatedebuginfod2 = {
       serviceConfig = {
         ExecStart = [
           (utils.escapeSystemdExecArgs (
             [
               (lib.getExe cfg.package)
-              "--listen-address"
-              url
               "--expiration"
               cfg.cacheExpirationDelay
             ]
@@ -59,6 +59,7 @@ in
             ]) cfg.substituters)
           ))
         ];
+        Type = "notify";
         Restart = "on-failure";
         CacheDirectory = "nixseparatedebuginfod2";
         DynamicUser = true;
@@ -101,7 +102,7 @@ in
       };
     };
 
-    environment.debuginfodServers = [ "http://${url}" ];
+    environment.debuginfodServers = [ "http://${address}" ];
 
   };
 }

--- a/nixos/tests/nixseparatedebuginfod2.nix
+++ b/nixos/tests/nixseparatedebuginfod2.nix
@@ -44,8 +44,7 @@
     start_all()
     cache.wait_for_unit("nginx.service")
     cache.wait_for_open_port(80)
-    machine.wait_for_unit("nixseparatedebuginfod2.service")
-    machine.wait_for_open_port(1949)
+    machine.wait_for_unit("nixseparatedebuginfod2.socket")
 
     with subtest("check that the binary cache works"):
       machine.succeed("nix-store --extra-substituters http://cache --option require-sigs false -r ${pkgs.sl}")

--- a/pkgs/by-name/ni/nixseparatedebuginfod2/package.nix
+++ b/pkgs/by-name/ni/nixseparatedebuginfod2/package.nix
@@ -10,24 +10,30 @@
   elfutils,
   nix,
   nixosTests,
+  systemd,
+  util-linux,
+  cacert,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixseparatedebuginfod2";
-  version = "1.0.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "symphorien";
     repo = "nixseparatedebuginfod2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-INY9mLJ+7i3BoShqFZMELm9aXiDbZkuLyokgm42kEbo=";
+    hash = "sha256-D327Pz3oHOHgfekXnDRQ0l+GrIcFUK1zcIqzR2Y3zqU=";
   };
 
-  cargoHash = "sha256-6JyC0CLGnkbQWp8l27DXZ04Gt0nsNNSBFfcvAQtllE4=";
+  cargoHash = "sha256-iAhm54jb+5Nv/XG6GYpoEgPjYmBTHvEnnmynFF8D8n4=";
 
   buildInputs = [
     libarchive
     openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    systemd
   ];
 
   nativeBuildInputs = [ pkg-config ];
@@ -37,6 +43,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     bubblewrap
     elfutils
     nix
+    util-linux
+    cacert
+  ];
+
+  # disable systemd feature on non linux
+  cargoBuildFlags = lib.optionals (!stdenv.hostPlatform.isLinux) [
+    "--no-default-features"
   ];
 
   env.OPENSSL_NO_VENDOR = "1";


### PR DESCRIPTION
Changelog: https://github.com/symphorien/nixseparatedebuginfod2/blob/master/CHANGELOG.md

Modify the module to use systemd activation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
