### PR TITLE
free5gc: init; linuxKernel.packages.linux_6_6.gtp5g: init at 0.10.2

### DIFF
--- a/pkgs/by-name/fr/free5gc-amf/package.nix
+++ b/pkgs/by-name/fr/free5gc-amf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-amf";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "amf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oH01ySslrVhreFIYcEGs3jBZy37wylwhtz8f4VjSlgk=";
+  };
+
+  vendorHash = "sha256-plUoCtHK8/cuYmPosV7ISIlqZGJZUJ4L0Fd0cWV+3zo=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-amf/package.nix
+++ b/pkgs/by-name/fr/free5gc-amf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-amf";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "amf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oH01ySslrVhreFIYcEGs3jBZy37wylwhtz8f4VjSlgk=";
+  };
+
+  vendorHash = "sha256-plUoCtHK8/cuYmPosV7ISIlqZGJZUJ4L0Fd0cWV+3zo=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-amf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/amf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-amf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-ausf/package.nix
+++ b/pkgs/by-name/fr/free5gc-ausf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-ausf";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "ausf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S96QhcerwA2c/fW7J0C4HlcQVeSHrob4VCKOSd4iUpo=";
+  };
+
+  vendorHash = "sha256-8oATdtM8pA8KKgPHFCqsEM0Lo93ZBkoTqLRPfHywCOY=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-ausf/package.nix
+++ b/pkgs/by-name/fr/free5gc-ausf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-ausf";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "ausf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S96QhcerwA2c/fW7J0C4HlcQVeSHrob4VCKOSd4iUpo=";
+  };
+
+  vendorHash = "sha256-8oATdtM8pA8KKgPHFCqsEM0Lo93ZBkoTqLRPfHywCOY=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-ausf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/ausf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-ausf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-bsf/package.nix
+++ b/pkgs/by-name/fr/free5gc-bsf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-bsf";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "bsf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LIsLaAt3EZMUJBIVErFUP/DLrJnFhu+8WJMiKAgxUYE=";
+  };
+
+  vendorHash = "sha256-2T6Al3/Z7TCRIAk96ygT9LOe2hmqsyPfKuXqjW8LGig=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-bsf/package.nix
+++ b/pkgs/by-name/fr/free5gc-bsf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-bsf";
+  version = "1.0.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "bsf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LIsLaAt3EZMUJBIVErFUP/DLrJnFhu+8WJMiKAgxUYE=";
+  };
+
+  vendorHash = "sha256-2T6Al3/Z7TCRIAk96ygT9LOe2hmqsyPfKuXqjW8LGig=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-bsf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/bsf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-bsf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-chf/package.nix
+++ b/pkgs/by-name/fr/free5gc-chf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-chf";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "chf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rKAig3y7rGDoUpMoB5k58eIf+w7S3PhTsxObzLmUrmM=";
+  };
+
+  vendorHash = "sha256-/7GH6f4+Ao183AWxJIv6cndhoVE6Dnishgl8ER0knsQ=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-chf/package.nix
+++ b/pkgs/by-name/fr/free5gc-chf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-chf";
+  version = "1.2.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "chf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rKAig3y7rGDoUpMoB5k58eIf+w7S3PhTsxObzLmUrmM=";
+  };
+
+  vendorHash = "sha256-/7GH6f4+Ao183AWxJIv6cndhoVE6Dnishgl8ER0knsQ=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-chf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/chf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-chf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-n3iwf/package.nix
+++ b/pkgs/by-name/fr/free5gc-n3iwf/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-n3iwf";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "n3iwf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BFr+d8YQNXcHcOgYZxuh+IFJ9/nMxEEDtTgbzhiFKCY=";
+  };
+
+  vendorHash = "sha256-tvMyRV/a40ubPoT1uGxZ1g2q4qJ3K9fof7Xt5IN8vC4=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  checkFlags = [
+    "-skip TestCheckIKEMessage"
+    # --- FAIL: TestCheckIKEMessage (0.00s)
+    #     Error Trace:    /build/source/internal/ike/server_test.go:170
+    #     Error:          Received unexpected error: dial udp 10.100.100.2:500: connect: network is unreachable
+  ];
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-n3iwf/package.nix
+++ b/pkgs/by-name/fr/free5gc-n3iwf/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-n3iwf";
+  version = "1.3.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "n3iwf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BFr+d8YQNXcHcOgYZxuh+IFJ9/nMxEEDtTgbzhiFKCY=";
+  };
+
+  vendorHash = "sha256-tvMyRV/a40ubPoT1uGxZ1g2q4qJ3K9fof7Xt5IN8vC4=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-n3iwf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  checkFlags = [
+    "-skip TestCheckIKEMessage"
+    # --- FAIL: TestCheckIKEMessage (0.00s)
+    #     Error Trace:    /build/source/internal/ike/server_test.go:170
+    #     Error:          Received unexpected error: dial udp 10.100.100.2:500: connect: network is unreachable
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/n3iwf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-n3iwf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-nef/package.nix
+++ b/pkgs/by-name/fr/free5gc-nef/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-nef";
+  version = "1.2.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "nef";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FaLL+RMAub8weCzE68UL6ZpjMf2GRfoekt1X2QjtVEw=";
+  };
+
+  vendorHash = "sha256-GS86eLcF0hlnnMPFsKGfhsUDcnjMQVq30oe0KxEbAzQ=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-nef/package.nix
+++ b/pkgs/by-name/fr/free5gc-nef/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-nef";
+  version = "1.2.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "nef";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FaLL+RMAub8weCzE68UL6ZpjMf2GRfoekt1X2QjtVEw=";
+  };
+
+  vendorHash = "sha256-GS86eLcF0hlnnMPFsKGfhsUDcnjMQVq30oe0KxEbAzQ=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-nef
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/nef/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-nef";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-nrf/package.nix
+++ b/pkgs/by-name/fr/free5gc-nrf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-nrf";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "nrf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NACwoa5ulIkEPtbHO5sFIyTPu5CDlj+AOCedMgNx3z4=";
+  };
+
+  vendorHash = "sha256-xfrDXKcAJvYYjplBTXS7SezQX9rLhRomNXilFYVUyLM=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-nrf/package.nix
+++ b/pkgs/by-name/fr/free5gc-nrf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-nrf";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "nrf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NACwoa5ulIkEPtbHO5sFIyTPu5CDlj+AOCedMgNx3z4=";
+  };
+
+  vendorHash = "sha256-xfrDXKcAJvYYjplBTXS7SezQX9rLhRomNXilFYVUyLM=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-nrf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/nrf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-nrf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-nssf/package.nix
+++ b/pkgs/by-name/fr/free5gc-nssf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-nssf";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "nssf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ggX4SwQFEYJj8NrlEaQ4I5o+xzJdUQDWAfAMHnNunRU=";
+  };
+
+  vendorHash = "sha256-HqLxGpW15vHRNLyc6lwaFD5J9TVoqFqH+hFFiivgITQ=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-nssf/package.nix
+++ b/pkgs/by-name/fr/free5gc-nssf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-nssf";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "nssf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ggX4SwQFEYJj8NrlEaQ4I5o+xzJdUQDWAfAMHnNunRU=";
+  };
+
+  vendorHash = "sha256-HqLxGpW15vHRNLyc6lwaFD5J9TVoqFqH+hFFiivgITQ=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-nssf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/nssf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-nssf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-pcf/package.nix
+++ b/pkgs/by-name/fr/free5gc-pcf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-pcf";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "pcf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nxs29ikm/NQTnVc2ANzZxMqC9Usui4E+0GrL5taO9aM=";
+  };
+
+  vendorHash = "sha256-m1IqVKnsT7vWJMWHGrA4QB3aXIkGsIJQQ7NAGT/Th38=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-pcf/package.nix
+++ b/pkgs/by-name/fr/free5gc-pcf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-pcf";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "pcf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nxs29ikm/NQTnVc2ANzZxMqC9Usui4E+0GrL5taO9aM=";
+  };
+
+  vendorHash = "sha256-m1IqVKnsT7vWJMWHGrA4QB3aXIkGsIJQQ7NAGT/Th38=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-pcf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/pcf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-pcf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-smf/package.nix
+++ b/pkgs/by-name/fr/free5gc-smf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-smf";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "smf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V5Z0AZMloCRgsCI0j8j9dnb2a+gKhu3M29Po3wY0RMk=";
+  };
+
+  vendorHash = "sha256-8sVuhlLN00TxTaQFtETvsuAIoW3yjy/CBGF4PQp2XQ4=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-smf/package.nix
+++ b/pkgs/by-name/fr/free5gc-smf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-smf";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "smf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V5Z0AZMloCRgsCI0j8j9dnb2a+gKhu3M29Po3wY0RMk=";
+  };
+
+  vendorHash = "sha256-8sVuhlLN00TxTaQFtETvsuAIoW3yjy/CBGF4PQp2XQ4=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-smf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/smf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-smf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-tngf/package.nix
+++ b/pkgs/by-name/fr/free5gc-tngf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-tngf";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "tngf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rWSx4FCAA1QL7F66swPdhDcDr60TrtMnXhTlVBRR2OY=";
+  };
+
+  vendorHash = "sha256-C0zs4+ypC0LI5tkjrs5ajiWnoArHvdOoXj1iaNqSXM0=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-tngf/package.nix
+++ b/pkgs/by-name/fr/free5gc-tngf/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-tngf";
+  version = "1.1.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "tngf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rWSx4FCAA1QL7F66swPdhDcDr60TrtMnXhTlVBRR2OY=";
+  };
+
+  vendorHash = "sha256-C0zs4+ypC0LI5tkjrs5ajiWnoArHvdOoXj1iaNqSXM0=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-tngf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/tngf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-tngf";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-udm/package.nix
+++ b/pkgs/by-name/fr/free5gc-udm/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-udm";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "udm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sxksDLI3xV/vz48F9s3TUga6hORaqRTwIiCzeNS0Ijs=";
+  };
+
+  vendorHash = "sha256-dl9rNeh4NurAcTFsca2189ReFdg8e5sMjvVGfe8EMWc=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-udm/package.nix
+++ b/pkgs/by-name/fr/free5gc-udm/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-udm";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "udm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sxksDLI3xV/vz48F9s3TUga6hORaqRTwIiCzeNS0Ijs=";
+  };
+
+  vendorHash = "sha256-dl9rNeh4NurAcTFsca2189ReFdg8e5sMjvVGfe8EMWc=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-udm
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/udm/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-udm";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-udr/package.nix
+++ b/pkgs/by-name/fr/free5gc-udr/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-udr";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "udr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZfZ9amkKSL+C6ArUmZ+ckj7w++qI1/nlJmPHtsxFaf4=";
+  };
+
+  vendorHash = "sha256-LCUT9bkUr7telvQMvg/ZgsLu6352DOP3iy9cBhDjsj8=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  checkFlags = [
+    "-skip TestUDR_InfluData_CreateThenGet"
+    # --- FAIL: TestUDR_InfluData_CreateThenGet (30.00s)
+    #     Error Trace:    /build/source/internal/sbi/api_sanity_test.go:64
+    #     Error:          Expected nil, but got: topology.ServerSelectionError
+  ];
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-udr/package.nix
+++ b/pkgs/by-name/fr/free5gc-udr/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-udr";
+  version = "1.4.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "udr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZfZ9amkKSL+C6ArUmZ+ckj7w++qI1/nlJmPHtsxFaf4=";
+  };
+
+  vendorHash = "sha256-LCUT9bkUr7telvQMvg/ZgsLu6352DOP3iy9cBhDjsj8=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-udr
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  checkFlags = [
+    "-skip TestUDR_InfluData_CreateThenGet"
+    # --- FAIL: TestUDR_InfluData_CreateThenGet (30.00s)
+    #     Error Trace:    /build/source/internal/sbi/api_sanity_test.go:64
+    #     Error:          Expected nil, but got: topology.ServerSelectionError
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/udr/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-udr";
+  };
+})

