### PR TITLE
pulumi-bin: 3.231.0 -> 3.232.0

### DIFF
--- a/pkgs/by-name/pu/pulumi-bin/data.nix
+++ b/pkgs/by-name/pu/pulumi-bin/data.nix
@@ -1,24 +1,24 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.231.0";
+  version = "3.232.0";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.231.0-linux-x64.tar.gz";
-        sha256 = "0xbibmm40gjic48m0zn9qbirl5rq41cawrzij79w6iqnxmr960jh";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-linux-x64.tar.gz";
+        sha256 = "08s4fbf7hvi2yyi3m7n5832cmjizpg8df1v9bkg0wlv6iffwcwlb";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.52.0-linux-amd64.tar.gz";
-        sha256 = "1n3ffjh664kdmy30ri222f9p74zzdfs2qqq3adlf0wjzk9ysx1j8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-linux-amd64.tar.gz";
+        sha256 = "08s30ng4bgk8p3rlazpclg36anjir2c2qvyyyfwpila7bf6h6f9b";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-akamai-v11.1.0-linux-amd64.tar.gz";
         sha256 = "139h210ixh4s46sa90p9ga9nl1bqb1m36hbr1ylcr80nx5hjh42p";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.99.0-linux-amd64.tar.gz";
-        sha256 = "113vdmi9y47c85rjps8p79g8knbpskq24raiwikiqr0y4qb94ml7";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-linux-amd64.tar.gz";
+        sha256 = "0znqp5vd9kd02zdsqr6avvrdvvcc3fh370llyxwgif8x1kh8ri19";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-linux-amd64.tar.gz";
@@ -29,8 +29,8 @@
         sha256 = "00xz7zb8z64fy9fwbl6797ndj8q9xb3xnxpi6f5s4sbg3lzicp7j";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.26.0-linux-amd64.tar.gz";
-        sha256 = "0rd6hi52b1wm8mqvhg69q11c0h7gk3ii74jyh9f8hc1bnn3nib4l";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-linux-amd64.tar.gz";
+        sha256 = "1gzxca78x7k9r9z54hgqpg93sybcpkw6vcizjdvkiw55g621a8k6";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-linux-amd64.tar.gz";
@@ -41,8 +41,8 @@
         sha256 = "14i18v6z68szdf1y1bg3m51kqn4i1fdv6jbi282f7rxr0fbzzmpl";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.34.0-linux-amd64.tar.gz";
-        sha256 = "0sv0d2srgzn2psaip3zgfnqr9d209vivqrnaxd06xjrjqg2ivfh5";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-linux-amd64.tar.gz";
+        sha256 = "1wlfds1g2wx08dwi2vbzz79wlwyk78brxxirlq8xblp4hi8wv72d";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-linux-amd64.tar.gz";
@@ -61,40 +61,40 @@
         sha256 = "1jaf26rrhwf4b2bakvf5sidbvq8flqp5jgs8r7x5zgidr27p06b1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v4.11.2-linux-amd64.tar.gz";
-        sha256 = "187qg3cdbd194qs1nqv51zxddvg0hvac3kkgqjd6hcfrg0wy70bs";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-linux-amd64.tar.gz";
+        sha256 = "177c2jh44fsr3m40g00qg7czlnmjl50z5dw7grf74jw7qdqj5ihl";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.2.1-linux-amd64.tar.gz";
         sha256 = "0hnardid0kbzy65dmn7vz8ddy5hq78nf2871zz6srf2hfyiv7qa4";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.0-linux-amd64.tar.gz";
