### PR TITLE
Init dolphin insync plugin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27518,6 +27518,12 @@
     githubId = 14172;
     name = "Tim Cuthbertson";
   };
+  timh-de = {
+    email = "hessberger.tim+m@gmail.com";
+    name = "Tim Hessberger";
+    github = "TimH-DE";
+    githubId = 79646946;
+  };
   timhae = {
     email = "tim.haering@posteo.net";
     githubId = 6264882;

--- a/pkgs/by-name/do/dolphin-insync-plugin/package.nix
+++ b/pkgs/by-name/do/dolphin-insync-plugin/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  kdePackages,
+}:
+
+stdenv.mkDerivation {
+  pname = "dolphin-insync-plugin";
+  version = "0-unstable-2024-03-12";
+
+  src = fetchFromGitHub {
+    owner = "insynchq";
+    repo = "dolphin-insync-plugin";
+    rev = "9fbf1c18ca14d4111d454a93c41ed2175fdcd4f5";
+    hash = "sha256-WgkfIf8RY4mO+JS2EPBFXuJNBM/TQV91uPKOjl0y9qM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+  ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.kio
+    kdePackages.kcoreaddons
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
+    "-DKDE_INSTALL_PLUGINDIR=lib/qt-6/plugins"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/scalable/emblems
+
+    cat << 'EOF' > $out/share/icons/hicolor/scalable/emblems/dolphin-emblem-insync-synced.svg
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="11" fill="#27ae60"/>
+      <path fill="#ffffff" d="M10 16.4l-4.2-4.2 1.4-1.4 2.8 2.8 6.8-6.8 1.4 1.4z"/>
+    </svg>
+    EOF
+
+    cat << 'EOF' > $out/share/icons/hicolor/scalable/emblems/dolphin-emblem-insync-syncing.svg
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="11" fill="#2980b9"/>
+      <path fill="#ffffff" d="M12 5V2l-4 4 4 4V7c2.8 0 5 2.2 5 5h2c0-3.9-3.1-7-7-7zm-7 5c0 3.9 3.1 7 7 7v3l4-4-4-4v3c-2.8 0-5-2.2-5-5H5z"/>
+    </svg>
+    EOF
+
+    cat << 'EOF' > $out/share/icons/hicolor/scalable/emblems/dolphin-emblem-insync-error.svg
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="11" fill="#c0392b"/>
+      <path fill="#ffffff" d="M11 6h2v8h-2zm0 10h2v2h-2z"/>
+    </svg>
+    EOF
+  '';
+
+  meta = with lib; {
+    description = "Dolphin plugin that adds Insync's context menus and overlay icons";
+    homepage = "https://www.insynchq.com";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ timh-de ];
+  };
+}


### PR DESCRIPTION
This PR adds the `dolphin-insync-plugin` package, which provides context menus and file status overlay icons for the Insync client in KDE's Dolphin file manager.

**Specific packaging choices & fixes:**
- Disables Qt app wrapping (`dontWrapQtApps = true`) because the output consists of `.so` library plugins that are loaded dynamically by Dolphin.
- Explicitly sets `-DKDE_INSTALL_PLUGINDIR=lib/qt-6/plugins` to ensure NixOS links the plugins into the correct environment path where Dolphin expects them.
- Uses `postInstall` to manually generate the required status SVG icons (`synced`, `syncing`, `error`). This is necessary because the `insync` package currently in Nixpkgs does not correctly expose these specific emblems to the system's hicolor icon cache, which would otherwise result in invisible overlay icons.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test