### PR TITLE
python3Packages.aioboto3: fix build

### DIFF
--- a/pkgs/development/python-modules/aioboto3/default.nix
+++ b/pkgs/development/python-modules/aioboto3/default.nix
@@ -75,6 +75,17 @@ buildPythonPackage (finalAttrs: {
     "test_s3_copy_multipart"
     "test_s3_download_file_404"
     "test_s3_upload_file"
+  ]
+  ++ [
+    # DynamoDB tests fail with aiobotocore 3.x due to HTTP header issue with moto:
+    # "Duplicate 'Server' header found" - same issue as aiobotocore disables
+    "test_dynamo_resource_query"
+    "test_dynamo_resource_put"
+    "test_dynamo_resource_batch_write_flush_on_exit_context"
+    "test_dynamo_resource_batch_write_flush_amount"
+    "test_flush_doesnt_reset_item_buffer"
+    "test_dynamo_resource_property"
+    "test_dynamo_resource_waiter"
   ];
 
   pythonImportsCheck = [ "aioboto3" ];


### PR DESCRIPTION
python3Packages.aioboto3: disable DynamoDB tests with aiobotocore 3.x

DynamoDB tests fail with aiobotocore 3.x due to HTTP header issue with moto: 'Duplicate Server header found'. This is the same issue that causes aiobotocore itself to disable its DynamoDB tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


CC @GaetanLepage @kirillrdy 