### PR TITLE
lilo: unbreak

### DIFF
--- a/pkgs/by-name/li/lilo/package.nix
+++ b/pkgs/by-name/li/lilo/package.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   # Workaround build failure on -fno-common toolchains:
   #   ld: identify.o:(.bss+0x0): multiple definition of `identify';
   #     common.o:(.bss+0x160): first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  # Without -std=gnu17, compilation fails with an error on incompatible pointer types
+  env.NIX_CFLAGS_COMPILE = "-fcommon -std=gnu17";
 
   makeFlags = [
     "DESTDIR=${placeholder "out"}"


### PR DESCRIPTION
This pull request unbreaks the build of our LILO package.

LILO is an ancient boot loader for Linux which is still useful in some settings, for instance generating bootable disk images for ancient Linux distributions.

The sources compile fine if we tell gcc to use an older C standard.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
