### PR TITLE
libbacktrace: Disable mtest_minidebug test on powerpc64-linux

### DIFF
--- a/pkgs/by-name/li/libbacktrace/package.nix
+++ b/pkgs/by-name/li/libbacktrace/package.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation {
     ./0004-libbacktrace-Support-NIX_DEBUG_INFO_DIRS-environment.patch
   ];
 
+  # https://github.com/ianlancetaylor/libbacktrace/issues/163
+  postPatch = lib.optionalString (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian) ''
+    substituteInPlace Makefile.am \
+      --replace-fail 'MAKETESTS += mtest_minidebug' '# MAKETESTS += mtest_minidebug'
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
   ];

--- a/pkgs/by-name/li/libbacktrace/package.nix
+++ b/pkgs/by-name/li/libbacktrace/package.nix
@@ -33,6 +33,15 @@ stdenv.mkDerivation {
     ./0004-libbacktrace-Support-NIX_DEBUG_INFO_DIRS-environment.patch
   ];
 
+  # https://github.com/ianlancetaylor/libbacktrace/issues/163
+  postPatch =
+    lib.optionalString
+      (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian && stdenv.hostPlatform.isAbiElfv1)
+      ''
+        substituteInPlace Makefile.am \
+          --replace-fail 'MAKETESTS += mtest_minidebug' '# MAKETESTS += mtest_minidebug'
+      '';
+
   nativeBuildInputs = [
     autoreconfHook
   ];


### PR DESCRIPTION
https://github.com/ianlancetaylor/libbacktrace/issues/163

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
