### PR TITLE
nixos/tlsrpt: add organization name to sender address

### DIFF
--- a/nixos/modules/services/mail/tlsrpt.nix
+++ b/nixos/modules/services/mail/tlsrpt.nix
@@ -244,12 +244,12 @@ in
               type = with types; nullOr str;
               default =
                 if config.services.postfix.enable && config.services.postfix.setSendmail then
-                  "/run/wrappers/bin/sendmail -i -t -f ${cfg.reportd.settings.sender_address}"
+                  "/run/wrappers/bin/sendmail -i -t -r '${cfg.reportd.settings.sender_address}'"
                 else
                   null;
               defaultText = lib.literalExpression ''
                 if config.services.postfix.enable && config.services.postfix.setSendmail then
-                  "/run/wrappers/bin/sendmail -i -t -f $${cfg.reportd.settings.sender_address}"
+                  "/run/wrappers/bin/sendmail -i -t -r '$${cfg.reportd.settings.sender_address}'"
                 else
                   null
               '';

--- a/pkgs/by-name/tl/tlsrpt-reporter/package.nix
+++ b/pkgs/by-name/tl/tlsrpt-reporter/package.nix
@@ -34,6 +34,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     })
     # https://github.com/sys4/tlsrpt-reporter/pull/48
     ./logging.patch
+    # Update 'From' header
+    ./update_from_header.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/tl/tlsrpt-reporter/update_from_header.patch
+++ b/pkgs/by-name/tl/tlsrpt-reporter/update_from_header.patch
@@ -1,0 +1,13 @@
+diff --git a/tlsrpt_reporter/tlsrpt.py b/tlsrpt_reporter/tlsrpt.py
+index b438650..dbcfaf2 100644
+--- a/tlsrpt_reporter/tlsrpt.py
++++ b/tlsrpt_reporter/tlsrpt.py
+@@ -1226,7 +1226,7 @@ class TLSRPTReportd(VersionedSQLite):
+         # Call send script
+         msg = EmailReport()
+         msg['Subject'] = self.create_email_subject(dom, self.report_id(day, uniqid, dom))
+-        msg['From'] = self.cfg.sender_address
++        msg['From'] = f'"{self.cfg.organization_name}" <{self.cfg.sender_address}>'
+         msg['To'] = dest
+         msg.add_header("Message-ID", email.utils.make_msgid(domain=msg["From"].groups[0].addresses[0].domain))
+         msg.add_header("TLS-Report-Domain", dom)


### PR DESCRIPTION
Add organization name to sender address.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
