### PR TITLE
ntfyr: init at 0.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12879,6 +12879,12 @@
     name = "João Moreira";
     keys = [ { fingerprint = "F457 0A3A 5F89 22F8 F572  E075 EF8B F2C8 C5F4 097D"; } ];
   };
+  joaqim = {
+    email = "mail@joaqim.xyz";
+    github = "Joaqim";
+    githubId = 5329209;
+    name = "Joaqim Planstedt";
+  };
   joaquintrinanes = {
     email = "hi@joaquint.io";
     github = "JoaquinTrinanes";

--- a/pkgs/by-name/nt/ntfyr/always-present-window-on-cli-reactivation.patch
+++ b/pkgs/by-name/nt/ntfyr/always-present-window-on-cli-reactivation.patch
@@ -1,0 +1,31 @@
+diff --git a/src/application.rs b/src/application.rs
+index 5bb0193..14a2bc3 100644
+--- a/src/application.rs
++++ b/src/application.rs
+@@ -114,7 +114,11 @@ mod imp {
+             let is_daemon = arguments.get(1).map(|x| x.to_str()) == Some(Some("--daemon"));
+             let app = self.obj();
+ 
+-            if self.hold_guard.get().is_none() {
++            // Capture whether the primary instance was already running BEFORE we
++            // touch hold_guard, so we can distinguish first launch from a CLI
++            // reactivation of an existing background instance.
++            let already_running = self.hold_guard.get().is_some();
++            if !already_running {
+                 app.ensure_rpc_running();
+             }
+ 
+@@ -130,7 +134,12 @@ mod imp {
+             let start_in_background = settings.boolean("start-in-background");
+             let has_window = app.imp().window.borrow().upgrade().is_some();
+ 
+-            if !start_in_background || has_window {
++            // start-in-background only suppresses the window on the very first
++            // launch (e.g. XDG autostart at login). Any subsequent CLI invocation
++            // -- including launcher activations against a background primary
++            // instance -- must always present a window, mirroring the semantics
++            // of the `activate` handler above.
++            if already_running || !start_in_background || has_window {
+                 app.ensure_window_present();
+             } else {
+                 debug!("Starting in background from command line as requested by preferences");

--- a/pkgs/by-name/nt/ntfyr/package.nix
+++ b/pkgs/by-name/nt/ntfyr/package.nix
@@ -62,6 +62,9 @@ stdenv.mkDerivation {
 
   passthru.updateScript = nix-update-script { };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "Linux desktop client for ntfy.sh with GTK4";
     longDescription = ''

--- a/pkgs/by-name/nt/ntfyr/package.nix
+++ b/pkgs/by-name/nt/ntfyr/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  cargo,
+  rustc,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  appstream,
+  glib,
+  gtk4,
+  gtksourceview5,
+  nix-update-script,
+  blueprint-compiler,
+  libadwaita,
+  sqlite,
+}:
+let
+  pname = "ntfyr";
+
+  version = "0.5.3";
+
+  src = fetchFromGitHub {
+    owner = "tobagin";
+    repo = "Ntfyr";
+    tag = "v${version}";
+    hash = "sha256-ZuBcHhcwP7posuAYhsWmhYWgXxZ+oLFtLTSj2NctVso=";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-ch4fKWH2dw1eGBvJcP6JOYu34DFLXXkbhju2KNDgHzw=";
+  };
+
+  nativeBuildInputs = [
+    appstream
+    blueprint-compiler
+    cargo
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    gtksourceview5
+    libadwaita
+    sqlite
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Linux desktop client for ntfy.sh with GTK4";
+    longDescription = ''
+      Ntfyr is a native Linux client for ntfy.sh, providing desktop
+      notifications via a GTK4 interface. It supports subscribing to
+      ntfy.sh topics as well as self-hosted ntfy server instances.
+    '';
+    homepage = "https://github.com/tobagin/Ntfyr";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ joaqim ];
+    mainProgram = "ntfyr";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/nt/ntfyr/package.nix
+++ b/pkgs/by-name/nt/ntfyr/package.nix
@@ -18,6 +18,7 @@
   blueprint-compiler,
   libadwaita,
   sqlite,
+  appstream-glib,
 }:
 let
   pname = "ntfyr";
@@ -41,6 +42,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     appstream
+    appstream-glib
     blueprint-compiler
     cargo
     desktop-file-utils

--- a/pkgs/by-name/nt/ntfyr/package.nix
+++ b/pkgs/by-name/nt/ntfyr/package.nix
@@ -40,6 +40,16 @@ stdenv.mkDerivation {
     hash = "sha256-ch4fKWH2dw1eGBvJcP6JOYu34DFLXXkbhju2KNDgHzw=";
   };
 
+  patches = [
+    # Without this patch, when ntfyr is launched at login with start-in-background=true
+    # the GtkApplication primary instance lives on D-Bus without ever creating a window,
+    # and every subsequent CLI invocation (launcher click or `ntfyr` from a shell) is
+    # absorbed as a remote command_line dispatch whose gate also refuses to create the
+    # window -- making the GUI unreachable while notifications keep working.
+    # Upstream: https://github.com/tobagin/Ntfyr
+    ./always-present-window-on-cli-reactivation.patch
+  ];
+
   nativeBuildInputs = [
     appstream
     appstream-glib


### PR DESCRIPTION
> Ntfyr is a native Linux client for ntfy.sh, providing notifications via a GTK4 interface. It supports subscribing to ntfy.sh topics as well as self-hosted ntfy server instances.

[https://github.com/tobagin/Ntfyr](https://github.com/tobagin/Ntfyr)

I wrote this first manually with [typewriter](pkgs/by-name/ty/typewriter/package.nix) rust derivation as a reference, then I cleaned it up using Claude Opus 4.7.

Several non-trivial commits in this PR furthermore contains content generated by AI assistance.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] ~[NixOS tests] in [nixos/tests].~
  - [ ] ~[Package tests] at `passthru.tests`.~
  - [ ] ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


