### PR TITLE
anydesk: add missing aarch64 dependencies (wayland, libepoxy, libxkbcommon)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9162,6 +9162,12 @@
     githubId = 119691;
     name = "Michael Gough";
   };
+  fraioveio = {
+    email = "francesco@vecchia.lol";
+    github = "FraioVeio";
+    githubId = 181361445;
+    name = "Francesco Vecchia";
+  };
   franciscod = {
     github = "franciscod";
     githubId = 726447;

--- a/pkgs/by-name/an/anydesk/package.nix
+++ b/pkgs/by-name/an/anydesk/package.nix
@@ -42,6 +42,9 @@
   copyDesktopItems,
   pulseaudio,
   udev,
+  libxkbcommon,
+  wayland,
+  libepoxy,
 }:
 
 let
@@ -100,6 +103,9 @@ stdenv.mkDerivation (finalAttrs: {
     libsm
     libxrender
     udev
+    libxkbcommon
+    wayland
+    libepoxy
   ];
 
   nativeBuildInputs = [
@@ -188,6 +194,6 @@ stdenv.mkDerivation (finalAttrs: {
       "aarch64-linux"
     ];
     mainProgram = "anydesk";
-    maintainers = [ ];
+    maintainers = [ fraioveio ];
   };
 })


### PR DESCRIPTION
The aarch64 binary of AnyDesk requires wayland, libepoxy and libxkbcommon,
which are not present in the x86_64 binary. Without these the package failed
to start on aarch64-linux. Also added myself as maintainer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.