### PR TITLE
treewide: add missing meta.homepage with source git repository

### DIFF
--- a/pkgs/applications/audio/mopidy/soundcloud.nix
+++ b/pkgs/applications/audio/mopidy/soundcloud.nix
@@ -32,6 +32,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Mopidy extension for playing music from SoundCloud";
+    homepage = "https://github.com/mopidy/mopidy-soundcloud";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -266,6 +266,7 @@ lib.makeScope pkgs.newScope (
 
       meta = {
         broken = gimp.majorVersion != "2.0";
+        homepage = "https://github.com/lmanul/gimp-texturize";
       };
     };
 
@@ -323,6 +324,7 @@ lib.makeScope pkgs.newScope (
 
       meta = {
         broken = gimp.majorVersion != "2.0";
+        homepage = "https://github.com/carlobaldassi/gimp-lqr-plugin";
       };
     };
 

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -264,6 +264,7 @@ lib.makeScope pkgs.newScope (
 
       meta = {
         broken = gimp.apiVersion != "2.0";
+        homepage = "https://github.com/lmanul/gimp-texturize";
       };
     };
 
@@ -321,6 +322,7 @@ lib.makeScope pkgs.newScope (
 
       meta = {
         broken = gimp.apiVersion != "2.0";
+        homepage = "https://github.com/carlobaldassi/gimp-lqr-plugin";
       };
     };
 

--- a/pkgs/applications/misc/ape/clex.nix
+++ b/pkgs/applications/misc/ape/clex.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Large lexicon for APE (~100,000 entries)";
+    homepage = "https://github.com/Attempto/Clex";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ yrashk ];

--- a/pkgs/applications/networking/irc/weechat/scripts/edit/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/edit/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   meta = {
     inherit (weechat.meta) platforms;
     description = "This simple weechat plugin allows you to compose messages in your $EDITOR";
+    homepage = "https://github.com/keith/edit-weechat";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eraserhd ];
   };

--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -109,6 +109,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Free distributed version control system";
+    homepage = "https://github.com/7c6f434c/monotone-mirror";
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Plus;

