### PR TITLE
qrq: fix build with gcc15

### DIFF
--- a/pkgs/by-name/qr/qrq/package.nix
+++ b/pkgs/by-name/qr/qrq/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   ncurses,
   pulseaudio,
 }:
@@ -19,6 +20,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
+  patches = [
+    # gcc15, remove after next release
+    (fetchpatch {
+      url = "https://github.com/dj1yfk/qrq/commit/f17363df923cd9d4607478a7406e0c4d3e044aae.patch";
+      hash = "sha256-EzGP6ExqiK30Vb4f8Q06zIP5Bebnw/jWvaAOb3juZMU=";
+      stripLen = 2;
+      extraPrefix = "";
+    })
+  ];
+
   buildInputs = [
     ncurses
     pulseaudio
@@ -33,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace qrq.c \
       --replace-fail '[80]' '[4000]' \
       --replace-fail '80,' '4000,'
+    substituteInPlace Makefile \
+      --replace-fail 'CC=gcc' 'CC=${stdenv.cc.targetPrefix}cc'
   '';
 
   meta = {


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324323502

```
qrq.c: In function 'morse':
qrq.c:1497:18: error: too many arguments to function 'open_dsp'; expected 0, have 1
 1497 |         dsp_fd = open_dsp(dspdevice);
      |                  ^~~~~~~~ ~~~~~~~~~
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
