### PR TITLE
tinycbor: 0.6.1 -> 7.0

### DIFF
--- a/pkgs/by-name/ti/tinycbor/package.nix
+++ b/pkgs/by-name/ti/tinycbor/package.nix
@@ -1,4 +1,5 @@
 {
+  cmake,
   lib,
   stdenv,
   fetchFromGitHub,
@@ -6,22 +7,22 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinycbor";
-  version = "0.6.1";
+  version = "7.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "tinycbor";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-JgkZAvZ63jjTdFRnyk+AeIWcGsg36UtPPFbhFjky9e8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Fuw/hV3tVzoKf2Xrw64xuU+7xzSRPWL/ZdLjF0qICDY=";
   };
 
-  makeFlags = [ "prefix=$(out)" ];
+  nativeBuildInputs = [ cmake ];
 
   meta = {
     description = "Concise Binary Object Representation (CBOR) Library";
     mainProgram = "cbordump";
     homepage = "https://github.com/intel/tinycbor";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
   };
 })


### PR DESCRIPTION
Update tinycbor to 7.0. Build changes from Makefiles to cmake.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