-        sha256 = "0cfmmrlcw7axfifha743gdms5mj5f11g9c07dbzwm42v9s8mpdkb";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.1-linux-amd64.tar.gz";
+        sha256 = "03w4kfws4zksmri961fs3lsvwg15mpj6nhc0a1zplqpw6rsjgcmr";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.20.0-linux-amd64.tar.gz";
-        sha256 = "1rxdalz46s6qicikkjgqyvspbysc1bb76chx9zpzkq5vm6y9gaxs";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-linux-amd64.tar.gz";
+        sha256 = "0c9fgan0c1chx452lm05vfnvkzzrwwmzgxabv0cwc0b2sr9sv199";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.12.2-linux-amd64.tar.gz";
-        sha256 = "000fpr8w20z3nq1mxjvlpi34xvc0klg69zivrxfhv9y9qmbnn5dq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-linux-amd64.tar.gz";
+        sha256 = "173gm48bs91f23zg3yds04zk70bwybr23cw3ljd28g5p3lzmxl33";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.10.0-linux-amd64.tar.gz";
-        sha256 = "16hgmcwchdamx825hav5qd37zli8bpa977qqkhxhhzmf54v29bkc";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-linux-amd64.tar.gz";
+        sha256 = "1hjdkyrn9wszykxi2mr4ncpbibggd4vz1fyba4jhnyl1j8xm5642";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-google-native-v0.32.0-linux-amd64.tar.gz";
         sha256 = "1zra1ck64gs4nwqf62ksfmpbx24lxw6vsgi47j4v8q051m89fgq3";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.32.1-linux-amd64.tar.gz";
-        sha256 = "19k79m8dhkiy4x4rs6dq4zkfczjsnmc0mvbh57b5l52imsv7ks7m";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-linux-amd64.tar.gz";
+        sha256 = "179hhd656hyl7nvcxzsrj98gbs2rw2l700a2kz6252yr0gq07482";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.29.0-linux-amd64.tar.gz";
-        sha256 = "1y3qvvnpdkzvq32zwh0gb8a56r5f369gg6cknj2drndx7nan7q2y";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-linux-amd64.tar.gz";
+        sha256 = "0yqbn1niyy2a4gq87r4wk75v3p114xf099gxqgyq39c079bdwlns";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v5.10.0-linux-amd64.tar.gz";
@@ -125,16 +125,16 @@
         sha256 = "1ind8360irxnnang0jw6dwm5m6bmn4f162yj7w4l6vi91k5d1s20";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.130.0-linux-amd64.tar.gz";
-        sha256 = "1c5wi6f94x86qvjjhlrnvicghp1nr5phil7mxn4kjj983fsi50qg";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.131.0-linux-amd64.tar.gz";
+        sha256 = "1l8wc8xhppjfbm9v60raqhgrimbbx2wqy0jj7r1nd7kw1b0x4kkh";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-sumologic-v1.0.11-linux-amd64.tar.gz";
         sha256 = "0pppwgwl726rfy92fnya9afj3cciw13vzs9r60w2477i3250slqj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.0-linux-amd64.tar.gz";
-        sha256 = "1xjmxigqak7f31g7hi9ljjw047ymgrkaap4nvi5lzkk37fmj8lk1";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.1-linux-amd64.tar.gz";
+        sha256 = "0n6j1s4xk5f9nmhldk2fbmp5h9p1vcr4733hhk45by3ffbd1fbrz";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tls-v5.3.1-linux-amd64.tar.gz";
@@ -163,20 +163,20 @@
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.231.0-darwin-x64.tar.gz";
-        sha256 = "1vlpyir3yvm4aixgvz8iiy41y6zzm6ybd29zkgrfdk004m06a6k4";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-darwin-x64.tar.gz";
+        sha256 = "0ah734rb7g9s7211yx2xfg4jykj52l4amrxhvpsnxlblj42kmy6v";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.52.0-darwin-amd64.tar.gz";
-        sha256 = "069qcq92phcdx78pjjbglzpwfwq3nv3sb87x0kdzm79hacgrhah4";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-darwin-amd64.tar.gz";
+        sha256 = "0ak7sxvgy9ribxcszs3wx36h0bqzlrqfa3acqhy3m769rgi7fk3f";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-akamai-v11.1.0-darwin-amd64.tar.gz";
         sha256 = "1r1j115bii4hv22z5pwp1yvcbi41j4mdcvwbn04xjridvrpsp63b";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.99.0-darwin-amd64.tar.gz";
