### PR TITLE
treewide: fix prelude builtins warnings

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -653,7 +653,7 @@ rec {
       in
       throw (
         builtins.seq traceFailures (
-          "${builtins.toString (builtins.length failures)} ${description} failed:\n- "
+          "${toString (builtins.length failures)} ${description} failed:\n- "
           + (concatMapStringsSep "\n- " (failure: failure.name) failures)
           + "\n\n"
           + builtins.toJSON failures

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -12,7 +12,7 @@ let
     split
     trace
     typeOf
-    fetchGit
+
     ;
 
   inherit (lib.attrsets)

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -12,7 +12,6 @@ let
     split
     trace
     typeOf
-    fetchGit
     ;
 
   inherit (lib.attrsets)

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -8,7 +8,6 @@
 let
   inherit (builtins)
     pathExists
-    toString
     ;
 
   inherit (lib.filesystem)

--- a/maintainers/scripts/update-ruby-packages.checks.nix
+++ b/maintainers/scripts/update-ruby-packages.checks.nix
@@ -20,7 +20,6 @@ let
     concatStrings
     filter
     genList
-    isNull
     length
     stringLength
     toJSON
@@ -182,7 +181,7 @@ let
 in
 if (length failedChecks) > 0 then
   # Fail the update script via `abort` on checks failure.
-  builtins.abort ''
+  abort ''
     ${"\n"}Gem upgrade aborted with the following failures:
 
     ${concatMapStringsSep "\n" (msg: " - ${msg}") failedChecks}

--- a/maintainers/scripts/update-ruby-packages.checks.nix
+++ b/maintainers/scripts/update-ruby-packages.checks.nix
@@ -179,7 +179,7 @@ let
 in
 if (length failedChecks) > 0 then
   # Fail the update script via `abort` on checks failure.
-  builtins.abort ''
+  abort ''
     ${"\n"}Gem upgrade aborted with the following failures:
 
     ${concatMapStringsSep "\n" (msg: " - ${msg}") failedChecks}

--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -83,8 +83,7 @@ let
                     vlanId = remoteIfaceMeta.vlan or null;
                   in
                   if vlanId != null && builtins.elem vlanId localVlans then
-                    builtins.map (addr: addr.address) ifaceCfg.ipv4.addresses
-                    ++ builtins.map (addr: addr.address) ifaceCfg.ipv6.addresses
+                    map (addr: addr.address) ifaceCfg.ipv4.addresses ++ map (addr: addr.address) ifaceCfg.ipv6.addresses
                   else
                     [ ]
                 ) remoteInterfaces

--- a/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
@@ -8,10 +8,8 @@
 let
   inherit (builtins)
     hashString
-    map
     substring
     toJSON
-    toString
     unsafeDiscardStringContext
     ;
 

--- a/nixos/modules/services/desktops/system76-scheduler.nix
+++ b/nixos/modules/services/desktops/system76-scheduler.nix
@@ -10,8 +10,6 @@ let
 
   inherit (builtins)
     concatStringsSep
-    map
-    toString
     attrNames
     ;
   inherit (lib)

--- a/nixos/modules/services/home-automation/wyoming/openwakeword.nix
+++ b/nixos/modules/services/home-automation/wyoming/openwakeword.nix
@@ -19,10 +19,6 @@ let
     types
     ;
 
-  inherit (builtins)
-    toString
-    ;
-
   inherit (utils)
     escapeSystemdExecArgs
     ;

--- a/nixos/modules/services/home-automation/wyoming/piper.nix
+++ b/nixos/modules/services/home-automation/wyoming/piper.nix
@@ -17,10 +17,6 @@ let
     types
     ;
 
-  inherit (builtins)
-    toString
-    ;
-
   inherit (utils)
     escapeSystemdExecArgs
     ;

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -150,7 +150,7 @@ let
     let
       configVersion = cfg.settings.dovecot_config_version;
       storageVersion = cfg.settings.dovecot_storage_version;
-      remainingSettings = builtins.removeAttrs cfg.settings [
+      remainingSettings = removeAttrs cfg.settings [
         "dovecot_config_version"
         "dovecot_storage_version"
       ];

--- a/nixos/modules/services/networking/amuled.nix
+++ b/nixos/modules/services/networking/amuled.nix
@@ -253,7 +253,7 @@ in
         section:
         lib.concatMapAttrsStringSep "" (
           param: value: ''
-            crudini --inplace --set "$AMULE_CONF" "${section}" "${param}" "${builtins.toString value}"
+            crudini --inplace --set "$AMULE_CONF" "${section}" "${param}" "${toString value}"
           ''
         )
       ) cfg.settings)

--- a/nixos/modules/services/networking/harmonia.nix
+++ b/nixos/modules/services/networking/harmonia.nix
@@ -227,7 +227,7 @@ in
             ProtectHome = true;
             # SQLite needs write access for WAL mode
             ReadWritePaths = [
-              (builtins.dirOf daemonCfg.dbPath) # Need write access for WAL and SHM files
+              (dirOf daemonCfg.dbPath) # Need write access for WAL and SHM files
             ];
             ReadOnlyPaths = [
               daemonCfg.storeDir

--- a/nixos/modules/services/networking/harmonia.nix
+++ b/nixos/modules/services/networking/harmonia.nix
@@ -233,7 +233,7 @@ in
             ProtectHome = true;
             # SQLite needs write access for WAL mode
             ReadWritePaths = [
-              (builtins.dirOf daemonCfg.dbPath) # Need write access for WAL and SHM files
+              (dirOf daemonCfg.dbPath) # Need write access for WAL and SHM files
             ];
             ReadOnlyPaths = [
               daemonCfg.storeDir

--- a/nixos/modules/services/web-apps/drasl.nix
+++ b/nixos/modules/services/web-apps/drasl.nix
@@ -9,8 +9,7 @@ let
   format = pkgs.formats.toml { };
   filterAttrs = x: lib.filterAttrs (n: v: n != "ClientSecretFile" || v != null) x;
   getIndex =
-    item:
-    builtins.toString (lib.lists.findFirstIndex (x: x == item) null cfg.settings.RegistrationOIDC);
+    item: toString (lib.lists.findFirstIndex (x: x == item) null cfg.settings.RegistrationOIDC);
   secretFiles = lib.filter (
     x: lib.hasAttr "ClientSecretFile" (filterAttrs x)
   ) cfg.settings.RegistrationOIDC;

--- a/nixos/modules/services/web-apps/goupile.nix
+++ b/nixos/modules/services/web-apps/goupile.nix
@@ -70,7 +70,7 @@ in
         services.nginx = {
           enable = lib.mkDefault true;
           virtualHosts.${cfg.hostName} = {
-            locations."/".proxyPass = "http://${cfg.hostName}:${builtins.toString cfg.settings.HTTP.Port}";
+            locations."/".proxyPass = "http://${cfg.hostName}:${toString cfg.settings.HTTP.Port}";
           };
         };
       }

--- a/nixos/modules/services/web-apps/goupile.nix
+++ b/nixos/modules/services/web-apps/goupile.nix
@@ -71,7 +71,7 @@ in
         services.nginx = {
           enable = lib.mkDefault true;
           virtualHosts.${cfg.hostName} = {
-            locations."/".proxyPass = "http://127.0.0.1:${builtins.toString cfg.settings.HTTP.Port}";
+            locations."/".proxyPass = "http://127.0.0.1:${toString cfg.settings.HTTP.Port}";
           };
         };
       }

--- a/nixos/modules/services/web-apps/writefreely.nix
+++ b/nixos/modules/services/web-apps/writefreely.nix
@@ -6,7 +6,6 @@
 }:
 
 let
