### PR TITLE
tdns-cli: unstable-2021-02-19 -> 0.0.5-unstable-2026-02-23

### DIFF
--- a/pkgs/by-name/td/tdns-cli/package.nix
+++ b/pkgs/by-name/td/tdns-cli/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "tdns-cli";
-  version = "unstable-2021-02-19";
+  version = "0.0.5-unstable-2026-02-23";
 
   src = fetchFromGitHub {
     owner = "rotty";
     repo = "tdns-cli";
-    rev = "9a5455fe8a52f3f14dc55ef81511b479c8cd70ea";
-    hash = "sha256-BGxkqlKg81izq4eOBEZFJ/MPb3UCSOo8ZTYTjtjierk=";
+    rev = "404ba636e031ff6101da633d3a572b1b075c0f37";
+    hash = "sha256-e1JEQQI8226Ey5b3Z02xEAfy22eLPC10ANQVHAM7hDs=";
   };
 
-  cargoHash = "sha256-KDZGTGLHLuZgFtzIp+lL0VIiQcYspvxAivp7hVE9V/A=";
+  cargoHash = "sha256-G6YVZf2TxtIvEEeUtHWDITQfUayhEjS2QtXNSsvwg2M=";
 
   meta = {
     description = "DNS tool that aims to replace dig and nsupdate";


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/324334347

Updated to latest commit. Fixed compilation error.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