--- a/pkgs/applications/video/kodi/addons/bluetooth-manager/default.nix
+++ b/pkgs/applications/video/kodi/addons/bluetooth-manager/default.nix
@@ -17,6 +17,7 @@ buildKodiAddon rec {
 
   meta = {
     description = "Addon that allows to manage bluetooth devices from within a Linux based Kodi";
+    homepage = "https://github.com/wastis/BluetoothManager";
     platforms = lib.platforms.all;
     maintainers = lib.teams.kodi.members;
     license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/video/kodi/addons/joystick/default.nix
+++ b/pkgs/applications/video/kodi/addons/joystick/default.nix
@@ -25,6 +25,7 @@ buildKodiBinaryAddon rec {
 
   meta = {
     description = "Binary addon for raw joystick input";
+    homepage = "https://github.com/xbmc/peripheral.joystick";
     platforms = lib.platforms.all;
     license = lib.licenses.gpl2Only;
     teams = [ lib.teams.kodi ];

--- a/pkgs/applications/video/kodi/addons/kodi-platform/default.nix
+++ b/pkgs/applications/video/kodi/addons/kodi-platform/default.nix
@@ -23,4 +23,8 @@ stdenv.mkDerivation rec {
     libcec_platform
     tinyxml
   ];
+
+  meta = {
+    homepage = "https://github.com/xbmc/kodi-platform";
+  };
 }

--- a/pkgs/applications/video/kodi/addons/kodi-platform/default.nix
+++ b/pkgs/applications/video/kodi/addons/kodi-platform/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
+    homepage = "https://github.com/xbmc/kodi-platform";
     license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/applications/video/kodi/addons/steam-controller/default.nix
+++ b/pkgs/applications/video/kodi/addons/steam-controller/default.nix
@@ -20,6 +20,7 @@ buildKodiBinaryAddon rec {
 
   meta = {
     description = "Binary addon for steam controller";
+    homepage = "https://github.com/kodi-game/peripheral.steamcontroller";
     platforms = lib.platforms.all;
     teams = [ lib.teams.kodi ];
   };

--- a/pkgs/applications/video/kodi/addons/steam-controller/default.nix
+++ b/pkgs/applications/video/kodi/addons/steam-controller/default.nix
@@ -20,6 +20,7 @@ buildKodiBinaryAddon rec {
 
   meta = {
     description = "Binary addon for steam controller";
+    homepage = "https://github.com/kodi-game/peripheral.steamcontroller";
     platforms = lib.platforms.all;
     teams = [ lib.teams.kodi ];
     license = lib.licenses.gpl2Only;

--- a/pkgs/applications/video/kodi/addons/vfs-libarchive/default.nix
+++ b/pkgs/applications/video/kodi/addons/vfs-libarchive/default.nix
@@ -35,6 +35,7 @@ buildKodiBinaryAddon rec {
 
   meta = {
     description = "LibArchive Virtual Filesystem add-on for Kodi";
+    homepage = "https://github.com/xbmc/vfs.libarchive";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     teams = [ lib.teams.kodi ];

--- a/pkgs/applications/video/kodi/addons/vfs-rar/default.nix
+++ b/pkgs/applications/video/kodi/addons/vfs-rar/default.nix
@@ -21,6 +21,7 @@ buildKodiBinaryAddon rec {
 
   meta = {
     description = "RAR archive Virtual Filesystem add-on for Kodi";
+    homepage = "https://github.com/xbmc/vfs.rar";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     teams = [ lib.teams.kodi ];

--- a/pkgs/applications/video/kodi/addons/vfs-sftp/default.nix
+++ b/pkgs/applications/video/kodi/addons/vfs-sftp/default.nix
@@ -27,6 +27,7 @@ buildKodiBinaryAddon rec {
 
   meta = {
     description = "SFTP Virtual Filesystem add-on for Kodi";
+    homepage = "https://github.com/xbmc/vfs.sftp";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     teams = [ lib.teams.kodi ];

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -19,6 +19,9 @@ let
       buildInputs = [ vdr ];
       preConfigure = "cd PLUGINS/src/${name}";
       installFlags = [ "DESTDIR=$(out)" ];
+      meta = {
+        homepage = "https://git.tvdr.de/?p=vdr.git";
+      };
     };
 in
 {

--- a/pkgs/by-name/_9/_90secondportraits/package.nix
+++ b/pkgs/by-name/_9/_90secondportraits/package.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Silly speed painting game";
+    homepage = "https://github.com/SimonLarsen/90-Second-Portraits";
     mainProgram = "90secondportraits";
     platforms = love.meta.platforms;
     license = with lib.licenses; [

--- a/pkgs/by-name/ai/aitrack/package.nix
+++ b/pkgs/by-name/ai/aitrack/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "6DoF Head tracking software";
+    homepage = "https://github.com/mdk97/aitrack-linux";
     mainProgram = "aitrack";
     maintainers = with lib.maintainers; [ ck3d ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/al/alkimia/package.nix
+++ b/pkgs/by-name/al/alkimia/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Library used by KDE finance applications";
+    homepage = "https://invent.kde.org/office/alkimia";
     mainProgram = "onlinequoteseditor5";
     longDescription = ''
       Alkimia is the infrastructure for common storage and business

--- a/pkgs/by-name/ar/archivemount/package.nix
+++ b/pkgs/by-name/ar/archivemount/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Gateway between FUSE and libarchive: allows mounting of cpio, .tar.gz, .tar.bz2 archives";
+    homepage = "https://git.sr.ht/~nabijaczleweli/archivemount-ng";
     changelog = "https://git.sr.ht/~nabijaczleweli/archivemount-ng/refs/${finalAttrs.version}";
     mainProgram = "archivemount";
     license = [

--- a/pkgs/by-name/ar/argpp/package.nix
+++ b/pkgs/by-name/ar/argpp/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Argument Parser for C++";
+    homepage = "https://github.com/Grumbel/argpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.free;

--- a/pkgs/by-name/as/asterisk-module-sccp/package.nix
+++ b/pkgs/by-name/as/asterisk-module-sccp/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Replacement for the SCCP channel driver in Asterisk";
+    homepage = "https://github.com/chan-sccp/chan-sccp";
     license = lib.licenses.gpl1Only;
     maintainers = with lib.maintainers; [ das_j ];
     # https://github.com/chan-sccp/chan-sccp/issues/609

--- a/pkgs/by-name/ba/bacnet-stack/package.nix
+++ b/pkgs/by-name/ba/bacnet-stack/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "BACnet open source protocol stack for embedded systems, Linux, and Windows";
+    homepage = "https://github.com/bacnet-stack/bacnet-stack";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ WhittlesJr ];

--- a/pkgs/by-name/ba/badvpn/package.nix
+++ b/pkgs/by-name/ba/badvpn/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Set of network-related (mostly VPN-related) tools";
+    homepage = "https://github.com/ambrop72/badvpn";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ba/bam/package.nix
+++ b/pkgs/by-name/ba/bam/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Yet another build manager";
+    homepage = "https://github.com/matricks/bam";
     mainProgram = "bam";
     maintainers = with lib.maintainers; [
       raskin

--- a/pkgs/by-name/ba/bash_unit/package.nix
+++ b/pkgs/by-name/ba/bash_unit/package.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Bash unit testing enterprise edition framework for professionals";
+    homepage = "https://github.com/bash-unit/bash_unit";
     maintainers = with lib.maintainers; [ pamplemousse ];
     platforms = lib.platforms.all;
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/bg/bgs/package.nix
+++ b/pkgs/by-name/bg/bgs/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Extremely fast and small background setter for X";
+    homepage = "https://github.com/Gottox/bgs";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ pSub ];

--- a/pkgs/by-name/bi/biosdevname/package.nix
+++ b/pkgs/by-name/bi/biosdevname/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Udev helper for naming devices per BIOS names";
+    homepage = "https://github.com/dell/biosdevname";
     license = lib.licenses.gpl2Only;
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/bl/blobfuse/package.nix
+++ b/pkgs/by-name/bl/blobfuse/package.nix
@@ -36,6 +36,7 @@ buildGoModule {
 
   meta = {
     description = "Mount an Azure Blob storage as filesystem through FUSE";
+    homepage = "https://github.com/Azure/azure-storage-fuse";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jbgi ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/bo/boxed-cpp/package.nix
+++ b/pkgs/by-name/bo/boxed-cpp/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Boxing primitive types in C++";
+    homepage = "https://github.com/contour-terminal/boxed-cpp";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.moni ];

--- a/pkgs/by-name/ci/cidrgrep/package.nix
+++ b/pkgs/by-name/ci/cidrgrep/package.nix
@@ -23,6 +23,7 @@ buildGoModule {
 
   meta = {
     description = "Like grep but for IPv4 CIDRs";
+    homepage = "https://github.com/tomdoherty/cidrgrep";
     mainProgram = "cidrgrep";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ das_j ];

--- a/pkgs/by-name/ck/ckdl/package.nix
+++ b/pkgs/by-name/ck/ckdl/package.nix
@@ -59,6 +59,7 @@ pkgs.stdenv.mkDerivation {
 
   meta = {
     description = "C library that implements reading and writing the KDL Document Language";
+    homepage = "https://github.com/tjol/ckdl";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/co/coc-cmake/package.nix
+++ b/pkgs/by-name/co/coc-cmake/package.nix
@@ -55,4 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  meta = {
+    homepage = "https://github.com/voldikss/coc-extensions";
+  };
 })

--- a/pkgs/by-name/co/coc-cmake/package.nix
+++ b/pkgs/by-name/co/coc-cmake/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    homepage = "https://github.com/voldikss/coc-extensions";
     license = lib.licenses.mit;
   };
 })

--- a/pkgs/by-name/co/convchain/package.nix
+++ b/pkgs/by-name/co/convchain/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
   buildInputs = [ mono ];
   meta = {
     description = "Bitmap generation from a single example with convolutions and MCMC";
+    homepage = "https://github.com/mxgmn/ConvChain";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/cr/crystal2nix/package.nix
+++ b/pkgs/by-name/cr/crystal2nix/package.nix
@@ -37,6 +37,7 @@ crystal.buildCrystalPackage rec {
 
   meta = {
     description = "Utility to convert Crystal's shard.lock files to a Nix file";
+    homepage = "https://github.com/nix-community/crystal2nix";
     mainProgram = "crystal2nix";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ct/ctrtool/package.nix
+++ b/pkgs/by-name/ct/ctrtool/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     license = lib.licenses.mit;
     description = "Tool to extract data from a 3ds rom";
+    homepage = "https://github.com/jakcron/Project_CTR";
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [ marius851000 ];
     mainProgram = "ctrtool";

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -145,6 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Debian package maintenance scripts";
+    homepage = "https://salsa.debian.org/debian/devscripts";
     license = lib.licenses.free; # Mix of public domain, Artistic+GPL, GPL1+, GPL2+, GPL3+, and GPL2-only... TODO
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/de/debian-devscripts/package.nix
+++ b/pkgs/by-name/de/debian-devscripts/package.nix
@@ -258,6 +258,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Debian package maintenance scripts";
+    homepage = "https://salsa.debian.org/debian/devscripts";
     license = lib.licenses.free; # Mix of public domain, Artistic+GPL, GPL1+, GPL2+, GPL3+, and GPL2-only... TODO
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/de/delly/package.nix
+++ b/pkgs/by-name/de/delly/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Structural variant caller for mapped DNA sequenced data";
+    homepage = "https://github.com/dellytools/delly";
     mainProgram = "delly";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/de/depotdownloader/package.nix
+++ b/pkgs/by-name/de/depotdownloader/package.nix
@@ -25,6 +25,7 @@ buildDotnetModule rec {
 
   meta = {
     description = "Steam depot downloader utilizing the SteamKit2 library";
+    homepage = "https://github.com/SteamRE/DepotDownloader";
     changelog = "https://github.com/SteamRE/DepotDownloader/releases/tag/DepotDownloader_${version}";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.babbaj ];

--- a/pkgs/by-name/di/diod/package.nix
+++ b/pkgs/by-name/di/diod/package.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "I/O forwarding server that implements a variant of the 9P protocol";
+    homepage = "https://github.com/chaos/diod";
     maintainers = with lib.maintainers; [ rnhmjoj ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;

--- a/pkgs/by-name/di/disorderfs/package.nix
+++ b/pkgs/by-name/di/disorderfs/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Overlay FUSE filesystem that introduces non-determinism into filesystem metadata";
+    homepage = "https://salsa.debian.org/reproducible-builds/disorderfs";
     mainProgram = "disorderfs";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dn/dnsviz/package.nix
+++ b/pkgs/by-name/dn/dnsviz/package.nix
@@ -50,6 +50,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
       This tool suite powers the Web-based analysis available at https://dnsviz.net/
     '';
+    homepage = "https://github.com/dnsviz/dnsviz";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ jojosch ];
   };

--- a/pkgs/by-name/do/domine/package.nix
+++ b/pkgs/by-name/do/domine/package.nix
@@ -16,5 +16,9 @@ buildDartApplication {
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
-  meta.mainProgram = "domine";
+
+  meta = {
+    homepage = "https://github.com/breitburg/domine";
+    mainProgram = "domine";
+  };
 }

--- a/pkgs/by-name/dr/drone-cli/package.nix
+++ b/pkgs/by-name/dr/drone-cli/package.nix
@@ -31,5 +31,6 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ techknowlogick ];
     license = lib.licenses.asl20;
     description = "Command line client for the Drone continuous integration server";
+    homepage = "https://github.com/harness/drone-cli";
   };
 }

--- a/pkgs/by-name/du/duckmarines/package.nix
+++ b/pkgs/by-name/du/duckmarines/package.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Duck-themed action puzzle video game";
+    homepage = "https://github.com/SimonLarsen/duckmarines";
     platforms = love.meta.platforms;
     hydraPlatforms = [ ];
     license = with lib.licenses; [

--- a/pkgs/by-name/dy/dydisnix/package.nix
+++ b/pkgs/by-name/dy/dydisnix/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation {
     longDescription = ''
       Dynamic Disnix is a (very experimental!) prototype extension framework for Disnix supporting dynamic (re)deployment of service-oriented systems.
     '';
+    homepage = "https://github.com/svanderburg/dydisnix";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.tomberek ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/en/envio/package.nix
+++ b/pkgs/by-name/en/envio/package.nix
@@ -44,6 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
+    homepage = "https://github.com/humblepenguinn/envio";
     changelog = "https://github.com/humblepenguinn/envio/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Modern and secure CLI tool for managing environment variables";
     mainProgram = "envio";

--- a/pkgs/by-name/ev/evdev-proto/package.nix
+++ b/pkgs/by-name/ev/evdev-proto/package.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Input event device header files for FreeBSD";
+    homepage = "https://git.FreeBSD.org/ports";
     maintainers = with lib.maintainers; [ qyliss ];
     platforms = lib.platforms.freebsd;
     license = lib.licenses.gpl2Only;

--- a/pkgs/by-name/ev/evdev-proto/package.nix
+++ b/pkgs/by-name/ev/evdev-proto/package.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Input event device header files for FreeBSD";
+    homepage = "https://cgit.freebsd.org/ports";
     maintainers = with lib.maintainers; [ qyliss ];
     platforms = lib.platforms.freebsd;
     license = lib.licenses.gpl2Only;

--- a/pkgs/by-name/ev/evtest/package.nix
+++ b/pkgs/by-name/ev/evtest/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple tool for input event debugging";
+    homepage = "https://gitlab.freedesktop.org/libevdev/evtest";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.bjornfor ];

--- a/pkgs/by-name/ex/expenses/package.nix
+++ b/pkgs/by-name/ex/expenses/package.nix
@@ -42,6 +42,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Interactive command line expense logger";
+    homepage = "https://github.com/manojkarthick/expenses";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.manojkarthick ];
     mainProgram = "expenses";

--- a/pkgs/by-name/fa/falcon/package.nix
+++ b/pkgs/by-name/fa/falcon/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Programming language with macros and syntax at once";
+    homepage = "https://github.com/falconpl/falcon";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ pSub ];
     platforms = with lib.platforms; unix;

--- a/pkgs/by-name/fb/fbpanel/package.nix
+++ b/pkgs/by-name/fb/fbpanel/package.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Stand-alone panel";
+    homepage = "https://github.com/aanatoly/fbpanel";
     maintainers = with lib.maintainers; [ raskin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;

--- a/pkgs/by-name/fi/filter-audio/package.nix
+++ b/pkgs/by-name/fi/filter-audio/package.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lightweight audio filtering library made from webrtc code";
+    homepage = "https://github.com/irungentoo/filter_audio";
     license = lib.licenses.bsd3;
     maintainers = [ ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fl/flightgear/package.nix
+++ b/pkgs/by-name/fl/flightgear/package.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Flight simulator";
+    homepage = "https://gitlab.com/flightgear/flightgear";
     maintainers = with lib.maintainers; [
       raskin
       kirillrdy

--- a/pkgs/by-name/fl/flip/package.nix
+++ b/pkgs/by-name/fl/flip/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Tool for visualizing and communicating the errors in rendered images";
+    homepage = "https://github.com/NVlabs/flip";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ zmitchell ];

--- a/pkgs/by-name/fp/fplll/package.nix
+++ b/pkgs/by-name/fp/fplll/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lattice algorithms using floating-point arithmetic";
+    homepage = "https://github.com/fplll/fplll";
     changelog = [
       # Some release notes are added to the github tags, though they are not
       # always complete.

--- a/pkgs/by-name/fp/fplll_20160331/package.nix
+++ b/pkgs/by-name/fp/fplll_20160331/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation {
   ];
   meta = {
     description = "Lattice algorithms using floating-point arithmetic";
+    homepage = "https://github.com/fplll/fplll";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gb/gbsplay/package.nix
+++ b/pkgs/by-name/gb/gbsplay/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Gameboy sound player";
+    homepage = "https://github.com/mmitch/gbsplay";
     license = lib.licenses.gpl1Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/by-name/ge/geomcpp/package.nix
+++ b/pkgs/by-name/ge/geomcpp/package.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Collection of point, size and rect classes";
+    homepage = "https://github.com/Grumbel/geomcpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.free;

--- a/pkgs/by-name/gf/gfxtablet/package.nix
+++ b/pkgs/by-name/gf/gfxtablet/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Uinput driver for Android GfxTablet tablet-as-input-device app";
+    homepage = "https://github.com/rfc2822/GfxTablet";
     mainProgram = "networktablet";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.raskin ];

--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -40,6 +40,7 @@ buildGo125Module rec {
 
   meta = {
     description = "GitLab Docker toolset to pack, ship, store, and deliver content";
+    homepage = "https://gitlab.com/gitlab-org/container-registry";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ e1mo ];
     teams = with lib.teams; [ gitlab ];

--- a/pkgs/by-name/gi/gitlab-elasticsearch-indexer/package.nix
+++ b/pkgs/by-name/gi/gitlab-elasticsearch-indexer/package.nix
@@ -52,6 +52,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Indexes Git repositories into Elasticsearch for GitLab";
+    homepage = "https://gitlab.com/gitlab-org/gitlab-elasticsearch-indexer";
     mainProgram = "gitlab-elasticsearch-indexer";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gl/glui/package.nix
+++ b/pkgs/by-name/gl/glui/package.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "User interface library using OpenGL";
+    homepage = "https://github.com/libglui/glui";
     license = lib.licenses.zlib;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gn/gnss-share/package.nix
+++ b/pkgs/by-name/gn/gnss-share/package.nix
@@ -24,6 +24,7 @@ buildGoModule (finalAttrs: {
       with geoclue* or other clients that support fetching NMEA location data over
       sockets.
     '';
+    homepage = "https://gitlab.com/postmarketOS/gnss-share";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ balsoft ];
     mainProgram = "gnss-share";

--- a/pkgs/by-name/go/go-bindata-assetfs/package.nix
+++ b/pkgs/by-name/go/go-bindata-assetfs/package.nix
@@ -24,6 +24,7 @@ buildGoModule {
 
   meta = {
     description = "Serve embedded files from jteeuwen/go-bindata";
+    homepage = "https://github.com/elazarl/go-bindata-assetfs";
     mainProgram = "go-bindata-assetfs";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ avnik ];

--- a/pkgs/by-name/go/golden-cheetah/package.nix
+++ b/pkgs/by-name/go/golden-cheetah/package.nix
@@ -118,6 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Performance software for cyclists, runners and triathletes. Built from source and without API tokens";
+    homepage = "https://github.com/GoldenCheetah/GoldenCheetah";
     mainProgram = "GoldenCheetah";
     platforms = with lib.platforms; darwin ++ linux;
     maintainers = with lib.maintainers; [ adamcstephens ];

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Tool to control GoPro webcam mode in Linux (requires v4l2loopback kernel module and a firewall rule)";
+    homepage = "https://github.com/juchem/gopro-tool";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ ZMon3y ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/go/gotemplate/package.nix
+++ b/pkgs/by-name/go/gotemplate/package.nix
@@ -23,6 +23,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "CLI for go text/template";
+    homepage = "https://github.com/coveooss/gotemplate";
     mainProgram = "gotemplate";
     changelog = "https://github.com/coveooss/gotemplate/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/gr/grimblast/package.nix
+++ b/pkgs/by-name/gr/grimblast/package.nix
@@ -66,6 +66,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Helper for screenshots within Hyprland, based on grimshot";
+    homepage = "https://github.com/hyprwm/contrib";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     teams = [ lib.teams.hyprland ];

--- a/pkgs/by-name/gt/gt/package.nix
+++ b/pkgs/by-name/gt/gt/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Linux command line tool for setting up USB gadgets using configfs";
+    homepage = "https://github.com/linux-usb-gadgets/gt";
     mainProgram = "gt";
     license = with lib.licenses; [ asl20 ];
     maintainers = [ ];

--- a/pkgs/by-name/gt/gtk-sharp-beans/package.nix
+++ b/pkgs/by-name/gt/gtk-sharp-beans/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Binds some API from GTK that isn't in GTK# 2.12.x";
+    homepage = "https://github.com/mono/gtk-sharp-beans";
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
   };

--- a/pkgs/by-name/gt/gtk4-layer-shell/package.nix
+++ b/pkgs/by-name/gt/gtk4-layer-shell/package.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Library to create panels and other desktop components for Wayland using the Layer Shell protocol and GTK4";
+    homepage = "https://github.com/wmww/gtk4-layer-shell";
     mainProgram = "gtk4-layer-demo";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ donovanglover ];

--- a/pkgs/by-name/gt/gtkclipblock/package.nix
+++ b/pkgs/by-name/gt/gtkclipblock/package.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "LD_PRELOAD hack to prevent GTK programs from interacting with the primary clipboard";
+    homepage = "https://github.com/notpeelz/gtkclipblock";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [ uartman ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/hf/hfsprogs/package.nix
+++ b/pkgs/by-name/hf/hfsprogs/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "HFS/HFS+ user space utils";
+    homepage = "https://github.com/glaubitz/hfs";
     license = lib.licenses.apple-psl20;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/hh/hhpc/package.nix
+++ b/pkgs/by-name/hh/hhpc/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Hides the mouse pointer in X11";
+    homepage = "https://github.com/aktau/hhpc";
     maintainers = with lib.maintainers; [ nico202 ];
     platforms = lib.platforms.unix;
     license = lib.licenses.bsd3;

--- a/pkgs/by-name/hi/hiraeth/package.nix
+++ b/pkgs/by-name/hi/hiraeth/package.nix
@@ -18,6 +18,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Share files with an expiration date";
+    homepage = "https://github.com/lukaswrz/hiraeth";
     license = lib.licenses.agpl3Plus;
     maintainers = [ lib.maintainers.lukaswrz ];
     mainProgram = "hiraeth";

--- a/pkgs/by-name/ho/hostess/package.nix
+++ b/pkgs/by-name/ho/hostess/package.nix
@@ -21,6 +21,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Idempotent command-line utility for managing your /etc/hosts* file";
+    homepage = "https://github.com/cbednarski/hostess";
     mainProgram = "hostess";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ edlimerkaj ];

--- a/pkgs/by-name/ht/https-dns-proxy/package.nix
+++ b/pkgs/by-name/ht/https-dns-proxy/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "DNS to DNS over HTTPS (DoH) proxy";
+    homepage = "https://github.com/aarond10/https_dns_proxy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/hy/hyprprop/package.nix
+++ b/pkgs/by-name/hy/hyprprop/package.nix
@@ -63,6 +63,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
   meta = {
     description = "Xprop replacement for Hyprland";
+    homepage = "https://github.com/hyprwm/contrib";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     teams = [ lib.teams.hyprland ];

--- a/pkgs/by-name/in/intel-media-sdk/package.nix
+++ b/pkgs/by-name/in/intel-media-sdk/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Intel Media SDK";
+    homepage = "https://github.com/Intel-Media-SDK/MediaSDK";
     mainProgram = "mfx-tracer-config";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/io/ioq3-scion/package.nix
+++ b/pkgs/by-name/io/ioq3-scion/package.nix
@@ -20,6 +20,7 @@ ioquake3.overrideAttrs (old: {
   };
   meta = {
     description = "ioquake3 with support for path aware networking";
+    homepage = "https://github.com/lschulz/ioq3-scion";
     maintainers = with lib.maintainers; [ matthewcroughan ];
   };
 })

--- a/pkgs/by-name/io/ioq3-scion/package.nix
+++ b/pkgs/by-name/io/ioq3-scion/package.nix
@@ -22,6 +22,7 @@ ioquake3.overrideAttrs (old: {
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";
   meta = {
     description = "ioquake3 with support for path aware networking";
+    homepage = "https://github.com/lschulz/ioq3-scion";
     maintainers = with lib.maintainers; [ matthewcroughan ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ip/ipgrep/package.nix
+++ b/pkgs/by-name/ip/ipgrep/package.nix
@@ -39,6 +39,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       ipgrep extracts possibly obfuscated host names and IP addresses
       from text, resolves host names, and prints them, sorted by ASN.
     '';
+    homepage = "https://github.com/jedisct1/ipgrep";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/ja/jack-passthrough/package.nix
+++ b/pkgs/by-name/ja/jack-passthrough/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
       more ports than they normally would or to prevent them from
       auto-connecting to certain things.
     '';
+    homepage = "https://github.com/guysherman/jack-passthrough";
     # license unknown: https://github.com/guysherman/jack-passthrough/issues/2
     license = lib.licenses.unfree;
     maintainers = [ lib.maintainers.PowerUser64 ];

--- a/pkgs/by-name/km/kminion/package.nix
+++ b/pkgs/by-name/km/kminion/package.nix
@@ -36,6 +36,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Feature-rich Prometheus exporter for Apache Kafka written in Go";
+    homepage = "https://github.com/redpanda-data/kminion";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cafkafk ];
     mainProgram = "kminion";

--- a/pkgs/by-name/ks/kstart/package.nix
+++ b/pkgs/by-name/ks/kstart/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
       "man"
     ];
     description = "Modified version of kerberos tools that support automatic ticket refresh";
+    homepage = "https://github.com/rra/kstart";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/kw/kwakd/package.nix
+++ b/pkgs/by-name/kw/kwakd/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Super small webserver that serves blank pages";
+    homepage = "https://github.com/fetchinson/kwakd";
     mainProgram = "kwakd";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.nicknovitski ];

--- a/pkgs/by-name/li/libloragw-2g4/package.nix
+++ b/pkgs/by-name/li/libloragw-2g4/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "LoRa 2.4Ghz Gateway - Linux host Hardware Abstraction Layer, and tools (Packet Forwarder...)";
+    homepage = "https://github.com/Lora-net/gateway_2g4_hal";
     license = [
       lib.licenses.bsd3
       lib.licenses.mit

--- a/pkgs/by-name/li/libloragw-sx1301/package.nix
+++ b/pkgs/by-name/li/libloragw-sx1301/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Driver/HAL to build a gateway using a concentrator board based on Semtech SX1301 multi-channel modem and SX1257/SX1255 RF transceivers";
+    homepage = "https://github.com/brocaar/lora_gateway";
     license = [
       lib.licenses.bsd3
       lib.licenses.mit

--- a/pkgs/by-name/li/libloragw-sx1302/package.nix
+++ b/pkgs/by-name/li/libloragw-sx1302/package.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "SX1302 Hardware Abstraction Layer and Tools (packet forwarder...)";
+    homepage = "https://github.com/brocaar/sx1302_hal";
     license = [
       lib.licenses.bsd3
       lib.licenses.mit

--- a/pkgs/by-name/li/libunicode/package.nix
+++ b/pkgs/by-name/li/libunicode/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Modern C++20 Unicode library";
+    homepage = "https://github.com/contour-terminal/libunicode";
     mainProgram = "unicode-query";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/li/libusbgx/package.nix
+++ b/pkgs/by-name/li/libusbgx/package.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
   buildInputs = [ libconfig ];
   meta = {
     description = "C library encapsulating the kernel USB gadget-configfs userspace API functionality";
+    homepage = "https://github.com/linux-usb-gadgets/libusbgx";
     license = with lib.licenses; [
       lgpl21Plus # library
       gpl2Plus # examples

--- a/pkgs/by-name/li/libxo/package.nix
+++ b/pkgs/by-name/li/libxo/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Library to generate text, XML, JSON, and HTML";
+    homepage = "https://github.com/Juniper/libxo";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.reckenrode ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/lo/loadwatch/package.nix
+++ b/pkgs/by-name/lo/loadwatch/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Run a program using only idle cycles";
+    homepage = "https://git.sr.ht/~woffs/loadwatch";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ woffs ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/lo/logmich/package.nix
+++ b/pkgs/by-name/lo/logmich/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A trivial logging library";
+    homepage = "https://github.com/logmich/logmich";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.zlib;

--- a/pkgs/by-name/ma/mari0/package.nix
+++ b/pkgs/by-name/ma/mari0/package.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Crossover between Super Mario Bros. and Portal";
+    homepage = "https://github.com/Stabyourself/mari0";
     mainProgram = "mari0";
     platforms = love.meta.platforms;
     license = lib.licenses.mit;

--- a/pkgs/by-name/mi/minio-certgen/package.nix
+++ b/pkgs/by-name/mi/minio-certgen/package.nix
@@ -19,6 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Simple Minio tool to generate self-signed certificates, and provides SAN certificates with DNS and IP entries";
+    homepage = "https://github.com/minio/certgen";
     downloadPage = "https://github.com/minio/certgen";
     license = lib.licenses.bsd3;
     maintainers = [ ];

--- a/pkgs/by-name/mi/mirakurun/package.nix
+++ b/pkgs/by-name/mi/mirakurun/package.nix
@@ -73,6 +73,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Resource manager for TV tuners";
+    homepage = "https://github.com/Chinachu/Mirakurun";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ midchildan ];
   };

--- a/pkgs/by-name/mi/mix2nix/package.nix
+++ b/pkgs/by-name/mi/mix2nix/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Generate nix expressions from mix.lock file";
+    homepage = "https://github.com/ydlr/mix2nix";
     mainProgram = "mix2nix";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ydlr ];

--- a/pkgs/by-name/mq/mqttmultimeter/package.nix
+++ b/pkgs/by-name/mq/mqttmultimeter/package.nix
@@ -60,6 +60,7 @@ buildDotnetModule rec {
   meta = {
     mainProgram = builtins.head executables;
     description = "MQTT traffic monitor";
+    homepage = "https://github.com/chkr1011/mqttMultimeter";
     license = lib.licenses.free;
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/mr/mrrescue/package.nix
+++ b/pkgs/by-name/mr/mrrescue/package.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Arcade-style fire fighting game";
+    homepage = "https://github.com/SimonLarsen/mrrescue";
     mainProgram = "mrrescue";
     maintainers = [ ];
     platforms = love.meta.platforms;

--- a/pkgs/by-name/ms/mscompress/package.nix
+++ b/pkgs/by-name/ms/mscompress/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = ''Microsoft "compress.exe/expand.exe" compatible (de)compressor'';
+    homepage = "https://github.com/stapelberg/mscompress";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ms/msr-tools/package.nix
+++ b/pkgs/by-name/ms/msr-tools/package.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Tools to read/write from/to MSR CPU registers on Linux";
+    homepage = "https://github.com/intel/msr-tools";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ peterhoeg ];

--- a/pkgs/by-name/mu/munge/package.nix
+++ b/pkgs/by-name/mu/munge/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = ''
       An authentication service for creating and validating credentials
     '';
+    homepage = "https://github.com/dun/munge";
     license = [
       # MUNGE
       lib.licenses.gpl3Plus

--- a/pkgs/by-name/mu/munge/package.nix
+++ b/pkgs/by-name/mu/munge/package.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = ''
       An authentication service for creating and validating credentials
     '';
+    homepage = "https://github.com/dun/munge";
     license = [
       # MUNGE
       lib.licenses.gpl3Plus

--- a/pkgs/by-name/mv/mvebu64boot/package.nix
+++ b/pkgs/by-name/mv/mvebu64boot/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Boot 64-bit Marvell EBU SoC over UART";
+    homepage = "https://github.com/pali/mvebu64boot";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ lukegb ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -29,6 +29,7 @@ buildDotnetModule rec {
 
   meta = {
     description = "Minimalist UTXO tracker for HD Cryptocurrency Wallets";
+    homepage = "https://github.com/dgarage/NBXplorer";
     maintainers = with lib.maintainers; [
       kcalvinalvin
       erikarvstedt

--- a/pkgs/by-name/ne/netris/package.nix
+++ b/pkgs/by-name/ne/netris/package.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Free networked version of T*tris";
+    homepage = "https://github.com/naclander/netris";
     mainProgram = "netris";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ patryk27 ];

--- a/pkgs/by-name/ne/networkmanager-iodine/package.nix
+++ b/pkgs/by-name/ne/networkmanager-iodine/package.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "NetworkManager's iodine plugin";
+    homepage = "https://gitlab.gnome.org/GNOME/network-manager-iodine";
     inherit (networkmanager.meta) maintainers teams platforms;
     license = lib.licenses.gpl2Plus;
   };

--- a/pkgs/by-name/ne/newtonwars/package.nix
+++ b/pkgs/by-name/ne/newtonwars/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Space battle game with gravity as the main theme";
+    homepage = "https://github.com/Draradech/NewtonWars";
     mainProgram = "nw";
     maintainers = with lib.maintainers; [ pSub ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ni/nilfs-utils/package.nix
+++ b/pkgs/by-name/ni/nilfs-utils/package.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "NILFS utilities";
+    homepage = "https://github.com/nilfs-dev/nilfs-utils";
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
     license = with lib.licenses; [

--- a/pkgs/by-name/ns/nsplist/package.nix
+++ b/pkgs/by-name/ns/nsplist/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation {
   meta = {
     maintainers = [ ];
     description = "Parses .plist files";
+    homepage = "https://github.com/matthewbauer/NSPlist";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/nu/numlockx/package.nix
+++ b/pkgs/by-name/nu/numlockx/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Allows to start X with NumLock turned on";
+    homepage = "https://github.com/rg3/numlockx";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     mainProgram = "numlockx";

--- a/pkgs/by-name/od/odroid-xu3-bootloader/package.nix
+++ b/pkgs/by-name/od/odroid-xu3-bootloader/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     license = lib.licenses.unfreeRedistributableFirmware;
     description = "Secure boot enabled boot loader for ODROID-XU{3,4}";
+    homepage = "https://github.com/hardkernel/u-boot";
     maintainers = [ ];
   };
 }

--- a/pkgs/by-name/oi/ois/package.nix
+++ b/pkgs/by-name/oi/ois/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Object-oriented C++ input system";
+    homepage = "https://github.com/wgois/OIS";
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;
     license = lib.licenses.zlib;

--- a/pkgs/by-name/or/orthorobot/package.nix
+++ b/pkgs/by-name/or/orthorobot/package.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Recharge the robot";
+    homepage = "https://github.com/Stabyourself/orthorobot";
     mainProgram = "orthorobot";
     platforms = love.meta.platforms;
     license = lib.licenses.wtfpl;

--- a/pkgs/by-name/ox/oxygenfonts/package.nix
+++ b/pkgs/by-name/ox/oxygenfonts/package.nix
@@ -51,6 +51,7 @@ stdenvNoCC.mkDerivation {
       See: http://sansoxygen.com/
     '';
 
+    homepage = "https://github.com/vernnobile/oxygenFont";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/pa/pa_applet/package.nix
+++ b/pkgs/by-name/pa/pa_applet/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "";
+    homepage = "https://github.com/fernandotcl/pa-applet";
     mainProgram = "pa-applet";
     license = lib.licenses.bsd2;
     maintainers = [ ];

--- a/pkgs/by-name/pb/pbzx/package.nix
+++ b/pkgs/by-name/pb/pbzx/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
   meta = {
     description = "Stream parser of Apple's pbzx compression format";
+    homepage = "https://github.com/NiklasRosenstein/pbzx";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl3;
     maintainers = [ ];

--- a/pkgs/by-name/pd/pdftag/package.nix
+++ b/pkgs/by-name/pd/pdftag/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Edit metadata found in PDFs";
+    homepage = "https://github.com/arrufat/pdftag";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
     mainProgram = "pdftag";

--- a/pkgs/by-name/ph/physlock/package.nix
+++ b/pkgs/by-name/ph/physlock/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Secure suspend/hibernate-friendly alternative to `vlock -an`";
+    homepage = "https://github.com/muennich/physlock";
     mainProgram = "physlock";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pi/pipenv/package.nix
+++ b/pkgs/by-name/pi/pipenv/package.nix
@@ -108,6 +108,7 @@ buildPythonApplication rec {
 
   meta = {
     description = "Python Development Workflow for Humans";
+    homepage = "https://github.com/pypa/pipenv";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     mainProgram = "pipenv";

--- a/pkgs/by-name/pi/pixz/package.nix
+++ b/pkgs/by-name/pi/pixz/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Parallel compressor/decompressor for xz format";
+    homepage = "https://github.com/vasi/pixz";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/pl/plistcpp/package.nix
+++ b/pkgs/by-name/pl/plistcpp/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
   meta = {
     maintainers = [ ];
     description = "CPP bindings for Plist";
+    homepage = "https://github.com/matthewbauer/PlistCpp";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/po/polonium/package.nix
+++ b/pkgs/by-name/po/polonium/package.nix
@@ -48,6 +48,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Auto-tiler that uses KWin 6.0+ tiling functionality";
+    homepage = "https://github.com/zeroxoneafour/polonium";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       peterhoeg

--- a/pkgs/by-name/po/powercap/package.nix
+++ b/pkgs/by-name/po/powercap/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Tools and library to read/write to the Linux power capping framework (sysfs interface)";
+    homepage = "https://github.com/powercap/powercap";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ rowanG077 ];

--- a/pkgs/by-name/po/powersploit/package.nix
+++ b/pkgs/by-name/po/powersploit/package.nix
@@ -26,6 +26,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     changelog = "https://github.com/PowerShellMafia/PowerSploit/releases/";
     description = "PowerShell Post-Exploitation Framework";
+    homepage = "https://github.com/PowerShellMafia/PowerSploit";
     license = with lib.licenses; [ bsd3 ];
     maintainers = with lib.maintainers; [ shard7 ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/pr/priocpp/package.nix
+++ b/pkgs/by-name/pr/priocpp/package.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Property I/O for C++";
+    homepage = "https://github.com/Grumbel/priocpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.free;

--- a/pkgs/by-name/pw/pwalarmctl/package.nix
+++ b/pkgs/by-name/pw/pwalarmctl/package.nix
@@ -35,6 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       for live configuration changes and access to the active state
       of pwalarmd.
     '';
+    homepage = "https://github.com/amyipdev/pwalarmd";
     mainProgram = "pwalarmctl";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/pw/pwalarmd/package.nix
+++ b/pkgs/by-name/pw/pwalarmd/package.nix
@@ -29,6 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       It has extensive configuration and personalization, PulseAudio
       and PipeWire support, and supports live configuration changes.
     '';
+    homepage = "https://github.com/amyipdev/pwalarmd";
     mainProgram = "pwalarmd";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/qu/quartz-wm/package.nix
+++ b/pkgs/by-name/qu/quartz-wm/package.nix
@@ -41,6 +41,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
+    homepage = "https://gitlab.freedesktop.org/xorg/app/quartz-wm";
     license = lib.licenses.apple-psl20;
     platforms = lib.platforms.darwin;
     maintainers = [ lib.maintainers.booxter ];

--- a/pkgs/by-name/qu/quirc/package.nix
+++ b/pkgs/by-name/qu/quirc/package.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Small QR code decoding library";
+    homepage = "https://github.com/dlbeer/quirc";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/re/reattach-to-user-namespace/package.nix
+++ b/pkgs/by-name/re/reattach-to-user-namespace/package.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Wrapper that provides access to the Mac OS X pasteboard service";
+    homepage = "https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ lnl7 ];
     platforms = lib.platforms.darwin;

--- a/pkgs/by-name/re/reattach-to-user-namespace/package.nix
+++ b/pkgs/by-name/re/reattach-to-user-namespace/package.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Wrapper that provides access to the Mac OS X pasteboard service";
+    homepage = "https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard";
     license = lib.licenses.bsd2;
     maintainers = [ ];
     platforms = lib.platforms.darwin;

--- a/pkgs/by-name/rt/rt/package.nix
+++ b/pkgs/by-name/rt/rt/package.nix
@@ -177,5 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     platforms = lib.platforms.unix;
+    homepage = "https://github.com/bestpractical/rt";
   };
 })

--- a/pkgs/by-name/rt/rt/package.nix
+++ b/pkgs/by-name/rt/rt/package.nix
@@ -183,6 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    homepage = "https://github.com/bestpractical/rt";
     platforms = lib.platforms.unix;
     license = lib.licenses.gpl2Only;
   };

--- a/pkgs/by-name/rt/rt5677-firmware/package.nix
+++ b/pkgs/by-name/rt/rt5677-firmware/package.nix
@@ -22,6 +22,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Firmware for Realtek rt5677 device";
+    homepage = "https://github.com/raphael/linux-samus";
     license = lib.licenses.unfreeRedistributableFirmware;
     maintainers = with lib.maintainers; [ zohl ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/rt/rtl8761b-firmware/package.nix
+++ b/pkgs/by-name/rt/rtl8761b-firmware/package.nix
@@ -27,6 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Firmware for Realtek RTL8761b";
+    homepage = "https://github.com/Realtek-OpenSource/android_hardware_realtek";
     license = lib.licenses.unfreeRedistributableFirmware;
     maintainers = with lib.maintainers; [ milibopp ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ru/runzip/package.nix
+++ b/pkgs/by-name/ru/runzip/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Tool to convert filename encoding inside a ZIP archive";
+    homepage = "https://github.com/vlm/zip-fix-filename-encoding";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ru/runzip/package.nix
+++ b/pkgs/by-name/ru/runzip/package.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Tool to convert filename encoding inside a ZIP archive";
+    homepage = "https://github.com/vlm/zip-fix-filename-encoding";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.raskin ];
     # runzip vendors libzip 0.7.1.

--- a/pkgs/by-name/rw/rwc/package.nix
+++ b/pkgs/by-name/rw/rwc/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Report when files are changed";
+    homepage = "https://github.com/leahneukirchen/rwc";
     license = lib.licenses.publicDomain;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ somasis ];

--- a/pkgs/by-name/se/seehecht/package.nix
+++ b/pkgs/by-name/se/seehecht/package.nix
@@ -23,6 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Tool to quickly open a markdown document with already filled out frontmatter";
+    homepage = "https://codeberg.org/annaaurora/seehecht";
     license = lib.licenses.lgpl3Only;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ annaaurora ];

--- a/pkgs/by-name/se/sexp-cpp/package.nix
+++ b/pkgs/by-name/se/sexp-cpp/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "S-Expression parser for C++";
+    homepage = "https://github.com/lispparser/sexp-cpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3;

--- a/pkgs/by-name/sh/sha1collisiondetection/package.nix
+++ b/pkgs/by-name/sh/sha1collisiondetection/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
       each file. It is very fast and takes less than twice the amount
       of time as regular SHA-1.
     '';
+    homepage = "https://github.com/cr-marcstevens/sha1collisiondetection";
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
     mainProgram = "sha1dcsum";

--- a/pkgs/by-name/si/sigtop/package.nix
+++ b/pkgs/by-name/si/sigtop/package.nix
@@ -28,6 +28,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Utility to export messages, attachments and other data from Signal Desktop";
+    homepage = "https://github.com/tbvdm/sigtop";
     mainProgram = "sigtop";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/sl/slack-cli/package.nix
+++ b/pkgs/by-name/sl/slack-cli/package.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    homepage = "https://github.com/rockymadden/slack-cli";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "slack";

--- a/pkgs/by-name/sn/snooze/package.nix
+++ b/pkgs/by-name/sn/snooze/package.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Tool for waiting until a particular time and then running a command";
+    homepage = "https://github.com/leahneukirchen/snooze";
     maintainers = with lib.maintainers; [ kaction ];
     license = lib.licenses.cc0;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/st/stlink/package.nix
+++ b/pkgs/by-name/st/stlink/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "In-circuit debug and programming for ST-Link devices";
+    homepage = "https://github.com/stlink-org/stlink";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     badPlatforms = lib.platforms.darwin;

--- a/pkgs/by-name/st/stress/package.nix
+++ b/pkgs/by-name/st/stress/package.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple workload generator for POSIX systems. It imposes a configurable amount of CPU, memory, I/O, and disk stress on the system";
+    homepage = "https://github.com/resurrecting-open-source-projects/stress";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     mainProgram = "stress";

--- a/pkgs/by-name/st/strutcpp/package.nix
+++ b/pkgs/by-name/st/strutcpp/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Collection of string utilities";
+    homepage = "https://github.com/Grumbel/strutcpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.free;

--- a/pkgs/by-name/st/stw/package.nix
+++ b/pkgs/by-name/st/stw/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Simple text widget for X resembling the watch(1) command";
+    homepage = "https://github.com/sineemore/stw";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ somasis ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sw/sway-assign-cgroups/package.nix
+++ b/pkgs/by-name/sw/sway-assign-cgroups/package.nix
@@ -44,6 +44,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       Therefore it's recommended to supplement the script with use of systemd user
       services for such background apps.
     '';
+    homepage = "https://github.com/alebastr/sway-systemd";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ nickhu ];

--- a/pkgs/by-name/sy/sympow/package.nix
+++ b/pkgs/by-name/sy/sympow/package.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Compute special values of symmetric power elliptic curve L-functions";
+    homepage = "https://gitlab.com/rezozer/forks/sympow";
     mainProgram = "sympow";
     license = {
       shortName = "sympow";

--- a/pkgs/by-name/sy/syntex/package.nix
+++ b/pkgs/by-name/sy/syntex/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
   buildInputs = [ mono ];
   meta = {
     description = "Texture synthesis from examples";
+    homepage = "https://github.com/mxgmn/SynTex";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ta/tar2ext4/package.nix
+++ b/pkgs/by-name/ta/tar2ext4/package.nix
@@ -20,6 +20,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Convert a tar archive to an ext4 image";
+    homepage = "https://github.com/microsoft/hcsshim";
     maintainers = with lib.maintainers; [ qyliss ];
     license = lib.licenses.mit;
     mainProgram = "tar2ext4";

--- a/pkgs/by-name/te/termbench-pro/package.nix
+++ b/pkgs/by-name/te/termbench-pro/package.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Terminal Benchmarking as CLI and library";
+    homepage = "https://github.com/contour-terminal/termbench-pro";
     mainProgram = "tb";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/te/termtekst/package.nix
+++ b/pkgs/by-name/te/termtekst/package.nix
@@ -39,6 +39,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       as a workaround the braille set is abused to approximate the
       graphics.
     '';
+    homepage = "https://github.com/zevv/termtekst";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/te/tesh/package.nix
+++ b/pkgs/by-name/te/tesh/package.nix
@@ -23,4 +23,8 @@ python3Packages.buildPythonPackage rec {
     pexpect
     distutils
   ];
+
+  meta = {
+    homepage = "https://github.com/OceanSprint/tesh";
+  };
 }

--- a/pkgs/by-name/te/tesh/package.nix
+++ b/pkgs/by-name/te/tesh/package.nix
@@ -29,6 +29,7 @@ python3Packages.buildPythonPackage rec {
   ];
 
   meta = {
+    homepage = "https://github.com/OceanSprint/tesh";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/by-name/ti/tinycmmc/package.nix
+++ b/pkgs/by-name/ti/tinycmmc/package.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Tiny CMake Module Collections";
+    homepage = "https://github.com/Grumbel/tinycmmc";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.zlib;

--- a/pkgs/by-name/ti/tinygettext/package.nix
+++ b/pkgs/by-name/ti/tinygettext/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "A simple gettext replacement that works directly on .po files";
+    homepage = "https://github.com/tinygettext/tinygettext";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.zlib;

--- a/pkgs/by-name/tp/tpacpi-bat/package.nix
+++ b/pkgs/by-name/tp/tpacpi-bat/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.orbekk ];
     platforms = lib.platforms.linux;
     description = "Tool to set battery charging thresholds on Lenovo Thinkpad";
+    homepage = "https://github.com/teleshoes/tpacpi-bat";
     mainProgram = "tpacpi-bat";
     license = lib.licenses.gpl3Plus;
   };

--- a/pkgs/by-name/ui/uitest/package.nix
+++ b/pkgs/by-name/ui/uitest/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Simple testing framework for interactive tests";
+    homepage = "https://github.com/Grumbel/uitest";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3;

--- a/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
+++ b/pkgs/by-name/un/unnamed-sdvx-clone/package.nix
@@ -103,6 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Game based on K-Shoot MANIA and Sound Voltex";
+    homepage = "https://github.com/Drewol/unnamed-sdvx-clone";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sako ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/wa/wavefunctioncollapse/package.nix
+++ b/pkgs/by-name/wa/wavefunctioncollapse/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
   buildInputs = [ mono ];
   meta = {
     description = "Generator of bitmaps that are locally similar to the input bitmap";
+    homepage = "https://github.com/mxgmn/WaveFunctionCollapse";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/we/webcord-vencord/package.nix
+++ b/pkgs/by-name/we/webcord-vencord/package.nix
@@ -21,6 +21,7 @@
     inherit (old.meta) license mainProgram platforms;
 
     description = "Webcord with Vencord web extension";
+    homepage = "https://github.com/SpacingBat3/WebCord";
     maintainers = with lib.maintainers; [
       FlafyDev
       NotAShelf

--- a/pkgs/by-name/wi/wireworld/package.nix
+++ b/pkgs/by-name/wi/wireworld/package.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Fascinating electronics logic puzzles, game where you'll learn how to build clocks, diodes, and logic gates";
+    homepage = "https://gitlab.com/blinry/wireworld";
     mainProgram = "Wireworld";
     license = with lib.licenses; [
       mit

--- a/pkgs/by-name/wm/wmfs/package.nix
+++ b/pkgs/by-name/wm/wmfs/package.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Window manager from scratch";
+    homepage = "https://github.com/xorg62/wmfs";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.balsoft ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ws/wstsound/package.nix
+++ b/pkgs/by-name/ws/wstsound/package.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Windstille Sound Library";
+    homepage = "https://github.com/WindstilleTeam/wstsound";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.free;

--- a/pkgs/by-name/xb/xbanish/package.nix
+++ b/pkgs/by-name/xb/xbanish/package.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       The name comes from ratpoison's "banish" command that sends the cursor to the
       corner of the screen.
     '';
+    homepage = "https://github.com/jcs/xbanish";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.choochootrain ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xd/xdg-desktop-portal-gtk/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-gtk/package.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Desktop integration portals for sandboxed apps";
+    homepage = "https://github.com/flatpak/xdg-desktop-portal-gtk";
     maintainers = with lib.maintainers; [ jtojnar ];
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21Plus;

--- a/pkgs/by-name/xd/xdgcpp/package.nix
+++ b/pkgs/by-name/xd/xdgcpp/package.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Implementation of the XDG Base Directory Specification in C++";
+    homepage = "https://github.com/Grumbel/xdgcpp";
     maintainers = [ lib.maintainers.SchweGELBin ];
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl3;

--- a/pkgs/by-name/xi/xib2nib/package.nix
+++ b/pkgs/by-name/xi/xib2nib/package.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
   meta = {
     maintainers = [ ];
     description = "Compiles CocoaTouch .xib files into .nib";
+    homepage = "https://github.com/matthewbauer/xib2nib";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/xs/xsensors/package.nix
+++ b/pkgs/by-name/xs/xsensors/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
+    homepage = "https://github.com/Mystro256/xsensors";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/by-name/xs/xss-lock/package.nix
+++ b/pkgs/by-name/xs/xss-lock/package.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Use external locker (such as i3lock) as X screen saver";
+    homepage = "https://github.com/xdbob/xss-lock";
     license = lib.licenses.mit;
     mainProgram = "xss-lock";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/xs/xssstate/package.nix
+++ b/pkgs/by-name/xs/xssstate/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
+    homepage = "https://git.suckless.org/xssstate/file/README.html";
     description = "Simple tool to retrieve the X screensaver state";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onemoresuza ];

--- a/pkgs/by-name/xt/xtreemfs/package.nix
+++ b/pkgs/by-name/xt/xtreemfs/package.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Distributed filesystem";
+    homepage = "https://github.com/xtreemfs/xtreemfs";
     maintainers = with lib.maintainers; [
       raskin
       matejc

--- a/pkgs/by-name/xv/xva-img/package.nix
+++ b/pkgs/by-name/xv/xva-img/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     maintainers = [ ];
     description = "Tool for converting Xen images to raw and back";
+    homepage = "https://github.com/eriklax/xva-img";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     mainProgram = "xva-img";

--- a/pkgs/by-name/xw/xwinmosaic/package.nix
+++ b/pkgs/by-name/xw/xwinmosaic/package.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "X window switcher drawing a colourful grid";
+    homepage = "https://github.com/soulthreads/xwinmosaic";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/zs/zs-apc-spdu-ctl/package.nix
+++ b/pkgs/by-name/zs/zs-apc-spdu-ctl/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "APC SPDU control utility";
+    homepage = "https://github.com/fogti/zs-apc-spdu-ctl";
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -245,6 +245,7 @@ stdenv.mkDerivation (
 
     meta = llvm_meta // {
       description = "man page for Clang ${version}";
+      homepage = "https://github.com/llvm/llvm-project";
     };
   }
 )

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -213,6 +213,7 @@ stdenv.mkDerivation (
 
     meta = llvm_meta // {
       description = "man pages for LLDB ${version}";
+      homepage = "https://github.com/llvm/llvm-project";
     };
   }
 )

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -626,6 +626,7 @@ stdenv.mkDerivation (
 
     meta = llvm_meta // {
       description = "man pages for LLVM ${version}";
+      homepage = "https://github.com/llvm/llvm-project";
     };
   }
 )

--- a/pkgs/development/compilers/yosys/plugins/bluespec.nix
+++ b/pkgs/development/compilers/yosys/plugins/bluespec.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Bluespec plugin for Yosys";
+    homepage = "https://github.com/thoughtpolice/yosys-bluespec";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/development/libraries/kdb/default.nix
+++ b/pkgs/development/libraries/kdb/default.nix
@@ -41,6 +41,7 @@ mkDerivation {
 
   meta = {
     description = "Database connectivity and creation framework for various database vendors";
+    homepage = "https://invent.kde.org/libraries/kdb";
     mainProgram = "kdb3_sqlite3_dump";
     license = lib.licenses.lgpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/development/libraries/kdiagram/default.nix
+++ b/pkgs/development/libraries/kdiagram/default.nix
@@ -31,6 +31,7 @@ mkDerivation rec {
   ];
   meta = {
     description = "Libraries for creating business diagrams";
+    homepage = "https://invent.kde.org/graphics/kdiagram";
     license = lib.licenses.gpl2;
     platforms = qtbase.meta.platforms;
     maintainers = [ lib.maintainers.ttuegel ];

--- a/pkgs/development/libraries/qoauth/default.nix
+++ b/pkgs/development/libraries/qoauth/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Qt library for OAuth authentication";
+    homepage = "https://github.com/ayoy/qoauth";
     inherit (qtbase.meta) platforms;
     license = lib.licenses.lgpl21;
   };

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -221,6 +221,9 @@ let
           "slynk/indentation"
           "slynk/retro"
         ];
+        meta = {
+          homepage = "https://github.com/joaotavora/sly";
+        };
       };
 
       cephes = build-with-compile-into-pwd {
@@ -331,6 +334,9 @@ let
         nativeLibs = [
           pkgs.gtk4
         ];
+        meta = {
+          homepage = "https://github.com/bohonghuang/cl-gtk4";
+        };
       };
 
       cl-gtk4_dot_adw = build-asdf-system {
@@ -347,6 +353,9 @@ let
         nativeLibs = [
           pkgs.libadwaita
         ];
+        meta = {
+          homepage = "https://github.com/bohonghuang/cl-gtk4";
+        };
       };
 
       cl-gtk4_dot_webkit = build-asdf-system {
@@ -363,6 +372,9 @@ let
         nativeLibs = [
           pkgs.webkitgtk_6_0
         ];
+        meta = {
+          homepage = "https://github.com/bohonghuang/cl-gtk4";
+        };
       };
 
       cl-avro = build-asdf-system {
@@ -389,6 +401,9 @@ let
           time-interval
           trivial-extensible-sequences
         ];
+        meta = {
+          homepage = "https://github.com/SahilKang/cl-avro";
+        };
       };
 
       frugal-uuid = super.frugal-uuid.overrideLispAttrs (o: {
@@ -434,6 +449,9 @@ let
           mcclim
           mcclim-layouts
         ];
+        meta = {
+          homepage = "https://github.com/kaveh808/kons-9";
+        };
       };
 
       kons-9 = build-asdf-system {
@@ -466,6 +484,9 @@ let
           shasht
           org_dot_melusina_dot_confidence
         ];
+        meta = {
+          homepage = "https://github.com/kaveh808/kons-9";
+        };
       };
 
       nsb-cga = super.nsb-cga.overrideLispAttrs (old: {
@@ -529,7 +550,10 @@ let
           runHook postInstall
         '';
 
-        meta.mainProgram = "qlot";
+        meta = {
+          mainProgram = "qlot";
+          homepage = "https://github.com/fukamachi/qlot";
+        };
       };
 
       fset = super.fset.overrideLispAttrs (old: {

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -221,6 +221,9 @@ let
           "slynk/indentation"
           "slynk/retro"
         ];
+        meta = {
+          homepage = "https://github.com/joaotavora/sly";
+        };
       };
 
       cephes = build-with-compile-into-pwd {
@@ -331,6 +334,9 @@ let
         nativeLibs = [
           pkgs.gtk4
         ];
+        meta = {
+          homepage = "https://github.com/bohonghuang/cl-gtk4";
+        };
       };
 
       cl-gtk4_dot_adw = build-asdf-system {
@@ -347,6 +353,9 @@ let
         nativeLibs = [
           pkgs.libadwaita
         ];
+        meta = {
+          homepage = "https://github.com/bohonghuang/cl-gtk4";
+        };
       };
 
       cl-gtk4_dot_webkit = build-asdf-system {
@@ -363,6 +372,9 @@ let
         nativeLibs = [
           pkgs.webkitgtk_6_0
         ];
+        meta = {
+          homepage = "https://github.com/bohonghuang/cl-gtk4";
+        };
       };
 
       cl-avro = build-asdf-system {
@@ -389,6 +401,9 @@ let
           time-interval
           trivial-extensible-sequences
         ];
+        meta = {
+          homepage = "https://github.com/SahilKang/cl-avro";
+        };
       };
 
       frugal-uuid = super.frugal-uuid.overrideLispAttrs (o: {
@@ -433,6 +448,9 @@ let
           mcclim
           mcclim-layouts
         ];
+        meta = {
+          homepage = "https://github.com/kaveh808/kons-9";
+        };
       };
 
       kons-9 = build-asdf-system {
@@ -465,6 +483,9 @@ let
           shasht
           org_dot_melusina_dot_confidence
         ];
+        meta = {
+          homepage = "https://github.com/kaveh808/kons-9";
+        };
       };
 
       nsb-cga = super.nsb-cga.overrideLispAttrs (old: {
@@ -528,7 +549,10 @@ let
           runHook postInstall
         '';
 
-        meta.mainProgram = "qlot";
+        meta = {
+          mainProgram = "qlot";
+          homepage = "https://github.com/fukamachi/qlot";
+        };
       };
 
       fset = super.fset.overrideLispAttrs (old: {

--- a/pkgs/development/misc/or1k/newlib.nix
+++ b/pkgs/development/misc/or1k/newlib.nix
@@ -43,4 +43,8 @@ stdenvNoLibc.mkDerivation {
     incdir = "/${stdenv.targetPlatform.config}/include";
     libdir = "/${stdenv.targetPlatform.config}/lib";
   };
+
+  meta = {
+    homepage = "https://github.com/openrisc/newlib";
+  };
 }

--- a/pkgs/development/misc/vc4/newlib.nix
+++ b/pkgs/development/misc/vc4/newlib.nix
@@ -39,4 +39,8 @@ stdenvNoLibc.mkDerivation {
     incdir = "/${stdenv.targetPlatform.config}/include";
     libdir = "/${stdenv.targetPlatform.config}/lib";
   };
+
+  meta = {
+    homepage = "https://github.com/itszor/newlib-vc4";
+  };
 }

--- a/pkgs/development/mobile/webos/cmake-modules.nix
+++ b/pkgs/development/mobile/webos/cmake-modules.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "CMake modules needed to build Open WebOS components";
+    homepage = "https://github.com/openwebos/cmake-modules-webos";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/mobile/webos/novacom.nix
+++ b/pkgs/development/mobile/webos/novacom.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Utility for communicating with WebOS devices";
+    homepage = "https://github.com/openwebos/novacom";
     license = lib.licenses.asl20;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/mobile/webos/novacomd.nix
+++ b/pkgs/development/mobile/webos/novacomd.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Daemon for communicating with WebOS devices";
+    homepage = "https://github.com/openwebos/novacomd";
     mainProgram = "novacomd";
     license = lib.licenses.asl20;
     maintainers = [ ];

--- a/pkgs/development/mobile/webos/novacomd.nix
+++ b/pkgs/development/mobile/webos/novacomd.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Daemon for communicating with WebOS devices";
+    homepage = "https://github.com/openwebos/novacomd";
     mainProgram = "novacomd";
     license = lib.licenses.asl20;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/aches/default.nix
+++ b/pkgs/development/ocaml-modules/aches/default.nix
@@ -14,6 +14,7 @@ buildDunePackage {
 
   meta = {
     description = "Caches (bounded-size stores) for in-memory values and for resources";
+    homepage = "https://gitlab.com/nomadic-labs/ringo";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/aches/lwt.nix
+++ b/pkgs/development/ocaml-modules/aches/lwt.nix
@@ -17,6 +17,7 @@ buildDunePackage {
 
   meta = {
     description = "Caches (bounded-size stores) for Lwt promises";
+    homepage = "https://gitlab.com/nomadic-labs/ringo";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/bz2/default.nix
+++ b/pkgs/development/ocaml-modules/bz2/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "OCaml bindings for the libbz2 (AKA, bzip2) (de)compression library";
+    homepage = "https://gitlab.com/irill/camlbz2";
     downloadPage = "https://gitlab.com/irill/camlbz2";
     license = lib.licenses.lgpl21;
     broken = lib.versionOlder ocaml.version "4.02" || lib.versionAtLeast ocaml.version "5.0";

--- a/pkgs/development/ocaml-modules/camlp-streams/default.nix
+++ b/pkgs/development/ocaml-modules/camlp-streams/default.nix
@@ -17,6 +17,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "Stream and Genlex libraries for use with Camlp4 and Camlp5";
+    homepage = "https://github.com/ocaml/camlp-streams";
     license = lib.licenses.lgpl21Only;
     maintainers = [ lib.maintainers.vbgl ];
   };

--- a/pkgs/development/ocaml-modules/clap/default.nix
+++ b/pkgs/development/ocaml-modules/clap/default.nix
@@ -19,6 +19,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "Command-Line Argument Parsing, imperative style with a consumption mechanism";
+    homepage = "https://github.com/rbardou/clap";
     license = lib.licenses.mit;
   };
 })

--- a/pkgs/development/ocaml-modules/fontconfig/default.nix
+++ b/pkgs/development/ocaml-modules/fontconfig/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Fontconfig bindings for OCaml";
+    homepage = "https://github.com/flh/ocaml-fontconfig";
     license = lib.licenses.gpl2Plus;
     platforms = ocaml.meta.platforms;
     maintainers = with lib.maintainers; [ vbgl ];

--- a/pkgs/development/ocaml-modules/hashcons/default.nix
+++ b/pkgs/development/ocaml-modules/hashcons/default.nix
@@ -19,6 +19,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "OCaml hash-consing library";
+    homepage = "https://github.com/backtracking/ocaml-hashcons";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/lwt-exit/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-exit/default.nix
@@ -26,6 +26,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "Opinionated clean-exit and signal-handling library for Lwt programs";
+    homepage = "https://gitlab.com/nomadic-labs/lwt-exit";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/lwt-watcher/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-watcher/default.nix
@@ -23,6 +23,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "One-to-many broadcast in Lwt";
+    homepage = "https://gitlab.com/nomadic-labs/lwt-watcher";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/reason-native/dir.nix
+++ b/pkgs/development/ocaml-modules/reason-native/dir.nix
@@ -22,6 +22,7 @@ buildDunePackage {
 
   meta = {
     description = "Library that provides a consistent API for common system, user and application directories consistently on all platforms";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/dir";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/fp.nix
+++ b/pkgs/development/ocaml-modules/reason-native/fp.nix
@@ -17,6 +17,7 @@ buildDunePackage {
 
   meta = {
     description = "Library for creating and operating on file paths consistently on multiple platforms";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/fp";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/frame.nix
+++ b/pkgs/development/ocaml-modules/reason-native/frame.nix
@@ -24,6 +24,7 @@ buildDunePackage {
 
   meta = {
     description = "Reason Native text layout library";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/frame";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/fs.nix
+++ b/pkgs/development/ocaml-modules/reason-native/fs.nix
@@ -22,6 +22,7 @@ buildDunePackage {
 
   meta = {
     description = "Reason Native file system API";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/fs";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
+++ b/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
@@ -26,6 +26,7 @@ buildDunePackage {
 
   meta = {
     description = "Library containing custom Rely matchers allowing for easily using QCheck with Rely. QCheck is a 'QuickCheck inspired property-based testing for OCaml, and combinators to generate random values to run tests on'";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/qcheck-rely";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/unicode-config.nix
+++ b/pkgs/development/ocaml-modules/reason-native/unicode-config.nix
@@ -17,6 +17,7 @@ buildDunePackage {
 
   meta = {
     description = "Configuration used to generate the @reason-native/unicode library";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/unicode-config";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/unicode.nix
+++ b/pkgs/development/ocaml-modules/reason-native/unicode.nix
@@ -17,6 +17,7 @@ buildDunePackage {
 
   meta = {
     description = "Easy to use and well documented Unicode symbols";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/unicode";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/reason-native/utf8.nix
+++ b/pkgs/development/ocaml-modules/reason-native/utf8.nix
@@ -17,6 +17,7 @@ buildDunePackage {
 
   meta = {
     description = "Utf8 logic with minimal dependencies";
+    homepage = "https://github.com/reasonml/reason-native";
     downloadPage = "https://github.com/reasonml/reason-native/tree/master/src/utf8";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/development/ocaml-modules/ringo/default.nix
+++ b/pkgs/development/ocaml-modules/ringo/default.nix
@@ -20,6 +20,7 @@ buildDunePackage rec {
 
   meta = {
     description = "Caches (bounded-size key-value stores) and other bounded-size stores";
+    homepage = "https://gitlab.com/nomadic-labs/ringo";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/ringo/default.nix
+++ b/pkgs/development/ocaml-modules/ringo/default.nix
@@ -20,6 +20,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "Caches (bounded-size key-value stores) and other bounded-size stores";
+    homepage = "https://gitlab.com/nomadic-labs/ringo";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
@@ -42,6 +42,7 @@ buildDunePackage rec {
 
   meta = {
     description = "Bindings to secp256k1 internal functions (generic operations on the curve)";
+    homepage = "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
+++ b/pkgs/development/ocaml-modules/secp256k1-internal/default.nix
@@ -42,6 +42,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "Bindings to secp256k1 internal functions (generic operations on the curve)";
+    homepage = "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };

--- a/pkgs/development/ocaml-modules/systemd/default.nix
+++ b/pkgs/development/ocaml-modules/systemd/default.nix
@@ -18,6 +18,7 @@ buildDunePackage {
   meta = {
     platforms = lib.platforms.linux;
     description = "OCaml module for native access to the systemd facilities";
+    homepage = "https://github.com/juergenhoetzel/ocaml-systemd";
     license = lib.licenses.lgpl3Only;
     maintainers = [ lib.maintainers.atagen ];
   };

--- a/pkgs/development/ocaml-modules/tezt/default.nix
+++ b/pkgs/development/ocaml-modules/tezt/default.nix
@@ -30,6 +30,7 @@ buildDunePackage rec {
 
   meta = {
     description = "Test framework for unit tests, integration tests, and regression tests";
+    homepage = "https://gitlab.com/nomadic-labs/tezt";
     license = lib.licenses.mit;
     broken = lib.versionAtLeast lwt.version "6.0.0";
   };

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -21,6 +21,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python library for translating ASN.1 into other forms";
+    homepage = "https://github.com/kimgr/asn1ate";
     mainProgram = "asn1ate";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;

--- a/pkgs/development/python-modules/cx-logging/default.nix
+++ b/pkgs/development/python-modules/cx-logging/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Python and C interfaces for logging";
+    homepage = "https://github.com/anthony-tuininga/cx_Logging";
     changelog = "https://github.com/anthony-tuininga/cx_Logging/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/development/python-modules/cx-logging/default.nix
+++ b/pkgs/development/python-modules/cx-logging/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Python and C interfaces for logging";
+    homepage = "https://github.com/anthony-tuininga/cx_Logging";
     changelog = "https://github.com/anthony-tuininga/cx_Logging/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/development/python-modules/django-auditlog/default.nix
+++ b/pkgs/development/python-modules/django-auditlog/default.nix
@@ -66,6 +66,7 @@ buildPythonPackage rec {
   meta = {
     changelog = "https://github.com/jazzband/django-auditlog/blob/${src.tag}/CHANGELOG.md";
     description = "Django app that keeps a log of changes made to an object";
+    homepage = "https://github.com/jazzband/django-auditlog";
     downloadPage = "https://github.com/jazzband/django-auditlog";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ leona ];

--- a/pkgs/development/python-modules/enocean-async/default.nix
+++ b/pkgs/development/python-modules/enocean-async/default.nix
@@ -45,6 +45,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     changelog = "https://github.com/henningkerstan/enocean-async/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Async implementation of the EnOcean Serial Protocol Version 3";
+    homepage = "https://github.com/henningkerstan/enocean-async";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.dotlambda ];
   };

--- a/pkgs/development/python-modules/freeze-core/default.nix
+++ b/pkgs/development/python-modules/freeze-core/default.nix
@@ -55,6 +55,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Core dependency for cx_Freeze";
+    homepage = "https://github.com/marcelotduarte/freeze-core";
     changelog = "https://github.com/marcelotduarte/freeze-core/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/development/python-modules/kmock/default.nix
+++ b/pkgs/development/python-modules/kmock/default.nix
@@ -71,6 +71,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "HTTP/API/Kubernetes Mock Server in Python";
+    homepage = "https://github.com/nolar/kmock";
     changelog = "https://github.com/nolar/kmock/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/development/python-modules/mdx-truly-sane-lists/default.nix
+++ b/pkgs/development/python-modules/mdx-truly-sane-lists/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
       Features custom indents for nested lists and fix for messy linebreaks and
       paragraphs between lists.
     '';
+    homepage = "https://github.com/radude/mdx_truly_sane_lists";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kaction ];
   };

--- a/pkgs/development/python-modules/outspin/default.nix
+++ b/pkgs/development/python-modules/outspin/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     changelog = "https://github.com/trag1c/outspin/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Conveniently read single char inputs in the console";
+    homepage = "https://github.com/trag1c/outspin";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];
   };

--- a/pkgs/development/python-modules/paperbush/default.nix
+++ b/pkgs/development/python-modules/paperbush/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     changelog = "https://github.com/trag1c/paperbush/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Super concise argument parsing tool for Python";
+    homepage = "https://github.com/trag1c/paperbush";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];
   };

--- a/pkgs/development/python-modules/paypal-checkout-serversdk/default.nix
+++ b/pkgs/development/python-modules/paypal-checkout-serversdk/default.nix
@@ -45,6 +45,7 @@ buildPythonPackage rec {
   meta = {
     changelog = "https://github.com/paypal/Checkout-Python-SDK/releases/tag/${version}";
     description = "Python SDK for Checkout RESTful APIs";
+    homepage = "https://github.com/paypal/Checkout-Python-SDK";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ hexa ];
   };

--- a/pkgs/development/python-modules/protoletariat/default.nix
+++ b/pkgs/development/python-modules/protoletariat/default.nix
@@ -52,6 +52,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Python protocol buffers for the rest of us";
+    homepage = "https://github.com/cpcloud/protoletariat";
     changelog = "https://github.com/cpcloud/protoletariat/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/development/python-modules/pyftgl/default.nix
+++ b/pkgs/development/python-modules/pyftgl/default.nix
@@ -47,6 +47,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python bindings for FTGL (FreeType for OpenGL)";
+    homepage = "https://github.com/umlaeute/pyftgl";
     license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/python-modules/tstr/default.nix
+++ b/pkgs/development/python-modules/tstr/default.nix
@@ -30,6 +30,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Backports of various template string utilities";
+    homepage = "https://github.com/ilotoki0804/tstr";
     license = [ lib.licenses.asl20 ];
     maintainers = with lib.maintainers; [ sigmanificient ];
   };

--- a/pkgs/development/rocm-modules/mscclpp/default.nix
+++ b/pkgs/development/rocm-modules/mscclpp/default.nix
@@ -39,4 +39,7 @@ stdenv.mkDerivation {
     "-DFETCHCONTENT_SOURCE_DIR_JSON=${nlohmann_json.src}"
   ];
   env.ROCM_PATH = clr;
+  meta = {
+    homepage = "https://github.com/microsoft/mscclpp";
+  };
 }

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -132,6 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Package manager for Lua";
+    homepage = "https://github.com/luarocks/luarocks";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       raskin

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -41,6 +41,7 @@ luarocks_bootstrap.overrideAttrs (old: {
       maintainers
       platforms
       ;
+    homepage = "https://github.com/nix-community/luarocks-nix";
     mainProgram = "luarocks";
   };
 })

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -89,6 +89,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Tora SQL tool";
+    homepage = "https://github.com/tora-tool/tora";
     mainProgram = "tora";
     maintainers = with lib.maintainers; [ peterhoeg ];
     platforms = lib.platforms.linux;

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -84,6 +84,9 @@ in
       tag = "v${version}";
       hash = "sha256-kyUrJdraDDye8WEBP2RgHN7kHmafToYtLmrMJ9u0f+0=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-battery";
+    };
   };
 
   better-mouse-mode = mkTmuxPlugin {
@@ -196,6 +199,9 @@ in
       rev = "77ca3aab2aed8ede3e2b941079b1c92dd221cf5f";
       hash = "sha256-ugVk1zpKeUjOlDWi3LEkJPFsCqyZEivGzGWiqODnkK0=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-copycat";
+    };
   };
 
   cpu = mkTmuxPlugin {
@@ -207,6 +213,9 @@ in
       rev = "98d787191bc3e8f19c3de54b96ba1caf61385861";
       hash = "sha256-ymmCI6VYvf94Ot7h2GAboTRBXPIREP+EB33+px5aaJk=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-cpu";
+    };
   };
 
   ctrlw = mkTmuxPlugin rec {
@@ -217,6 +226,9 @@ in
       repo = "tmux-ctrlw";
       rev = "v${version}";
       hash = "sha256-YYbPkGQmukIDD1fcYleioETFai/SOJni+aZ9Jh2+Zc8=";
+    };
+    meta = {
+      homepage = "https://github.com/eraserhd/tmux-ctrlw";
     };
   };
 
@@ -315,6 +327,9 @@ in
     postInstall = ''
       sed -i -e 's|fpp |${pkgs.fpp}/bin/fpp |g' $target/fpp.tmux
     '';
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-fpp";
+    };
   };
 
   fuzzback = mkTmuxPlugin {
@@ -378,6 +393,9 @@ in
       repo = "tmux-gruvbox";
       tag = "v${version}";
       hash = "sha256-TuWPw6sk61k7GnHwN2zH6x6mGurTHiA9f0E6NJfMa6g=";
+    };
+    meta = {
+      homepage = "https://github.com/egel/tmux-gruvbox";
     };
   };
 
@@ -488,6 +506,9 @@ in
       rev = "b085ad423b5d59a2c8b8d71772352e7028b8e1d0";
       hash = "sha256-Wp4xY2nxv4jl/G7bjNokYk3TcbS9waLERBFSpT1XGlw=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-logging";
+    };
   };
 
   minimal-tmux-status = mkTmuxPlugin {
@@ -544,6 +565,9 @@ in
       rev = "58abb615971cb617821e2e7e41c660334f55a92d";
       hash = "sha256-LFPcPDBiSvsOhOhlAScajr/Y/Uw2CPdl87qzD9szQKo=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-net-speed";
+    };
   };
 
   nord = mkTmuxPlugin {
@@ -579,6 +603,9 @@ in
       rev = "9415f0207e71e37cbd870c9443426dbea6da78b9";
       hash = "sha256-RFdnF/ScOPoeVgGXWhQs28tS7CmsRA0DyFyutCPEmzc=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-maildir-counter";
+    };
   };
 
   online-status = mkTmuxPlugin {
@@ -590,6 +617,9 @@ in
       rev = "ea86704ced8a20f4a431116aa43f57edcf5a6312";
       hash = "sha256-OQW2WcNDVBMgX5IIlykn7f1wI8miXuqLQTlqsdHbw8M=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-online-status";
+    };
   };
 
   open = mkTmuxPlugin {
@@ -600,6 +630,9 @@ in
       repo = "tmux-open";
       rev = "cedb4584908bd8458fadc8d3e64101d3cbb48d46";
       hash = "sha256-sFl+wkvQ498irwKWXXAT6/XBrziYLT+CvLCBV2HrQIM=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-open";
     };
   };
 
@@ -613,6 +646,9 @@ in
       rev = "3607ef889a47dd3b4b31f66cda7f36da6f81b85c";
       hash = "sha256-pQooiDEeB8NvBOQ1IKUgPSSQDK+hMTLMGuiKy6GWVKY=";
     };
+    meta = {
+      homepage = "https://github.com/odedlaz/tmux-onedark-theme";
+    };
   };
 
   pain-control = mkTmuxPlugin {
@@ -623,6 +659,9 @@ in
       repo = "tmux-pain-control";
       rev = "2db63de3b08fc64831d833240749133cecb67d92";
       hash = "sha256-84NJtxoz4KTVv+i3cde235WcHhRSBIkZjtobZIk16nA=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-pain-control";
     };
   };
 
@@ -677,6 +716,9 @@ in
     postInstall = ''
       sed -i -e 's,9 plumb,${pkgs.plan9port}/bin/9 plumb,' $target/scripts/plumb
     '';
+    meta = {
+      homepage = "https://github.com/eraserhd/tmux-plumb";
+    };
   };
 
   power-theme = mkTmuxPlugin {
@@ -705,6 +747,9 @@ in
       repo = "tmux-prefix-highlight";
       rev = "15acc6172300bc2eb13c81718dc53da6ae69de4f";
       hash = "sha256-9LWRV0Hw8MmDwn5hWl3DrBuYUqBjLCO02K9bbx11MyM=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-prefix-highlight";
     };
   };
 
@@ -774,6 +819,9 @@ in
     postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
       sed -e 's:reattach-to-user-namespace:${pkgs.reattach-to-user-namespace}/bin/reattach-to-user-namespace:g' -i $target/sensible.tmux
     '';
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-sensible";
+    };
   };
 
   session-wizard = mkTmuxPlugin rec {
@@ -829,6 +877,9 @@ in
       rev = "09ec86be38eae98ffc27bd0dde605ed10ae0dc89";
       hash = "sha256-hFNrdbhmBUAyJ73RCG4RILzJ3LHIYiuNYGsqJGsVGAw=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-sessionist";
+    };
   };
 
   sidebar = mkTmuxPlugin {
@@ -840,6 +891,9 @@ in
       rev = "aacbdb45bc5ab69db448a72de4155d0b8dbac677";
       hash = "sha256-7MCouewjpTCMGmWMaTWWQevlR0LrLTBjXGumsNcH6a4=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-sidebar";
+    };
   };
 
   sysstat = mkTmuxPlugin {
@@ -850,6 +904,9 @@ in
       repo = "tmux-plugin-sysstat";
       rev = "29e150f403151f2341f3abcb2b2487a5f011dd23";
       hash = "sha256-2EMSV6z9FZHq20dkPna0qELSVIOIAnOHpiCLbG7adQQ=";
+    };
+    meta = {
+      homepage = "https://github.com/samoshkin/tmux-plugin-sysstat";
     };
   };
 
@@ -899,6 +956,9 @@ in
       repo = "tmux-colors-solarized";
       rev = "e5e7b4f1af37f8f3fc81ca17eadee5ae5d82cd09";
       hash = "sha256-nVA4fkmxf8he3lxG6P0sASvH6HlSt8dKGovEv5RAcdA=";
+    };
+    meta = {
+      homepage = "https://github.com/seebi/tmux-colors-solarized";
     };
   };
 
@@ -1084,6 +1144,9 @@ in
       find $target -type f -print0 | xargs -0 sed -i -e 's|fzf |${pkgs.fzf}/bin/fzf |g'
       find $target -type f -print0 | xargs -0 sed -i -e 's|zoxide |${pkgs.zoxide}/bin/zoxide |g'
     '';
+    meta = {
+      homepage = "https://github.com/joshmedeski/t-smart-tmux-session-manager";
+    };
   };
 
   urlview = mkTmuxPlugin {
@@ -1098,6 +1161,9 @@ in
     postInstall = ''
       sed -i -e '14,20{s|extract_url|${pkgs.extract_url}/bin/extract_url|g}' $target/urlview.tmux
     '';
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-urlview";
+    };
   };
 
   vim-tmux-focus-events = mkTmuxPlugin {
@@ -1128,6 +1194,9 @@ in
       repo = "vim-tmux-navigator";
       rev = "c45243dc1f32ac6bcf6068e5300f3b2b237e576a";
       hash = "sha256-IEPnr/GdsAnHzdTjFnXCuMyoNLm3/Jz4cBAM0AJBrj8=";
+    };
+    meta = {
+      homepage = "https://github.com/christoomey/vim-tmux-navigator";
     };
   };
 
@@ -1163,6 +1232,9 @@ in
       repo = "tmux-yank";
       rev = "acfd36e4fcba99f8310a7dfb432111c242fe7392";
       hash = "sha256-/5HPaoOx2U2d8lZZJo5dKmemu6hKgHJYq23hxkddXpA=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-yank";
     };
   };
 

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -85,6 +85,9 @@ in
       tag = "v${version}";
       hash = "sha256-kyUrJdraDDye8WEBP2RgHN7kHmafToYtLmrMJ9u0f+0=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-battery";
+    };
   };
 
   better-mouse-mode = mkTmuxPlugin {
@@ -197,6 +200,9 @@ in
       rev = "77ca3aab2aed8ede3e2b941079b1c92dd221cf5f";
       hash = "sha256-ugVk1zpKeUjOlDWi3LEkJPFsCqyZEivGzGWiqODnkK0=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-copycat";
+    };
   };
 
   cpu = mkTmuxPlugin {
@@ -208,6 +214,9 @@ in
       rev = "98d787191bc3e8f19c3de54b96ba1caf61385861";
       hash = "sha256-ymmCI6VYvf94Ot7h2GAboTRBXPIREP+EB33+px5aaJk=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-cpu";
+    };
   };
 
   ctrlw = mkTmuxPlugin rec {
@@ -218,6 +227,9 @@ in
       repo = "tmux-ctrlw";
       rev = "v${version}";
       hash = "sha256-YYbPkGQmukIDD1fcYleioETFai/SOJni+aZ9Jh2+Zc8=";
+    };
+    meta = {
+      homepage = "https://github.com/eraserhd/tmux-ctrlw";
     };
   };
 
