### PR TITLE
xr-chaperone: init at 0-unstable-2026-05-20

### DIFF
--- a/pkgs/by-name/xr/xr-chaperone/package.nix
+++ b/pkgs/by-name/xr/xr-chaperone/package.nix
@@ -1,0 +1,54 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  cmake,
+  git,
+  python3,
+  openxr-loader,
+  libxkbcommon,
+  lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xr-chaperone";
+  version = "0-unstable-2026-03-16";
+
+  src = fetchFromGitHub {
+    owner = "FrostyCoolSlug";
+    repo = "xr-chaperone";
+    rev = "bb3a78dc8abc802f51b4a257a019b31e0e03c940";
+    hash = "sha256-djMOvA1XIYlQgXxBNEbCbSdHAMOmyUGTVqeIEV8Nv3c=";
+  };
+
+  cargoHash = "sha256-9uEosKwKGNruwxp/uslXj0WAFowY4Tu2CikWa2JiOf4=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    git
+    python3
+  ];
+
+  buildInputs = [ openxr-loader ];
+
+  runtimeDependencies = [
+    libxkbcommon
+  ];
+
+  postInstall = ''
+    install -m 444 -D resources/xr-chaperone.desktop $out/share/applications/${finalAttrs.pname}.desktop
+    install -m 444 -D resources/xr-chaperone.png $out/share/icons/hicolor/256x256/apps/${finalAttrs.pname}.png
+    install -m 444 -D resources/xr-chaperone.svg $out/share/icons/hicolor/scalable/apps/${finalAttrs.pname}.svg
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "VR Chaperone System for OpenXR ";
+    homepage = "https://github.com/FrostyCoolSlug/xr-chaperone";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "xr-chaperone";
+    maintainers = with lib.maintainers; [ toasteruwu ];
+  };
+})

--- a/pkgs/by-name/xr/xr-chaperone/package.nix
+++ b/pkgs/by-name/xr/xr-chaperone/package.nix
@@ -1,0 +1,52 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  cmake,
+  gitMinimal,
+  python3,
+  openxr-loader,
+  libxkbcommon,
+  lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xr-chaperone";
+  version = "0-unstable-2026-05-20";
+
+  src = fetchFromGitHub {
+    owner = "FrostyCoolSlug";
+    repo = "xr-chaperone";
+    rev = "a0351bd00f208e9f7c7917d413de2accbf9208eb";
+    hash = "sha256-d3h3xBxEMza4MmmpDiUCHeaC6MVg1yUwZjMCwBEyLos=";
+  };
+
+  cargoHash = "sha256-9uEosKwKGNruwxp/uslXj0WAFowY4Tu2CikWa2JiOf4=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    gitMinimal
+    python3
+  ];
+
+  buildInputs = [ openxr-loader ];
+
+  runtimeDependencies = [ libxkbcommon ];
+
+  postInstall = ''
+    install -m 444 -D resources/xr-chaperone.desktop $out/share/applications/xr-chaperone.desktop
+    install -m 444 -D resources/xr-chaperone.png $out/share/icons/hicolor/256x256/apps/xr-chaperone.png
+    install -m 444 -D resources/xr-chaperone.svg $out/share/icons/hicolor/scalable/apps/xr-chaperone.svg
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "VR Chaperone System for OpenXR ";
+    homepage = "https://github.com/FrostyCoolSlug/xr-chaperone";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "xr-chaperone";
+    maintainers = with lib.maintainers; [ toasteruwu ];
+  };
+})


### PR DESCRIPTION
Added a package for https://github.com/FrostyCoolSlug/xr-chaperone

For line 35-37 i took the "Wrapping an Appimage" documentation as inspiration. Let me know if something is sub optimal or wrong.

For line 33 i took https://github.com/merrkry/nixpkgs/blob/f2a1154c651c5bf9ffc9efe3edaff45bbd9bc18b/pkgs/by-name/as/asusctl/package.nix#L94 as the inspiration. Neither adding libxkbcommon to nativeBuildInputs or buildInputs worked to fix the error, and when looking for the exact same runtime error message i got i found the PR that added this line to the asusctl package, done by notable established people not too long ago. This does fix the issue just like it did for asusctl, but if there is a cleaner or better way, let me know and im happy to change it.

There are no releases for this program yet, so i had to go with the unstable version naming, let me know if thats OK the way it is. Its unclear if there ever will be a proper release from upstream, so i decided waiting for one would be silly. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
