### PR TITLE
gscreenshot: meta.mainProgram

### DIFF
--- a/pkgs/by-name/gs/gscreenshot/package.nix
+++ b/pkgs/by-name/gs/gscreenshot/package.nix
@@ -90,6 +90,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/thenaterhood/gscreenshot";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
+    mainProgram = "gscreenshot";
     maintainers = [ lib.maintainers.davisrichard437 ];
   };
 })


### PR DESCRIPTION
This will:

- change the output hash (thus cause rebuilds)
- not change behaviour for anything using `lib.getExe`
- silence warnings for `lib.getExe`
- do the right thing in most circumstances

There are two binaries; gscreenshot and gscreenshot-cli. The latter [will skip showing the GUI by default](https://github.com/thenaterhood/gscreenshot/blob/e498082bc14c038858acf6517dbfd7dc9706b31e/src/gscreenshot/frontend/cli/args.py#L13-L14) (which can be supressed by arguments). So basically this will codify the de-facto state.
Technically when using the `-cli` variant all GUI features are available using `--gui`, yet the GUI version cannot replicate the CLI version verbatim, however passing as much as `--filename` with an argument is enough to get virtually the same results. CLI users who wish to make a screenshot with the default filename convention right away should use `lib.getExe' _ "gscreenshot-cli"` or provide `--filename` with the argument `.`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