-        sha256 = "184v0cw24dwqs116ql8jbskbp9ckljwq5967dxc6rxj7z5cnsnrx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-darwin-amd64.tar.gz";
+        sha256 = "08fh378b7nv6cpdppiw9knnkr5nz7zvw4yikrbc607pinkby33qf";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-darwin-amd64.tar.gz";
@@ -187,8 +187,8 @@
         sha256 = "020sgrldrfj13y19n0vvblrc0jb7mssa1rx0izar0b93xdvywy0g";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.26.0-darwin-amd64.tar.gz";
-        sha256 = "01bgd1jvkash862wfpqpg0yd5yxw7grvv06zxnfp8d1jbhma8lia";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-darwin-amd64.tar.gz";
+        sha256 = "0a0vwb9vndi7s0arll0ppyp9w46n730rf2jd74qck05j2f3cmlbs";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-darwin-amd64.tar.gz";
@@ -199,8 +199,8 @@
         sha256 = "1pvliacpzv58kfi3sq1xa8b16aa14gs23wh1gm12kb8lyrh9cvwf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.34.0-darwin-amd64.tar.gz";
-        sha256 = "1siccb0vis674gkjgv55rnww5z4xvcfrhl96gcv9bazbcb5w4ik0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-darwin-amd64.tar.gz";
+        sha256 = "0c381vy7j2flvlcri2yadw3i983dgmi28y6xxz2x8psgy48ic7zd";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-darwin-amd64.tar.gz";
@@ -219,40 +219,40 @@
         sha256 = "1cn36p8qs1chnbwf78s56r1rbr1dvk15ahad3p5gr3q7kpxwa4cf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v4.11.2-darwin-amd64.tar.gz";
-        sha256 = "14q83v6nr61gjap1044kglqw99f8injvdqk1b0367jbzcqkgni3g";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-darwin-amd64.tar.gz";
+        sha256 = "1rj9iiphaqbsrd9g5a6ci47qpp7vdv60h186lzv3aqnl104g4ka6";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.2.1-darwin-amd64.tar.gz";
         sha256 = "1m5lh59h7nck1flzxs9m4n0ag0klk3jmnpf7hc509vffxs89xnjq";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.0-darwin-amd64.tar.gz";
-        sha256 = "1jdyv9bjc03zpiq4x3ns37ililcz97bqv6gq6csdx38abql6nnjv";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.1-darwin-amd64.tar.gz";
+        sha256 = "1h8s1pc8bdpbhr2v8cfzn59mczpnwdi26x9dplkf95ck6r4s96gh";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.20.0-darwin-amd64.tar.gz";
-        sha256 = "0hrplkwvmrhn686pg4fk00xq6p9n280lq5vx9xki26443ayj4vjq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-darwin-amd64.tar.gz";
+        sha256 = "17wlk03and5hw07cydlzpd5c8pxnfjd7drfgr41rjyq5gcrn1z6r";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.12.2-darwin-amd64.tar.gz";
-        sha256 = "109czcvbzv17l5wdbiksknn554d3p6jc18d8gqp8qx24ha01nl3z";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-darwin-amd64.tar.gz";
+        sha256 = "08lwfgna0xh3fmrgmzzsbm9wy2z36kvgqm0pqnh82cvhgrbrikpk";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.10.0-darwin-amd64.tar.gz";
-        sha256 = "0xmm1y2fj5nnhkxsmnzlfqr4v6ymlldn1kdv584bv08ycb3vgc7i";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-darwin-amd64.tar.gz";
+        sha256 = "0bwb4a1s2543s754bzs5i1vm3z9axp45bv5b5311add9x6bb3d1n";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-google-native-v0.32.0-darwin-amd64.tar.gz";
         sha256 = "0ddd0pgpyywq291r9q8w6bn41r2px595017iihx4n2cnb1c4v6d5";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.32.1-darwin-amd64.tar.gz";
