### PR TITLE
lilypond: 2.24.4 -> 2.26.0

### DIFF
--- a/pkgs/by-name/li/lilypond/package.nix
+++ b/pkgs/by-name/li/lilypond/package.nix
@@ -78,8 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "mem=mf2pt1" "mem=$PWD/mf/mf2pt1"
   '';
 
-  patches = [ ];
-
   strictDeps = true;
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/lilypond/package.nix
+++ b/pkgs/by-name/li/lilypond/package.nix
@@ -41,12 +41,11 @@
     ]
   ),
   writeScript,
-  fetchpatch2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lilypond";
-  version = "2.24.4";
+  version = "2.26.0";
   outputs = [
     "out"
     "man"
@@ -54,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchzip {
     url = "https://lilypond.org/download/sources/v${lib.versions.majorMinor finalAttrs.version}/lilypond-${finalAttrs.version}.tar.gz";
-    hash = "sha256-UYdORvodrVchxslOxpMiXrAh7DtB9sWp9yqZU/jeB9Y=";
+    hash = "sha256-HUkPhaWNZ4UKbmlEyLXepHCFcgrdoRSDtjZMriO68RM=";
   };
 
   postInstall = ''
@@ -79,17 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "mem=mf2pt1" "mem=$PWD/mf/mf2pt1"
   '';
 
-  patches = [
-    # fixes #475503
-    # distilled version of https://gitweb.git.savannah.gnu.org/gitweb/?p=lilypond.git;a=commit;h=f2192eb294e
-    # so, remove once that commit reaches a stable release
-    (fetchpatch2 {
-      name = "fix-clang-21-build.patch";
-      url = "https://cgit.freebsd.org/ports/plain/print/lilypond/files/patch-lily_include_smobs.hh?id=58bab68c706086774b17dcacc61c8fd37ecc8a15";
-      extraPrefix = ""; # adds old/new prefixes to process properly in patchPhase
-      hash = "sha256-nT8+nYU+m6lLTvHEvSIpG/yAwy1Omb6+4Z+NGwEVE4Q=";
-    })
-  ];
+  patches = [ ];
 
   strictDeps = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
