### PR TITLE
streamlink: disable broken tests on darwin

### DIFF
--- a/pkgs/by-name/st/streamlink/package.nix
+++ b/pkgs/by-name/st/streamlink/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   python3Packages,
   fetchPypi,
   replaceVars,
@@ -41,6 +42,13 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [
     # requires ffmpeg to be in PATH
     "test_no_cache"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # requires Linux-only socket.SO_BINDTODEVICE
+    "test_set_interface[unix-iface]"
+    "test_set_interface[unix-iface-prefix]"
+    "test_set_interface[unix-ifhost-prefix]"
+    "test_set_interface[unix-ifhost-prefix-invalid]"
   ];
 
   propagatedBuildInputs =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Disables tests that rely on the SO_BINDTODEVICE socket option, which is not available on macOS.

I'll open an issue upstream so that they can fix this on their end.
Update: https://github.com/streamlink/streamlink/issues/6903

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
