### PR TITLE
noto-fonts-cjk-sans: use installFonts, finalAttrs and rootDir

### DIFF
--- a/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
   nixosTests,
   gitUpdater,
   static ? false,
@@ -22,13 +23,9 @@ stdenvNoCC.mkDerivation rec {
     ];
   };
 
-  installPhase =
-    let
-      font-path = if static then "Sans/OTC/*.ttc" else "Sans/Variable/OTC/*.otf.ttc";
-    in
-    ''
-      install -m444 -Dt $out/share/fonts/opentype/noto-cjk ${font-path}
-    '';
+  sourceRoot = "source/${if static then "Sans/OTC" else "Sans/Variable/OTC"}";
+
+  nativeBuildInputs = [ installFonts ];
 
   passthru.tests.noto-fonts = nixosTests.noto-fonts;
 

--- a/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
@@ -8,14 +8,14 @@
   static ? false,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noto-fonts-cjk-sans";
   version = "2.004";
 
   src = fetchFromGitHub {
     owner = "notofonts";
     repo = "noto-cjk";
-    tag = "Sans${version}";
+    tag = "Sans${finalAttrs.version}";
     hash = "sha256-i3ZKoSy2SVs46IViha+Sg8atH4n3ywgrunHPLtVT4Pk=";
     sparseCheckout = [
       "Sans/OTC"
@@ -55,4 +55,4 @@ stdenvNoCC.mkDerivation rec {
       emily
     ];
   };
-}
+})

--- a/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
+++ b/pkgs/by-name/no/noto-fonts-cjk-sans/package.nix
@@ -17,13 +17,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     repo = "noto-cjk";
     tag = "Sans${finalAttrs.version}";
     hash = "sha256-i3ZKoSy2SVs46IViha+Sg8atH4n3ywgrunHPLtVT4Pk=";
-    sparseCheckout = [
-      "Sans/OTC"
-      "Sans/Variable/OTC"
-    ];
+    rootDir = if static then "Sans/OTC" else "Sans/Variable/OTC";
   };
-
-  sourceRoot = "source/${if static then "Sans/OTC" else "Sans/Variable/OTC"}";
 
   nativeBuildInputs = [ installFonts ];
 


### PR DESCRIPTION
1. Move to `finalAttrs`.
2. Use `installFonts` hook as tracked in #495640.
3. Replace `sparseCheckout`+`sourceRoot` with `rootDir`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
