### PR TITLE
pgadmin4: pin yarn-berry_4 to 4.9.2

### DIFF
--- a/pkgs/by-name/pg/pgadmin4/package.nix
+++ b/pkgs/by-name/pg/pgadmin4/package.nix
@@ -17,6 +17,17 @@ let
   version = "9.14";
   yarnHash = "sha256-j/5qoCrhC7xBPaS6NhZFFQtJ7ThL/wkFXoCtyreLHco=";
 
+  yarnVersion = "4.9.2";
+  yarn-berry = yarn-berry_4.overrideAttrs (old: {
+    version = yarnVersion;
+    src = fetchFromGitHub {
+      owner = "yarnpkg";
+      repo = "berry";
+      tag = "@yarnpkg/cli/${yarnVersion}";
+      hash = "sha256-MZB70hgPiQuHHLibhrGZ11vcvtZsCDkqR1NxSq8bXps=";
+    };
+  });
+
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
@@ -45,7 +56,7 @@ pythonPackages.buildPythonApplication rec {
   inherit pname version src;
   missingHashes = ./missing-hashes.json;
 
-  offlineCache = yarn-berry_4.fetchYarnBerryDeps {
+  offlineCache = yarn-berry.fetchYarnBerryDeps {
     inherit missingHashes;
     src = src + "/web";
     hash = yarnHash;
@@ -85,6 +96,7 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   dontYarnBerryInstallDeps = true;
+  yarnBerryCheckVersionHookPackageJson = "web/package.json";
   preBuild = ''
     # Adapted from pkg/pip/build.sh
     echo Creating required directories...
@@ -137,8 +149,9 @@ pythonPackages.buildPythonApplication rec {
     cython
     pip
     sphinx
-    yarn-berry_4
-    yarn-berry_4.yarnBerryConfigHook
+    yarn-berry
+    yarn-berry.yarnBerryConfigHook
+    yarn-berry.yarnBerryCheckVersionHook
     nodejs
   ];
 

--- a/pkgs/by-name/ya/yarn-berry/package.nix
+++ b/pkgs/by-name/ya/yarn-berry/package.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = ./update.sh;
 
+    yarnBerryCheckVersionHook = callPackage ./yarn-berry-check-version-hook.nix { };
+
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.nix
+++ b/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.nix
@@ -1,0 +1,10 @@
+{
+  makeSetupHook,
+}:
+
+makeSetupHook {
+  name = "yarn-berry-check-version-hook";
+  meta = {
+    description = "Check if the version in package.json matches the available version of Yarn";
+  };
+} ./yarn-berry-check-version-hook.sh

--- a/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.sh
+++ b/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.sh
@@ -1,0 +1,17 @@
+yarnBerryCheckVersionHook() {
+  if [[ -z "$yarnBerryCheckVersionHookPackageJson" ]]; then
+    yarnBerryCheckVersionHookPackageJson="package.json"
+  fi
+
+  YARN_VERSION=$(yarn -v)
+  PACKAGE_MANAGER=$(node -p "require(\"./$yarnBerryCheckVersionHookPackageJson\").packageManager")
+  echo "Yarn version is $YARN_VERSION"
+  echo "Package manager in package.json is $PACKAGE_MANAGER"
+
+  if [[ "$PACKAGE_MANAGER" != "yarn@$YARN_VERSION" ]]; then
+    echo "The value for package manager in package.json doesn't match the version of Yarn that has been provided in this builder"
+    exit 1
+  fi
+}
+
+preConfigureHooks+=(yarnBerryCheckVersionHook)


### PR DESCRIPTION
## Things done

See #513716

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
