### PR TITLE
fromager: 0.71.0 -> 0.91.0; python3Packages.pypi-simple: init at 1.8.0; python3Packages.mailbits: init at 0.2.3

### DIFF
--- a/pkgs/by-name/fr/fromager/package.nix
+++ b/pkgs/by-name/fr/fromager/package.nix
@@ -1,53 +1,54 @@
 {
   lib,
-  stdenv,
-  python3,
   fetchFromGitHub,
+  python3Packages,
   writableTmpDirAsHomeHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "fromager";
-  version = "0.71.0";
+  version = "0.82.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-wheel-build";
     repo = "fromager";
     tag = finalAttrs.version;
-    hash = "sha256-3zz37BZx8FcKNl8mSmClIrZxvL+2AS0hJDct6K7BhBE=";
+    hash = "sha256-RlmbpnnwOWM5KLo4z1brdZnULGk3raGYassEqwWy0W0=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     hatchling
     hatch-vcs
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
     elfdeps
-    html5lib
+    license-expression
     packaging
-    pkginfo
+    packageurl-python
     psutil
     pydantic
+    pypi-simple
     pyproject-hooks
     pyyaml
     requests
-    requests-mock
     resolvelib
     rich
-    setuptools
+    starlette
     stevedore
     tomlkit
     tqdm
     uv
+    uvicorn
     wheel
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     requests-mock
+    spdx-tools
     twine
     uv
     writableTmpDirAsHomeHook
@@ -57,20 +58,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "fromager"
   ];
 
-  disabledTestPaths = [
-    # Depends on wheel.cli module that is private since wheel 0.46.0
-    "tests/test_wheels.py"
-  ];
+  # Upstream runs pytest with `--log-level DEBUG`, which this test suite
+  # relies on for caplog assertions against INFO records.
+  # Reported: https://github.com/python-wheel-build/fromager/issues/1092
+  pytestFlags = [ "--log-level=DEBUG" ];
 
   disabledTests = [
     # Accessing pypi.org (not allowed in sandbox)
+    # Fixed in: https://github.com/python-wheel-build/fromager/pull/1093
     "test_get_build_backend_dependencies"
     "test_get_build_sdist_dependencies"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
-    # Assumes platform.machine() returns 'arm64' on ARM64, which is not true for Linux.
-    # Re-enable once https://github.com/python-wheel-build/fromager/pull/849 is merged.
-    "test_add_constraint_conflict"
   ];
 
   meta = {

--- a/pkgs/by-name/fr/fromager/package.nix
+++ b/pkgs/by-name/fr/fromager/package.nix
@@ -1,53 +1,55 @@
 {
   lib,
-  stdenv,
-  python3,
   fetchFromGitHub,
+  python3Packages,
   writableTmpDirAsHomeHook,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "fromager";
-  version = "0.71.0";
+  version = "0.91.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-wheel-build";
     repo = "fromager";
     tag = finalAttrs.version;
-    hash = "sha256-3zz37BZx8FcKNl8mSmClIrZxvL+2AS0hJDct6K7BhBE=";
+    hash = "sha256-N+4DbKNUpQdkJAfr0vwlfXJS8FLLBOXxuzkLoJblJM4=";
   };
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     hatchling
     hatch-vcs
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
     elfdeps
-    html5lib
+    license-expression
     packaging
-    pkginfo
+    packageurl-python
     psutil
     pydantic
+    pypi-simple
     pyproject-hooks
     pyyaml
     requests
-    requests-mock
     resolvelib
     rich
-    setuptools
+    starlette
     stevedore
     tomlkit
     tqdm
     uv
+    uvicorn
     wheel
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
+    pytest-xdist
     requests-mock
+    spdx-tools
     twine
     uv
     writableTmpDirAsHomeHook
@@ -57,21 +59,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "fromager"
   ];
 
