### PR TITLE
fcitx5-sitelen-pona: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25927,6 +25927,12 @@
     githubId = 4061736;
     name = "Severen Redwood";
   };
+  ssnoer = {
+    email = "ssnoer@proton.me";
+    github = "Seba244c";
+    githubId = 23051740;
+    name = "Sebastian August Snoer";
+  };
   sstef = {
     email = "stephane@nix.frozenid.net";
     github = "haskelious";

--- a/pkgs/by-name/fc/fcitx5-sitelen-pona/package.nix
+++ b/pkgs/by-name/fc/fcitx5-sitelen-pona/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  libime,
+  fcitx5,
+  qt6Packages,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "fcitx5-sitelen-pona";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Toastberries";
+    repo = "fcitx5-sitelen-pona";
+    tag = "v${version}";
+    hash = "sha256-ZLp/p5umewp1seXFPtMevVBXfoNwHXAojYl5jWHHsTU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ libime ];
+
+  buildInputs = [
+    fcitx5
+    qt6Packages.fcitx5-chinese-addons
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p fcitx5/table
+    for file in table_sources/*; do
+      libime_tabledict "$file" "fcitx5/table/$(basename "$file" .txt).dict"
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fcitx5/inputmethod
+    mkdir -p $out/share/fcitx5/punctuation
+    mkdir -p $out/share/fcitx5/table
+    mkdir -p $out/share/icons/hicolor/scalable/status
+
+    for file in fcitx5/inputmethod/*; do
+      install -Dm644 "$file" "$out/share/fcitx5/inputmethod/$(basename "$file")"
+    done
+
+    for file in fcitx5/punctuation/*; do
+      install -Dm644 "$file" "$out/share/fcitx5/punctuation/$(basename "$file")"
+    done
+
+    for file in fcitx5/table/*; do
+      install -Dm644 "$file" "$out/share/fcitx5/table/$(basename "$file")"
+    done
+
+    for icon in icons/*; do
+      install -Dm644 "$icon" "$out/share/icons/hicolor/scalable/status/fcitx5-$(basename "$icon")"
+    done
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (fcitx5.meta) platforms;
+    description = "IME using Fcitx5 for writing toki pona's sitelen pona glyphs";
+    longDescription = ''
+      This tool is an IME using Fcitx5
+      With it, you can easily write toki pona's sitelen pona glyphs
+      Simply type your words in latin characters, and they'll be changed into sitelen pona
+    '';
+    homepage = "https://github.com/Toastberries/fcitx5-sitelen-pona";
+    changelog = "https://github.com/Toastberries/fcitx5-sitelen-pona/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ssnoer ];
+  };
+}

--- a/pkgs/by-name/fc/fcitx5-sitelen-pona/package.nix
+++ b/pkgs/by-name/fc/fcitx5-sitelen-pona/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  libime,
+  fcitx5,
+  qt6Packages,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "fcitx5-sitelen-pona";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Toastberries";
+    repo = "fcitx5-sitelen-pona";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZLp/p5umewp1seXFPtMevVBXfoNwHXAojYl5jWHHsTU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ libime ];
+
+  buildInputs = [
+    fcitx5
+    qt6Packages.fcitx5-chinese-addons
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p fcitx5/table
+    for file in table_sources/*; do
+      libime_tabledict "$file" "fcitx5/table/$(basename "$file" .txt).dict"
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fcitx5
+    cp -r fcitx5/{inputmethod,punctuation,table} "$out/share/fcitx5/"
+
+    mkdir -p $out/share/icons/hicolor/scalable/status
+    for icon in icons/*; do
+      install -Dm644 "$icon" "$out/share/icons/hicolor/scalable/status/fcitx5-$(basename "$icon")"
+    done
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (fcitx5.meta) platforms;
+    description = "IME using Fcitx5 for writing toki pona's sitelen pona glyphs";
+    longDescription = ''
+      This tool is an IME using Fcitx5
+      With it, you can easily write toki pona's sitelen pona glyphs
+      Simply type your words in latin characters, and they'll be changed into sitelen pona
+    '';
+    homepage = "https://github.com/Toastberries/fcitx5-sitelen-pona";
+    changelog = "https://github.com/Toastberries/fcitx5-sitelen-pona/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ssnoer ];
+  };
+})


### PR DESCRIPTION
Adds support for the logographic script "sitelen pona". The build method reflects the one found in the source repo in install.sh

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
