### PR TITLE
lp_solve: 5.5.2.11 -> 5.5.2.14

### DIFF
--- a/pkgs/by-name/lp/lp_solve/0001-fix-cross-compilation.patch
+++ b/pkgs/by-name/lp/lp_solve/0001-fix-cross-compilation.patch
@@ -2,14 +2,6 @@ diff --git a/lp_solve/ccc b/lp_solve/ccc
 index bd5a938..7fe0427 100644
 --- a/lp_solve/ccc
 +++ b/lp_solve/ccc
-@@ -1,6 +1,6 @@
- :
- src='../lp_MDO.c ../shared/commonlib.c ../colamd/colamd.c ../shared/mmio.c ../shared/myblas.c ../ini.c ../fortify.c ../lp_rlp.c ../lp_crash.c ../bfp/bfp_LUSOL/lp_LUSOL.c ../bfp/bfp_LUSOL/LUSOL/lusol.c ../lp_Hash.c ../lp_lib.c ../lp_wlp.c ../lp_matrix.c ../lp_mipbb.c ../lp_MPS.c ../lp_params.c ../lp_presolve.c ../lp_price.c ../lp_pricePSE.c ../lp_report.c ../lp_scale.c ../lp_simplex.c lp_solve.c ../lp_SOS.c ../lp_utils.c ../yacc_read.c'
--c=cc
-+c=$CC
- 
- MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
- 
 @@ -10,7 +10,7 @@ echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
  echo '#include <stdio.h>'>>"$MYTMP"/platform.c
  echo 'main(){printf("ux%d", (int) (sizeof(void *)*8));}'>>"$MYTMP"/platform.c
@@ -23,14 +15,6 @@ diff --git a/lpsolve55/ccc b/lpsolve55/ccc
 index 999f5f6..ff69b17 100644
 --- a/lpsolve55/ccc
 +++ b/lpsolve55/ccc
-@@ -1,6 +1,6 @@
- :
- src='../lp_MDO.c ../shared/commonlib.c ../shared/mmio.c ../shared/myblas.c ../ini.c ../fortify.c ../colamd/colamd.c ../lp_rlp.c ../lp_crash.c ../bfp/bfp_LUSOL/lp_LUSOL.c ../bfp/bfp_LUSOL/LUSOL/lusol.c ../lp_Hash.c ../lp_lib.c ../lp_wlp.c ../lp_matrix.c ../lp_mipbb.c ../lp_MPS.c ../lp_params.c ../lp_presolve.c ../lp_price.c ../lp_pricePSE.c ../lp_report.c ../lp_scale.c ../lp_simplex.c ../lp_SOS.c ../lp_utils.c ../yacc_read.c'
--c=cc
-+c=$CC
- 
- MYTMP=`mktemp -d "${TMPDIR:-/tmp}"/lp_solve_XXXXXX`
- 
 @@ -10,7 +10,7 @@ echo '#include <stdlib.h>'>>"$MYTMP"/platform.c
  echo '#include <stdio.h>'>>"$MYTMP"/platform.c
  echo 'main(){printf("ux%d", (int) (sizeof(void *)*8));}'>>"$MYTMP"/platform.c

--- a/pkgs/by-name/lp/lp_solve/package.nix
+++ b/pkgs/by-name/lp/lp_solve/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   cctools,
   fixDarwinDylibNames,
   darwin,
@@ -12,11 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lp_solve";
-  version = "5.5.2.11";
+  version = "5.5.2.14";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/lpsolve/lpsolve/${finalAttrs.version}/lp_solve_${finalAttrs.version}_source.tar.gz";
-    hash = "sha256-bUq/9cxqqpM66ObBeiJt8PwLZxxDj2lxXUHQn+gfkC8=";
+  src = fetchFromGitHub {
+    owner = "lp-solve";
+    repo = "lp_solve";
+    tag = finalAttrs.version;
+    hash = "sha256-mCYstt0vEGZk7rjcXmxqZjYTviF8xfg1mvA4jqKCYgE=";
   };
 
   nativeBuildInputs =
@@ -76,9 +78,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Mixed Integer Linear Programming (MILP) solver";
     mainProgram = "lp_solve";
-    homepage = "https://lpsolve.sourceforge.net";
-    license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    homepage = "https://github.com/lp-solve/lp_solve";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Update to 5.5.2.14

Moved to github:
https://groups.google.com/g/lp_solve/c/4GNqUKBQXnA

License is actually LGPL 2.1


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
