### PR TITLE
stacktile: fix build with gcc15

### DIFF
--- a/pkgs/by-name/st/stacktile/package.nix
+++ b/pkgs/by-name/st/stacktile/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromSourcehut,
+  fetchpatch,
   wayland,
   wayland-scanner,
 }:
@@ -16,6 +17,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-IOFxgYMjh92jx2CPfBRZDL/1ucgfHtUyAL5rS2EG+Gc=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/fix-compilation.patch?h=stacktile&id=388a522b69e34c01cc5d57341d8578470a7dccfb";
+      hash = "sha256-y5ArQyjIqT2ICmm8ZYDHZ04DwGgw2d7wsgoH5XJPZf0=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324332901

```
stacktile.c:934:25: error: initialization of 'void (*)(void *, struct zriver_output_status_v1 *, uint32_t)' {aka 'void (*)(void *, struct zriver_output_status_v1 *, unsigned int)'} from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
  934 |         .focused_tags = noop,
      |                         ^~~~
stacktile.c:934:25: note: (near initialization for 'river_output_status_listener.focused_tags')
stacktile.c:931:13: note: 'noop' declared here
  931 | static void noop () {}
      |             ^~~~
```

The upstream has migrated to `zig` but there is no release yet. Fetched a patch to fix this for now.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
