### PR TITLE
ready-check: 1.2.6 -> 1.7.0

### DIFF
--- a/pkgs/by-name/re/ready-check/package.nix
+++ b/pkgs/by-name/re/ready-check/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "ready-check";
-  version = "1.2.6";
+  version = "1.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sesh";
     repo = "ready";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j0UY2Q1jYGRtjvaWMwgMJrNaQZQnEJ5ST4o4PAVYWVc=";
+    hash = "sha256-QdYg2kemfZCY5RkEiry1U5eLStd10HdRpQHn7+hOL/g=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -22,6 +22,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   propagatedBuildInputs = with python3.pkgs; [
     beautifulsoup4
+    cryptography
     thttp
     tld
   ];


### PR DESCRIPTION
Update to 1.7.0

Adding additional python dep "cryptography"

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