@@ -316,6 +328,9 @@ in
     postInstall = ''
       sed -i -e 's|fpp |${pkgs.fpp}/bin/fpp |g' $target/fpp.tmux
     '';
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-fpp";
+    };
   };
 
   fuzzback = mkTmuxPlugin {
@@ -496,6 +511,9 @@ in
       rev = "b085ad423b5d59a2c8b8d71772352e7028b8e1d0";
       hash = "sha256-Wp4xY2nxv4jl/G7bjNokYk3TcbS9waLERBFSpT1XGlw=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-logging";
+    };
   };
 
   minimal-tmux-status = mkTmuxPlugin {
@@ -552,6 +570,9 @@ in
       rev = "58abb615971cb617821e2e7e41c660334f55a92d";
       hash = "sha256-LFPcPDBiSvsOhOhlAScajr/Y/Uw2CPdl87qzD9szQKo=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-net-speed";
+    };
   };
 
   nord = mkTmuxPlugin {
@@ -587,6 +608,9 @@ in
       rev = "9415f0207e71e37cbd870c9443426dbea6da78b9";
       hash = "sha256-RFdnF/ScOPoeVgGXWhQs28tS7CmsRA0DyFyutCPEmzc=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-maildir-counter";
+    };
   };
 
   online-status = mkTmuxPlugin {
@@ -598,6 +622,9 @@ in
       rev = "ea86704ced8a20f4a431116aa43f57edcf5a6312";
       hash = "sha256-OQW2WcNDVBMgX5IIlykn7f1wI8miXuqLQTlqsdHbw8M=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-online-status";
+    };
   };
 
   open = mkTmuxPlugin {
@@ -608,6 +635,9 @@ in
       repo = "tmux-open";
       rev = "cedb4584908bd8458fadc8d3e64101d3cbb48d46";
       hash = "sha256-sFl+wkvQ498irwKWXXAT6/XBrziYLT+CvLCBV2HrQIM=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-open";
     };
   };
 
