### PR TITLE
restman: 0.3.0 -> 0.4.9

### DIFF
--- a/pkgs/by-name/re/restman/package.nix
+++ b/pkgs/by-name/re/restman/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   buildGoModule,
   testers,
   restman,
@@ -8,16 +9,24 @@
 
 buildGoModule (finalAttrs: {
   pname = "restman";
-  version = "0.3.0";
+  version = "0.4.9";
 
   src = fetchFromGitHub {
     repo = "restman";
     owner = "jackMort";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-KN3iahDdPSHPnGEacsmaVMRNI3mV9qrH3HyJOTtB2hA=";
+    hash = "sha256-advp7w9SbMKcuvQhR7pF95VV4J6hUl8rV+9Uu4EaGpc=";
   };
 
-  vendorHash = "sha256-hXd7E6yowuY3+ZpGyCzlcqwFqFrQzXBWYRMjsrxBlwI=";
+  patches = [
+    (fetchpatch {
+      # fix for tests committed shortly after 0.4.9
+      url = "https://github.com/jackMort/Restman/commit/2d5edd4e4faa0499bf93741fed250f8f13efa9c3.patch";
+      hash = "sha256-Mv7+eAKczR4YZDdevK60I1WZrmEumqsXhXMQVwu1zLo=";
+    })
+  ];
+
+  vendorHash = "sha256-+qjJhDQvZi+SstE2uo+2hsoG2MTRdI6d79Vga3/7gTY=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 0.4.9

Add patch that fixes app test.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
