### PR TITLE
rocq-mcp: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ro/rocq-mcp/package.nix
+++ b/pkgs/by-name/ro/rocq-mcp/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "rocq-mcp";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "rocq-mcp";
+    tag = finalAttrs.version;
+    hash = "sha256-EO7M6x/rboC41aYcyQbcJymqlYbIxir2P9Ib1CIO3kE=";
+  };
+
+  __structuredAttrs = true;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"pytanque @ git+https://github.com/LLM4Rocq/pytanque.git"' '"pytanque"'
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    mcp
+    pytanque
+  ];
+
+  pythonImportsCheck = [ "rocq_mcp" ];
+
+  meta = {
+    description = "Model Context Protocol server for the Rocq/Coq proof assistant";
+    homepage = "https://github.com/LLM4Rocq/rocq-mcp";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ damhiya ];
+    mainProgram = "rocq-mcp";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/pytanque/default.nix
+++ b/pkgs/development/python-modules/pytanque/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  requests,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytanque";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LLM4Rocq";
+    repo = "pytanque";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1Hae21BuMdE6MjRdiBO7fcsuS4HzahOdLLhynAUox3I=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    typing-extensions
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "pytanque" ];
+
+  meta = {
+    description = "Python API for lightweight communication with the Rocq proof assistant via coq-lsp";
+    homepage = "https://github.com/LLM4Rocq/pytanque";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ damhiya ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15226,6 +15226,8 @@ self: super: with self; {
 
   pytankerkoenig = callPackage ../development/python-modules/pytankerkoenig { };
 
+  pytanque = callPackage ../development/python-modules/pytanque { };
+
   pytap2 = callPackage ../development/python-modules/pytap2 { };
 
   pytapo = callPackage ../development/python-modules/pytapo { };


### PR DESCRIPTION
Add [rocq-mcp](https://github.com/LLM4Rocq/rocq-mcp) package and its dependency [pytanque](https://github.com/LLM4Rocq/pytanque). rocq-mcp is a model context protocol server implementation for the Rocq proof assistant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
