### PR TITLE
stdenv.mkDerivation: small performance wins

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -274,6 +274,8 @@
 
 - The default packages in `services.jenkins.packages` have been dropped, since not every Jenkins installation needs any package at all. It's more reasonable to leave it empty and let users configure what they need.
 
+- The `pie` hardening flag has been removed and will now error, after being deprecated in 25.11. Compilers are expected to enable PIE by default, as has been common practice since 2016 outside of Nixpkgs. If a package needs `pie` disabled pass `-no-pie` in `CFLAGS`. It is unlikely this will be necessary in many cases; due to the prevalence of default PIE toolchains, most packages incompatible with PIE already pass `-no-pie`.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -434,7 +434,7 @@ let
         else
           subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
       # hardeningDisable additionally supports "all".
-      erroneousHardeningFlags = subtractLists (knownHardeningFlags ++ [ "pie" ]) (
+      erroneousHardeningFlags = subtractLists knownHardeningFlags (
         hardeningEnable ++ remove "all" hardeningDisable
       );
 
@@ -636,9 +636,7 @@ let
             else
               null
           } =
-            lib.warnIf (elem "pie" hardeningEnable || elem "pie" hardeningDisable)
-              "The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future."
-              (concatStringsSep " " enabledHardeningOptions);
+            concatStringsSep " " enabledHardeningOptions;
 
           # TODO: remove platform condition
           # Enabling this check could be a breaking change as it requires to edit nix.conf

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -427,7 +427,7 @@ let
 
       concretizeFlagImplications =
         flag: impliesFlags: list:
-        if builtins.elem flag list then (list ++ impliesFlags) else list;
+        if elem flag list then (list ++ impliesFlags) else list;
 
       hardeningDisable' = unique (
         pipe hardeningDisable [
@@ -440,7 +440,7 @@ let
         ]
       );
       enabledHardeningOptions =
-        if builtins.elem "all" hardeningDisable' then
+        if elem "all" hardeningDisable' then
           [ ]
         else
           subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
@@ -454,7 +454,7 @@ let
         positions: name: deps:
         imap1 (
           index: dep:
-          if dep == null || isDerivation dep || builtins.isString dep || builtins.isPath dep then
+          if dep == null || isDerivation dep || isString dep || builtins.isPath dep then
             dep
           else if isList dep then
             checkDependencyList' ([ index ] ++ positions) name dep
@@ -640,9 +640,9 @@ let
             else
               null
           } =
-            lib.warnIf ((builtins.elem "pie" hardeningEnable) || (builtins.elem "pie" hardeningDisable))
+            lib.warnIf (elem "pie" hardeningEnable || elem "pie" hardeningDisable)
               "The 'pie' hardening flag has been removed in favor of enabling PIE by default in compilers and should no longer be used. PIE can be disabled with the -no-pie compiler flag, but this is usually not necessary as most build systems pass this if needed. Usage of the 'pie' hardening flag will become an error in future."
-              (builtins.concatStringsSep " " enabledHardeningOptions);
+              (concatStringsSep " " enabledHardeningOptions);
 
           # TODO: remove platform condition
           # Enabling this check could be a breaking change as it requires to edit nix.conf
@@ -718,7 +718,7 @@ let
           # -- Windows/Cygwin-specific attrs --
           ${if isWindows || isCygwin then "allowedImpureDLLs" else null} =
             allowedImpureDLLs
