### PR TITLE
tecoc: fix build with gcc15

### DIFF
--- a/pkgs/by-name/te/tecoc/fix-gcc15.patch
+++ b/pkgs/by-name/te/tecoc/fix-gcc15.patch
@@ -1,0 +1,101 @@
+diff --git a/src/popmac.c b/src/popmac.c
+index 91329da..46ccdea 100644
+--- a/src/popmac.c
++++ b/src/popmac.c
+@@ -38,7 +38,7 @@ DEFAULT PopMac()		/* restore environment after macro exit */
+ 		ZFree((voidptr)QRp->Start);
+ 	    }
+ 	}
+-	ZFree(MSp->QRgstr);
++	ZFree((voidptr)MSp->QRgstr);
+     }
+     --MStTop;
+ #if DEBUGGING
+diff --git a/src/readcs.c b/src/readcs.c
+index 9dd4458..135f240 100644
+--- a/src/readcs.c
++++ b/src/readcs.c
+@@ -488,7 +488,7 @@ VVOID ReadCS()
+ 			}
+ #if CURSES
+ 			if (ScroLn > 0 || skiprefresh)
+-			    dolf(HowFar);
++			    dolf();
+ 			if (ScroLn == 0 || skiprefresh)
+ #endif
+ 			    ZDspCh('*');
+@@ -537,7 +537,7 @@ VVOID ReadCS()
+ 			}
+ #if CURSES
+ 			if (ScroLn > 0 && !skiprefresh)
+-			    dobs(HowFar);
++			    dobs();
+ 			if (ScroLn == 0 || skiprefresh)
+ #endif
+ 			    ZDspCh('*');
+diff --git a/src/tecoc.h b/src/tecoc.h
+index 0debaa7..25a028b 100644
+--- a/src/tecoc.h
++++ b/src/tecoc.h
+@@ -684,7 +684,7 @@ VVOID	ZVrbos();	/* display verbose form of an error message */
+ DEFAULT	ZWrBfr();	/* write line to file */
+ #endif
+ #if CURSES
+-void Scope();
++void Scope(int bot);
+ void centre();
+ void dolf();
+ void dobs();
+diff --git a/src/zlinux.c b/src/zlinux.c
+index c2c120c..62eb0d4 100644
+--- a/src/zlinux.c
++++ b/src/zlinux.c
+@@ -103,7 +103,7 @@ static char tbuf[1024];		/* store TERMCAP entry here */
+ int	tputs();		/* send termcap string to a given function */
+ int	tgetent();		/* load a terminal capability buffer */
+ char 	*tgetstr();		/* get str value of a terminal capability */
+-static int vernum();		/* see bottom of this file */
++static int vernum(char *target);		/* see bottom of this file */
+ static	int SupGotCtC = 0;
+ static glob_t pglob;
+ static int globindex = 0;
+@@ -1479,7 +1479,7 @@ character is received when it is struck, and no echoing is performed.  Save
+ the terminal characteristics so when we exit we can reset them (in ZClnUp)
+ to what they were before we changed them.
+ *****************************************************************************/
+-static VVOID CntrlC()
++static VVOID CntrlC(int sig)
+ {
+     signal(SIGINT, SIG_IGN);
+     SupGotCtC = 0;
+@@ -1497,7 +1497,7 @@ static VVOID CntrlC()
+ /*
+  * sighup - what we do if we get a hang up?
+  */
+-static void sighup()
++static void sighup(int sig)
+ {
+ 	TAbort(EXIT_FAILURE);
+ }
+diff --git a/src/zport.h b/src/zport.h
+index f842ae2..eeb5315 100644
+--- a/src/zport.h
++++ b/src/zport.h
+@@ -192,7 +192,7 @@ just don't use prototypes in GNU C.
+ #if defined(VAX11C) || defined(__TURBOC__) || defined(__POWERC) || defined(ULTRIX)
+ #define USE_PROTOTYPES TRUE
+ #else
+-#define USE_PROTOTYPES FALSE
++#define USE_PROTOTYPES TRUE
+ #endif
+ 
+ /****************************************************************************
+@@ -533,7 +533,7 @@ EXTERN VVOID bcopy();
+ 
+ #elif defined(unix) || defined(AMIGA) || (defined(UNKNOWN) && !defined(__STDC__))
+ 
+-EXTERN VVOID ZCpyBl();
++EXTERN VVOID ZCpyBl(charptr dest, charptr source, SIZE_T len);
+ #define MEMMOVE(dest,source,len) ZCpyBl((dest),(source),(len))
+ 
+ #elif defined(__TURBOC__) || defined(__POWERC)

--- a/pkgs/by-name/te/tecoc/package.nix
+++ b/pkgs/by-name/te/tecoc/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-KTOGsTtxJh2sneU2VoDNUHcL3m8zt+3rBZTDvK1n02A=";
   };
 
+  patches = [
+    ./fix-gcc15.patch
+  ];
+
   buildInputs = [ ncurses ];
 
   makefile =


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/326908919

```
tecoc.c: In function 'main':
tecoc.c:585:12: warning: old-style function definition [-Wold-style-definition]
  585 | int _Cdecl main(argc, argv)             /* _Cdecl defined in ZPORT.H */
      |            ^~~~
tecoc.c:592:9: error: too many arguments to function 'Init'; expected 0, have 2
  592 |         Init(argc, argv);               /* initialize TECO */
      |         ^~~~ ~~~~
In file included from tecoc.c:27:
tecoc.h:629:9: note: declared here
  629 | VVOID   Init();         /* initialize TECO-C */
      |         ^~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
