### PR TITLE
python3Packages.pyclip: unbreak on darwin

### DIFF
--- a/pkgs/development/python-modules/pyclip/default.nix
+++ b/pkgs/development/python-modules/pyclip/default.nix
@@ -39,8 +39,11 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
+  # Tests require `pbcopy` and `pbpaste` on darwin, which are dependencies that are not
+  # available in the build environemt.
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Cross-platform clipboard utilities supporting both binary and text data";
     mainProgram = "pyclip";
     homepage = "https://github.com/spyoungtech/pyclip";


### PR DESCRIPTION
Using `pyclip` works without any issues on `darwin`. Just the tests require `pbcopy` and `pbpaste` which we can't provide in the derivation. They are both system binaries provided by `macOS`. There might be a better way to fix the issue by for example faking them,  similar how pandas did it?  Since we need the functionality of both it probably doesn't work that way though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
