### PR TITLE
zinit: fix installation path of share/ files

### DIFF
--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -35,8 +35,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Source files
     mkdir -p $out/share/zinit
     install -m0444 zinit{,-side,-install,-autoload,-additional}.zsh _zinit $out/share/zinit
-    install -m0555 share/git-process-output.zsh $out/share/zinit
-    install -m0444 share/rpm2cpio.zsh $out/share/zinit
+    mkdir $out/share/zinit/share
+    install -m0555 share/git-process-output.zsh $out/share/zinit/share
+    install -m0444 share/rpm2cpio.zsh $out/share/zinit/share
 
     # Autocompletion
     installShellCompletion --zsh _zinit


### PR DESCRIPTION
The `share/git-process-output.zsh` and `share/rpm2cpio.zsh` files were installed directly into `$out/share/zinit/` instead of the expected `$out/share/zinit/share/` subdirectory. This broke zinit's runtime lookups since it resolves these files relative to `$ZINIT[BIN_DIR]/share/`:

- `share/git-process-output.zsh` is referenced by [`zinit-install.zsh`, line 431](https://github.com/zdharma-continuum/zinit/blob/v3.14.0/zinit-install.zsh#L431) , by [`zinit-autoload.zsh`, line 2007](https://github.com/zdharma-continuum/zinit/blob/v3.14.0/zinit-autoload.zsh#L2007), and by [`scripts/install.sh`, line 104](https://github.com/zdharma-continuum/zinit/blob/v3.14.0/scripts/install.sh#L104).
- `share/rpm2cpio.zsh` is referenced by [`zinit-install.zsh`, line 1703](https://github.com/zdharma-continuum/zinit/blob/v3.14.0/zinit-install.zsh#L1703).

Refs: https://github.com/zdharma-continuum/zinit/blob/v3.14.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
