### PR TITLE
parallel-overhead: init at 1.1.4

### DIFF
--- a/pkgs/by-name/pa/parallel-overhead/package.nix
+++ b/pkgs/by-name/pa/parallel-overhead/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  SDL2,
+  libGL,
+  fetchpatch,
+  help2man,
+  sfxr-qt,
+  lmms,
+  desktop-file-utils,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "parallel-overhead";
+  version = "1.1.4";
+
+  src = fetchFromCodeberg {
+    owner = "Huitsi";
+    repo = "ParallelOverhead";
+    tag = finalAttrs.version;
+    hash = "sha256-jWjFT0Je+G/WtXIwOrDDt2/fBjRe4LC+DDODypfBq50=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-gcc15.patch";
+      url = "https://codeberg.org/Huitsi/ParallelOverhead/commit/1379f48d793807278eb954e93218021a9cdf8099.patch";
+      hash = "sha256-mdHZsPBGPY3BwVsM/oUr6j3ccolLbeFvj2u8TxUGSFU=";
+    })
+    (fetchpatch {
+      name = "fix-hardening-error.patch";
+      url = "https://codeberg.org/Huitsi/ParallelOverhead/commit/dc5cf737235757e7bf90ed5dab37473b71655b13.patch";
+      hash = "sha256-yAicPkLXkt8jTbw7Hd6V2l4oIKScUFe4XLYhOlocuSU=";
+    })
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    help2man
+    sfxr-qt
+    lmms
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    SDL2
+    libGL
+  ];
+
+  makeFlags = [
+    "version=${finalAttrs.version}"
+    "prefix=${placeholder "out"}"
+    "bindir=$(exec_prefix)/bin"
+  ];
+
+  meta = {
+    description = "Endless runner game";
+    homepage = "https://huitsi.net/#ParallelOverhead";
+    license = with lib.licenses; [
+      mit
+
+      # Music
+      cc0
+    ];
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+    mainProgram = "parallel_overhead";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
An endless runner game.

https://huitsi.net/#ParallelOverhead

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
