### PR TITLE
esphome: 2026.3.3 -> 2026.4.3

### DIFF
--- a/pkgs/by-name/es/esphome/dashboard.nix
+++ b/pkgs/by-name/es/esphome/dashboard.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "esphome-dashboard";
-  version = "20260210.0";
+  version = "20260408.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "dashboard";
     tag = finalAttrs.version;
-    hash = "sha256-Edd2ZOSBAZSrGVjbncyPhhjFjE0CxBHz16ZHXyzx9LI=";
+    hash = "sha256-OY7s/b0rWmjI9QfmEwj3VxbTFrj99fyf9x1tPl24RbI=";
   };
 
   npmDeps = fetchNpmDeps {

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -31,16 +31,16 @@ let
     };
   };
 in
-python.pkgs.buildPythonApplication rec {
+python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "esphome";
-  version = "2026.3.3";
+  version = "2026.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "esphome";
-    tag = version;
-    hash = "sha256-yMPHz6IZIGM4oJw1wspEL3lIIiPv4WZALUJ7J1UWukY=";
+    tag = finalAttrs.version;
+    hash = "sha256-+esSczOBIT4dJEyzqmEv6YMU4wGkN4lFGmuZKRp5/bo=";
   };
 
   patches = [
@@ -49,6 +49,10 @@ python.pkgs.buildPythonApplication rec {
     # own python environment through `python -m esptool` and then fails to find
     # the esptool library.
     ./esp32-post-build-esptool-reference.patch
+    # Call the platformio binary directly instead of `python -m
+    # esphome.platformio_runner`, which tries to import platformio as a Python
+    # module.
+    ./platformio-binary-reference.patch
   ];
 
   build-system = with python.pkgs; [
@@ -119,7 +123,7 @@ python.pkgs.buildPythonApplication rec {
     }"
     # The dashboard requires esphome to be importable
     # dependencies are added to show better error messages
-    "--prefix PYTHONPATH : $out/${python.sitePackages}:${python.pkgs.makePythonPath dependencies}"
+    "--prefix PYTHONPATH : $out/${python.sitePackages}:${python.pkgs.makePythonPath finalAttrs.passthru.dependencies}"
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc ]}"
     "--set ESPHOME_USE_SUBPROCESS ''"
     # https://github.com/NixOS/nixpkgs/issues/362193
@@ -173,9 +177,10 @@ python.pkgs.buildPythonApplication rec {
     "test_clean_all"
     "test_clean_all_partial_exists"
     # tries to use esptool, which is wrapped in an fhsenv
-    "test_upload_using_esptool_path_conversion"
-    "test_upload_using_esptool_with_file_path"
     "test_upload_using_esptool_passes_crystal_callback"
+    "test_upload_using_esptool_path_conversion"
+    "test_upload_using_esptool_skips_missing_extra_flash_images"
+    "test_upload_using_esptool_with_file_path"
     # AssertionError: Expected 'run_external_command' to have been called once. Called 0 times.
     "test_run_platformio_cli_sets_environment_variables"
     # Expects a full git clone
@@ -190,7 +195,7 @@ python.pkgs.buildPythonApplication rec {
   };
 
   meta = {
-    changelog = "https://github.com/esphome/esphome/releases/tag/${version}";
+    changelog = "https://github.com/esphome/esphome/releases/tag/${finalAttrs.src.tag}";
     description = "Make creating custom firmwares for ESP32/ESP8266 super easy";
     homepage = "https://esphome.io/";
     license = with lib.licenses; [
@@ -204,4 +209,4 @@ python.pkgs.buildPythonApplication rec {
     ];
     mainProgram = "esphome";
   };
-}
+})

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -206,6 +206,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
       hexa
       picnoir
       thanegill
+      karlbeecken
     ];
     mainProgram = "esphome";
   };

--- a/pkgs/by-name/es/esphome/platformio-binary-reference.patch
+++ b/pkgs/by-name/es/esphome/platformio-binary-reference.patch
@@ -1,0 +1,13 @@
+diff --git a/esphome/platformio_api.py b/esphome/platformio_api.py
+index fc21977f..e5059f1d 100644
+--- a/esphome/platformio_api.py
++++ b/esphome/platformio_api.py
+@@ -63,7 +63,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
+     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
+     # Increase uv retry count to handle transient network errors (default is 3)
+     os.environ.setdefault("UV_HTTP_RETRIES", "10")
+-    cmd = [sys.executable, "-m", "esphome.platformio_runner"] + list(args)
++    cmd = ["platformio"] + list(args)
+
+     return run_external_process(*cmd, **kwargs)
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Based on #510390

https://esphome.io/changelog/2026.4.0/
https://esphome.io/changelog/2026.4.0/#release-202641---april-20
https://esphome.io/changelog/2026.4.0/#release-202642---april-23
https://esphome.io/changelog/2026.4.0/#release-202643---april-28

## Things done

Added a new patch to fix the issue appearing with 2026.4, described here: https://github.com/NixOS/nixpkgs/pull/510390#issuecomment-4321834986
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
