### PR TITLE
stui: init at 0.3.6

### DIFF
--- a/pkgs/by-name/st/stui/package.nix
+++ b/pkgs/by-name/st/stui/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "stui";
+  version = "0.3.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mil-ad";
+    repo = "stui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-shdQcjPs65fFdbCQG/nhKgXhHzrFrqHflrq0RmknR20=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  dependencies = [
+    python3.pkgs.urwid
+    python3.pkgs.fabric
+  ];
+
+  pythonImportsCheck = [
+    "stui"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A Slurm dashboard for the terminal";
+    homepage = "https://github.com/mil-ad/stui";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nemeott ];
+    mainProgram = "stui";
+  };
+})


### PR DESCRIPTION
Added `stui`, which is a SLURM dashboard TUI. Looks useful for HPC users. Hasn't been updated recently, but still is functional. [https://github.com/mil-ad/stui](https://github.com/mil-ad/stui).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
