### PR TITLE
python3Packages.cryptography: Fix installing stray files into site-packages

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -9,6 +9,7 @@
   cffi,
   cryptography-vectors ? (callPackage ./vectors.nix { }),
   fetchFromGitHub,
+  fetchpatch,
   isPyPy,
   libiconv,
   openssl,
@@ -30,6 +31,14 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-b6wQnPEf18ViqQVch+Jg1w0Cn372QKxLknD9rL4JjxY=";
   };
+
+  # Fix installing stray files into site-packages
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/pyca/cryptography/commit/43eb178ee3aae8d0060221118437b03c23570a41.patch";
+      hash = "sha256-dJkdt28Q0BrM2hNLcOD9f+RWTLelrZTPrm1NZG0HzN0=";
+    })
+  ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;


### PR DESCRIPTION
Fixes this build error from `python3.withPackages (ps: [ps.cryptography ps.jax])`:

```
structuredAttrs is enabled
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  `/nix/store/7lk7273b4ysjqzy9lml63i6aa9nkdnq8-python3.13-jax-0.9.2/lib/python3.13/site-packages/docs/__pycache__/conf.cpython-313.opt-1.pyc' and
  `/nix/store/k7waldkbjrkkvs9xj35mbag9a0jjf4a7-python3.13-cryptography-46.0.6/lib/python3.13/site-packages/docs/__pycache__/conf.cpython-313.opt-1.pyc'
hint: this may be caused by two different versions of the same package in buildEnv's `paths` parameter
hint: `pkgs.nix-diff` can be used to compare derivations
```

- https://github.com/pyca/cryptography/pull/14319

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
