### PR TITLE
j: 9.6.2 -> 9.7.1

### DIFF
--- a/pkgs/by-name/j/j/package.nix
+++ b/pkgs/by-name/j/j/package.nix
@@ -7,28 +7,7 @@
   avx2Support ? stdenv.hostPlatform.avx2Support,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "j";
-  version = "9.6.2";
-
-  src = fetchFromGitHub {
-    owner = "jsoftware";
-    repo = "jsource";
-    tag = version;
-    hash = "sha256-Afa2QzzgJYijcavurgGH/qwyofNn4rtFMIHzlqJwFGU=";
-  };
-
-  nativeBuildInputs = [ which ];
-  buildInputs = [ gmp ];
-
-  patches = [
-    ./fix-install-path.patch
-  ];
-
-  enableParallelBuilding = true;
-
-  dontConfigure = true;
-
+let
   # Emulate jplatform64.sh configuration variables
   jplatform =
     if stdenv.hostPlatform.isDarwin then
@@ -49,6 +28,28 @@ stdenv.mkDerivation rec {
       if stdenv.hostPlatform.isDarwin then "j64arm" else "j64"
     else
       "unsupported";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "j";
+  version = "9.7.1";
+
+  src = fetchFromGitHub {
+    owner = "jsoftware";
+    repo = "jsource";
+    tag = finalAttrs.version;
+    hash = "sha256-fW6Tc0UEPYFTgEFMUxZaVm2NU5LNFqszifqOqfdFJZY=";
+  };
+
+  nativeBuildInputs = [ which ];
+  buildInputs = [ gmp ];
+
+  patches = [
+    ./fix-install-path.patch
+  ];
+
+  enableParallelBuilding = true;
+
+  dontConfigure = true;
 
   env.NIX_LDFLAGS = "-lgmp";
 
@@ -94,4 +95,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     mainProgram = "jconsole";
   };
-}
+})


### PR DESCRIPTION
changelog: https://code.jsoftware.com/wiki/System/ReleaseNotes/J9.7

Fixes: #479840

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