@@ -621,6 +651,9 @@ in
       rev = "3607ef889a47dd3b4b31f66cda7f36da6f81b85c";
       hash = "sha256-pQooiDEeB8NvBOQ1IKUgPSSQDK+hMTLMGuiKy6GWVKY=";
     };
+    meta = {
+      homepage = "https://github.com/odedlaz/tmux-onedark-theme";
+    };
   };
 
   pain-control = mkTmuxPlugin {
@@ -631,6 +664,9 @@ in
       repo = "tmux-pain-control";
       rev = "2db63de3b08fc64831d833240749133cecb67d92";
       hash = "sha256-84NJtxoz4KTVv+i3cde235WcHhRSBIkZjtobZIk16nA=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-pain-control";
     };
   };
 
@@ -685,6 +721,9 @@ in
     postInstall = ''
       sed -i -e 's,9 plumb,${pkgs.plan9port}/bin/9 plumb,' $target/scripts/plumb
     '';
+    meta = {
+      homepage = "https://github.com/eraserhd/tmux-plumb";
+    };
   };
 
   power-theme = mkTmuxPlugin {
@@ -713,6 +752,9 @@ in
       repo = "tmux-prefix-highlight";
       rev = "15acc6172300bc2eb13c81718dc53da6ae69de4f";
       hash = "sha256-9LWRV0Hw8MmDwn5hWl3DrBuYUqBjLCO02K9bbx11MyM=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-prefix-highlight";
     };
   };
 
