### PR TITLE
reposilite: move plugins to passthru

### DIFF
--- a/nixos/modules/services/web-apps/reposilite.nix
+++ b/nixos/modules/services/web-apps/reposilite.nix
@@ -272,7 +272,7 @@ in
         List of plugins to add to Reposilite.
       '';
       default = [ ];
-      example = "with reposilitePlugins; [ checksum groovy ]";
+      example = "with pkgs.reposilite.plugins; [ checksum groovy ]";
     };
 
     database = lib.mkOption {

--- a/nixos/tests/reposilite.nix
+++ b/nixos/tests/reposilite.nix
@@ -20,7 +20,7 @@
 
           reposilite = {
             enable = true;
-            plugins = with pkgs.reposilitePlugins; [
+            plugins = with pkgs.reposilite.plugins; [
               checksum
               groovy
             ];

--- a/pkgs/by-name/re/reposilite/package.nix
+++ b/pkgs/by-name/re/reposilite/package.nix
@@ -6,6 +6,7 @@
   linkFarm,
   makeWrapper,
   nixosTests,
+  callPackage,
   plugins ? [ ],
 }:
 let
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     tests = nixosTests.reposilite;
     updateScript = ./update.sh;
+    plugins = lib.recurseIntoAttrs (callPackage ./plugins.nix { });
   };
 
   meta = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1760,6 +1760,7 @@ mapAliases {
   redshift-plasma-applet = throw "'redshift-plasma-applet' has been removed as it is obsolete and lacks maintenance upstream."; # Added 2025-11-09
   reiserfsprogs = throw "'reiserfsprogs' has been removed as ReiserFS has not been actively maintained for many years."; # Added 2025-11-13
   remotebox = throw "remotebox has been removed because it was unmaintained and broken for a long time"; # Added 2025-09-11
+  reposilitePlugins = reposilite.plugins; # Added 2026-04-24
   resp-app = throw "'resp-app' has been replaced by 'redisinsight'"; # Added 2025-12-17
   responsively-app = throw "'responsively-app' has been removed due to lack of maintenance upstream."; # Added 2025-06-25
   retroarchBare = throw "'retroarchBare' has been renamed to/replaced by 'retroarch-bare'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7277,8 +7277,6 @@ with pkgs;
     useQt6 = true;
   };
 
-  reposilitePlugins = recurseIntoAttrs (callPackage ../by-name/re/reposilite/plugins.nix { });
-
   rocksdb_9_10 = rocksdb.overrideAttrs rec {
     pname = "rocksdb";
     version = "9.10.0";


### PR DESCRIPTION
This pull request refactors how Reposilite plugins are accessed and referenced in NixOS modules and packages. The main change is to move the `reposilitePlugins` attribute under `reposilite.plugins`, update all references accordingly, and add an alias for backward compatibility. This makes the structure more consistent with other package sets and simplifies plugin usage.

**Refactoring plugin access and references:**

* Moved the `reposilitePlugins` attribute from a top-level package in `pkgs` to `reposilite.plugins`, and updated the NixOS module option example and test to use `pkgs.reposilite.plugins` instead of `pkgs.reposilitePlugins` 

* Added `plugins` to the `passthru` attributes of the `reposilite` package, exposing all plugins via `reposilite.plugins`.
* Removed the top-level `reposilitePlugins` attribute from `all-packages.nix` to avoid duplication and potential confusion.
* Added an alias in `aliases.nix` so that `reposilitePlugins` still points to `reposilite.plugins`, ensuring backward compatibility for users of the old attribute.

**Internal code improvements:**

* Updated the `reposilite` package derivation to use `callPackage` for plugin handling, improving maintainability.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
