### PR TITLE
groff: fix cross-compiling error

### DIFF
--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -34,6 +34,10 @@ let
     tag = "20200910";
     hash = "sha256-YQl5IDtodcbTV3D6vtJi7CwxVtHHl58fG6qCAoSaP4U=";
   };
+  nativeGroffBinPath = lib.makeBinPath [
+    buildPackages.groff
+    (lib.getOutput "perl" buildPackages.groff)
+  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "groff";
@@ -125,13 +129,18 @@ stdenv.mkDerivation (finalAttrs: {
     # Move mom docs instead of linking them to avoid dangling symlinks
     substituteInPlace Makefile \
       --replace-fail '$(LN_S) $(exampledir)' 'mv $(exampledir)'
+  ''
+  + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    # pdfmom uses GROFF_COMMAND to find the groff executable internally.
+    substituteInPlace Makefile \
+      --replace-fail 'GROFF_COMMAND=test-groff \' 'GROFF_COMMAND=$(GROFFBIN) \'
   '';
 
   makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     # Trick to get the build system find the proper 'native' groff
     # http://www.mail-archive.com/bug-groff@gnu.org/msg01335.html
-    "GROFF_BIN_PATH=${lib.getBin buildPackages.groff}/bin"
-    "GROFFBIN=${lib.getExe buildPackages.groff}"
+    "GROFF_BIN_PATH=${nativeGroffBinPath}"
+    "GROFFBIN=${lib.getExe' buildPackages.groff "groff"}"
   ];
 
   doCheck = true;


### PR DESCRIPTION
This fixes `groff` when cross-compiling by ensuring build-time tools use the native `groff` from `buildPackages.groff` instead of trying to execute a target-built binary.
The cross-build `GROFF_BIN_PATH` now includes both the main and `perl` outputs of native groff, so helper programs can be found during the build. For cross compilation, the generated Makefile is also patched so `pdfmom` uses `GROFFBIN` instead of `test-groff`, avoiding execution of the target `groff` on the build platform.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.