### PR TITLE
root: 6.38.02 -> 6.40.00

### DIFF
--- a/pkgs/by-name/ro/root/clang-root.nix
+++ b/pkgs/by-name/ro/root/clang-root.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "clang-root";
-  version = "20-20250925-01";
+  version = "20-20260408-01";
 
   src = fetchgit {
     url = "https://github.com/root-project/llvm-project";
     tag = "ROOT-llvm${version}";
-    hash = "sha256-qEoQVv/Aw9gqKSNa8ZJGqPzwXvH1yXiSOkvrUWeXI+g=";
+    hash = "sha256-EXBUI1+DWkqTH4KdVoqxPjG8WyL0P5AEemLvBJqaVrQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -1,7 +1,9 @@
 {
   stdenv,
   lib,
+  blas,
   callPackage,
+  curl,
   fetchFromGitHub,
   fetchurl,
   makeWrapper,
@@ -14,7 +16,6 @@
   fftw,
   ftgl,
   gl2ps,
-  glew,
   gnugrep,
   gnused,
   gsl,
@@ -54,15 +55,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "root";
-  version = "6.38.02";
+  version = "6.40.00";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
   };
 
   src = fetchurl {
-    url = "https://root.cern.ch/download/root_v${finalAttrs.version}.source.tar.gz";
-    hash = "sha256-d9NNK8oOpyCs/UN5i8tdCaKFhAE7TQopEII8hn1L+kI=";
+    url = "https://root.cern.ch/download/root_v${finalAttrs.version}-rc1.source.tar.gz";
+    hash = "sha256-gt9uRuo5bg7L/RQM50gNamU9rRTOfMdA0chNioyKLGg=";
   };
 
   clad_src = fetchFromGitHub {
@@ -70,8 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "clad";
     # Make sure that this is the same tag as in the ROOT build files!
     # https://github.com/root-project/root/blob/master/interpreter/cling/tools/plugins/clad/CMakeLists.txt#L76
-    tag = "v2.0";
-    hash = "sha256-Oj7gGSvnGuYdggonPWjrwPn/06cD+ig3eefRh7xaiPs=";
+    tag = "v2.3";
+    hash = "sha256-gEJlQ2Vg9EUX1tslI4HaUnusvdSomsYHiE8mZMygEOw=";
   };
 
   # ROOT requires a patched version of clang
@@ -88,12 +89,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [
     finalAttrs.clang
+    blas
+    curl
     davix
     fftw
     ftgl
     giflib
     gl2ps
-    glew
     gsl
     libjpeg
     libpng
@@ -167,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = ''
-    for prog in rootbrowse rootcp rooteventselector rootls rootmkdir rootmv rootprint rootrm rootslimtree; do
+    for prog in rooteventselector rootmv rootprint rootslimtree; do
       wrapProgram "$out/bin/$prog" \
         --set PYTHONPATH "$out/lib"
     done

--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -1,7 +1,9 @@
 {
   stdenv,
   lib,
+  blas,
   callPackage,
+  curl,
   fetchFromGitHub,
   fetchurl,
   makeWrapper,
@@ -14,7 +16,6 @@
   fftw,
   ftgl,
   gl2ps,
-  glew,
   gnugrep,
   gnused,
   gsl,
@@ -54,7 +55,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "root";
-  version = "6.38.02";
+  version = "6.40.00";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
@@ -62,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${finalAttrs.version}.source.tar.gz";
-    hash = "sha256-d9NNK8oOpyCs/UN5i8tdCaKFhAE7TQopEII8hn1L+kI=";
+    hash = "sha256-Z2+P3okmzgWQK+f0TOfUkqSiBgAi/KsOPRxE9twPveg=";
   };
 
   clad_src = fetchFromGitHub {
@@ -70,8 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "clad";
     # Make sure that this is the same tag as in the ROOT build files!
     # https://github.com/root-project/root/blob/master/interpreter/cling/tools/plugins/clad/CMakeLists.txt#L76
-    tag = "v2.0";
-    hash = "sha256-Oj7gGSvnGuYdggonPWjrwPn/06cD+ig3eefRh7xaiPs=";
+    tag = "v2.3";
+    hash = "sha256-gEJlQ2Vg9EUX1tslI4HaUnusvdSomsYHiE8mZMygEOw=";
   };
 
   # ROOT requires a patched version of clang
@@ -88,12 +89,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   buildInputs = [
     finalAttrs.clang
+    blas
+    curl
     davix
     fftw
     ftgl
     giflib
     gl2ps
-    glew
     gsl
     libjpeg
     libpng
@@ -167,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = ''
-    for prog in rootbrowse rootcp rooteventselector rootls rootmkdir rootmv rootprint rootrm rootslimtree; do
+    for prog in rooteventselector rootmv rootprint rootslimtree; do
       wrapProgram "$out/bin/$prog" \
         --set PYTHONPATH "$out/lib"
     done


### PR DESCRIPTION
Also, don't set the `PYTHONPATH` for some command line utilities, because they have been rewritten in C++.