-            ++ lib.optionals isCygwin [
+            ++ optionals isCygwin [
               "KERNEL32.dll"
             ];
 
@@ -741,7 +741,7 @@ let
                 inherit name;
                 value =
                   let
-                    raw = zipAttrsWith (_: builtins.concatLists) [
+                    raw = zipAttrsWith (_: concatLists) [
                       attrsOutputChecksFiltered
                       (makeOutputChecks attrs.outputChecks.${name} or { })
                     ];
@@ -905,7 +905,7 @@ let
           removeAttrs derivationArg attrsToRemove
           // {
             # Add a name in case the original drv didn't have one
-            name = "inputDerivation" + lib.optionalString (derivationArg ? name) "-${derivationArg.name}";
+            name = "inputDerivation" + optionalString (derivationArg ? name) "-${derivationArg.name}";
             # This always only has one output
             outputs = [ "out" ];
             # This doesn’t require any system features even if the original

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -823,9 +823,8 @@ let
       );
 
     let
-      mainProgram = meta.mainProgram or null;
       env' = env // {
-        ${if mainProgram != null then "NIX_MAIN_PROGRAM" else null} = mainProgram;
+        ${if meta ? mainProgram then "NIX_MAIN_PROGRAM" else null} = meta.mainProgram;
       };
 
       derivationArg = makeDerivationArgument (

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -96,48 +96,44 @@ let
       overrideAttrs =
         f0:
         makeDerivationExtensible (
-          (
-            overlay: f: final:
-            let
-              prev = f final;
-              thisOverlay = overlay final prev;
-              pos = builtins.unsafeGetAttrPos "version" thisOverlay;
-            in
-            lib.warnIf
-              (
-                prev ? src
-                && thisOverlay ? version
-                && prev ? version
-                # We could check that the version is actually distinct, but that
-                # would probably just delay the inevitable, or preserve tech debt.
-                # && prev.version != thisOverlay.version
-                && !(thisOverlay ? src)
-                && !(thisOverlay.__intentionallyOverridingVersion or false)
-              )
-              ''
-                ${
-                  args.name or "${args.pname or "<unknown name>"}-${args.version or "<unknown version>"}"
-                } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
-                  toString pos.line or "<unknown line>"
-                }:${toString pos.column or "<unknown column>"}.
+          final:
+          let
+            prev = rattrs final;
+            thisOverlay = lib.toExtension f0 final prev;
+            pos = builtins.unsafeGetAttrPos "version" thisOverlay;
+          in
+          lib.warnIf
+            (
+              prev ? src
+              && thisOverlay ? version
+              && prev ? version
+              # We could check that the version is actually distinct, but that
+              # would probably just delay the inevitable, or preserve tech debt.
+              # && prev.version != thisOverlay.version
+              && !(thisOverlay ? src)
+              && !(thisOverlay.__intentionallyOverridingVersion or false)
+            )
+            ''
+              ${
+                args.name or "${args.pname or "<unknown name>"}-${args.version or "<unknown version>"}"
+              } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
+                toString pos.line or "<unknown line>"
+              }:${toString pos.column or "<unknown column>"}.
 
-                This is most likely not what you want. In order to properly change the version of a package, override
-                both the `version` and `src` attributes:
+              This is most likely not what you want. In order to properly change the version of a package, override
+              both the `version` and `src` attributes:
 
-                hello.overrideAttrs (oldAttrs: rec {
-                  version = "1.0.0";
-                  src = pkgs.fetchurl {
-                    url = "mirror://gnu/hello/hello-''${version}.tar.gz";
-                    hash = "...";
-                  };
-                })
+              hello.overrideAttrs (oldAttrs: rec {
+                version = "1.0.0";
+                src = pkgs.fetchurl {
+                  url = "mirror://gnu/hello/hello-''${version}.tar.gz";
+                  hash = "...";
+                };
+              })
 
-                (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
-              ''
-              (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
-          )
-            (lib.toExtension f0)
-            rattrs
+              (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
+            ''
+            (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
         );
 
       finalPackage = mkDerivationSimple overrideAttrs args;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -855,12 +855,12 @@ let
       checkedEnv =
         let
           overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
-          makeError =
+          errors = lib.concatMapStringsSep "\n" (
             name:
             "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
                 lib.generators.toPretty { } derivationArg.${name}
-              }";
-          errors = lib.concatMapStringsSep "\n" makeError overlappingNames;
+              }"
+          ) overlappingNames;
         in
         assert assertMsg (isAttrs env && !isDerivation env)
           "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -413,7 +413,7 @@ let
       outputs' = outputs ++ optional separateDebugInfo' "debug";
 
       noNonNativeDeps =
-        builtins.length (
+        (
           depsBuildTarget
           ++ depsBuildTargetPropagated
           ++ depsHostHost
@@ -422,7 +422,7 @@ let
           ++ propagatedBuildInputs
           ++ depsTargetTarget
           ++ depsTargetTargetPropagated
-        ) == 0;
+        ) == [ ];
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
 
       concretizeFlagImplications =
@@ -464,7 +464,7 @@ let
             }${name} for ${attrs.name or attrs.pname}"
         ) deps;
     in