--- a/pkgs/by-name/fr/free5gc-upf/package.nix
+++ b/pkgs/by-name/fr/free5gc-upf/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-upf";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "upf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BQKM8KtZyQWpNuW8G/nRvFBButAjcwPWDX8CEwd72PY=";
+  };
+
+  vendorHash = "sha256-i/UcpdPp6gnS9ituXxtEPscF/I/kDgDiwhTNmS4PHwM=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/fr/free5gc-upf/package.nix
+++ b/pkgs/by-name/fr/free5gc-upf/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "free5gc-upf";
+  version = "1.2.12";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "go-upf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MfQbHVEqnoFzUL5FPIE6dQSJxQD7PAZSbAgy/skHs+8=";
+  };
+
+  vendorHash = "sha256-VPm0Z67Sm/liIofVm1bI3/HU+lwYtwkg6zMRdZFZTZ8=";
+
+  ldflags = [
+    "-X github.com/free5gc/util/version.VERSION=v${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv -v $out/bin/cmd $out/bin/free5gc-upf
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "irrelevant"; # has no version flag, empty string didn't work
+
+  checkFlags =
+    let
+      # Skip tests that require gtp5g kernel module
+      # result in: create: operation not permitted or get family: no such file or directory
+      skippedTests = [
+        "TestGtp5g_CreateRules"
+        "TestNewFlowDesc"
+        "TestServer"
+        "TestWaitRoutineStopped"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source 5G core network based on 3GPP R15";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/go-upf/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+    mainProgram = "free5gc-upf";
+  };
+})

