### PR TITLE
hexer: init 1.0.7

### DIFF
--- a/pkgs/by-name/he/hexer/package.nix
+++ b/pkgs/by-name/he/hexer/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hexer";
+  version = "1.0.7";
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "hexer";
+    repo = "hexer";
+    tag = "release/${finalAttrs.version}";
+    hash = "sha256-xDgqz2n9urquJHq4N6prh0DYDb3BvH/ijPLgPMbrSLU=";
+  };
+
+  buildInputs = [
+    ncurses
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "-lcurses" "-lncurses"
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "DESTDIR="
+  ];
+
+  meta = {
+    description = "Multi-buffer editor for binary files with a Vi-like interface";
+    longDescription = ''
+      Hexer is a multi-buffer editor for binary files for Unix-like systems
+      that displays its buffer(s) as a hex dump.  The user interface is kept
+      similar to vi/ex.
+    '';
+    homepage = "https://devel.ringlet.net/editors/hexer/";
+    license = [
+      lib.licenses.bsd2
+      lib.licenses.bsd3
+    ];
+    mainProgram = "hexer";
+    maintainers = with lib.maintainers; [ tbutter ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Init hexer at 1.0.7
Homepage: https://gitlab.com/hexer/hexer

Hexer is a multi-buffer editor for binary files for Unix-like systems
that displays its buffer(s) as a hex dump.  The user interface is kept
similar to vi/ex.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
