### PR TITLE
threadcat: init at 0.1.2

### DIFF
--- a/pkgs/by-name/th/threadcat/package.nix
+++ b/pkgs/by-name/th/threadcat/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromCodeberg,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "threadcat";
+  version = "0.1.2";
+
+  src = fetchFromCodeberg {
+    owner = "blinry";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-AbdxEgnUM5iqFTKrMK2FnFWvELk46PEEWSVAlv1MBzQ=";
+  };
+
+  cargoHash = "sha256-F46gEUWcKl1nFS1faXeWJLV0lmCrJhBN3XpOiTcGXEc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Converts a Mastodon thread to Markdown, and downloads all contained media files";
+    homepage = "https://codeberg.org/blinry/threadcat";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.aiyion ];
+    mainProgram = "threadcat";
+  };
+})

--- a/pkgs/by-name/th/threadcat/package.nix
+++ b/pkgs/by-name/th/threadcat/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromCodeberg,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "threadcat";
+  version = "0.1.2";
+
+  src = fetchFromCodeberg {
+    owner = "blinry";
+    repo = "threadcat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AbdxEgnUM5iqFTKrMK2FnFWvELk46PEEWSVAlv1MBzQ=";
+  };
+
+  cargoHash = "sha256-F46gEUWcKl1nFS1faXeWJLV0lmCrJhBN3XpOiTcGXEc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Converts a Mastodon thread to Markdown, and downloads all contained media files";
+    homepage = "https://codeberg.org/blinry/threadcat";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.aiyion ];
+    mainProgram = "threadcat";
+  };
+})


### PR DESCRIPTION
> Converts a Mastodon thread to Markdown, and downloads all contained media files.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
