### PR TITLE
nixos: Set mmap ASLR entropy to a safe default on AArch64

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -96,18 +96,10 @@ in
       # Maximise address space randomisation.
       "vm.mmap_rnd_bits" = lib.mkMerge [
         (lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (
-          let
-            kernel = config.boot.kernelPackages.kernel;
-            isYes = kernel.config.isYes or (_: false);
-          in
-          lib.mkDefault (
-            if isYes "ARM64_64K_PAGES" then
-              29
-            else if isYes "ARM64_16K_PAGES" then
-              31
-            else
-              33
-          )
+          # Ideally, we'd want to set this to 33 on 4K pagesize
+          # kernels, but some vendor kernels e.g. linux_rpi can
+          # do a maximum of 24.
+          lib.mkDefault 24
         ))
         (lib.mkIf pkgs.stdenv.hostPlatform.isx86_64 (lib.mkDefault 32))
       ];


### PR DESCRIPTION
The eval-time access to kernel config is not enabled for any nixpkgs-packaged kernels by default since it requires IFD and so all kernels (including nixos-apple-silicon and rpi kernel) will end up with the max of 33, which will lead to the systemd-sysctl service failing. Additionally, there are factors other than the pagesize which can cause 33 to be an invalid argument.

Followup to #510943 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
