### PR TITLE
guac: init at 0.0.2

### DIFF
--- a/pkgs/by-name/gu/guac/package.nix
+++ b/pkgs/by-name/gu/guac/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildGo126Module,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib,
+  libx11,
+  libxrandr,
+  libxi,
+  libxcursor,
+  libxinerama,
+  libGL,
+  mesa,
+  libxxf86vm,
+  libglvnd,
+  makeWrapper,
+}:
+
+buildGo126Module rec {
+  pname = "guac";
+  version = "0.0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aabalke";
+    repo = "guac";
+    rev = "v${version}";
+    hash = "sha256-iHqeeo4MXYDjtJQ667gOYTZX8RbZ4HZspNt4so0ps8c=";
+  };
+
+  vendorHash = "sha256-tJYuEzk0yyEycFOneig9E3HI7xBT2EVy97itssSx5Lk=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libGL
+    libx11
+    libxrandr
+    libxi
+    libxcursor
+    libxinerama
+    mesa
+    libxxf86vm
+    libglvnd
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    go build -o guac .
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv guac $out/bin/guac
+    wrapProgram $out/bin/guac --set LD_LIBRARY_PATH "${mesa}/lib:${libglvnd}/lib:${libGL}/lib"
+  '';
+
+  meta = {
+    description = "NDS, GBA, GBC, DMG Emulator written in golang";
+    homepage = "https://github.com/aabalke/guac";
+    license = lib.licenses.bsd3;
+    maintainers = [ ];
+    mainProgram = "guac";
+  };
+}


### PR DESCRIPTION
Init `guac` at 0.0.2 a NDS, GBA, GBC, DMG Emulator written in golang.
It ran the games i threw at it, so it should work fine.

https://github.com/aabalke/guac
https://www.youtube.com/watch?v=AsWBItlGmZg

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
