### PR TITLE
anydesk: add missing aarch64 dependencies (wayland, libepoxy, libxkbcommon) and package update

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9162,6 +9162,12 @@
     githubId = 119691;
     name = "Michael Gough";
   };
+  fraioveio = {
+    email = "francesco@vecchia.lol";
+    github = "FraioVeio";
+    githubId = 181361445;
+    name = "Francesco Vecchia";
+  };
   franciscod = {
     github = "franciscod";
     githubId = 726447;

--- a/pkgs/by-name/an/anydesk/package.nix
+++ b/pkgs/by-name/an/anydesk/package.nix
@@ -42,6 +42,9 @@
   copyDesktopItems,
   pulseaudio,
   udev,
+  libxkbcommon,
+  wayland,
+  libepoxy,
 }:
 
 let
@@ -100,6 +103,9 @@ stdenv.mkDerivation (finalAttrs: {
     libsm
     libxrender
     udev
+    libxkbcommon
+    wayland
+    libepoxy
   ];
 
   nativeBuildInputs = [
@@ -188,6 +194,6 @@ stdenv.mkDerivation (finalAttrs: {
       "aarch64-linux"
     ];
     mainProgram = "anydesk";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ fraioveio ];
   };
 })

--- a/pkgs/by-name/an/anydesk/pin.json
+++ b/pkgs/by-name/an/anydesk/pin.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.3",
-  "x86_64-linux": "sha256-b1WSQMRlFaqhECCBKoPjUIww5Fj3yfN8wxwACuO7RR4=",
-  "aarch64-linux": "sha256-Yb5Jnjxs8AmMeFvWY+VYGTovpLwW1PRPBEJZUF63gA0="
+  "version": "8.0.2",
+  "x86_64-linux": "sha256-6noMPfe0x6kx/whyd66qcmk7WhEivx3xK5q58Se9Ij0=",
+  "aarch64-linux": "sha256-wfY+OCx9OyLCmiA29RjnYzcg/pApMIXWT5UrcdcyRYM="
 }


### PR DESCRIPTION
The aarch64 binary of AnyDesk requires wayland, libepoxy and libxkbcommon,
which are not present in the x86_64 binary. Without these the package failed
to start on aarch64-linux. Also added myself as maintainer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.