### PR TITLE
nomacs: 3.21.1 -> 3.22.0

### DIFF
--- a/pkgs/by-name/no/nomacs/package.nix
+++ b/pkgs/by-name/no/nomacs/package.nix
@@ -13,8 +13,8 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "nomacs";
-  version = "3.21.1";
-  hash = "sha256-RRa19vj7iTtGzdssdtHVOsDzS4X+p1HeiZKy8EIWxq8=";
+  version = "3.22.0";
+  hash = "sha256-yheDM92AtojGXCx0UrK5gBvQgyGSxcsKPzl93HpHRt8=";
 
   src = fetchFromGitHub {
     owner = "nomacs";
@@ -24,13 +24,6 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) hash;
   };
 
-  plugins = fetchFromGitHub {
-    owner = "novomesk";
-    repo = "nomacs-plugins";
-    rev = "20101da282f13d3184ece873388e1c234a79b5e7";
-    hash = "sha256-gcRc4KoWJQ5BirhLuk+c+5HwBeyQtlJ3iyX492DXeVk=";
-  };
-
   outputs = [
     "out"
   ]
@@ -38,13 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ "man" ];
 
   sourceRoot = "${finalAttrs.src.name}/ImageLounge";
-
-  postUnpack = ''
-    rm -rf $sourceRoot/plugins
-    mkdir $sourceRoot/plugins
-    cp -r ${finalAttrs.plugins}/* $sourceRoot/plugins/
-    chmod -R +w $sourceRoot/plugins
-  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Diff: https://github.com/nomacs/nomacs/compare/3.21.1...3.22.0

Changelog: https://github.com/nomacs/nomacs/releases/tag/3.22.0

`novomesk/nomacs-plugins` was merged into the main `nomacs/nomacs` repository in:

```gitcommit
commit 326ce6257865c710464d818ed6a880a0116058be
Merge: 03997 20101
Author: Scrubs <scrubbbbs@gmail.com>
Date:   Mon Jun 23 19:43:44 2025 -0500

    Add 'ImageLounge/plugins/' from commit '20101da282f13d3184ece873388e1c234a79b5e7'

    git-subtree-dir: ImageLounge/plugins
    git-subtree-mainline: 0399773e3cdce75aca6b591f6ffd71a9362e9d8b
    git-subtree-split: 20101da282f13d3184ece873388e1c234a79b5e7
```

It has been updated to compile with Qt6 and reformatted.  While `novomesk/nomacs-plugins` does not compile with 3.22.0 any more, due to the Qt version update.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - `N/A` [NixOS tests] in [nixos/tests].
  - `N/A` [Package tests] at `passthru.tests`.
  - `N/A` Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - `N/A` Package update: when the change is major or breaking.
- NixOS Release Notes
  - `N/A` Module addition: when adding a new NixOS module.
  - `N/A` Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
