### PR TITLE
lpac, easylpac: fix Darwin build

### DIFF
--- a/pkgs/by-name/ea/easylpac/package.nix
+++ b/pkgs/by-name/ea/easylpac/package.nix
@@ -20,22 +20,16 @@
 
 buildGoModule rec {
   pname = "easylpac";
-  version = "0.8.0.2";
+  version = "0.8.0.3";
 
   src = fetchFromGitHub {
     owner = "creamlike1024";
     repo = "EasyLPAC";
     tag = version;
-    hash = "sha256-GxcaMyEaPIGf+/wzmmycmFssTkP5Praj4GCYbxbJU28=";
+    hash = "sha256-q76p0BqrG8opuTClYKLfmM5hdziJIrZCwQmg2NkzW/E=";
   };
 
   vendorHash = "sha256-52I8hlnoHPhygwr0dxDP50X2A7Gsh0v/0SGQFH3FG/8=";
-
-  # also include $PATH lookup logic for `lpac` in the darwin case.
-  postPatch = ''
-    substituteInPlace config.go --replace-fail \
-      'case "linux":' 'case "linux", "darwin":'
-  '';
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/by-name/ea/easylpac/package.nix
+++ b/pkgs/by-name/ea/easylpac/package.nix
@@ -79,6 +79,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ stargate01 ];
     mainProgram = "EasyLPAC";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ea/easylpac/package.nix
+++ b/pkgs/by-name/ea/easylpac/package.nix
@@ -31,6 +31,12 @@ buildGoModule rec {
 
   vendorHash = "sha256-52I8hlnoHPhygwr0dxDP50X2A7Gsh0v/0SGQFH3FG/8=";
 
+  # also include $PATH lookup logic for `lpac` in the darwin case.
+  postPatch = ''
+    substituteInPlace config.go --replace-fail \
+      'case "linux":' 'case "linux", "darwin":'
+  '';
+
   nativeBuildInputs = [
     copyDesktopItems
     pkg-config

--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   lib,
   cmake,
   pkg-config,
@@ -10,8 +11,8 @@
   libqmi,
   withDrivers ? true,
   withLibeuicc ? true,
-  withMbim ? true,
-  withQmi ? true,
+  withMbim ? stdenv.hostPlatform.isLinux,
+  withQmi ? stdenv.hostPlatform.isLinux,
   nix-update-script,
 }:
 
@@ -32,13 +33,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.LPAC_VERSION = finalAttrs.version;
 
-  patches = [ ./lpac-version.patch ];
+  patches = [
+    ./lpac-version.patch
+
+    # CMAKE_OSX_ARCHITECTURES is set to "arm64;x86_64", and not overridable without this fix.
+    # https://github.com/estkme-group/lpac/pull/346
+    (fetchpatch {
+      url = "https://github.com/estkme-group/lpac/commit/be86645e596ee34f6d85cd0f3e039d5b31f35856.patch";
+      hash = "sha256-Y3tL9A1uKjX0x1O2WrQQ9k88Zu+Lpc+MNV9DRYePwgs=";
+    })
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "LPAC_DYNAMIC_DRIVERS" withDrivers)
     (lib.cmakeBool "LPAC_DYNAMIC_LIBEUICC" withLibeuicc)
     (lib.cmakeBool "LPAC_WITH_APDU_MBIM" withMbim)
     (lib.cmakeBool "LPAC_WITH_APDU_QMI" withQmi)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "CMAKE_OSX_ARCHITECTURES" stdenv.hostPlatform.darwinArch)
   ];
 
   nativeBuildInputs = [
@@ -48,6 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     curl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     pcsclite
   ]
   ++ optional withMbim libmbim


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (`--option sandbox true`)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @creamlike1024