### PR TITLE
nixos/parallels-guest: fix prltoolsd on NixOS for Parallels 26+

### DIFF
--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -60,7 +60,11 @@ in
       # prltoolsd mount scripts invoke coreutils (tail, mkdir, chmod)
       # and gnused (sed) without inheriting the service PATH in all
       # code paths. Make them available alongside prl-tools.
-      path = [ prl-tools pkgs.coreutils pkgs.gnused ];
+      path = [
+        prl-tools
+        pkgs.coreutils
+        pkgs.gnused
+      ];
       serviceConfig = {
         ExecStart = "${prl-tools}/bin/prltoolsd -f";
         PIDFile = "/var/run/prltoolsd.pid";

--- a/nixos/modules/virtualisation/parallels-guest.nix
+++ b/nixos/modules/virtualisation/parallels-guest.nix
@@ -47,10 +47,20 @@ in
 
     services.timesyncd.enable = false;
 
+    # Parallels Desktop 26+ mounts shared folders under /mnt/psf by default.
+    # prltoolsd tries to create subdirectories there at runtime, which fails
+    # if /mnt/psf does not exist. Create it declaratively via tmpfiles.
+    systemd.tmpfiles.rules = [
+      "d /mnt/psf 0755 root root - -"
+    ];
+
     systemd.services.prltoolsd = {
       description = "Parallels Tools Service";
       wantedBy = [ "multi-user.target" ];
-      path = [ prl-tools ];
+      # prltoolsd mount scripts invoke coreutils (tail, mkdir, chmod)
+      # and gnused (sed) without inheriting the service PATH in all
+      # code paths. Make them available alongside prl-tools.
+      path = [ prl-tools pkgs.coreutils pkgs.gnused ];
       serviceConfig = {
         ExecStart = "${prl-tools}/bin/prltoolsd -f";
         PIDFile = "/var/run/prltoolsd.pid";


### PR DESCRIPTION
Parallels Desktop 26+ changed the shared folder mount base path from /media/psf to /mnt/psf. The prltoolsd daemon tries to create mount point subdirectories under /mnt/psf at runtime using mkdir, which fails on NixOS because /mnt/psf does not exist.

Fix: create /mnt/psf declaratively via systemd.tmpfiles.

Additionally, prltoolsd's shell mount scripts invoke coreutils utilities (tail, mkdir, chmod) and sed without inheriting the service PATH in all execution paths. Add coreutils and gnused to the service path so these tools are reliably available.

Note: prltoolsd also attempts to update /etc/fstab, which is a read-only Nix store symlink on NixOS. This produces a harmless warning but does not affect the FUSE-based mounting via prl_fsd.

Tested on: NixOS 26.05, Parallels Desktop 26.3.0-57392, aarch64


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
