### PR TITLE
nixos/rauthy: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -147,6 +147,8 @@
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
+- [Rauthy](https://github.com/sebadob/rauthy), a lightweight and easy to use Identity Provider supporting OpenID Connect, OAuth 2, and PAM. Available as [services.rauthy](#opt-services.rauthy.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1525,6 +1525,7 @@
   ./services/security/pass-secret-service.nix
   ./services/security/physlock.nix
   ./services/security/pocket-id.nix
+  ./services/security/rauthy.nix
   ./services/security/reaction.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix

--- a/nixos/modules/services/security/rauthy.nix
+++ b/nixos/modules/services/security/rauthy.nix
@@ -1,0 +1,182 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.rauthy;
+  format = pkgs.formats.toml { };
+  settings = format.generate "rauthy-config.toml" cfg.settings;
+in
+{
+  options.services.rauthy = {
+    enable = lib.mkEnableOption "Rauthy";
+    package = lib.mkPackageOption pkgs "rauthy" { };
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      description = ''
+        Configuration for Rauthy. See the
+        [Rauthy documentation](https://sebadob.github.io/rauthy/config/config.html)
+        for possible options.
+
+        You can generate a base config using Rauthy's config wizard:
+        ```bash
+        nix-shell -p rauthy --run "rauthy generate-config --output-file config.toml"
+        ```
+
+        To convert the config file to Nix, use
+        `builtins.fromTOML (builtins.readFile ./config.toml)`
+        or run the following command:
+        ```bash
+        nix-shell -p toml2nix --run "cat config.toml | toml2nix"
+        ```
+
+        ::: {.caution}
+        The settings will be stored in the world-readable Nix store.
+        Use {option}`services.rauthy.environmentFile` instead for setting secrets.
+        :::
+      '';
+    };
+    environmentFile = lib.mkOption {
+      type = lib.types.oneOf [
+        lib.types.str
+        lib.types.path
+      ];
+      default = "";
+      description = ''
+        Environment file to pass to Rauthy. Use this option to set secrets.
+        See the
+        [Rauthy documentation](https://sebadob.github.io/rauthy/config/config.html)
+        for possible environment variables.
+      '';
+    };
+    enableUnixSocket = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable a UNIX domain socket at `/run/rauthy/rauthy.sock`
+        instead of listening on an IP address and port.
+
+        Make sure to set {option}`services.rauthy.settings.server.scheme`
+        to `unix_http` or `unix_https`.
+      '';
+    };
+    configurePostgres = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to use PostgreSQL instead of Hiqlite.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          cfg.enableUnixSocket
+          && cfg.settings ? server.scheme
+          && (cfg.settings.server.scheme == "unix_http" || cfg.settings.server.scheme == "unix_https");
+        message =
+          "`services.rauthy.settings.server.scheme` must be set to 'unix_http' "
+          + "or 'unix_https' when `services.rauthy.enableUnixSocket` is enabled.";
+      }
+    ];
+
+    services.postgresql = lib.mkIf cfg.configurePostgres {
+      enable = true;
+      ensureDatabases = [ "rauthy" ];
+      ensureUsers = [
+        {
+          name = "rauthy";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    systemd.services.rauthy = {
+      description = "Rauthy";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ] ++ lib.optional cfg.configurePostgres "postgresql.target";
+      requires = lib.mkIf cfg.configurePostgres [ "postgresql.target" ];
+      wants = [ "network-online.target" ];
+      environment = lib.mkMerge [
+        (lib.mkIf cfg.enableUnixSocket { LISTEN_ADDRESS = "%t/rauthy/rauthy.sock"; })
+        (lib.mkIf cfg.configurePostgres {
+          HIQLITE = "false";
+          PG_DB_NAME = "rauthy";
+          PG_HOST = "%t/postgresql";
+          PG_PORT = "5432";
+          PG_USER = "rauthy";
+          PG_TLS = "disable";
+          PG_PASSWORD = "";
+        })
+      ];
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve --config-file ${settings}";
+        DynamicUser = true;
+        StateDirectory = "rauthy";
+        WorkingDirectory = "%S/rauthy";
+        RuntimeDirectory = lib.mkIf cfg.enableUnixSocket "rauthy";
+        RuntimeDirectoryMode = lib.mkIf cfg.enableUnixSocket "750";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != "") [ cfg.environmentFile ];
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
+        AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+        PrivateTmp = "disconnected";
+        ProcSubset = "pid";
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = [
+          "~cgroup"
+          "~ipc"
+          "~mnt"
+          "~net"
+          "~pid"
+          "~user"
+          "~uts"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@clock"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@swap"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    ungeskriptet
+  ];
+}


### PR DESCRIPTION
Add a module for Rauthy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
