### PR TITLE
signal-desktop: 8.6.1 -> 8.8.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop/force-90-days-expiration.patch
+++ b/pkgs/by-name/si/signal-desktop/force-90-days-expiration.patch
@@ -1,12 +1,12 @@
-diff --git a/ts/scripts/get-expire-time.node.ts b/ts/scripts/get-expire-time.node.ts
-index deebfcee6..50f6df652 100644
---- a/ts/scripts/get-expire-time.node.ts
-+++ b/ts/scripts/get-expire-time.node.ts
-@@ -18,7 +18,7 @@ const buildCreation = unixTimestamp * 1000;
+diff --git a/scripts/get-expire-time.mjs b/scripts/get-expire-time.mjs
+index 8c520ba5b..f23c32e35 100644
+--- a/scripts/get-expire-time.mjs
++++ b/scripts/get-expire-time.mjs
+@@ -19,7 +19,7 @@ const isNotUpdatable = !parseVersion(packageJson.version).isUpdatable;
  
  // NB: Build expirations are also determined via users' auto-update settings; see
  // getExpirationTimestamp
--const validDuration = isNotUpdatable(packageJson.version) ? DAY * 30 : DAY * 90;
+-const validDuration = isNotUpdatable ? DAY * 30 : DAY * 90;
 +const validDuration = DAY * 90;
  const buildExpiration = buildCreation + validDuration;
  

--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -15,23 +15,23 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.91.0";
+  version = "0.92.1";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-icmmQWWVCWg8dpNkQtLi3YWSxBrUwaGP4ezTDqC/0kc=";
+    hash = "sha256-gAXLt0e2k5PA6PgFRQa22oGuNLM7TGkOKQnYtFhn8I8=";
   };
 
-  cargoHash = "sha256-NaFl9r4e08I3+/asek7VMA0yikxPR0MtBX9TnHaebSU=";
+  cargoHash = "sha256-TqYxkkzlbgrc7jkAubz3TsXhcU8Do5IFaLRqSPiZVR0=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-TTU7cfoS0h2fqHanSOCsF+dtkhBfaWApfOC3O4DGClo=";
+    hash = "sha256-c6Alk2tyloaPAP2Qfgurle0ziVs8vbxb2klKJZaGlaQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -3,9 +3,10 @@
   lib,
   nodejs_24,
   pnpm_10_29_2,
+  node-gyp,
   fetchPnpmDeps,
   pnpmConfigHook,
-  electron_40,
+  electron_41,
   python3,
   makeWrapper,
   callPackage,
@@ -29,7 +30,7 @@ assert lib.warnIf (commandLineArgs != "")
 let
   nodejs = nodejs_24;
   pnpm = pnpm_10_29_2;
-  electron = electron_40;
+  electron = electron_41;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };
   signal-sqlcipher = callPackage ./signal-sqlcipher.nix { inherit pnpm nodejs; };
@@ -58,13 +59,13 @@ let
     '';
   });
 
-  version = "8.6.1";
+  version = "8.8.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-UeCjj3txcBQxfvEJOuCKka3VVfd4OY/4wXoQ4lq4NiE=";
+    hash = "sha256-moWEqKWZgqIfhK01RUROF4Waxbn5kcmxZQ94PGai4ww=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -76,7 +77,7 @@ let
       inherit (finalAttrs) pname src version;
       inherit pnpm;
       fetcherVersion = 3;
-      hash = "sha256-WbdYcI5y01gdS9AIzy4VZZ6eFaTHaVPscTawLSsHzlc=";
+      hash = "sha256-CPZkybD/rCBMBK9qUSweBdLr9hXu0Ztn8fekqrRzUR4=";
     };
 
     strictDeps = true;
