### PR TITLE
nixos/facter: enable trackpoint if detected

### DIFF
--- a/nixos/modules/hardware/facter/default.nix
+++ b/nixos/modules/hardware/facter/default.nix
@@ -17,6 +17,7 @@
     ./keyboard.nix
     ./networking
     ./system.nix
+    ./trackpoint.nix
     ./virtualisation.nix
   ];
 

--- a/nixos/modules/hardware/facter/trackpoint.nix
+++ b/nixos/modules/hardware/facter/trackpoint.nix
@@ -1,0 +1,23 @@
+{ lib, config, ... }:
+let
+  cfg = config.hardware.facter;
+
+  isTrackpoint = device: device.mouse_type.name == "Track Point";
+
+  # Trackpoint devices does not seem to be added to `report.hardware.mouse`, but
+  # are available in `report.smbios.pointing_device`
+  pointingDevices = lib.attrByPath [ "report" "smbios" "pointing_device" ] [ ] cfg;
+in
+{
+  options.hardware.facter.detected.trackpoint.enable =
+    lib.mkEnableOption "Trackpoint input device"
+    // {
+      default = lib.any isTrackpoint pointingDevices;
+      defaultText = "Enabled if trackpoint is found in facter report";
+    };
+
+  config.hardware.trackpoint = lib.mkIf (cfg.enable && cfg.detected.trackpoint.enable) {
+    enable = lib.mkDefault cfg.detected.trackpoint.enable;
+    emulateWheel = lib.mkDefault cfg.detected.trackpoint.enable;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

What it says on the tin. If a trackpoint device is found in the facter report, it'll enable the configuration for it. I tested it on my Lenovo P14s Gen3 and it seems to be working as intended.

I used the `smbios.pointing_device` instead of `hardware.mouse`, as the latter doesn't seem to include trackpoint devices. I think this would have to be implemented upstream in `nixos-facter` itself to be included.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
