### PR TITLE
libhwy: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/by-name/li/libhwy/package.nix
+++ b/pkgs/by-name/li/libhwy/package.nix
@@ -5,35 +5,18 @@
   ninja,
   gtest,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libhwy";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "highway";
     rev = version;
-    hash = "sha256-8QOk96Y3GIIvBUGIDikMgTylx8y5aCyr68/TP5w5ha4=";
+    hash = "sha256-YUYZO9KLffczjwIz3mBBceD6oM1giLCFLDHgDCevdRA=";
   };
-
-  patches = [
-    # Apply upstream workaround for gcc-15 bug:
-    #   https://github.com/google/highway/issues/2813
-    #   https://github.com/google/highway/pull/2824
-    (fetchpatch {
-      name = "gcc-15-clone-hack-prerequisite.patch";
-      url = "https://github.com/google/highway/commit/3b680cde3a556bead9cc23c8f595d07a44d5a0d5.patch";
-      hash = "sha256-8xBPuhsifalhzKgeEOQq6yZw2NWas+SFQrNIaMicRnY=";
-    })
-    (fetchpatch {
-      name = "gcc-15-clone-hack.patch";
-      url = "https://github.com/google/highway/commit/5af21b8a9078330a3d7456d855e69245bb87bc7a.patch";
-      hash = "sha256-hC/oEdxHsdZKlLFIw929ZHjffPURGzk9jiKz6iGSLkY=";
-    })
-  ];
 
   hardeningDisable = lib.optionals stdenv.hostPlatform.isAarch64 [
     # aarch64-specific code gets:


### PR DESCRIPTION
Changes: https://github.com/google/highway/releases/tag/1.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
