### PR TITLE
prettier: pin yarn-berry_4 to 4.9.2

### DIFF
--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -5,7 +5,7 @@
   nodejs,
   stdenv,
   versionCheckHook,
-  yarn-berry,
+  yarn-berry_4,
   plugins ? [ ],
 }:
 let
@@ -68,6 +68,17 @@ let
         pathAbsoluteNaive -> ${pathAbsoluteNaive}
         pathAbsoluteFallback -> ${pathAbsoluteFallback}
       '' throw "${plugin.pname}: does not provide parse-able entry point";
+
+  yarnVersion = "4.9.2";
+  yarn-berry = yarn-berry_4.overrideAttrs (old: {
+    version = yarnVersion;
+    src = fetchFromGitHub {
+      owner = "yarnpkg";
+      repo = "berry";
+      tag = "@yarnpkg/cli/${yarnVersion}";
+      hash = "sha256-MZB70hgPiQuHHLibhrGZ11vcvtZsCDkqR1NxSq8bXps=";
+    };
+  });
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "prettier";

--- a/pkgs/by-name/ya/yarn-berry/package.nix
+++ b/pkgs/by-name/ya/yarn-berry/package.nix
@@ -55,6 +55,10 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = ./update.sh;
 
+    yarnBerryCheckVersionHook = callPackage ./yarn-berry-check-version-hook.nix {
+      yarnVersion = finalAttrs.version;
+    };
+
     tests = {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;

--- a/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.nix
+++ b/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.nix
@@ -1,0 +1,16 @@
+{
+  makeSetupHook,
+  jq,
+  yarnVersion,
+}:
+
+makeSetupHook {
+  name = "yarn-berry-check-version-hook";
+  substitutions = {
+    inherit yarnVersion;
+    jq = "${jq}/bin/jq";
+  };
+  meta = {
+    description = "Check if the version in package.json matches the available version of Yarn";
+  };
+} ./yarn-berry-check-version-hook.sh

--- a/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.sh
+++ b/pkgs/by-name/ya/yarn-berry/yarn-berry-check-version-hook.sh
@@ -1,0 +1,17 @@
+yarnBerryCheckVersionHook() {
+  if [[ -z "$yarnBerryCheckVersionHookPackageJson" ]]; then
+    yarnBerryCheckVersionHookPackageJson="package.json"
+  fi
+
+  YARN_VERSION="@yarnVersion@"
+  PACKAGE_MANAGER=$(@jq@ -r .packageManager $yarnBerryCheckVersionHookPackageJson)
+  echo "Yarn version is $YARN_VERSION"
+  echo "Package manager in package.json is $PACKAGE_MANAGER"
+
+  if [[ "$PACKAGE_MANAGER" != "yarn@$YARN_VERSION" ]]; then
+    echo "The value for package manager in package.json doesn't match the version of Yarn that has been provided in this builder"
+    exit 1
+  fi
+}
+
+preConfigureHooks+=(yarnBerryCheckVersionHook)


### PR DESCRIPTION
## Things done

See #513716

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