@@ -818,6 +860,9 @@ in
     postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
       sed -e 's:reattach-to-user-namespace:${pkgs.reattach-to-user-namespace}/bin/reattach-to-user-namespace:g' -i $target/sensible.tmux
     '';
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-sensible";
+    };
   };
 
   session-wizard = mkTmuxPlugin rec {
@@ -873,6 +918,9 @@ in
       rev = "09ec86be38eae98ffc27bd0dde605ed10ae0dc89";
       hash = "sha256-hFNrdbhmBUAyJ73RCG4RILzJ3LHIYiuNYGsqJGsVGAw=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-sessionist";
+    };
   };
 
   sidebar = mkTmuxPlugin {
@@ -884,6 +932,9 @@ in
       rev = "aacbdb45bc5ab69db448a72de4155d0b8dbac677";
       hash = "sha256-7MCouewjpTCMGmWMaTWWQevlR0LrLTBjXGumsNcH6a4=";
     };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-sidebar";
+    };
   };
 
   sysstat = mkTmuxPlugin {
@@ -894,6 +945,9 @@ in
       repo = "tmux-plugin-sysstat";
       rev = "29e150f403151f2341f3abcb2b2487a5f011dd23";
       hash = "sha256-2EMSV6z9FZHq20dkPna0qELSVIOIAnOHpiCLbG7adQQ=";
+    };
+    meta = {
+      homepage = "https://github.com/samoshkin/tmux-plugin-sysstat";
     };
   };
 
