### PR TITLE
picocrypt-ng: 2.00 -> 2.08

### DIFF
--- a/pkgs/by-name/pi/picocrypt-ng/package.nix
+++ b/pkgs/by-name/pi/picocrypt-ng/package.nix
@@ -11,22 +11,23 @@
   gtk3,
   pkg-config,
   wrapGAppsHook3,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "picocrypt-ng";
-  version = "2.00";
+  version = "2.08";
 
   src = fetchFromGitHub {
     owner = "Picocrypt-NG";
     repo = "Picocrypt-NG";
     tag = finalAttrs.version;
-    hash = "sha256-+Ecvy4h0aC9Gra9BcN8L/vgpnflq6W7KcnYCVr8uaQQ=";
+    hash = "sha256-dXIJTpoupfmHtxhnqroQaxrcTsW07G4zxSib1vs1DaA=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
-  vendorHash = "sha256-0fEy/YuZa7dENfL3y+NN4SLWYwOLmXqHHJEiU37AkX4=";
+  vendorHash = "sha256-qluJIsd7g2UNYQwsDW7ugVzh5Z0xJkHe6OlMt04d/cc=";
 
   ldflags = [
     "-s"
@@ -46,12 +47,13 @@ buildGoModule (finalAttrs: {
     copyDesktopItems
     pkg-config
     wrapGAppsHook3
+    writableTmpDirAsHomeHook
   ];
 
   env.CGO_ENABLED = 1;
 
   postInstall = ''
-    mv $out/bin/Picocrypt $out/bin/picocrypt-ng-gui
+    mv $out/bin/picocrypt $out/bin/picocrypt-ng-gui
     install -Dm644 $src/images/key.svg $out/share/icons/hicolor/scalable/apps/picocrypt-ng.svg
   '';
 
@@ -71,7 +73,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/Picocrypt-NG/Picocrypt-NG";
     changelog = "https://github.com/Picocrypt-NG/Picocrypt-NG/blob/${finalAttrs.version}/Changelog.md";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     mainProgram = "picocrypt-ng-gui";
   };
 })


### PR DESCRIPTION
update picocrypt-ng to 2.08

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
