### PR TITLE
build-support/vm: fix fillDiskWith*

### DIFF
--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -730,9 +730,8 @@ let
             memSize
             ;
 
-          # Flatten this into string explicitly to allow IFS tricks below to work,
-          # and support structuredAttrs
-          debsInterspersed = toString (lib.intersperse "|" debs);
+          debsFlat = lib.flatten debs;
+          debsGrouped = debs;
 
           preVM = createEmptyImage { inherit size fullName; };
 
@@ -751,11 +750,9 @@ let
             # (which have lots of circular dependencies) from barfing.
             echo "unpacking Debs..."
 
-            for deb in $debsInterspersed; do
-              if test "$deb" != "|"; then
-                echo "$deb..."
-                dpkg-deb --extract "$deb" /mnt
-              fi
+            for deb in "''${debsFlat[@]}"; do
+              echo "$deb..."
+              dpkg-deb --extract "$deb" /mnt
             done
 
             # Make the Nix store available in /mnt, because that's where the .debs live.
@@ -778,10 +775,7 @@ let
 
             export DEBIAN_FRONTEND=noninteractive
 
-            oldIFS="$IFS"
-            IFS="|"
-            for component in $debsInterspersed; do
-              IFS="$oldIFS"
+            for component in "''${debsGrouped[@]}"; do
               echo
               echo ">>> INSTALLING COMPONENT: $component"
               debs=

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -568,7 +568,7 @@ let
 
           echo "unpacking RPMs..."
           set +o pipefail
-          for i in $rpms; do
+          for i in "''${rpms[@]}"; do
               echo "$i..."
               ${rpm}/bin/rpm2cpio "$i" | chroot /mnt ${cpio}/bin/cpio -i --make-directories --unconditional
           done
@@ -585,7 +585,7 @@ let
 
           echo "installing RPMs..."
           PATH=/usr/bin:/bin:/usr/sbin:/sbin $chroot /mnt \
-            rpm -iv --nosignature ${lib.optionalString (!runScripts) "--noscripts"} $rpms
+            rpm -iv --nosignature ${lib.optionalString (!runScripts) "--noscripts"} "''${rpms[@]}"
 
           echo "running post-install script..."
           eval "$postInstall"

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -730,7 +730,9 @@ let
             memSize
             ;
 
-          debs = (lib.intersperse "|" debs);
+          # Flatten this into string explicitly to allow IFS tricks below to work,
+          # and support structuredAttrs
+          debsInterspersed = toString (lib.intersperse "|" debs);
 
           preVM = createEmptyImage { inherit size fullName; };
 
@@ -749,7 +751,7 @@ let
             # (which have lots of circular dependencies) from barfing.
             echo "unpacking Debs..."
 
-            for deb in $debs; do
+            for deb in $debsInterspersed; do
               if test "$deb" != "|"; then
                 echo "$deb..."
                 dpkg-deb --extract "$deb" /mnt
@@ -778,7 +780,7 @@ let
 
             oldIFS="$IFS"
             IFS="|"
-            for component in $debs; do
+            for component in $debsInterspersed; do
               IFS="$oldIFS"
               echo
               echo ">>> INSTALLING COMPONENT: $component"


### PR DESCRIPTION
After `__structuredAttrs` was enabled in `runInLinuxVM`, the structure of `debs` and `rpms` matters.

Fixes https://github.com/NixOS/nixpkgs/issues/505925 .

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
