### PR TITLE
vangers: pin to ffmpeg 7

### DIFF
--- a/pkgs/by-name/va/vangers/package.nix
+++ b/pkgs/by-name/va/vangers/package.nix
@@ -9,7 +9,7 @@
   SDL2_net,
   libogg,
   libvorbis,
-  ffmpeg,
+  ffmpeg_7,
   zlib,
 }:
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     SDL2_net
     libogg
     libvorbis
-    ffmpeg
+    ffmpeg_7
     clunk
     zlib
   ];


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/324351066

```
/build/source/lib/xsound/avi.cpp: In member function 'void AVIFile::draw()':
/build/source/lib/xsound/avi.cpp:179:33: error: 'avcodec_close' was not declared in this scope; did you mean 'avio_close'?
  179 |                                 avcodec_close(pCodecCtx);
      |                                 ^~~~~~~~~~~~~
      |                                 avio_close
/build/source/lib/xsound/avi.cpp: In member function 'void AVIFile::close()':
/build/source/lib/xsound/avi.cpp:237:9: error: 'avcodec_close' was not declared in this scope; did you mean 'avio_close'?
  237 |         avcodec_close(pCodecCtx);
      |         ^~~~~~~~~~~~~
      |         avio_close
```

Deprecated API removed in ffmpeg 8.
Should be easy to fix but I don't have the data files to properly test it. Pinned to ffmpeg 7 for a more reliable fix.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
