### PR TITLE
make-derivation: use attrset lookup for configurePlatforms flags

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -219,13 +219,12 @@ let
     "build"
     "host"
   ];
-  buildPlatformConfigureFlag = "--build=${buildPlatform.config}";
-  hostPlatformConfigureFlag = "--host=${hostPlatform.config}";
-  targetPlatformConfigureFlag = "--target=${targetPlatform.config}";
-  defaultConfigurePlatformsFlags = optionals useDefaultConfigurePlatforms [
-    buildPlatformConfigureFlag
-    hostPlatformConfigureFlag
-  ];
+  configurePlatformFlagMap = {
+    build = "--build=${buildPlatform.config}";
+    host = "--host=${hostPlatform.config}";
+    target = "--target=${targetPlatform.config}";
+  };
+  defaultConfigurePlatformsFlags = map (p: configurePlatformFlagMap.${p}) defaultConfigurePlatforms;
 
   # TODO(@Ericson2314): Make always true and remove / resolve #178468
   defaultStrictDeps = if config.strictDepsByDefault then true else hostPlatform != buildPlatform;
@@ -607,9 +606,7 @@ let
               if configurePlatforms == defaultConfigurePlatforms then
                 defaultConfigurePlatformsFlags
               else
-                optional (elem "build" configurePlatforms) buildPlatformConfigureFlag
-                ++ optional (elem "host" configurePlatforms) hostPlatformConfigureFlag
-                ++ optional (elem "target" configurePlatforms) targetPlatformConfigureFlag
+                map (p: configurePlatformFlagMap.${p}) configurePlatforms
             );
 
           inherit patches;


### PR DESCRIPTION
Follow-up to #506793. Replace three separate platform flag bindings and the `elem`+`optional`+`++` chain with a single `configurePlatformFlagMap` attrset and `map`-based lookup.

- Single source of truth for name→flag mapping
- Respects user-specified `configurePlatforms` order
- Invalid platform names fail at eval time instead of being silently dropped

### Eval performance  😀

| metric | before | after | diff |
|---|---|---|---|
| envs.number | 28,244,142 | 28,243,546 | −596 (−0.002%) |
| nrFunctionCalls | 25,272,295 | 25,271,700 | −596 (−0.002%) |
| nrThunks | 39,049,160 | 39,048,697 | −462 (−0.001%) |
| list.concats | 2,286,693 | 2,286,528 | −165 (−0.007%) |
| nrAvoided | 35,645,368 | 35,644,494 | −874 (−0.002%) |
| gc.totalBytes | 3,626 MB | 3,626 MB | −9 KB |

The fast path (`configurePlatforms == defaultConfigurePlatforms`) still returns pre-computed `defaultConfigurePlatformsFlags`.

~35k rebuilds from flag reordering on packages with non-default `configurePlatforms`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test