### PR TITLE
promptfoo & sillytavern: un-pin nodejs 22

### DIFF
--- a/pkgs/by-name/pr/promptfoo/package.nix
+++ b/pkgs/by-name/pr/promptfoo/package.nix
@@ -1,6 +1,5 @@
 {
   buildNpmPackage,
-  nodejs_22,
   fetchFromGitHub,
   lib,
 }:
@@ -17,9 +16,6 @@ buildNpmPackage (finalAttrs: {
   };
 
   npmDepsHash = "sha256-mpe00J5iRwaH7hJIDP3fDuJSUOKk01COpOOvF1YJMyg=";
-
-  # https://github.com/NixOS/nixpkgs/issues/474535
-  nodejs = nodejs_22;
 
   # don't fetch playwright binary
   env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";

--- a/pkgs/by-name/si/sillytavern/package.nix
+++ b/pkgs/by-name/si/sillytavern/package.nix
@@ -1,7 +1,6 @@
 {
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_22,
   lib,
 }:
 buildNpmPackage (finalAttrs: {
@@ -17,9 +16,6 @@ buildNpmPackage (finalAttrs: {
   npmDepsHash = "sha256-BE8B7yALOi5WLWHAvSPC2lUCgAFjUCOUMc4Ru2RBdJM=";
 
   dontNpmBuild = true;
-
-  # https://github.com/NixOS/nixpkgs/issues/474535
-  nodejs = nodejs_22;
 
   # These dirs are not installed automatically.
   # And if they were not in place, the app would try to create them at runtime, which is of course impossible to achieve.


### PR DESCRIPTION
Drop the obsolete nodejs 22 hack in `promptfoo` & `sillytavern` (see #474535), they build fine with `nodejs_24` now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
