### PR TITLE
openldap: bump syncrepl test sleep timeouts

### DIFF
--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -124,6 +124,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     rm -f tests/scripts/test063-delta-multiprovider
 
+    # syncrepl tests wait a fixed $SLEEP1/$SLEEP2 and then compare once
+    # without retrying, which is flaky on heavily loaded builders
+    export SLEEP1=15 SLEEP2=30
+
     # https://bugs.openldap.org/show_bug.cgi?id=10009
     # can probably be re-added once https://github.com/cyrusimap/cyrus-sasl/pull/772
     # has made it to a release


### PR DESCRIPTION
The syncrepl test scripts (test017, test019, etc.) wait a fixed `$SLEEP1`/`$SLEEP2` interval for replication to catch up and then compare provider/consumer databases once without retrying. On heavily loaded or slower (e.g. i686-linux) builders the default 7s/15s is not always enough, causing intermittent "provider and consumer databases differ" failures.

Raise `SLEEP1`/`SLEEP2` to 15s/30s, which the test suite already supports via environment variables, instead of skipping individual tests.

## Things done

- [x] Built on platform(s) - TODO
  - [ ] x86_64-linux
  - [ ] i686-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).