### PR TITLE
verifpal: 0.31.2 -> 0.52.0

### DIFF
--- a/pkgs/by-name/ve/verifpal/package.nix
+++ b/pkgs/by-name/ve/verifpal/package.nix
@@ -1,24 +1,21 @@
 {
   lib,
   fetchFromGitHub,
-  buildGoModule,
-  pigeon,
+  rustPlatform,
 }:
 
-buildGoModule (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "verifpal";
-  version = "0.31.2";
+  version = "0.51.0";
 
   src = fetchFromGitHub {
     owner = "symbolicsoft";
     repo = "verifpal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-k8SGCo36tk4Etg4jt0NDeEj1BmSYjaZZptNNnrOXs4E=";
+    hash = "sha256-k13pf7uWTuxeTAvY5Dw0WYA6PGa6uvsX537HLCHP2qE=";
   };
 
-  vendorHash = "sha256-Vg375DBPvurRpwl918AGQU+wJGnB1tYisgch9FA+Y/g=";
-
-  nativeBuildInputs = [ pigeon ];
+  cargoHash = "sha256-7aW3ppvtnqgmBtuwVkM1jPjtSRtB1dSjpogz0XfzKpM=";
 
   subPackages = [ "cmd/verifpal" ];
 

--- a/pkgs/by-name/ve/verifpal/package.nix
+++ b/pkgs/by-name/ve/verifpal/package.nix
@@ -1,26 +1,21 @@
 {
   lib,
   fetchFromGitHub,
-  buildGoModule,
-  pigeon,
+  rustPlatform,
 }:
 
-buildGoModule (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "verifpal";
-  version = "0.31.2";
+  version = "0.51.0";
 
   src = fetchFromGitHub {
     owner = "symbolicsoft";
     repo = "verifpal";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-k8SGCo36tk4Etg4jt0NDeEj1BmSYjaZZptNNnrOXs4E=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k13pf7uWTuxeTAvY5Dw0WYA6PGa6uvsX537HLCHP2qE=";
   };
 
-  vendorHash = "sha256-Vg375DBPvurRpwl918AGQU+wJGnB1tYisgch9FA+Y/g=";
-
-  nativeBuildInputs = [ pigeon ];
-
-  subPackages = [ "cmd/verifpal" ];
+  cargoHash = "sha256-7aW3ppvtnqgmBtuwVkM1jPjtSRtB1dSjpogz0XfzKpM=";
 
   meta = {
     homepage = "https://verifpal.com/";

--- a/pkgs/by-name/ve/verifpal/package.nix
+++ b/pkgs/by-name/ve/verifpal/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "verifpal";
-  version = "0.51.0";
+  version = "0.52.0";
 
   src = fetchFromGitHub {
     owner = "symbolicsoft";
     repo = "verifpal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-k13pf7uWTuxeTAvY5Dw0WYA6PGa6uvsX537HLCHP2qE=";
+    hash = "sha256-o59Pn5B1GW8fzSsUzaJaK1S/CWaYLLVpqIcQ0L5P1KA=";
   };
 
-  cargoHash = "sha256-7aW3ppvtnqgmBtuwVkM1jPjtSRtB1dSjpogz0XfzKpM=";
+  cargoHash = "sha256-BvaCEqxdY16oHb2jHsqu6mL4ZNtIhY4S+OnrqQ80Yhc=";
 
   meta = {
     homepage = "https://verifpal.com/";


### PR DESCRIPTION
Update verifpal to version 0.51.0 ([Changelog](https://github.com/symbolicsoft/verifpal/releases/tag/v0.51.0), [more details](https://symbolic.software/blog/2026-04-20-verifpal-0-51/))
Update verifpal to version 0.52.0 ([Changelog](https://github.com/symbolicsoft/verifpal/releases/tag/v0.52.0))

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