-    if builtins.length erroneousHardeningFlags != 0 then
+    if erroneousHardeningFlags != [ ] then
       abort (
         "mkDerivation was called with unsupported hardening flags: "
         + lib.generators.toPretty { } {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -589,19 +589,19 @@ let
           __ignoreNulls = true;
           inherit __structuredAttrs strictDeps;
 
-          depsBuildBuild = elemAt (elemAt dependencies 0) 0;
-          nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
-          depsBuildTarget = elemAt (elemAt dependencies 0) 2;
-          depsHostHost = elemAt (elemAt dependencies 1) 0;
+          depsBuildBuild = head (head dependencies);
+          nativeBuildInputs = elemAt (head dependencies) 1;
+          depsBuildTarget = elemAt (head dependencies) 2;
+          depsHostHost = head (elemAt dependencies 1);
           buildInputs = elemAt (elemAt dependencies 1) 1;
-          depsTargetTarget = elemAt (elemAt dependencies 2) 0;
+          depsTargetTarget = head (elemAt dependencies 2);
 
-          depsBuildBuildPropagated = elemAt (elemAt propagatedDependencies 0) 0;
-          propagatedNativeBuildInputs = elemAt (elemAt propagatedDependencies 0) 1;
-          depsBuildTargetPropagated = elemAt (elemAt propagatedDependencies 0) 2;
-          depsHostHostPropagated = elemAt (elemAt propagatedDependencies 1) 0;
+          depsBuildBuildPropagated = head (head propagatedDependencies);
+          propagatedNativeBuildInputs = elemAt (head propagatedDependencies) 1;
+          depsBuildTargetPropagated = elemAt (head propagatedDependencies) 2;
+          depsHostHostPropagated = head (elemAt propagatedDependencies 1);
           propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
-          depsTargetTargetPropagated = elemAt (elemAt propagatedDependencies 2) 0;
+          depsTargetTargetPropagated = head (elemAt propagatedDependencies 2);
 
           # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
           configureFlags =

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -20,7 +20,6 @@ let
     concatMapStrings
     concatStringsSep
     elem
-    elemAt
     extendDerivation
     filter
     filterAttrs
@@ -476,61 +475,59 @@ let
 
         outputs = outputs';
 
-        buildDependencies = [
-          (map (drv: getDev drv.__spliced.buildBuild or drv) (
-            checkDependencyList "depsBuildBuild" depsBuildBuild
-          ))
-          (map (drv: getDev drv.__spliced.buildHost or drv) (
-            checkDependencyList "nativeBuildInputs" nativeBuildInputs'
-          ))
-          (map (drv: getDev drv.__spliced.buildTarget or drv) (
-            checkDependencyList "depsBuildTarget" depsBuildTarget
-          ))
+        buildBuildOutputs = map (drv: getDev drv.__spliced.buildBuild or drv) (
+          checkDependencyList "depsBuildBuild" depsBuildBuild
+        );
+        buildHostOutputs = map (drv: getDev drv.__spliced.buildHost or drv) (
+          checkDependencyList "nativeBuildInputs" nativeBuildInputs'
+        );
+        buildTargetOutputs = map (drv: getDev drv.__spliced.buildTarget or drv) (
+          checkDependencyList "depsBuildTarget" depsBuildTarget
+        );
+        hostHostOutputs = map (drv: getDev drv.__spliced.hostHost or drv) (
+          checkDependencyList "depsHostHost" depsHostHost
+        );
+        hostTargetOutputs = map (drv: getDev drv.__spliced.hostTarget or drv) (
+          checkDependencyList "buildInputs" buildInputs'
+        );
+        targetTargetOutputs = map (drv: getDev drv.__spliced.targetTarget or drv) (
+          checkDependencyList "depsTargetTarget" depsTargetTarget
+        );
+        allDependencies = concatLists [
+          buildBuildOutputs
+          buildHostOutputs
+          buildTargetOutputs
+          hostHostOutputs
+          hostTargetOutputs
+          targetTargetOutputs
         ];
-        hostDependencies = [
-          (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
-          (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
-        ];
-        targetDependencies = [
-          (map (drv: getDev drv.__spliced.targetTarget or drv) (
-            checkDependencyList "depsTargetTarget" depsTargetTarget
-          ))
-        ];
-        allDependencies = concatLists (concatLists [
-          buildDependencies
-          hostDependencies
-          targetDependencies
-        ]);
 
-        propagatedBuildDependencies = [
-          (map (drv: getDev drv.__spliced.buildBuild or drv) (
-            checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated
-          ))
-          (map (drv: getDev drv.__spliced.buildHost or drv) (
-            checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs
-          ))
-          (map (drv: getDev drv.__spliced.buildTarget or drv) (
-            checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated
-          ))
+        propagatedBuildBuildOutputs = map (drv: getDev drv.__spliced.buildBuild or drv) (
+          checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated
+        );
+        propagatedBuildHostOutputs = map (drv: getDev drv.__spliced.buildHost or drv) (
+          checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs
+        );
+        propagatedBuildTargetOutputs = map (drv: getDev drv.__spliced.buildTarget or drv) (
+          checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated
+        );
+        propagatedHostHostOutputs = map (drv: getDev drv.__spliced.hostHost or drv) (
+          checkDependencyList "depsHostHostPropagated" depsHostHostPropagated
+        );
+        propagatedHostTargetOutputs = map (drv: getDev drv.__spliced.hostTarget or drv) (
+          checkDependencyList "propagatedBuildInputs" propagatedBuildInputs
+        );
+        propagatedTargetTargetOutputs = map (drv: getDev drv.__spliced.targetTarget or drv) (
+          checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated
+        );
+        allPropagatedDependencies = concatLists [
+          propagatedBuildBuildOutputs
+          propagatedBuildHostOutputs
+          propagatedBuildTargetOutputs
+          propagatedHostHostOutputs
+          propagatedHostTargetOutputs
+          propagatedTargetTargetOutputs
         ];
-        propagatedHostDependencies = [
-          (map (drv: getDev drv.__spliced.hostHost or drv) (
-            checkDependencyList "depsHostHostPropagated" depsHostHostPropagated
-          ))
-          (map (drv: getDev drv.__spliced.hostTarget or drv) (
-            checkDependencyList "propagatedBuildInputs" propagatedBuildInputs
-          ))
-        ];
-        propagatedTargetDependencies = [
-          (map (drv: getDev drv.__spliced.targetTarget or drv) (
-            checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated
-          ))
-        ];
-        allPropagatedDependencies = concatLists (concatLists [
-          propagatedBuildDependencies
-          propagatedHostDependencies
-          propagatedTargetDependencies
-        ]);
 
         derivationArg = removeAttrs attrs removedOrReplacedAttrNames // {
           ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
@@ -581,19 +578,19 @@ let
           __ignoreNulls = true;
           inherit __structuredAttrs strictDeps;
 
-          depsBuildBuild = head buildDependencies;
-          nativeBuildInputs = elemAt buildDependencies 1;
-          depsBuildTarget = elemAt buildDependencies 2;
-          depsHostHost = head hostDependencies;
-          buildInputs = elemAt hostDependencies 1;
-          depsTargetTarget = head targetDependencies;
+          depsBuildBuild = buildBuildOutputs;
+          nativeBuildInputs = buildHostOutputs;
+          depsBuildTarget = buildTargetOutputs;
+          depsHostHost = hostHostOutputs;
+          buildInputs = hostTargetOutputs;
+          depsTargetTarget = targetTargetOutputs;
 
-          depsBuildBuildPropagated = head propagatedBuildDependencies;
-          propagatedNativeBuildInputs = elemAt propagatedBuildDependencies 1;
-          depsBuildTargetPropagated = elemAt propagatedBuildDependencies 2;
-          depsHostHostPropagated = head propagatedHostDependencies;
-          propagatedBuildInputs = elemAt propagatedHostDependencies 1;
-          depsTargetTargetPropagated = head propagatedTargetDependencies;
+          depsBuildBuildPropagated = propagatedBuildBuildOutputs;
+          propagatedNativeBuildInputs = propagatedBuildHostOutputs;
+          depsBuildTargetPropagated = propagatedBuildTargetOutputs;
+          depsHostHostPropagated = propagatedHostHostOutputs;
+          propagatedBuildInputs = propagatedHostTargetOutputs;
+          depsTargetTargetPropagated = propagatedTargetTargetOutputs;
 
           # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
           configureFlags =

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -491,54 +491,61 @@ let
 
         outputs = outputs';
 
-        dependencies = [
-          [
-            (map (drv: getDev drv.__spliced.buildBuild or drv) (
-              checkDependencyList "depsBuildBuild" depsBuildBuild
-            ))
-            (map (drv: getDev drv.__spliced.buildHost or drv) (
-              checkDependencyList "nativeBuildInputs" nativeBuildInputs'
-            ))
-            (map (drv: getDev drv.__spliced.buildTarget or drv) (
-              checkDependencyList "depsBuildTarget" depsBuildTarget
-            ))
-          ]
-          [
-            (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
-            (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
-          ]
-          [
-            (map (drv: getDev drv.__spliced.targetTarget or drv) (
-              checkDependencyList "depsTargetTarget" depsTargetTarget
-            ))
-          ]
+        buildDependencies = [
+          (map (drv: getDev drv.__spliced.buildBuild or drv) (
+            checkDependencyList "depsBuildBuild" depsBuildBuild
+          ))
+          (map (drv: getDev drv.__spliced.buildHost or drv) (
+            checkDependencyList "nativeBuildInputs" nativeBuildInputs'
+          ))
+          (map (drv: getDev drv.__spliced.buildTarget or drv) (
+            checkDependencyList "depsBuildTarget" depsBuildTarget
+          ))
         ];
-        propagatedDependencies = [
-          [
-            (map (drv: getDev drv.__spliced.buildBuild or drv) (
-              checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated
-            ))
-            (map (drv: getDev drv.__spliced.buildHost or drv) (
-              checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs
-            ))
-            (map (drv: getDev drv.__spliced.buildTarget or drv) (
-              checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated
-            ))
-          ]
-          [
-            (map (drv: getDev drv.__spliced.hostHost or drv) (
-              checkDependencyList "depsHostHostPropagated" depsHostHostPropagated
-            ))
-            (map (drv: getDev drv.__spliced.hostTarget or drv) (
-              checkDependencyList "propagatedBuildInputs" propagatedBuildInputs
-            ))
-          ]
-          [
-            (map (drv: getDev drv.__spliced.targetTarget or drv) (
-              checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated
-            ))
-          ]
+        hostDependencies = [
+          (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
+          (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
         ];
+        targetDependencies = [
+          (map (drv: getDev drv.__spliced.targetTarget or drv) (
+            checkDependencyList "depsTargetTarget" depsTargetTarget
+          ))
+        ];
+        allDependencies = concatLists (concatLists [
+          buildDependencies
+          hostDependencies
+          targetDependencies
+        ]);
+
+        propagatedBuildDependencies = [
+          (map (drv: getDev drv.__spliced.buildBuild or drv) (
+            checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated
+          ))
+          (map (drv: getDev drv.__spliced.buildHost or drv) (
+            checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs
+          ))
+          (map (drv: getDev drv.__spliced.buildTarget or drv) (
+            checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated
+          ))
+        ];
+        propagatedHostDependencies = [
+          (map (drv: getDev drv.__spliced.hostHost or drv) (
+            checkDependencyList "depsHostHostPropagated" depsHostHostPropagated
+          ))
+          (map (drv: getDev drv.__spliced.hostTarget or drv) (
+            checkDependencyList "propagatedBuildInputs" propagatedBuildInputs
+          ))
+        ];
+        propagatedTargetDependencies = [
+          (map (drv: getDev drv.__spliced.targetTarget or drv) (
+            checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated
+          ))
+        ];
+        allPropagatedDependencies = concatLists (concatLists [
+          propagatedBuildDependencies
+          propagatedHostDependencies
+          propagatedTargetDependencies
+        ]);
 
         derivationArg = removeAttrs attrs removedOrReplacedAttrNames // {
           ${if (attrs ? name || (attrs ? pname && attrs ? version)) then "name" else null} =
@@ -589,19 +596,19 @@ let
           __ignoreNulls = true;
           inherit __structuredAttrs strictDeps;
 
-          depsBuildBuild = head (head dependencies);
-          nativeBuildInputs = elemAt (head dependencies) 1;
-          depsBuildTarget = elemAt (head dependencies) 2;
-          depsHostHost = head (elemAt dependencies 1);
-          buildInputs = elemAt (elemAt dependencies 1) 1;
-          depsTargetTarget = head (elemAt dependencies 2);
+          depsBuildBuild = head buildDependencies;
+          nativeBuildInputs = elemAt buildDependencies 1;
+          depsBuildTarget = elemAt buildDependencies 2;
+          depsHostHost = head hostDependencies;
+          buildInputs = elemAt hostDependencies 1;
+          depsTargetTarget = head targetDependencies;
 
-          depsBuildBuildPropagated = head (head propagatedDependencies);
-          propagatedNativeBuildInputs = elemAt (head propagatedDependencies) 1;
-          depsBuildTargetPropagated = elemAt (head propagatedDependencies) 2;
-          depsHostHostPropagated = head (elemAt propagatedDependencies 1);
-          propagatedBuildInputs = elemAt (elemAt propagatedDependencies 1) 1;
-          depsTargetTargetPropagated = head (elemAt propagatedDependencies 2);
+          depsBuildBuildPropagated = head propagatedBuildDependencies;
+          propagatedNativeBuildInputs = elemAt propagatedBuildDependencies 1;
+          depsBuildTargetPropagated = elemAt propagatedBuildDependencies 2;
+          depsHostHostPropagated = head propagatedHostDependencies;
+          propagatedBuildInputs = elemAt propagatedHostDependencies 1;
+          depsTargetTargetPropagated = head propagatedTargetDependencies;
 
           # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
           configureFlags =
@@ -654,8 +661,6 @@ let
           ${if buildIsDarwin then "__darwinAllowLocalNetworking" else null} = __darwinAllowLocalNetworking;
           ${if buildIsDarwin then "__sandboxProfile" else null} =
             let
-              allDependencies = concatLists (concatLists dependencies);
-              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
               computedSandboxProfile = concatMap (input: input.__propagatedSandboxProfile or [ ]) (
                 extraNativeBuildInputs ++ extraBuildInputs ++ allDependencies
               );
@@ -676,7 +681,6 @@ let
             concatStringsSep "\n" (filter (x: x != "") (unique profiles));
           ${if buildIsDarwin then "__propagatedSandboxProfile" else null} =
             let
-              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
               computedPropagatedSandboxProfile = concatMap (
                 input: input.__propagatedSandboxProfile or [ ]
               ) allPropagatedDependencies;
@@ -684,8 +688,6 @@ let
             unique (computedPropagatedSandboxProfile ++ [ propagatedSandboxProfile ]);
           ${if buildIsDarwin then "__impureHostDeps" else null} =
             let
-              allDependencies = concatLists (concatLists dependencies);
-              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
               computedImpureHostDeps = unique (
                 concatMap (input: input.__propagatedImpureHostDeps or [ ]) (
                   extraNativeBuildInputs ++ extraBuildInputs ++ allDependencies
@@ -708,7 +710,6 @@ let
             ];
           ${if buildIsDarwin then "__propagatedImpureHostDeps" else null} =
             let
-              allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
               computedPropagatedImpureHostDeps = unique (
                 concatMap (input: input.__propagatedImpureHostDeps or [ ]) allPropagatedDependencies
               );

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -95,31 +95,28 @@ let
       # NOTE: the above documentation had to be duplicated in `lib/customisation.nix`: `makeOverridable`.
       overrideAttrs =
         f0:
-        let
-          extends' =
-            overlay: f:
-            (
-              final:
-              let
-                prev = f final;
-                thisOverlay = overlay final prev;
-                warnForBadVersionOverride = (
-                  prev ? src
-                  && thisOverlay ? version
-                  && prev ? version
-                  # We could check that the version is actually distinct, but that
-                  # would probably just delay the inevitable, or preserve tech debt.
-                  # && prev.version != thisOverlay.version
-                  && !(thisOverlay ? src)
-                  && !(thisOverlay.__intentionallyOverridingVersion or false)
-                );
-                pname = args.pname or "<unknown name>";
-                version = args.version or "<unknown version>";
-                pos = builtins.unsafeGetAttrPos "version" thisOverlay;
-              in
-              lib.warnIf warnForBadVersionOverride ''
+        makeDerivationExtensible (
+          (
+            overlay: f: final:
+            let
+              prev = f final;
+              thisOverlay = overlay final prev;
+              pos = builtins.unsafeGetAttrPos "version" thisOverlay;
+            in
+            lib.warnIf
+              (
+                prev ? src
+                && thisOverlay ? version
+                && prev ? version
+                # We could check that the version is actually distinct, but that
+                # would probably just delay the inevitable, or preserve tech debt.
+                # && prev.version != thisOverlay.version
+                && !(thisOverlay ? src)
+                && !(thisOverlay.__intentionallyOverridingVersion or false)
+              )
+              ''
                 ${
-                  args.name or "${pname}-${version}"
+                  args.name or "${args.pname or "<unknown name>"}-${args.version or "<unknown version>"}"
                 } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
                   toString pos.line or "<unknown line>"
                 }:${toString pos.column or "<unknown column>"}.
@@ -136,10 +133,12 @@ let
                 })
 
                 (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
-              '' (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
-            );
-        in
-        makeDerivationExtensible (extends' (lib.toExtension f0) rattrs);
+              ''
+              (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
+          )
+            (lib.toExtension f0)
+            rattrs
+        );
 
       finalPackage = mkDerivationSimple overrideAttrs args;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -871,20 +871,18 @@ let
           v
         ) env';
 
-      # Fixed-output derivations may not reference other paths, which means that
-      # for a fixed-output derivation, the corresponding inputDerivation should
-      # *not* be fixed-output. To achieve this we simply delete the attributes that
-      # would make it fixed-output.
-      fixedOutputRelatedAttrs = [
+      attrsToRemove = [
+        # Fixed-output derivations may not reference other paths, which means that
+        # for a fixed-output derivation, the corresponding inputDerivation should
+        # *not* be fixed-output. To achieve this we simply delete the attributes that
+        # would make it fixed-output.
         "outputHashAlgo"
         "outputHash"
         "outputHashMode"
-      ];
 
-      # inputDerivation produces the inputs; not the outputs, so any
-      # restrictions on what used to be the outputs don't serve a purpose
-      # anymore.
-      outputCheckAttrs = [
+        # inputDerivation produces the inputs; not the outputs, so any
+        # restrictions on what used to be the outputs don't serve a purpose
+        # anymore.
         "allowedReferences"
         "allowedRequisites"
         "disallowedReferences"
@@ -902,7 +900,7 @@ let
         # needed to enter a nix-shell with
         #   nix-build shell.nix -A inputDerivation
         inputDerivation = derivation (
-          removeAttrs derivationArg (fixedOutputRelatedAttrs ++ outputCheckAttrs)
+          removeAttrs derivationArg attrsToRemove
           // {
             # Add a name in case the original drv didn't have one
             name = "inputDerivation" + lib.optionalString (derivationArg ? name) "-${derivationArg.name}";

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -851,11 +851,10 @@ let
       checkedEnv =
         let
           overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
-          prettyPrint = lib.generators.toPretty { };
           makeError =
             name:
-            "  - ${name}: in `env`: ${prettyPrint env'.${name}}; in derivation arguments: ${
-                prettyPrint derivationArg.${name}
+            "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
+                lib.generators.toPretty { } derivationArg.${name}
               }";
           errors = lib.concatMapStringsSep "\n" makeError overlappingNames;
         in

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -394,13 +394,17 @@ let
       separateDebugInfo' =
         let
           actualValue = separateDebugInfo && isLinux;
-          conflictingOption =
+        in
+        if
+          actualValue
+          && (
             attrs ? "disallowedReferences"
             || attrs ? "disallowedRequisites"
             || attrs ? "allowedRequisites"
-            || attrs ? "allowedReferences";
-        in
-        if actualValue && conflictingOption && !__structuredAttrs then
+            || attrs ? "allowedReferences"
+          )
+          && !__structuredAttrs
+        then
           throw "separateDebugInfo = true in ${
             attrs.pname or "mkDerivation argument"
           } requires __structuredAttrs if {dis,}allowedRequisites or {dis,}allowedReferences is set"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -374,17 +374,6 @@ let
 
       ...
     }@attrs:
-
-    # Policy on acceptable hash types in nixpkgs
-    assert
-      attrs ? outputHash
-      -> (
-        let
-          algo = attrs.outputHashAlgo or (head (splitString "-" attrs.outputHash));
-        in
-        if algo == "md5" then throw "Rejected insecure ${algo} hash '${attrs.outputHash}'" else true
-      );
-
     let
       # TODO(@oxij, @Ericson2314): This is here to keep the old semantics, remove when
       # no package has `doCheck = true`.


### PR DESCRIPTION
Just a once-over of the file, changing a few small things that can save on evaluation time.

Since I'd prefer not to eval-the-world for every change, I choose to eval `pkgs.git` for each commit defined here with a custom jq script.

```jsonc
// First commit performance diff
{
  "attrset": {
    "lookups": 0,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -3
  },
  "memory": {
    "envs": -11000,
    "list": 0,
    "sets": 0,
    "symbols": -26,
    "values": -22000,
    "total": -33026
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": -1375,
    "thunksAvoided": 0
  }
}

// Second commit performance diff
{
  "attrset": {
    "lookups": 0,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -6
  },
  "memory": {
    "envs": -11520,
    "list": 0,
    "sets": 0,
    "symbols": -33,
    "values": -13968,
    "total": -25521
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": -873,
    "thunksAvoided": -306
  }
}

❯ jq -s -f merge.jq 3.json 4.json
{
  "attrset": {
    "lookups": 0,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": 0
  },
  "memory": {
    "envs": -11000,
    "list": 0,
    "sets": 0,
    "symbols": -11,
    "values": -22000,
    "total": -33011
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": -1375,
    "thunksAvoided": 0
  }
}

// Fourth commit performance diff
{
  "attrset": {
    "lookups": 0,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -1
  },
  "memory": {
    "envs": -11000,
    "list": 0,
    "sets": 0,
    "symbols": -17,
    "values": -22000,
    "total": -33017
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": -1375,
    "thunksAvoided": 0
  }
}

// Fifth commit performance diff
{
  "attrset": {
    "lookups": -253,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -9
  },
  "memory": {
    "envs": 0,
    "list": 0,
    "sets": 0,
    "symbols": 0,
    "values": 0,
    "total": 0
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": 0,
    "thunksAvoided": 0
  }
}
// Sixth commit performance diff
{
  "attrset": {
    "lookups": 43,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": 1
  },
  "memory": {
    "envs": -11000,
    "list": 0,
    "sets": 0,
    "symbols": -9,
    "values": -22000,
    "total": -33009
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": -1375,
    "thunksAvoided": 0
  }
}

// Seventh commit performance diff
{
  "attrset": {
    "lookups": -4145,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -3
  },
  "memory": {
    "envs": -35336,
    "list": -12000,
    "sets": -23328,
    "symbols": 0,
    "values": -41600,
    "total": -112264
  },
  "speed": {
    "primops": -1500,
    "functionCalls": -1514,
    "thunksMade": -2600,
    "thunksAvoided": -400
  }
}

// Eighth commit performance diff
{
  "attrset": {
    "lookups": -1744,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -10
  },
  "memory": {
    "envs": 0,
    "list": 0,
    "sets": 0,
    "symbols": 0,
    "values": -5216,
    "total": -5216
  },
  "speed": {
    "primops": -1701,
    "functionCalls": 0,
    "thunksMade": -326,
    "thunksAvoided": -1375
  }
}

// Ninth commit performance diff
{
  "attrset": {
    "lookups": 15,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -12
  },
  "memory": {
    "envs": 0,
    "list": 0,
    "sets": 0,
    "symbols": 0,
    "values": 0,
    "total": 0
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": 0,
    "thunksAvoided": -11808
  }
}

// Tenth commit performance diff (the big one)
{
  "attrset": {
    "lookups": 0,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -46
  },
  "memory": {
    "envs": 66000,
    "list": -47472,
    "sets": 0,
    "symbols": 110,
    "values": -152032,
    "total": -133394
  },
  "speed": {
    "primops": -11818,
    "functionCalls": 0,
    "thunksMade": -9502,
    "thunksAvoided": -5914
  }
}

// Eleventh commit performance diff
{
  "attrset": {
    "lookups": -326,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": 0
  },
  "parser": {
    "expressions": -29
  },
  "memory": {
    "envs": -5216,
    "list": 0,
    "sets": 0,
    "symbols": 0,
    "values": -5216,
    "total": -10432
  },
  "speed": {
    "primops": 0,
    "functionCalls": 0,
    "thunksMade": -326,
    "thunksAvoided": 0
  }
}

// Twelfth commit performance diff
{
  "attrset": {
    "lookups": -28,
    "merges": 0,
    "mergeCopies": 0
  },
  "list": {
    "concats": -76
  },
  "parser": {
    "expressions": -16
  },
  "memory": {
    "envs": -1344,
    "list": -12768,
    "sets": 0,
    "symbols": 0,
    "values": -22896,
    "total": -37008
  },
  "speed": {
    "primops": -56,
    "functionCalls": -84,
    "thunksMade": -1431,
    "thunksAvoided": 1159
  }
}
```

For posterity, here's the jq script used:
```jq
def prettify: {
  "attrset": {
    "lookups": .nrLookups,
    "merges": .nrOpUpdates,
    "mergeCopies": .nrOpUpdateValuesCopied
  },
  "list": {
    "concats": .list.concats,
  },
  "parser": {
    expressions: .nrExprs
  },
  "memory": {
    "envs": .envs.bytes,
    "list": .list.bytes,
    "sets": .sets.bytes,
    "symbols": .symbols.bytes,
    "values": .values.bytes,
    "total": .envs.bytes + .list.bytes + .sets.bytes + .symbols.bytes + .values.bytes
  },
  "speed": {
    "primops": .nrPrimOpCalls,
    "functionCalls": .nrFunctionCalls,
    "thunksMade": .nrThunks,
    "thunksAvoided": .nrAvoided,
  }
};

[(.[] | prettify)] as [$stats_before, $stats_after] |
reduce ($stats_before | paths(numbers)) as $path (
  $stats_after;
    setpath(
      $path;
      getpath($path) as $after |
      ($stats_before | getpath($path)) as $before |
      if $before == 0 then
        false
      else
        ($after - $before)
      end
    )
)
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