-        sha256 = "04rmlydspvgbcgn7qd9sk0bd70axz2rmpiydfw383352bxrinlvs";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-darwin-amd64.tar.gz";
+        sha256 = "1l0n97dx3fdrjk5qrwfh72ib42c1kd5mj5zbsly8rc2l92bw63cq";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.29.0-darwin-amd64.tar.gz";
-        sha256 = "0kyz6jp890gba3rah5wbz3phlp38wzyzpvnryzfdy5v5c0520sb8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-darwin-amd64.tar.gz";
+        sha256 = "0f313ir5kjv8fqyyrp4k12d3nd5cy4jibjym2p5v88drjn3w1g19";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v5.10.0-darwin-amd64.tar.gz";
@@ -283,16 +283,16 @@
         sha256 = "16347ib8lq81v9vmc6953g293zqvqpfg6g6ggw7q5chbjlfkvzhr";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.130.0-darwin-amd64.tar.gz";
-        sha256 = "1l5r5bggkkkbn9j1i1p7hplyllskwrm2zxdl34pywc3g23hqil5y";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.131.0-darwin-amd64.tar.gz";
+        sha256 = "14diyvn5cr0fihmbf8093gdwwgyrrx2xlj24wpqffn84jsmskgai";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-sumologic-v1.0.11-darwin-amd64.tar.gz";
         sha256 = "1jpcyp3lqiz4aab331x7shhqxzp4m6nz68vhkyqksvdplzr9rj44";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.0-darwin-amd64.tar.gz";
-        sha256 = "1ia6nvcgcwm2263yyyka65f0ja741z1bw6xvf6a0f6fkwkavkbk5";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.1-darwin-amd64.tar.gz";
+        sha256 = "06kgqzqadzdjmq7sach2wwq6j125pc5pibis7b7gyx3x9mjvnccl";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tls-v5.3.1-darwin-amd64.tar.gz";
@@ -321,20 +321,20 @@
     ];
     aarch64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.231.0-linux-arm64.tar.gz";
-        sha256 = "0y71qkbv5rasrriw1p0yp0jcf6lynpfrc86ykjrzsm6scaaa94si";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-linux-arm64.tar.gz";
+        sha256 = "1l87s3g3yz75xwp0l43psa5ngb9cwv8kmimlybn87drnj6klkih2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.52.0-linux-arm64.tar.gz";
-        sha256 = "10b1mrbi9q086rdlwjj0y2z97alc8wwb7whmqskxbmr315fhp1h9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-linux-arm64.tar.gz";
+        sha256 = "16x8b648cin42nj25sjhf6z6mp34m3v9jmfwav6lh65x8halxa6j";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-akamai-v11.1.0-linux-arm64.tar.gz";
         sha256 = "0v84z83y56lnvrgsmla4qnig8cs57ynilib4ah29wb0dwkxvzamf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.99.0-linux-arm64.tar.gz";
-        sha256 = "107pwj3774fqr2gkz2r3aawsm0fklh9f3lgr721f7l1hnd7wjjb9";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-linux-arm64.tar.gz";
+        sha256 = "0n455bfxf6r4ffrg773rhr57m230ldap58dpxm1dnrx640vc7wdd";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-linux-arm64.tar.gz";
@@ -345,8 +345,8 @@
         sha256 = "0cn81fmbgkx1c8cdlsmkxncfq7xfxb08lpkw9419p0kzrvqkgd3l";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.26.0-linux-arm64.tar.gz";
-        sha256 = "050yqp827zp63c9yrsdx39ps7xm2cwkij31s63ha7vwm4rjb21kn";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-linux-arm64.tar.gz";
+        sha256 = "1vbi2yap9z5rr9b5yybyfr9y6h8a2910gs8kwh8yxp6ipn94dwa3";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-linux-arm64.tar.gz";
@@ -357,8 +357,8 @@
         sha256 = "027nbrks3n634nsmlwis1qwklj615ixknr6k5jg0q4wd1mwxhsjm";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.34.0-linux-arm64.tar.gz";
