### PR TITLE
ffmpeg-headless: fix signing on darwin

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -3,6 +3,7 @@
   config,
   stdenv,
   buildPackages,
+  darwin,
   removeReferencesTo,
   addDriverRunpath,
   pkg-config,
@@ -836,6 +837,7 @@ stdenv.mkDerivation (
       perl
       pkg-config
     ]
+    ++ optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ]
     ++ optionals stdenv.hostPlatform.isx86 [ nasm ]
     # Texinfo version 7.1 introduced breaking changes, which older versions of ffmpeg do not handle.
     ++ optionals (lib.versionAtLeast version "6") [ texinfo ]
@@ -1044,6 +1046,11 @@ stdenv.mkDerivation (
         patchelf $lib/lib/libavcodec.so --add-needed libvulkan.so --add-rpath ${
           lib.makeLibraryPath [ vulkan-loader ]
         }
+      ''
+      # Re-sign binaries and libraries on Darwin to ensure valid and deterministic signatures
+      + optionalString stdenv.hostPlatform.isDarwin ''
+        find "$bin" -type f -executable -exec codesign -f -s - {} +
+        find "$lib" -name "*.dylib" -exec codesign -f -s - {} +
       '';
 
     enableParallelBuilding = true;


### PR DESCRIPTION
not sure if the best fix, but fixes a bunch of consumers of ffmpeg-headless on darwin

cc @GaetanLepage @sarahec 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
