### PR TITLE
nixos/keycloak: Add option for configuring a vault

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -65,6 +65,9 @@
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],
+  "module-services-keycloak-vault": [
+    "index.html#module-services-keycloak-vault"
+  ],
   "module-services-tandoor-recipes-migrating-media-option-move": [
     "index.html#module-services-tandoor-recipes-migrating-media-option-move",
     "index.html#module-services-tandoor-recipes-migrating-media-option-1"

--- a/nixos/modules/services/web-apps/keycloak.md
+++ b/nixos/modules/services/web-apps/keycloak.md
@@ -128,6 +128,15 @@ Keycloak through [](#opt-services.keycloak.themes). See the
 ) and the description of the aforementioned NixOS option for
 more information.
 
+## Secret vault {#module-services-keycloak-vault}
+
+The Keycloak vault is a useful tool for managing secrets, and can easily
+integrate with secret management tools like [sops-nix](https://github.com/Mic92/sops-nix)
+through the file based nature. See the
+[Using a vault section of the Keycloak Server Administration Guide](
+  https://www.keycloak.org/server/vault
+) and the description of the NixOS option for more information.
+
 ## Configuration file settings {#module-services-keycloak-settings}
 
 Keycloak server configuration parameters can be set in

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -148,6 +148,20 @@ in
         '';
       };
 
+      vault = lib.mkOption {
+        type = lib.types.nullOr (lib.types.attrsOf lib.types.path);
+        default = null;
+        description = ''
+          Secrets that will available to Keycloak inside the file vault.
+          The `keycloak` user must have read access to the secret files.
+
+          See [Keycloak documentation](https://www.keycloak.org/server/vault) for more info.
+        '';
+        example = {
+          master_smtpPassword = "/var/lib/secrets/smtpPassword";
+        };
+      };
+
       database = {
         type = mkOption {
           type = enum [
@@ -519,6 +533,7 @@ in
             quarkus-systemd-notify
             quarkus-systemd-notify-deployment
           ]);
+        vaultType = if (cfg.vault != null) then "file" else null;
       };
     in
     mkIf cfg.enable {
@@ -711,8 +726,18 @@ in
               "L+".argument = "${f}";
             };
           }) cfg.realmFiles;
+          vaultList =
+            if (cfg.vault != null) then
+              (lib.mapAttrsToList (name: value: {
+                name = "/run/keycloak/secrets/${name}";
+                value = {
+                  "L+".argument = value;
+                };
+              }) cfg.vault)
+            else
+              [ ];
         in
-        builtins.listToAttrs settingsList;
+        builtins.listToAttrs (settingsList ++ vaultList);
 
       systemd.services.keycloak =
         let
@@ -751,6 +776,9 @@ in
           // lib.optionalAttrs (cfg.initialAdminPassword != null) {
             KC_BOOTSTRAP_ADMIN_USERNAME = "admin";
             KC_BOOTSTRAP_ADMIN_PASSWORD = cfg.initialAdminPassword;
+          }
+          // lib.optionalAttrs (cfg.vault != null) {
+            KC_VAULT_DIR = "/run/keycloak/secrets";
           };
           serviceConfig = {
             LoadCredential =

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -149,11 +149,14 @@ in
       };
 
       vault = lib.mkOption {
-        type = lib.types.nullOr (lib.types.attrsOf lib.types.path);
+        type = nullOr (lib.types.attrsOf path);
+        apply = value: builtins.mapAttrs (name: value: assertStringPath name value) value;
         default = null;
         description = ''
-          Secrets that will available to Keycloak inside the file vault.
-          The `keycloak` user must have read access to the secret files.
+          Secrets that will be available to Keycloak inside the file vault.
+
+          The attribute name must be in the format of `<realm name>_<secret name>` for the
+          secrets to be accessible.
 
           See [Keycloak documentation](https://www.keycloak.org/server/vault) for more info.
         '';
@@ -533,7 +536,7 @@ in
             quarkus-systemd-notify
             quarkus-systemd-notify-deployment
           ]);
-        vaultType = if (cfg.vault != null) then "file" else null;
+        vaultType = if (cfg.vault != null && cfg.vault != { }) then "file" else null;
       };
     in
     mkIf cfg.enable {
@@ -726,18 +729,8 @@ in
               "L+".argument = "${f}";
             };
           }) cfg.realmFiles;
-          vaultList =
-            if (cfg.vault != null) then
-              (lib.mapAttrsToList (name: value: {
-                name = "/run/keycloak/secrets/${name}";
-                value = {
-                  "L+".argument = value;
-                };
-              }) cfg.vault)
-            else
-              [ ];
         in
-        builtins.listToAttrs (settingsList ++ vaultList);
+        builtins.listToAttrs settingsList;
 
       systemd.services.keycloak =
         let
@@ -786,7 +779,10 @@ in
               ++ optionals (cfg.sslCertificate != null && cfg.sslCertificateKey != null) [
                 "ssl_cert:${cfg.sslCertificate}"
                 "ssl_key:${cfg.sslCertificateKey}"
-              ];
+              ]
+              ++ optionals (cfg.vault != null && cfg.vault != { }) (
+                lib.mapAttrsToList (name: value: "${name}:${value}") cfg.vault
+              );
             User = "keycloak";
             Group = "keycloak";
             DynamicUser = true;
