### PR TITLE
nixos/tailscale: harden using suggested hardening options

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -142,6 +142,14 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ]; # for the CLI
+
+    users.users.tailscaled = {
+      isSystemUser = true;
+      group = "tailscaled";
+      extraGroups = [ "tss" ];
+    };
+    users.groups.tailscaled = { };
+    users.groups.tss = { };
     systemd.packages = [ cfg.package ];
     systemd.services.tailscaled = {
       after = lib.mkIf (config.networking.networkmanager.enable) [ "NetworkManager-wait-online.service" ];
@@ -153,19 +161,80 @@ in
         pkgs.kmod # required to pass tailscale's v6nat check
       ]
       ++ lib.optional config.networking.resolvconf.enable config.networking.resolvconf.package;
-      serviceConfig.Environment = [
-        "PORT=${toString cfg.port}"
-        ''"FLAGS=--tun ${lib.escapeShellArg cfg.interfaceName} ${lib.concatStringsSep " " cfg.extraDaemonFlags}"''
-      ]
-      ++ (lib.optionals (cfg.permitCertUid != null) [
-        "TS_PERMIT_CERT_UID=${cfg.permitCertUid}"
-      ])
-      ++ (lib.optionals (cfg.disableTaildrop) [
-        "TS_DISABLE_TAILDROP=true"
-      ])
-      ++ (lib.optionals (cfg.disableUpstreamLogging) [
-        "TS_NO_LOGS_NO_SUPPORT=true"
-      ]);
+      serviceConfig = {
+        Environment = [
+          "PORT=${toString cfg.port}"
+          ''"FLAGS=--tun ${lib.escapeShellArg cfg.interfaceName} ${lib.concatStringsSep " " cfg.extraDaemonFlags}"''
+        ]
+        ++ (lib.optionals (cfg.permitCertUid != null) [
+          "TS_PERMIT_CERT_UID=${cfg.permitCertUid}"
+        ])
+        ++ (lib.optionals (cfg.disableTaildrop) [
+          "TS_DISABLE_TAILDROP=true"
+        ])
+        ++ (lib.optionals (cfg.disableUpstreamLogging) [
+          "TS_NO_LOGS_NO_SUPPORT=true"
+        ]);
+
+        User = "tailscaled";
+        Group = "tailscaled";
+        SupplementaryGroups = "tss";
+        # Hardening options, using the configuration from
+        # https://tailscale.com/docs/reference/best-practices/device-hardening#suggested-hardening-configuration-based-on-systemd
+        DeviceAllow = [
+          "/dev/tun"
+          "/dev/net/tun"
+          "/dev/tpmrm0 rw"
+        ];
+        AmbientCapabilities = [
+          "CAP_NET_RAW"
+          "CAP_NET_ADMIN"
+          "CAP_SYS_MODULE"
+        ];
+        CapabilityBoundingSet = [
+          "CAP_NET_RAW"
+          "CAP_NET_ADMIN"
+          "CAP_SYS_MODULE"
+        ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = false;
+        ProtectKernelTunables = true;
+        ProtectProc = "noaccess";
+        ProtectSystem = "full";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@known"
+          "~@clock"
+          "@cpu-emulation"
+          "@raw-io"
+          "@reboot"
+          "@mount"
+          "@obsolete"
+          "@swap"
+          "@debug"
+          "@keyring"
+          "@mount"
+          "@pkey"
+        ];
+
+      };
       # Restart tailscaled with a single `systemctl restart` at the
       # end of activation, rather than a `stop` followed by a later
       # `start`. Activation over Tailscale can hang for tens of


### PR DESCRIPTION
Uses the upstream suggested configuration(https://tailscale.com/docs/reference/best-practices/device-hardening#suggested-hardening-configuration-based-on-systemd) to harden the service. Massively reduces the scope of permissions allocated to the systemd service, notably it no longer runs as root.

Before:
```
Overall exposure level for tailscaled.service: 9.6 UNSAFE 😨
```

After:
```
Overall exposure level for tailscaled.service: 3.5 OK 🙂
```

Manually tested by trying to add tailscale to my personal tailnet with this new configuration, and it worked well. I was still able to change its settings and ping other machines, so I consider this functional.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
