### PR TITLE
keyscope: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/by-name/ke/keyscope/package.nix
+++ b/pkgs/by-name/ke/keyscope/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "keyscope";
-  version = "1.4.0";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "spectralops";
     repo = "keyscope";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2DhKiQixhTCQD/SYIQa+o1kzEsslu6wAReuWr0rTrH8=";
+    hash = "sha256-PjuBRxW42DIOyHPqs5sOFBUrPPzVVoYAeKtyIWfA+28=";
   };
 
-  cargoHash = "sha256-f4r0zZTkVDfycrGqRCaBQrncpAm0NP6XYkj3w7fzQeY=";
+  cargoHash = "sha256-Oi/F89uRuwqWTa7E/PDVdj/VAnYYeG0BSs+pM41AXCU=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Update to 1.4.2


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
