### PR TITLE
eigen: 3.4.1 -> 5.0.1

### DIFF
--- a/pkgs/by-name/ei/eigen/package.nix
+++ b/pkgs/by-name/ei/eigen/package.nix
@@ -3,7 +3,6 @@
 
   stdenv,
   fetchFromGitLab,
-  fetchpatch,
 
   # nativeBuildInputs
   cmake,
@@ -14,23 +13,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eigen";
-  version = "3.4.1";
+  version = "5.0.1";
 
   src = fetchFromGitLab {
     owner = "libeigen";
     repo = "eigen";
     tag = finalAttrs.version;
-    hash = "sha256-NSq1tUfy2thz5gtsyASsKeYE4vMf71aSG4uXfrX86rk=";
+    hash = "sha256-8TW1MUXt2gWJmu5YbUWhdvzNBiJ/KIVwIRf2XuVZeqo=";
   };
-
-  patches = [
-    # fix bug1213 test
-    # ref https://gitlab.com/libeigen/eigen/-/merge_requests/2005 merged upstream
-    (fetchpatch {
-      url = "https://gitlab.com/libeigen/eigen/-/commit/3e1367a3b5efcdc8ce716db77a322cedeb5e01b4.patch";
-      hash = "sha256-oykUbzaZeVW1A8nBoiMtJvh68Zpu7PDFtAfAjtTQoC0=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -44,13 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "EIGEN_LEAVE_TEST_IN_ALL_TARGET" true) # Build tests in parallel
   ];
 
-  # too many flaky tests
-  doCheck = false;
+  doCheck = true;
 
   meta = {
     homepage = "https://eigen.tuxfamily.org";
     description = "C++ template library for linear algebra: vectors, matrices, and related algorithms";
-    license = lib.licenses.lgpl3Plus;
+    license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       raskin
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updates eigen to 5.0.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
