### PR TITLE
vncdotool: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/vn/vncdotool/package.nix
+++ b/pkgs/by-name/vn/vncdotool/package.nix
@@ -1,20 +1,14 @@
 {
   lib,
-  buildPythonPackage,
   fetchFromGitHub,
-  pexpect,
-  pillow,
-  cryptography,
-  pytestCheckHook,
-  pyvirtualdisplay,
-  setuptools,
-  twisted,
+  python3Packages,
 }:
 
-buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "vncdotool";
   version = "1.3.0";
   pyproject = true;
+
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
@@ -24,15 +18,15 @@ buildPythonPackage rec {
     hash = "sha256-CXxuaAi/B7NiGp1dhhe7iBw0qOdPfsKg7zMMwavGCW8=";
   };
 
-  build-system = [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = [
+  dependencies = with python3Packages; [
     pillow
     cryptography
     twisted
   ];
 
-  nativeCheckInputs = [
+  nativeCheckInputs = with python3Packages; [
     pexpect
     pytestCheckHook
     pyvirtualdisplay

--- a/pkgs/development/python-modules/vncdo/default.nix
+++ b/pkgs/development/python-modules/vncdo/default.nix
@@ -23,9 +23,9 @@ buildPythonPackage rec {
     hash = "sha256-CXxuaAi/B7NiGp1dhhe7iBw0qOdPfsKg7zMMwavGCW8=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pillow
     cryptography
     twisted

--- a/pkgs/development/python-modules/vncdo/default.nix
+++ b/pkgs/development/python-modules/vncdo/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pexpect,
   pillow,
-  pycryptodomex,
+  cryptography,
   pytestCheckHook,
   pyvirtualdisplay,
   setuptools,
@@ -13,21 +13,21 @@
 
 buildPythonPackage rec {
   pname = "vncdo";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sibson";
     repo = "vncdotool";
     tag = "v${version}";
-    hash = "sha256-QrD6z/g85FwaZCJ1PRn8CBKCOQcbVjQ9g0NpPIxguqk=";
+    hash = "sha256-CXxuaAi/B7NiGp1dhhe7iBw0qOdPfsKg7zMMwavGCW8=";
   };
 
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [
     pillow
-    pycryptodomex
+    cryptography
     twisted
   ];
 

--- a/pkgs/development/python-modules/vncdo/default.nix
+++ b/pkgs/development/python-modules/vncdo/default.nix
@@ -37,6 +37,16 @@ buildPythonPackage rec {
     pyvirtualdisplay
   ];
 
+  #  Disable integration tests that require LibVNCServer examples.
+  #  The pure Nix sandbox prohibits vncdotool to download these.
+  #
+  #  libvncserver outputs do not include examples since upstream
+  #  LibVNCServer does not easily provide examples.
+  #
+  #  Perhaps a Patch to tests/functional/libvncserver.py to provide
+  #  LibVNCServer examples via eg. LIBVNCSERVER_DIR is a solution.
+  disabledTestPaths = [ "tests/functional" ];
+
   pythonImportsCheck = [ "vncdotool" ];
 
   meta = {

--- a/pkgs/development/python-modules/vncdotool/default.nix
+++ b/pkgs/development/python-modules/vncdotool/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pexpect,
   pillow,
-  pycryptodomex,
+  cryptography,
   pytestCheckHook,
   pyvirtualdisplay,
   setuptools,
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "vncdotool";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -21,14 +21,14 @@ buildPythonPackage rec {
     owner = "sibson";
     repo = "vncdotool";
     tag = "v${version}";
-    hash = "sha256-QrD6z/g85FwaZCJ1PRn8CBKCOQcbVjQ9g0NpPIxguqk=";
+    hash = "sha256-CXxuaAi/B7NiGp1dhhe7iBw0qOdPfsKg7zMMwavGCW8=";
   };
 
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [
     pillow
-    pycryptodomex
+    cryptography
     twisted
   ];
 

--- a/pkgs/development/python-modules/vncdotool/default.nix
+++ b/pkgs/development/python-modules/vncdotool/default.nix
@@ -24,9 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-CXxuaAi/B7NiGp1dhhe7iBw0qOdPfsKg7zMMwavGCW8=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     pillow
     cryptography
     twisted

--- a/pkgs/development/python-modules/vncdotool/default.nix
+++ b/pkgs/development/python-modules/vncdotool/default.nix
@@ -38,6 +38,16 @@ buildPythonPackage rec {
     pyvirtualdisplay
   ];
 
+  #  Disable integration tests that require LibVNCServer examples.
+  #  The pure Nix sandbox prohibits vncdotool to download these.
+  #
+  #  libvncserver outputs do not include examples since upstream
+  #  LibVNCServer does not easily provide examples.
+  #
+  #  Perhaps a Patch to tests/functional/libvncserver.py to provide
+  #  LibVNCServer examples via eg. LIBVNCSERVER_DIR is a solution.
+  disabledTestPaths = [ "tests/functional" ];
+
   pythonImportsCheck = [ "vncdotool" ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3002,8 +3002,6 @@ with pkgs;
 
   vinyl-cache = vinyl-cache_9;
 
-  vncdotool = with python3Packages; toPythonApplication vncdotool;
-
   # An alias to work around the splicing incidents
   # Related:
   # https://github.com/NixOS/nixpkgs/issues/204303

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -753,7 +753,7 @@ mapAliases {
   vcver = throw "vcver has been removed, since it was an unused leaf package"; # added 2025-08-25
   vega_datasets = throw "'vega_datasets' has been renamed to/replaced by 'vega-datasets'"; # Converted to throw 2025-10-29
   ViennaRNA = throw "'ViennaRNA' has been renamed to/replaced by 'viennarna'"; # Converted to throw 2025-10-29
-  vncdo = vncdotool; # Added 2026-06-30
+  vncdo = throw "'python3Packages.vncdo' has been moved to top-level as 'vncdotool'"; # Added 2026-08-23
   volvooncall = throw "'volvooncall' was removed because Home Assistant dropped the integration"; # added 2026-07-20
   vqgan-jax = throw "'vqgan-jax' has been removed, as it was unmaintained upstream and has unclear license"; # Added 2026-08-07
   vulcan-api = throw "vulcan-api has been removed. Their API has changed and they don't allow access from unofficial software anymore."; # added 2025-09-05

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -22253,8 +22253,6 @@ self: super: with self; {
 
   vmprof = callPackage ../development/python-modules/vmprof { };
 
-  vncdotool = callPackage ../development/python-modules/vncdotool { };
-
   vnoise = callPackage ../development/python-modules/vnoise { };
 
   vobject = callPackage ../development/python-modules/vobject { };


### PR DESCRIPTION
hi, thank you for Nix I love this!

this is a version update of [vncdo](https://github.com/sibson/vncdotool).
Here is the [upstream changelog](https://github.com/sibson/vncdotool/blob/90cde5f682c0864e38825850b02f9c8e3545f527/CHANGELOG.rst#130-2026-04-03).

I personally use version 1.3.0, and perhaps this is relevant for others as well.
I hope this pr is correct. Please let me know if there is anything I should change.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
