### PR TITLE
python3Packages.build: 1.4.2 -> 1.4.4

### DIFF
--- a/pkgs/development/python-modules/build/default.nix
+++ b/pkgs/development/python-modules/build/default.nix
@@ -13,20 +13,21 @@
   pytest-xdist,
   pytestCheckHook,
   setuptools,
+  uv,
   virtualenv,
   wheel,
 }:
 
 buildPythonPackage rec {
   pname = "build";
-  version = "1.4.2";
+  version = "1.4.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "build";
     tag = version;
-    hash = "sha256-wPTiiBaPBy8hsxJHhoeohsqoaMG7VXN5Vv7+PK9ZaO4=";
+    hash = "sha256-QprU0sXL6FL0rSVJwu8cYpcPlnYKzKAbkyDaTV778js=";
   };
 
   build-system = [ flit-core ];
@@ -59,6 +60,7 @@ buildPythonPackage rec {
         pytest-xdist
         pytestCheckHook
         setuptools
+        uv
         virtualenv
         wheel
       ];
@@ -79,8 +81,11 @@ buildPythonPackage rec {
         "test_output"
         "test_wheel_metadata"
         # Tests require network access to run pip install
-        "test_verbose_output"
+        "test_logging_output"
+        "test_pythonpath_does_not_interfere_with_outer_pip"
         "test_requirement_installation"
+        "test_verbose_logging_output"
+        "test_verbose_output"
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # Expects Apple's Python and its quirks


### PR DESCRIPTION
https://github.com/pypa/build/blob/1.4.4/CHANGELOG.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
