### PR TITLE
burpsuite: 2026.3.2 -> 2026.4.3

### DIFF
--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -3,36 +3,25 @@
   buildFHSEnv,
   fetchurl,
   jdk,
+  iconName ? "community",
   makeDesktopItem,
-  proEdition ? false,
   unzip,
 }:
+assert lib.assertMsg (
+  iconName == "pro" || iconName == "community"
+) "iconName has to be either pro or community";
 
 let
-  version = "2026.3.2";
-
-  product =
-    if proEdition then
-      {
-        productName = "pro";
-        productDesktop = "Burp Suite Professional Edition";
-        hash = "sha256-oZGSP19ejP9amfXV89kNDQwxLekZCs7oGKaX/DDHSZM=";
-      }
-    else
-      {
-        productName = "community";
-        productDesktop = "Burp Suite Community Edition";
-        hash = "sha256-PuV5XmgdBBkfPS0pc3xENtTUPMpemyHDDOTLVux24Xs=";
-      };
+  version = "2026.4";
 
   src = fetchurl {
     name = "burpsuite.jar";
     urls = [
-      "https://portswigger-cdn.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
-      "https://portswigger.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
-      "https://web.archive.org/web/https://portswigger.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
+      "https://portswigger-cdn.net/burp/releases/download?product=desktop&version=${version}&type=Jar"
+      "https://portswigger.net/burp/releases/download?product=desktop&version=${version}&type=Jar"
+      "https://web.archive.org/web/https://portswigger.net/burp/releases/download?product=desktop&version=${version}&type=Jar"
     ];
-    hash = product.hash;
+    hash = "sha256-gH4L6wwdSn87zx9bmjI0k8aFqRPnp3LwFuBSJ6ppqNE=";
   };
 
   pname = "burpsuite";
@@ -41,7 +30,7 @@ let
     name = "burpsuite";
     exec = pname;
     icon = pname;
