### PR TITLE
eas-cli: fix missing commands

### DIFF
--- a/pkgs/by-name/ea/eas-cli/package.nix
+++ b/pkgs/by-name/ea/eas-cli/package.nix
@@ -8,6 +8,8 @@
   makeWrapper,
   pkg-config,
   python3,
+  runCommand,
+  eas-cli,
 }:
 let
   version = "18.7.0";
@@ -54,6 +56,12 @@ stdenv.mkDerivation (finalAttrs: {
     mv "$tmpfile" lerna.json
   '';
 
+  buildPhase = ''
+    runHook preBuild
+    yarn build
+    runHook postBuild
+  '';
+
   # yarnInstallHook strips out build outputs within packages/eas-cli resulting in most commands missing from eas-cli.
   installPhase = ''
     runHook preInstall
@@ -61,15 +69,25 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib/node_modules/eas-cli-root
     cp -r . $out/lib/node_modules/eas-cli-root
 
+    mkdir -p $out/bin
+    patchShebangs $out/lib/node_modules/eas-cli-root/packages/eas-cli/bin/run
+    ln -sf $out/lib/node_modules/eas-cli-root/packages/eas-cli/bin/run $out/bin/eas
+
     runHook postInstall
   '';
 
-  # postFixup is used to override the symlink created in the fixupPhase
-  postFixup = ''
-    mkdir -p $out/bin
-    ln -sf $out/lib/node_modules/eas-cli-root/packages/eas-cli/bin/run $out/bin/eas
-    wrapProgram $out/bin/eas --suffix PATH : ${lib.makeBinPath [ nodejs ]}
-  '';
+  passthru.tests = {
+    # CLI command registration is dynamic. There have been multiple issues
+    # where the build succeeds and the CLI executes, but the author does not
+    # catch that the install caused command registration to fail. This tests
+    # that a TOPICS section exists. In the previous failure modes, only a
+    # COMMAND section exists.
+    check-topics = runCommand "${finalAttrs.pname}-check-topics" { nativeBuildInputs = [ eas-cli ]; } ''
+      if eas | grep -q "^TOPICS$"; then
+          touch $out
+      fi
+    '';
+  };
 
   meta = {
     changelog = "https://github.com/expo/eas-cli/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
After moving to Yarn 4, "yarn build" is required to build subpackages. This also adds a test to confirm that the build is configured properly, as a similar issue has happened once before. This moves to patching shebangs rather than wrapping the executable so this can execute in a chroot environment for tests.

Resolves #512803  

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
