### PR TITLE
protobuf*: Fix tests on big-endian again

### DIFF
--- a/pkgs/development/libraries/protobuf/fix-BoolKeys-test-on-be.patch
+++ b/pkgs/development/libraries/protobuf/fix-BoolKeys-test-on-be.patch
@@ -1,0 +1,32 @@
+From 02774a2aea957c552383cc6cae43076f5436d867 Mon Sep 17 00:00:00 2001
+From: Sai Sindhuri Avulamanda <sai.sindhuri.avulamanda@ibm.com>
+Date: Wed, 11 Feb 2026 11:00:05 +0530
+Subject: [PATCH] Fix BoolKeys test to use integer-to-bool cast
+
+Signed-off-by: saisindhuri91 <Sai.Sindhuri.Avulamanda@ibm.com>
+---
+ upb/hash/test.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/upb/hash/test.cc b/upb/hash/test.cc
+index 546df9d71c1f0..fcb7deaa8e4bc 100644
+--- a/upb/hash/test.cc
++++ b/upb/hash/test.cc
+@@ -336,7 +336,7 @@ TEST(IntTableTest, BoolKeys) {
+   // First element.
+   EXPECT_TRUE(upb_inttable_next(&t, &key, &val, &iter));
+   bool key_bool;
+-  memcpy(&key_bool, &key, sizeof(key_bool));
++  key_bool = static_cast<bool>(key);
+   EXPECT_EQ(key_bool, false);
+   EXPECT_EQ(upb_inttable_iter_key(&t, iter), false);
+   EXPECT_EQ(val.val, true);
+@@ -345,7 +345,7 @@ TEST(IntTableTest, BoolKeys) {
+ 
+   // Second element.
+   EXPECT_TRUE(upb_inttable_next(&t, &key, &val, &iter));
+-  memcpy(&key_bool, &key, sizeof(key_bool));
++  key_bool = static_cast<bool>(key);
+   EXPECT_EQ(key_bool, true);
+   EXPECT_EQ(upb_inttable_iter_key(&t, iter), true);
+   EXPECT_EQ(val.val, false);

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -82,6 +82,10 @@ stdenv.mkDerivation (finalAttrs: {
       # entries in `linkarr_upb_AllExts` during test builds.
       # Context: https://github.com/protocolbuffers/protobuf/issues/21021
       ./fix-upb-linkarr-sentinel-init.patch
+
+      # Fix BoolKeys test on big-endian
+      # https://github.com/protocolbuffers/protobuf/pull/25862
+      ./fix-BoolKeys-test-on-be.patch
     ];
 
   postPatch =

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -83,6 +83,10 @@ stdenv.mkDerivation (finalAttrs: {
       # entries in `linkarr_upb_AllExts` during test builds.
       # Context: https://github.com/protocolbuffers/protobuf/issues/21021
       ./fix-upb-linkarr-sentinel-init.patch
+
+      # Fix BoolKeys test on big-endian
+      # https://github.com/protocolbuffers/protobuf/pull/25862
+      ./fix-BoolKeys-test-on-be.patch
     ];
 
   postPatch =

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -73,6 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/protocolbuffers/protobuf/commit/8282f0f8ecf8b847e5964a308e041ba3b049811c.patch";
         hash = "sha256-4c/yLuAd29Cxrz6I9F2Lj02lW2bazIcGb+86uxZY7qA=";
       })
+    ]
+    ++ lib.optionals ((lib.versionAtLeast version "33") && (lib.versionOlder version "36")) [
       # Fix packed enum decoding on big-endian platforms
       # https://github.com/protocolbuffers/protobuf/pull/25683
       ./fix-upb-packed-enum-be.patch


### PR DESCRIPTION
First commit fixes `protobuf_34` on big-endian. Second commit fixes `protobuf_35` on big-endian.

1. Applies https://github.com/protocolbuffers/protobuf/pull/25862 to fix `protobuf_34`'s `BoolToKeys` test on big-endian archs. Branch name indicates that this might also affect 33.4+, but at least 33.5 builds fine as-is on my machine… :woman_shrugging:

2. `protobuf_35` init excluded the `fix-upb-packed-enum-be.patch` from being applied to the new version, but it's still needed there and applies without issues. Pull it into a separate condition - it's part of the 36.0 RC, so `version < 36` seems like the correct upper limit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- (predates the new AI policy checkbox, but i don't use LLMs and have thus no usage to declare, so it would be checked)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
