### PR TITLE
screenie: init at 20120406

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28680,6 +28680,13 @@
     githubId = 24815061;
     name = "Kevin De Baerdemaeker";
   };
+  ventu06 = {
+    name = "Eduardo Venturini";
+    email = "ventu06g@gmail.com";
+    github = "ventu06";
+    githubId = 35201396;
+    keys = [ { fingerprint = "65E8 A0BF 95E0 044E 952C  8D8C 0C22 EDEC CE5B 24CE"; } ];
+  };
   veprbl = {
     email = "veprbl@gmail.com";
     github = "veprbl";

--- a/pkgs/by-name/sc/screenie/package.nix
+++ b/pkgs/by-name/sc/screenie/package.nix
@@ -1,0 +1,63 @@
+{
+  fetchurl,
+  lib,
+  stdenv,
+  runCommand,
+  perl,
+  screen,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "screenie";
+  version = "20120406";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/screenie/screenie-${finalAttrs.version}.tar.gz";
+    hash = "sha256-g+XmSdOZTgPrkqDQoEoOx07jlzqDwcpLq5KPPTt22HA=";
+  };
+
+  buildInputs = [
+    perl
+    screen
+  ];
+
+  postPatch = ''
+    substituteInPlace screenie --replace-fail "my \$SCREEN = 'screen';" "my \$SCREEN = '${lib.getExe' screen "screen"}';"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/{bin,share/man/man1}
+    cp screenie $out/bin/
+    cp screenie.1 $out/share/man/man1/
+  '';
+
+  passthru.tests = {
+    help =
+      runCommand "${finalAttrs.pname}-test-help"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          screenie --help 2>&1 > help.txt || true
+          grep "screenie - terminal screen-session handler\." help.txt
+          touch $out
+        '';
+  };
+
+  meta = {
+    description = "Lightweight GNU screen wrapper";
+    homepage = "https://sourceforge.net/projects/screenie/";
+    license = lib.licenses.artistic1;
+    longDescription = ''
+      screenie is a small and lightweight screen wrapper designed to simplify session selection on a system with multiple screen sessions.
+      screenie provides simple interactive menu to select the existing screen session or to create a new one.
+    '';
+    mainProgram = "screenie";
+    maintainers = [ lib.maintainers.ventu06 ];
+    platforms = lib.platforms.unix;
+  };
+
+})


### PR DESCRIPTION
screenie is a small and lightweight screen(1) wrapper designed to simplify session selection on a system with multiple screen sessions. screenie provides simple interactive menu to select the existing screen session or to create a new one.

The [source code](https://sourceforge.net/projects/screenie/) is currently hosted on SourceForge and it consists on a simple perl program and a manpage.
The package is already present in others distributions repository, such as [Debian](https://packages.debian.org/forky/source/screenie) and [Fedora](https://packages.fedoraproject.org/pkgs/screenie/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
