### PR TITLE
oxygenfonts: Include missing Oxygen Sans font files and migrate to installFonts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29343,6 +29343,11 @@
     githubId = 223833;
     name = "Klaas van Schelven";
   };
+  VarNepvius = {
+    name = "VarNapvius";
+    github = "VarNapvius";
+    githubId = 14352929;
+  };
   varunpatro = {
     email = "varun.kumar.patro@gmail.com";
     github = "varunpatro";

--- a/pkgs/by-name/ox/oxygenfonts/package.nix
+++ b/pkgs/by-name/ox/oxygenfonts/package.nix
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/share/fonts/truetype
-    cp */Oxygen-Sans.ttf */Oxygen-Sans-Bold.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
+    cp OxygenSans-version-0.4/*/Oxygen-Sans*.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ox/oxygenfonts/package.nix
+++ b/pkgs/by-name/ox/oxygenfonts/package.nix
@@ -53,6 +53,7 @@ stdenvNoCC.mkDerivation {
 
     homepage = "https://github.com/vernnobile/oxygenFont";
     license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ VarNepvius ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ox/oxygenfonts/package.nix
+++ b/pkgs/by-name/ox/oxygenfonts/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -15,14 +16,7 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-0LKq8nChkDAb6U1sOUyga/DvzpDmIjoRn+2PB9rok4w=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/fonts/truetype
-    cp */Oxygen-Sans.ttf */Oxygen-Sans-Bold.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Desktop/gui font for integrated use with the KDE desktop";

--- a/pkgs/by-name/ox/oxygenfonts/package.nix
+++ b/pkgs/by-name/ox/oxygenfonts/package.nix
@@ -1,19 +1,17 @@
 {
   lib,
   stdenvNoCC,
-  fetchFromGitHub,
+  fetchzip,
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "oxygenfonts";
-  version = "20160824";
+  version = "5.4.3";
 
-  src = fetchFromGitHub {
-    owner = "vernnobile";
-    repo = "oxygenFont";
-    rev = "62db0ebe3488c936406685485071a54e3d18473b";
-    hash = "sha256-0LKq8nChkDAb6U1sOUyga/DvzpDmIjoRn+2PB9rok4w=";
+  src = fetchzip {
+    url = "https://invent.kde.org/unmaintained/oxygen-fonts/-/archive/v${finalAttrs.version}/oxygen-fonts-v${finalAttrs.version}.zip";
+    hash = "sha256-N8fU5/iqgtFqaqdGuqbEVDsFCmVcHXLodo/T5NZMu8U=";
   };
 
   nativeBuildInputs = [ installFonts ];
@@ -50,4 +48,4 @@ stdenvNoCC.mkDerivation {
     maintainers = with lib.maintainers; [ VarNepvius ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
The oxygen fonts package should include the Oxygen Sans font family. However, due to how the paths to the TTF files were given, the built package actually contained only Oxygen Mono. This PR fixes this by transitioning the package to the `installFonts` hook, which finds the files by itself.

Apart from that this PR:
* Adds myself to the maintainers list
* Adds myself as maintainer of this package
* Changes the source to [the KDE repo, where the font family was tracked as part of KDE](https://invent.kde.org/unmaintained/oxygen-fonts). 
  This is to simplify the build, as the former source contained two conflicting versions of the Oxygen Sans fonts as well as other font files as “source“, which we don't want to include here. The relevant files are the same in both repositories


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