-    desktopName = product.productDesktop;
+    desktopName = "Burp Suite Desktop";
     comment = description;
     categories = [
       "Development"
@@ -88,7 +77,7 @@ buildFHSEnv {
 
   extraInstallCommands = ''
     mkdir -p "$out/share/icons/hicolor/64x64/apps"
-    ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${product.productName}.png > "$out/share/icons/hicolor/64x64/apps/burpsuite.png"
+    ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${iconName}.png > "$out/share/icons/hicolor/64x64/apps/burpsuite.png"
     cp -r ${desktopItem}/share/applications $out/share
   '';
 
@@ -103,9 +92,9 @@ buildFHSEnv {
       exploiting security vulnerabilities.
     '';
     homepage = "https://portswigger.net/burp/";
-    changelog =
-      "https://portswigger.net/burp/releases/professional-community-"
-      + lib.replaceStrings [ "." ] [ "-" ] version;
+    changelog = "https://portswigger.net/burp/releases/professional-community-${
+      lib.replaceStrings [ "." ] [ "-" ] version
+    }";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.unfree;
     platforms = jdk.meta.platforms;

--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -4,44 +4,36 @@
   fetchurl,
   jdk,
   makeDesktopItem,
-  proEdition ? false,
   unzip,
+
+  # Either "community" or "pro"
+  iconName ? "community",
 }:
+assert lib.assertMsg (
+  iconName == "pro" || iconName == "community"
+) "iconName has to be either pro or community";
 
 let
-  version = "2026.3.2";
-
-  product =
-    if proEdition then
-      {
-        productName = "pro";
-        productDesktop = "Burp Suite Professional Edition";
-        hash = "sha256-oZGSP19ejP9amfXV89kNDQwxLekZCs7oGKaX/DDHSZM=";
-      }
-    else
-      {
-        productName = "community";
-        productDesktop = "Burp Suite Community Edition";
-        hash = "sha256-PuV5XmgdBBkfPS0pc3xENtTUPMpemyHDDOTLVux24Xs=";
-      };
+  pname = "burpsuite";
+  version = "2026.4.3";
 
   src = fetchurl {
     name = "burpsuite.jar";
     urls = [
-      "https://portswigger-cdn.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
-      "https://portswigger.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
-      "https://web.archive.org/web/https://portswigger.net/burp/releases/download?product=${product.productName}&version=${version}&type=Jar"
+      "https://portswigger-cdn.net/burp/releases/download?product=desktop&version=${version}&type=Jar"
+      "https://portswigger.net/burp/releases/download?product=desktop&version=${version}&type=Jar"
+      "https://web.archive.org/web/https://portswigger.net/burp/releases/download?product=desktop&version=${version}&type=Jar"
     ];
-    hash = product.hash;
+    hash = "sha256-mewbN1uZAFCsxAiXsrNKJ/AexCccVcza40DjxMDbrlM=";
   };
 
-  pname = "burpsuite";
   description = "Integrated platform for performing security testing of web applications";
+
   desktopItem = makeDesktopItem {
-    name = "burpsuite";
+    name = pname;
     exec = pname;
     icon = pname;
-    desktopName = product.productDesktop;
+    desktopName = "Burp Suite Desktop";
     comment = description;
     categories = [
       "Development"
@@ -49,12 +41,11 @@ let
       "System"
     ];
   };
-
 in
 buildFHSEnv {
   inherit pname version;
 
-  runScript = "${jdk}/bin/java -jar ${src}";
+  runScript = "${lib.getExe jdk} -jar ${src}";
 
   targetPkgs =
     pkgs: with pkgs; [
@@ -88,7 +79,7 @@ buildFHSEnv {
 
   extraInstallCommands = ''
     mkdir -p "$out/share/icons/hicolor/64x64/apps"
-    ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${product.productName}.png > "$out/share/icons/hicolor/64x64/apps/burpsuite.png"
+    ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${iconName}.png > "$out/share/icons/hicolor/64x64/apps/burpsuite.png"
     cp -r ${desktopItem}/share/applications $out/share
   '';
 
@@ -103,9 +94,9 @@ buildFHSEnv {
       exploiting security vulnerabilities.
     '';
     homepage = "https://portswigger.net/burp/";
-    changelog =
-      "https://portswigger.net/burp/releases/professional-community-"
-      + lib.replaceStrings [ "." ] [ "-" ] version;
+    changelog = "https://portswigger.net/burp/releases/professional-community-${
+      lib.replaceStrings [ "." ] [ "-" ] version
+    }";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.unfree;
     platforms = jdk.meta.platforms;

--- a/pkgs/by-name/bu/burpsuite/update.sh
+++ b/pkgs/by-name/bu/burpsuite/update.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl jq xxd gnused diffutils
 set -eu -o pipefail
+trap 'rm -f latest.json' EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 curl -s 'https://portswigger.net/burp/releases/data' | jq -r '
       def verarr: (.Version // "") | split(".") | map(tonumber? // 0);
       [ .ResultSet.Results[]
-        | select((.categories|sort) == (["Professional","Community"]|sort))
+        | select(.categories == ["Desktop"])
         | .builds[]
         | select(.BuildCategoryPlatform == "Jar")
       ] as $all
@@ -16,23 +17,13 @@ curl -s 'https://portswigger.net/burp/releases/data' | jq -r '
       ' > latest.json
 
 version=$(jq -r '.[0].Version' latest.json)
-
-comm_hex=$(jq -r '.[] | select(.BuildCategoryId=="community") .Sha256Checksum' latest.json)
-pro_hex=$(jq -r '.[] | select(.BuildCategoryId=="pro") .Sha256Checksum' latest.json)
-
-comm_sri="sha256-$(printf %s "$comm_hex" | xxd -r -p | base64 -w0)"
-pro_sri="sha256-$(printf %s "$pro_hex" | xxd -r -p | base64 -w0)"
+hex=$(jq -r '.[0].Sha256Checksum' latest.json)
+sri="sha256-$(printf %s "$hex" | xxd -r -p | base64 -w0)"
 
 sed -i \
-  -e "s|^\(\s*version = \)\"[^\"]*\";|\1\"$version\";|" \
-  -e "/productName = \"community\"/,/hash =/ {
-        s|sha256-[^\"]*|$comm_sri|
-     }" \
-  -e "/productName = \"pro\"/,/hash =/ {
-        s|sha256-[^\"]*|$pro_sri|
-     }" \
-  $SCRIPT_DIR/package.nix
+    -e "s|^\(\s*version = \)\"[^\"]*\";|\1\"$version\";|" \
+    -e "s|^\(\s*hash = \)\"[^\]*\";|\1\"$sri\";|" \
+    $SCRIPT_DIR/package.nix
 
 echo "burpsuite → $version"
-echo "  community: $comm_sri"
-echo "  pro      : $pro_sri"
+echo "     hash: $sri"


### PR DESCRIPTION
closes: #513630

Changelogs:
- https://portswigger.net/burp/releases/professional-community-2026-4-3
- https://portswigger.net/burp/releases/professional-community-2026-4-2
- https://portswigger.net/burp/releases/professional-community-2026-4
- https://portswigger.net/burp/releases/professional-community-2026-3-3

`2026.4.2` merged community and pro into a single jar.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
