### PR TITLE
python3Packages.supabase: 2.28.3 -> 2.29.0

### DIFF
--- a/pkgs/development/python-modules/postgrest/default.nix
+++ b/pkgs/development/python-modules/postgrest/default.nix
@@ -14,19 +14,19 @@
   unasync,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "postgrest";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/postgrest";
+  sourceRoot = "${finalAttrs.src.name}/src/postgrest";
 
   build-system = [ uv-build ];
 
@@ -61,8 +61,8 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/postgrest/default.nix
+++ b/pkgs/development/python-modules/postgrest/default.nix
@@ -14,19 +14,19 @@
   unasync,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "postgrest";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/postgrest";
+  sourceRoot = "${finalAttrs.src.name}/src/postgrest";
 
   build-system = [ uv-build ];
 
@@ -61,8 +61,8 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "realtime";
-  version = "3.0.0a1";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Pvu2zyRKS99/KEIWwQXBR7Moegt0KITiaMWi5mi+CL4=";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/realtime";
@@ -57,6 +57,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/supabase/supabase-py";
     changelog = "https://github.com/supabase/supabase-py/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ siegema ];
+    maintainers = with lib.maintainers; [
+      siegema
+      macbucheron
+    ];
   };
 })

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "realtime";
-  version = "3.0.0a1";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Pvu2zyRKS99/KEIWwQXBR7Moegt0KITiaMWi5mi+CL4=";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src/realtime";
@@ -57,6 +57,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/supabase/supabase-py";
     changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ siegema ];
+    maintainers = with lib.maintainers; [
+      siegema
+      macbucheron
+    ];
   };
 })

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -14,19 +14,19 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "storage3";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/storage";
+  sourceRoot = "${finalAttrs.src.name}/src/storage";
 
   build-system = [ uv-build ];
 
@@ -61,8 +61,11 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ siegema ];
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      siegema
+      macbucheron
+    ];
   };
-}
+})

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -14,19 +14,19 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "storage3";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/storage";
+  sourceRoot = "${finalAttrs.src.name}/src/storage";
 
   build-system = [ uv-build ];
 
@@ -61,8 +61,11 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ siegema ];
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      siegema
+      macbucheron
+    ];
   };
-}
+})

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -12,19 +12,19 @@
   pytest-mock,
   pytest-asyncio,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "supabase-auth";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/auth";
+  sourceRoot = "${finalAttrs.src.name}/src/auth";
 
   build-system = [ uv-build ];
 
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Auth";
     homepage = "https://github.com/supabase/supabase-py/";
-    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ macbucheron ];
   };
-}
+})

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -12,19 +12,19 @@
   pytest-mock,
   pytest-asyncio,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "supabase-auth";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/auth";
+  sourceRoot = "${finalAttrs.src.name}/src/auth";
 
   build-system = [ uv-build ];
 
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Auth";
     homepage = "https://github.com/supabase/supabase-py/";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ macbucheron ];
   };
-}
+})

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -11,19 +11,19 @@
   yarl,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "supabase-functions";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/functions";
+  sourceRoot = "${finalAttrs.src.name}/src/functions";
 
   build-system = [ uv-build ];
 
@@ -53,8 +53,8 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -11,19 +11,19 @@
   yarl,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "supabase-functions";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/functions";
+  sourceRoot = "${finalAttrs.src.name}/src/functions";
 
   build-system = [ uv-build ];
 
@@ -53,8 +53,8 @@ buildPythonPackage rec {
   meta = {
     description = "Client library for Supabase Functions";
     homepage = "https://github.com/supabase/supabase-py";
-    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/supabase/default.nix
+++ b/pkgs/development/python-modules/supabase/default.nix
@@ -16,19 +16,19 @@
   pytest-cov-stub,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "supabase";
-  version = "2.28.3";
+  version = "2.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
-    tag = "v${version}";
-    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LaSlAYFvx/HHdfmc9J+KScVQ9JFGS98Yfihzn8F7t3g=";
   };
 
-  sourceRoot = "${src.name}/src/supabase";
+  sourceRoot = "${finalAttrs.src.name}/src/supabase";
 
   build-system = [ uv-build ];
 
@@ -61,7 +61,11 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/supabase/supabase-py";
     license = lib.licenses.mit;
+    changelog = "https://github.com/supabase/supabase-py/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Supabas client for Python";
-    maintainers = with lib.maintainers; [ siegema ];
+    maintainers = with lib.maintainers; [
+      siegema
+      macbucheron
+    ];
   };
-}
+})


### PR DESCRIPTION
Updates the Supabase Python client stack to **v2.29.0**
Also add myself as a maintainer for the following packages:
- realtime
- storage3
- supabase

Tried to modernize by migrating to finalAttrs

Changelog:
- https://github.com/supabase/supabase-py/blob/v2.29.0/CHANGELOG.md
- https://github.com/supabase/supabase-py/releases/tag/v2.29.0

## Things done

- Built on platform:
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#python3Packages.postgrest`
  - `nix build -L .#python3Packages.supabase`
  - `nix build -L .#python3Packages.realtime`
  - `nix build -L .#python3Packages.storage3`
  - `nix build -L .#python3Packages.supabase-auth`
  - `nix build -L .#python3Packages.supabase-functions`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.