### PR TITLE
wolfstoneextract: change source, modernize

### DIFF
--- a/pkgs/by-name/wo/wolfstoneextract/package.nix
+++ b/pkgs/by-name/wo/wolfstoneextract/package.nix
@@ -1,34 +1,44 @@
 {
   lib,
   stdenv,
-  fetchFromBitbucket,
+  fetchFromGitHub,
   cmake,
+  nix-update-script,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wolfstoneextract";
   version = "1.2";
 
-  src = fetchFromBitbucket {
-    owner = "ecwolf";
-    repo = "wolfstoneextract";
-    rev = finalAttrs.version;
+  src = fetchFromGitHub {
+    owner = "ECWolfEngine";
+    repo = "WolfstoneExtract";
+    tag = finalAttrs.version;
     hash = "sha256-yrYLP2ewOtiry+EgH1IEaxz2Q55mqQ6mRGSxzVUnJ8Q=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
   ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--help" ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Utility to extract Wolfstone data from Wolfenstein II";
-    mainProgram = "wolfstoneextract";
-    homepage = "https://bitbucket.org/ecwolf/wolfstoneextract/src/master/";
-    platforms = [ "x86_64-linux" ];
-    license = with lib.licenses; [
-      gpl3Only
-      bsd3
-    ];
+    homepage = "https://github.com/ECWolfEngine/WolfstoneExtract";
+    changelog = "https://github.com/ECWolfEngine/WolfstoneExtract/blob/${finalAttrs.src.rev}/changelog";
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ keenanweaver ];
+    mainProgram = "wolfstoneextract";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = [ "x86_64-linux" ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Change source to current repository. [See note at original BitBucket repo](https://bitbucket.org/ecwolf/wolfstoneextract)
- Add modernized nixpkgs standards: src.tag, versionCheckHook, updateScript, sourceProvenance
- Changed license as I could find no indication of the BSD3 license anywhere.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
