### PR TITLE
python3Packages.embreex: revert drop, 2.17.7.post6 -> 4.4.0

### DIFF
--- a/pkgs/development/python-modules/embreex/default.nix
+++ b/pkgs/development/python-modules/embreex/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  buildPythonPackage,
+  embree2,
+  cython,
+  numpy,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "embreex";
+  version = "2.17.7.post6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "trimesh";
+    repo = "embreex";
+    tag = version;
+    hash = "sha256-iLIfhngorSFOdkOvlCAJQXGQrVuRfBSDGzvjXOlQuHk=";
+  };
+
+  patches = [
+    # https://github.com/trimesh/embreex/pull/7
+    (fetchpatch {
+      name = "fix-use-after-free.patch";
+      url = "https://github.com/trimesh/embreex/commit/c6b047285419f8986fae962e2734a01522be7ef7.patch";
+      hash = "sha256-s8x2vsqbsIR3aoNUDrYs2vQttuNY8lLJ6TC7H8FMRyQ=";
+    })
+  ];
+
+  build-system = [
+    setuptools
+    numpy
+    cython
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  buildInputs = [
+    embree2
+    embree2.tbb
+  ];
+
+  pythonImportsCheck = [
+    "embreex"
+    "embreex.mesh_construction"
+    "embreex.rtcore"
+    "embreex.rtcore_scene"
+    "embreex.triangles"
+  ];
+
+  preCheck = ''
+    # conflicts with $out
+    rm -rf embreex/
+  '';
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Maintained PyEmbree fork, wrapper for Embree v2";
+    homepage = "https://github.com/trimesh/embreex";
+    changelog = "https://github.com/trimesh/embreex/releases/tag/${src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ pbsds ];
+    inherit (embree2.meta) platforms;
+  };
+}

--- a/pkgs/development/python-modules/embreex/default.nix
+++ b/pkgs/development/python-modules/embreex/default.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   fetchpatch,
   buildPythonPackage,
-  embree2,
+  embree,
   cython,
   numpy,
   setuptools,
@@ -12,24 +12,15 @@
 
 buildPythonPackage rec {
   pname = "embreex";
-  version = "2.17.7.post6";
+  version = "4.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "trimesh";
     repo = "embreex";
     tag = version;
-    hash = "sha256-iLIfhngorSFOdkOvlCAJQXGQrVuRfBSDGzvjXOlQuHk=";
+    hash = "sha256-mUPc9CMHsFYb1ELBmj+XXCjYEIW1iV8ZaRCQ40tYS8w=";
   };
-
-  patches = [
-    # https://github.com/trimesh/embreex/pull/7
-    (fetchpatch {
-      name = "fix-use-after-free.patch";
-      url = "https://github.com/trimesh/embreex/commit/c6b047285419f8986fae962e2734a01522be7ef7.patch";
-      hash = "sha256-s8x2vsqbsIR3aoNUDrYs2vQttuNY8lLJ6TC7H8FMRyQ=";
-    })
-  ];
 
   build-system = [
     setuptools
@@ -42,8 +33,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    embree2
-    embree2.tbb
+    embree
   ];
 
   pythonImportsCheck = [
@@ -51,7 +41,6 @@ buildPythonPackage rec {
     "embreex.mesh_construction"
     "embreex.rtcore"
     "embreex.rtcore_scene"
-    "embreex.triangles"
   ];
 
   preCheck = ''
@@ -62,11 +51,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
-    description = "Maintained PyEmbree fork, wrapper for Embree v2";
+    description = "Maintained PyEmbree fork, bindings for Intel's Embree ray engine";
     homepage = "https://github.com/trimesh/embreex";
     changelog = "https://github.com/trimesh/embreex/releases/tag/${src.tag}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ pbsds ];
-    inherit (embree2.meta) platforms;
+    inherit (embree.meta) platforms;
   };
 }

--- a/pkgs/development/python-modules/trimesh/default.nix
+++ b/pkgs/development/python-modules/trimesh/default.nix
@@ -23,6 +23,7 @@
   scipy,
   pillow,
   mapbox-earcut,
+  embreex,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -59,7 +60,9 @@ buildPythonPackage (finalAttrs: {
       pillow
       # vhacdx # not packaged
       mapbox-earcut
-      # embreex # not packaged
+    ]
+    ++ lib.optionals embreex.meta.available [
+      embreex
     ];
   };
 

--- a/pkgs/development/python-modules/trimesh/default.nix
+++ b/pkgs/development/python-modules/trimesh/default.nix
@@ -6,7 +6,6 @@
   pytestCheckHook,
   numpy,
   lxml,
-  trimesh,
 
   # optional deps
   colorlog,
@@ -28,14 +27,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "trimesh";
-  version = "4.11.5";
+  version = "4.12.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mikedh";
     repo = "trimesh";
     tag = finalAttrs.version;
-    hash = "sha256-LF7tjthYtsEZJLqBiQZBe4urLjSD3Vbi3g1ZJ++0Tyk=";
+    hash = "sha256-+Xmy3/GSnfj7u1sapMscoCGlRsz00IkUzEo9CJ5Ja3s=";
   };
 
   build-system = [ setuptools ];
@@ -69,6 +68,11 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     lxml
     pytestCheckHook
+  ]
+  # embreex is maintained by trimesh devs
+  ++ lib.optionals embreex.meta.available [
+    embreex
+    rtree
   ];
 
   disabledTests = [
@@ -76,7 +80,12 @@ buildPythonPackage (finalAttrs: {
     "test_load"
   ];
 
-  enabledTestPaths = [ "tests/test_minimal.py" ];
+  enabledTestPaths = [
+    "tests/test_minimal.py"
+  ]
+  ++ lib.optionals embreex.meta.available [
+    "tests/test_ray.py"
+  ];
 
   pythonImportsCheck = [
     "trimesh"

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -192,7 +192,6 @@ mapAliases {
   elegy = throw "elegy has been removed because it has transitively been marked as broken since 2023."; # Added 2025-10-11
   email_validator = throw "'email_validator' has been renamed to/replaced by 'email-validator'"; # Converted to throw 2025-10-29
   emailthreads = throw "'emailthreads' has been removed because the upstream repository was archived in 2024"; # Added 2026-04-09
-  embreex = throw "embreex has been removed, as it required embree2"; # added 2025-09-14
   enocean = throw "'enocean' was removed because Home Assistant switched to 'enocean-async'"; # added 2026-03-31
   eris = throw "eris has been removed due to a hostile upstream moving tags and breaking src FODs"; # Added 2025-09-01
   et_xmlfile = throw "'et_xmlfile' has been renamed to/replaced by 'et-xmlfile'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4994,6 +4994,8 @@ self: super: with self; {
 
   embrace = callPackage ../development/python-modules/embrace { };
 
+  embreex = callPackage ../development/python-modules/embreex { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   emoji = callPackage ../development/python-modules/emoji { };


### PR DESCRIPTION
embreex finally migrated from embree v2 to embree v4, great work @trimesh!

- **Revert "python313Packages.embreex: drop"**
- **python3Packages.embreex: 2.17.7.post6 -> 4.4.0**
- **python3Packages.trimesh: 4.11.5 -> 4.12.1, enable embreex tests**

Release: https://github.com/mikedh/trimesh/releases/tag/4.12.1
Release: https://github.com/trimesh/embreex/releases/tag/4.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
