### PR TITLE
tlsclient: 1.6.6 -> 1.7

### DIFF
--- a/pkgs/by-name/tl/tlsclient/package.nix
+++ b/pkgs/by-name/tl/tlsclient/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tlsclient";
-  version = "1.6.6";
+  version = "1.7";
 
   src = fetchFromSourcehut {
     owner = "~moody";
     repo = "tlsclient";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-nUvOmEwdMKuPM9KaMGxmW0Lvo3968wjDc95pLB17YnM=";
+    hash = "sha256-oClIbswConBrmU0hpIVcS2L0DVF2/xdnbAv3X0RvNZ0=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324339538

```
curve25519.c:228:1: error: conflicting types for 'fmul'; have 'void(felem *, felem *, felem *)' {aka 'void(long long int *, long long int *, long long int *)'}
  228 | fmul(felem *output, felem *in, felem *in2) {
      | ^~~~
In file included from ../include/unix.h:18,
                 from ../include/dtos.h:2,
                 from ../include/u.h:1,
                 from os.h:1,
                 from curve25519.c:48:
/nix/store/h0ip0h6qp7kc2wm7mwjaglkxxbzmjri4-glibc-2.42-51-dev/include/bits/mathcalls-narrow.h:33:20: note: previous declaration of 'fmul' with type 'float(double,  double)'
   33 | __MATHCALL_NARROW (__MATHCALL_NAME (mul), __MATHCALL_REDIR_NAME (mul), 2);
      |                    ^~~~~~~~~~~~~~~
...
```

Definition of `fmul` conflicts with C23 in which is now a built-in.
~Technically only needs to substitute fmul for something else but that's fragile so just pin to gnu17.~

Fixed [upstream](https://git.sr.ht/~moody/tlsclient/commit/a693c27c19a3fc6b8cda44f1fa5d45e423a5c532). Updated to latest version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
