### PR TITLE
dummyhttp: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/by-name/du/dummyhttp/package.nix
+++ b/pkgs/by-name/du/dummyhttp/package.nix
@@ -1,27 +1,32 @@
 {
   lib,
+  cacert,
   fetchFromGitHub,
   rustPlatform,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dummyhttp";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = "dummyhttp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-J8TOOLTNvm6udkPdYTrjrCX/3D35lXeFDc0H5kki+Uk=";
+    hash = "sha256-JfI6r1hSCZePzUFpmR1vBU4qHXAvfSL5snF/X2zfN4o=";
   };
 
-  cargoHash = "sha256-566hk79oXApJm5p+gEgikV08n19hH1Tk36DvgPuQKLI=";
+  nativeBuildInputs = [
+    cacert
+  ];
+
+  cargoHash = "sha256-klUifN8I0c7SnsH1V+LdUKJYimTnGV3QMRjEnUAVkfI=";
 
   meta = {
     description = "Super simple HTTP server that replies a fixed body with a fixed response code";
     homepage = "https://github.com/svenstaro/dummyhttp";
     license = with lib.licenses; [ mit ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     mainProgram = "dummyhttp";
   };
 })

--- a/pkgs/by-name/du/dummyhttp/package.nix
+++ b/pkgs/by-name/du/dummyhttp/package.nix
@@ -1,27 +1,43 @@
 {
   lib,
+  cacert,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dummyhttp";
-  version = "1.1.2";
+  version = "1.1.3";
 
   src = fetchFromGitHub {
     owner = "svenstaro";
     repo = "dummyhttp";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-J8TOOLTNvm6udkPdYTrjrCX/3D35lXeFDc0H5kki+Uk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JfI6r1hSCZePzUFpmR1vBU4qHXAvfSL5snF/X2zfN4o=";
   };
 
-  cargoHash = "sha256-566hk79oXApJm5p+gEgikV08n19hH1Tk36DvgPuQKLI=";
+  patches = [
+    # https://github.com/svenstaro/dummyhttp/pull/557
+    (fetchpatch {
+      url = "https://github.com/svenstaro/dummyhttp/commit/3418c1b29f1fbb007c3b559901aa1927ba41de37.patch";
+      hash = "sha256-jiDXuySZ+JRqqbx5zr5ES/OvxajQOsxj3DZ6AYGxkms=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cacert
+  ];
+
+  cargoHash = "sha256-klUifN8I0c7SnsH1V+LdUKJYimTnGV3QMRjEnUAVkfI=";
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "Super simple HTTP server that replies a fixed body with a fixed response code";
     homepage = "https://github.com/svenstaro/dummyhttp";
     license = with lib.licenses; [ mit ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     mainProgram = "dummyhttp";
   };
 })


### PR DESCRIPTION
Update dummyhttp to 1.1.3 / add missing build/test dependency

## Things done

AI Disclosure: No AI output was used in this PR, but antigravity was used to reproduce flaky test and provide patch upstream.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
