### PR TITLE
 nixos/channel: fix channel linkage if broken channel link already exists 

### DIFF
--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -92,7 +92,7 @@ in
             -i ${channelSources} --quiet --option build-use-substitutes false \
             ${lib.optionalString config.boot.initrd.systemd.enable "--option sandbox false"} # There's an issue with pivot_root
           mkdir -m 0700 -p /root/.nix-defexpr
-          ln -s /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels
+          ln -sfvT /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels
           mkdir -m 0755 -p /var/lib/nixos
           touch /var/lib/nixos/did-channel-init
         fi

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -45,6 +45,15 @@ in
     };
   };
 
+  channel = incusRunTest {
+    name = "channel";
+
+    instances.c1 = {
+      type = "container";
+      copyChannel = true;
+    };
+  };
+
   # used in lxc tests to verify container functionality
   container = incusRunTest {
     name = "container";

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -60,6 +60,11 @@ in
                 default = { };
               };
 
+              copyChannel = lib.mkEnableOption ''
+                copy channel in test image. disabled by default as it forces image
+                rebuilds excessively. enable to validate channel things.
+              '';
+
               testScript = lib.mkOption {
                 type = lib.types.str;
                 description = "final script provided to test runner";
@@ -104,7 +109,7 @@ in
                   documentation.enable = lib.mkForce false;
                   documentation.nixos.enable = lib.mkForce false;
                   # including a channel forces images to be rebuilt on any changes
-                  system.installer.channel.enable = lib.mkForce false;
+                  system.installer.channel.enable = lib.mkForce config.copyChannel;
 
                   environment.etc."nix/registry.json".text = lib.mkForce "{}";
 
@@ -170,64 +175,67 @@ in
                 #
                 # container specific
                 #
-                +
-                  lib.optionalString (config.type == "container")
-                    # python
-                    ''
-                      with subtest("[${image_id}] switch-to-configuration updates /sbin/init via installBootLoader"):
-                          # Remove /sbin/init so we can verify installBootLoader recreates it
-                          server.succeed(f"incus exec {instance_name} -- rm -f /sbin/init")
-                          server.fail(f"incus exec {instance_name} -- test -e /sbin/init")
+                + lib.optionalString (config.type == "container") (
+                  # python
+                  ''
+                    with subtest("[${image_id}] switch-to-configuration updates /sbin/init via installBootLoader"):
+                        # Remove /sbin/init so we can verify installBootLoader recreates it
+                        server.succeed(f"incus exec {instance_name} -- rm -f /sbin/init")
+                        server.fail(f"incus exec {instance_name} -- test -e /sbin/init")
 
-                          server.succeed(
-                              f"incus exec {instance_name} -- /run/current-system/bin/switch-to-configuration switch"
-                          )
+                        server.succeed(
+                            f"incus exec {instance_name} -- /run/current-system/bin/switch-to-configuration switch"
+                        )
 
-                          # Verify installBootLoader recreated /sbin/init pointing to the system's init
-                          server.succeed(f"incus exec {instance_name} -- test -x /sbin/init")
-                          target = server.succeed(f"incus exec {instance_name} -- readlink -f /sbin/init").strip()
-                          current = server.succeed(f"incus exec {instance_name} -- readlink -f /run/current-system/init").strip()
-                          assert target == current, f"/sbin/init -> {target}, expected {current}"
+                        # Verify installBootLoader recreated /sbin/init pointing to the system's init
+                        server.succeed(f"incus exec {instance_name} -- test -x /sbin/init")
+                        target = server.succeed(f"incus exec {instance_name} -- readlink -f /sbin/init").strip()
+                        current = server.succeed(f"incus exec {instance_name} -- readlink -f /run/current-system/init").strip()
+                        assert target == current, f"/sbin/init -> {target}, expected {current}"
 
-                      # TODO troubleshoot VM hot memory resizing which was introduced in 6.12
-                      with subtest("[${image_id}] memory limits can be hotplug changed"):
-                          server.set_instance_config(instance_name, "limits.memory 512MB")
-                          # can't use lsmem since it sees the host's memory size
-                          server.wait_instance_exec_success(instance_name, "grep 'MemTotal:[[:space:]]*500000 kB' /proc/meminfo", timeout=1)
+                    # TODO troubleshoot VM hot memory resizing which was introduced in 6.12
+                    with subtest("[${image_id}] memory limits can be hotplug changed"):
+                        server.set_instance_config(instance_name, "limits.memory 512MB")
+                        # can't use lsmem since it sees the host's memory size
+                        server.wait_instance_exec_success(instance_name, "grep 'MemTotal:[[:space:]]*500000 kB' /proc/meminfo", timeout=1)
 
-                      # verify the patched container systemd generator from `pkgs.distrobuilder.generator`
-                      with subtest("[${image_id}] lxc-generator compatibility"):
-                          with subtest("[${image_id}] lxc-container generator configures plain container"):
-                              # default container is plain
-                              server.succeed(f"incus exec {instance_name} test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+                    # verify the patched container systemd generator from `pkgs.distrobuilder.generator`
+                    with subtest("[${image_id}] lxc-generator compatibility"):
+                        with subtest("[${image_id}] lxc-container generator configures plain container"):
+                            # default container is plain
+                            server.succeed(f"incus exec {instance_name} test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
 
-                              server.check_instance_sysctl(instance_name)
+                            server.check_instance_sysctl(instance_name)
 
-                          with subtest("[${image_id}] lxc-container generator configures nested container"):
-                              server.set_instance_config(instance_name, "security.nesting=true", restart=True)
+                        with subtest("[${image_id}] lxc-container generator configures nested container"):
+                            server.set_instance_config(instance_name, "security.nesting=true", restart=True)
 
-                              server.fail(f"incus exec {instance_name} test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-                              target = server.succeed(f"incus exec {instance_name} readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
-                              assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
+                            server.fail(f"incus exec {instance_name} test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+                            target = server.succeed(f"incus exec {instance_name} readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
+                            assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
 
-                              server.check_instance_sysctl(instance_name)
+                            server.check_instance_sysctl(instance_name)
 
-                      with subtest("[${image_id}] lxcfs"):
-                          with subtest("[${image_id}] mounts lxcfs overlays"):
-                              server.succeed(f"incus exec {instance_name} mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
-                              server.succeed(f"incus exec {instance_name} mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
+                    with subtest("[${image_id}] lxcfs"):
+                        with subtest("[${image_id}] mounts lxcfs overlays"):
+                            server.succeed(f"incus exec {instance_name} mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
+                            server.succeed(f"incus exec {instance_name} mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
 
-                          with subtest("[${image_id}] supports per-instance lxcfs"):
-                              server.succeed(f"incus stop {instance_name}")
-                              server.fail(f"pgrep -a lxcfs | grep 'incus/devices/{instance_name}/lxcfs'")
+                        with subtest("[${image_id}] supports per-instance lxcfs"):
+                            server.succeed(f"incus stop {instance_name}")
+                            server.fail(f"pgrep -a lxcfs | grep 'incus/devices/{instance_name}/lxcfs'")
 
-                              server.succeed("incus config set instances.lxcfs.per_instance=true")
+                            server.succeed("incus config set instances.lxcfs.per_instance=true")
 
-                              server.succeed(f"incus start {instance_name}")
-                              server.wait_for_instance(instance_name)
-                              server.succeed(f"pgrep -a lxcfs | grep 'incus/devices/{instance_name}/lxcfs'")
-                    ''
-
+                            server.succeed(f"incus start {instance_name}")
+                            server.wait_for_instance(instance_name)
+                            server.succeed(f"pgrep -a lxcfs | grep 'incus/devices/{instance_name}/lxcfs'")
+                  ''
+                  + lib.optionalString (config.copyChannel) ''
+                    with subtest("[${image_id}] channel copied correctly"):
+                        server.succeed(f"incus exec {instance_name} -- systemctl status nix-channel-init.service")
+                  ''
+                )
                 #
                 # virtual-machine specific
                 #


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

nix-channel-init is failing on incus container boot, as there's already a broken link in `/root/.nix-defexpr/channels` so the current link attempts to create `/root/.nix-defexpr/channels/channels` and fails.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
