### PR TITLE
tacacsplus: 4.0.4.28 -> 4.0.4.31

### DIFF
--- a/pkgs/by-name/ta/tacacsplus/package.nix
+++ b/pkgs/by-name/ta/tacacsplus/package.nix
@@ -6,18 +6,17 @@
   bison,
   perl,
   libnsl,
-  # --with-libwrap=yes is currently broken, TODO unbreak
-  withLibWrap ? false,
+  withLibWrap ? true,
   tcp_wrappers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tacacsplus";
-  version = "4.0.4.28";
+  version = "4.0.4.31";
 
   src = fetchurl {
     url = "ftp://ftp.shrubbery.net/pub/tac_plus/tacacs-F${finalAttrs.version}.tar.gz";
-    hash = "sha256-FH8tyY0m0vk/Crp2yYjO0Zb/4cAB3C6R94ihosdHIZ4=";
+    hash = "sha256-MKad/Ax1vbz7GPV23l79cq6qBwnDGMBPFTcjn0UeyA8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324333965

Changelog:
```
F4.0.4.29
	- spec file update - from Sten Spans
	- add SHA512 support to tac_pwd - from Sten Spans
	  XXX needs a configure test to check for sha512 support.
	- fix libtacacs link - from Gentoo via Ruben Farrelly
	- fix -U decription in manpage
	- call correct function for host key look-up by hostname - Adam Dyess
	- GC regeerror() from the private regex lib.  Causing segfault
	- a bug with quoted strings was that whitespace was not handled
	  reasonably.  since quoted strings may also be used for regex, it also
	  needs to handle regex atoms.  so, quoted string parsing has been
	  changed to only treat \" specially, all other backslash-quoted
	  characters are simply copied, including the backslash.  add test
	  example to the sample configuration.
	- fdes.c: add parens to make OoO explicit and shut-up compiler warnings

F4.0.4.30
	- pull do_auth 2.0 and the example config file from github, with
	  python3 updates and more.
	  https://github.com/helpdeskdan/do_auth
	- SafeConfigParser class has been renamed to ConfigParser
	- Misc C99 prototype clean-up

F4.0.4.31
	- update autoconf to search for libnsl instead of assume.  Debian
	  no longer has one, at least not by default.
```

Fixes gcc15 prototype errors:
```
tac_pwd.c: In function 'main':
tac_pwd.c:139:26: error: conflicting types for 'crypt'; have 'char *(void)'
  139 |     char                *crypt();
      |                          ^~~~~
In file included from tac_pwd.c:52:
/nix/store/g01r8955ar8skb2ngly2sqf8f1vj9yck-libxcrypt-4.5.2/include/crypt.h:63:14: note: previous declaration of 'crypt' with type 'char *(const char *, const char *)'
   63 | extern char *crypt (const char *__phrase, const char *__setting)
      |              ^~~~~
tac_pwd.c:182:5: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
  182 |     write(1, prompt, strlen(prompt));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tac_pwd.c:187:9: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
  187 |         write(1, "\n", strlen("\n"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
tac_pwd.c:197:5: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
  197 |     write(1, result, strlen(result));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tac_pwd.c:198:5: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
  198 |     write(1, "\n", 1);
      |     ^~~~~~~~~~~~~~~~~
```

`withLibWrap=true` seems to build fine now so I reenabled it. I have no idea how to use this so no actual testing has been done.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
