### PR TITLE
scrutiny{,-collector}: 0.9.0 -> 0.9.1; convert to finalAttrs

### DIFF
--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 let
-  version = "0.9.0";
+  version = "0.9.1";
 in
 buildGoModule rec {
   inherit version;
@@ -18,12 +18,12 @@ buildGoModule rec {
     owner = "AnalogJ";
     repo = "scrutiny";
     tag = "v${version}";
-    hash = "sha256-N6CYVhdA0BWewGUxyHtkW1ZFDGBYI7QfUo5er7xRcFw=";
+    hash = "sha256-xEMHkISPBHinT6vRyrWPudvmTiX5gYxMkCEoSm2gLWA=";
   };
 
   subPackages = "collector/cmd/collector-metrics";
 
-  vendorHash = "sha256-fyHWy1TwwzFMIFzwilu4osfl/iI+2KqI6Bjr1UYUS68=";
+  vendorHash = "sha256-Em8k2AFoZv4TD4HFkkNIdyPj7IBOFiUIKffkifWfZFY=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/by-name/sc/scrutiny-collector/package.nix
+++ b/pkgs/by-name/sc/scrutiny-collector/package.nix
@@ -7,17 +7,15 @@
   lib,
   nix-update-script,
 }:
-let
+
+buildGoModule (finalAttrs: {
   version = "0.9.1";
-in
-buildGoModule rec {
-  inherit version;
   pname = "scrutiny-collector";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = "scrutiny";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xEMHkISPBHinT6vRyrWPudvmTiX5gYxMkCEoSm2gLWA=";
   };
 
@@ -48,6 +46,7 @@ buildGoModule rec {
   meta = {
     description = "Hard disk metrics collector for Scrutiny";
     homepage = "https://github.com/AnalogJ/scrutiny";
+    changelog = "https://github.com/AnalogJ/scrutiny/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       samasaur
@@ -55,4 +54,4 @@ buildGoModule rec {
     ];
     mainProgram = "scrutiny-collector-metrics";
   };
-}
+})

--- a/pkgs/by-name/sc/scrutiny/package.nix
+++ b/pkgs/by-name/sc/scrutiny/package.nix
@@ -8,13 +8,13 @@
 }:
 let
   pname = "scrutiny";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = "scrutiny";
     tag = "v${version}";
-    hash = "sha256-N6CYVhdA0BWewGUxyHtkW1ZFDGBYI7QfUo5er7xRcFw=";
+    hash = "sha256-xEMHkISPBHinT6vRyrWPudvmTiX5gYxMkCEoSm2gLWA=";
   };
 
   frontend = buildNpmPackage {
@@ -46,7 +46,7 @@ buildGoModule rec {
 
   subPackages = "webapp/backend/cmd/scrutiny";
 
-  vendorHash = "sha256-fyHWy1TwwzFMIFzwilu4osfl/iI+2KqI6Bjr1UYUS68=";
+  vendorHash = "sha256-Em8k2AFoZv4TD4HFkkNIdyPj7IBOFiUIKffkifWfZFY=";
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/sc/scrutiny/package.nix
+++ b/pkgs/by-name/sc/scrutiny/package.nix
@@ -7,42 +7,42 @@
   nix-update-script,
 }:
 let
+  frontend =
+    finalAttrs:
+    buildNpmPackage {
+      inherit (finalAttrs) version;
+      pname = "${finalAttrs.pname}-webapp";
+      src = "${finalAttrs.src}/webapp/frontend";
+
+      npmDepsHash = "sha256-1lOskHEU/3CmhQkUkQExryK6eMOSWvMI+Y+cX4Dlj98=";
+
+      buildPhase = ''
+        runHook preBuild
+        mkdir dist
+        npm run build:prod --offline -- --output-path=dist
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir $out
+        cp -r dist/* $out
+        runHook postInstall
+      '';
+
+      passthru.updateScript = nix-update-script { };
+    };
+in
+buildGoModule (finalAttrs: {
   pname = "scrutiny";
   version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = "scrutiny";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xEMHkISPBHinT6vRyrWPudvmTiX5gYxMkCEoSm2gLWA=";
   };
-
-  frontend = buildNpmPackage {
-    inherit version;
-    pname = "${pname}-webapp";
-    src = "${src}/webapp/frontend";
-
-    npmDepsHash = "sha256-1lOskHEU/3CmhQkUkQExryK6eMOSWvMI+Y+cX4Dlj98=";
-
-    buildPhase = ''
-      runHook preBuild
-      mkdir dist
-      npm run build:prod --offline -- --output-path=dist
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      mkdir $out
-      cp -r dist/* $out
-      runHook postInstall
-    '';
-
-    passthru.updateScript = nix-update-script { };
-  };
-in
-buildGoModule rec {
-  inherit pname src version;
 
   subPackages = "webapp/backend/cmd/scrutiny";
 
@@ -56,7 +56,7 @@ buildGoModule rec {
 
   postInstall = ''
     mkdir -p $out/share/scrutiny
-    cp -r ${frontend}/* $out/share/scrutiny
+    cp -r ${frontend finalAttrs}/* $out/share/scrutiny
   '';
 
   passthru.tests.scrutiny = nixosTests.scrutiny;
@@ -65,7 +65,7 @@ buildGoModule rec {
   meta = {
     description = "Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds";
     homepage = "https://github.com/AnalogJ/scrutiny";
-    changelog = "https://github.com/AnalogJ/scrutiny/releases/tag/v${version}";
+    changelog = "https://github.com/AnalogJ/scrutiny/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       samasaur
@@ -74,4 +74,4 @@ buildGoModule rec {
     mainProgram = "scrutiny";
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Updates scrutiny and scrutiny-collector from 0.9.0 to 0.9.1. Also converts both packages from using `rec` to using `finalAttrs`, which will allow overriding the version/src.

I'm aware that the `frontend` block in the scrutiny let-in looks a little weird, but it means that doing `overrideAttrs` on scrutiny will affect the webapp in the same way. The `rec` -> `finalAttrs` conversion is a zero-rebuild change (eval-only), which you can check by building from the first commit in this PR and then rebuilding from the second commit in this PR.

Closes: #513352

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
