### PR TITLE
writeTextFile: restructure with lib.extendMkDerivation

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -97,29 +97,28 @@ rec {
 
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md
   # See https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-writeTextFile
-  writeTextFile =
-    lib.extendMkDerivation {
-      constructDrv = stdenvNoCC.mkDerivation;
+  writeTextFile = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
 
-      excludeDrvArgNames = [
-        "derivationArgs"
-      ];
+    excludeDrvArgNames = [
+      "derivationArgs"
+    ];
 
-      extendDrvArgs =
-        finalAttrs:
-    {
-      name,
-      text,
-      executable ? false,
-      destination ? "",
-      checkPhase ? "",
-      meta ? { },
-      passthru ? { },
-      allowSubstitutes ? false,
-      preferLocalBuild ? true,
-      derivationArgs ? { },
-      pos ? builtins.unsafeGetAttrPos "name" args,
-    }@args:
+    extendDrvArgs =
+      finalAttrs:
+      {
+        name,
+        text,
+        executable ? false,
+        destination ? "",
+        checkPhase ? "",
+        meta ? { },
+        passthru ? { },
+        allowSubstitutes ? false,
+        preferLocalBuild ? true,
+        derivationArgs ? { },
+        pos ? builtins.unsafeGetAttrPos "name" args,
+      }@args:
       {
         inherit
           pos
@@ -175,9 +174,9 @@ rec {
         "passthru"
       ];
 
-      # `writeTextFile`'s set pattern doesn't have ellipses.
-      inheritFunctionArgs = false;
-    };
+    # `writeTextFile`'s set pattern doesn't have ellipses.
+    inheritFunctionArgs = false;
+  };
 
   # See doc/build-helpers/trivial-build-helpers.chapter.md
   # or https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-text-writing

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -98,6 +98,15 @@ rec {
   # Docs in doc/build-helpers/trivial-build-helpers.chapter.md
   # See https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-writeTextFile
   writeTextFile =
+    lib.extendMkDerivation {
+      constructDrv = stdenvNoCC.mkDerivation;
+
+      excludeDrvArgNames = [
+        "derivationArgs"
+      ];
+
+      extendDrvArgs =
+        finalAttrs:
     {
       name,
       text,
@@ -111,9 +120,6 @@ rec {
       derivationArgs ? { },
       pos ? builtins.unsafeGetAttrPos "name" args,
     }@args:
-
-    stdenvNoCC.mkDerivation (
-      finalAttrs:
       {
         inherit
           pos
@@ -167,8 +173,11 @@ rec {
         "passAsFile"
         "meta"
         "passthru"
-      ]
-    );
+      ];
+
+      # `writeTextFile`'s set pattern doesn't have ellipses.
+      inheritFunctionArgs = false;
+    };
 
   # See doc/build-helpers/trivial-build-helpers.chapter.md
   # or https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-text-writing


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Restructure trivial build helper `writeTextFile` with `lib.extendMkDerivation` with no rebuilds and minimal diff.

All the rebuilding changes were in PR #458888
- #458888

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
