### PR TITLE
[Backport release-25.11] daisydisk: 4.31 -> 4.33.3

### DIFF
--- a/pkgs/by-name/da/daisydisk/package.nix
+++ b/pkgs/by-name/da/daisydisk/package.nix
@@ -11,11 +11,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "daisydisk";
-  version = "4.31";
+  version = "4.32";
 
   src = fetchzip {
     url = "https://daisydiskapp.com/download/DaisyDisk.zip";
-    hash = "sha256-z0F1sHihmXR5hN/AwrxLr9ZxfcCN+OSeWvWBe+qwWMU=";
+    hash = "sha256-HRW851l3zCq43WmLkElvVlIEmfCsCUMFw/LL2cPa2Xk=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/da/daisydisk/package.nix
+++ b/pkgs/by-name/da/daisydisk/package.nix
@@ -8,14 +8,13 @@
   common-updater-scripts,
   writeShellApplication,
 }:
-
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "daisydisk";
-  version = "4.32";
+  version = "4.33.2";
 
   src = fetchzip {
     url = "https://daisydiskapp.com/download/DaisyDisk.zip";
-    hash = "sha256-HRW851l3zCq43WmLkElvVlIEmfCsCUMFw/LL2cPa2Xk=";
+    hash = "sha256-YkXjaDbnwkQUsfhzCA5xQ6C6NGjQV6qj7znyjcKgwIg=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/da/daisydisk/package.nix
+++ b/pkgs/by-name/da/daisydisk/package.nix
@@ -10,11 +10,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "daisydisk";
-  version = "4.33.2";
+  version = "4.33.3";
 
   src = fetchzip {
     url = "https://daisydiskapp.com/download/DaisyDisk.zip";
-    hash = "sha256-YkXjaDbnwkQUsfhzCA5xQ6C6NGjQV6qj7znyjcKgwIg=";
+    hash = "sha256-2QhaY4oQV+bkvcyC88Zsk7eZJ6dySsb5G2+juH8HNjI=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
## Things done

Backported DaisyDisk

<img width="612" height="512" alt="image" src="https://github.com/user-attachments/assets/fbde3007-9090-49e6-8d0e-2f1d0ac4ea56" />


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
