### PR TITLE
sftool-gui: 1.0.3 -> 1.1.4-unstable-2026-04-16

### DIFF
--- a/pkgs/by-name/sf/sftool-gui/disable-bundling.patch
+++ b/pkgs/by-name/sf/sftool-gui/disable-bundling.patch
@@ -1,0 +1,22 @@
+diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
+index 419c116..aa3fece 100644
+--- a/src-tauri/tauri.conf.json
++++ b/src-tauri/tauri.conf.json
+@@ -23,7 +23,7 @@
+     "frontendDist": "../dist"
+   },
+   "bundle": {
+-    "active": true,
++    "active": false,
+     "icon": [
+       "icons/32x32.png",
+       "icons/128x128.png",
+@@ -39,7 +39,7 @@
+       "app",
+       "dmg"
+     ],
+-    "createUpdaterArtifacts": true
++    "createUpdaterArtifacts": false
+   },
+   "plugins": {
+     "updater": {

--- a/pkgs/by-name/sf/sftool-gui/package.nix
+++ b/pkgs/by-name/sf/sftool-gui/package.nix
@@ -20,21 +20,28 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sftool-gui";
-  version = "1.0.3";
+  version = "1.1.4-unstable-2026-04-16";
   src = fetchFromGitHub {
     owner = "OpenSiFli";
     repo = "sftool-gui";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-kjxUl9YrvTgJby+FvUbx5ugucK8NiBqzGBhTi9Zwd1s=";
+    rev = "e182a5973a4e23f8af078f3480a8b2416d7439b3";
+    hash = "sha256-6wYf0DNn5cjJTeuVfOB91RQP/E2YWr6PlGUnzZdwgNY=";
   };
 
-  cargoHash = "sha256-XAU3ru+TxUo99OQwcXNLJ8gzBOZUkC8UCAApz7M/QTM=";
+  patches = [
+    # We don't want tauri to bundle the built binaries as we only use them and not the
+    # bundled .deb, .appimage, and so on. Bundling the binaries would also require a signing
+    # key, which we don't have.
+    ./disable-bundling.patch
+  ];
+
+  cargoHash = "sha256-hwQJnhWgPqQ3ZudCsEEuWoygYDcUKXgWz15dHZ+vR6Q=";
   cargoRoot = "src-tauri";
 
   pnpmDeps = fetchPnpmDeps {
-    fetcherVersion = 2;
+    fetcherVersion = 3;
     inherit (finalAttrs) pname version src;
-    hash = "sha256-gamgu9koBf+JLDswi3eGXRZybF8UiYE8CoifpQCgLaI=";
+    hash = "sha256-DwDXfbwgt/OSNOQbzCBlathX9QDnbEsXZLsgB67LOEk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
diff: https://github.com/OpenSiFli/sftool-gui/compare/v1.0.3...e182a5973a4e23f8af078f3480a8b2416d7439b3

Also fixes the current build failure of `sftool-gui` (https://hydra.nixos.org/job/nixpkgs/unstable/sftool-gui.x86_64-linux). The version is pinned as there is a tauri version mismatch between `Cargo` and `npm`.

ZHF: #516381

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
