### PR TITLE
nixos/duplicity: remove absolute path literals

### DIFF
--- a/nixos/modules/services/backup/duplicity.nix
+++ b/nixos/modules/services/backup/duplicity.nix
@@ -47,7 +47,7 @@ in
     includeFileList = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
-      example = /path/to/fileList.txt;
+      example = "/path/to/fileList.txt";
       description = ''
         File containing newline-separated list of paths to include into the
         backups. See the FILE SELECTION section in {manpage}`duplicity(1)` for
@@ -58,7 +58,7 @@ in
     excludeFileList = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       default = null;
-      example = /path/to/fileList.txt;
+      example = "/path/to/fileList.txt";
       description = ''
         File containing newline-separated list of paths to exclude into the
         backups. See the FILE SELECTION section in {manpage}`duplicity(1)` for


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Absolute path literals are not portable.
Nix complains about the changed lines if the option `lint-absolute-path-literals` is set to `warn`.

`lint-absolute-path-literals` Option Documentation:
https://nix.dev/manual/nix/2.34/command-ref/conf-file.html#conf-lint-absolute-path-literals

I'm making several PRs to Nixpkgs to resolve all instances of this issue.
https://github.com/NixOS/nixpkgs/pull/511569 was merged before I make this PR.

This PR is part of a batch of 5 PRs:
- https://github.com/NixOS/nixpkgs/pull/513210
- https://github.com/NixOS/nixpkgs/pull/513211 (This PR)
- https://github.com/NixOS/nixpkgs/pull/513212
- https://github.com/NixOS/nixpkgs/pull/513213
- https://github.com/NixOS/nixpkgs/pull/513214

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
