### PR TITLE
prover9: 2009-11A -> 2026-3K

### DIFF
--- a/pkgs/by-name/pr/prover9/package.nix
+++ b/pkgs/by-name/pr/prover9/package.nix
@@ -1,45 +1,60 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   versionCheckHook,
+  cctools,
+  coreutils,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "prover9";
-  version = "2009-11A";
+  version = "2026-3K";
 
-  src = fetchurl {
-    url = "https://www.cs.unm.edu/~mccune/mace4/download/LADR-2009-11A.tar.gz";
-    hash = "sha256-wyvtWAcADAtxYcJ25Q2coK8MskjfLBr/svb8AkcbUdA=";
+  src = fetchFromGitHub {
+    owner = "AlgorithmicTruth";
+    repo = "Prover9";
+    tag = "LADR-${finalAttrs.version}";
+    hash = "sha256-1qK0GXF/KFzjt9+/T7+IWyi2QEjNjt5JZ3nvRdTKnYc=";
   };
 
-  hardeningDisable = [ "format" ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools.libtool
+  ];
+
+  makeFlags = [
+    "CC=${lib.getExe stdenv.cc}"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "PLATFORM_FLAGS="
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    [
+      "-Wno-error=implicit-int"
+      "-Wno-error=implicit-function-declaration"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "-Wno-error=incompatible-library-redeclaration"
+      "-Wno-error=return-type"
+    ]
+  );
 
   postPatch = ''
-    RM=$(type -tp rm)
-    MV=$(type -tp mv)
-    CP=$(type -tp cp)
     for f in Makefile */Makefile; do
-      substituteInPlace $f --replace-quiet "/bin/rm" "$RM" \
-        --replace-quiet "/bin/mv" "$MV" \
-        --replace-quiet "/bin/cp" "$CP";
+      substituteInPlace $f \
+        --replace-quiet "/bin/rm" ${lib.getExe' coreutils "rm"} \
+        --replace-quiet "/bin/mv" ${lib.getExe' coreutils "mv"} \
+        --replace-quiet "/bin/cp" ${lib.getExe' coreutils "cp"}
     done
   '';
 
   buildFlags = [ "all" ];
 
-  # Fails the build on clang-16 and gcc-14.
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-int";
-
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-
-    make test1
-    make test2
-    make test3
-
+    make test1 test2 test3
     runHook postCheck
   '';
 
@@ -47,28 +62,21 @@ stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out/bin
     for f in mace4 prover9 fof-prover9 autosketches4 newauto newsax ladr_to_tptp tptp_to_ladr; do
-      install -Dm555 bin/$f $out/bin/$f;
+      install -Dm555 bin/$f $out/bin/$f
     done
     install -Dm644 -t $out/share/man/man1 manpages/*.1
     runHook postInstall
   '';
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
   meta = {
-    homepage = "https://www.cs.unm.edu/~mccune/mace4/";
+    homepage = "https://prover9.org/";
     license = lib.licenses.gpl2Only;
     description = "Automated theorem prover for first-order and equational logic";
-    longDescription = ''
-      Prover9 is a resolution/paramodulation automated theorem prover
-      for first-order and equational logic. Prover9 is a successor of
-      the Otter Prover. This is the LADR command-line version.
-    '';
     mainProgram = "prover9";
-    platforms = lib.platforms.linux;
-    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    maintainers = [ "manmatteo" ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The development has been restarted after a long hiatus, and a backwards-compatible updated version has been released: https://github.com/AlgorithmicTruth/Prover9/releases/tag/LADR-2026-3K

@SkohTV I had an issue with the previous PR and opened a new one, sorry
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
