### PR TITLE
bluez: fix btctl noninteractive regression

### DIFF
--- a/pkgs/by-name/bl/bluez/lreadline.patch
+++ b/pkgs/by-name/bl/bluez/lreadline.patch
@@ -1,0 +1,91 @@
+# Adjusted version of https://lore.kernel.org/linux-bluetooth/20250703182908.2370130-1-hi@alyssa.is/raw
+diff --git a/Makefile.tools b/Makefile.tools
+index 2080f0978..885371de9 100644
+--- a/Makefile.tools
++++ b/Makefile.tools
+@@ -19,7 +19,7 @@ client_bluetoothctl_SOURCES = client/main.c \
+ 					client/telephony.h client/telephony.c
+ client_bluetoothctl_LDADD = lib/libbluetooth-internal.la \
+ 			gdbus/libgdbus-internal.la src/libshared-glib.la \
+-			$(GLIB_LIBS) $(DBUS_LIBS) -lreadline
++			$(GLIB_LIBS) $(DBUS_LIBS) $(READLINE_LIBS)
+ endif
+ 
+ if ZSH_COMPLETIONS
+@@ -385,7 +385,7 @@ tools_meshctl_SOURCES = tools/meshctl.c \
+ 				tools/mesh-gatt/onoff-model.c
+ tools_meshctl_LDADD = gdbus/libgdbus-internal.la src/libshared-glib.la \
+ 				lib/libbluetooth-internal.la \
+-				$(GLIB_LIBS) $(DBUS_LIBS) -ljson-c -lreadline
++				$(GLIB_LIBS) $(DBUS_LIBS) -ljson-c $(READLINE_LIBS)
+ 
+ EXTRA_DIST += tools/mesh-gatt/local_node.json tools/mesh-gatt/prov_db.json
+ endif
+@@ -404,7 +404,7 @@ tools_mesh_cfgclient_SOURCES = tools/mesh-cfgclient.c \
+ 				mesh/crypto.h mesh/crypto.c
+ 
+ tools_mesh_cfgclient_LDADD = lib/libbluetooth-internal.la src/libshared-ell.la \
+-						$(ell_ldadd) -ljson-c -lreadline
++						$(ell_ldadd) -ljson-c $(READLINE_LIBS)
+ 
+ bin_PROGRAMS +=  tools/mesh-cfgtest
+ 
+@@ -512,7 +512,7 @@ noinst_PROGRAMS += tools/btmgmt tools/obex-client-tool tools/obex-server-tool \
+ tools_obex_client_tool_SOURCES = $(gobex_sources) $(btio_sources) \
+ 						tools/obex-client-tool.c
+ tools_obex_client_tool_LDADD = lib/libbluetooth-internal.la \
+-			       src/libshared-glib.la $(GLIB_LIBS) -lreadline
++			       src/libshared-glib.la $(GLIB_LIBS) $(READLINE_LIBS)
+ 
+ tools_obex_server_tool_SOURCES = $(gobex_sources) $(btio_sources) \
+ 						tools/obex-server-tool.c
+@@ -523,16 +523,16 @@ tools_bluetooth_player_SOURCES = tools/bluetooth-player.c client/print.c \
+ 				client/player.c
+ tools_bluetooth_player_LDADD = gdbus/libgdbus-internal.la \
+ 				src/libshared-glib.la \
+-				$(GLIB_LIBS) $(DBUS_LIBS) -lreadline
++				$(GLIB_LIBS) $(DBUS_LIBS) $(READLINE_LIBS)
+ 
+ tools_obexctl_SOURCES = tools/obexctl.c
+ tools_obexctl_LDADD = gdbus/libgdbus-internal.la src/libshared-glib.la \
+-			$(GLIB_LIBS) $(DBUS_LIBS) -lreadline
++			$(GLIB_LIBS) $(DBUS_LIBS) $(READLINE_LIBS)
+ 
+ tools_btmgmt_SOURCES = tools/btmgmt.c src/uuid-helper.c client/display.c \
+ 			client/mgmt.c
+ tools_btmgmt_LDADD = lib/libbluetooth-internal.la src/libshared-glib.la \
+-				$(GLIB_LIBS) -lreadline
++				$(GLIB_LIBS) $(READLINE_LIBS)
+ if DEPRECATED
+ noinst_PROGRAMS += attrib/gatttool
+ 
+@@ -542,7 +542,7 @@ attrib_gatttool_SOURCES = attrib/gatttool.c attrib/att.c attrib/gatt.c \
+ 				attrib/utils.c src/log.c client/display.c \
+ 				client/display.h
+ attrib_gatttool_LDADD = lib/libbluetooth-internal.la \
+-			src/libshared-glib.la $(GLIB_LIBS) -lreadline
++			src/libshared-glib.la $(GLIB_LIBS) $(READLINE_LIBS)
+ 
+ endif
+ endif
+@@ -592,5 +592,5 @@ tools/btpclient.$(OBJEXT): src/libshared-ell.la ell/internal
+ 
+ tools_btpclientctl_SOURCES = tools/btpclientctl.c client/display.c
+ tools_btpclientctl_LDADD = src/libshared-mainloop.la src/libshared-glib.la \
+-				lib/libbluetooth-internal.la -lreadline
++				lib/libbluetooth-internal.la $(READLINE_LIBS)
+ endif
+diff --git a/configure.ac b/configure.ac
+index 52de7d665..f110ab103 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -338,8 +338,7 @@ AC_ARG_ENABLE(client, AS_HELP_STRING([--disable-client],
+ AM_CONDITIONAL(CLIENT, test "${enable_client}" != "no")
+ 
+ if (test "${enable_client}" != "no" || test "${enable_mesh}" = "yes"); then
+-        AC_CHECK_HEADERS(readline/readline.h, enable_readline=yes,
+-                AC_MSG_ERROR(readline header files are required))
++        PKG_CHECK_MODULES([READLINE], [readline], enable_readline=yes)
+ fi
+ AM_CONDITIONAL(READLINE, test "${enable_readline}" = "yes")
+ 

--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -8,7 +8,7 @@
   docutils,
   ell,
   enableExperimental ? false,
-  fetchurl,
+  fetchpatch2,
   glib,
   json_c,
   libical,
@@ -32,11 +32,19 @@ stdenv.mkDerivation (finalAttrs: {
   inherit (bluez-headers) version src;
 
   patches = [
-    (fetchurl {
-      name = "static.patch";
-      url = "https://lore.kernel.org/linux-bluetooth/20250703182908.2370130-1-hi@alyssa.is/raw";
-      hash = "sha256-4Yz3ljsn2emJf+uTcJO4hG/YXvjERtitce71TZx5Hak=";
+    # https://github.com/bluez/bluez/issues/1896
+    # Remove the following 2 in the next release
+    (fetchpatch2 {
+      name = "fix-btctl-noninteractive-regression";
+      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=b33e923b55e4d0e9d78a83cfcb541fd1f687ef54";
+      hash = "sha256-q7eN4ktw7DtdwMHHi7GU7fbvHAdMttKF1kDSWzZqa6A=";
     })
+    (fetchpatch2 {
+      name = "fix-btctl-noninteractive-regression-2";
+      url = "https://git.kernel.org/pub/scm/bluetooth/bluez.git/patch/?id=21e13976f2e375d701b8b7032ba5c1b2e56c305f";
+      hash = "sha256-JrdmYiC+U0KeMP8oVg12Z8CvkMEKWBVgiiUACx0E7dY=";
+    })
+    ./lreadline.patch
   ];
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/bluez/bluez/issues/1896

also replaced `fetchurl` with `fetchpatch2`

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
