### PR TITLE
xdg-desktop-portal-gnome: 49.0 -> 50.0; gsettings-desktop-schemas: 49.1 -> 50.1

### DIFF
--- a/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
+++ b/pkgs/by-name/gs/gsettings-desktop-schemas/package.nix
@@ -17,11 +17,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gsettings-desktop-schemas";
-  version = "49.1";
+  version = "50.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gsettings-desktop-schemas/${lib.versions.major version}/gsettings-desktop-schemas-${version}.tar.xz";
-    hash = "sha256-d3p/g9XlqAdrm/gJyyQQGxsbqcIwI148PejhOWjtDmM=";
+    hash = "sha256-CiqiUIJnJYXRb82rYcew4z8DX7h0dlBceU8pVlr6SFs=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/xd/xdg-desktop-portal-gnome/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-gnome/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-gnome";
-  version = "49.0";
+  version = "50.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/xdg-desktop-portal-gnome/${lib.versions.major finalAttrs.version}/xdg-desktop-portal-gnome-${finalAttrs.version}.tar.xz";
-    hash = "sha256-QB2vzfjLkR8JwI0oE/d03YZBJ6v8qT/0yvH8TJtexNI=";
+    hash = "sha256-zu7y+2izSz9mo97wozKiKnCvJyZB+2xQBlt6L949V1k=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
xdg-desktop-portal-gnome:
Diff: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/compare/49.0...50.0?from_project_id=16052 Changelog: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/blob/50.0/NEWS

gsettings-desktop-schemas:
Diff: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/compare/49.1...50.1?from_project_id=1669 Changelog: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/blob/50.1/NEWS

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
