### PR TITLE
nixos: Set mmap ASLR entropy dynamically

### DIFF
--- a/nixos/modules/config/sysctl.nix
+++ b/nixos/modules/config/sysctl.nix
@@ -66,11 +66,32 @@ in
 
   config = {
 
-    environment.etc."sysctl.d/60-nixos.conf".text = lib.concatStrings (
-      lib.mapAttrsToList (
-        n: v: lib.optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
-      ) config.boot.kernel.sysctl
-    );
+    environment.etc = {
+      "sysctl.d/55-nixos-aslr-entropy.conf".source =
+        pkgs.runCommand "55-nixos-aslr-entropy.conf"
+          {
+            inherit (config.boot.kernelPackages.kernel) configfile;
+          }
+          ''
+            mmap_rnd_bits_max=$(grep "^CONFIG_ARCH_MMAP_RND_BITS_MAX=" $configfile | grep --only-matching "[0-9]*$")
+            if [[ -z "$mmap_rnd_bits_max" ]]; then
+              echo "Unable to determine mmap_rnd_bits_max. Check your kernel configfile is valid."
+              exit 1
+            fi
+            mmap_rnd_compat_bits_max=$(grep "^CONFIG_ARCH_MMAP_RND_COMPAT_BITS_MAX=" $configfile | grep --only-matching "[0-9]*$")
+            if [[ -z "$mmap_rnd_compat_bits_max" ]]; then
+              echo "Unable to determine mmap_rnd_compat_bits_max. Check your kernel configfile is valid."
+              exit 1
+            fi
+            echo "vm.mmap_rnd_bits=$mmap_rnd_bits_max" >> $out
+            echo "vm.mmap_rnd_compat_bits=$mmap_rnd_compat_bits_max" >> $out
+          '';
+      "sysctl.d/60-nixos.conf".text = lib.concatStrings (
+        lib.mapAttrsToList (
+          n: v: lib.optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
+        ) config.boot.kernel.sysctl
+      );
+    };
 
     systemd.services.systemd-sysctl = {
       wantedBy = [ "multi-user.target" ];
@@ -92,20 +113,6 @@ in
       # the value below is used by default on several other distros.
       "fs.inotify.max_user_instances" = lib.mkDefault 524288;
       "fs.inotify.max_user_watches" = lib.mkDefault 524288;
-
-      # Maximise address space randomisation.
-      "vm.mmap_rnd_bits" = lib.mkMerge [
-        (lib.mkIf pkgs.stdenv.hostPlatform.isAarch64 (
-          # Ideally, we'd want to set this to 33 on 4K pagesize
-          # kernels, but some vendor kernels e.g. linux_rpi can
-          # do a maximum of 24.
-          lib.mkDefault 24
-        ))
-        (lib.mkIf pkgs.stdenv.hostPlatform.isx86_64 (lib.mkDefault 32))
-      ];
-      "vm.mmap_rnd_compat_bits" = lib.mkIf (
-        pkgs.stdenv.hostPlatform.isx86_64 || pkgs.stdenv.hostPlatform.isAarch64
-      ) (lib.mkDefault 16);
     };
   };
 }


### PR DESCRIPTION
This determines the correct maximum value on mainline (33), Asahi (31) & linux_rpi (24).

We could theoretically always do this regardless of the arch. I don't know if that's a good idea.


Related:
https://github.com/NixOS/nixpkgs/pull/510943
https://github.com/NixOS/nixpkgs/pull/513672


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
