### PR TITLE
onedpl: init at 2022.11.1

### DIFF
--- a/pkgs/by-name/on/onedpl/package.nix
+++ b/pkgs/by-name/on/onedpl/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  intelLlvmStdenv,
+  fetchFromGitHub,
+  cmake,
+  onetbb,
+  nix-update-script,
+}:
+intelLlvmStdenv.mkDerivation (finalAttrs: {
+  pname = "onedpl";
+  version = "2022.11.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "uxlfoundation";
+    repo = "oneDPL";
+    tag = "oneDPL-${finalAttrs.version}-release";
+    hash = "sha256-NfyV34mdKfCxlU+l6ETKWcC9MwvVEgwcBedtLe6WCV4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    onetbb
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "ONEDPL_BACKEND" "dpcpp")
+  ];
+
+  # Build times for the tests are excessive
+  # and to be truly meaningful, they'd require a GPU
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "'oneDPL-(.*)-release'"
+    ];
+  };
+
+  meta = {
+    description = "oneAPI DPC++ Library (oneDPL)";
+    homepage = "http://uxlfoundation.github.io/oneDPL";
+    changelog = "https://github.com/uxlfoundation/oneDPL/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ arunoruto ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Intel's onedpl library packaged using the `intel-llvm.stdenv`.

Replaces #495872

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
