### PR TITLE
cage: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/by-name/ca/cage/package.nix
+++ b/pkgs/by-name/ca/cage/package.nix
@@ -2,14 +2,13 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   meson,
   ninja,
   pkg-config,
   wayland-scanner,
   scdoc,
   makeWrapper,
-  wlroots_0_19,
+  wlroots_0_20,
   wayland,
   wayland-protocols,
   pixman,
@@ -23,24 +22,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cage";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "cage-kiosk";
     repo = "cage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-P9MhIl2YIE2hwT5Yr0Cpes5S12evb0aj9oOPLeehkw0=";
+    hash = "sha256-NLoz11bfeZwesmwLmyytuB6/vSwIsnDWKzyAXFe+YZ0=";
   };
-
-  patches = [
-    # backport of https://github.com/cage-kiosk/cage/pull/461
-    # to fix https://github.com/cage-kiosk/cage/issues/456
-    # remove on next release
-    (fetchpatch {
-      url = "https://github.com/cage-kiosk/cage/commit/832e88b0c964a324bb09c7af02ed0650b73dfb9b.patch";
-      hash = "sha256-8dyJL46xXGkw3pF9uskX8H72s0hUO1BhU2UMaoEwz4U=";
-    })
-  ];
 
   depsBuildBuild = [
     pkg-config
@@ -56,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    wlroots_0_19
+    wlroots_0_20
     wayland
     wayland-protocols
     pixman
@@ -66,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
   ];
 
-  postFixup = lib.optionalString wlroots_0_19.enableXWayland ''
+  postFixup = lib.optionalString wlroots_0_20.enableXWayland ''
     wrapProgram $out/bin/cage --prefix PATH : "${xwayland}/bin"
   '';
 


### PR DESCRIPTION
Remove previously applied patches as it's now upstream in 0.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
