### PR TITLE
pkgs/nixUnitVersions: init

### DIFF
--- a/pkgs/by-name/ni/nix-unit/package.nix
+++ b/pkgs/by-name/ni/nix-unit/package.nix
@@ -12,13 +12,10 @@
   nlohmann_json,
   pkg-config,
   fetchFromGitHub,
+  # Override to link nix-unit against a different Nix version; must
+  # expose nix-main, nix-store, nix-expr, nix-cmd, nix-flake.
+  nixComponents ? nixVersions.nixComponents_2_30,
 }:
-let
-  # We pin the nix version to a known working one here as upgrades can likely break the build.
-  # Since the nix language is rather stable we don't always need to have the latest and greatest for unit tests
-  # On each update of nix unit we should re-evaluate what version we need.
-  nixComponents = nixVersions.nixComponents_2_30;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nix-unit";
   version = "2.30.0";

--- a/pkgs/by-name/ni/nix-unit/versions.nix
+++ b/pkgs/by-name/ni/nix-unit/versions.nix
@@ -1,0 +1,13 @@
+{
+  nix-unit,
+  nixVersions,
+}:
+
+# nix-unit linked against different Nix releases.
+# This will get populated over time with nix-unit compiled against all nix versions that nixpkgs supports
+
+{
+  nix_2_30 = nix-unit.override {
+    nixComponents = nixVersions.nixComponents_2_30;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11869,6 +11869,8 @@ with pkgs;
     }
   );
 
+  nixUnitVersions = recurseIntoAttrs (callPackage ../by-name/ni/nix-unit/versions.nix { });
+
   nix = nixVersions.stable;
 
   nixStatic = pkgsStatic.nix;


### PR DESCRIPTION
Allow to add more nix-unit versions. Over time adding all supported nix-versions.

Motivation: replacing the lib tests modules.sh with a proper testing utility such as nix-unit. Need to test every nix version, which means we need nix-unit for every nix version for equivalent testing.


CC: @infinisil @roberth 

Opening this PR after our stalled attempt in #381342 to migrate the extensive module system test suites.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
