### PR TITLE
rstudio{,-server}: 2026.01.1+403 -> 2026.04.0+526

### DIFF
--- a/pkgs/by-name/rs/rstudio/dont-npm-ci.patch
+++ b/pkgs/by-name/rs/rstudio/dont-npm-ci.patch
@@ -1,8 +1,8 @@
 diff --git a/src/node/desktop/CMakeLists.txt b/src/node/desktop/CMakeLists.txt
-index bccf5b3..71e10a7 100644
+index 7917f0b59e..38d0023922 100644
 --- a/src/node/desktop/CMakeLists.txt
 +++ b/src/node/desktop/CMakeLists.txt
-@@ -117,11 +117,7 @@ file(MAKE_DIRECTORY "${ELECTRON_BINARY_DIR}")
+@@ -201,11 +201,7 @@ file(MAKE_DIRECTORY "${ELECTRON_BINARY_DIR}")
  file(
     COPY "${CMAKE_CURRENT_SOURCE_DIR}/"
     DESTINATION "${ELECTRON_BINARY_DIR}/"
@@ -16,13 +16,13 @@ index bccf5b3..71e10a7 100644
  configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/main/build-info.ts.in
 diff --git a/src/node/desktop/package.json b/src/node/desktop/package.json
-index df92166..47ca4b4 100644
+index 613361fb8a..0b186c9a76 100644
 --- a/src/node/desktop/package.json
 +++ b/src/node/desktop/package.json
-@@ -10,7 +10,7 @@
-   "scripts": {
+@@ -11,7 +11,7 @@
      "clean": "ts-node scripts/clean.ts",
      "lint": "eslint ./src ./test",
+     "typecheck": "tsc --noEmit",
 -    "package": "npm ci && electron-forge package",
 +    "package": "electron-forge package",
      "start": "electron-forge start -- --no-sandbox",

--- a/pkgs/by-name/rs/rstudio/dont-yarn-install.patch
+++ b/pkgs/by-name/rs/rstudio/dont-yarn-install.patch
@@ -1,16 +1,18 @@
 diff --git a/src/gwt/build.xml b/src/gwt/build.xml
-index 27ffe33..4218678 100644
+index abf850ee3d..3e3d5fea57 100644
 --- a/src/gwt/build.xml
 +++ b/src/gwt/build.xml
-@@ -139,11 +139,6 @@
+@@ -267,13 +267,6 @@
        <echo message="panmirror minify: ${panmirror.minify}"/>
  
        <mkdir dir="${panmirror.build.dir}"/>
--      <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
--         <arg value="install"/>
--         <arg value="--network-timeout"/>
--         <arg value="240000"/>
--      </exec>
+-      <retry retrycount="3">
+-         <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
+-            <arg value="install"/>
+-            <arg value="--network-timeout"/>
+-            <arg value="240000"/>
+-         </exec>
+-      </retry>
        <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
           <arg value="build"/>
           <arg value="--minify"/>

--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -17,15 +17,16 @@
   git,
   jdk,
   makeWrapper,
-  nodejs-slim,
+  nodejs,
   npmHooks,
+  python3,
   xcbuild,
   yarn,
   yarnConfigHook,
   zip,
 
-  boost187,
-  electron_38,
+  boost190,
+  electron_39,
   fontconfig,
   gnumake,
   hunspellDicts,
@@ -44,7 +45,8 @@
 }:
 
 let
-  electron = electron_38;
+  electron = electron_39;
+  boost = boost190;
 
   mathJaxSrc = fetchzip {
     url = "https://s3.amazonaws.com/rstudio-buildtools/mathjax-27.zip";
@@ -62,8 +64,8 @@ let
     owner = "quarto-dev";
     repo = "quarto";
     # Note: rev should ideally be the last commit of the release/rstudio-[codename] branch
-    rev = "591b3520eafbb4da7b26b9f31aac6948801f19d8";
-    hash = "sha256-scdm66Ekfjp5wdNDXcVZA5ZhNgFvuf/kIBF56HrE8uM=";
+    rev = "8c1669f3095c5afee6bcd98a659d51a43300bda9";
+    hash = "sha256-01urKiFz5iDtW8r+w7zwUDXUOKZIOhi/ip329RsuQ+Q=";
   };
 
   hunspellDictionaries = lib.filter lib.isDerivation (lib.unique (lib.attrValues hunspellDicts));
@@ -85,13 +87,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rstudio";
-  version = "2026.01.1+403";
+  version = "2026.04.0+526";
 
   src = fetchFromGitHub {
     owner = "rstudio";
     repo = "rstudio";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-s+t48LLvxdit6US6MB4DvpEZtUY6SSK5Qha1k4VW0Qk=";
+    hash = "sha256-6oHH3C3/MGFSOuI+FvyrLyOKRyy455Wkr75ZL8ZeiWg=";
   };
 
   # sources fetched into _deps via cmake's FetchContent
@@ -123,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     dontBuild = true;
     dontFixup = true;
 
-    outputHash = "sha256-t2kWnviFMw7TdxaJpiGDXe0M5HSIGD7o5hqWiPKUdOc=";
+    outputHash = "sha256-XzSDU4GVY6OrIFG4qCWUF94nV6fcz9zyFSlSvttVrYw=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };
@@ -135,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     ant
     jdk
 
-    nodejs-slim
+    nodejs
     yarn
     yarnConfigHook
     zip
@@ -145,12 +147,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (!server) [
     makeWrapper
-    (nodejs-slim.python.withPackages (ps: [ ps.setuptools ]))
+    (python3.withPackages (ps: [ ps.setuptools ]))
     npmHooks.npmConfigHook
   ];
 
   buildInputs = [
-    boost187
+    boost
     libuuid
     openssl
     R
@@ -249,7 +251,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "rstudio-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
     postPatch = "cd ${finalAttrs.npmRoot}";
-    hash = "sha256-7gXLCFhan/TCTlc2okMWuWzfRYXmuwcqhmGKAqJOEM0=";
+    hash = "sha256-lO+wJk0HWYrKO1Rqz8laVpZK5RUfA9ijYvtPEtVf1r4=";
   };
 
   preConfigure = ''
@@ -285,12 +287,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     # node used by cmake and node used for distribution
     # version in cmake/globals.cmake
-    RSTUDIO_NODE_VERSION="22.13.1"
-    RSTUDIO_INSTALLED_NODE_VERSION="22.21.1"
+    RSTUDIO_NODE_VERSION="22.22.2"
+    RSTUDIO_INSTALLED_NODE_VERSION="22.22.2"
 
     mkdir -p dependencies/common/node
-    ln -s ${nodejs-slim} dependencies/common/node/$RSTUDIO_NODE_VERSION
-    ln -s ${nodejs-slim} dependencies/common/node/$RSTUDIO_INSTALLED_NODE_VERSION-installed
+    ln -s ${nodejs} dependencies/common/node/$RSTUDIO_NODE_VERSION
+    ln -s ${nodejs} dependencies/common/node/$RSTUDIO_INSTALLED_NODE_VERSION-installed
 
   ''
   + lib.optionalString (!server) ''
@@ -314,7 +316,9 @@ stdenv.mkDerivation (finalAttrs: {
     rm -r electron-dist
 
     # force @electron/packager to use our electron instead of downloading it
-    substituteInPlace node_modules/@electron/packager/dist/packager.js \
+    substituteInPlace \
+      node_modules/@electron/packager/dist/packager.js \
+      node_modules/@electron-forge/core/node_modules/@electron/packager/dist/packager.js \
       --replace-fail "await this.getElectronZipPath(downloadOpts)" "'$(pwd)/electron.zip'"
 
     # now that we patched everything, we still have to run the scripts we ignored with --ignore-scripts


### PR DESCRIPTION
Updated rstudio to [2026.04.0+526](https://docs.posit.co/ide/news/#rstudio-2026.04.0).

Most notably, since this version uses Electron 39 (previously 38), it can be built without allowing insecure packages.

I've also fixed the issue caused by <https://github.com/NixOS/nixpkgs/pull/505334>, meaning <https://github.com/NixOS/nixpkgs/pull/512208> is not needed.

The PRs updating Quarto to 1.9.x (https://github.com/NixOS/nixpkgs/pull/480694 / https://github.com/NixOS/nixpkgs/pull/480693) would ideally land before this, since upstream rstudio is now shipping Quarto 1.9 with their packages. It seems to work fine as is, although I didn't fully exercise the Quarto-related features.

I've done my best with our vendored patches, but I must admit I am not fully confident that I've made all the necessary changes.
In particular, since I lack any darwin devices, I have not touched those or been able to test if the build still works.

This is my first PR, and I'd appreciate any feedback.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
