### PR TITLE
sayonara: 1.10.0-stable1 -> 1.11.0-stable1

### DIFF
--- a/pkgs/by-name/sa/sayonara/package.nix
+++ b/pkgs/by-name/sa/sayonara/package.nix
@@ -24,20 +24,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sayonara";
-  version = "1.10.0-stable1";
+  version = "1.11.0-stable1";
 
   src = fetchFromGitLab {
     owner = "luciocarreras";
     repo = "sayonara-player";
     tag = finalAttrs.version;
-    hash = "sha256-ZcuWe1dsLJS4/nLXSSKB7wzPU9COFyE4vPSwZIo0bgI=";
+    hash = "sha256-MvL5czJkvHNQkuoPtGq+q7fkJIX75IXmQCWmpgisqNI=";
   };
-
-  # error: no matching function for call to 'max'
-  postPatch = ''
-    substituteInPlace src/Components/Playlist/PlaylistModifiers.cpp \
-      --replace-fail "std::max" "std::max<MilliSeconds>"
-  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324329607
- Changelog: https://sayonara-player.com/changelog/changelog-1-11-0-stable1
- Diff: https://gitlab.com/luciocarreras/sayonara-player/-/compare/1.10.0-stable1...1.11.0-stable1

```
In file included from /build/source/src/Components/Library/PlayActionEventHandler.cpp:20:
/build/source/src/Components/Library/PlayActionEventHandler.h:32:30: warning: elaborated-type-specifier for a scoped enum must not use the 'class' keyword
   32 |                         enum class TrackSet :
      |                         ~~~~ ^~~~~
      |                              -----
/build/source/src/Components/Library/PlayActionEventHandler.h:32:36: error: use of enum 'TrackSet' without previous declaration
   32 |                         enum class TrackSet :
      |                                    ^~~~~~~~
/build/source/src/Components/Library/PlayActionEventHandler.h:33:33: error: 'uint8_t' was not declared in this scope
   33 |                                 uint8_t
      |                                 ^~~~~~~
/build/source/src/Components/Library/PlayActionEventHandler.h:24:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   23 | #include <memory>
  +++ |+#include <cstdint>
   24 | 
...
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
