### PR TITLE
ultrastar-creator: 2019-04-23 -> 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18317,6 +18317,11 @@
     githubId = 3579600;
     name = "Jacob Moody";
   };
+  mooses = {
+    name = "Remu Salminen";
+    github = "RemuSalminen";
+    githubId = 85031022;
+  };
   moosingin3space = {
     email = "moosingin3space@gmail.com";
     github = "moosingin3space";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18493,6 +18493,11 @@
     githubId = 3579600;
     name = "Jacob Moody";
   };
+  mooses = {
+    name = "Remu Salminen";
+    github = "RemuSalminen";
+    githubId = 85031022;
+  };
   moosingin3space = {
     email = "moosingin3space@gmail.com";
     github = "moosingin3space";

--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -2,64 +2,109 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qmake,
-  qtbase,
+  qt6,
   pkg-config,
-  wrapQtAppsHook,
   taglib,
+  alsa-lib,
+  pulseaudio,
+  cld2,
   libbass,
   libbass_fx,
+  makeDesktopItem,
 }:
 
-# TODO: get rid of (unfree) libbass
-# issue:https://github.com/UltraStar-Deluxe/UltraStar-Creator/issues/3
-# there’s a WIP branch here:
-# https://github.com/UltraStar-Deluxe/UltraStar-Creator/commits/BASS_removed
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ultrastar-creator";
-  version = "2019-04-23";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "UltraStar-Deluxe";
     repo = "UltraStar-Creator";
-    rev = "36583b4e482b68f6aa949e77ef2744776aa587b1";
-    sha256 = "1rzz04l7s7pxj74xam0cxlq569lfpgig35kpbsplq531d4007pc9";
+    tag = finalAttrs.version;
+    hash = "sha256-QWlgMpyNadRh6Tkg1mAtb11mKbk4thE6sCQKiDyR/SA=";
   };
 
   postPatch = ''
-    # we don’t want prebuilt binaries checked into version control!
-    rm -rf lib include
-    sed -e "s|DESTDIR =.*$|DESTDIR = $out/bin|" \
-        -e 's|-L".*unix"||' \
-        -e "/QMAKE_POST_LINK/d" \
-        -e "s|../include/bass|${lib.getLib libbass}/include|g" \
-        -e "s|../include/bass_fx|${lib.getLib libbass_fx}/include|g" \
-        -e "s|../include/taglib|${lib.getLib taglib}/include|g" \
-        -i src/UltraStar-Creator.pro
+    rm -rf lib include/bass include/bass_fx include/cld2
+
+    echo 'const char *revision = "${finalAttrs.version}"; const char *date_time = "unknown";' \
+      > src/version.h
+
+    substituteInPlace src/UltraStar-Creator.pro \
+      --replace-fail 'DESTDIR = ../bin/release' "DESTDIR = $out/bin" \
+      --replace-fail 'DESTDIR = ../bin/debug'   "DESTDIR = $out/bin" \
+      --replace-fail '../include/bass_fx'        '${lib.getLib libbass_fx}/include' \
+      --replace-fail '../include/bass'           '${lib.getLib libbass}/include' \
+      --replace-fail '../include/cld2/public'    '${cld2}/include/cld2/public' \
+      --replace-fail '../include/taglib'         '${lib.getDev taglib}/include'
+
+    sed -i \
+      -e 's|-L"../lib/unix"||' \
+      -e 's|-L"/usr/lib/x86_64-linux-gnu"||' \
+      -e '/QMAKE_POST_LINK/d' \
+      src/UltraStar-Creator.pro
+
+    sed -i \
+      -e '/QMAKE_EXTRA_TARGETS.*revtarget/d' \
+      -e '/PRE_TARGETDEPS.*version\.h/d' \
+      -e '/^revtarget\.target/d' \
+      -e '/^\trevtarget\./d' \
+      -e '/^revtarget\.depends/,/[^\\]$/d' \
+      src/UltraStar-Creator.pro
   '';
 
   preConfigure = ''
     cd src
   '';
 
-  nativeBuildInputs = [
-    qmake
-    pkg-config
-    wrapQtAppsHook
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [
+        alsa-lib
+        pulseaudio
+      ]
+    }"
   ];
+
+  nativeBuildInputs = [
+    pkg-config
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
   buildInputs = [
-    qtbase
-    taglib
+    cld2
     libbass
     libbass_fx
+    qt6.qtbase
+    taglib
+    alsa-lib
+    pulseaudio
   ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/"
+
+    ln -s "$desktopItem/share/applications" "$out/share/"
+
+    runHook postInstall
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = finalAttrs.pname;
+    desktopName = "UltraStar-Creator";
+    exec = "UltraStar-Creator";
+    icon = "${finalAttrs.src}/setup/unix/UltraStar-Creator.png";
+  };
 
   meta = {
     mainProgram = "UltraStar-Creator";
     description = "Ultrastar karaoke song creation tool";
     homepage = "https://github.com/UltraStar-Deluxe/UltraStar-Creator";
     license = lib.licenses.gpl2Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ mooses ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -2,64 +2,108 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qmake,
-  qtbase,
+  qt6,
   pkg-config,
-  wrapQtAppsHook,
   taglib,
+  alsa-lib,
+  pulseaudio,
+  cld2,
   libbass,
   libbass_fx,
+  makeDesktopItem,
 }:
 
-# TODO: get rid of (unfree) libbass
-# issue:https://github.com/UltraStar-Deluxe/UltraStar-Creator/issues/3
-# there’s a WIP branch here:
-# https://github.com/UltraStar-Deluxe/UltraStar-Creator/commits/BASS_removed
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ultrastar-creator";
-  version = "2019-04-23";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "UltraStar-Deluxe";
     repo = "UltraStar-Creator";
-    rev = "36583b4e482b68f6aa949e77ef2744776aa587b1";
-    sha256 = "1rzz04l7s7pxj74xam0cxlq569lfpgig35kpbsplq531d4007pc9";
+    tag = finalAttrs.version;
+    hash = "sha256-QWlgMpyNadRh6Tkg1mAtb11mKbk4thE6sCQKiDyR/SA=";
   };
 
   postPatch = ''
