### PR TITLE
ungoogled-chromium: 147.0.7727.101-1 -> 147.0.7727.116-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -828,11 +828,11 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "147.0.7727.101",
+    "version": "147.0.7727.116",
     "deps": {
       "depot_tools": {
-        "rev": "442cbd6d584d2c992ca9bcc19ecbd2235bea772e",
-        "hash": "sha256-CgEu3y/MNRcCN2EmtcVgmGW/bEPKypeyLaANtiplDJU="
+        "rev": "3d94d7c3056847db821c6451be61054c36d7c6d5",
+        "hash": "sha256-hWfmidLPY0bXI58xAwkGnmb3GnSsKIUlDM91MYWfgpM="
       },
       "gn": {
         "version": "0-unstable-2026-03-05",
@@ -840,16 +840,16 @@
         "hash": "sha256-3AfExm7NL5GJXyC5JCPbGC70D59doRfIZIgpt6MLy9Y="
       },
       "ungoogled-patches": {
-        "rev": "147.0.7727.101-1",
-        "hash": "sha256-w/9bzbYHZM3Ot26ZcYWB51z7T+I4OBOxflo1dWxghyQ="
+        "rev": "147.0.7727.116-1",
+        "hash": "sha256-MmVLgbT+uzFzRt7faNvnWrlDwChDPth5eVqcGBXwUu4="
       },
       "npmHash": "sha256-ByB1Ea5tduIJZXyydeBWsoS8OPABOgwHe+dNXRssdvc="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "56536d2a8034c51b0e68e1a0483ab9f1a0165ae3",
-        "hash": "sha256-94TMvPkcWm+IEVYwTh+m1ys5du75bvJcc1RpkSKpAwc=",
+        "rev": "dbcf1b1bfb506cc580859bcb5ff9460a8443af90",
+        "hash": "sha256-pcrElIGFOcPQjJUF1ceHMRjS3YLjbTa9cM3Qg/G3u6I=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -919,8 +919,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "cbc4f074126e6f1acf72ad620a28cd4a8dd86f2a",
-        "hash": "sha256-MUgLUj2L0vmpAoxt/TJy1clsJfvYkQqe3Xm2+e4Y6tw="
+        "rev": "82ab43bfda5a3f59e1876fd3c828f047c689bc12",
+        "hash": "sha256-6WjecQRoyCLUoSbqDMpmsJ5tZazPF171KWnjxxK8hd4="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -959,8 +959,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "2c681aed02b0add6bcf6724175660c4b35ece843",
-        "hash": "sha256-io3X9zu6tHgqJGXjygUXMa98rXELRNl6Y330U2nRc/M="
+        "rev": "ff7b4f6c5d964879b5f4356ef6e732adeed2f627",
+        "hash": "sha256-pURclm6gi0am32tohZTB4iT2BWa55uRBJNRVW0gjDcY="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1089,8 +1089,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "82a48c1595e5aefc899ed4528dbd7da0ac9e40e2",
-        "hash": "sha256-nlpFDS04LenRcQqnCkSdX/cUoC/gJcHaGUq+zrrkLSY="
+        "rev": "854a02be78c7ffea104cb523636efa991bef5c5b",
+        "hash": "sha256-CzzUueh2QXX+ExGqh5+JpnDoWF8DiFDff7fWmC01xfg="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1619,8 +1619,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "9179833d210d105aede5d4ec516734a6bd1ef2e8",
-        "hash": "sha256-DuHZimj7Zbx0QGH2ZrdGiSJg2PTwZUipyY06ZWr2fxg="
+        "rev": "997079137283f693a0fac6a5350ae7f6f2cf3b59",
+        "hash": "sha256-SOV9YS8Dk1HFCo00Qe6zttJOP0PEBS4B6Ah79OXmTew="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1649,8 +1649,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "c207e34c08865143dc6774c1c624f3cea07f7420",
-        "hash": "sha256-5rc28tPK9mOJDO3HA3F1ZgsRQmWXhoLZGeKTzxWSISw="
+        "rev": "9b21082faf16a5f029a4316272c9a627d8b33eb4",
+        "hash": "sha256-dT1f9Df1K1ZLp346Tpqn6Lkq2HDYWWQIAuhqXMIIydk="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #512492

https://chromereleases.googleblog.com/2026/04/stable-channel-update-for-desktop_22.html

This update includes 19 security fixes.

CVEs:
CVE-2026-6919 CVE-2026-6920 CVE-2026-6921

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
