### PR TITLE
ocis: apply patch to fix broken kopano tarball, migrate to fetcherVersion = 3

### DIFF
--- a/pkgs/by-name/oc/ocis/package.nix
+++ b/pkgs/by-name/oc/ocis/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  applyPatches,
   buildGoModule,
   callPackage,
   gnumake,
@@ -36,11 +37,20 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  src = fetchFromGitHub {
-    owner = "owncloud";
-    repo = "ocis";
-    tag = "v${version}";
-    hash = "sha256-TsMrQx+P1F2t66e0tGG0VvRi4W7+pCpDHd0aNsacOsI=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "owncloud";
+      repo = "ocis";
+      tag = "v${version}";
+      hash = "sha256-TsMrQx+P1F2t66e0tGG0VvRi4W7+pCpDHd0aNsacOsI=";
+    };
+    patches = [
+      # Remove the kpop dependency, whose upstream tarball
+      # (https://download.kopano.io/community/kapp:/kpop-2.2.0.tgz) is no longer
+      # available. Adapted from the upstream fix in v8.0.1
+      # (https://github.com/owncloud/ocis/pull/12043).
+      ./remove-kpop.patch
+    ];
   };
 
   nativeBuildInputs = [
@@ -58,8 +68,8 @@ buildGoModule rec {
       ;
     pnpm = pnpm_9;
     sourceRoot = "${src.name}/services/idp";
-    fetcherVersion = 1;
-    hash = "sha256-gNlN+u/bobnTsXrsOmkDcWs67D/trH3inT5AVQs3Brs=";
+    fetcherVersion = 3;
+    hash = "sha256-5iRnRxFJAWePyx83464guOqBqmao2pybaC4sFVPCOqk=";
   };
   pnpmRoot = "services/idp";
 

--- a/pkgs/by-name/oc/ocis/remove-kpop.patch
+++ b/pkgs/by-name/oc/ocis/remove-kpop.patch
@@ -1,0 +1,107 @@
+--- a/services/idp/package.json	2026-04-24 21:57:00.890593062 +0300
++++ b/services/idp/package.json	2026-04-24 21:57:25.907633711 +0300
+@@ -7,7 +7,7 @@
+     "analyze": "source-map-explorer 'build/static/js/*.js'",
+     "build": "node --openssl-legacy-provider scripts/build.js && rm -f build/service-worker.js",
+     "licenses": "NODE_PATH=./node_modules node ../scripts/js-license-ranger.js",
+-    "licenses:check": "license-checker-rseidelsohn --summary --relativeLicensePath --onlyAllow 'Python-2.0;Apache*;Apache License, Version 2.0;Apache-2.0;Apache 2.0;Artistic-2.0;BSD;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT;MPL-2.0;Public Domain;Unicode-TOU;Unlicense;WTFPL;ODC-By-1.0;BlueOak-1.0.0'  --excludePackages 'identifier;kpop;unicoderegexp' --clarificationsFile license-checker-clarifications.json",
++    "licenses:check": "license-checker-rseidelsohn --summary --relativeLicensePath --onlyAllow 'Python-2.0;Apache*;Apache License, Version 2.0;Apache-2.0;Apache 2.0;Artistic-2.0;BSD;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT;MPL-2.0;Public Domain;Unicode-TOU;Unlicense;WTFPL;ODC-By-1.0;BlueOak-1.0.0'  --excludePackages 'identifier;unicoderegexp' --clarificationsFile license-checker-clarifications.json",
+     "licenses:csv": "license-checker-rseidelsohn --relativeLicensePath --csv --out ../../third-party-licenses/node/idp/third-party-licenses.csv",
+     "licenses:save": "license-checker-rseidelsohn --relativeLicensePath --out /dev/null --files ../../third-party-licenses/node/idp/third-party-licenses",
+     "lint": "eslint ./**/*.{tsx,ts,jsx,js}",
+@@ -89,7 +89,6 @@
+     "i18next-browser-languagedetector": "^7.1.0",
+     "i18next-http-backend": "^2.2.2",
+     "i18next-resources-to-backend": "^1.1.4",
+-    "kpop": "https://download.kopano.io/community/kapp:/kpop-2.2.0.tgz",
+     "query-string": "^8.1.0",
+     "react": "^17.0.2",
+     "react-app-polyfill": "^2.0.0",
+@@ -153,10 +152,5 @@
+     "webpack": "4.47.0",
+     "webpack-manifest-plugin": "4.1.1",
+     "workbox-webpack-plugin": "7.0.0"
+-  },
+-  "pnpm": {
+-    "overrides": {
+-      "kpop>cldr": ""
+-    }
+   }
+ }
+--- a/services/idp/pnpm-lock.yaml	2026-04-24 21:57:00.893597991 +0300
++++ b/services/idp/pnpm-lock.yaml	2026-04-24 21:59:04.272001217 +0300
+@@ -4,9 +4,6 @@
+   autoInstallPeers: true
+   excludeLinksFromLockfile: false
+ 
+-overrides:
+-  kpop>cldr: ''
+-
+ dependencies:
+   '@fontsource/roboto':
+     specifier: ^5.0.8
+@@ -62,9 +59,6 @@
+   i18next-resources-to-backend:
+     specifier: ^1.1.4
+     version: 1.1.4
+-  kpop:
+-    specifier: https://download.kopano.io/community/kapp:/kpop-2.2.0.tgz
+-    version: '@download.kopano.io/community/kapp+/kpop-2.2.0.tgz(@gluejs/glue@0.3.0)(@material-ui/core@4.12.4)(@material-ui/icons@4.11.3)(notistack@0.8.9)(oidc-client@1.11.5)(react-dom@17.0.2)(react-intl@2.9.0)(react@17.0.2)(render-if@0.1.1)'
+   query-string:
+     specifier: ^8.1.0
+     version: 8.1.0
+@@ -12515,34 +12509,3 @@
+     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+     engines: {node: '>=10'}
+ 
+-  '@download.kopano.io/community/kapp+/kpop-2.2.0.tgz(@gluejs/glue@0.3.0)(@material-ui/core@4.12.4)(@material-ui/icons@4.11.3)(notistack@0.8.9)(oidc-client@1.11.5)(react-dom@17.0.2)(react-intl@2.9.0)(react@17.0.2)(render-if@0.1.1)':
+-    resolution: {registry: https://registry.npmjs.org/, tarball: https://download.kopano.io/community/kapp:/kpop-2.2.0.tgz}
+-    id: '@download.kopano.io/community/kapp+/kpop-2.2.0.tgz'
+-    name: kpop
+-    version: 2.2.0
+-    engines: {node: '>=6.11.0'}
+-    peerDependencies:
+-      '@gluejs/glue': ^0.3.0
+-      '@material-ui/core': ^4.8.0
+-      '@material-ui/icons': ^4.5.1
+-      notistack: ^0.8.8
+-      oidc-client: ^1.9.1
+-      react: ^16.8.0
+-      react-dom: ^16.8.0
+-      react-intl: ^2.6.0
+-      render-if: ^0.1.1
+-    dependencies:
+-      '@gluejs/glue': 0.3.0
+-      '@material-ui/core': 4.12.4(@types/react@17.0.65)(react-dom@17.0.2)(react@17.0.2)
+-      '@material-ui/icons': 4.11.3(@material-ui/core@4.12.4)(@types/react@17.0.65)(react-dom@17.0.2)(react@17.0.2)
+-      cldr: 7.5.0
+-      crc32: 0.2.2
+-      hsv-rgb: 1.0.0
+-      iso-639-1: 2.1.15
+-      notistack: 0.8.9(@material-ui/core@4.12.4)(react-dom@17.0.2)(react@17.0.2)
+-      oidc-client: 1.11.5
+-      react: 17.0.2
+-      react-dom: 17.0.2(react@17.0.2)
+-      react-intl: 2.9.0(prop-types@15.8.1)(react@17.0.2)
+-      render-if: 0.1.1
+-    dev: false
+--- a/services/idp/src/App.jsx	2026-04-24 21:57:00.894599634 +0300
++++ b/services/idp/src/App.jsx	2026-04-24 22:24:12.978001165 +0300
+@@ -1,14 +1,12 @@
+ import React, { ReactElement, Suspense, lazy } from 'react';
+ import PropTypes from 'prop-types';
+ 
+-import { MuiThemeProvider } from '@material-ui/core/styles';
+-import { defaultTheme as theme } from 'kpop/es/theme';
++import { MuiThemeProvider, createTheme } from '@material-ui/core/styles';
+ 
+-import 'kpop/static/css/base.css';
+-import 'kpop/static/css/scrollbar.css';
+-
+ import Spinner from './components/Spinner';
+ import * as version from './version';
++
++const theme = createTheme();
+ 
+ const LazyMain = lazy(() => import(/* webpackChunkName: "identifier-main" */ './Main'));
+ 


### PR DESCRIPTION
## Summary

- Adds a local patch that removes the `kpop` dependency from `services/idp`, whose upstream tarball (`https://download.kopano.io/community/kapp:/kpop-2.2.0.tgz`) is no longer served by kopano.io. The patch is adapted from the upstream fix ([owncloud/ocis#12043](https://github.com/owncloud/ocis/pull/12043), first released in **v8.0.1**) since oCIS is pinned to 5.0.9 in nixpkgs and the upstream diff doesn't apply to that version.
- Migrates `pnpmDeps` from `fetcherVersion = 1` to `fetcherVersion = 3` with a freshly computed hash.

With this change, the last package in nixpkgs using `fetcherVersion = 1` is migrated (after #494402 lands). Fresh builds of `ocis.pnpmDeps` no longer hit the dead kopano URL.

The patch removes `kpop` from `services/idp/package.json` and `pnpm-lock.yaml`, and replaces the kpop theme import in `services/idp/src/App.jsx` with `@material-ui/core/styles`' stock `createTheme()`. The IDP sign-in page therefore renders with a default Material-UI v4 theme instead of the Kopano-branded one (functional but unstyled by the old CSS resets).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [x] Manually verified: ran \`ocis init\` + \`ocis server\`, reached the sign-in page at \`https://localhost:9200\`, logged in as a demo user.
- [ ] Ran [nixpkgs-review](https://github.com/Mic92/nixpkgs-review) on this PR.
- [x] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.