### PR TITLE
ebuse: init at 0-unstable-2024-12-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17861,6 +17861,12 @@
     name = "Marcin Mikuła";
     keys = [ { fingerprint = "5547 2A56 AC30 69C9 15C8  B98D 997F 71FA 1D74 6E37"; } ];
   };
+  mildsunrise = {
+    email = "me@alba.sh";
+    github = "mildsunrise";
+    githubId = 1177304;
+    name = "Alba Mendez";
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "MilesBreslin";

--- a/pkgs/by-name/eb/ebuse/package.nix
+++ b/pkgs/by-name/eb/ebuse/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  pname = "ebuse";
+  version = "0-unstable-2024-12-02";
+
+  src = fetchFromGitHub {
+    owner = "ebroder";
+    repo = "ebuse";
+    rev = "7069d850c8f3925956965ee1a8e3e7b80582c76e";
+    hash = "sha256-utBnNuSuwxY5myE9kW1j2O7PFypmZPWPnzd9MeKVT4g=";
+  };
+
+  vendorHash = "sha256-svAuNUCLCnD7HiQkszrdG2QA9yTujTD49FArO8h+O9g=";
+
+  # needed because of #506926
+  proxyVendor = true;
+
+  tags = [
+    # the application doesn't use gonbdserver's ceph support; disabling it makes the build much more portable / small
+    # https://github.com/abligh/gonbdserver/blob/9abaa2fed84fea02e090dbdd16be7bd20162e8b6/nbd/rbd.go#L3-L7
+    "noceph"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Access an EBS snapshot directly through NBD";
+    homepage = "https://github.com/ebroder/ebuse";
+    license = lib.licenses.mit;
+    mainProgram = "ebuse";
+    maintainers = with lib.maintainers; [ mildsunrise ];
+  };
+}


### PR DESCRIPTION
[ebuse](https://github.com/ebroder/ebuse) is a simple Go tool that exposes the contents of an AWS snapshot as a block device. This is very helpful if you need to recover a few files from a backup, as you can mount the snapshot's filesystem and copy those specific files out. I've been using it for the past year and I think it'd be useful for a lot of people.

I did not make the tool, although I've contributed a fix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
