### PR TITLE
nixos/testing: init meta.teams

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -2249,6 +2249,9 @@
   "test-opt-meta.maintainers": [
     "index.html#test-opt-meta.maintainers"
   ],
+  "test-opt-meta.teams": [
+    "index.html#test-opt-meta.teams"
+  ],
   "test-opt-meta.platforms": [
     "index.html#test-opt-meta.platforms"
   ],

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -22,6 +22,13 @@ in
                 The [list of maintainers](https://nixos.org/manual/nixpkgs/stable/#var-meta-maintainers) for this test.
               '';
             };
+            teams = mkOption {
+              type = types.listOf types.raw;
+              default = [ ];
+              description = ''
+                The [list of teams](https://nixos.org/manual/nixpkgs/stable/#var-meta-teams) for this test.
+              '';
+            };
             timeout = mkOption {
               type = types.nullOr types.int;
               default = 3600; # 1 hour


### PR DESCRIPTION
This PR adds the `meta.teams` option to the NixOS test framework. It would be great if NixOS tests also supported `meta.teams`, since other resources in nixpkgs such as packages and modules already support it. NixOS tests are currently the only ones that do not.

The change touches only one file and is non-breaking with no rebuilds required. All consumer-side plumbing, including meta validation in stdenv (`check-meta.nix`) and forwarding in the test runner (`nixos/lib/testing/run.nix`), already supports `meta.teams`. This PR just exposes it as a configurable knob on the test framework. 

If this lands, NixOS test files that currently work around the missing option by wiring `meta.maintainers = lib.teams.*.members` can be migrated to using the proper `meta.teams = [ lib.teams.* ]`. Examples of such tests are: `gnome`, `cosmic`, and `forgejo`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
