### PR TITLE
siketyan-ghr: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/by-name/si/siketyan-ghr/package.nix
+++ b/pkgs/by-name/si/siketyan-ghr/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ghr";
-  version = "0.4.4";
+  version = "0.4.5";
 
   src = fetchFromGitHub {
     owner = "siketyan";
     repo = "ghr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-L9+rcdt+MGZSCOJyCE4t/TT6Fjtxvfr9LBJYyRrx208=";
+    hash = "sha256-8DnujtAtJiSnrC3k5vGRQuk6RfC5Vn+z4HAVsEnXN7c=";
   };
 
-  cargoHash = "sha256-xRa/brOYJ19J25wGdtNR2g+ouMyvz9YFXnzepeipWNQ=";
+  cargoHash = "sha256-8b9kAl9KoeWG+LEFkRQd6zbiWqyIybbcXpImz+akS7M=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
- https://hydra.nixos.org/build/326905944
- Release notes: https://github.com/siketyan/ghr/releases/tag/v0.4.5
- Diff: https://github.com/siketyan/ghr/compare/v0.4.4...v0.4.5

```
error: this function depends on never type fallback being `()`
  --> src/profile.rs:89:5
   |
89 | /     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
90 | |     where
91 | |         S: Serializer,
   | |______________________^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
   = help: specify the types explicitly
note: in edition 2024, the requirement `!: FromIterator<()>` will fail
  --> src/profile.rs:98:14
   |
98 |             .try_collect()?;
   |              ^^^^^^^^^^^
   = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
help: use `()` annotations to avoid fallback changes
   |
98 |             .try_collect::<_, (), _>()?;
   |                         ++++++++++++
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
