### PR TITLE
fetchFromForgejo: implement as first-class fetcher

### DIFF
--- a/pkgs/build-support/fetchcodeberg/default.nix
+++ b/pkgs/build-support/fetchcodeberg/default.nix
@@ -1,2 +1,2 @@
-{ lib, fetchFromGitea }:
-lib.makeOverridable (args: fetchFromGitea ({ domain = "codeberg.org"; } // args))
+{ lib, fetchFromForgejo }:
+lib.makeOverridable (args: fetchFromForgejo ({ domain = "codeberg.org"; } // args))

--- a/pkgs/build-support/fetchforgejo/default.nix
+++ b/pkgs/build-support/fetchforgejo/default.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  repoRevToNameMaybe,
+  fetchgit,
+  fetchzip,
+}:
+lib.makeOverridable (
+  {
+    owner,
+    repo,
+    rev ? null,
+    tag ? null,
+    name ? repoRevToNameMaybe repo (lib.revOrTag rev tag) "forgejo",
+    domain,
+    fetchSubmodules ? false,
+    leaveDotGit ? false,
+    deepClone ? false,
+    forceFetchGit ? false,
+    sparseCheckout ? [ ],
+    private ? false,
+    varPrefix ? null,
+    meta ? { },
+    ...
+  }@args:
+  assert (
+    lib.assertMsg (lib.xor (tag == null) (
+      rev == null
+    )) "fetchFromForgejo requires one of either `rev` or `tag` to be provided (not both)."
+  );
+  let
+    revOrTag = if tag != null then tag else rev;
+    baseUrl = "https://${domain}/${owner}/${repo}";
+    gitRepoUrl = "${baseUrl}.git";
+
+    useFetchGit =
+      fetchSubmodules || leaveDotGit || deepClone || forceFetchGit || (sparseCheckout != [ ]);
+
+    fetcher = if useFetchGit then fetchgit else fetchzip;
+
+    varBase = "NIX${lib.optionalString (varPrefix != null) "_${varPrefix}"}_FORGEJO_PRIVATE_";
+
+    privateAttrs = lib.optionalAttrs private {
+      netrcPhase = ''
+        if [ -z "''$${varBase}TOKEN" ]; then
+          echo "Error: Private fetchFromForgejo requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}TOKEN env var set." >&2
+          exit 1
+        fi
+      ''
+      + ''
+        cat > netrc <<EOF
+        machine ${domain}
+                login token
+                password ''$${varBase}TOKEN
+        EOF
+      '';
+      netrcImpureEnvVars = [ "${varBase}TOKEN" ];
+    };
+
+    passthruAttrs = removeAttrs args [
+      "owner"
+      "repo"
+      "rev"
+      "tag"
+      "domain"
+      "fetchSubmodules"
+      "forceFetchGit"
+      "private"
+      "varPrefix"
+      "leaveDotGit"
+      "deepClone"
+      "meta"
+    ];
+
+    position =
+      if args.meta.description or null != null then
+        builtins.unsafeGetAttrPos "description" args.meta
+      else if tag != null then
+        builtins.unsafeGetAttrPos "tag" args
+      else
+        builtins.unsafeGetAttrPos "rev" args;
+
+    newMeta =
+      meta
+      // {
+        homepage = meta.homepage or baseUrl;
+      }
+      // lib.optionalAttrs (position != null) {
+        position = "${position.file}:${toString position.line}";
+      };
+
+    fetcherArgs =
+      (
+        if useFetchGit then
+          {
+            url = gitRepoUrl;
+            inherit
+              rev
+              tag
+              deepClone
+              fetchSubmodules
+              sparseCheckout
+              leaveDotGit
+              ;
+          }
+        else
+          {
+            url =
+              if private then
+                "https://${domain}/api/v1/repos/${owner}/${repo}/archive/${revOrTag}.tar.gz"
+              else
+                "${baseUrl}/archive/${revOrTag}.tar.gz";
+            extension = "tar.gz";
+            passthru = {
+              inherit gitRepoUrl;
+            };
+          }
+      )
+      // privateAttrs
+      // passthruAttrs
+      // {
+        inherit name;
+      };
+  in
+  fetcher fetcherArgs
+  // {
+    meta = newMeta;
+    inherit owner repo tag;
+    rev = revOrTag;
+  }
+)

--- a/pkgs/build-support/fetchforgejo/tests.nix
+++ b/pkgs/build-support/fetchforgejo/tests.nix
@@ -1,0 +1,37 @@
+{
+  testers,
+  fetchFromForgejo,
+  ...
+}:
+{
+  # Simple tag-based archive fetch.
+  simple-tag = testers.invalidateFetcherByDrvHash fetchFromForgejo {
+    name = "zig-source";
+    domain = "codeberg.org";
+    owner = "ziglang";
+    repo = "zig";
+    tag = "0.14.0";
+    hash = "sha256-VyteIp5ZRt6qNcZR68KmM7CvN2GYf8vj5hP+gHLkuVk=";
+  };
+
+  # Rev-based archive fetch (0.16.0, the first release made natively on Codeberg).
+  simple-rev = testers.invalidateFetcherByDrvHash fetchFromForgejo {
+    name = "zig-0.16.0-source";
+    domain = "codeberg.org";
+    owner = "ziglang";
+    repo = "zig";
+    rev = "44d9672fed001115e674fd5ddb32747ef43a7af4";
+    hash = "sha256-2sTMhaasyrKoBnyH/hQrNCbi0Vh6HekIrpE4XkyQulQ=";
+  };
+
+  # Git-based fetch (exercises the fetchgit path).
+  fetch-git = testers.invalidateFetcherByDrvHash fetchFromForgejo {
+    name = "zig-git-source";
+    domain = "codeberg.org";
+    owner = "ziglang";
+    repo = "zig";
+    tag = "0.14.0";
+    forceFetchGit = true;
+    hash = "sha256-VyteIp5ZRt6qNcZR68KmM7CvN2GYf8vj5hP+gHLkuVk=";
+  };
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -152,6 +152,7 @@ in
     callPackages ../build-support/fetchnextcloudapp/tests.nix { }
   );
   fetchFromBitbucket = recurseIntoAttrs (callPackages ../build-support/fetchbitbucket/tests.nix { });
+  fetchFromForgejo = recurseIntoAttrs (callPackages ../build-support/fetchforgejo/tests.nix { });
   fetchFromGitHub = recurseIntoAttrs (callPackages ../build-support/fetchgithub/tests.nix { });
   fetchFirefoxAddon = recurseIntoAttrs (
     callPackages ../build-support/fetchfirefoxaddon/tests.nix { }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -708,7 +708,7 @@ with pkgs;
 
   fetchFromGitea = callPackage ../build-support/fetchgitea { };
 
-  fetchFromForgejo = fetchFromGitea;
+  fetchFromForgejo = callPackage ../build-support/fetchforgejo { };
 
   fetchFromCodeberg = callPackage ../build-support/fetchcodeberg { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`fetchFromForgejo` was previously an alias for `fetchFromGitea`, which delegates to `fetchFromGitHub` with `githubBase = domain`.
Public repos work fine (same archive URL shape).
Private ones break: the inherited path hits `/api/v3/` (GitHub Enterprise prefix), whereas Forgejo's API lives at `/api/v1/`.
Auth env vars were also GitHub-namespaced.

Replaces the alias with a proper first-class fetcher modeled after `fetchFromGitLab`, with correct Forgejo API paths, netrc token auth, and `NIX_FORGEJO_PRIVATE_TOKEN`.
`fetchFromCodeberg` updated to delegate to it directly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test