### PR TITLE
noriskclient-launcher-unwrapped: 0.6.19 -> 0.6.20

### DIFF
--- a/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/no/noriskclient-launcher-unwrapped/package.nix
@@ -2,6 +2,8 @@
   cargo-tauri,
   desktop-file-utils,
   fetchFromGitHub,
+  fetchpatch,
+  fetchurl,
   fetchYarnDeps,
   glib,
   gtk3,
@@ -18,18 +20,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "noriskclient-launcher-unwrapped";
-  version = "0.6.19";
+  version = "0.6.20";
 
   src = fetchFromGitHub {
     owner = "NoRiskClient";
     repo = "noriskclient-launcher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SHLYCpflIjslCuCPROyuVsIdNIkHWl2BVflgxAz3RYg=";
+    hash = "sha256-VChMA6XXKgtytLFOORxnpNnTrunKaIJkFge2Xu4FjG0=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-tRvtYeOUn3xm7dhLWnzlpS8SK8NVVQAtNgvyiM48X28=";
+    yarnLock = fetchurl {
+      url = "https://raw.githubusercontent.com/NoRiskClient/noriskclient-launcher/937b275341191552a08757c9b4e5eb7802d54945/yarn.lock";
+      hash = "sha256-IqhgDMthwEAd/rzat119Ajaf8p8LgTDEj/KrS2xVFuQ=";
+    };
+    hash = "sha256-VWl6YqTiBRz85GICFKGwDZRBcITGQdWE7EUzW58wHdY=";
   };
 
   patches = [
@@ -38,6 +43,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     # Make the launcher find java from PATH, instead of downloading its own, which is not going to work on NixOS.
     ./java-from-path.patch
+
+    # The version of tauri in Cargo.toml and in package.json aren't matching, causing the build to fail. Upstream PR is https://github.com/NoRiskClient/noriskclient-launcher/pull/222.
+    (fetchpatch {
+      name = "fix-tauri-version-mismatch";
+      url = "https://github.com/NoRiskClient/noriskclient-launcher/commit/937b275341191552a08757c9b4e5eb7802d54945.patch";
+      hash = "sha256-jI0KnvUpSJU739BfZeYFMhtZKjno1UrWWGwMLS3I6ag=";
+    })
   ];
 
   postPatch = ''
@@ -45,7 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
 
-  cargoHash = "sha256-j41whr62i0FlTe/fWoPsMS9kX5aPgCjM9TckeZpnwgw=";
+  cargoHash = "sha256-FiM1FuWeGmfZlnKiIImGOsJnKt3qsLqvY6oRUvOSBWM=";
 
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;


### PR DESCRIPTION
diff: https://github.com/NoRiskClient/noriskclient-launcher/compare/v0.6.19...v0.6.20

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
