### PR TITLE
hackrf: 2024.02.1 -> 2026.01.3

### DIFF
--- a/pkgs/by-name/ha/hackrf/package.nix
+++ b/pkgs/by-name/ha/hackrf/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   libusb1,
@@ -11,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hackrf";
-  version = "2024.02.1";
+  version = "2026.01.3";
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "hackrf";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-b3nGrk2P6ZLYBSCSD7c0aIApCh3ZoVDcFftybqm4vx0=";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-/RSZ+jkh4wmb0n8Kiee9Nr5D6LPYdmZVigpsBagAaLg=";
   };
 
   nativeBuildInputs = [
@@ -30,14 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     fftwSinglePrec
   ];
 
-  patches = [
-    # CMake < 3.5 fix. Remove upon next version bump.
-    (fetchpatch {
-      url = "https://github.com/greatscottgadgets/hackrf/commit/5c394520403c40b656a7400681e4ae167943e43f.patch";
-      hash = "sha256-FRzb+Bt5fQm94d1EDbMv8oUFwD93VZQHFpQpMDe/BAA=";
-    })
-  ];
-
   cmakeFlags = [
     "-DUDEV_RULES_GROUP=plugdev"
     "-DUDEV_RULES_PATH=lib/udev/rules.d"
@@ -48,11 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doInstallCheck = true;
-
-  postPatch = ''
-    substituteInPlace host/cmake/modules/FindFFTW.cmake \
-      --replace "find_library (FFTW_LIBRARIES NAMES fftw3)" "find_library (FFTW_LIBRARIES NAMES fftw3f)"
-  '';
 
   meta = {
     description = "Open source SDR platform";


### PR DESCRIPTION
With the release of the [HackRF Pro](https://greatscottgadgets.com/hackrf/pro/), an upgrade is badly needed.

A variety of other fixes and enhancements are included. The [release notes](https://github.com/greatscottgadgets/hackrf/releases) mention the following highlights (I'm excluding changes to the firmware, which this package doesn't build):

### 2026.01.1
- HackRF Pro, a new hardware platform, is now supported. Initially HackRF Pro supports a legacy radio configuration mode that makes it compatible with software designed for use with HackRF One. Future releases will enable extended precision and other modes.
- Added support for newer PortaPacks with AGM Microelectronics CPLDs

### 2026.01.3
- Add access to larger SPI flash on HackRF Pro.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