-  inherit (builtins) toString;
   inherit (lib)
     types
     mkIf
@@ -15,7 +14,6 @@ let
     ;
   inherit (lib)
     optional
-    optionals
     optionalAttrs
     optionalString
     ;

--- a/nixos/modules/services/web-apps/writefreely.nix
+++ b/nixos/modules/services/web-apps/writefreely.nix
@@ -6,7 +6,6 @@
 }:
 
 let
-  inherit (builtins) toString;
   inherit (lib)
     types
     mkIf

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -14,7 +14,6 @@ let
     optionalString
     concatMap
     ;
-  inherit (builtins) isNull;
 
   cfg = config.services.varnish;
 

--- a/nixos/tests/guix/publish.nix
+++ b/nixos/tests/guix/publish.nix
@@ -6,7 +6,6 @@ import ../make-test-python.nix (
   { pkgs, lib, ... }:
   let
     publishPort = 8181;
-    inherit (builtins) toString;
   in
   {
     name = "guix-publish";

--- a/nixos/tests/ncps-ha-pg-redis.nix
+++ b/nixos/tests/ncps-ha-pg-redis.nix
@@ -37,7 +37,7 @@ let
 
         lock.backend = "redis";
 
-        secretKeyPath = builtins.toString (
+        secretKeyPath = toString (
           pkgs.writeText "ncps-cache-key" "ncps:dcrGsrku0KvltFhrR5lVIMqyloAdo0y8vYZOeIFUSLJS2IToL7dPHSSCk/fi+PJf8EorpBn8PU7MNhfvZoI8mA=="
         );
 

--- a/nixos/tests/pocket-id.nix
+++ b/nixos/tests/pocket-id.nix
@@ -61,7 +61,6 @@ in
     let
       settingsSqlite = nodes.machineSqlite.services.pocket-id.settings;
       settingsPostgres = nodes.machinePostgres.services.pocket-id.settings;
-      inherit (builtins) toString;
     in
     ''
       machineSqlite.wait_for_unit("pocket-id.service")

--- a/nixos/tests/stirling-pdf-desktop.nix
+++ b/nixos/tests/stirling-pdf-desktop.nix
@@ -43,7 +43,7 @@ in
         imports = [ ./common/wayland-cage.nix ];
         services.cage.program = lib.getExe pkgs.stirling-pdf-desktop;
         systemd.tmpfiles.settings."stirling-provisioning.json"."/etc/stirling-pdf/stirling-provisioning.json"."L+".argument =
-          builtins.toString (
+          toString (
             pkgs.writeText "stirling-provisioning.json" ''
               {
                 "serverUrl": "${server}",

--- a/nixos/tests/web-apps/goupile/default.nix
+++ b/nixos/tests/web-apps/goupile/default.nix
@@ -97,7 +97,7 @@ in
   testScript =
     { nodes, ... }:
     let
-      port = builtins.toString nodes.machine.services.goupile.settings.HTTP.Port;
+      port = toString nodes.machine.services.goupile.settings.HTTP.Port;
     in
     # py
     ''

--- a/nixos/tests/web-apps/goupile/default.nix
+++ b/nixos/tests/web-apps/goupile/default.nix
@@ -96,7 +96,7 @@ in
   testScript =
     { nodes, ... }:
     let
-      port = builtins.toString nodes.machine.services.goupile.settings.HTTP.Port;
+      port = toString nodes.machine.services.goupile.settings.HTTP.Port;
     in
     # py
     ''

--- a/pkgs/build-support/dart/build-dart-application/default.nix
+++ b/pkgs/build-support/dart/build-dart-application/default.nix
@@ -144,7 +144,7 @@ lib.extendMkDerivation {
       !(builtins.isString dartOutputType && dartOutputType != "")
       -> throw "dartOutputType must be a non-empty string";
 
-    (builtins.removeAttrs args [
+    (removeAttrs args [
       "gitHashes"
       "sdkSourceBuilders"
       "pubspecLock"

--- a/pkgs/build-support/lake/default.nix
+++ b/pkgs/build-support/lake/default.nix
@@ -92,7 +92,7 @@ lib.extendMkDerivation {
             patches = finalAttrs.patches or [ ];
             prePatch = finalAttrs.prePatch or "";
             postPatch = finalAttrs.postPatch or "";
-            excludePackages = builtins.map (dep: dep.passthru.lakePackageName or dep.pname) allLeanDeps;
+            excludePackages = map (dep: dep.passthru.lakePackageName or dep.pname) allLeanDeps;
           }).overrideAttrs
             (lib.toExtension overrideLakeDepsAttrs);
 

--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -13,7 +13,7 @@ let
     elemAt
     toJSON
     toFile
-    removeAttrs
+
     ;
   inherit (lib) importJSON mapAttrs;
 

--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -13,7 +13,6 @@ let
     elemAt
     toJSON
     toFile
-    removeAttrs
     ;
   inherit (lib) importJSON mapAttrs;
 

--- a/pkgs/by-name/bl/blightmud/package.nix
+++ b/pkgs/by-name/bl/blightmud/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "test_tls_init_verify"
       ];
     in
-    builtins.map (x: "--skip=" + x) skipList;
+    map (x: "--skip=" + x) skipList;
 
   meta = {
     description = "Terminal MUD client written in Rust";

--- a/pkgs/by-name/bl/blightmud/package.nix
+++ b/pkgs/by-name/bl/blightmud/package.nix
@@ -73,7 +73,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "test_mccp2_negotiation"
       ];
     in
-    builtins.map (x: "--skip=" + x) skipList;
+    map (x: "--skip=" + x) skipList;
 
   meta = {
     description = "Terminal MUD client written in Rust";

--- a/pkgs/by-name/el/ela-widget-tools/package.nix
+++ b/pkgs/by-name/el/ela-widget-tools/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
       includePaths = builtins.concatStringsSep " " (
         lib.flatten (
-          builtins.map includeBaseFor [
+          map includeBaseFor [
             "QtCore"
             "QtGui"
             "QtWidgets"

--- a/pkgs/by-name/gr/graphite/package.nix
+++ b/pkgs/by-name/gr/graphite/package.nix
@@ -86,7 +86,7 @@ let
       echo '${
         builtins.toJSON {
           type = "minimal";
-          name = builtins.baseNameOf finalAttrs.src.url;
+          name = baseNameOf finalAttrs.src.url;
           sha1 = "";
         }
       }' > $out/archive.json

--- a/pkgs/by-name/gr/grcov/package.nix
+++ b/pkgs/by-name/gr/grcov/package.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "test_integration_zip_zip"
       ];
     in
-    builtins.map (x: "--skip=" + x) skipList;
+    map (x: "--skip=" + x) skipList;
 
   meta = {
     description = "Rust tool to collect and aggregate code coverage data for multiple source files";

--- a/pkgs/by-name/in/inventree/package.nix
+++ b/pkgs/by-name/in/inventree/package.nix
@@ -188,7 +188,7 @@ python3Packages.buildPythonApplication rec {
         # TODO figure out why this fails
         "test_setting_object"
       ];
-      skippedFuncScripts = builtins.map (funcName: ''
+      skippedFuncScripts = map (funcName: ''
         grep -rlZ ${funcName} . | while IFS= read -r -d "" file; do
           substituteInPlace "$file" --replace-fail "${funcName}" "skip_${funcName}"
         done

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -27,14 +27,13 @@ let
   # plugin derivations in the Nix store and nowhere else.
   pluginLoadPathsPatch =
     let
-      inherit (builtins) toString;
       inherit (lib.strings)
         readFile
         concatStrings
         replaceStrings
         unsafeDiscardStringContext
         ;
-      inherit (lib.lists) map length;
+      inherit (lib.lists) length;
       inherit (lib) add;
 
       outputLc = toString (add 7 (length plugins));

--- a/pkgs/by-name/mi/mill/package.nix
+++ b/pkgs/by-name/mi/mill/package.nix
@@ -79,7 +79,7 @@ stdenvNoCC.mkDerivation rec {
     latestVersion="$(curl -sS $metadataUrl | xmllint --xpath '/metadata/versioning/release/text()' -)"
 
     ${lib.strings.concatStrings (
-      builtins.map (
+      map (
         platform:
         let
           suffix = suffixMap.${platform} or (throw "Platform not in suffixMap: ${platform}");

--- a/pkgs/by-name/mk/mkp224o/package.nix
+++ b/pkgs/by-name/mk/mkp224o/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
             inherit version src;
             configureFlags =
               configureFlags
-              ++ [ "--enable-batchnum=${builtins.toString batchSize}" ]
+              ++ [ "--enable-batchnum=${toString batchSize}" ]
               ++ lib.optionals regexSupport [ "--enable-regex=yes" ];
             nativeBuildInputs = [ autoreconfHook ];
             buildInputs = [ libsodium ] ++ lib.optionals regexSupport [ pcre2 ];

--- a/pkgs/by-name/op/openbao/ui.nix
+++ b/pkgs/by-name/op/openbao/ui.nix
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   dontInstall = true;
 
-  meta = (builtins.removeAttrs openbao.meta [ "mainProgram" ]) // {
+  meta = (removeAttrs openbao.meta [ "mainProgram" ]) // {
     description = openbao.meta.description + " - web UI";
   };
 })

--- a/pkgs/development/compilers/factor-lang/0.100.nix
+++ b/pkgs/development/compilers/factor-lang/0.100.nix
@@ -8,7 +8,7 @@ callPackage ./unwrapped.nix (
       hash = "sha256-ei1x6mgEoDVe1mKfoWSGC9RgZCONovAPYfIdAlOGi+0=";
     };
   }
-  // (builtins.removeAttrs args [
+  // (removeAttrs args [
     "callPackage"
     "fetchurl"
   ])

--- a/pkgs/development/compilers/factor-lang/0.101.nix
+++ b/pkgs/development/compilers/factor-lang/0.101.nix
@@ -8,7 +8,7 @@ callPackage ./unwrapped.nix (
       hash = "sha256-uIuk309xZt+sV7WUza/tpeJRA6CnXAajL15X6S6vtFY=";
     };
   }
-  // (builtins.removeAttrs args [
+  // (removeAttrs args [
     "callPackage"
     "fetchurl"
   ])

--- a/pkgs/development/compilers/factor-lang/0.99.nix
+++ b/pkgs/development/compilers/factor-lang/0.99.nix
@@ -8,7 +8,7 @@ callPackage ./unwrapped.nix (
       sha256 = "f5626bb3119bd77de9ac3392fdbe188bffc26557fab3ea34f7ca21e372a8443e";
     };
   }
-  // (builtins.removeAttrs args [
+  // (removeAttrs args [
     "callPackage"
     "fetchurl"
   ])

--- a/pkgs/development/compilers/idris2/build-idris.nix
+++ b/pkgs/development/compilers/idris2/build-idris.nix
@@ -50,7 +50,7 @@ let
   libSuffix = "lib/${idrName}";
   libDirs = libs: (lib.makeSearchPath libSuffix libs) + ":${idris2}/${idrName}";
   supportDir = "${idris2.libidris2_support}/lib";
-  drvAttrs = builtins.removeAttrs attrs [
+  drvAttrs = removeAttrs attrs [
     "ipkgName"
     "idrisLibraries"
   ];

--- a/pkgs/development/compilers/squeak/default.nix
+++ b/pkgs/development/compilers/squeak/default.nix
@@ -34,7 +34,7 @@
 }@args:
 
 let
-  inherit (builtins) elemAt toString;
+  inherit (builtins) elemAt;
 
   nullableOr = o: default: if o == null then default else o;
 

--- a/pkgs/development/cuda-modules/_cuda/manifests/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/manifests/default.nix
@@ -16,4 +16,4 @@ lib.mapAttrs (
       "${version}" = lib.importJSON (redistManifestDir + "/${fileName}");
     }
   ) (builtins.readDir redistManifestDir)
-) (builtins.removeAttrs (builtins.readDir ./.) [ "default.nix" ])
+) (removeAttrs (builtins.readDir ./.) [ "default.nix" ])

--- a/pkgs/development/cuda-modules/backendStdenv/default.nix
+++ b/pkgs/development/cuda-modules/backendStdenv/default.nix
@@ -16,9 +16,7 @@
 }:
 let
   inherit (builtins)
-    throw
     toJSON
-    toString
     ;
   inherit (_cuda.db) allSortedCudaCapabilities cudaCapabilityToInfo nvccCompatibilities;
   inherit (_cuda.lib)

--- a/pkgs/development/cuda-modules/packages/tests/cmake/package.nix
+++ b/pkgs/development/cuda-modules/packages/tests/cmake/package.nix
@@ -59,8 +59,8 @@ let
         __structuredAttrs = true;
         strictDeps = true;
 
-        testSuiteName = builtins.throw "testSuiteName must be set";
-        testName = builtins.throw "testName must be set";
+        testSuiteName = throw "testSuiteName must be set";
+        testName = throw "testName must be set";
 
         name = "${cudaNamePrefix}-${finalAttrs.pname}-${finalAttrs.version}";
         pname = "tests-cmake-${finalAttrs.testSuiteName}-${finalAttrs.testName}";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -45,7 +45,7 @@ mkDerivation rec {
 
   env = sys.passthru.env;
   SYSDIR = "${sys.src}/sys";
-  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR = "${placeholder "debug"}/lib/debug";
   KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
   KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
 

--- a/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/package.nix
@@ -25,7 +25,7 @@ mkDerivation rec {
 
   env = sys.passthru.env;
   SYSDIR = "${sys.src}/sys";
-  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR = "${placeholder "debug"}/lib/debug";
   KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
   KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
   KMODDIR = "${placeholder "out"}/kernel";

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-driver/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-driver/package.nix
@@ -32,7 +32,7 @@ mkDerivation rec {
     "BSDSRCTOP=${sys.src}"
     "SYSDIR=${sys.src}/sys"
     "DRMKMODDIR=${drm-kmod.src}"
-    "KMODDIR=${builtins.placeholder "out"}/kernel"
+    "KMODDIR=${placeholder "out"}/kernel"
     "NO_XREF=1"
     "DEBUG_FLAGS=-g"
   ];

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod-firmware/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod-firmware/package.nix
@@ -18,7 +18,7 @@ mkDerivation {
 
   makeFlags = [
     "SYSDIR=${sys.src}/sys"
-    "KMODDIR=${builtins.placeholder "out"}/kernel"
+    "KMODDIR=${placeholder "out"}/kernel"
     "NO_XREF=1"
   ];
 

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-drm-kmod/package.nix
@@ -67,8 +67,8 @@ mkDerivation rec {
     "DEBUG_FLAGS=-g"
   ];
 
-  KMODDIR = "${builtins.placeholder "out"}/kernel";
-  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KMODDIR = "${placeholder "out"}/kernel";
+  KERN_DEBUGDIR = "${placeholder "debug"}/lib/debug";
   KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
   KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
 

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-libs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-libs.nix
@@ -38,11 +38,11 @@ mkDerivation {
     libx11
   ];
 
-  env.LOCALBASE = "${builtins.placeholder "out"}";
-  env.VKICD_PATH = "${builtins.placeholder "out"}/share/vulkan/icd.d";
-  env.VKLAYERS_PATH = "${builtins.placeholder "out"}/share/vulkan/implicit_layer.d";
-  env.EGL_GLVND_JSON_PATH = "${builtins.placeholder "out"}/share/glvnd/egl_vendor.d";
-  env.EGL_EXTERNAL_PLATFORM_JSON_PATH = "${builtins.placeholder "out"}/share/egl/egl_external_platform.d";
+  env.LOCALBASE = "${placeholder "out"}";
+  env.VKICD_PATH = "${placeholder "out"}/share/vulkan/icd.d";
+  env.VKLAYERS_PATH = "${placeholder "out"}/share/vulkan/implicit_layer.d";
+  env.EGL_GLVND_JSON_PATH = "${placeholder "out"}/share/glvnd/egl_vendor.d";
+  env.EGL_EXTERNAL_PLATFORM_JSON_PATH = "${placeholder "out"}/share/egl/egl_external_platform.d";
 
   postPatch = ''
     substituteInPlace lib/libGLX_nvidia/Makefile \

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-nvml.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-nvml.nix
@@ -17,7 +17,7 @@ mkDerivation {
   runtimeDependencies = [ nvidia-libs ];
   buildInputs = [ nvidia-libs ];
 
-  env.LOCALBASE = "${builtins.placeholder "out"}";
+  env.LOCALBASE = "${placeholder "out"}";
 
   dontBuild = true;
   installPhase = ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-x11.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/nvidia-x11.nix
@@ -18,7 +18,7 @@ mkDerivation {
     nvidia-libs
   ];
 
-  env.LOCALBASE = "${builtins.placeholder "out"}";
+  env.LOCALBASE = "${placeholder "out"}";
 
   dontBuild = true;
   installPhase = ''

--- a/pkgs/os-specific/bsd/freebsd/pkgs/uathload.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/uathload.nix
@@ -15,6 +15,6 @@ mkDerivation {
     bintrans
   ];
   postPatch = ''
-    substituteInPlace usr.sbin/uathload/uathload.c --replace-fail _PATH_FIRMWARE '"${builtins.placeholder "out"}/share/firmware"'
+    substituteInPlace usr.sbin/uathload/uathload.c --replace-fail _PATH_FIRMWARE '"${placeholder "out"}/share/firmware"'
   '';
 }

--- a/pkgs/os-specific/linux/firmware/ath9k/default.nix
+++ b/pkgs/os-specific/linux/firmware/ath9k/default.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
         listToAttrs
         pipe
         ;
-      inherit (builtins) map;
       urls-and-hashes = import (./. + "/urls-and-hashes-${finalAttrs.version}.nix");
       make-links =
         pipe


### PR DESCRIPTION
This pull request primarily refactors Nix code by removing unnecessary imports and redundant use of the `builtins` namespace, simplifying expressions, and improving code clarity and maintainability. Most changes involve replacing `builtins.toString` and similar calls with unqualified `toString` (or other functions), and cleaning up unused or redundant imports across various modules and test files.

**Refactoring of builtins usage and import cleanup:**

* Replaced `builtins.toString` and similar qualified calls with unqualified `toString` in multiple files, such as `lib/debug.nix`, `nixos/modules/services/networking/amuled.nix`, `nixos/modules/services/web-apps/goupile.nix`, and others, to simplify expressions and improve readability.

* Removed unnecessary or unused imports of `toString`, `map`, `isNull`, and other builtins from various modules and test files, reducing clutter and potential confusion.

* Replaced `builtins.removeAttrs` and `builtins.dirOf` with unqualified `removeAttrs` and `dirOf` to match the import conventions and reduce verbosity in service modules.

**Modernization and simplification of functional expressions:**

* Updated map and list operations to use unqualified `map` instead of `builtins.map` in networking and service modules, streamlining the code and leveraging existing imports.

**Consistency improvements in error handling:**

* Replaced `builtins.abort` with unqualified `abort` in script checks to maintain consistency with other function usage patterns.

These changes collectively make the codebase more idiomatic, easier to read, and maintain, without altering functionality.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