-        sha256 = "1p59zhn0yjxrl0cw9bh2pym4jg7q3f05jd5bqcsmy17d9vrhj5m0";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-linux-arm64.tar.gz";
+        sha256 = "0hrn1bw7hr15j29ghw7c18nkpkwmfkqjh62vxmnrs26r9qawzyl5";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-linux-arm64.tar.gz";
@@ -377,40 +377,40 @@
         sha256 = "0kliiasvaxxhbgaw00686rmb1sx9ml4njm6vxxs90bz77vq4y6kh";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v4.11.2-linux-arm64.tar.gz";
-        sha256 = "1cpz86gqsi6azjj4xc3z16ggyrim0ww5x0w5hl98b9qvn4agxgar";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-linux-arm64.tar.gz";
+        sha256 = "10z2d328rqls7zbmbh167s9dqv446aiwwivafm9lxv76zyp8mk7j";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.2.1-linux-arm64.tar.gz";
         sha256 = "111pia2f5xwkwaqs6p90ri29l5b3ivmahsa1bji4fwyyjyp22h4r";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.0-linux-arm64.tar.gz";
-        sha256 = "1vzz310wfq3m5vcwc5fhyj0rkxrzq3sd7scqy69bi755f2jg137j";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.1-linux-arm64.tar.gz";
+        sha256 = "1zagad13q8xgpicqz2d0qgrj4qxg9iqvmmw6di8n2nqhy4hczv8f";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.20.0-linux-arm64.tar.gz";
-        sha256 = "1z40a8m2vdj6djif92ydkwf141s12zln0p6i161mlnx9d0yzxvx4";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-linux-arm64.tar.gz";
+        sha256 = "0ab5m34s7cbyf7gsb6gb1kgsyb09l33wb4bn62x9l21pk11ra9w7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.12.2-linux-arm64.tar.gz";
-        sha256 = "1wnj70pj5s4fdyxcljr6ryrdp0z47l9n5792s70fj2535l60mfz7";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-linux-arm64.tar.gz";
+        sha256 = "1p5r5mgyknvsxpcr0blplj654s0wdzpaap22ia21k34krzjf41ii";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.10.0-linux-arm64.tar.gz";
-        sha256 = "1y9vsix2agv2yw99p180qnbxd48ppzhx0gd60gng4abfqxy6ly3f";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-linux-arm64.tar.gz";
+        sha256 = "1lk2f3rbr5p2z5zyqn05yldw238rc23avldgrf2fizda9wr8qmj6";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-google-native-v0.32.0-linux-arm64.tar.gz";
         sha256 = "0d8m2krbzxjhfm82dgf8p4vm3kk9gk98l798q4ayjrddqqb4mxq4";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.32.1-linux-arm64.tar.gz";
-        sha256 = "094pmichc66fnd38vfn4hb2dl3v88vqfx00smk0b19fdbrafcp5j";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-linux-arm64.tar.gz";
+        sha256 = "04spc869y5pl9fdrs75sand1345hx25r21fv2xvglmifgjk2b93j";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.29.0-linux-arm64.tar.gz";
-        sha256 = "0py7m3xam70g0xv74jz1937z3zfwvh31zjvx66ln9ixcnh6jw1m2";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-linux-arm64.tar.gz";
+        sha256 = "1ax41ricywlhy1nxjl1gybv9xkfw6ifz1xwlzcps7xdw8bcnrcj0";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v5.10.0-linux-arm64.tar.gz";
@@ -441,16 +441,16 @@
         sha256 = "16jl5fbzb7w93bksfnk32h2hqfdnr6qb9722jfbpzv5ksdw8f7g9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.130.0-linux-arm64.tar.gz";
-        sha256 = "135kfkyg8kki6rsc097i8ssj6vl4nxkn5rk3id7b0nw734c4k0hm";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.131.0-linux-arm64.tar.gz";
+        sha256 = "0pzlnw3x10ad9h948g5fxz0a0vxl0k63ll8r8ysdckwnrm4a9b1a";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-sumologic-v1.0.11-linux-arm64.tar.gz";
         sha256 = "0glljz03v764n53n5l33ji64vj86ipdv5bkr03ijl8wrc22j5syy";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.0-linux-arm64.tar.gz";
