### PR TITLE
nixos/dhparams: deprecate, schedule removal

### DIFF
--- a/nixos/modules/security/dhparams.nix
+++ b/nixos/modules/security/dhparams.nix
@@ -143,68 +143,81 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.enable && cfg.stateful) {
-    systemd.services = {
-      dhparams-init = {
-        description = "Clean Up Old Diffie-Hellman Parameters";
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      warnings = [
+        ''
+          The `security.dhparam` module is deprecated and scheduled for removal in NixOS 26.11.
+          Generating your own params has been shown to be problematic in RFC 7919 (2016).
 
-        # Clean up even when no DH params is set
-        wantedBy = [ "multi-user.target" ];
+          Remove any uses of DHE and migrate to ECDHE (RFC 8422, 2018) and
+          Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchange algorithms.
+        ''
+      ];
+    })
+    (lib.mkIf (cfg.enable && cfg.stateful) {
+      systemd.services = {
+        dhparams-init = {
+          description = "Clean Up Old Diffie-Hellman Parameters";
 
-        serviceConfig.RemainAfterExit = true;
-        serviceConfig.Type = "oneshot";
+          # Clean up even when no DH params is set
+          wantedBy = [ "multi-user.target" ];
 
-        script = ''
-          if [ ! -d ${cfg.path} ]; then
-            mkdir -p ${cfg.path}
-          fi
+          serviceConfig.RemainAfterExit = true;
+          serviceConfig.Type = "oneshot";
 
-          # Remove old dhparams
-          for file in ${cfg.path}/*; do
-            if [ ! -f "$file" ]; then
-              continue
+          script = ''
+            if [ ! -d ${cfg.path} ]; then
+              mkdir -p ${cfg.path}
             fi
-            ${lib.concatStrings (
-              lib.mapAttrsToList (
-                name:
-                { bits, path, ... }:
-                ''
-                  if [ "$file" = ${lib.escapeShellArg path} ] && \
-                     ${pkgs.openssl}/bin/openssl dhparam -in "$file" -text \
-                     | head -n 1 | grep "(${toString bits} bit)" > /dev/null; then
-                    continue
-                  fi
-                ''
-              ) cfg.params
-            )}
-            rm "$file"
-          done
 
-          # TODO: Ideally this would be removing the *former* cfg.path, though
-          # this does not seem really important as changes to it are quite
-          # unlikely
-          rmdir --ignore-fail-on-non-empty ${cfg.path}
-        '';
-      };
-    }
-    // lib.mapAttrs' (
-      name:
-      { bits, path, ... }:
-      lib.nameValuePair "dhparams-gen-${name}" {
-        description = "Generate Diffie-Hellman Parameters for ${name}";
-        after = [ "dhparams-init.service" ];
-        before = [ "${name}.service" ];
-        requiredBy = [ "${name}.service" ];
-        wantedBy = [ "multi-user.target" ];
-        unitConfig.ConditionPathExists = "!${path}";
-        serviceConfig.Type = "oneshot";
-        script = ''
-          mkdir -p ${lib.escapeShellArg cfg.path}
-          ${pkgs.openssl}/bin/openssl dhparam -out ${lib.escapeShellArg path} \
-            ${toString bits}
-        '';
+            # Remove old dhparams
+            for file in ${cfg.path}/*; do
+              if [ ! -f "$file" ]; then
+                continue
+              fi
+              ${lib.concatStrings (
+                lib.mapAttrsToList (
+                  name:
+                  { bits, path, ... }:
+                  ''
+                    if [ "$file" = ${lib.escapeShellArg path} ] && \
+                       ${pkgs.openssl}/bin/openssl dhparam -in "$file" -text \
+                       | head -n 1 | grep "(${toString bits} bit)" > /dev/null; then
+                      continue
+                    fi
+                  ''
+                ) cfg.params
+              )}
+              rm "$file"
+            done
+
+            # TODO: Ideally this would be removing the *former* cfg.path, though
+            # this does not seem really important as changes to it are quite
+            # unlikely
+            rmdir --ignore-fail-on-non-empty ${cfg.path}
+          '';
+        };
       }
-    ) cfg.params;
-  };
+      // lib.mapAttrs' (
+        name:
+        { bits, path, ... }:
+        lib.nameValuePair "dhparams-gen-${name}" {
+          description = "Generate Diffie-Hellman Parameters for ${name}";
+          after = [ "dhparams-init.service" ];
+          before = [ "${name}.service" ];
+          requiredBy = [ "${name}.service" ];
+          wantedBy = [ "multi-user.target" ];
+          unitConfig.ConditionPathExists = "!${path}";
+          serviceConfig.Type = "oneshot";
+          script = ''
+            mkdir -p ${lib.escapeShellArg cfg.path}
+            ${pkgs.openssl}/bin/openssl dhparam -out ${lib.escapeShellArg path} \
+              ${toString bits}
+          '';
+        }
+      ) cfg.params;
+    })
+  ];
 
 }


### PR DESCRIPTION
Generating your own dhparams has been obsoleted by RFC 7919 (2016).

DHE itself has been obsoleted by ECHDE (RFC8422, 2018) and Hybrid PQ (draft-ietf-tls-ecdhe-mlkem, 2026) key exchanges.

TLS 1.3 (RFC8446, 2018) stopped defining any DHE cipher suites and lists this as a major difference from TLS 1.2.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (the dhparam test shows the warning but still works)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
