### PR TITLE
Fixing the vega CLI "Jq not found" error

### DIFF
--- a/pkgs/by-name/ve/vega-cli/package.nix
+++ b/pkgs/by-name/ve/vega-cli/package.nix
@@ -72,6 +72,9 @@ buildNpmPackage (finalAttrs: {
     description = "Command line tools for the Vega visualization grammar";
     homepage = "https://vega.github.io/vega/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = with lib.maintainers; [
+      pyrox0
+      philocalyst
+    ];
   };
 })

--- a/pkgs/by-name/ve/vega-cli/package.nix
+++ b/pkgs/by-name/ve/vega-cli/package.nix
@@ -73,7 +73,6 @@ buildNpmPackage (finalAttrs: {
     homepage = "https://vega.github.io/vega/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      pyrox0
       philocalyst
     ];
   };

--- a/pkgs/by-name/ve/vega-cli/package.nix
+++ b/pkgs/by-name/ve/vega-cli/package.nix
@@ -27,8 +27,8 @@ buildNpmPackage (finalAttrs: {
       --replace-fail "npm run data" "true"
 
     # Patch lerna.json to not use nx
-    mv lerna.json lerna.old.json
-    ${jq}/bin/jq '. + {useNx: false}' < lerna.old.json > lerna.json
+    ${jq}/bin/jq '. + {useNx: false}' lerna.json > lerna.json.tmp
+    mv lerna.json.tmp lerna.json
   '';
 
   npmDepsHash = "sha256-mBe1fHnhor7ZR8CuRNs1zD7JzaZXZI5VM7mdAieVKqE=";

--- a/pkgs/by-name/ve/vega-cli/package.nix
+++ b/pkgs/by-name/ve/vega-cli/package.nix
@@ -28,7 +28,7 @@ buildNpmPackage (finalAttrs: {
 
     # Patch lerna.json to not use nx
     mv lerna.json lerna.old.json
-    jq '. + {useNx: false}' < lerna.old.json > lerna.json
+    ${jq}/bin/jq '. + {useNx: false}' < lerna.old.json > lerna.json
   '';
 
   npmDepsHash = "sha256-mBe1fHnhor7ZR8CuRNs1zD7JzaZXZI5VM7mdAieVKqE=";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Was getting:
```
error: builder for '/nix/store/b959bv5176jrfp40zmqd4hcrssc15dws-vega-cli-6.2.0-npm-deps.drv' failed with exit code 127

last 7 log lines:
> Running phase: unpackPhase
> unpacking source archive /nix/store/nn8jngzsqbwv8d7007f09ypsjrkj5w05-source
> source root is source
> Running phase: patchPhase
> patching script interpreter paths in scripts/postinstall.sh
> scripts/postinstall.sh: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/s0psayl7zvkvwdcqc8fy1sbv8rlf1yq8-bash-5.3p9/bin/bash"
> /nix/store/n2x56qqqs07kmkfnjgk7fi5l6d9kvk5j-stdenv-darwin/setup: line 274: jq: command not found

For full logs, run:
  nix log /nix/store/b959bv5176jrfp40zmqd4hcrssc15dws-vega-cli-6.2.0-npm-deps.drv

error: 1 dependencies of derivation '/nix/store/8q8pwqgb12dfx071gyr0glvxddixh7sn-vega-cli-6.2.0.drv' failed to build
```

Cannot reproduce now, which is a bit jarring, but this was my best guess as to why things failed. On nix-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