-        sha256 = "0y9jwwwr28j28da1lxq7p39csnab7g2b97vpfzgaxi327xbgs2zz";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.1-linux-arm64.tar.gz";
+        sha256 = "1vh5cqyj3kifvk59s8hhfpi7fvy3av1ss78mpim4gyjqjf82rf0b";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tls-v5.3.1-linux-arm64.tar.gz";
@@ -479,20 +479,20 @@
     ];
     aarch64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.231.0-darwin-arm64.tar.gz";
-        sha256 = "1xvy351b2hvdc89q9k943hsrh4ar1mypx9xqk8f5k4l5har6wdb2";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.232.0-darwin-arm64.tar.gz";
+        sha256 = "1v2h6a6qb2i94nx43rxilxc04nmzcpmh75bm4ha0nyg1x6q9g6mj";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.52.0-darwin-arm64.tar.gz";
-        sha256 = "1ad1rdd18f9j4qqx47k6s1j1xd4x3m5ghs4mm1prqwhi4rdz78kg";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aiven-v6.53.1-darwin-arm64.tar.gz";
+        sha256 = "09iz2jkcmj5hg5p56d1lj6xii32q2fhsqjm5xfinhzlg7ryjv6bk";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-akamai-v11.1.0-darwin-arm64.tar.gz";
         sha256 = "0zsa46x3fqmbicfm6lg10k9ghj40pjq0v889ksqpws2d4jlhbwp7";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.99.0-darwin-arm64.tar.gz";
-        sha256 = "1840mp4vq1ag50jgnhwld68dcfai6xgcvbbbgjybp97s12fhy2k8";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-alicloud-v3.100.0-darwin-arm64.tar.gz";
+        sha256 = "1v73xq38hnr8lh6z2ma7sks6a7z2awb388pfcifa2wna13i36dy1";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-artifactory-v8.10.4-darwin-arm64.tar.gz";
@@ -503,8 +503,8 @@
         sha256 = "13cmpgxyg8qcpdrv6qf5ik401khf76h04qrphy8avggzzsqb2vfs";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.26.0-darwin-arm64.tar.gz";
-        sha256 = "0x3kwazc516nfdlna6zypr73c899mzg91xjfszjwpby0dk0yxy2k";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-aws-v7.27.0-darwin-arm64.tar.gz";
+        sha256 = "0l1msjdcibyg7h33zfsbgrc0cz4alzy914dh2ck8l2amd1x1r1s4";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azuread-v6.9.0-darwin-arm64.tar.gz";
@@ -515,8 +515,8 @@
         sha256 = "0bgv7zbszr2x175x6qm124giplb6a182kabd34kxlp3rddikcyl1";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.34.0-darwin-arm64.tar.gz";
-        sha256 = "0kq8zvhsni19rari53rl24ixds7hi1mn0wcams8wxavff43x1xjz";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-azure-v6.35.0-darwin-arm64.tar.gz";
+        sha256 = "1g076zzz792s9ywc81xwm7y6r6nfwglwxapcyl0jnlc873mdf842";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-cloudflare-v6.14.0-darwin-arm64.tar.gz";
@@ -535,40 +535,40 @@
         sha256 = "1y9sl873la0k3fkkl8y7rfzzq5sl9qayks7zvpasacpykpr5fi7x";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v4.11.2-darwin-arm64.tar.gz";
-        sha256 = "0sz3nvjjwy9ryjhbj7c02dz1qlqybcj3kwd8w2a2jlg0ajbkvwmk";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-docker-v5.0.0-darwin-arm64.tar.gz";
+        sha256 = "0a6xryj1ksn10cf6lmnvq1yyydvxr2vys4mwmdn0h2xp3s4z5qc8";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-equinix-metal-v3.2.1-darwin-arm64.tar.gz";
         sha256 = "12bzicm43l7yvh02v5fx3z8v46l9i7a9f677735xi5rjbmd2an4c";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.0-darwin-arm64.tar.gz";
