### PR TITLE
kubernetes-mcp-server: init at 0.0.60

### DIFF
--- a/pkgs/by-name/ku/kubernetes-mcp-server/package.nix
+++ b/pkgs/by-name/ku/kubernetes-mcp-server/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kubernetes-mcp-server";
+  version = "0.0.60";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "kubernetes-mcp-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-btFtMO0+cIJ44cHMYLUrYMpamBhuiLgxCf8gzEXYCHs=";
+  };
+
+  vendorHash = "sha256-JlbkmVa1CbfybU2554p0yuf1NsSqx3ZohZCcWpoFWgo=";
+
+  subPackages = [ "cmd/kubernetes-mcp-server" ];
+
+  meta = {
+    description = "Model Context Protocol server for Kubernetes and OpenShift";
+    homepage = "https://github.com/containers/kubernetes-mcp-server";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dudeofawesome ];
+    platforms = lib.platforms.unix;
+    mainProgram = "kubernetes-mcp-server";
+  };
+})


### PR DESCRIPTION
Adds `kubernetes-mcp-server`, a Go-based Model Context Protocol (MCP) server for Kubernetes and OpenShift.

Upstream: https://github.com/containers/kubernetes-mcp-server

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Additional verification:
- `nix-build -A kubernetes-mcp-server`
- Upstream Go tests ran successfully during `checkPhase`.
- `./result/bin/kubernetes-mcp-server --help`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test