### PR TITLE
fetchPnpmDeps: don't fail on empty lockfile

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -162,9 +162,9 @@ in
               # See https://github.com/NixOS/nixpkgs/pull/350063
               # See https://github.com/NixOS/nixpkgs/issues/422889
               if [[ ${toString fetcherVersion} -ge 2 ]]; then
-                find $storePath -type f -name "*-exec" -print0 | xargs -0 chmod 555
-                find $storePath -type f -not -name "*-exec" -print0 | xargs -0 chmod 444
-                find $storePath -type d -print0 | xargs -0 chmod 555
+                find $storePath -type f -name "*-exec" -print0 | xargs --no-run-if-empty -0 chmod 555
+                find $storePath -type f -not -name "*-exec" -print0 | xargs --no-run-if-empty -0 chmod 444
+                find $storePath -type d -print0 | xargs --no-run-if-empty -0 chmod 555
               fi
 
               if [[ ${toString fetcherVersion} -ge 3 ]]; then

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -170,6 +170,8 @@ in
 
   php = recurseIntoAttrs (callPackages ./php { });
 
+  pnpm = recurseIntoAttrs (callPackages ./pnpm { });
+
   go = recurseIntoAttrs (callPackage ../build-support/go/tests.nix { });
 
   lake = callPackage ../build-support/lake/test { };

--- a/pkgs/test/pnpm/default.nix
+++ b/pkgs/test/pnpm/default.nix
@@ -1,0 +1,4 @@
+{ callPackage }:
+{
+  pnpm-empty-lockfile = callPackage ./pnpm-empty-lockfile { };
+}

--- a/pkgs/test/pnpm/pnpm-empty-lockfile/default.nix
+++ b/pkgs/test/pnpm/pnpm-empty-lockfile/default.nix
@@ -1,0 +1,32 @@
+{
+  pkgs,
+  stdenv,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+}:
+stdenv.mkDerivation {
+  name = "pnpm-empty-lockfile";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pnpm_10
+    pnpmConfigHook
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    pname = "pnpm-empty-lockfile";
+    fetcherVersion = 3;
+    pnpm = pnpm_10;
+    src = ./.;
+    hash = "sha256-u0GOAX5B1f2ANWbOezScp/eKQRRZA/JoYfQ5zLrNip4=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    touch $out
+    runHook postBuild
+  '';
+}

--- a/pkgs/test/pnpm/pnpm-empty-lockfile/package.json
+++ b/pkgs/test/pnpm/pnpm-empty-lockfile/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "pnpm-empty-lockfile",
+    "main": "main.mjs",
+    "dependencies": {
+    }
+}

--- a/pkgs/test/pnpm/pnpm-empty-lockfile/pnpm-lock.yaml
+++ b/pkgs/test/pnpm/pnpm-empty-lockfile/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
If the lockfile is empty, no files will be put in the output directory.  In this case, the find invocations produce an empty list of results.  xargs' default behaviour is to always invoke its command at least once;  if its input is empty, then its command will not be passed any  filenames. This produces an invocation like `chmod 555`, with no further operands. chmod, however,  fails in this case, expecting an operand. So we need to tell xargs not  to invoke its command at all in the case of empty input.

I went looking for some examples of fetchPnpmDeps tests to pattern off, since this is an almost ideal bug to have a regression test for (literally no network access needed!), but I couldn't find any; figuring out a good way to set up tests for it is more effort than I want to spend on this, so no test is being added. If there are some and I just missed them, I'm happy to amend the PR and add to their number. In their absence, I offer an assurance that I have manually tested it and found the patch fixed the failure I saw (albeit rebased on a commit from a few days ago instead of the present master).

Because this is only fixing a case that was failing builds before, this shouldn't change any previously-working output and hence isn't a fetcher version change. (I think, anyway!)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
