### PR TITLE
intel-llvm: fix linking for consumers using strictDeps

### DIFF
--- a/pkgs/by-name/in/intel-llvm/package.nix
+++ b/pkgs/by-name/in/intel-llvm/package.nix
@@ -24,6 +24,19 @@ let
   #      .override { .. }
   #      .overrideAttrs { .. }
   #  })
+  #
+  # Note that this package does not support cross-compilation at the moment.
+  #
+  # TODO: Support cross
+  #  The easiest path for this will likely be to use standalone packaging,
+  #  and use the existing LLVM derivation with overrides. Though that won't
+  #  be very workable until upstream support for standalone improves,
+  #  see https://github.com/intel/llvm/issues/21877 for that.
+  #
+  #  Due to the multi-stage build, at several times during compilation
+  #  the package runs binaries that were just compiled, and for cross these
+  #  would need to be compiled for the host and not target platform,
+  #  which is non-trivial to configure.
   scope = lib.makeScope newScope (self: {
     # == Parameters for overriding ==
 
@@ -89,22 +102,23 @@ let
         ;
     };
 
-    wrapper =
-      (wrapCCWith {
-        cc = self.unwrapped;
-        # This is needed for tools like clang-scan-deps to find headers.
-        # The build commands here are the same as the vanilla LLVM derivation.
-        extraBuildCommands = ''
-          rsrc="$out/resource-root"
-          mkdir "$rsrc"
-          echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-          ln -s "${lib.getLib self.unwrapped}/lib/clang/${self.llvmMajorVersion}/include" "$rsrc"
-        '';
-      }).overrideAttrs
-        (old: {
-          # OpenCL needs to be passed through
-          propagatedBuildInputs = old.propagatedBuildInputs ++ self.unwrapped.propagatedBuildInputs;
-        });
+    wrapper = wrapCCWith {
+      cc = self.unwrapped;
+      # This is needed for tools like clang-scan-deps to find headers.
+      # The build commands here are the same as the vanilla LLVM derivation.
+      extraBuildCommands = ''
+        rsrc="$out/resource-root"
+        mkdir "$rsrc"
+        echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+        ln -s "${lib.getLib self.unwrapped}/lib/clang/${self.llvmMajorVersion}/include" "$rsrc"
+      '';
+
+      extraPackages =
+        # We need to explicitly link to the dev package to get headers like sycl.hpp
+        [ self.unwrapped.dev ] # TODO: This needs to be from targetPackages once the package gets cross support
+        # OpenCL and such need to be passed through
+        ++ self.unwrapped.propagatedBuildInputs;
+    };
 
     clang-tools-wrapper = callPackage ./clang-tools.nix {
       inherit (self) unwrapped wrapper;


### PR DESCRIPTION
Fixes an issue where packages built with `intel-llvm.stdenv` that use `strictDeps = true;` fail to discover sycl headers and other intel-specific includes.

Encountered in #513438

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
