### PR TITLE
Fix version overriding for some `coqPackages`

### DIFF
--- a/pkgs/development/coq-modules/bignums/default.nix
+++ b/pkgs/development/coq-modules/bignums/default.nix
@@ -52,9 +52,35 @@ let
       license = lib.licenses.lgpl2;
     };
   };
+  useRocqPackages =
+    if builtins.isNull version then
+      coq.rocqPackages ? bignums
+    else
+      lib.elem version [
+        "9.0.0+coq8.20"
+        "9.0.0+coq8.19"
+        "9.0.0+coq8.18"
+        "9.0.0+coq8.17"
+        "9.0.0+coq8.16"
+        "9.0.0+coq8.15"
+        "9.0.0+coq8.14"
+        "9.0.0+coq8.13"
+        "8.17.0"
+        "8.16.0"
+        "8.15.0"
+        "8.14.0"
+        "8.13.0"
+        "8.12.0"
+        "8.11.0"
+        "8.10.0"
+        "8.9.0"
+        "8.8.0"
+        "8.7.0"
+        "8.6.0"
+      ];
 in
 # this is just a wrapper for rocqPackages.bignums for Rocq >= 9.0
-if coq.rocqPackages ? bignums then
+if useRocqPackages then
   coq.rocqPackages.bignums.override {
     inherit version stdlib;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -153,9 +153,14 @@ let
         '';
       }
   );
+  useRocqPackages =
+    if builtins.isNull version then
+      coq.rocqPackages ? rocq-elpi
+    else
+      lib.versionAtLeast version "2.5.2";
 in
 # this is just a wrapper for rocqPackages.stdlib for Rocq >= 9.0
-if coq.rocqPackages ? rocq-elpi then
+if useRocqPackages then
   coq.rocqPackages.rocq-elpi.override {
     inherit version elpi-version;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/hierarchy-builder/default.nix
+++ b/pkgs/development/coq-modules/hierarchy-builder/default.nix
@@ -72,9 +72,14 @@ let
       propagatedBuildInputs = o.propagatedBuildInputs ++ [ stdlib ];
     }
   );
+  useRocqPackages =
+    if builtins.isNull version then
+      coq.rocqPackages ? hierarchy-builder
+    else
+      lib.versionAtLeast version "1.9.1";
 in
 # this is just a wrapper for rocqPackages.hierarchy-builder for Rocq >= 9.0
-if coq.rocqPackages ? hierarchy-builder then
+if useRocqPackages then
   coq.rocqPackages.hierarchy-builder.override {
     inherit version;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/iris/default.nix
+++ b/pkgs/development/coq-modules/iris/default.nix
@@ -54,9 +54,11 @@ let
       ];
     };
   };
+  useRocqPackages =
+    if builtins.isNull version then coq.rocqPackages ? iris else lib.versionAtLeast version "4.5.0";
 in
 # this is just a wrapper for rocqPackages.iris for Rocq >= 9.0
-if coq.rocqPackages ? iris then
+if useRocqPackages then
   coq.rocqPackages.iris.override {
     inherit version stdpp;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -230,17 +230,14 @@ let
       );
     in
     patched-derivation;
+  useRocqPackages =
+    if builtins.isNull version then
+      coq.rocqPackages ? mathcomp-analysis
+    else
+      lib.versionAtLeast version "1.16.0";
 in
 # this is just a wrapper for rocqPackages.mathcomp-analysis for Rocq >= 9.0
-if
-  coq.rocqPackages ? mathcomp-analysis
-  && !(lib.elem version [
-    "1.12.0"
-    "1.13.0"
-    "1.14.0"
-    "1.15.0"
-  ])
-then
+if useRocqPackages then
   coq.rocqPackages.mathcomp-analysis.override {
     inherit version single;
     inherit

--- a/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-bigenough/default.nix
@@ -41,9 +41,14 @@ let
       license = lib.licenses.cecill-b;
     };
   };
+  useRocqPackages =
+    if builtins.isNull version then
+      coq.rocqPackages ? mathcomp-bigenough
+    else
+      lib.versionAtLeast version "1.0.4";
 in
 # this is just a wrapper for rocqPackages.mathcomp-bigenough for Rocq >= 9.0
-if coq.rocqPackages ? mathcomp-bigenough then
+if useRocqPackages then
   coq.rocqPackages.mathcomp-bigenough.override {
     inherit version mathcomp-boot;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -68,9 +68,14 @@ let
       license = lib.licenses.cecill-b;
     };
   };
+  useRocqPackages =
+    if builtins.isNull version then
+      coq.rocqPackages ? mathcomp-finmap
+    else
+      lib.versionAtLeast version "2.2.2";
 in
 # this is just a wrapper for rocqPackages.mathcomp-finmap for Rocq >= 9.0
-if coq.rocqPackages ? mathcomp-finmap then
+if useRocqPackages then
   coq.rocqPackages.mathcomp-finmap.override {
     inherit version mathcomp-boot;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -243,9 +243,11 @@ let
       );
     in
     patched-derivation5;
+  useRocqPackages =
+    if builtins.isNull version then coq.rocqPackages ? mathcomp else lib.versionAtLeast version "2.5.0";
 in
 # this is just a wrapper for rocqPackages.mathcomp for Rocq >= 9.0
-if coq.rocqPackages ? mathcomp && version != "2.3.0" && version != "2.4.0" then
+if useRocqPackages then
   let
     mc = coq.rocqPackages.mathcomp.override {
       inherit version withDoc single;

--- a/pkgs/development/coq-modules/parseque/default.nix
+++ b/pkgs/development/coq-modules/parseque/default.nix
@@ -30,9 +30,11 @@ let
       license = lib.licenses.mit;
     };
   };
+  useRocqPackages =
+    if builtins.isNull version then coq.rocqPackages ? parseque else lib.versionAtLeast version "0.3.0";
 in
 # this is just a wrapper for rocqPackages.parseque for Rocq >= 9.0
-if coq.rocqPackages ? parseque then
+if useRocqPackages then
   coq.rocqPackages.parseque.override {
     inherit version;
     inherit (coq.rocqPackages) rocq-core;

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -54,9 +54,11 @@ let
       ];
     };
   };
+  useRocqPackages =
+    if builtins.isNull version then coq.rocqPackages ? stdpp else lib.versionAtLeast version "1.13.0";
 in
 # this is just a wrapper for rocqPackages.stdpp for Rocq >= 9.0
-if coq.rocqPackages ? stdpp then
+if useRocqPackages then
   coq.rocqPackages.stdpp.override {
     inherit version stdlib;
     inherit (coq.rocqPackages) rocq-core;


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/513029.

I didn't touched `coqPackages.relation-algebra` because that package does not reexport `rocqPackages.relation-algebra`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
