### PR TITLE
tartan: use llvmPackages_20

### DIFF
--- a/pkgs/by-name/ta/tartan/package.nix
+++ b/pkgs/by-name/ta/tartan/package.nix
@@ -5,7 +5,7 @@
   meson,
   ninja,
   pkg-config,
-  llvmPackages,
+  llvmPackages_20,
   gobject-introspection,
   glib,
   unstableGitUpdater,
@@ -32,8 +32,9 @@ stdenv.mkDerivation {
   buildInputs = [
     gobject-introspection
     glib
-    llvmPackages.libclang
-    llvmPackages.libllvm
+    # https://gitlab.freedesktop.org/tartan/tartan/-/merge_requests/29
+    llvmPackages_20.libclang
+    llvmPackages_20.libllvm
   ];
 
   passthru = {


### PR DESCRIPTION
- #516381
- https://hydra.nixos.org/build/324334141

```
../clang-plugin/gerror-checker.cpp: In member function 'clang::ento::ProgramStateRef tartan::GErrorChecker::_gerror_new(const clang::Expr*, bool, clang::ento::DefinedSVal**, clang::ento::ProgramStateRef, clang::ento::CheckerContext&, const clang::SourceRange&) const':
../clang-plugin/gerror-checker.cpp:664:47: error: cannot convert 'const clang::Expr*' to 'clang::ConstCFGElementRef' {aka 'clang::CFGBlock::ElementRefImpl<true>'}
  664 |                 symbol_manager.conjureSymbol (call_expr, location_context,
      |                                               ^~~~~~~~~
      |                                               |
      |                                               const clang::Expr*
In file included from /nix/store/5vr6xi5jkadpqcx008z4sxpnkgbpm2pi-clang-21.1.8-dev/include/clang/StaticAnalyzer/Core/PathSensitive/SValBuilder.h:30,
                 from /nix/store/5vr6xi5jkadpqcx008z4sxpnkgbpm2pi-clang-21.1.8-dev/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h:20,
                 from /nix/store/5vr6xi5jkadpqcx008z4sxpnkgbpm2pi-clang-21.1.8-dev/include/clang/StaticAnalyzer/Core/CheckerManager.h:20,
                 from /nix/store/5vr6xi5jkadpqcx008z4sxpnkgbpm2pi-clang-21.1.8-dev/include/clang/StaticAnalyzer/Core/Checker.h:18,
                 from /nix/store/5vr6xi5jkadpqcx008z4sxpnkgbpm2pi-clang-21.1.8-dev/include/clang/StaticAnalyzer/Core/BugReporter/BugType.h:18,
                 from ../clang-plugin/gerror-checker.cpp:77:
/nix/store/5vr6xi5jkadpqcx008z4sxpnkgbpm2pi-clang-21.1.8-dev/include/clang/StaticAnalyzer/Core/PathSensitive/SymbolManager.h:537:58: note: initializing argument 1 of 'const clang::ento::SymbolConjured* clang::ento::SymbolManager::conjureSymbol(clang::ConstCFGElementRef, const clang::LocationContext*, clang::QualType, unsigned int, const void*)'
  537 |   const SymbolConjured *conjureSymbol(ConstCFGElementRef Elem,
      |                                       ~~~~~~~~~~~~~~~~~~~^~~~
...
```

There is an upstream [merge request](https://gitlab.freedesktop.org/tartan/tartan/-/merge_requests/29) for LLVM 21 compatibility. Hopefully it can be merged before we drop llvm 20.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
