### PR TITLE
fortitude: 0.7.5-unstable-2025-10-14 -> 0.8

### DIFF
--- a/pkgs/by-name/fo/fortitude/package.nix
+++ b/pkgs/by-name/fo/fortitude/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fortitude";
-  version = "0.7.5-unstable-2025-10-14";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "PlasmaFAIR";
     repo = "fortitude";
-    rev = "ca65546d69947500eeb37a2bbc58151012ab40d9";
-    hash = "sha256-PKOPQnVQbvqEoCPO9K3ofajbcId83uLbma6R9RiBzys=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tJDvXmc0y5Gpk7uvk7mRq3b0MwkhVTx77bXik0Rfop8=";
   };
 
-  cargoHash = "sha256-hNAONXSy1uxm7AHvMHWNboL9NpQfvEOfTQivushp7S4=";
+  cargoHash = "sha256-kZsFDZGg89O3WCC9AyBXsOzzPVz8PPfOQG8t/eEXt34=";
 
   meta = {
     description = "Fortran linter written in Rust inspired by Ruff";
@@ -27,4 +27,4 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [ loicreynier ];
     platforms = with lib.platforms; windows ++ darwin ++ linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
