### PR TITLE
mozillavpn: 2.35.0 → 2.36.0

### DIFF
--- a/pkgs/by-name/mo/mozillavpn/package.nix
+++ b/pkgs/by-name/mo/mozillavpn/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mozillavpn";
-  version = "2.35.0";
+  version = "2.36.0";
   src = fetchFromGitHub {
     owner = "mozilla-mobile";
     repo = "mozilla-vpn-client";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-H3Oa0SJR74dzZvg9u2drLmH/FNsc1hVUz2MEz/TV1rg=";
+    hash = "sha256-Mig/GJCFodOoTGk5iCO5WoFGYv3CdD7de65xgLf4xgk=";
   };
   patches = [
   ];
@@ -43,12 +43,12 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     modRoot = "linux/netfilter";
-    vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
+    vendorHash = "sha256-RDSZdmQ31RW4PjZsula9V/asT36GJRdxlAHV/wX2DS8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src patches;
-    hash = "sha256-ZcLbrLtaGOPSi9AUtiaFYefdlGMq5ygZF6KOgSQehAE=";
+    hash = "sha256-5147SMY/lowPr4LYhaCBMRxDG53bxc67tsl8WaRuaQc=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Upgrade the Mozilla VPN client from 2.35.0 to 2.36.0. 

- https://github.com/mozilla-mobile/mozilla-vpn-client/releases/tag/v2.36.0
- https://github.com/mozilla-mobile/mozilla-vpn-client/compare/v2.35.0...v2.36.0

Fixes this build error:

```
/build/source/src/translations/i18nstrings.cpp: In constructor 'I18nStrings::I18nStrings(QObject*)':
/build/source/src/translations/i18nstrings.cpp:25:67: error: 'QQmlPropertyMap::QQmlPropertyMap(QObject*)' is deprecated: Use create() or the protected two-argument con
structor instead. [-Werror=deprecated-declarations]
   25 | I18nStrings::I18nStrings(QObject* parent) : QQmlPropertyMap(parent) {
      |                                                                   ^
In file included from /nix/store/lwa1k7ni8d4ljj44mzzlagk4qnngrsr8-qtdeclarative-6.11.0/include/QtQml/QQmlPropertyMap:1,
                 from /build/source/build/src/translations/generated/i18nstrings.h:10,
                 from /build/source/src/translations/i18nstrings.cpp:5:
/nix/store/lwa1k7ni8d4ljj44mzzlagk4qnngrsr8-qtdeclarative-6.11.0/include/QtQml/qqmlpropertymap.h:28:14: note: declared here
   28 |     explicit QQmlPropertyMap(QObject *parent = nullptr);
      |              ^~~~~~~~~~~~~~~
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
