### PR TITLE
nixos: Remove length limit for users and groups

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -11,10 +11,8 @@ let
     any
     attrNames
     attrValues
-    boolToString
     concatMap
     concatMapStringsSep
-    concatStrings
     elem
     filter
     filterAttrs
@@ -39,12 +37,9 @@ let
     mkRenamedOptionModule
     optional
     optionals
-    sort
     stringAfter
-    stringLength
     trace
     types
-    versionOlder
     xor
     ;
 
@@ -147,12 +142,6 @@ let
 
         name = mkOption {
           type = types.passwdEntry types.str;
-          apply =
-            x:
-            assert (
-              stringLength x < 32 || abort "Username '${x}' is longer than 31 characters which is not allowed!"
-            );
-            x;
           description = ''
             The name of the user account. If undefined, the name of the
             attribute set will be used.
@@ -210,12 +199,6 @@ let
 
         group = mkOption {
           type = types.str;
-          apply =
-            x:
-            assert (
-              stringLength x < 32 || abort "Group name '${x}' is longer than 31 characters which is not allowed!"
-            );
-            x;
           default = "";
           description = "The user's primary group.";
         };


### PR DESCRIPTION
Originally introduced by https://github.com/NixOS/nixpkgs/pull/36556. The referenced systemd implementation back then did in fact return invalid in this case. This has been fixed though: https://github.com/systemd/systemd/blob/79862d3/src/basic/user-util.c#L789 In relaxed mode (which is used a lot of the time), this is now allowed. Having a strict denial in NixOS isn't necessary anymore imo.

Disclaimer: No LLM was used in the creation of this Pull Request.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
