### PR TITLE
ci/github-script/merge: clarify maintainership is based on target branch

### DIFF
--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -66,8 +66,9 @@ function runChecklist({
     if (allByName) {
       // We can only determine the below, if all packages are in by-name, since
       // we can't reliably relate changed files to packages outside by-name.
-      checklist[`${user.login} is a maintainer of all touched packages.`] =
-        eligible.has(user.id)
+      checklist[
+        `${user.login} is a maintainer of all touched packages on the ${pull_request.base.ref} branch.`
+      ] = eligible.has(user.id)
     }
   } else {
     // This is only used when no user is passed, i.e. for labeling.


### PR DESCRIPTION
Tested locally: displays as "[user] is a maintainer of all touched packages on the [branch] branch." 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
