### PR TITLE
nixos/wpa_supplicant: add extraConfigFiles to BindReadOnlyPaths

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -158,6 +158,7 @@ let
           builtins.storeDir
           "/etc/"
         ]
+        ++ cfg.extraConfigFiles
         ++ lib.optional (cfg.secretsFile != null) cfg.secretsFile;
         DeviceAllow = "/dev/rfkill rw";
         LockPersonality = true;


### PR DESCRIPTION
Include `cfg.extraConfigFiles` in `serviceConfig.BindReadOnlyPaths` to allow the hardened service to read configuration files located outside the Nix store (e.g., in /run/agenix).

### Motivation
When `enableHardening = true` (default), `wpa_supplicant` runs in a restricted systemd sandbox. Currently, the module doesn't add paths from `extraConfigFiles` to `BindReadOnlyPaths`. 

This makes it impossible to use configuration files outside the Nix store, such as secrets managed by `agenix` or `sops-nix` (typically located in `/run/agenix/`), resulting in a "No such file or directory" error.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.