@@ -159,11 +160,11 @@ stdenv.mkDerivation (finalAttrs: {
     # language-pack postprocessing), and they expect a different macOS
     # app layout than nixpkgs' Electron provides.
     substituteInPlace package.json \
-      --replace-fail '"artifactBuildCompleted": "ts/scripts/artifact-build-completed.node.ts",' "" \
-      --replace-fail '"afterSign": "ts/scripts/after-sign.node.ts",' "" \
-      --replace-fail '"afterPack": "ts/scripts/after-pack.node.ts",' "" \
-      --replace-fail '"sign": "./ts/scripts/sign-macos.node.ts",' "" \
-      --replace-fail '"afterAllArtifactBuild": "ts/scripts/after-all-artifact-build.node.ts",' ""
+      --replace-fail '"artifactBuildCompleted": "scripts/artifact-build-completed.mjs",' "" \
+      --replace-fail '"afterSign": "scripts/after-sign.mjs",' "" \
+      --replace-fail '"afterPack": "scripts/after-pack.mjs",' "" \
+      --replace-fail '"sign": "scripts/sign-macos.mjs",' "" \
+      --replace-fail '"afterAllArtifactBuild": "scripts/after-all-artifact-build.mjs",' ""
   '';
 
   pnpmDeps = fetchPnpmDeps {
@@ -177,15 +178,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 3;
     hash =
       if withAppleEmojis then
-        "sha256-d6ul6MTJhnM4PyxMlMaVovnvSPfYh3DmMjHjmOideB4="
+        "sha256-Ib+NQbnCawbGgx45u27ubf1a6lHkrGde+m1DUT23w5Y="
       else
-        "sha256-JymcPdFMi0wfceOJnPrwEBG4PnosIFnrxiIrTlcGf/g=";
+        "sha256-0HzY/4XHjc8uAIMy6OzgGcuDNGfqQVW2RHOtyeYPJaw=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1776101010;
+    SOURCE_DATE_EPOCH = 1777225303;
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # Disable code signing during local macOS builds.
@@ -240,7 +241,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Build it explicitly against Electron headers ahead of packaging.
     export npm_config_nodedir=${electron.headers}
     pushd node_modules/fs-xattr
-    pnpm exec node-gyp rebuild
+    ${lib.getExe node-gyp} rebuild
     popd
     test -f node_modules/fs-xattr/build/Release/xattr.node
   '';

--- a/pkgs/by-name/si/signal-desktop/replace-apple-emoji-with-noto-emoji.patch
+++ b/pkgs/by-name/si/signal-desktop/replace-apple-emoji-with-noto-emoji.patch
@@ -46,32 +46,32 @@ index 483d1c4e4..66609d9e9 100644
      getBadgesPath(userDataPath),
      getDraftPath(userDataPath),
 diff --git a/package.json b/package.json
-index 8585e6bdc..4d900ebfe 100644
+index dd87037e7..f16dd8d1f 100644
 --- a/package.json
 +++ b/package.json
-@@ -122,7 +122,6 @@
-     "@signalapp/sqlcipher": "3.2.1",
-     "@signalapp/windows-ucv": "1.0.1",
-     "emoji-datasource": "16.0.0",
+@@ -240,7 +240,6 @@
+     "electron": "41.2.2",
+     "electron-builder": "26.0.14",
+     "electron-mocha": "13.1.0",
 -    "emoji-datasource-apple": "16.0.0",
-     "google-libphonenumber": "3.2.39"
-   },
-   "devDependencies": {
+     "emoji-regex": "10.6.0",
+     "enhanced-resolve": "5.20.1",
+     "enquirer": "2.4.1",
 diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 756130661..4872be4cf 100644
+index d659475fc..2f1e3cfdb 100644
 --- a/pnpm-lock.yaml
 +++ b/pnpm-lock.yaml
-@@ -97,9 +97,6 @@ importers:
-       emoji-datasource:
-         specifier: 16.0.0
-         version: 16.0.0
+@@ -430,9 +430,6 @@ importers:
+       electron-mocha:
+         specifier: 13.1.0
+         version: 13.1.0
 -      emoji-datasource-apple:
 -        specifier: 16.0.0
 -        version: 16.0.0
-       google-libphonenumber:
-         specifier: 3.2.39
-         version: 3.2.39
-@@ -6068,9 +6065,6 @@ packages:
+       emoji-regex:
+         specifier: 10.6.0
+         version: 10.6.0
+@@ -6154,9 +6151,6 @@ packages:
      resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
      engines: {node: '>=12'}
  
@@ -81,7 +81,7 @@ index 756130661..4872be4cf 100644
    emoji-datasource@16.0.0:
      resolution: {integrity: sha512-/qHKqK5Nr3+8zhgO6kHmF43Fm5C8HNn0AaFRIpgw8HF3+uF0Vfc8jgLI1ZQS5ba1vBzksS8NBCjHejwLb2D/Sg==}
  
-@@ -16954,8 +16948,6 @@ snapshots:
+@@ -16387,8 +16381,6 @@ snapshots:
  
    emittery@0.13.1: {}
  
@@ -89,7 +89,7 @@ index 756130661..4872be4cf 100644
 -
    emoji-datasource@16.0.0: {}
  
-   emoji-regex@10.4.0: {}
+   emoji-regex@10.6.0: {}
 diff --git a/stylesheets/components/fun/FunEmoji.scss b/stylesheets/components/fun/FunEmoji.scss
 index 1cc4bb43c..a6444101a 100644
 --- a/stylesheets/components/fun/FunEmoji.scss


### PR DESCRIPTION
diff: https://github.com/signalapp/Signal-Desktop/compare/v8.6.1...v8.7.0
release: https://github.com/signalapp/Signal-Desktop/releases/tag/v8.7.0

r-ryantm: https://nixpkgs-update-logs.nix-community.org/signal-desktop/2026-04-22.log

I was waiting for `r-ryantm` to make a PR but turns out the patches need some additional patching for this update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (rebased onto `nixpkgs-unstable`)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
