### PR TITLE
[25.11] nghttp3: 1.12.0 -> 1.15.0; ngtcp2: 1.17.0 -> 1.22.1

### DIFF
--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nghttp3";
-  version = "1.13.0";
+  version = "1.13.1";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/nghttp3/releases/download/v${finalAttrs.version}/nghttp3-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-hl22uuyA5zo7cXIJVgajvK85I0iQbhBBGtaQb6SfRy4=";
+    hash = "sha256-8lH+Vm4oIdz9BChVN15QsevqxfHKeUjQDiFWPFgiHiA=";
   };
 
   outputs = [

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nghttp3";
-  version = "1.13.1";
+  version = "1.14.0";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/nghttp3/releases/download/v${finalAttrs.version}/nghttp3-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-8lH+Vm4oIdz9BChVN15QsevqxfHKeUjQDiFWPFgiHiA=";
+    hash = "sha256-JUi0zz3Bl6hB30/rBv1jfRlx4dahu+ES3KLsYYqz6UU=";
   };
 
   outputs = [

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nghttp3";
-  version = "1.12.0";
+  version = "1.13.0";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/nghttp3/releases/download/v${finalAttrs.version}/nghttp3-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-KFl4NTevIT1npc5Cd923nIlBrUXtv6XM3VLZz0/6Qi0=";
+    hash = "sha256-hl22uuyA5zo7cXIJVgajvK85I0iQbhBBGtaQb6SfRy4=";
   };
 
   outputs = [

--- a/pkgs/by-name/ng/nghttp3/package.nix
+++ b/pkgs/by-name/ng/nghttp3/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nghttp3";
-  version = "1.14.0";
+  version = "1.15.0";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/nghttp3/releases/download/v${finalAttrs.version}/nghttp3-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-JUi0zz3Bl6hB30/rBv1jfRlx4dahu+ES3KLsYYqz6UU=";
+    hash = "sha256-xsSRpSgEgUCY5EZjDm78RZr8DT2nlS/+bL3As/mbK2I=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
-  version = "1.17.0";
+  version = "1.18.0";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/ngtcp2/releases/download/v${finalAttrs.version}/ngtcp2-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-j8hYGdFp5il4pODbNlVILOdJUafqsMdmc3tXoxQY2mE=";
+    hash = "sha256-E7r7bFCdv2pw2WBaLIkuE/WuuTZnOZWHeKhXvHDOH6c=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
-  version = "1.18.0";
+  version = "1.19.0";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/ngtcp2/releases/download/v${finalAttrs.version}/ngtcp2-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-E7r7bFCdv2pw2WBaLIkuE/WuuTZnOZWHeKhXvHDOH6c=";
+    hash = "sha256-snZBbT1cChV4En+8Q2qXLRD0vK66g6aj2ukbQcxRqTI=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
-  version = "1.19.0";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/ngtcp2/releases/download/v${finalAttrs.version}/ngtcp2-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-snZBbT1cChV4En+8Q2qXLRD0vK66g6aj2ukbQcxRqTI=";
+    hash = "sha256-P+q2i4PqGpbXur+mxvYYaYmJ2+HAm9dglpuCJ429GGM=";
   };
 
   outputs = [

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ngtcp2";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "https://github.com/ngtcp2/ngtcp2/releases/download/v${finalAttrs.version}/ngtcp2-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-P+q2i4PqGpbXur+mxvYYaYmJ2+HAm9dglpuCJ429GGM=";
+    hash = "sha256-hzVHltWssZvzEMt3vgS9IgDDImWmvnyUuGMeJsjpPKQ=";
   };
 
   outputs = [


### PR DESCRIPTION
Backports #445771 
Backports #465692
Backports #467611
Backports #478944
Backports #474554
Backports #495630
Backports #493447
Backports #511009

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