@@ -943,6 +997,9 @@ in
       repo = "tmux-colors-solarized";
       rev = "e5e7b4f1af37f8f3fc81ca17eadee5ae5d82cd09";
       hash = "sha256-nVA4fkmxf8he3lxG6P0sASvH6HlSt8dKGovEv5RAcdA=";
+    };
+    meta = {
+      homepage = "https://github.com/seebi/tmux-colors-solarized";
     };
   };
 
@@ -1171,6 +1228,9 @@ in
       find $target -type f -print0 | xargs -0 sed -i -e 's|fzf |${pkgs.fzf}/bin/fzf |g'
       find $target -type f -print0 | xargs -0 sed -i -e 's|zoxide |${pkgs.zoxide}/bin/zoxide |g'
     '';
+    meta = {
+      homepage = "https://github.com/joshmedeski/t-smart-tmux-session-manager";
+    };
   };
 
   urlview = mkTmuxPlugin {
@@ -1185,6 +1245,9 @@ in
     postInstall = ''
       sed -i -e '14,20{s|extract_url|${pkgs.extract_url}/bin/extract_url|g}' $target/urlview.tmux
     '';
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-urlview";
+    };
   };
 
   vim-tmux-focus-events = mkTmuxPlugin {
@@ -1215,6 +1278,9 @@ in
       repo = "vim-tmux-navigator";
       rev = "c45243dc1f32ac6bcf6068e5300f3b2b237e576a";
       hash = "sha256-IEPnr/GdsAnHzdTjFnXCuMyoNLm3/Jz4cBAM0AJBrj8=";
+    };
+    meta = {
+      homepage = "https://github.com/christoomey/vim-tmux-navigator";
     };
   };
 
