### PR TITLE
iterm2: fix download URL extraction in update.sh

### DIFF
--- a/pkgs/by-name/it/iterm2/update.sh
+++ b/pkgs/by-name/it/iterm2/update.sh
@@ -4,12 +4,12 @@ set -eu -o pipefail
 
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; iterm2.version or (lib.getVersion iterm2)" | tr -d '"')
 
-downloadUrl=$(
+downloadUrls=$(
   curl -sL "https://iterm2.com/downloads.html" |
   grep -o -E 'href="[^"]*iTerm2[^"]*\.zip"' |
-  sed 's/href="//;s/"//' |
-  head -1
+  sed 's/href="//;s/"//'
 )
+downloadUrl=$(echo "$downloadUrls" | head -1)
 
 if [[ -z "$downloadUrl" ]]; then
   echo >&2 "Failed to extract download url from iTerm2 downloads page"


### PR DESCRIPTION
iterm2: fix update script SIGPIPE failure

The `update.sh` script fails silently with `exit code 141` (`SIGPIPE`) due to `head -1` in a pipeline combined with `set -o pipefail`. The iterm2 downloads page lists 28 `.zip` links, so when `head -1` exits after reading the first line, `sed` and `grep` receive `SIGPIPE`, and `pipefail` propagates the non-zero exit code. `set -e` then kills the script with no error message.

Fix: capture all URLs first, then select the first one outside the pipeline.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
