### PR TITLE
squishyball: fix build with gcc15

### DIFF
--- a/pkgs/by-name/sq/squishyball/package.nix
+++ b/pkgs/by-name/sq/squishyball/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   autoreconfHook,
   fetchFromGitLab,
+  fetchDebianPatch,
   fetchpatch,
   flac,
   libao,
@@ -46,6 +47,22 @@ stdenv.mkDerivation {
       name = "ncurses-6.3.patch";
       url = "https://gitlab.xiph.org/xiph/squishyball/uploads/5609ceaf85ebb6dc297c0efe61b9a1b7/0001-mincurses.c-use-ncurses-API-to-enter-raw-mode-ncurse.patch";
       sha256 = "06llp7cd77f4vvhz8qdld551dnlpjxf98j7rmp3i1x1kng4f0iy3";
+    })
+
+    (fetchDebianPatch {
+      pname = "squishyball";
+      version = "0.1~svn19085";
+      debianRevision = "8";
+      patch = "0006-Workaround-opaqueness-of-struct-term.patch";
+      hash = "sha256-7zXPsJxIpQI2Ro+GNIZEASxHFrRqSUiXjQl9/KeHSAk=";
+    })
+
+    (fetchDebianPatch {
+      pname = "squishyball";
+      version = "0.1~svn19085";
+      debianRevision = "8";
+      patch = "0007-ncurses-internals.patch";
+      hash = "sha256-GzYV0Oas1Amte0m5XCAUfEMRUTYI3UticCdASCn+s28=";
     })
   ];
 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324332705

```
main.c: In function 'main':
main.c:1087:3: warning: ignoring return value of 'write' declared with attribute 'warn_unused_result' [-Wunused-result]
 1087 |   write(exit_fds[1]," ",1);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
  CC       mincurses.o
mincurses.c:262:1: error: unknown type name 'TTY'
  262 | TTY orig;
      | ^~~
mincurses.c: In function 'min_panel_init':
mincurses.c:353:5: error: implicit declaration of function 'GET_TTY' [-Wimplicit-function-declaration]
  353 |     GET_TTY(outfd,&orig);
      |     ^~~~~~~
mincurses.c:367:7: error: implicit declaration of function 'SET_TTY' [-Wimplicit-function-declaration]
  367 |       SET_TTY(outfd,&orig);
      |       ^~~~~~~
```

Fetch debian patches to fix the problem.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
