### PR TITLE
bitwarden-cli: 2026.3.0 -> 2026.4.1

### DIFF
--- a/pkgs/by-name/bi/bitwarden-cli/package.nix
+++ b/pkgs/by-name/bi/bitwarden-cli/package.nix
@@ -14,20 +14,20 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "bitwarden-cli";
-  version = "2026.3.0";
+  version = "2026.4.1";
 
   src = fetchFromGitHub {
     owner = "bitwarden";
     repo = "clients";
     tag = "cli-v${finalAttrs.version}";
-    hash = "sha256-ecaCHk04N9h0RP8gK0o+MLgYS6Linsqi7AaC86hwQ3U=";
+    hash = "sha256-QhkuGW3R577zHpTZ1+GPhEtSUdZAKrAN/WPJhA5AA7c=";
   };
 
   postPatch = ''
     # remove code under unfree license
     rm -r bitwarden_license
 
-    # Upstream cli-v2026.3.0 bumps @napi-rs/cli to 3.5.1 in the desktop workspace,
+    # Upstream cli-v2026.4.1 bumps @napi-rs/cli to 3.5.1 in the desktop workspace,
     # but the root lockfile still points that entry at 3.2.0.
     substituteInPlace package-lock.json \
       --replace-fail \
@@ -38,7 +38,7 @@ buildNpmPackage (finalAttrs: {
   nodejs = nodejs_22;
   npmDepsFetcherVersion = 2;
 
-  npmDepsHash = "sha256-JVRwU5MUQ8YzhCW7ODiyVqbgq7/PxgMV9dlw7i32MfI=";
+  npmDepsHash = "sha256-QCN0fyXr/D39MJnwOyAvYu5hANj8flk3HMVuw9kaJwc=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     perl
@@ -97,6 +97,7 @@ buildNpmPackage (finalAttrs: {
   versionCheckKeepEnvironment = [ "HOME" ];
 
   passthru = {
+    inherit (finalAttrs) npmDeps;
     tests = {
       vaultwarden = nixosTests.vaultwarden.sqlite;
     };


### PR DESCRIPTION
## Summary
- `bitwarden-cli`: 2026.3.0 -> 2026.4.1
- expose `passthru.npmDeps` so `nix-update` can refresh `npmDepsHash` during unattended updates

Bitwarden describes `cli-v2026.4.1` as a re-release of `cli-v2026.3.0` after the malicious npm-only `@bitwarden/cli@2026.4.0` publish was revoked:

- https://github.com/bitwarden/clients/releases/tag/cli-v2026.4.1
- https://community.bitwarden.com/t/bitwarden-statement-on-checkmarx-supply-chain-incident/96127

The upstream source diff between `cli-v2026.3.0` and `cli-v2026.4.1` is only the CLI version metadata bump, but updating nixpkgs keeps the packaged version aligned with the clean re-release and avoids leaving the package marked as outdated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
