### PR TITLE
neovim: handle plugins without pname

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -247,6 +247,15 @@ pkgs.lib.recurseIntoAttrs rec {
       };
     };
 
+  nvim_with_no_pname_plugin = neovim.override {
+    extraName = "-with-no-pname-plugin";
+    configure.packages.plugins = {
+      start = [
+        vimPlugins.corePlugins
+      ];
+    };
+  };
+
   # regression test that ftplugin files from plugins are loaded before the ftplugin
   # files from $VIMRUNTIME
   run_nvim_with_ftplugin = runTest nvim_with_ftplugin ''
@@ -258,6 +267,10 @@ pkgs.lib.recurseIntoAttrs rec {
     result="$(cat plugin_was_loaded_too_late)"
     echo $result
     [ "$result" = 0 ]
+  '';
+
+  run_nvim_with_no_pname_plugin = runTest nvim_with_no_pname_plugin ''
+    ${nvim_with_no_pname_plugin}/bin/nvim -i NONE -e --headless +quit
   '';
 
   # Generate a neovim wrapper with only a init.lua and no init.vim file

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -218,7 +218,7 @@ let
             paths = allGrammars;
           };
 
-          allAndOptPluginNames = map (plugin: plugin.pname) (allPlugins ++ opt);
+          allAndOptPluginNames = map (plugin: plugin.pname or null) (allPlugins ++ opt);
 
           packdirStart = vimFarm "pack/${packageName}/start" "packdir-start" (
             if allGrammars != [ ] then allPlugins ++ [ allGrammarsSymlinked ] else allPlugins


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Related https://github.com/nix-community/nixvim/issues/4261

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
