### PR TITLE
nixos/luksroot: Improve systemd stage 1 assertion messages

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -610,6 +610,17 @@ let
     )
   );
 
+  systemdStage1HardwareKeyAssertionMessage = opt: ''
+    ${opt} is deprecated, and it is unsupported with systemd stage 1. Support will be removed in 26.11 along with scripted stage 1. Hardware keys in systemd stage 1 are supported with systemd-cryptsetup(8). To migrate, enroll a key in a LUKS slot with systemd-cryptenroll(1). Usually, systemd will automatically detect the configuration at runtime, but if necessary, configure the corresponding crypttab(5) options with boot.initrd.luks.devices.<name>.crypttabExtraOpts.
+
+    Note: After migrating to a new LUKS slot, the old LUKS slot used for the scripted stage 1 implementation should be removed, otherwise it could interfere with falling back to a passphrase prompt in the event the hardware key fails.
+
+    See:
+    - https://www.freedesktop.org/software/systemd/man/systemd-cryptsetup.html
+    - https://www.freedesktop.org/software/systemd/man/systemd-cryptenroll.html
+    - https://www.freedesktop.org/software/systemd/man/crypttab.html
+  '';
+
 in
 {
   imports = [
@@ -1106,21 +1117,16 @@ in
       # TODO
       {
         assertion = config.boot.initrd.systemd.enable -> !luks.gpgSupport;
-        message = "systemd stage 1 does not support GPG smartcards yet.";
+        message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.gpgSupport";
       }
       {
         assertion = config.boot.initrd.systemd.enable -> !luks.fido2Support;
-        message = ''
-          systemd stage 1 does not support configuring FIDO2 unlocking through `boot.initrd.luks.fido2Support`.
-          Use systemd-cryptenroll(1) to configure FIDO2 support, and set
-          `boot.initrd.luks.devices.''${DEVICE}.crypttabExtraOpts` as appropriate per crypttab(5)
-          (e.g. `fido2-device=auto`).
-        '';
+        message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.fido2Support";
       }
       # TODO
       {
         assertion = config.boot.initrd.systemd.enable -> !luks.yubikeySupport;
-        message = "systemd stage 1 does not support Yubikeys yet.";
+        message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.yubikeySupport";
       }
     ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
