### PR TITLE
vkpeak: init at 0-unstable-2026-01-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18220,6 +18220,12 @@
     githubId = 14153763;
     name = "modderme123";
   };
+  moeleak = {
+    email = "i@leak.moe";
+    github = "moeleak";
+    githubId = 52288096;
+    name = "moeleak";
+  };
   mofrim = {
     email = "mofrim@posteo.de";
     github = "mofrim";

--- a/pkgs/by-name/vk/vkpeak/package.nix
+++ b/pkgs/by-name/vk/vkpeak/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  makeWrapper,
+  moltenvk,
+  vulkan-headers,
+  vulkan-loader,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vkpeak";
+  version = "0-unstable-2026-01-12";
+
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "nihui";
+    repo = "vkpeak";
+    tag = "20260112";
+    fetchSubmodules = true;
+    hash = "sha256-m/qv8E8KqF4lr/xp0Bf8MMLSiPV8JQdID7NBEWhFjaA=";
+  };
+
+  postPatch = ''
+    echo 'install(TARGETS vkpeak RUNTIME DESTINATION bin)' >> CMakeLists.txt
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "GLSLANG_ENABLE_INSTALL" false)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin moltenvk;
+
+  postFixup =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        wrapProgram $out/bin/vkpeak \
+          --set-default NCNN_VULKAN_DRIVER ${moltenvk}/lib/libMoltenVK.dylib \
+          --set-default VK_DRIVER_FILES ${moltenvk}/share/vulkan/icd.d/MoltenVK_icd.json
+      ''
+    else
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        wrapProgram $out/bin/vkpeak \
+          --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+      '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Synthetic benchmark for measuring peak capabilities of Vulkan devices";
+    homepage = "https://github.com/nihui/vkpeak";
+    license = lib.licenses.mit;
+    mainProgram = "vkpeak";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ moeleak ];
+  };
+})


### PR DESCRIPTION
vkpeak is a tool which profiles Vulkan devices to find their peak capacities.
https://github.com/nihui/vkpeak

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
