### PR TITLE
Darwin build fixes for dante, pwgen, and srm.

### DIFF
--- a/pkgs/by-name/da/dante/package.nix
+++ b/pkgs/by-name/da/dante/package.nix
@@ -37,7 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     if !stdenv.hostPlatform.isDarwin then
       [ "--with-libc=libc.so.6" ]
     else
-      [ "--with-libc=libc${stdenv.hostPlatform.extensions.sharedLibrary}" ];
+      [
+        "--with-libc=libc${stdenv.hostPlatform.extensions.sharedLibrary}"
+        "CFLAGS=-std=gnu17"
+      ];
 
   dontAddDisableDepTrack = stdenv.hostPlatform.isDarwin;
 

--- a/pkgs/by-name/pw/pwgen/package.nix
+++ b/pkgs/by-name/pw/pwgen/package.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
   ];
 
+  configureFlags = [ "CFLAGS=-std=gnu17" ];
+
   meta = {
     description = "Password generator which creates passwords which can be easily memorized by a human";
     homepage = "https://github.com/tytso/pwgen";

--- a/pkgs/by-name/sr/srm/package.nix
+++ b/pkgs/by-name/sr/srm/package.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation {
 
   patches = [ ./fix-output-in-verbose-mode.patch ];
   nativeBuildInputs = [ autoreconfHook ];
+  configureFlags = [ "CFLAGS=-std=gnu17" ];
 
   meta = {
     description = "Delete files securely";


### PR DESCRIPTION
See [Darwin regressions from autoconf update on staging-next](https://github.com/NixOS/nixpkgs/issues/511329). This PR contains fixes for three of the affected packages.