@@ -820,6 +816,18 @@ in
             mkdir -p /run/keycloak/ssl
             cp "$CREDENTIALS_DIRECTORY"/ssl_{cert,key} /run/keycloak/ssl/
           ''
+          + optionalString (cfg.vault != null && cfg.vault != { }) (
+            lib.concatStrings (
+              [
+                ''
+                  mkdir -p /run/keycloak/secrets
+                ''
+              ]
+              ++ (lib.mapAttrsToList (name: value: ''
+                cp "$CREDENTIALS_DIRECTORY"/${name} /run/keycloak/secrets/
+              '') cfg.vault)
+            )
+          )
           + ''
             kc.sh --verbose start --optimized ${lib.optionalString (cfg.realmFiles != [ ]) "--import-realm"}
           '';

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -150,7 +150,7 @@ in
 
       vault = lib.mkOption {
         type = nullOr (lib.types.attrsOf path);
-        apply = value: builtins.mapAttrs (name: value: assertStringPath name value) value;
+        apply = lib.mapNullable (builtins.mapAttrs (name: assertStringPath "vault.${name}"));
         default = null;
         description = ''
           Secrets that will be available to Keycloak inside the file vault.
@@ -527,6 +527,7 @@ in
         ]
       )) cfg.settings;
       confFile = pkgs.writeText "keycloak.conf" (keycloakConfig filteredConfig);
+      hasVault = cfg.vault != null && cfg.vault != { };
       keycloakBuild = cfg.package.override {
         inherit confFile;
         plugins =
@@ -536,7 +537,7 @@ in
             quarkus-systemd-notify
             quarkus-systemd-notify-deployment
           ]);
-        vaultType = if (cfg.vault != null && cfg.vault != { }) then "file" else null;
+        vaultType = if hasVault then "file" else null;
       };
     in
     mkIf cfg.enable {
@@ -770,7 +771,7 @@ in
             KC_BOOTSTRAP_ADMIN_USERNAME = "admin";
             KC_BOOTSTRAP_ADMIN_PASSWORD = cfg.initialAdminPassword;
           }
-          // lib.optionalAttrs (cfg.vault != null) {
+          // lib.optionalAttrs hasVault {
             KC_VAULT_DIR = "/run/keycloak/secrets";
           };
           serviceConfig = {
@@ -780,9 +781,7 @@ in
                 "ssl_cert:${cfg.sslCertificate}"
                 "ssl_key:${cfg.sslCertificateKey}"
               ]
-              ++ optionals (cfg.vault != null && cfg.vault != { }) (
-                lib.mapAttrsToList (name: value: "${name}:${value}") cfg.vault
-              );
+              ++ optionals hasVault (lib.mapAttrsToList (name: value: "${name}:${value}") cfg.vault);
             User = "keycloak";
             Group = "keycloak";
             DynamicUser = true;
@@ -816,7 +815,7 @@ in
             mkdir -p /run/keycloak/ssl
             cp "$CREDENTIALS_DIRECTORY"/ssl_{cert,key} /run/keycloak/ssl/
           ''
-          + optionalString (cfg.vault != null && cfg.vault != { }) (
+          + optionalString hasVault (
             lib.concatStrings (
               [
                 ''

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -52,6 +52,9 @@ let
                   keycloak-discord
                   keycloak-metrics-spi
                 ];
+                vault = {
+                  master_test = "${pkgs.writeText "test" "test"}";
+                };
               };
               environment.systemPackages = with pkgs; [
                 htmlq
@@ -180,6 +183,22 @@ let
             # realm with.
             keycloak.succeed(
                 "curl -sSf -H @auth_header '${frontendUrl}/realms/${realm.realm}/protocol/openid-connect/userinfo' | jq -f ${jqCheckUserinfo}"
+            )
+
+            ### Vault testing ###
+
+            # Verify that secrets are correctly placed into the runtime directory
+            keycloak.succeed(
+                """[[ "$(cat /run/keycloak/secrets/master_test)" = "test" ]]"""
+            )
+
+            keycloak.succeed(
+                "systemctl restart keycloak.service"
+            )
+
+            # Make sure they are correctly recreated after Keycloak restarts
+            keycloak.succeed(
+                """[[ "$(cat /run/keycloak/secrets/master_test)" = "test" ]]"""
             )
           '';
       }

--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -10,6 +10,7 @@
   plugins ? [ ],
   extraFeatures ? [ ],
   disabledFeatures ? [ ],
+  vaultType ? null,
 }:
 
 let
@@ -21,6 +22,7 @@ let
       disabledFeatures != [ ]
     ) "--features-disabled=${lib.concatStringsSep "," disabledFeatures}"}
   '';
+  vaultSubcommand = lib.optionalString (vaultType != null) "--vault=${vaultType}";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "keycloak";
@@ -62,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs bin/kc.sh
     export KC_HOME_DIR=$(pwd)
     export KC_CONF_DIR=$(pwd)/conf
-    bin/kc.sh build ${featuresSubcommand}
+    bin/kc.sh build ${vaultSubcommand} ${featuresSubcommand}
 
     runHook postBuild
   '';


### PR DESCRIPTION
Added support for configuring a file based Keycloak vault for secret management. It makes it easier to make sure secrets
are correct when multiple services are in use, and it makes rotating the secrets easier as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
