### PR TITLE
virtme-ng: init at 1.41

### DIFF
--- a/pkgs/by-name/vi/virtme-ng/package.nix
+++ b/pkgs/by-name/vi/virtme-ng/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "virtme-ng";
+  version = "1.41";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "arighi";
+    repo = "virtme-ng";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/R+2ND/N+exF9eDSxAN8LR3cDuxBvpGSkiXcckyq8TY=";
+    fetchSubmodules = true;
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    argcomplete
+    argparse-manpage
+    requests
+    setuptools
+  ];
+
+  optional-dependencies = with python3Packages; {
+    mcp = [
+      anyio
+      mcp
+    ];
+  };
+
+  pythonImportsCheck = [
+    "virtme_ng"
+  ];
+
+  meta = {
+    description = "Quickly build and run kernels inside a virtualized snapshot of your live system";
+    longDescription = ''
+      virtme-ng is a tool that allows to easily and quickly recompile and test
+      a Linux kernel, starting from the source code.
+
+      It allows recompiling the kernel in few minutes (rather than hours), then
+      the kernel is automatically started in a virtualized environment that is
+      an exact copy-on-write copy of your live system, which means that any
+      changes made to the virtualized environment do not affect the host
+      system.
+    '';
+    homepage = "https://github.com/arighi/virtme-ng";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ eljamm ];
+    mainProgram = "virtme-ng";
+  };
+})


### PR DESCRIPTION
Adds [virtme-ng](https://github.com/arighi/virtme-ng), a CLI tool that makes it easy to recompile and test Linux kernels.

```shellSession
$ nix shell github:eljamm/nixpkgs/init/virtme-ng#virtme-ng --command nix develop github:eljamm/nixpkgs/init/virtme-ng#linux
$ uname -r
6.19.11-xanmod1
$ git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
$ cd linux
$ vng --build --commit v7.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
