### PR TITLE
python3Packages.cssutils: 2.11.1 -> 2.14.0

### DIFF
--- a/pkgs/development/python-modules/cssutils/default.nix
+++ b/pkgs/development/python-modules/cssutils/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools-scm,
+  encutils,
   more-itertools,
   cssselect,
   jaraco-test,
@@ -13,19 +14,27 @@
 
 buildPythonPackage rec {
   pname = "cssutils";
-  version = "2.11.1";
+  version = "2.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jaraco";
     repo = "cssutils";
     tag = "v${version}";
-    hash = "sha256-U9myMfKz1HpYVJXp85izRBpm2wjLHYZj8bUVt3ROTEg=";
+    hash = "sha256-kuqHfwJn+GT1VIC2PWu5Oj1X6SGn/bi2QPN8kfposVs=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"coherent.licensed",' ""
+  '';
 
   build-system = [ setuptools-scm ];
 
-  dependencies = [ more-itertools ];
+  dependencies = [
+    encutils
+    more-itertools
+  ];
 
   nativeCheckInputs = [
     cssselect
@@ -37,7 +46,6 @@ buildPythonPackage rec {
 
   disabledTests = [
     # access network
-    "encutils"
     "website.logging"
   ];
 

--- a/pkgs/development/python-modules/encutils/default.nix
+++ b/pkgs/development/python-modules/encutils/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  chardet,
+  fetchPypi,
+  flit-core,
+  lib,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "encutils";
+  version = "1.0.0";
+  pyproject = true;
+
+  # pyproject.toml on GitHub uses coherent.build as build-system
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-OOylrxjOur2L5DwX8UydP7uoPMX3rI46schuJMSyuRo=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    chardet
+  ];
+
+  pythonImportsCheck = [ "encutils" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Collection of helper functions to detect encodings of text files";
+    homepage = "https://github.com/coherent-oss/encutils";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5016,6 +5016,8 @@ self: super: with self; {
 
   encodec = callPackage ../development/python-modules/encodec { };
 
+  encutils = callPackage ../development/python-modules/encutils { };
+
   energyflip-client = callPackage ../development/python-modules/energyflip-client { };
 
   energyflow = callPackage ../development/python-modules/energyflow { };


### PR DESCRIPTION
Diff: https://github.com/jaraco/cssutils/compare/v2.11.1...v2.14.0

Changelog: https://github.com/jaraco/cssutils/blob/refs/tags/v2.14.0/NEWS.rst

I'm not going to package [coherent.build](https://github.com/coherent-oss/coherent.build) because its pyproject.toml literally specifies itself as a requirement for the build-system.
I don't get what this jaraco guy is smoking to believe that he has to [reinvent the wheel](https://github.com/coherent-oss/system) and make packaging his software hell.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