-    # we don’t want prebuilt binaries checked into version control!
-    rm -rf lib include
-    sed -e "s|DESTDIR =.*$|DESTDIR = $out/bin|" \
-        -e 's|-L".*unix"||' \
-        -e "/QMAKE_POST_LINK/d" \
-        -e "s|../include/bass|${lib.getLib libbass}/include|g" \
-        -e "s|../include/bass_fx|${lib.getLib libbass_fx}/include|g" \
-        -e "s|../include/taglib|${lib.getLib taglib}/include|g" \
-        -i src/UltraStar-Creator.pro
+    rm -rf lib include/bass include/bass_fx include/cld2
+
+    echo 'const char *revision = "${finalAttrs.version}"; const char *date_time = "unknown";' \
+      > src/version.h
+
+    substituteInPlace src/UltraStar-Creator.pro \
+      --replace-fail 'DESTDIR = ../bin/release' "DESTDIR = $out/bin" \
+      --replace-fail 'DESTDIR = ../bin/debug'   "DESTDIR = $out/bin" \
+      --replace-fail '../include/bass_fx'        '${lib.getLib libbass_fx}/include' \
+      --replace-fail '../include/bass'           '${lib.getLib libbass}/include' \
+      --replace-fail '../include/cld2/public'    '${cld2}/include/cld2/public' \
+      --replace-fail '../include/taglib'         '${lib.getDev taglib}/include'
+
+    sed -i \
+      -e 's|-L"../lib/unix"||' \
+      -e 's|-L"/usr/lib/x86_64-linux-gnu"||' \
+      -e '/QMAKE_POST_LINK/d' \
+      src/UltraStar-Creator.pro
+
+    sed -i \
+      -e '/QMAKE_EXTRA_TARGETS.*revtarget/d' \
+      -e '/PRE_TARGETDEPS.*version\.h/d' \
+      -e '/^revtarget\.target/d' \
+      -e '/^\trevtarget\./d' \
+      -e '/^revtarget\.depends/,/[^\\]$/d' \
+      src/UltraStar-Creator.pro
   '';
 
   preConfigure = ''
     cd src
   '';
 
-  nativeBuildInputs = [
-    qmake
-    pkg-config
-    wrapQtAppsHook
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [
+        alsa-lib
+        pulseaudio
+      ]
+    }"
   ];
+
+  nativeBuildInputs = [
+    pkg-config
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
   buildInputs = [
-    qtbase
-    taglib
+    cld2
     libbass
     libbass_fx
+    qt6.qtbase
+    taglib
+    alsa-lib
+    pulseaudio
   ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ../setup/unix/UltraStar-Creator.png $out/share/icons/hicolor/128x128/apps/ultrastar-creator.png
+    ln -s "$desktopItem/share/applications" "$out/share/"
+
+    runHook postInstall
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = finalAttrs.pname;
+    desktopName = "UltraStar-Creator";
+    exec = "UltraStar-Creator";
+    icon = "ultrastar-creator";
+  };
 
   meta = {
     mainProgram = "UltraStar-Creator";
     description = "Ultrastar karaoke song creation tool";
     homepage = "https://github.com/UltraStar-Deluxe/UltraStar-Creator";
     license = lib.licenses.gpl2Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ mooses ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11132,7 +11132,7 @@ with pkgs;
 
   tibia = pkgsi686Linux.callPackage ../games/tibia { };
 
-  ultrastar-creator = libsForQt5.callPackage ../tools/misc/ultrastar-creator { };
+  ultrastar-creator = callPackage ../tools/misc/ultrastar-creator { };
 
   ultrastar-manager = libsForQt5.callPackage ../tools/misc/ultrastar-manager { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10526,7 +10526,7 @@ with pkgs;
     ];
   };
 
-  ultrastar-creator = libsForQt5.callPackage ../tools/misc/ultrastar-creator { };
+  ultrastar-creator = callPackage ../tools/misc/ultrastar-creator { };
 
   ultrastar-manager = libsForQt5.callPackage ../tools/misc/ultrastar-manager { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update ultrastar-creator to the latest release. From an unreleased version in 2019 to the latest release 1.3.1.
I've added myself as the maintainer for this.

Major change being the move from Qt5 to Qt6.
The old version's filepicker was no longer functional, but the new UI has fixed this as well.
Now includes the desktop entry as well.

Brief Changelog: https://github.com/UltraStar-Deluxe/UltraStar-Creator/releases/tag/1.3.1
In addition, the new UI has significantly improved the user experience.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
