### PR TITLE
devilspie2: 0.44 -> 0.45

### DIFF
--- a/pkgs/by-name/de/devilspie2/package.nix
+++ b/pkgs/by-name/de/devilspie2/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   intltool,
   pkg-config,
   glib,
@@ -12,11 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "devilspie2";
-  version = "0.44";
+  version = "0.45";
 
-  src = fetchurl {
-    url = "mirror://savannah/devilspie2/devilspie2-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Cp8erdKyKjGBY+QYAGXUlSIboaQ60gIepoZs0RgEJkA=";
+  src = fetchFromGitHub {
+    owner = "dsalt";
+    repo = "devilspie2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3TLA4vvTY8nt2LupLH8btdGhz7mfWYHnwRf7lQKGq8A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update version and move to github repo (linked from original homepage)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
