### PR TITLE
psi-plus: migrate to qt6, drop 'webkit' chat backend

### DIFF
--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -7,10 +7,9 @@
   qtbase,
   qtmultimedia,
   qtimageformats,
-  qtx11extras,
   qttools,
   libidn,
-  qca-qt5,
+  qca,
   libxscrnsaver,
   hunspell,
   libsecret,
@@ -20,7 +19,6 @@
   qtkeychain,
 
   chatType ? "basic", # See the assertion below for available options
-  qtwebkit,
   qtwebengine,
 
   enablePlugins ? true,
@@ -34,11 +32,16 @@
   gst_all_1,
   enablePsiMedia ? false,
   pkg-config,
+
+  # For tests
+  psi-plus,
 }:
+
+assert lib.assertMsg (lib.toLower chatType != "webkit")
+  "psi-plus: chatType = \"webkit\" was removed because qtwebkit had known vulns and has no Qt6 equivalent. Use chatType = \"webengine\" instead.";
 
 assert builtins.elem (lib.toLower chatType) [
   "basic" # Basic implementation, no web stuff involved
-  "webkit" # Legacy one, based on WebKit (see https://wiki.qt.io/Qt_WebKit)
   "webengine" # QtWebEngine (see https://wiki.qt.io/QtWebEngine)
 ];
 
@@ -59,6 +62,7 @@ stdenv.mkDerivation rec {
     "-DCHAT_TYPE=${chatType}"
     "-DENABLE_PLUGINS=${if enablePlugins then "ON" else "OFF"}"
     "-DBUILD_PSIMEDIA=${if enablePsiMedia then "ON" else "OFF"}"
+    "-DQT_DEFAULT_MAJOR_VERSION=6"
   ];
 
   nativeBuildInputs = [
@@ -74,9 +78,8 @@ stdenv.mkDerivation rec {
     qtbase
     qtmultimedia
     qtimageformats
-    qtx11extras
     libidn
-    qca-qt5
+    qca
     libxscrnsaver
     hunspell
     libsecret
@@ -95,9 +98,6 @@ stdenv.mkDerivation rec {
     libotr
     libomemo-c
   ]
-  ++ lib.optionals (chatType == "webkit") [
-    qtwebkit
-  ]
   ++ lib.optionals (chatType == "webengine") [
     qtwebengine
   ];
@@ -107,6 +107,10 @@ stdenv.mkDerivation rec {
       --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
     )
   '';
+
+  passthru.tests = {
+    webengine = psi-plus.override { chatType = "webengine"; };
+  };
 
   meta = {
     homepage = "https://psi-plus.com";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10144,7 +10144,7 @@ with pkgs;
 
   psi = libsForQt5.callPackage ../applications/networking/instant-messengers/psi { };
 
-  psi-plus = libsForQt5.callPackage ../applications/networking/instant-messengers/psi-plus { };
+  psi-plus = qt6Packages.callPackage ../applications/networking/instant-messengers/psi-plus { };
 
   pulseview = libsForQt5.callPackage ../applications/science/electronics/pulseview { };
 


### PR DESCRIPTION
Dropped the qtwebkit backend and migrated to Qt6.
Builds, runs, haven't tested chatting as I don't use XMPP.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
