### PR TITLE
noto-fonts-monochrome-emoji: use installFonts, rootDir

### DIFF
--- a/pkgs/by-name/no/noto-fonts-monochrome-emoji/package.nix
+++ b/pkgs/by-name/no/noto-fonts-monochrome-emoji/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
   rename,
 }:
 
@@ -17,13 +18,12 @@ stdenvNoCC.mkDerivation {
     sparseCheckout = [ "ofl/notoemoji" ];
   };
 
-  installPhase = ''
-    runHook preInstall
+  sourceRoot = "source/ofl/notoemoji";
 
-    install -m444 -Dt $out/share/fonts/noto ofl/notoemoji/*.ttf
-    ${rename}/bin/rename 's/\[.*\]//' $out/share/fonts/noto/*
+  nativeBuildInputs = [ installFonts ];
 
-    runHook postInstall
+  postFixup = ''
+    ${rename}/bin/rename 's/\[.*\]//' $out/share/fonts/truetype/*
   '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/by-name/no/noto-fonts-monochrome-emoji/package.nix
+++ b/pkgs/by-name/no/noto-fonts-monochrome-emoji/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  rename,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -14,17 +14,10 @@ stdenvNoCC.mkDerivation {
     repo = "fonts";
     rev = "a73b9ab0a5df191bcfed817159a903911ea7958a";
     hash = "sha256-qVFU4uZius8oFPJCIL9ek2YdS3jru5mmTHp2L9RIXfg=";
-    sparseCheckout = [ "ofl/notoemoji" ];
+    rootDir = "ofl/notoemoji";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -m444 -Dt $out/share/fonts/noto ofl/notoemoji/*.ttf
-    ${rename}/bin/rename 's/\[.*\]//' $out/share/fonts/noto/*
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/by-name/no/noto-fonts-monochrome-emoji/update.sh
+++ b/pkgs/by-name/no/noto-fonts-monochrome-emoji/update.sh
@@ -18,7 +18,7 @@ newhash=$(nix-prefetch "{ stdenv, fetchurl }: stdenv.mkDerivation {
     owner = \"google\";
     repo = \"fonts\";
     rev = \"$newrev\";
-    sparseCheckout = [ \"ofl/notoemoji\" ];
+    rootDir = \"ofl/notoemoji\";
   };
 }")
 


### PR DESCRIPTION
Use `installFonts` hook as tracked in #495640.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
