### PR TITLE
unsloth: fix build on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -181,6 +181,9 @@ buildPythonPackage (finalAttrs: {
 
     # ImportError: cannot import name 'PretrainedConfig' from 'transformers.modeling_utils'
     "test_nested_hook"
+
+    # torch.mps does not have set_device attribute
+    "test_env_var_device"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # RuntimeError: torch_shm_manager: execl failed: Permission denied

--- a/pkgs/development/python-modules/cut-cross-entropy/default.nix
+++ b/pkgs/development/python-modules/cut-cross-entropy/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -43,6 +44,8 @@ buildPythonPackage {
 
   dependencies = [
     torch
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     triton
   ];
 

--- a/pkgs/development/python-modules/unsloth-zoo/default.nix
+++ b/pkgs/development/python-modules/unsloth-zoo/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
 
@@ -65,6 +66,11 @@ buildPythonPackage (finalAttrs: {
     "transformers"
   ];
 
+  pythonRemoveDeps = lib.optionals (!stdenv.hostPlatform.isLinux) [
+    "cut_cross_entropy"
+    "triton"
+  ];
+
   patches = [
     # Avoid circular dependency in Nix, since `unsloth` depends on `unsloth-zoo`.
     ./dont-require-unsloth.patch
@@ -77,7 +83,6 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     accelerate
-    cut-cross-entropy
     datasets
     filelock
     hf-transfer
@@ -93,12 +98,15 @@ buildPythonPackage (finalAttrs: {
     sentencepiece
     torch
     torchao
-    triton
     tqdm
     transformers
     trl
     tyro
     typing-extensions
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    cut-cross-entropy
+    triton
   ];
 
   # No tests

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -122,6 +122,8 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
     scipy
     timm
     transformers
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     triton
   ];
 
@@ -147,7 +149,11 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
     "tests/test_fwbw_overlap.py"
   ];
 
-  disabledTests =
+  disabledTests = [
+    # torch._C._set_print_stack_traces_on_fatal_signal removed in torch 2.11
+    "test_env_vars"
+  ]
+  ++
     # The following tests fail without cudaSupport
     lib.optionals (!cudaSupport) [
       # AssertionError: Torch not compiled with CUDA enabled


### PR DESCRIPTION
## Things done

This PR selectively disables some packages to make the unsloth package build on aarch64-darwin again

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
