### PR TITLE
python3Packages.virtualenv: 20.36.1 -> 21.2.4

### DIFF
--- a/pkgs/development/python-modules/filelock/default.nix
+++ b/pkgs/development/python-modules/filelock/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   hatch-vcs,
   hatchling,
   pytest-asyncio,
@@ -12,12 +12,14 @@
 
 buildPythonPackage rec {
   pname = "filelock";
-  version = "3.20.3";
+  version = "3.29.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-GMV+6RXH7GHP8Oz38Phpk2x8MBkbsM9AbxNBd40INOE=";
+  src = fetchFromGitHub {
+    owner = "tox-dev";
+    repo = "filelock";
+    tag = version;
+    hash = "sha256-efBEyjuCcLkHsfpG61eKN6ALk4QW4UMdNmD56rSgFLc=";
   };
 
   build-system = [
@@ -43,7 +45,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/tox-dev/py-filelock/releases/tag/${version}";
     description = "Platform independent file lock for Python";
     homepage = "https://github.com/benediktschmitt/py-filelock";
-    license = lib.licenses.unlicense;
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/virtualenv/default.nix
+++ b/pkgs/development/python-modules/virtualenv/default.nix
@@ -12,19 +12,20 @@
   pytest-freezer,
   pytest-mock,
   pytestCheckHook,
+  python-discovery,
   time-machine,
 }:
 
 buildPythonPackage rec {
   pname = "virtualenv";
-  version = "20.36.1";
+  version = "21.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "virtualenv";
     tag = version;
-    hash = "sha256-8fiC7+9FzQnmoI+N4cA5kKBLH9tpU7LXZ7pVj8Bz8Wc=";
+    hash = "sha256-3Ed2h5zzjpm+D1fQW2urWYcO/6sFGuZtueQxUnIu3MY=";
   };
 
   build-system = [
@@ -36,6 +37,7 @@ buildPythonPackage rec {
     distlib
     filelock
     platformdirs
+    python-discovery
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Diff: https://github.com/pypa/virtualenv/compare/20.36.1...21.2.4

Changelog: https://github.com/pypa/virtualenv/blob/21.2.4/docs/changelog.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
