### PR TITLE
movim: 0.32.1 → 0.33.1; nixos/movim: add public/images

### DIFF
--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -71,9 +71,10 @@ let
         stateDirectories = # sh
           ''
             # Symlinking in our state directories
-            rm -rf $out/{.env,cache} ${appDir}/{log,public/cache}
+            rm -rf $out/{.env,cache} ${appDir}/{log,public/cache,public/images}
             ln -s ${cfg.dataDir}/.env ${appDir}/.env
             ln -s ${cfg.dataDir}/public/cache ${appDir}/public/cache
+            ln -s ${cfg.dataDir}/public/images ${appDir}/public/images
             ln -s ${cfg.logDir} ${appDir}/log
             ln -s ${cfg.runtimeDir}/cache ${appDir}/cache
           '';
@@ -867,8 +868,9 @@ in
           fi
 
           # Caches, logs
-          mkdir -p ${cfg.dataDir}/public/cache ${cfg.logDir} ${cfg.runtimeDir}/cache
+          mkdir -p ${cfg.dataDir}/public/{cache,images} ${cfg.logDir} ${cfg.runtimeDir}/cache
           chmod -R ug+rw ${cfg.dataDir}/public/cache
+          chmod -R ug+rw ${cfg.dataDir}/public/images
           chmod -R ug+rw ${cfg.logDir}
           chmod -R ug+rwx ${cfg.runtimeDir}/cache
 
@@ -943,6 +945,10 @@ in
           mode = "0750";
         };
         "${dataDir}/public/cache".d = {
+          inherit user group;
+          mode = "0750";
+        };
+        "${dataDir}/public/images".d = {
           inherit user group;
           mode = "0750";
         };

--- a/pkgs/by-name/mo/movim/package.nix
+++ b/pkgs/by-name/mo/movim/package.nix
@@ -44,13 +44,13 @@ let
 in
 php.buildComposerProject2 (finalAttrs: {
   pname = "movim";
-  version = "0.32.1";
+  version = "0.33.1";
 
   src = fetchFromGitHub {
     owner = "movim";
     repo = "movim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1sNStxgvP8iaiINIa4UOFz8RGeQlFvJK5+RGlK/3Xa8=";
+    hash = "sha256-TQ8PLmz9hn+OFfIF5cckv5gGhID7vuA5O1xVJ6PSPVA=";
   };
 
   php = php.buildEnv (
@@ -88,12 +88,12 @@ php.buildComposerProject2 (finalAttrs: {
     ++ lib.optional minify.style.enable lightningcss
     ++ lib.optional minify.svg.enable scour;
 
-  vendorHash = "sha256-8tEs+kQGB0pmhEQndOOOUDTFkIq+OvyKTmi9YAvK6qc=";
+  vendorHash = "sha256-iy869AKgn/ZL1jYFvqvYkfr4lv5J4l2W6glGqZvJLhE=";
 
   postPatch = ''
     # Our modules are already wrapped, removes missing *.so warnings;
     # replacing `$configuration` with actually-used flags.
-    substituteInPlace src/Movim/Daemon/Session.php \
+    substituteInPlace src/Movim/Daemon/SessionsWorker.php \
       --replace-fail \
         "'exec ' . PHP_BINARY . ' ' . \$configuration . '" \
         "'exec ' . PHP_BINARY . ' -dopcache.enable=1 -dopcache.enable_cli=1 ' . '"
@@ -110,6 +110,10 @@ php.buildComposerProject2 (finalAttrs: {
     substituteInPlace src/Movim/Image.php \
       --replace-fail "Imagick::ALPHACHANNEL_REMOVE" "Imagick::ALPHACHANNEL_OFF" \
       --replace-fail "Imagick::ALPHACHANNEL_ACTIVATE" "Imagick::ALPHACHANNEL_ON"
+
+    # Remove debug var_dump that was accidentally left in
+    substituteInPlace src/Movim/i18n/Locale.php \
+      --replace-fail "var_dump(LOCALES_PATH . \$language . '.po');" ""
   '';
 
   preBuild =

--- a/pkgs/by-name/mo/movim/package.nix
+++ b/pkgs/by-name/mo/movim/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   writeShellScript,
   dash,
   php,
@@ -52,6 +53,14 @@ php.buildComposerProject2 (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-TQ8PLmz9hn+OFfIF5cckv5gGhID7vuA5O1xVJ6PSPVA=";
   };
+
+  patches = [
+    # Removes debug var_dump that was accidentally left in
+    (fetchpatch2 {
+      url = "https://github.com/movim/movim/commit/239bd099711d196df574106155374f301f2c9531.patch";
+      hash = "sha256-tLWUOKTJDFE9obrnghG/S8FHJY0rcWlueWncHVdi0Jk=";
+    })
+  ];
 
   php = php.buildEnv (
     {
@@ -110,10 +119,6 @@ php.buildComposerProject2 (finalAttrs: {
     substituteInPlace src/Movim/Image.php \
       --replace-fail "Imagick::ALPHACHANNEL_REMOVE" "Imagick::ALPHACHANNEL_OFF" \
       --replace-fail "Imagick::ALPHACHANNEL_ACTIVATE" "Imagick::ALPHACHANNEL_ON"
-
-    # Remove debug var_dump that was accidentally left in
-    substituteInPlace src/Movim/i18n/Locale.php \
-      --replace-fail "var_dump(LOCALES_PATH . \$language . '.po');" ""
   '';
 
   preBuild =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
