### PR TITLE
nixos/snmptrapd: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13825,6 +13825,13 @@
     email = "nixos@karpfen.dev";
     matrix = "@karpfen:matrix.org";
   };
+  kashu-02 = {
+    email = "kashu@kashu.dev";
+    github = "kashu-02";
+    githubId = 64694079;
+    name = "Shunsuke Kasuya";
+    keys = [ { fingerprint = "7C7C 0516 D651 D2C4 86F9  2A9F 0F44 84A6 5691 E216"; } ];
+  };
   kashw2 = {
     email = "supra4keanu@hotmail.com";
     github = "kashw2";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -123,6 +123,8 @@
 
 - [udp-over-tcp](https://github.com/mullvad/udp-over-tcp), a tunnel for proxying UDP traffic over a TCP stream. Available as `services.udp-over-tcp`.
 
+- [snmptrapd](https://net-snmp.sourceforge.io/), a SNMP trap daemon for receiving and logging SNMP traps. Available as [services.snmptrapd](#opt-services.snmptrapd.enable).
+
 - [turborepo-remote-cache](https://ducktors.github.io/turborepo-remote-cache/), an open-source implementation of the [Turborepo custom remote cache server](https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting). Available as [services.turborepo-remote-cache](options.html#opt-services.turborepo-remote-cache).
 
 - [RSSHub](https://github.com/DIYgod/RSSHub), a service to convert many sources into rss. Available as `services.rsshub`.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1068,6 +1068,7 @@
   ./services/monitoring/scrutiny.nix
   ./services/monitoring/smartd.nix
   ./services/monitoring/snmpd.nix
+  ./services/monitoring/snmptrapd.nix
   ./services/monitoring/sysstat.nix
   ./services/monitoring/teamviewer.nix
   ./services/monitoring/telegraf.nix

--- a/nixos/modules/services/monitoring/snmptrapd.nix
+++ b/nixos/modules/services/monitoring/snmptrapd.nix
@@ -1,0 +1,97 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.snmptrapd;
+  configFile = pkgs.writeText "snmptrapd.conf" ''
+    ${cfg.configText}
+  '';
+in
+{
+  options.services.snmptrapd = {
+    enable = lib.mkEnableOption "snmptrapd";
+
+    package = lib.mkPackageOption pkgs "net-snmp" { };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0";
+      description = ''
+        The address to listen on for SNMP trap messages.
+      '';
+      example = "127.0.0.1";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 162;
+      description = ''
+        The port to listen on for SNMP trap messages.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Open port in firewall for snmptrapd.
+      '';
+    };
+
+    configText = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        The contents of the snmptrapd.conf. If the {option}`configFile` option
+        is set, this value will be ignored.
+
+        Note that the contents of this option will be added to the Nix
+        store as world-readable plain text, {option}`configFile` can be used in
+        addition to a secret management tool to protect sensitive data, such as
+        SNMPv3 authentication and privacy credentials.
+      '';
+      example = ''
+        authCommunity log,execute,net public
+      '';
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      default = configFile;
+      defaultText = lib.literalMD "The value of {option}`configText`.";
+      description = ''
+        Path to the snmptrapd.conf file. By default, a config file is
+        automatically generated from {option}`configText`.
+
+        Use this option with a secret management tool for SNMPv3 configuration
+        containing credentials.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.snmptrapd = {
+      description = "Simple Network Management Protocol (SNMP) trap daemon.";
+      documentation = [
+        "man:snmptrapd(8)"
+        "man:snmptrapd.conf(5)"
+      ];
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe' cfg.package "snmptrapd"} -f -Lo -c ${cfg.configFile} ${cfg.listenAddress}:${toString cfg.port}";
+      };
+    };
+
+    networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [
+      cfg.port
+    ];
+  };
+
+  meta.maintainers = [ lib.maintainers.kashu-02 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1494,6 +1494,7 @@ in
   snipe-it = runTest ./web-apps/snipe-it.nix;
   snips-sh = runTest ./snips-sh.nix;
   snmpd = runTest ./snmpd.nix;
+  snmptrapd = runTest ./snmptrapd.nix;
   soapui = runTest ./soapui.nix;
   soft-serve = runTest ./soft-serve.nix;
   sogo = runTest ./sogo.nix;

--- a/nixos/tests/snmptrapd.nix
+++ b/nixos/tests/snmptrapd.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+{
+  name = "snmptrapd";
+
+  nodes.snmptrapd = {
+    environment.systemPackages = with pkgs; [
+      net-snmp
+    ];
+
+    services.snmptrapd = {
+      enable = true;
+      configText = ''
+        authCommunity log,execute,net public
+      '';
+    };
+  };
+
+  testScript = ''
+    start_all();
+    machine.wait_for_unit("snmptrapd.service")
+
+    machine.succeed("snmptrap -v 2c -c public localhost \'\' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.2.1.1.6.0 s 'Just here'");
+    machine.wait_until_succeeds("journalctl -u snmptrapd -n 200 -o cat | grep -F 'Just here'");
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This pull request introduces a new NixOS module for managing the `snmptrapd` SNMP trap daemon.

Added a new module `services/monitoring/snmptrapd.nix` that allows users to enable and configure the `snmptrapd` service, including options for authorization, community strings, firewall integration, and extra configuration.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