--- a/pkgs/os-specific/linux/gtp5g/default.nix
+++ b/pkgs/os-specific/linux/gtp5g/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  kmod,
+  kernel,
+  kernelModuleMakeFlags,
+
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gtp5g";
+  version = "0.10.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "free5gc";
+    repo = "gtp5g";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GJV7iLCbjHn6YxyWLFqS+EATWdZVbVBoJMZdTVG/8bo=";
+  };
+
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "KVER=${kernel.modDirVersion}"
+  ];
+
+  installPhase = ''
+    install -Dm644 gtp5g.ko "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/gtp5g.ko"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GTP-U Linux Kernel Module";
+    homepage = "https://free5gc.org/";
+    changelog = "https://github.com/free5gc/gtp5g";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ felbinger ];
+    broken = lib.versionAtLeast kernel.version "6.18";
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -345,6 +345,8 @@ in
 
         gcadapter-oc-kmod = callPackage ../os-specific/linux/gcadapter-oc-kmod { };
 
+        gtp5g = callPackage ../os-specific/linux/gtp5g { };
+
         hyperv-daemons = callPackage ../os-specific/linux/hyperv-daemons { };
 
         e1000e =


### PR DESCRIPTION
The free5GC is an open-source project for 5th generation (5G) mobile core networks.

5G networks are implemented as service based architecture (sba), they consist of many so called functions. Functions from different packages (like open5gs) can be used to build a network, which is why I packaged all 14 packages individual.

They do not share a common version number, so I left it out of the title for now. I'm not that experienced with nixpkgs yet, so please tell me which adjustments are necessary for this to be merged.

Should I move the functions to separate directories in `by-name/fr/` or make a derivation out of it (how? Maybe something with passthrough?)?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
