### PR TITLE
everforest-gtk-theme: Expose variants options 

### DIFF
--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -2,44 +2,121 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  sassc,
   gnome-themes-extra,
   gtk-engine-murrine,
+  unstableGitUpdater,
+  colorVariants ? [ ],
+  sizeVariants ? [ ],
+  themeVariants ? [ ],
+  tweakVariants ? [ ],
+  iconVariants ? [ ],
 }:
 
-stdenvNoCC.mkDerivation {
+let
   pname = "everforest-gtk-theme";
-  version = "0-unstable-2025-10-15";
-
-  src = fetchFromGitHub {
-    owner = "Fausto-Korpsvart";
-    repo = "Everforest-GTK-Theme";
-    rev = "930a5dc57f7a06e8c6538d531544e41c56dbb27a";
-    hash = "sha256-mlJE7gVElWUjJIZnAL5ztchphmaU82llol+YdKqnSxg=";
-  };
-
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine
+  colorVariantList = [
+    "dark"
+    "light"
   ];
-
-  buildInputs = [
-    gnome-themes-extra
+  sizeVariantList = [
+    "compact"
+    "standard"
   ];
+  themeVariantList = [
+    "default"
+    "green"
+    "grey"
+    "orange"
+    "pink"
+    "purple"
+    "red"
+    "teal"
+    "yellow"
+    "all"
+  ];
+  tweakVariantList = [
+    "medium"
+    "soft"
+    "black"
+    "float"
+    "outline"
+    "macos"
+  ];
+  iconVariantList = [
+    "Everforest-Dark"
+    "Everforest-Light"
+  ];
+in
+lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants lib.checkListOfEnum
+  "${pname}: sizeVariants"
+  sizeVariantList
+  sizeVariants
+  lib.checkListOfEnum
+  "${pname}: themeVariants"
+  themeVariantList
+  themeVariants
+  lib.checkListOfEnum
+  "${pname}: tweakVariants"
+  tweakVariantList
+  tweakVariants
+  lib.checkListOfEnum
+  "${pname}: iconVariants"
+  iconVariantList
+  iconVariants
 
-  dontBuild = true;
+  stdenvNoCC.mkDerivation
+  {
+    inherit pname;
+    version = "0-unstable-2025-10-24";
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p "$out/share/"{themes,icons}
-    cp -a icons/* "$out/share/icons/"
-    cp -a themes/* "$out/share/themes/"
-    runHook postInstall
-  '';
+    src = fetchFromGitHub {
+      owner = "Fausto-Korpsvart";
+      repo = "Everforest-GTK-Theme";
+      rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
+      hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
+    };
 
-  meta = {
-    description = "Everforest colour palette for GTK";
-    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
-    license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ jn-sena ];
-    platforms = lib.platforms.unix;
-  };
-}
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine
+    ];
+
+    nativeBuildInputs = [ sassc ];
+    buildInputs = [
+      gnome-themes-extra
+    ];
+
+    dontBuild = true;
+
+    passthru.updateScript = unstableGitUpdater { };
+
+    postPatch = ''
+      patchShebangs themes/install.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/themes
+      cd themes
+      ./install.sh -n Everforest \
+      ${lib.optionalString (colorVariants != [ ]) "-c " + toString colorVariants} \
+      ${lib.optionalString (sizeVariants != [ ]) "-s " + toString sizeVariants} \
+      ${lib.optionalString (themeVariants != [ ]) "-t " + toString themeVariants} \
+      ${lib.optionalString (tweakVariants != [ ]) "--tweaks " + toString tweakVariants} \
+      -d "$out/share/themes"
+      cd ../icons
+      ${lib.optionalString (iconVariants != [ ]) ''
+        mkdir -p $out/share/icons
+        cp -a ${toString (map (v: "${v}") iconVariants)} $out/share/icons/
+      ''}
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Everforest colour palette for GTK";
+      homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ jn-sena ];
+      platforms = lib.platforms.unix;
+    };
+  }

--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -6,69 +6,140 @@
   gtk-engine-murrine,
   gtk3,
   sassc,
+  unstableGitUpdater,
+  colorVariants ? [ ],
+  sizeVariants ? [ ],
+  themeVariants ? [ ],
+  tweakVariants ? [ ],
+  iconVariants ? [ ],
 }:
 
-stdenvNoCC.mkDerivation {
+let
   pname = "everforest-gtk-theme";
-  version = "0-unstable-2025-10-23";
 
-  src = fetchFromGitHub {
-    owner = "Fausto-Korpsvart";
-    repo = "Everforest-GTK-Theme";
-    rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
-    hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
-  };
-
-  patches = [
-    # remove when merged
-    # https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/pull/34
-    ./fix-install-script.patch
+  colorVariantList = [
+    "dark"
+    "light"
   ];
-
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine
+  sizeVariantList = [
+    "compact"
+    "standard"
   ];
-
-  buildInputs = [
-    gnome-themes-extra
+  themeVariantList = [
+    "default"
+    "green"
+    "grey"
+    "orange"
+    "pink"
+    "purple"
+    "red"
+    "teal"
+    "yellow"
+    "all"
   ];
-
-  nativeBuildInputs = [
-    gtk3
-    sassc
+  tweakVariantList = [
+    "medium"
+    "soft"
+    "black"
+    "float"
+    "outline"
+    "macos"
   ];
+  iconVariantList = [
+    "Dark"
+    "Light"
+  ];
+in
+lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants lib.checkListOfEnum
+  "${pname}: sizeVariants"
+  sizeVariantList
+  sizeVariants
+  lib.checkListOfEnum
+  "${pname}: themeVariants"
+  themeVariantList
+  themeVariants
+  lib.checkListOfEnum
+  "${pname}: tweakVariants"
+  tweakVariantList
+  tweakVariants
+  lib.checkListOfEnum
+  "${pname}: iconVariants"
+  iconVariantList
+  iconVariants
 
-  dontBuild = true;
-  dontFixup = true;
-  dontDropIconThemeCache = true;
+  stdenvNoCC.mkDerivation
+  {
+    inherit pname;
+    version = "0-unstable-2025-10-23";
 
-  postPatch = ''
-    patchShebangs themes/install.sh
-  '';
+    src = fetchFromGitHub {
+      owner = "Fausto-Korpsvart";
+      repo = "Everforest-GTK-Theme";
+      rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
+      hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
+    };
 
-  installPhase = ''
-    runHook preInstall
+    patches = [
+      # remove when merged
+      # https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme/pull/34
+      ./fix-install-script.patch
+    ];
 
-    mkdir -p "$out/share/"{themes,icons}
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine
+    ];
 
-    cp -a icons/* "$out/share/icons/"
+    nativeBuildInputs = [
+      gtk3
+      sassc
+    ];
 
-    for theme in "$out/share/icons/"*; do
-      gtk-update-icon-cache "$theme"
-    done
+    buildInputs = [
+      gnome-themes-extra
+    ];
 
-    cd themes
-    ./install.sh --name Everforest --theme all --dest "$out/share/themes"
-    cd ..
+    dontBuild = true;
+    dontFixup = true;
+    dontDropIconThemeCache = true;
 
-    runHook postInstall
-  '';
+    postPatch = ''
+      patchShebangs themes/install.sh
+    '';
 
-  meta = {
-    description = "Everforest colour palette for GTK";
-    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
-    license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ jn-sena ];
-    platforms = lib.platforms.unix;
-  };
-}
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/share/"{themes,icons}
+
+      cd themes
+      ./install.sh --name Everforest \
+      ${lib.optionalString (colorVariants != [ ]) "--color " + toString colorVariants} \
+      ${lib.optionalString (sizeVariants != [ ]) "--size " + toString sizeVariants} \
+      ${lib.optionalString (themeVariants != [ ]) "--theme " + toString themeVariants} \
+      ${lib.optionalString (tweakVariants != [ ]) "--tweaks " + toString tweakVariants} \
+      --dest "$out/share/themes"
+      cd ..
+
+      ${lib.optionalString (iconVariants != [ ]) ''
+        cd icons
+        mkdir -p $out/share/icons
+        cp -a ${toString (map (v: "Everforest-${v}") iconVariants)} $out/share/icons/
+        for theme in "$out/share/icons/"*; do
+          gtk-update-icon-cache "$theme"
+        done
+        cd ..
+      ''}
+
+      runHook postInstall
+    '';
+
+    passthru.updateScript = unstableGitUpdater { };
+
+    meta = {
+      description = "Everforest colour palette for GTK";
+      homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ jn-sena ];
+      platforms = lib.platforms.unix;
+    };
+  }


### PR DESCRIPTION
Update https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme
I changed the package.nix to follow the format of nightfox and other gtk themes. This adds options for color, size, theme, tweak, icon variants that get passed to install.sh 

Ping maintainer: 
@jn-sena 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
