### PR TITLE
yarn-berry: add package tests

### DIFF
--- a/pkgs/by-name/ya/yarn-berry/package.nix
+++ b/pkgs/by-name/ya/yarn-berry/package.nix
@@ -1,6 +1,7 @@
 {
   fetchFromGitHub,
   lib,
+  pkgs,
   nodejs,
   stdenv,
   testers,
@@ -55,11 +56,31 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = ./update.sh;
 
-    tests = {
-      version = testers.testVersion {
-        package = finalAttrs.finalPackage;
+    tests =
+      let
+        packageTests =
+          if berryVersion == 4 then
+            {
+              inherit (pkgs)
+                prettier
+                corepack
+                katex
+                ;
+            }
+          else
+            {
+              inherit (pkgs)
+                svgo
+                yarn-lock-converter
+                ;
+            };
+      in
+      packageTests
+      // {
+        version = testers.testVersion {
+          package = finalAttrs.finalPackage;
+        };
       };
-    };
   }
   // (callPackage ./fetcher { yarn-berry = finalAttrs; });
 


### PR DESCRIPTION
Added package tests for `yarn-berry_4` and `yarn-berry_3`. Chose packages based on the following criteria:
- Packages support both Linux and Darwin platforms
- Packages do not have heavy dependencies like Electron or Python
- Packages are not marked as broken
- Package licenses is not unfree


## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