@@ -1250,6 +1316,9 @@ in
       repo = "tmux-yank";
       rev = "acfd36e4fcba99f8310a7dfb432111c242fe7392";
       hash = "sha256-/5HPaoOx2U2d8lZZJo5dKmemu6hKgHJYq23hxkddXpA=";
+    };
+    meta = {
+      homepage = "https://github.com/tmux-plugins/tmux-yank";
     };
   };
 

--- a/pkgs/misc/tmux-plugins/tmux-fingers/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-fingers/default.nix
@@ -29,6 +29,10 @@ let
     # Unhandled exception: Missing ENV key: "TMUX" (KeyError)
     doCheck = false;
     doInstallCheck = false;
+
+    meta = {
+      homepage = "https://github.com/Morantron/tmux-fingers";
+    };
   };
 in
 mkTmuxPlugin {

--- a/pkgs/os-specific/darwin/by-name/lo/locale/package.nix
+++ b/pkgs/os-specific/darwin/by-name/lo/locale/package.nix
@@ -54,6 +54,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Locale data for Darwin";
+    homepage = "https://github.com/apple-oss-distributions/adv_cmds";
     license = [
       lib.licenses.apsl10
       lib.licenses.apsl20

--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation rec {
       If you want to use this driver, you might need to blacklist the r8169 driver
       by adding "r8169" to boot.blacklistedKernelModules.
     '';
+    homepage = "https://github.com/mtorromeo/r8168";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/os-specific/linux/sheep-net/default.nix
+++ b/pkgs/os-specific/linux/sheep-net/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    homepage = "https://github.com/kanjitalk755/macemu";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ matthewcroughan ];
     platforms = lib.platforms.linux;

--- a/pkgs/servers/monitoring/nagios-plugins/check_openvpn/default.nix
+++ b/pkgs/servers/monitoring/nagios-plugins/check_openvpn/default.nix
@@ -21,6 +21,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "Nagios/icinga/sensu check plugin for OpenVPN";
+    homepage = "https://github.com/liquidat/nagios-icinga-openvpn";
     license = lib.licenses.mit;
     mainProgram = "check_openvpn";
     maintainers = with lib.maintainers; [ peterhoeg ];

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -36,6 +36,7 @@ postgresqlBuildExtension {
       is tightly integrated in the RDBMS in the sense that it defines operators so instead of the traditional
       operators (= and <>) you can use ~~~ and ~!~ (any of these operators represents a similarity function).
     '';
+    homepage = "https://github.com/eulerto/pg_similarity";
     platforms = postgresql.meta.platforms;
     license = lib.licenses.bsd3;
     maintainers = [ ];

--- a/pkgs/servers/sql/postgresql/ext/pgjwt.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgjwt.nix
@@ -38,6 +38,7 @@ postgresqlBuildExtension (finalAttrs: {
     longDescription = ''
       sign() and verify() functions to create and verify JSON Web Tokens.
     '';
+    homepage = "https://github.com/michelp/pgjwt";
     license = lib.licenses.mit;
     platforms = postgresql.meta.platforms;
     maintainers = with lib.maintainers; [ spinus ];

--- a/pkgs/shells/fish/plugins/foreign-env/default.nix
+++ b/pkgs/shells/fish/plugins/foreign-env/default.nix
@@ -22,6 +22,7 @@ buildFishPlugin {
 
   meta = {
     description = "Foreign environment interface for Fish shell";
+    homepage = "https://github.com/oh-my-fish/plugin-foreign-env";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jgillich

--- a/pkgs/shells/fish/plugins/grc.nix
+++ b/pkgs/shells/fish/plugins/grc.nix
@@ -21,6 +21,7 @@ buildFishPlugin {
 
   meta = {
     description = "Grc Colourizer for some commands on Fish shell";
+    homepage = "https://github.com/oh-my-fish/plugin-grc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onny ];
     platforms = with lib.platforms; unix;

--- a/pkgs/tools/compression/bzip2/1_1.nix
+++ b/pkgs/tools/compression/bzip2/1_1.nix
@@ -46,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "High-quality data compression program";
+    homepage = "https://gitlab.com/federicomenaquintero/bzip2";
     license = lib.licenses.bzip2;
     pkgConfigModules = [ "bz2" ];
     platforms = lib.platforms.all;

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation rec {
   meta = {
     isIbusEngine = true;
     description = "IBus interface to the libpinyin input method";
+    homepage = "https://github.com/libpinyin/ibus-libpinyin";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       linsui

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-pinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-pinyin/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
   meta = {
     isIbusEngine = true;
     description = "PinYin engine for IBus";
+    homepage = "https://github.com/ibus/ibus-pinyin";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ azuwis ];
     platforms = lib.platforms.linux;

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -78,6 +78,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Convenience script to run a virtualized X-Server";
+    homepage = "https://github.com/archlinux/svntogit-packages";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.artturin ];

--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -78,6 +78,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Convenience script to run a virtualized X-Server";
+    homepage = "https://github.com/archlinux/svntogit-packages";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.artturin ];

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -155,6 +155,10 @@ rec {
       cp README.md $doc/share/${pname}
     '';
     checkPhase = "";
+
+    meta = {
+      homepage = "https://gitlab.com/odfplugfest/xmlmirror.git";
+    };
   };
 
   zlib =

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -155,6 +155,10 @@ rec {
       cp README.md $doc/share/${pname}
     '';
     checkPhase = "";
+
+    meta = {
+      homepage = "https://gitlab.com/odfplugfest/xmlmirror";
+    };
   };
 
   zlib =


### PR DESCRIPTION
Added homepage where missing, where the sources are pulled from:
- https://github.com
- https://git.sr.ht
- https://gitlab.com
- https://invent.kde.org
- https://codeberg.org
- https://gitlab.gnome.org
- https://gitlab.freedesktop.org
- https://git.freebsd.org
- https://salsa.debian.org
- https://git.tvdr.de
- https://git.suckless.org

Got inspired by #512551

```nix
{
  pkgs ? import ./.. { },
}:

let
  inherit (pkgs) lib;

  packagesWith =
    cond: return: prefix: set:
    (lib.flatten (
      lib.mapAttrsToList (
        name: pkg:
        let
          result = builtins.tryEval (
            if lib.isDerivation pkg && cond name pkg then
              [ (return pkg "${prefix}${name}") ]
            else if pkg.recurseForDerivations or false || pkg.recurseForRelease or false then
              packagesWith cond return "${name}." pkg
            else
              [ ]
          );
        in
        if result.success then result.value else [ ]
      ) set
    ));

  packages =
    packagesWith
      (
        name: pkg:
        (
          (builtins.hasAttr "meta" pkg)
          && !(builtins.hasAttr "homepage" pkg.meta)
          && (builtins.hasAttr "src" pkg)
          && !(builtins.isNull pkg.src)
          && !(builtins.isPath pkg.src)
          && !(builtins.isString pkg.src)
          && !(builtins.isList pkg.src)
          && (builtins.hasAttr "gitRepoUrl" pkg.src)
          # && (
          #   (lib.strings.hasPrefix "https://github.com" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://git.sr.ht" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://gitlab.com" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://invent.kde.org" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://codeberg.org" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://gitlab.gnome.org" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://gitlab.freedesktop.org" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://git.FreeBSD.org" pkg.src.gitRepoUrl)
          #   || (lib.strings.hasPrefix "https://salsa.debian.org" pkg.src.gitRepoUrl)
          # )
        )
      )
      (pkg: name: {
        inherit name;
        repoUrl = lib.strings.removeSuffix ".git" pkg.src.gitRepoUrl;
        position = lib.last (lib.splitString "nixpkgs/" pkg.meta.position);
      })
      ""
      pkgs;

in
packages
```

Added the `meta.homepage` attribute for the 378 out of 382 packages caught.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
