### PR TITLE
wireshark: ln ext bins to $out for discoverability

### DIFF
--- a/pkgs/by-name/wi/wireshark/package.nix
+++ b/pkgs/by-name/wi/wireshark/package.nix
@@ -52,6 +52,7 @@
   withQt ? true,
   qt6,
   libpcap' ? libpcap.override { withBluez = stdenv.hostPlatform.isLinux; },
+  withExtras ? stdenv.hostPlatform.isLinux,
 }:
 let
   isAppBundle = withQt && stdenv.hostPlatform.isDarwin;
@@ -184,6 +185,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     cmake --install . --prefix "''${!outputDev}" --component Development
+  ''
+  + lib.optionalString withExtras ''
+    ln -s $out/libexec/wireshark/extcap/* -t $out/bin/
   ''
   + lib.optionalString isAppBundle ''
     mkdir -p $out/Applications


### PR DESCRIPTION
this change shouldn't increase the closure size except for a few bytes for the symlinks, since the binaries are already included in the package anyway. And it will cause e.g. androiddump to appear on https://search.nixos.org/ while also offering adding all the extcap binaries to your path when using wireshark from a nix-shell.

the change is guarded behind a optional flag for stdenv.hostPlatform.isLinux, because darwin doesn't appear to ship the extra bins. I don't currently have a darwin system on hand for testing. But used:

```bash
curl https://cache.nixos.org/nar/0m8147jar72c94gs1ryfrigiiq0gn52dqpw3f3bbnp0rhk3xb4q4.nar.xz -o /tmp/wireshark.nar.xz
cat wireshark.nar.xz | xz -dc | nix-store --restore /tmp/darwin-wireshark
tree /tmp/darwin-wireshark
```

to check that this is the case.
the CNO url was derived from
https://cache.nixos.org/iy72vcwvwd2inhsmqvpsi451fph85gzi.narinfo by looking at the latest build results of wireshark from HNO for aarch64-darwin.