### PR TITLE
nim: deprecate and move os and cpu to stdenv.targetPlatform.nim

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -621,6 +621,64 @@ let
             else
               null;
         };
+
+        nim = {
+          # See these locations for a known list of cpu/os idntifeiers:
+          # - https://nim-lang.org/docs/system.html#hostCPU
+          # - https://nim-lang.org/docs/system.html#hostOS
+          cpu =
+            if final.isAarch32 then
+              "arm"
+            else if final.isAarch64 then
+              "arm64"
+            else if final.isAlpha then
+              "alpha"
+            else if final.isAvr then
+              "avr"
+            else if final.isMips && final.is32Bit then
+              "mips"
+            else if final.isMips && final.is64Bit then
+              "mips64"
+            else if final.isMsp430 then
+              "msp430"
+            else if final.isPower && final.is32bit then
+              "powerpc"
+            else if final.isPower && final.is64bit then
+              "powerpc64"
+            else if final.isRiscV && final.is64bit then
+              "riscv64"
+            else if final.isSparc then
+              "sparc"
+            else if final.isx86_32 then
+              "i386"
+            else if final.isx86_64 then
+              "amd64"
+            else
+              null;
+          os =
+            if final.isAndroid then
+              "Android"
+            else if final.isDarwin then
+              "MacOSX"
+            else if final.isFreeBSD then
+              "FreeBSD"
+            else if final.isGenode then
+              "Genode"
+            else if final.isLinux then
+              "Linux"
+            else if final.isNetBSD then
+              "NetBSD"
+            else if final.isNone then
+              "Standalone"
+            else if final.isOpenBSD then
+              "OpenBSD"
+            else if final.isWindows then
+              "Windows"
+            else if final.isiOS then
+              "iOS"
+            else
+              null;
+        };
       };
     in
     assert final.useAndroidPrebuilt -> final.isAndroid;

--- a/pkgs/by-name/ni/nim-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-2_2/package.nix
@@ -48,8 +48,8 @@ let
           runHook preBuild
           cat >> config/config.nims << WTF
 
-          switch("os", "${nimUnwrapped.passthru.nimTarget.os}")
-          switch("cpu", "${nimUnwrapped.passthru.nimTarget.cpu}")
+          switch("os", "${stdenv.targetPlatform.nim.os}")
+          switch("cpu", "${stdenv.targetPlatform.nim.cpu}")
           switch("define", "nixbuild")
 
           # Configure the compiler using the $CC set by Nix at build time
@@ -63,8 +63,8 @@ let
 
           mv config/nim.cfg config/nim.cfg.old
           cat > config/nim.cfg << WTF
-          os = "${nimUnwrapped.passthru.nimTarget.os}"
-          cpu =  "${nimUnwrapped.passthru.nimTarget.cpu}"
+          os = "${stdenv.targetPlatform.nim.os}"
+          cpu =  "${stdenv.targetPlatform.nim.cpu}"
           define:"nixbuild"
           WTF
 

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -11,77 +11,6 @@
   sqlite,
   darwin,
 }:
-
-let
-  parseCpu =
-    platform:
-    with platform;
-    # Derive a Nim CPU identifier
-    if isAarch32 then
-      "arm"
-    else if isAarch64 then
-      "arm64"
-    else if isAlpha then
-      "alpha"
-    else if isAvr then
-      "avr"
-    else if isMips && is32bit then
-      "mips"
-    else if isMips && is64bit then
-      "mips64"
-    else if isMsp430 then
-      "msp430"
-    else if isPower && is32bit then
-      "powerpc"
-    else if isPower && is64bit then
-      "powerpc64"
-    else if isRiscV && is64bit then
-      "riscv64"
-    else if isSparc then
-      "sparc"
-    else if isx86_32 then
-      "i386"
-    else if isx86_64 then
-      "amd64"
-    else
-      throw "no Nim CPU support known for ${config}";
-
-  parseOs =
-    platform:
-    with platform;
-    # Derive a Nim OS identifier
-    if isAndroid then
-      "Android"
-    else if isDarwin then
-      "MacOSX"
-    else if isFreeBSD then
-      "FreeBSD"
-    else if isGenode then
-      "Genode"
-    else if isLinux then
-      "Linux"
-    else if isNetBSD then
-      "NetBSD"
-    else if isNone then
-      "Standalone"
-    else if isOpenBSD then
-      "OpenBSD"
-    else if isWindows then
-      "Windows"
-    else if isiOS then
-      "iOS"
-    else
-      throw "no Nim OS support known for ${config}";
-
-  parsePlatform = p: {
-    cpu = parseCpu p;
-    os = parseOs p;
-  };
-
-  nimHost = parsePlatform stdenv.hostPlatform;
-  nimTarget = parsePlatform stdenv.targetPlatform;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "nim-unwrapped";
   version = "2.2.4";
@@ -135,8 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   kochArgs = [
-    "--cpu:${nimHost.cpu}"
-    "--os:${nimHost.os}"
+    "--cpu:${stdenv.hostPlatform.nim.cpu}"
+    "--os:${stdenv.hostPlatform.nim.os}"
     "-d:release"
     "-d:useGnuReadline"
   ]
@@ -168,7 +97,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    inherit nimHost nimTarget;
+    nimHost = lib.warn "nimHost is deprecated, please use stdenv.hostPlatform.nim.os instead." stdenv.hostPlatform.nim.os;
+    nimTarget = lib.warn "nimTarget is deprecated, please use stdenv.hostPlatform.nim.cpu instead." stdenv.hostPlatform.cpu;
   };
 
   meta = {


### PR DESCRIPTION
This change makes it more accesssable to using nim cpu and os without
referencing nim.

Derived from https://github.com/NixOS/nixpkgs/pull/496960 to help with merge/reviewing process.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
