### PR TITLE
exegol: relax requests deps

### DIFF
--- a/pkgs/by-name/ex/exegol/package.nix
+++ b/pkgs/by-name/ex/exegol/package.nix
@@ -22,6 +22,7 @@ python3Packages.buildPythonApplication rec {
     "rich"
     "argcomplete"
     "supabase"
+    "requests"
   ];
 
   dependencies =


### PR DESCRIPTION

Fixes the build of `exegol` by relaxing its `requests` dependency constraint.

The package was failing during `pythonRuntimeDepsCheckHook` because upstream requires `requests~=2.32.5`, while nixpkgs currently provides `requests` 2.33.1:

```text
requests~=2.32.5 not satisfied by version 2.33.1
````

Relaxing the dependency allows `exegol` to build against the `requests` version available in nixpkgs.

## Things done

* Built on platform:

  * [x] x86_64-linux
  * [ ] aarch64-linux
  * [ ] x86_64-darwin
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [ ] [NixOS tests] in [nixos/tests].
  * [ ] [Package tests] at `passthru.tests`.
  * [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
* [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
* [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
* Nixpkgs Release Notes

  * [ ] Package update: when the change is major or breaking.
* NixOS Release Notes

  * [ ] Module addition: when adding a new NixOS module.
  * [ ] Module update: when the change is significant.
* [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.