### PR TITLE
mattermost: 10.11.15 -> 11.6.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -182,6 +182,9 @@
 
 - `services.uptime` has been removed because the package it relies on does not exist anymore in nixpkgs.
 
+- `services.mattermost` now defaults to version 11, which has dropped support for MySQL in favor of Postgres. As a result, all support for MySQL has been removed from the module.
+  See the [migration steps](https://docs.mattermost.com/deployment-guide/manual-postgres-migration.html) if you were not running Postgres.
+
 - `post-resume.target` has been removed. See {manpage}`systemd.special(7)` about `sleep.target` for instructions on ordering a process after resume with `ExecStop=`.
 
 - `services.kubernetes.addons.dns.coredns` has been renamed to `services.kubernetes.addons.dns.corednsImage` and now expects a

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -27,9 +27,9 @@ let
 
   inherit (lib.modules)
     mkRenamedOptionModule
+    mkRemovedOptionModule
     mkMerge
     mkIf
-    mkDefault
     ;
 
   inherit (lib.trivial) warnIf throwIf;
@@ -55,10 +55,13 @@ let
   # Ensure that it's inside mutableDataDir since it can get rather large.
   tempDir = "${mutableDataDir}/tmp";
 
+  # Database supported by Mattermost.
+  databaseDriverName = "postgres";
+
   # Creates a database URI.
   mkDatabaseUri =
     {
-      scheme,
+      scheme ? databaseDriverName,
       user ? null,
       password ? null,
       escapeUserAndPassword ? true,
@@ -105,54 +108,24 @@ let
     let
       hostIsPath = hasInfix "/" cfg.database.host;
     in
-    if cfg.database.driver == "postgres" then
-      if cfg.database.peerAuth then
-        mkDatabaseUri {
-          scheme = cfg.database.driver;
-          inherit (cfg.database) user;
-          path = escapeURL cfg.database.name;
-          query = {
-            host = cfg.database.socketPath;
-          }
-          // cfg.database.extraConnectionOptions;
+    if cfg.database.peerAuth then
+      mkDatabaseUri {
+        inherit (cfg.database) user;
+        path = escapeURL cfg.database.name;
+        query = {
+          host = cfg.database.socketPath;
         }
-      else
-        mkDatabaseUri {
-          scheme = cfg.database.driver;
-          inherit (cfg.database) user password;
-          host = if hostIsPath then null else cfg.database.host;
-          port = if hostIsPath then null else cfg.database.port;
-          path = escapeURL cfg.database.name;
-          query =
-            optionalAttrs hostIsPath { host = cfg.database.host; } // cfg.database.extraConnectionOptions;
-        }
-    else if cfg.database.driver == "mysql" then
-      if cfg.database.peerAuth then
-        mkDatabaseUri {
-          scheme = null;
-          inherit (cfg.database) user;
-          escapeUserAndPassword = false;
-          host = "unix(${cfg.database.socketPath})";
-          escapeHost = false;
-          path = escapeURL cfg.database.name;
-          query = cfg.database.extraConnectionOptions;
-        }
-      else
-        mkDatabaseUri {
-          scheme = null;
-          inherit (cfg.database) user password;
-          escapeUserAndPassword = false;
-          host =
-            if hostIsPath then
-              "unix(${cfg.database.host})"
-            else
-              "tcp(${cfg.database.host}:${toString cfg.database.port})";
-          escapeHost = false;
-          path = escapeURL cfg.database.name;
-          query = cfg.database.extraConnectionOptions;
-        }
+        // cfg.database.extraConnectionOptions;
+      }
     else
-      throw "Invalid database driver: ${cfg.database.driver}";
+      mkDatabaseUri {
+        inherit (cfg.database) user password;
+        host = if hostIsPath then null else cfg.database.host;
+        port = if hostIsPath then null else cfg.database.port;
+        path = escapeURL cfg.database.name;
+        query =
+          optionalAttrs hostIsPath { host = cfg.database.host; } // cfg.database.extraConnectionOptions;
+      };
 
   mattermostPluginDerivations = map (
     plugin:
@@ -213,7 +186,7 @@ let
       EnableSecurityFixAlert = cfg.telemetry.enableSecurityAlerts;
     };
     TeamSettings.SiteName = cfg.siteName;
-    SqlSettings.DriverName = cfg.database.driver;
+    SqlSettings.DriverName = databaseDriverName;
     SqlSettings.DataSource =
       if cfg.database.fromEnvironment then
         null
@@ -358,6 +331,11 @@ in
         "dataDir"
       ]
     )
+    (mkRemovedOptionModule [ "services" "mattermost" "database" "driver" ] ''
+      services.mattermost.database.driver has been removed, as the only option is '${databaseDriverName}' in v11+.
+      If you were using MySQL, please migrate to Postgres:
+      https://docs.mattermost.com/deployment-guide/manual-postgres-migration.html
+    '')
   ];
 
   options = {
@@ -558,22 +536,11 @@ in
       };
 
       database = {
-        driver = mkOption {
-          type = types.enum [
-            "postgres"
-            "mysql"
-          ];
-          default = "postgres";
-          description = ''
-            The database driver to use (Postgres or MySQL).
-          '';
-        };
-
         create = mkOption {
           type = types.bool;
           default = true;
           description = ''
-            Create a local PostgreSQL or MySQL database for Mattermost automatically.
+            Create a local PostgreSQL database for Mattermost automatically.
           '';
         };
 
@@ -591,13 +558,9 @@ in
 
         socketPath = mkOption {
           type = types.path;
-          default =
-            if cfg.database.driver == "postgres" then "/run/postgresql" else "/run/mysqld/mysqld.sock";
-          defaultText = ''
-            if config.services.mattermost.database.driver == "postgres" then "/run/postgresql" else "/run/mysqld/mysqld.sock";
-          '';
+          default = "/run/postgresql";
           description = ''
-            The database (Postgres or MySQL) socket path.
+            The database socket path.
           '';
         };
 
@@ -630,11 +593,8 @@ in
 
         port = mkOption {
           type = types.port;
-          default = if cfg.database.driver == "postgres" then 5432 else 3306;
-          defaultText = ''
-            if config.services.mattermost.database.type == "postgres" then 5432 else 3306
-          '';
-          example = 3306;
+          default = 5432;
+          example = 1234;
           description = ''
             Port to use for the database.
           '';
@@ -660,34 +620,15 @@ in
 
         extraConnectionOptions = mkOption {
           type = with types; attrsOf (either int str);
-          default =
-            if cfg.database.driver == "postgres" then
-              {
-                sslmode = "disable";
-                connect_timeout = 60;
-              }
-            else if cfg.database.driver == "mysql" then
-              {
-                charset = "utf8mb4";
-                writeTimeout = "60s";
-                readTimeout = "60s";
-              }
-            else
-              throw "Invalid database driver ${cfg.database.driver}";
+          default = {
+            sslmode = "disable";
+            connect_timeout = 60;
+          };
           defaultText = ''
-            if config.mattermost.database.driver == "postgres" then
-              {
-                sslmode = "disable";
-                connect_timeout = 60;
-              }
-            else if config.mattermost.database.driver == "mysql" then
-              {
-                charset = "utf8mb4";
-                writeTimeout = "60s";
-                readTimeout = "60s";
-              }
-            else
-              throw "Invalid database driver";
+            {
+              sslmode = "disable";
+              connect_timeout = 60;
+            }
           '';
           description = ''
             Extra options that are placed in the connection URI's query parameters.
@@ -756,7 +697,7 @@ in
         };
       };
 
-      services.postgresql = mkIf (cfg.database.driver == "postgres" && cfg.database.create) {
+      services.postgresql = mkIf cfg.database.create {
         enable = true;
         ensureDatabases = singleton cfg.database.name;
         ensureUsers = singleton {
@@ -769,26 +710,6 @@ in
               ''
               cfg.database.user;
           ensureDBOwnership = true;
-        };
-      };
-
-      services.mysql = mkIf (cfg.database.driver == "mysql" && cfg.database.create) {
-        enable = true;
-        package = mkDefault pkgs.mariadb;
-        ensureDatabases = singleton cfg.database.name;
-        ensureUsers = singleton {
-          name = cfg.database.user;
-          ensurePermissions = {
-            "${cfg.database.name}.*" = "ALL PRIVILEGES";
-          };
-        };
-        settings = rec {
-          mysqld = {
-            collation-server = mkDefault "utf8mb4_general_ci";
-            init-connect = mkDefault "SET NAMES utf8mb4";
-            character-set-server = mkDefault "utf8mb4";
-          };
-          mysqld_safe = mysqld;
         };
       };
 
@@ -840,8 +761,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = mkMerge [
           [ "network.target" ]
-          (mkIf (cfg.database.driver == "postgres" && cfg.database.create) [ "postgresql.target" ])
-          (mkIf (cfg.database.driver == "mysql" && cfg.database.create) [ "mysql.service" ])
+          (mkIf cfg.database.create [ "postgresql.target" ])
         ];
         requires = after;
 
@@ -945,8 +865,7 @@ in
         ];
 
         unitConfig.JoinsNamespaceOf = mkMerge [
-          (mkIf (cfg.database.driver == "postgres" && cfg.database.create) [ "postgresql.target" ])
-          (mkIf (cfg.database.driver == "mysql" && cfg.database.create) [ "mysql.service" ])
+          (mkIf cfg.database.create [ "postgresql.target" ])
         ];
       };
 