-  disabledTestPaths = [
-    # Depends on wheel.cli module that is private since wheel 0.46.0
-    "tests/test_wheels.py"
-  ];
-
-  disabledTests = [
-    # Accessing pypi.org (not allowed in sandbox)
-    "test_get_build_backend_dependencies"
-    "test_get_build_sdist_dependencies"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) [
-    # Assumes platform.machine() returns 'arm64' on ARM64, which is not true for Linux.
-    # Re-enable once https://github.com/python-wheel-build/fromager/pull/849 is merged.
-    "test_add_constraint_conflict"
-  ];
+  # Upstream runs pytest with `--log-level DEBUG`, which this test suite
+  # relies on for caplog assertions against INFO records.
+  # Reported: https://github.com/python-wheel-build/fromager/issues/1274
+  pytestFlags = [ "--log-level=DEBUG" ];
 
   meta = {
     description = "Wheel maker";

--- a/pkgs/development/python-modules/mailbits/default.nix
+++ b/pkgs/development/python-modules/mailbits/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  attrs,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mailbits";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ExQL6Ugl1ECYbe4KbmU9gdO030sAWfvbbXi6jMsMTsA=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    attrs
+  ];
+
+  pythonImportsCheck = [
+    "mailbits"
+  ];
+
+  meta = {
+    description = "Assorted e-mail utility functions";
+    homepage = "https://pypi.org/project/mailbits";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ booxter ];
+  };
+})

--- a/pkgs/development/python-modules/pypi-simple/default.nix
+++ b/pkgs/development/python-modules/pypi-simple/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  beautifulsoup4,
+  mailbits,
+  packaging,
+  pydantic,
+  requests,
+  tqdm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pypi-simple";
+  version = "1.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pypi_simple";
+    inherit (finalAttrs) version;
+    hash = "sha256-Rm8vzQ1yOCKq46DM/aIuaP+M1/UKrmiRGUarHdHVh+E=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    beautifulsoup4
+    mailbits
+    packaging
+    pydantic
+    requests
+  ];
+
+  optional-dependencies = {
+    tqdm = [
+      tqdm
+    ];
+  };
+
+  pythonImportsCheck = [
+    "pypi_simple"
+  ];
+
+  meta = {
+    description = "PyPI Simple Repository API client library";
+    homepage = "https://pypi.org/project/pypi-simple";
+    changelog = "https://github.com/jwodder/pypi-simple/blob/master/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ booxter ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14635,6 +14635,8 @@ self: super: with self; {
 
   pyphotonfile = callPackage ../development/python-modules/pyphotonfile { };
 
+  pypi-simple = callPackage ../development/python-modules/pypi-simple { };
+
   pypika = callPackage ../development/python-modules/pypika { };
 
   pypillowfight = callPackage ../development/python-modules/pypillowfight { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9453,6 +9453,8 @@ self: super: with self; {
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
+  mailbits = callPackage ../development/python-modules/mailbits { };
+
   mailcap-fix = callPackage ../development/python-modules/mailcap-fix { };
 
   mailchecker = callPackage ../development/python-modules/mailchecker { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15403,6 +15403,8 @@ self: super: with self; {
 
   pyphotonfile = callPackage ../development/python-modules/pyphotonfile { };
 
+  pypi-simple = callPackage ../development/python-modules/pypi-simple { };
+
   pypika = callPackage ../development/python-modules/pypika { };
 
   pypillowfight = callPackage ../development/python-modules/pypillowfight { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10022,6 +10022,8 @@ self: super: with self; {
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
+  mailbits = callPackage ../development/python-modules/mailbits { };
+
   mailcap-fix = callPackage ../development/python-modules/mailcap-fix { };
 
   mailchecker = callPackage ../development/python-modules/mailchecker { };


### PR DESCRIPTION
- **python3Packages.mailbits: init at 0.2.3**
- **python3Packages.pypi-simple: init at 1.8.0**
- **fromager: 0.71.0 -> 0.91.0**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
