### PR TITLE
nixos-test-driver: add release notes for 26.05

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -51,6 +51,11 @@
 
   Users who wish to keep the classic daemon can set: `services.dbus.implementation = "dbus";`
 
+- The NixOS integration test driver now supports `systemd-nspawn` containers as an alternative backend to QEMU virtual machines ([#470248](https://github.com/NixOS/nixpkgs/pull/470248), [#478109](https://github.com/NixOS/nixpkgs/pull/478109), [#479968](https://github.com/NixOS/nixpkgs/pull/479968)).
+  Most NixOS integration tests do not require a full VM, and switching them to containers can considerably reduce test time and resource usage.
+  Container-based tests also run fine on Nix builders that are themselves VMs without KVM, and because containers can bind-mount host device nodes, they make it possible to exercise GPU/CUDA workloads from within NixOS integration tests.
+  See [the NixOS manual section on writing tests](https://nixos.org/manual/nixos/stable/#sec-writing-nixos-tests) for details on how to opt in and on the limitations of the container backend.
+
 ## New Modules {#sec-release-26.05-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->


### PR DESCRIPTION
cc 26.05 release editors @NotAShelf @bryanhonof 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
