### PR TITLE
nixos/programs/ghost-complete: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -97,6 +97,8 @@
 
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).
 
+- [Ghost Complete](https://github.com/StanMarek/ghost-complete), a terminal-native autocomplete engine using PTY proxying for macOS terminals. Available as [programs.ghost-complete](#opt-programs.ghost-complete.enable).
+
 - [pyroscope](https://github.com/grafana/pyroscope), a continuous profiling platform. that allows for performance debugging. Available as [services.pyroscope](#opt-services.pyroscope.enable)
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -227,6 +227,7 @@
   ./programs/gdk-pixbuf.nix
   ./programs/geary.nix
   ./programs/ghidra.nix
+  ./programs/ghost-complete.nix
   ./programs/git-worktree-switcher.nix
   ./programs/git.nix
   ./programs/gnome-disks.nix

--- a/nixos/modules/programs/ghost-complete.nix
+++ b/nixos/modules/programs/ghost-complete.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.ghost-complete;
+
+  shellDir = "${cfg.package}/share/ghost-complete/shell";
+in
+{
+  options.programs.ghost-complete = {
+    enable = lib.mkEnableOption "ghost-complete";
+
+    package = lib.mkPackageOption pkgs "ghost-complete" { };
+
+    enableBashIntegration = lib.mkEnableOption "Bash integration" // {
+      default = config.programs.bash.enable;
+      defaultText = lib.literalExpression "config.programs.bash.enable";
+    };
+
+    enableZshIntegration = lib.mkEnableOption "Zsh integration" // {
+      default = config.programs.zsh.enable;
+      defaultText = lib.literalExpression "config.programs.zsh.enable";
+    };
+
+    enableFishIntegration = lib.mkEnableOption "Fish integration" // {
+      default = config.programs.fish.enable;
+      defaultText = lib.literalExpression "config.programs.fish.enable";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # `init.zsh` must run as early as possible in `/etc/zshrc` because on a
+    # supported terminal it `exec`s the ghost-complete binary to wrap the
+    # shell in a PTY proxy. Anything before it in the first-pass shell init
+    # is wasted; anything after is never reached. The spawned child zsh
+    # re-enters `/etc/zshrc` with `GHOST_COMPLETE_ACTIVE=1` set, which the
+    # guard inside `init.zsh` uses to short-circuit on the second pass.
+    #
+    # `ghost-complete.zsh` installs OSC 133 / 7771 prompt markers, OSC 7
+    # cwd reporting, and a `zle-line-pre-redraw` buffer hook, so it must
+    # run after the user's prompt/zle configuration is in place.
+    programs.zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration (
+      lib.mkMerge [
+        (lib.mkBefore "source ${shellDir}/init.zsh")
+        (lib.mkAfter "source ${shellDir}/ghost-complete.zsh")
+      ]
+    );
+
+    programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
+      source ${shellDir}/ghost-complete.bash
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      source ${shellDir}/ghost-complete.fish
+    '';
+  };
+
+  meta.maintainers = cfg.package.meta.maintainers;
+}


### PR DESCRIPTION
Adds a NixOS module that installs the ghost-complete package and sources the store-installed shell integration scripts, replacing the imperative `ghost-complete install` step. Supports zsh (init.zsh + ghost-complete.zsh), bash, and fish, gated on the respective `programs.<shell>.enable`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
