### PR TITLE
trailmark: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/trailmark/default.nix
+++ b/pkgs/development/python-modules/trailmark/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  hatchling,
+  rustworkx,
+  tree-sitter,
+  tree-sitter-language-pack,
+  hypothesis,
+  mutmut,
+  pytest,
+  pytest-cov,
+  pytestCheckHook,
+  versionCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "trailmark";
+  version = "0.2.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "trailmark";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e+IcCiILDBJNaLjkBl+i7NVcYp5r8/7KrR6dFvK0NwM=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    rustworkx
+    tree-sitter
+    tree-sitter-language-pack
+  ];
+
+  pythonImportsCheck = [ "trailmark" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+
+  checkInputs = [
+    hypothesis
+    mutmut
+    pytest
+    pytest-cov
+  ];
+
+  disabledTests = [
+    # searches git via shutil
+    "test_worktree_materializes_a_ref"
+    # fail with requires networking
+    "test_single_language_directory"
+    "test_multiple_languages_in_one_dir"
+    "test_skips_vendor_directories"
+    "test_detects_modern_javascript_module_extensions"
+    "test_auto_detects_and_merges"
+    "test_auto_merges_entrypoints"
+    "test_auto_parses_mjs_files_into_nodes"
+  ];
+
+  versionCheckProgram = "${placeholder "out"}/bin/trailmark";
+
+  meta = {
+    homepage = "https://github.com/trailofbits/trailmark/";
+    description = "Build and query a graph database representation of source code";
+    changelog = "https://github.com/trailofbits/trailmark/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    mainProgram = "bw";
+    license = [ lib.licenses.asl20 ];
+    maintainers = with lib.maintainers; [ wamserma ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7617,6 +7617,8 @@ with pkgs;
 
   ### DEVELOPMENT / TESTING TOOLS
 
+  trailmark = with python3.pkgs; toPythonApplication trailmark;
+
   ### DEVELOPMENT / LIBRARIES / AGDA
 
   agdaPackages = recurseIntoAttrs (

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19658,6 +19658,8 @@ self: super: with self; {
 
   trafilatura = callPackage ../development/python-modules/trafilatura { };
 
+  trailmark = callPackage ../development/python-modules/trailmark { };
+
   trailrunner = callPackage ../development/python-modules/trailrunner { };
 
   trainer = callPackage ../development/python-modules/trainer { };


### PR DESCRIPTION
A Python library and CI tool for call graph analysis.

Announced in https://blog.trailofbits.com/2026/04/23/trailmark-turns-code-into-graphs/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
