### PR TITLE
openvr: unbreak jsoncpp abi

### DIFF
--- a/pkgs/by-name/op/openvr/package.nix
+++ b/pkgs/by-name/op/openvr/package.nix
@@ -20,6 +20,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xtCqro73fWQ6i0PiVmWYCK30DUSq1WeALoUolUjuWlE=";
   };
 
+  postUnpack = ''
+    # Move in-tree jsoncpp out to complement the patch above
+    # fetchpatch2 is not able to handle these renames
+    mkdir source/thirdparty
+    mv source/src/json source/thirdparty/jsoncpp
+  '';
+
   patches = [
     # https://github.com/ValveSoftware/openvr/pull/594
     (fetchpatch2 {
@@ -35,11 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postUnpack = ''
-    # Move in-tree jsoncpp out to complement the patch above
-    # fetchpatch2 is not able to handle these renames
-    mkdir source/thirdparty
-    mv source/src/json source/thirdparty/jsoncpp
+  postPatch = ''
+    # Fix jsoncpp ABI for downstream packages
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "-std=c++11" "-std=c++17"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
At current nixpkgs master, build of monado (not openvr, openvr build succeeds for some reason, despite producing broken `libopenvr_api.so`) fails with
```
            > /nix/store/p2vkw5s89ff1fs2d2rxqxiqil9s0jpcm-binutils-2.46/bin/ld.bfd: /nix/store/vfi2d566b6wxgxy9hc0m5c6ch0mqq22g-openvr-2.15.6/lib/libopenvr_api.so: undefined reference to `Json::Value::isMember(char const*) const'
            > /nix/store/p2vkw5s89ff1fs2d2rxqxiqil9s0jpcm-binutils-2.46/bin/ld.bfd: /nix/store/vfi2d566b6wxgxy9hc0m5c6ch0mqq22g-openvr-2.15.6/lib/libopenvr_api.so: undefined reference to `Json::Value::operator[](char const*)'      
            > /nix/store/p2vkw5s89ff1fs2d2rxqxiqil9s0jpcm-binutils-2.46/bin/ld.bfd: /nix/store/vfi2d566b6wxgxy9hc0m5c6ch0mqq22g-openvr-2.15.6/lib/libopenvr_api.so: undefined reference to `Json::Value::operator[](char const*) const'
```

It is caused because jsoncpp we have packaged in nixpkgs is built with cpp17, thus the `operator[]` accepts `string_view`, and not `char const*` as expected by openvr headers

```cpp
#ifndef JSONCPP_HAS_STRING_VIEW
#if __cplusplus >= 201703L
#define JSONCPP_HAS_STRING_VIEW 1
#endif
#endif

#ifdef JSONCPP_HAS_STRING_VIEW
  /// Access an object value by name, create a null member if it does not exist.
  /// \param key may contain embedded nulls.
  Value& operator[](std::string_view key);
  /// Access an object value by name, returns null if there is no member with
  /// that name.
  /// \param key may contain embedded nulls.
  const Value& operator[](std::string_view key) const;
#else
  /// Access an object value by name, create a null member if it does not exist.
  /// \note Because of our implementation, keys are limited to 2^30 -1 chars.
  /// Exceeding that will cause an exception.
  Value& operator[](const char* key);
  /// Access an object value by name, returns null if there is no member with
  /// that name.
  const Value& operator[](const char* key) const;
  /// Access an object value by name, create a null member if it does not exist.
  /// \param key may contain embedded nulls.
  Value& operator[](const String& key);
  /// Access an object value by name, returns null if there is no member with
  /// that name.
  /// \param key may contain embedded nulls.
  const Value& operator[](const String& key) const;
#endif
```

Forcing openvr to use `c++17` seems to work fine

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
