### PR TITLE
installFonts: add `{include,exclude}Fonts`

### DIFF
--- a/pkgs/build-support/setup-hooks/install-fonts.sh
+++ b/pkgs/build-support/setup-hooks/install-fonts.sh
@@ -42,7 +42,7 @@ installFont() {
 
     findExpr+=( \( )
     for p in "${includeFonts[@]}"; do
-      findExpr+=( "-name" "$p.$ext" "-o" )
+      findExpr+=( "-iname" "$p.$ext" "-o" )
     done
     unset 'findExpr[${#findExpr[@]}-1]'
     findExpr+=( \) )
@@ -51,7 +51,7 @@ installFont() {
   fi
 
   for p in "${excludeFonts[@]}"; do
-    findExpr+=( -not -name "$p.$ext" )
+    findExpr+=( -not -iname "$p.$ext" )
   done
 
   find . -type f "${findExpr[@]}" -print0 | \
@@ -61,23 +61,22 @@ installFont() {
 installFonts() {
   if [ "${dontInstallFonts-}" == 1 ]; then return; fi
 
-  installFont 'ttf' "$out/share/fonts/truetype"
-  installFont 'ttc' "$out/share/fonts/truetype"
-  installFont 'otf' "$out/share/fonts/opentype"
-  installFont 'otc' "$out/share/fonts/opentype"
-  installFont 'pfa' "$out/share/fonts/type1"
-  installFont 'pfb' "$out/share/fonts/type1"
-  installFont 'pfm' "$out/share/fonts/type1"
-  installFont 'afm' "$out/share/fonts/type1"
-  installFont 'bdf' "$out/share/fonts/misc"
-  installFont 'pcf' "$out/share/fonts/misc"
-  installFont 'otb' "$out/share/fonts/misc"
-  installFont 'psf' "$out/share/consolefonts"
-  installFont 'psfu' "$out/share/consolefonts"
+  declare -A font_dirs=(
+    ["ttf ttc"]="$out/share/fonts/truetype"
+    ["otf otc"]="$out/share/fonts/opentype"
+    ["pfa pfb pfm afm"]="$out/share/fonts/type1"
+    ["bdf pcf otb"]="$out/share/fonts/misc"
+    ["psf psfu"]="$out/share/consolefonts"
+  )
+
+  for exts in "${!font_dirs[@]}"; do
+    for ext in $exts; do
+      installFont "$ext" "${font_dirs[$exts]}"
+    done
+  done
 
   if [ -n "${webfont-}" ]; then
     installFont 'woff' "$webfont/share/fonts/woff"
     installFont 'woff2' "$webfont/share/fonts/woff2"
   fi
-
 }

--- a/pkgs/build-support/setup-hooks/install-fonts.sh
+++ b/pkgs/build-support/setup-hooks/install-fonts.sh
@@ -29,7 +29,33 @@ installFont() {
     exit 1
   fi
 
-  find -iname "*.$1" -print0 | xargs -0 -r install -m644 -D -t "$2"
+  local ext="$1"
+  local targetDir="$2"
+  local findExpr=()
+
+  set -f
+  includeFonts=(${includeFonts[@]})
+  excludeFonts=(${excludeFonts[@]})
+  set +f
+
+  if [ ${#includeFonts[@]} -gt 0 ]; then
+
+    findExpr+=( \( )
+    for p in "${includeFonts[@]}"; do
+      findExpr+=( "-name" "$p.$ext" "-o" )
+    done
+    unset 'findExpr[${#findExpr[@]}-1]'
+    findExpr+=( \) )
+  else
+    findExpr+=( -iname "*.$ext" )
+  fi
+
+  for p in "${excludeFonts[@]}"; do
+    findExpr+=( -not -name "$p.$ext" )
+  done
+
+  find . -type f "${findExpr[@]}" -print0 | \
+    xargs -0 -r install -m644 -D -t "$targetDir"
 }
 
 installFonts() {

--- a/pkgs/build-support/setup-hooks/install-fonts.sh
+++ b/pkgs/build-support/setup-hooks/install-fonts.sh
@@ -42,7 +42,7 @@ installFont() {
 
     findExpr+=( \( )
     for p in "${includeFonts[@]}"; do
-      findExpr+=( "-name" "$p.$ext" "-o" )
+      findExpr+=( "-iname" "$p.$ext" "-o" )
     done
     unset 'findExpr[${#findExpr[@]}-1]'
     findExpr+=( \) )
@@ -51,7 +51,7 @@ installFont() {
   fi
 
   for p in "${excludeFonts[@]}"; do
-    findExpr+=( -not -name "$p.$ext" )
+    findExpr+=( -not -iname "$p.$ext" )
   done
 
   find . -type f "${findExpr[@]}" -print0 | \
@@ -61,19 +61,19 @@ installFont() {
 installFonts() {
   if [ "${dontInstallFonts-}" == 1 ]; then return; fi
 
-  installFont 'ttf' "$out/share/fonts/truetype"
-  installFont 'ttc' "$out/share/fonts/truetype"
-  installFont 'otf' "$out/share/fonts/opentype"
-  installFont 'otc' "$out/share/fonts/opentype"
-  installFont 'pfa' "$out/share/fonts/type1"
-  installFont 'pfb' "$out/share/fonts/type1"
-  installFont 'pfm' "$out/share/fonts/type1"
-  installFont 'afm' "$out/share/fonts/type1"
-  installFont 'bdf' "$out/share/fonts/misc"
-  installFont 'pcf' "$out/share/fonts/misc"
-  installFont 'otb' "$out/share/fonts/misc"
-  installFont 'psf' "$out/share/consolefonts"
-  installFont 'psfu' "$out/share/consolefonts"
+  declare -A font_dirs=(
+    ["ttf ttc"]="$out/share/fonts/truetype"
+    ["otf otc"]="$out/share/fonts/opentype"
+    ["pfa pfb pfm afm"]="$out/share/fonts/type1"
+    ["bdf pcf otb"]="$out/share/fonts/misc"
+    ["psf psfu"]="$out/share/consolefonts"
+  )
+
+  for exts in "${!font_dirs[@]}"; do
+    for ext in $exts; do
+      installFont "$ext" "${font_dirs[$exts]}"
+    done
+  done
 
   if [ -n "${webfont-}" ]; then
     installFont 'woff' "$webfont/share/fonts/woff"

--- a/pkgs/by-name/in/installFonts/install-fonts.sh
+++ b/pkgs/by-name/in/installFonts/install-fonts.sh
@@ -29,7 +29,33 @@ installFont() {
     exit 1
   fi
 
-  find -iname "*.$1" -print0 | xargs -0 -r install -m644 -D -t "$2"
+  local ext="$1"
+  local targetDir="$2"
+  local findExpr=()
+
+  set -f
+  includeFonts=(${includeFonts[@]})
+  excludeFonts=(${excludeFonts[@]})
+  set +f
+
+  if [ ${#includeFonts[@]} -gt 0 ]; then
+
+    findExpr+=( \( )
+    for p in "${includeFonts[@]}"; do
+      findExpr+=( "-name" "$p.$ext" "-o" )
+    done
+    unset 'findExpr[${#findExpr[@]}-1]'
+    findExpr+=( \) )
+  else
+    findExpr+=( -iname "*.$ext" )
+  fi
+
+  for p in "${excludeFonts[@]}"; do
+    findExpr+=( -not -name "$p.$ext" )
+  done
+
+  find . -type f "${findExpr[@]}" -print0 | \
+    xargs -0 -r install -m644 -D -t "$targetDir"
 }
 
 installFonts() {

--- a/pkgs/by-name/in/installFonts/install-fonts.sh
+++ b/pkgs/by-name/in/installFonts/install-fonts.sh
@@ -42,7 +42,7 @@ installFont() {
 
     findExpr+=( \( )
     for p in "${includeFonts[@]}"; do
-      findExpr+=( "-name" "$p.$ext" "-o" )
+      findExpr+=( "-iname" "$p.$ext" "-o" )
     done
     unset 'findExpr[${#findExpr[@]}-1]'
     findExpr+=( \) )
@@ -51,7 +51,7 @@ installFont() {
   fi
 
   for p in "${excludeFonts[@]}"; do
-    findExpr+=( -not -name "$p.$ext" )
+    findExpr+=( -not -iname "$p.$ext" )
   done
 
   find . -type f "${findExpr[@]}" -print0 | \
@@ -61,20 +61,19 @@ installFont() {
 installFonts() {
   if [ "${dontInstallFonts-}" == 1 ]; then return; fi
 
-  installFont 'ttf' "$out/share/fonts/truetype"
-  installFont 'ttc' "$out/share/fonts/truetype"
-  installFont 'otf' "$out/share/fonts/opentype"
-  installFont 'otc' "$out/share/fonts/opentype"
-  installFont 'pfa' "$out/share/fonts/type1"
-  installFont 'pfb' "$out/share/fonts/type1"
-  installFont 'pfm' "$out/share/fonts/type1"
-  installFont 'afm' "$out/share/fonts/type1"
-  installFont 'bdf' "$out/share/fonts/misc"
-  installFont 'pcf' "$out/share/fonts/misc"
-  installFont 'otb' "$out/share/fonts/misc"
-  installFont 'pcf.gz' "$out/share/fonts/misc"
-  installFont 'psf' "$out/share/consolefonts"
-  installFont 'psfu' "$out/share/consolefonts"
+  declare -A font_dirs=(
+    ["ttf ttc"]="$out/share/fonts/truetype"
+    ["otf otc"]="$out/share/fonts/opentype"
+    ["pfa pfb pfm afm"]="$out/share/fonts/type1"
+    ["bdf pcf otb pcf.gz"]="$out/share/fonts/misc"
+    ["psf psfu"]="$out/share/consolefonts"
+  )
+
+  for exts in "${!font_dirs[@]}"; do
+    for ext in $exts; do
+      installFont "$ext" "${font_dirs[$exts]}"
+    done
+  done
 
   if [ -n "${webfont-}" ]; then
     installFont 'woff' "$webfont/share/fonts/woff"

--- a/pkgs/by-name/my/myrica/package.nix
+++ b/pkgs/by-name/my/myrica/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -16,14 +17,14 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-kx+adbN2DsO81KJFt+FGAPZN+1NpE9xiagKZ4KyaJV0=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  nativeBuildInputs = [ installFonts ];
 
-    mkdir -p $out/share/fonts/truetype
-    cp product/*.TTC $out/share/fonts/truetype
+  # only collect font collections
 
-    runHook postInstall
-  '';
+  includeFonts = [
+    "Myrica"
+    "MyricaM"
+  ];
 
   meta = {
     homepage = "https://myrica.estable.jp/";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/495640 (myrica)
- closes: #513517

Use `myrica` as an example, since it would bundle other fonts when moving to `installFonts`.

Changes ouput from
```
result
└── share
    └── fonts
        └── truetype
            ├── MyricaM.TTC
            └── Myrica.TTC
```
to
```
result
└── share
    └── fonts
        └── truetype
            ├── MyricaMM.ttf
            ├── MyricaMN.ttf
            ├── MyricaMP.ttf
            ├── myricaM_ReplaceParts.ttf
            ├── MyricaM.TTC
            ├── myrica_ReplaceParts.ttf
            └── Myrica.TTC
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
