### PR TITLE
acme-client: 1.3.3 -> 1.3.7, fix src url, adopt, updateScript

### DIFF
--- a/pkgs/by-name/ac/acme-client/package.nix
+++ b/pkgs/by-name/ac/acme-client/package.nix
@@ -9,11 +9,11 @@
 
 gccStdenv.mkDerivation (finalAttrs: {
   pname = "acme-client";
-  version = "1.3.3";
+  version = "1.3.7";
 
   src = fetchurl {
-    url = "https://data.wolfsden.cz/sources/acme-client-${finalAttrs.version}.tar.gz";
-    hash = "sha256-HJOk2vlDD7ADrLdf/eLEp+teu9XN0KrghEe6y4FIDoI=";
+    url = "https://files.wolfsden.cz/releases/acme-client/acme-client-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Mq+6epLcgEnlQ0JAPYCxGQu7EM0VS0Y32PYuvEuliAE=";
   };
 
   nativeBuildInputs = [
@@ -29,12 +29,17 @@ gccStdenv.mkDerivation (finalAttrs: {
     "PREFIX=${placeholder "out"}"
   ];
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Secure ACME/Let's Encrypt client";
     homepage = "https://git.wolfsden.cz/acme-client-portable";
     platforms = lib.platforms.unix;
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ pmahoney ];
+    maintainers = with lib.maintainers; [
+      pmahoney
+      kybe236
+    ];
     mainProgram = "acme-client";
   };
 })

--- a/pkgs/by-name/ac/acme-client/update.sh
+++ b/pkgs/by-name/ac/acme-client/update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep nix-update
+
+set -euo pipefail
+
+VERSION=$(curl https://files.wolfsden.cz/releases/acme-client/ | grep -oP 'acme-client-\K\d+\.\d+\.\d+(?=\.tar\.gz)' | sort -V | tail -n1)
+
+echo ">> acme-client: $VERSION"
+
+nix-update --version "$VERSION" acme-client


### PR DESCRIPTION
## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
