### PR TITLE
nixos/syncthing-relay: add cert and key option

### DIFF
--- a/nixos/modules/services/networking/syncthing-relay.nix
+++ b/nixos/modules/services/networking/syncthing-relay.nix
@@ -29,6 +29,22 @@ in
   options.services.syncthing.relay = {
     enable = mkEnableOption "Syncthing relay service";
 
+    cert = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Path to the `cert.pem` file, which will be copied into `dataDirectory`
+      '';
+    };
+
+    key = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Path to the `key.pem` file, which will be copied into `dataDirectory`
+      '';
+    };
+
     listenAddress = mkOption {
       type = types.str;
       default = "";
@@ -119,6 +135,17 @@ in
         StateDirectory = baseNameOf dataDirectory;
 
         Restart = "on-failure";
+        ExecStartPre =
+          mkIf (cfg.cert != null || cfg.key != null)
+            "${pkgs.writers.writeBash "syncthing-relay-copy-keys" ''
+              install -dm700 ${dataDirectory}
+              ${optionalString (cfg.cert != null) ''
+                install -Dm644 ${toString cfg.cert} ${dataDirectory}/cert.pem
+              ''}
+              ${optionalString (cfg.key != null) ''
+                install -Dm600 ${toString cfg.key} ${dataDirectory}/key.pem
+              ''}
+            ''}";
         ExecStart = "${pkgs.syncthing-relay}/bin/strelaysrv ${concatStringsSep " " relayOptions}";
       };
     };

--- a/nixos/modules/services/networking/syncthing-relay.nix
+++ b/nixos/modules/services/networking/syncthing-relay.nix
@@ -29,6 +29,22 @@ in
   options.services.syncthing.relay = {
     enable = mkEnableOption "Syncthing relay service";
 
+    cert = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Path to the `cert.pem` file, which will be copied into `dataDirectory`
+      '';
+    };
+
+    key = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Path to the `key.pem` file, which will be copied into `dataDirectory`
+      '';
+    };
+
     listenAddress = mkOption {
       type = types.str;
       default = "";
@@ -118,7 +134,21 @@ in
         DynamicUser = true;
         StateDirectory = baseNameOf dataDirectory;
 
+        LoadCredential =
+          optional (cfg.key != null) "key:${cfg.key}" ++ optional (cfg.cert != null) "cert:${cfg.cert}";
+
         Restart = "on-failure";
+        ExecStartPre =
+          mkIf (cfg.cert != null || cfg.key != null)
+            "${pkgs.writers.writeBash "syncthing-relay-copy-keys" ''
+              install -dm700 ${dataDirectory}
+              ${optionalString (cfg.cert != null) ''
+                install -Dm644 "$CREDENTIALS_DIRECTORY/cert" ${dataDirectory}/cert.pem
+              ''}
+              ${optionalString (cfg.key != null) ''
+                install -Dm600 "$CREDENTIALS_DIRECTORY/key" ${dataDirectory}/key.pem
+              ''}
+            ''}";
         ExecStart = "${pkgs.syncthing-relay}/bin/strelaysrv ${concatStringsSep " " relayOptions}";
       };
     };


### PR DESCRIPTION
Copy from `services.syncthing` so you can create key and cert file for the relay https://github.com/NixOS/nixpkgs/blob/cc5425a49c9698c12d5b8beb63d95e76612c757c/nixos/modules/services/networking/syncthing.nix#L988-L998

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
