### PR TITLE
berglas: 2.0.11 -> 2.0.12

### DIFF
--- a/pkgs/by-name/be/berglas/package.nix
+++ b/pkgs/by-name/be/berglas/package.nix
@@ -27,24 +27,24 @@ let
     ''
       ${acc}
       substituteInPlace pkg/berglas/${goFileName}_test.go \
-        --replace "TestClient_${testName}_storage" "SkipClient_${testName}_storage" \
-        --replace "TestClient_${testName}_secretManager" "SkipClient_${testName}_secretManager"
+        --replace-fail "TestClient_${testName}_storage" "SkipClient_${testName}_storage" \
+        --replace-fail "TestClient_${testName}_secretManager" "SkipClient_${testName}_secretManager"
     ''
   ) "" (builtins.attrNames skipTests);
 in
 
 buildGoModule (finalAttrs: {
   pname = "berglas";
-  version = "2.0.11";
+  version = "2.0.12";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "berglas";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-NIAnVjZZKey+XFxS1jryr4cWEmjtznXaLc1DZJldjxY=";
+    sha256 = "sha256-4Y53psmHpe1JmTKfvOS5f0VHCp/GuC4kDWiHWl5ty3Q=";
   };
 
-  vendorHash = "sha256-I0Tdjw9cd9eufEwnxC4E0tB7KPE7jQKJPrUQbFgqQVI=";
+  vendorHash = "sha256-Bz+4hlT5ZqpDnquGirooyFMG8FNUU2NO60Ih3Et3Y3o=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 2.0.12

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
