### PR TITLE
various: remove xcbuild build time dependency

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -28,7 +28,6 @@ let
       systemdLibs,
       system-sendmail,
       valgrind,
-      xcbuild,
       writeShellScript,
       common-updater-scripts,
       curl,
@@ -240,8 +239,7 @@ let
             libtool
             pkg-config
             re2c
-          ]
-          ++ lib.optional stdenv.hostPlatform.isDarwin xcbuild;
+          ];
 
           buildInputs =
             # PCRE extension

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -21,7 +21,6 @@
   rustc,
   which,
   zip,
-  xcbuild,
 
   # runtime
   icu75,
@@ -32,6 +31,9 @@
   libiconv,
 }:
 
+let
+  apple-sdk = (if (lib.versionAtLeast version "140") then apple-sdk_15 else apple-sdk_14);
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "spidermonkey";
   inherit version;
@@ -87,9 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (lib.versionAtLeast version "128") [
     rust-cbindgen
     rustPlatform.bindgenHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    xcbuild
   ];
 
   buildInputs = [
@@ -100,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
-    (if (lib.versionAtLeast version "140") then apple-sdk_15 else apple-sdk_14)
+    apple-sdk
   ];
 
   depsBuildBuild = [
@@ -128,6 +127,9 @@ stdenv.mkDerivation (finalAttrs: {
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1907030
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1957023
     "--includedir=${placeholder "dev"}/include"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+    "--with-macos-sdk=${apple-sdk.sdkroot}"
   ]
   ++ [
     "--disable-jemalloc"

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -16,7 +16,6 @@
   pythran,
   pkg-config,
   setuptools,
-  xcbuild,
 
   # buildInputs
   # Upstream has support for using Darwin's Accelerate package. However this
@@ -78,6 +77,12 @@ buildPythonPackage (finalAttrs: {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "numpy>=2.0.0,<2.7" numpy
+  ''
+  + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace scipy/meson.build \
+      --replace-fail "r = run_command('xcrun', '-sdk', 'macosx', '--show-sdk-version', check: true)" ""
+    substituteInPlace scipy/meson.build \
+      --replace-fail "sdkVersion = r.stdout().strip()" "sdkVersion = '${stdenv.hostPlatform.darwinSdkVersion}'"
   '';
 
   build-system = [
@@ -88,13 +93,6 @@ buildPythonPackage (finalAttrs: {
     pythran
     pkg-config
     setuptools
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # Minimal version required according to:
-    # https://github.com/scipy/scipy/blob/v1.16.0/scipy/meson.build#L238-L244
-    (xcbuild.override {
-      sdkVer = "13.3";
-    })
   ];
 
   buildInputs = [


### PR DESCRIPTION
While preparing [xcbuild changes](https://github.com/NixOS/nixpkgs/issues/512622), I wanted to first remove it from as many packages as I can to limit / speed up rebuilds.

Here's the first batch:
- php - doesn't actually depend on xcbuild
- spidermonkey - it was used to find the sdkroot, but we can provide that directly
- scipy - it was used to find the sdk version, but we can provide that directly

Validation - I replaced `xcbuild` with a fake version providing just an `echo FAIL ; exit 1` script for every utility. Confirmed no failures happened in testing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
