### PR TITLE
picoc: Fix build with gcc15

### DIFF
--- a/pkgs/by-name/pi/picoc/gcc15-fixes.patch
+++ b/pkgs/by-name/pi/picoc/gcc15-fixes.patch
@@ -1,0 +1,45 @@
+--- a/interpreter.h
++++ b/interpreter.h
+@@ -173,6 +173,7 @@ struct ValueType
+ };
+ 
+ /* function definition */
++typedef struct Value Value;         /* Needed to allow reference before definition */
+ struct FuncDef
+ {
+     struct ValueType *ReturnType;   /* the return value type */
+@@ -180,7 +181,12 @@ struct FuncDef
+     int VarArgs;                    /* has a variable number of arguments after the explicitly specified ones */
+     struct ValueType **ParamType;   /* array of parameter types */
+     char **ParamName;               /* array of parameter names */
+-    void (*Intrinsic)();            /* intrinsic call address or NULL */
++    void (*Intrinsic)(              /* intrinsic call address or NULL */
++        struct ParseState *Parser,
++        Value *ReturnValue,
++        Value **ParamArray,
++        int ArgCount
++    );
+     struct ParseState Body;         /* lexical tokens of the function body if not intrinsic */
+ };
+ 
+@@ -610,8 +616,8 @@ void IncludeFile(Picoc *pc, char *Filename);
+  * void PicocIncludeAllSystemHeaders(); */
+  
+ /* debug.c */
+-void DebugInit();
+-void DebugCleanup();
++void DebugInit(Picoc *pc);
++void DebugCleanup(Picoc *pc);
+ void DebugCheckStatement(struct ParseState *Parser);
+ 
+ 
+--- a/platform/library_unix.c
++++ b/platform/library_unix.c
+@@ -1,6 +1,6 @@
+ #include "../interpreter.h"
+ 
+-void UnixSetupFunc()
++void UnixSetupFunc(Picoc *pc)
+ {    
+ }
+ 

--- a/pkgs/by-name/pi/picoc/package.nix
+++ b/pkgs/by-name/pi/picoc/package.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation {
 
   buildInputs = [ readline ];
 
+  patches = [ ./gcc15-fixes.patch ];
+
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   env.NIX_CFLAGS_COMPILE = toString (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Based on #475479, add arguments to functions that don't have them to fix errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
