### PR TITLE
OVMFFull: fix build on aarch64-darwin

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -274,6 +274,5 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
       mjoerg
       sigmasquadron
     ];
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 })

--- a/pkgs/by-name/ac/acpica-tools/package.nix
+++ b/pkgs/by-name/ac/acpica-tools/package.nix
@@ -39,6 +39,13 @@ stdenv.mkDerivation (finalAttrs: {
       "-O3"
     ];
 
+    # ACPICA emits packed structs that produce unaligned pointers. Apple's
+    # arm64 linker rejects these under chained fixups; opt back into the
+    # legacy fixup format so the link succeeds.
+    NIX_LDFLAGS = lib.optionalString (
+      stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
+    ) "-no_fixup_chains";
+
     # i686 builds fail with hardening enabled (due to -Wformat-overflow). Disable
     # -Werror altogether to make this derivation less fragile to toolchain
     # updates.
@@ -46,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # We can handle stripping ourselves.
     # Unless we are on Darwin. Upstream makefiles degrade coreutils install to cp if _APPLE is detected.
-    INSTALLFLAGS = lib.optionals (!stdenv.hostPlatform.isDarwin) "-m 555";
+    INSTALLFLAGS = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-m 555";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
This patch fixes OVMFFull build on aarch64-darwin. Manually built on `{x86_64,aarch64}-{linux,darwin}` and the `basic-systemd-boot` & `secureBoot-systemd-boot` NixOS tests on `x86_64-linux`/`aarch64-linux` platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
