### PR TITLE
python3Modules.mlflow: 3.8.1 -> 3.11.1

### DIFF
--- a/pkgs/development/python-modules/mlflow/default.nix
+++ b/pkgs/development/python-modules/mlflow/default.nix
@@ -7,6 +7,7 @@
   setuptools,
 
   # dependencies
+  aiohttp,
   alembic,
   cachetools,
   click,
@@ -38,12 +39,12 @@
   requests,
   scikit-learn,
   scipy,
+  skops,
   sqlalchemy,
   sqlparse,
   uvicorn,
 
   # tests
-  aiohttp,
   azure-core,
   azure-storage-blob,
   azure-storage-file,
@@ -76,20 +77,20 @@
 
 buildPythonPackage rec {
   pname = "mlflow";
-  version = "3.8.1";
+  version = "3.11.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mlflow";
     repo = "mlflow";
     tag = "v${version}";
-    hash = "sha256-QjRFQRShVjTnCN7/+LJ0iiB/h0+P4GJJV4RaviQdS2U=";
+    hash = "sha256-Oe6nBnnOz7MvGUNCcCGhHl6ZbyDfAhQ0LlfMBF4p6Hc=";
   };
 
   pythonRelaxDeps = [
     "cryptography"
     "gunicorn"
-    "importlib-metadata"
+    "importlib_metadata"
     "packaging"
     "protobuf"
     "pytz"
@@ -99,6 +100,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
+    aiohttp
     alembic
     cachetools
     click
@@ -132,6 +134,7 @@ buildPythonPackage rec {
     scikit-learn
     scipy
     shap
+    skops
     sqlalchemy
     sqlparse
     uvicorn


### PR DESCRIPTION
`python3Packages.mlflow` build is currently broken with an invalid package version (9) on `importlib_metadata`.

The previous builds applied `pythonRelaxDeps` to `import-metadata` unsuccessfully. Renamed to `import_metadata` to match `pyproject.toml`.

Version bump: 3.8.1 -> 3.11.1
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