@@ -964,13 +883,6 @@ in
           message = ''
             services.mattermost.host should not include a port. Use services.mattermost.host for the address
             or hostname, and services.mattermost.port to specify the port separately.
-          '';
-        }
-        {
-          # Can't use MySQL on version 11.
-          assertion = versionAtLeast cfg.package.version "11" -> cfg.database.driver == "postgres";
-          message = ''
-            Only Postgres is supported as the database driver in Mattermost 11 and later.
           '';
         }
       ];

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -5,7 +5,7 @@
   buildGoModule,
   fetchFromGitHub,
   buildNpmPackage,
-  nodejs_22,
+  nodejs,
   nix-update-script,
   npm-lockfile-fix,
   fetchNpmDeps,
@@ -13,20 +13,21 @@
   nixosTests,
 
   versionInfo ? {
-    # ESR releases only.
-    # See https://docs.mattermost.com/upgrade/extended-support-release.html
+    # ESR releases only. Note: if NixOS would release with an ESR that goes out
+    # of support during the lifetime of the NixOS release, it is acceptable
+    # to put the latest non-ESR release here if we change it to an ESR shortly after
+    # the NixOS release.
+    #
+    # See <https://docs.mattermost.com/upgrade/extended-support-release.html>.
     # When a new ESR version is available (e.g. 8.1.x -> 9.5.x), update
     # the version regex here as well.
     #
     # Ensure you also check ../mattermostLatest/package.nix.
-    regex = "^v(10\\.11\\.[0-9]+)$";
-    version = "10.11.15";
-    srcHash = "sha256-b/hXZHYULl9nNJZT4GtKsaOfX8BEzz/v3Uy3EEbzN8U=";
-    vendorHash = "sha256-Z94d1eCIkuMG72Mlvk5su/99+4kJoaeHxaeZuk96Hlc=";
-    npmDepsHash = "sha256-p9dq31qw0EZDQIl2ysKE38JgDyLA6XvSv+VtHuRh+8A=";
-    lockfileOverlay = ''
-      unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
-    '';
+    regex = "^v(11\\.[67]\\.[0-9]+)$";
+    version = "11.6.1";
+    srcHash = "sha256-0TUh5qKi64jt3YhgCTceoizOGzqyt70Rh8VH+bSfS5o=";
+    vendorHash = "sha256-bWl1rdVRTOJzS2HKKsSRhzVcH1sPgEAlRLjrc+/o0lo=";
+    npmDepsHash = "sha256-30xwoizNh6fAWS0YdEheXtcO6I9MjoFdCekvLnnoBMc=";
   },
   ...
 }:
@@ -223,9 +224,7 @@ buildMattermost rec {
           --replace-fail 'options: {}' 'options: { disable: true }'
       '';
 
-      # https://github.com/NixOS/nixpkgs/issues/474535
-      nodejs = nodejs_22;
-
+      inherit nodejs;
       npmDepsHash = npmDeps.hash;
       makeCacheWritable = true;
       forceGitDeps = true;
@@ -235,10 +234,9 @@ buildMattermost rec {
       buildPhase = ''
         runHook preBuild
 
-        npm run build --workspace=platform/types
-        npm run build --workspace=platform/client
-        npm run build --workspace=platform/components
-        npm run build --workspace=channels
+        for ws in platform/{types,client,components,shared} channels; do
+          npm run build --workspace="$ws"
+        done
 
         runHook postBuild
       '';

--- a/pkgs/by-name/ma/mattermost/tests.nix
+++ b/pkgs/by-name/ma/mattermost/tests.nix
@@ -4,7 +4,6 @@
   gotestsum,
   which,
   postgresql,
-  mariadb,
   redis,
   curl,
   net-tools,
@@ -20,7 +19,6 @@ mattermost.overrideAttrs (
     nativeCheckInputs = [
       which
       postgresql
-      mariadb
       redis
       curl
       net-tools
@@ -113,11 +111,6 @@ mattermost.overrideAttrs (
         fi
       }
 
-      # Waits for MySQL to come up or down.
-      wait_mysql() {
-        wait_cmd mysql "$1" mysqladmin ping
-      }
-
       # Waits for Postgres to come up or down.
       wait_postgres() {
         wait_cmd postgres "$1" pg_isready -h localhost
@@ -126,33 +119,6 @@ mattermost.overrideAttrs (
       # Waits for Redis to come up or down.
       wait_redis() {
         wait_cmd redis "$1" redis-cli ping
-      }
-
-      # Starts MySQL.
-      start_mysql() {
-        echo "Starting MySQL at $MYSQL_HOME" >&2
-        mysqld &
-        mysql_pid=$!
-        echo "... PID $mysql_pid" >&2
-        wait_mysql up
-      }
-
-      # Stops MySQL.
-      stop_mysql() {
-        if [ "$mysql_pid" -gt 0 ]; then
-          echo "Terminating MySQL at $MYSQL_HOME (PID $mysql_pid)" >&2
-          mysqladmin --host=127.0.0.1 --user=root --password=mostest --wait-for-all-slaves --shutdown-timeout=30 shutdown
-          wait_mysql down
-          wait_cmd 'mysql pid' down kill -0 "$mysql_pid"
-
-          # Make sure the worker PID went down too (but it may be already gone).
-          local worker_pid="$(<"$MYSQL_HOME"/mysqld.pid || echo 0)"
-          if [ -n "$worker_pid" ] && [ $worker_pid -gt 0 ]; then
-            wait_cmd 'mysql workers' down kill -0 "$worker_pid"
-          fi
-
-          mysql_pid=0
-        fi
       }
 
       # Starts Postgres.
@@ -185,52 +151,6 @@ mattermost.overrideAttrs (
         wait_redis down
         redis_pid=0
       }
-
-      # Configure MySQL.
-      export MYSQL_HOME="$NIX_BUILD_TOP/.mysql"
-      mkdir -p "$MYSQL_HOME"
-      cat <<EOF >"$MYSQL_HOME/my.cnf"
-      [client]
-      port = 3306
-      default-character-set = utf8mb4
-      socket = $MYSQL_HOME/mysqld.sock
-
-      [mysqld]
-      skip-host-cache
-      skip-name-resolve
-      basedir = ${mariadb}
-      datadir = $MYSQL_HOME/
-      pid-file = $MYSQL_HOME/mysqld.pid
-      socket = $MYSQL_HOME/mysqld.sock
-      port = 3306
-      explicit_defaults_for_timestamp
-      collation-server = utf8mb4_general_ci
-      init-connect = 'SET NAMES utf8mb4'
-      character-set-server = utf8mb4
-      EOF
-
-      # Start MySQL.
-      mysql_install_db --skip-name-resolve --auth-root-authentication-method=normal
-      start_mysql
-
-      # Init MySQL.
-      cat <<EOF | mysql --defaults-file="$MYSQL_HOME/my.cnf" -u root -v
-      -- This is the admin password for tests; see the docker-compose:
-      -- https://github.com/mattermost/mattermost/blob/v${final.version}/server/docker-compose.yaml
-      create user if not exists 'mmuser' identified by 'mostest';
-      create database if not exists mattermost_test;
-      grant all privileges on *.* to 'mmuser' with grant option;
-
-      -- Also need to set up root (tests seem to override the user to root)
-      alter user 'root'@'127.0.0.1' identified by 'mostest';
-
-      flush privileges;
-      show grants for 'root'@'127.0.0.1';
-      show grants for 'mmuser';
-      EOF
-
-      # Need to change this so we use 127.0.0.1 in tests.
-      export TEST_DATABASE_MYSQL_DSN='root:mostest@tcp(127.0.0.1:3306)/mattermost_test?charset=utf8mb4&readTimeout=30s&writeTimeout=30s'
 
       # Start Postgres.
       export PGDATA="$NIX_BUILD_TOP/.postgres"
@@ -284,12 +204,6 @@ mattermost.overrideAttrs (
     '';
 
     postCheck = ''
-      # Clean up MySQL.
-      if [ -d "$MYSQL_HOME" ]; then
-        stop_mysql
-        rm -rf "$MYSQL_HOME"
-      fi
-
       # Clean up Postgres.
       if [ -d "$PGDATA" ]; then
         stop_postgres

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -3,25 +3,4 @@
   ...
 }@args:
 
-mattermost.override (
-  {
-    versionInfo = {
-      # Latest, non-RC releases only.
-      # If the latest is an ESR (Extended Support Release),
-      # duplicate it here to facilitate the update script.
-      # See https://docs.mattermost.com/about/mattermost-server-releases.html
-      # and make sure the version regex is up to date here.
-      # Ensure you also check ../mattermost/package.nix for ESR releases.
-      regex = "^v(11\\.[0-9]+\\.[0-9]+)$";
-      version = "11.5.3";
-      srcHash = "sha256-r7rfiQ4C0E511QWdpQihydsuoRZCzboodmh1iT4a8r4=";
-      vendorHash = "sha256-/ts6j86tvbYFjVACkJwcSnXDd+8BXzpaFVdV9DRHkqY=";
-      npmDepsHash = "sha256-r7iq1pCAJjFyspZBdeNWe00W7A3l73PGC6rrsZ7O6Uw=";
-      lockfileOverlay = ''
-        unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
-      '';
-      autoUpdate = ./package.nix;
-    };
-  }
-  // args
-)
+mattermost.override args


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Note that this is not yet an ESR. However, 10 -> 11 will be breaking and 11.6 -> 11.7 (which is an ESR) will not be. So push mattermost to be identical to mattermostLatest until the two diverge.

Should get in before the breaking change restriction @ 2026-04-27 07:00.

mattermost.tests succeed for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