-        sha256 = "1hxk2i3ykyidxf82agp1b8h118cmv2314qrnsq62hjcb7ji33lld";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-fastly-v12.0.1-darwin-arm64.tar.gz";
+        sha256 = "13lgi9zy9cxs6zwc1whw3qhq6hk1kgi72p4yvhdavdc3j4nf241p";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.20.0-darwin-arm64.tar.gz";
-        sha256 = "1ra0sh4zzmwkg6z856668g8bx5qrczgiqs2gqv7wx09sjx3lcfvx";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gcp-v9.21.0-darwin-arm64.tar.gz";
+        sha256 = "1h9fnc878f3r1nyd0a6rbzmanxsv5ymc1k63kqvc0lcny4k8w6m9";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.12.2-darwin-arm64.tar.gz";
-        sha256 = "0gzzzfs65pq3j05k39j3n4vxlpqi3v5v3jxvcj273gvh369cq1sq";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-github-v6.13.0-darwin-arm64.tar.gz";
+        sha256 = "1kmapqwa3vdi7caf1ir9r2ypx7g062lgn8xqdda5rq5yclkv3jqi";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.10.0-darwin-arm64.tar.gz";
-        sha256 = "1m5aywahwc6q1ig196013rfca3c8n1yzksj9b4kq9ld1snb804i7";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-gitlab-v9.11.0-darwin-arm64.tar.gz";
+        sha256 = "1b80p3wjvs740rih0afjiw2scwc0m3ykhla5fg7kqhf6xlmrliqj";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-google-native-v0.32.0-darwin-arm64.tar.gz";
         sha256 = "0caz4kgnnrmdr7n571xc7yqscac9jnjwwpjzbnvx4ib6a91wvsdn";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.32.1-darwin-arm64.tar.gz";
-        sha256 = "150kg8brpsazpdd6laywwvbrjmzl4n3w7saf9vidiwsv01zpl90m";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-hcloud-v1.33.0-darwin-arm64.tar.gz";
+        sha256 = "17507yg6izmnwaw029wvg5r0xnnsh4fcjczd61ajbhs7vqysrvx2";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.29.0-darwin-arm64.tar.gz";
-        sha256 = "1gvwpd280xdykmp30gnnnb5d4fhlr20dgi173kp8f9gccczwivpr";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-kubernetes-v4.30.0-darwin-arm64.tar.gz";
+        sha256 = "0n8my65zbia3kyhcfrzi7119kggkzldmcljhw3i3zh9839a52p7a";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-linode-v5.10.0-darwin-arm64.tar.gz";
@@ -599,16 +599,16 @@
         sha256 = "0bdvm3lgihf4nn8l1r9cla23ww9vxqb2km8z02argsms14ry0dg6";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.130.0-darwin-arm64.tar.gz";
-        sha256 = "0v8l25zsm5zfwyfl90p9cxbawi1ym2kl27djlfmd19srgad01jhw";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-spotinst-v3.131.0-darwin-arm64.tar.gz";
+        sha256 = "1ixsmykdi9q3xd3v3i95alhfmdylak44wmxisinfw09c23l3fx1f";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-sumologic-v1.0.11-darwin-arm64.tar.gz";
         sha256 = "1c4pn5nr8d97n9bqd7vz9gzlbi50hnfjylwwch445ylqp5l8gvqf";
       }
       {
-        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.0-darwin-arm64.tar.gz";
-        sha256 = "0wmpsw8lm83vlkxk2wyg0dj895yn9zi52qzjam0svcnz5xdhd31x";
+        url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tailscale-v0.27.1-darwin-arm64.tar.gz";
+        sha256 = "08aapfbkaqn7q1ngqg4sv070js1zkz1wd6v1hsigi217cgn7l4zc";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-tls-v5.3.1-darwin-arm64.tar.gz";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/pulumi/pulumi/releases/tag/v3.232.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
