### PR TITLE
polybarFull: fix build

### DIFF
--- a/pkgs/by-name/po/polybar/package.nix
+++ b/pkgs/by-name/po/polybar/package.nix
@@ -102,8 +102,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Replace hardcoded /etc when copying and reading the default config.
   postPatch = ''
-    substituteInPlace CMakeLists.txt --replace "/etc" $out
+    substituteInPlace CMakeLists.txt --replace-fail "/etc" $out
     substituteAllInPlace src/utils/file.cpp
+    # Fix gcc15 build: i3ipcpp forces -std=c++11 but the jsoncpp library was
+    # compiled with C++17 (JSONCPP_HAS_STRING_VIEW=1), causing ABI mismatch.
+    # The i3ipcpp code resolves operator[](const char*) but the library only
+    # exports operator[](std::string_view). Bump i3ipcpp to C++17 to match.
+    substituteInPlace lib/i3ipcpp/CMakeLists.txt --replace-fail \
+      "-std=c++11" \
+      "-std=c++17"
   '';
 
   postInstall = ''


### PR DESCRIPTION
polybarFull: fix gcc15 build by bumping i3ipcpp to C++17

The i3ipcpp submodule (used when i3Support=true) forces -std=c++11, but the jsoncpp library is compiled with C++17 (JSONCPP_HAS_STRING_VIEW=1). This causes an ABI mismatch: i3ipcpp resolves operator[](const char*) but the jsoncpp library only exports operator[](std::string_view), resulting in undefined references at link time.

Fix by changing i3ipcpp's compile standard from C++11 to C++17 to match the jsoncpp ABI. Polybar itself already uses C++17.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

# Alternatively

- https://github.com/NixOS/nixpkgs/pull/514317