### PR TITLE
fetchPnpmDeps: deprecate fetcherVersion = 1, schedule removal for 26.11

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -483,40 +483,29 @@ In this example, `prePnpmInstall` will be run by both `pnpmConfigHook` and by th
 
 #### pnpm `fetcherVersion` {#javascript-pnpm-fetcherVersion}
 
-This is the version of the output of `fetchPnpmDeps`, if you haven't set it already, you can use `1` with your current hash:
+This is the version of the output of `fetchPnpmDeps`. New packages should use `3`:
 
 ```nix
 {
   # ...
   pnpmDeps = fetchPnpmDeps {
     # ...
-    fetcherVersion = 1;
-    hash = "..."; # you can use your already set hash here
-  };
-}
-```
-
-After upgrading to a newer `fetcherVersion`, you need to regenerate the hash:
-
-```nix
-{
-  # ...
-  pnpmDeps = fetchPnpmDeps {
-    # ...
-    fetcherVersion = 2;
+    fetcherVersion = 3;
     hash = "..."; # clear this hash and generate a new one
   };
 }
 ```
+
+When upgrading to a newer `fetcherVersion`, you need to regenerate the hash.
 
 This variable ensures that we can make changes to the output of `fetchPnpmDeps` without breaking existing hashes.
 Changes can include workarounds or bug fixes to existing PNPM issues.
 
 ##### Version history {#javascript-pnpm-fetcherVersion-versionHistory}
 
