### PR TITLE
nixos/systemd-networkd: add new options for v260

### DIFF
--- a/nixos/lib/systemd-network-units.nix
+++ b/nixos/lib/systemd-network-units.nix
@@ -413,6 +413,10 @@ in
       [QuickFairQueueingClass]
       ${attrsToSection def.quickFairQueueingConfigClass}
     ''
+    + optionalString (def.mobileNetworkConfig != { }) ''
+      [MobileNetwork]
+      ${attrsToSection def.mobileNetworkConfig}
+    ''
     + flip concatMapStrings def.bridgeVLANs (x: ''
       [BridgeVLAN]
       ${attrsToSection x}

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -180,6 +180,12 @@ let
           "StatisticsBlockCoalesceSec"
           "MDI"
           "SR-IOVVirtualFunctions"
+          "ScatterGather"
+          "ScatterGatherFragmentList"
+          "TCPECNSegmentationOffload"
+          "TCPMangleIdSegmentationOffload"
+          "GenericReceiveOffloadList"
+          "GenericReceiveOffloadUDPForwarding"
         ])
         (assertValueOneOf "MACAddressPolicy" [
           "persistent"
@@ -271,6 +277,12 @@ let
           "auto"
         ])
         (assertRange "SR-IOVVirtualFunctions" 0 2147483647)
+        (assertValueOneOf "ScatterGather" boolValues)
+        (assertValueOneOf "ScatterGatherFragmentList" boolValues)
+        (assertValueOneOf "TCPECNSegmentationOffload" boolValues)
+        (assertValueOneOf "TCPMangleIdSegmentationOffload" boolValues)
+        (assertValueOneOf "GenericReceiveOffloadList" boolValues)
+        (assertValueOneOf "GenericReceiveOffloadUDPForwarding" boolValues)
       ];
 
       sectionSR-IOV = checkUnitConfig "SR-IOV" [
@@ -2413,6 +2425,38 @@ let
         (assertInt "PVID")
         (assertRange "PVID" 0 4094)
       ];
+
+      sectionMobileNetwork = checkUnitConfig "MobileNetwork" [
+        (assertOnlyFields [
+          "APN"
+          "AllowedAuthenticationMechanisms"
+          "User"
+          "Password"
+          "IPFamily"
+          "AllowRoaming"
+          "PIN"
+          "OperatorId"
+          "RouteMetric"
+          "UseGateway"
+        ])
+        (assertValuesSomeOfOr "AllowedAuthenticationMechanisms" [
+          "none"
+          "pap"
+          "chap"
+          "mschap"
+          "mschapv2"
+          "eap"
+        ] "")
+        (assertValueOneOf "IPFamily" [
+          "ipv4"
+          "ipv6"
+          "both"
+          "any"
+        ])
+        (assertValueOneOf "AllowRoaming" boolValues)
+        (assertRange "RouteMetric" 0 4294967295)
+        (assertValueOneOf "UseGateway" boolValues)
+      ];
     };
   };
 
@@ -3743,6 +3787,20 @@ let
       type = types.listOf (mkSubsectionType "bridgeVLANConfig" check.network.sectionBridgeVLAN);
       description = ''
         A list of BridgeVLAN sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    mobileNetworkConfig = mkOption {
+      default = { };
+      example = {
+        APN = "access-point-name";
+        AllowRoaming = false;
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.network.sectionMobileNetwork;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[MobileNetwork]` section of the unit.  See
         {manpage}`systemd.network(5)` for details.
       '';
     };


### PR DESCRIPTION
systemd 260 introduces some new linkConfig options to configure ethernet devices and a new [MobileNetwork] section (and options) to configure cellular network connections using a new integration with ModemManager.

- https://github.com/systemd/systemd/releases/tag/v260

The one thing I am unsure of is if this option check is the most appropriate:

```nix
(assertValuesSomeOfOr "AllowedAuthenticationMechanisms" [
  "none" "pap" "chap" "mschap" "mschapv2" "eap"
] "")
```



The `systemd.network` man page (see [here](https://www.freedesktop.org/software/systemd/man/260/systemd.network.html#AllowedAuthenticationMechanisms=)) says the value should be: 

> Specifies the white-space separated list of "none", "pap", "chap", "mschap", "mschapv2", or "eap" methods. ... Defaults to unset and an automatically picked authentication method will be used.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
