### PR TITLE
tinyfugue: fix build with gcc15; migrate to pcre2

### DIFF
--- a/pkgs/by-name/ti/tinyfugue/package.nix
+++ b/pkgs/by-name/ti/tinyfugue/package.nix
@@ -2,7 +2,9 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   ncurses,
+  pcre2,
   zlib,
   openssl,
   sslSupport ? true,
@@ -31,12 +33,30 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-build.patch
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/tinyfugue/raw/ce016e8fb60a51de7c9d0c45dad109b3809de048/f/tinyfigue-configure-c99.patch";
+      hash = "sha256-Ge6545PCgcvnSgtDChqUQgf6b3BMjNveBAxQ8fAy8f4=";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/tinyfugue/raw/ce016e8fb60a51de7c9d0c45dad109b3809de048/f/tf-50b8.pcre.patch";
+      hash = "sha256-T0XiadrviyuvtZZKYG/kXHQSC7RZkLKQGHOMrnfyLVg=";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/tinyfugue/raw/ce016e8fb60a51de7c9d0c45dad109b3809de048/f/tf-50b8-pcre2.patch";
+      hash = "sha256-pTtCUwMBk+t4lK0Z1fKPKaQemdpEdVPe2NScpD8QBS8=";
+    })
   ];
+
+  postPatch = ''
+    # remove bundled old PCRE
+    rm -rv src/pcre-2.08
+  '';
 
   configureFlags = optional (!sslSupport) "--disable-ssl";
 
   buildInputs = [
     ncurses
+    pcre2
     zlib
   ]
   ++ optional sslSupport openssl;
@@ -45,7 +65,7 @@ stdenv.mkDerivation rec {
   # gcc-10. Otherwise build fails as:
   #   ld: world.o:/build/tf-50b8/src/socket.h:24: multiple definition of
   #     `world_decl'; command.o:/build/tf-50b8/src/socket.h:24: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  env.NIX_CFLAGS_COMPILE = "-fcommon -Wno-incompatible-pointer-types -Wno-return-mismatch";
 
   meta = {
     homepage = "https://tinyfugue.sourceforge.net/";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324339506
- #356387 

```
In file included from attr.c:11:
port.h:87:13: warning: conflicting types for built-in function 'free'; expected 'void(void *)' [-Wbuiltin-declaration-mismatch]
   87 | extern void free();
      |             ^~~~
port.h:75:1: note: 'free' is declared in header '<stdlib.h>'
   74 | # include <unistd.h>
  +++ |+#include <stdlib.h>
   75 | #endif
In file included from malloc.h:37,
                 from tf.h:46,
                 from attr.c:12:
/nix/store/h0ip0h6qp7kc2wm7mwjaglkxxbzmjri4-glibc-2.42-51-dev/include/stdlib.h:687:13: error: conflicting types for 'free'; have 'void(void *)'
  687 | extern void free (void *__ptr) __THROW;
      |             ^~~~
port.h:87:13: note: previous declaration of 'free' with type 'void(void)'
   87 | extern void free();
      |             ^~~~
```

Fetched Fedora patches to unvendor the bundled pcre and use pcre2.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
