### PR TITLE
nxdumpclient: init at 1.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22609,6 +22609,13 @@
     github = "ranfdev";
     githubId = 23294184;
   };
+  ranidspace = {
+    name = "ranidspace";
+    email = "dev@ranid.space";
+    matrix = "@ranidspace:4d2.org";
+    github = "ranidspace";
+    githubId = 56847308;
+  };
   raphaelr = {
     email = "raphael-git@tapesoftware.net";
     matrix = "@raphi:tapesoftware.net";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -285,6 +285,7 @@
   ./programs/noisetorch.nix
   ./programs/npm.nix
   ./programs/ns-usbloader.nix
+  ./programs/nxdumpclient.nix
   ./programs/oblogout.nix
   ./programs/obs-studio.nix
   ./programs/oddjobd.nix

--- a/nixos/modules/programs/nxdumpclient.nix
+++ b/nixos/modules/programs/nxdumpclient.nix
@@ -1,0 +1,17 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+{
+  options.programs.nxdumpclient = {
+    enable = lib.mkEnableOption "NX Dump Client";
+  };
+
+  config = lib.mkIf config.programs.nxdumpclient.enable {
+    environment.systemPackages = [ pkgs.nxdumpclient ];
+    services.udev.packages = [ pkgs.nxdumpclient ];
+  };
+}

--- a/pkgs/by-name/nx/nxdumpclient/package.nix
+++ b/pkgs/by-name/nx/nxdumpclient/package.nix
@@ -17,6 +17,9 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
   pname = "nxdumpclient";
   version = "1.1.4";
 

--- a/pkgs/by-name/nx/nxdumpclient/package.nix
+++ b/pkgs/by-name/nx/nxdumpclient/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  vala,
+  meson,
+  ninja,
+  pkg-config,
+  desktop-file-utils,
+  gusb,
+  gtk4,
+  glib,
+  wrapGAppsHook4,
+  blueprint-compiler,
+  libadwaita,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nxdumpclient";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "v1993";
+    repo = "nxdumpclient";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6jekESpsV6sDhBh23D7d5/BlGWI1G5SYgWudNvQKzqc=";
+  };
+
+  nativeBuildInputs = [
+    vala
+    meson
+    ninja
+    pkg-config
+    desktop-file-utils
+    wrapGAppsHook4
+    blueprint-compiler
+  ];
+
+  buildInputs = [
+    gtk4
+    glib
+    gusb
+    libadwaita
+  ];
+
+  mesonFlags = [
+    (lib.mesonEnable "libportal" false)
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A client program for dumping over USB with nxdumptool";
+    homepage = "https://github.com/v1993/nxdumpclient";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ranidspace ];
+    mainProgram = "nxdumpclient";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A GUI to interact with nxdumptool homebrew on switch.

Includes a NixOS module, `programs.nxdumpclient.enable`, to load the udev rule.

https://github.com/v1993/nxdumpclient
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
