### PR TITLE
ceph: ship upstream tmpfiles.d configuration

### DIFF
--- a/pkgs/by-name/ce/ceph/ceph.nix
+++ b/pkgs/by-name/ce/ceph/ceph.nix
@@ -352,10 +352,13 @@ stdenv.mkDerivation {
     # silently drop it with misconfigurations.
     test -f $out/bin/ceph-volume
 
+    install -m 0644 -D $src/systemd/ceph.tmpfiles.d $out/lib/tmpfiles.d/ceph.conf
+
     # Assert that getopt patch from preConfigure covered all instances
     ! grep -F -r 'GETOPT=getopt' $out
     ! grep -F -r 'GETOPT=/usr/local/bin/getopt' $out
 
+    # client output
     mkdir -p $client/{bin,etc,$sitePackages,share/bash-completion/completions}
     cp -r $out/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $client/bin
     cp -r $out/bin/ceph-{authtool,conf,dencoder,rbdnamer,syn} $client/bin


### PR DESCRIPTION
Ceph does have some (very minor) *tmpfiles.d* configuration which would be useful to ship. However the upstream build process relegates installing those files to the distro packaging, which in our case is here. For a more in-depth explanation there is [a summary comment on my research](https://redirect.github.com/NixOS/nixpkgs/pull/512912#discussion_r3143802592) in the PR where this was brought up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