-- 1: Initial version, nothing special
+- 1: Initial version, nothing special. **Deprecated: Scheduled for removal in the 26.11 release.**. New packages must not use this value.
 - 2: [Ensure consistent permissions](https://github.com/NixOS/nixpkgs/pull/422975)
-- 3: [Build a reproducible tarball](https://github.com/NixOS/nixpkgs/pull/469950)
+- 3: [Build a reproducible tarball](https://github.com/NixOS/nixpkgs/pull/469950). **Recommended**
 
 ### Yarn {#javascript-yarn}
 

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -298,6 +298,12 @@
 
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
+- `fetchPnpmDeps`' `fetcherVersion = 1` is deprecated and scheduled for removal
+  in the 26.11 release. A deprecation warning has been added. Packages still on
+  `fetcherVersion = 1` should migrate to `fetcherVersion = 3` and regenerate
+  their hashes. See the [pnpm `fetcherVersion`
+  section](#javascript-pnpm-fetcherVersion) of the manual for details.
+
 - `buildNpmPackage` now supports `npmDepsFetcherVersion` (and `fetchNpmDeps` now supports `fetcherVersion`). Set to `2` to enable packument caching, which fixes builds for projects using npm workspaces.
 
 - Added `dell-bios-fan-control` package and service.

--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -61,139 +61,143 @@ in
       "fetchPnpmDeps `fetcherVersion` is not set to a supported value (${lib.concatStringsSep ", " (map toString supportedFetcherVersions)}), see https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
     ) true;
 
-    stdenvNoCC.mkDerivation (
-      finalAttrs:
+    lib.warnIf (fetcherVersion == 1)
+      "fetchPnpmDeps: `fetcherVersion = 1` is deprecated and scheduled for removal in the 26.11 release. Please migrate `${pname}` to `fetcherVersion = 3` and regenerate the hash. See https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion."
+
+      stdenvNoCC.mkDerivation
       (
-        args'
-        // {
-          name = "${pname}-pnpm-deps";
+        finalAttrs:
+        (
+          args'
+          // {
+            name = "${pname}-pnpm-deps";
 
-          nativeBuildInputs = [
-            cacert
-            jq
-            moreutils
-            pnpm # from args
-            yq
-            zstd
-          ]
-          ++ args.nativeBuildInputs or [ ];
+            nativeBuildInputs = [
+              cacert
+              jq
+              moreutils
+              pnpm # from args
+              yq
+              zstd
+            ]
+            ++ args.nativeBuildInputs or [ ];
 
-          impureEnvVars =
-            lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_REGISTRY" ] ++ args.impureEnvVars or [ ];
+            impureEnvVars =
+              lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_REGISTRY" ] ++ args.impureEnvVars or [ ];
 
-          installPhase = ''
-            runHook preInstall
+            installPhase = ''
+              runHook preInstall
 
-            lockfileVersion="$(yq -r .lockfileVersion pnpm-lock.yaml)"
-            if [[ ''${lockfileVersion:0:1} -gt ${lib.versions.major pnpm.version} ]]; then
-              echo "ERROR: lockfileVersion $lockfileVersion in pnpm-lock.yaml is too new for the provided pnpm version ${lib.versions.major pnpm.version}!"
-              exit 1
-            fi
+              lockfileVersion="$(yq -r .lockfileVersion pnpm-lock.yaml)"
+              if [[ ''${lockfileVersion:0:1} -gt ${lib.versions.major pnpm.version} ]]; then
+                echo "ERROR: lockfileVersion $lockfileVersion in pnpm-lock.yaml is too new for the provided pnpm version ${lib.versions.major pnpm.version}!"
+                exit 1
+              fi
 
-            export HOME=$(mktemp -d)
+              export HOME=$(mktemp -d)
 
-            # For fetcherVersion < 3, the pnpm store files are placed directly into $out.
-            # For fetcherVersion >= 3, it is bundled into a compressed tarball within $out,
-            # without distributing the uncompressed store files.
-            if [[ ${toString fetcherVersion} -ge 3 ]]; then
-              mkdir $out
-              storePath=$(mktemp -d)
-            else
-              storePath=$out
-            fi
+              # For fetcherVersion < 3, the pnpm store files are placed directly into $out.
+              # For fetcherVersion >= 3, it is bundled into a compressed tarball within $out,
+              # without distributing the uncompressed store files.
+              if [[ ${toString fetcherVersion} -ge 3 ]]; then
+                mkdir $out
+                storePath=$(mktemp -d)
+              else
+                storePath=$out
+              fi
 
-            # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
-            # any pnpm command would fail in that directory, the following disables this
-            pushd ..
-            pnpm config set manage-package-manager-versions false
-            popd
+              # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
+              # any pnpm command would fail in that directory, the following disables this
+              pushd ..
+              pnpm config set manage-package-manager-versions false
+              popd
 
-            pnpm config set store-dir $storePath
-            # Some packages produce platform dependent outputs. We do not want to cache those in the global store
-            pnpm config set side-effects-cache false
-            # As we pin pnpm versions, we don't really care about updates
-            pnpm config set update-notifier false
-            # Run any additional pnpm configuration commands that users provide.
-            ${prePnpmInstall}
-            # pnpm is going to warn us about using --force
-            # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
-            pnpm install \
-                --force \
-                --ignore-scripts \
-                ${lib.escapeShellArgs filterFlags} \
-                ${lib.escapeShellArgs pnpmInstallFlags} \
-                --registry="$NIX_NPM_REGISTRY" \
-                --frozen-lockfile
+              pnpm config set store-dir $storePath
+              # Some packages produce platform dependent outputs. We do not want to cache those in the global store
+              pnpm config set side-effects-cache false
+              # As we pin pnpm versions, we don't really care about updates
+              pnpm config set update-notifier false
+              # Run any additional pnpm configuration commands that users provide.
+              ${prePnpmInstall}
+              # pnpm is going to warn us about using --force
+              # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
+              pnpm install \
+                  --force \
+                  --ignore-scripts \
+                  ${lib.escapeShellArgs filterFlags} \
+                  ${lib.escapeShellArgs pnpmInstallFlags} \
+                  --registry="$NIX_NPM_REGISTRY" \
+                  --frozen-lockfile
 
-            # Store newer fetcherVersion in case pnpmConfigHook also needs it
-            if [[ ${toString fetcherVersion} -gt 1 ]]; then
-              echo ${toString fetcherVersion} > $out/.fetcher-version
-            fi
+              # Store newer fetcherVersion in case pnpmConfigHook also needs it
+              if [[ ${toString fetcherVersion} -gt 1 ]]; then
+                echo ${toString fetcherVersion} > $out/.fetcher-version
+              fi
 
-            runHook postInstall
-          '';
+              runHook postInstall
+            '';
 
-          fixupPhase = ''
-            runHook preFixup
+            fixupPhase = ''
+              runHook preFixup
 
-            # Remove timestamp and sort the json files
-            rm -rf $storePath/{v3,v10}/tmp
-            for f in $(find $storePath -name "*.json"); do
-              jq --sort-keys "del(.. | .checkedAt?)" $f | sponge $f
-            done
+              # Remove timestamp and sort the json files
+              rm -rf $storePath/{v3,v10}/tmp
+              for f in $(find $storePath -name "*.json"); do
+                jq --sort-keys "del(.. | .checkedAt?)" $f | sponge $f
+              done
 
-            # This folder contains symlinks to /build/source which we don't need
-            # since https://github.com/pnpm/pnpm/releases/tag/v10.27.0
-            rm -rf $storePath/{v3,v10}/projects
+              # This folder contains symlinks to /build/source which we don't need
+              # since https://github.com/pnpm/pnpm/releases/tag/v10.27.0
+              rm -rf $storePath/{v3,v10}/projects
 
-            # Ensure consistent permissions
-            # NOTE: For reasons not yet fully understood, pnpm might create files with
-            # inconsistent permissions, for example inside the ubuntu-24.04
-            # github actions runner.
-            # To ensure stable derivations, we need to set permissions
-            # consistently, namely:
-            # * All files with `-exec` suffix have 555.
-            # * All other files have 444.
-            # * All folders have 555.
-            # See https://github.com/NixOS/nixpkgs/pull/350063
-            # See https://github.com/NixOS/nixpkgs/issues/422889
-            if [[ ${toString fetcherVersion} -ge 2 ]]; then
-              find $storePath -type f -name "*-exec" -print0 | xargs -0 chmod 555
-              find $storePath -type f -not -name "*-exec" -print0 | xargs -0 chmod 444
-              find $storePath -type d -print0 | xargs -0 chmod 555
-            fi
+              # Ensure consistent permissions
+              # NOTE: For reasons not yet fully understood, pnpm might create files with
+              # inconsistent permissions, for example inside the ubuntu-24.04
+              # github actions runner.
+              # To ensure stable derivations, we need to set permissions
+              # consistently, namely:
+              # * All files with `-exec` suffix have 555.
+              # * All other files have 444.
+              # * All folders have 555.
+              # See https://github.com/NixOS/nixpkgs/pull/350063
+              # See https://github.com/NixOS/nixpkgs/issues/422889
+              if [[ ${toString fetcherVersion} -ge 2 ]]; then
+                find $storePath -type f -name "*-exec" -print0 | xargs -0 chmod 555
+                find $storePath -type f -not -name "*-exec" -print0 | xargs -0 chmod 444
+                find $storePath -type d -print0 | xargs -0 chmod 555
+              fi
 
-            if [[ ${toString fetcherVersion} -ge 3 ]]; then
-              (
-                cd $storePath
+              if [[ ${toString fetcherVersion} -ge 3 ]]; then
+                (
+                  cd $storePath
 
-                # Build a reproducible tarball, per instructions at https://reproducible-builds.org/docs/archives/
-                tar --sort=name \
-                  --mtime="@$SOURCE_DATE_EPOCH" \
-                  --owner=0 --group=0 --numeric-owner \
-                  --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
-                  --zstd -cf $out/pnpm-store.tar.zst .
-              )
-            fi
+                  # Build a reproducible tarball, per instructions at https://reproducible-builds.org/docs/archives/
+                  tar --sort=name \
+                    --mtime="@$SOURCE_DATE_EPOCH" \
+                    --owner=0 --group=0 --numeric-owner \
+                    --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+                    --zstd -cf $out/pnpm-store.tar.zst .
+                )
+              fi
 
-            runHook postFixup
-          '';
+              runHook postFixup
+            '';
 
-          passthru = args.passthru or { } // {
-            inherit fetcherVersion;
-            serve = callPackage ./serve.nix {
-              inherit pnpm; # from args
-              pnpmDeps = finalAttrs.finalPackage;
+            passthru = args.passthru or { } // {
+              inherit fetcherVersion;
+              serve = callPackage ./serve.nix {
+                inherit pnpm; # from args
+                pnpmDeps = finalAttrs.finalPackage;
+              };
             };
-          };
 
-          dontConfigure = true;
-          dontBuild = true;
-          outputHashMode = "recursive";
-        }
-        // hash'
+            dontConfigure = true;
+            dontBuild = true;
+            outputHashMode = "recursive";
+          }
+          // hash'
+        )
       )
-    )
   );
 
   pnpmConfigHook = makeSetupHook {


### PR DESCRIPTION
Depends on #513204. Please review diff with whitespaces off.

`fetcherVersion = 1` was kept around for backwards compatibility while callers migrated to `2`/`3`. With #494402 merged, only #513204 remains on master.

This PR emits a `lib.warnIf` warning whenever `fetchPnpmDeps` is called with `fetcherVersion = 1`, giving callers advance notice before the planned removal in 26.11. Per @Scrumplex's review the warning fires immediately on merge rather than being gated by `lib.oldestSupportedReleaseIsAtLeast`, since 26.05 will not include any packages with `fetcherVersion = 1` once #513204 lands.

After 26.11 ships, a follow-up PR should drop `1` from `supportedFetcherVersions` and clean up the dead v1 branches in `default.nix`, `pnpm-config-hook.sh`, and `serve.nix`.

## Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.