### PR TITLE
mactracker: 7.13.5 -> 8.2.1

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -135,6 +135,8 @@
 
 - `pulsar` has finally migrated from electron v12 to v30, backup `~/.pulsar` before upgrading. See [Pulsar on Electron 30: what it means for you](https://blog.pulsar-edit.dev/posts/20251202-savetheclocktower-pulsar-on-electron-30/).
 
+- `mactracker` has been updated to major version 8, which now [requires macOS 11 Big Sur or later](https://mactracker.ca/releasenotes-mac.html#:~:text=System%20requirements%20updated%20to%20macOS%2011%20Big%20Sur%20and%20later). The previous version supported Mac OS X 10.6.8 or later.
+
 - `bartender` has been updated to major version 6. This removes support for MacOS Sonoma (and adds support for Tahoe). For more information, see [the release notes](https://www.macbartender.com/Bartender6/release_notes/) or [the Bartender 6 support page](https://www.macbartender.com/Bartender6/support/).
 
 - `lima` has been updated from `1.x` to `2.x`. This major update includes several breaking changes, such as `/tmp/lima` no longer being mounted by default.

--- a/pkgs/by-name/ma/mactracker/package.nix
+++ b/pkgs/by-name/ma/mactracker/package.nix
@@ -11,16 +11,16 @@
   common-updater-scripts,
   versionCheckHook,
   writeShellScript,
-  xcbuild,
+  re-plistbuddy,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mactracker";
-  version = "7.13.5";
+  version = "8.2.1";
 
   src = fetchurl {
     url = "https://mactracker.ca/downloads/Mactracker_${finalAttrs.version}.zip";
-    hash = "sha256-VCcpEgMWo5U3BJpDSc0mQUIlmPuTKD7JBcmmKmYNf1Y=";
+    hash = "sha256-c78Bj63nJ+/qejUiD7hBEJlxubmIc+wElazwHGRRyfI=";
   };
 
   dontPatch = true;
@@ -58,7 +58,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = writeShellScript "version-check" ''
-    ${xcbuild}/bin/PlistBuddy -c "Print :CFBundleVersion" "$1"
+    ${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleVersion" "$1"
   '';
   versionCheckProgramArg = [ "${placeholder "out"}/Applications/Mactracker.app/Contents/Info.plist" ];
   doInstallCheck = true;


### PR DESCRIPTION
## Things done

Updated [Mactracker to v8.2.1](https://mactracker.ca/releasenotes-mac.html#:~:text=Release%20Notes%20%2D%20Mac-,8.2.1,-April%207%2C%202026)

<img width="961" height="672" alt="image" src="https://github.com/user-attachments/assets/5d393f20-bd99-43c0-a375-6ac57037073e" />


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
