### PR TITLE
python3Packages: transition from pytestFlagsArray (round 3) and ban pytestFlagsArray

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -168,6 +168,10 @@
 
 - the `xorg` package set has been deprecated, packages have moved to the top level.
 
+- `python3Packages.buildPythonPackage` and `python3Packages.buildPythonApplication` now throw errors in the presence of `pytestFlagsArray`.
+  Please use [`pytestFlags` and `(enabled|disabled)(TestPaths|Tests|TestMarks)`](#using-pytestcheckhook) instead.
+  If modifying the Nix expression is not feasible, users can remediate the error by overriding `pytestFlagsArray` with `null` or `[ ]`.
+
 - `python3Packages.pygame` has been been renamed to `python3Packages.pygame-original`, the attribute `python3Packages.pygame` will from python 3.14 default to the more actively maintained `python3Packages.pygame-ce`
 
 - `fastly` has been updated to major version 14. For more information, you can check the [release notes](https://github.com/fastly/cli/releases/tag/v14.0.0)

--- a/pkgs/by-name/kh/khard/package.nix
+++ b/pkgs/by-name/kh/khard/package.nix
@@ -60,7 +60,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     python3.pkgs.pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # Nixpkgs' default is `--capture=fd`, and with it, 2 command mock tests
     # fail, see: https://github.com/lucc/khard/issues/353
     "--capture=no"

--- a/pkgs/by-name/op/openfreebuds/package.nix
+++ b/pkgs/by-name/op/openfreebuds/package.nix
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "openfreebuds/driver/huawei/test/"
     "openfreebuds/test/test_event_bus.py"
   ];

--- a/pkgs/by-name/yb/yb/package.nix
+++ b/pkgs/by-name/yb/yb/package.nix
@@ -66,7 +66,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   # Run subset of tests that don't require YubiKey hardware
   doCheck = true;
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests"
   ];
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -112,6 +112,9 @@ lib.extendMkDerivation {
     "dependencies"
     "optional-dependencies"
     "build-system"
+
+    # Deprecated arguments
+    "pytestFlagsArray"
   ];
 
   extendDrvArgs =
@@ -439,6 +442,19 @@ lib.extendMkDerivation {
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
       installCheckPhase = attrs.checkPhase;
     }
+    // (
+      let
+        deprecatedFlagNotEmpty =
+          attrs ? pytestFlagsArray && attrs.pytestFlagsArray != null && attrs.pytestFlagsArray != [ ];
+        pos = builtins.unsafeGetAttrPos "pytestFlagsArray" attrs;
+      in
+      {
+        ${if deprecatedFlagNotEmpty then "pytestFlagsArray" else null} = throw ''
+          buildPythonPackage: Deprecated flag pytestFlagsArray found at ${pos.file}:${toString pos.line}
+            Use pytestFlags or (enabled|disabled)(TestPaths|Tests|TestMarks) instead.
+        '';
+      }
+    )
     //
       lib.mapAttrs
         (

--- a/pkgs/development/python-modules/connect-box/default.nix
+++ b/pkgs/development/python-modules/connect-box/default.nix
@@ -41,10 +41,9 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "connect_box" ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--vcr-record=none"
-    "-W"
-    "ignore::DeprecationWarning"
+    "-Wignore::DeprecationWarning"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/country-list/default.nix
+++ b/pkgs/development/python-modules/country-list/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "tests.py"
   ];
 

--- a/pkgs/development/python-modules/crewai/default.nix
+++ b/pkgs/development/python-modules/crewai/default.nix
@@ -552,7 +552,7 @@ buildPythonPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  pytestFlagsArray = [
+  pytestFlags = [
     "--override-ini=addopts="
   ];
 

--- a/pkgs/development/python-modules/django-jinja/default.nix
+++ b/pkgs/development/python-modules/django-jinja/default.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
     export DJANGO_SETTINGS_MODULE=settings
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "testapp/tests.py"
   ];
 

--- a/pkgs/development/python-modules/scanpy/default.nix
+++ b/pkgs/development/python-modules/scanpy/default.nix
@@ -180,7 +180,7 @@ buildPythonPackage (finalAttrs: {
     export NUMBA_CACHE_DIR=$(mktemp -d);
   '';
 
-  pytestFlagsArray = [
+  pytestFlags = [
     # UserWarning: 'where' used without 'out', expect unitialized memory in output.
     # If this is intentional, use out=None.
     "-Wignore::UserWarning"

--- a/pkgs/development/python-modules/sklearn2pmml/default.nix
+++ b/pkgs/development/python-modules/sklearn2pmml/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage (finalAttrs: {
     statsmodels
   ];
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     # Only run the main test suite; subpackage tests require
     # sklearn-pandas which is not available in nixpkgs
     "sklearn2pmml/tests"

--- a/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
@@ -127,7 +127,7 @@ buildPythonPackage (finalAttrs: {
     EOF
   '';
 
-  pytestFlagsArray = [
+  enabledTestPaths = [
     "e2e/python/tests"
     "tests/test_apps/python/smoke_test.py"
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Transition the 10 remaining `pytestFlagsArray` use cases to `pytestFlags` or `enabledTestPaths`, cleaning the leftover of PR #452102.
2. Throw errors against `pytestFlagsArray`.
   If modifying the Nix expression is not feasible, users can remediate the error by overriding `pytestFlagsArray` with `null` or `[ ]`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
