### PR TITLE
nixos/modemmanager: systemd-networkd integration

### DIFF
--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -71,6 +71,9 @@ in
         pkgs.libqmi
         pkgs.libmbim
       ];
+
+      # systemd-networkd doesn't start ModemManager when required
+      wantedBy = lib.mkIf useNetworkd [ "network-online.target" ];
     };
 
     /*

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -6,6 +6,9 @@
 }:
 let
   cfg = config.networking.modemmanager;
+
+  useNetworkManager = config.networking.networkmanager.enable;
+  useNetworkd = config.systemd.network.enable;
 in
 {
   meta = {
@@ -79,15 +82,26 @@ in
       ResultActive=yes
     */
     security.polkit.enable = true;
-    security.polkit.extraConfig = ''
-      polkit.addRule(function(action, subject) {
-        if (
-          subject.isInGroup("networkmanager")
-          && action.id.indexOf("org.freedesktop.ModemManager") == 0
-          )
-            { return polkit.Result.YES; }
-      });
-    '';
+    security.polkit.extraConfig = lib.strings.concatStrings [
+      (lib.strings.optionalString useNetworkManager ''
+        polkit.addRule(function(action, subject) {
+          if (
+            subject.isInGroup("networkmanager")
+            && action.id.indexOf("org.freedesktop.ModemManager") == 0
+            )
+              { return polkit.Result.YES; }
+        });
+      '')
+      (lib.strings.optionalString useNetworkd ''
+        polkit.addRule(function(action, subject) {
+          if (
+            subject.isInGroup("systemd-network")
+            && action.id.indexOf("org.freedesktop.ModemManager") == 0
+            )
+              { return polkit.Result.YES; }
+        });
+      '')
+    ];
 
     environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -72,6 +72,8 @@ in
         pkgs.libmbim
       ];
 
+      serviceConfig.KillMode = "mixed";
+
       # systemd-networkd doesn't start ModemManager when required
       wantedBy = lib.mkIf useNetworkd [ "network-online.target" ];
     };


### PR DESCRIPTION
The newish systemd release v260 has a new ModemManager integration for systemd-networkd. I've had a PR (#513521) merged for configuring the networkd side of things but in testing I've found the following are needed that I think are more to do with the `nixos/modemmanager` module:

1. a new Polkit rule to allow systemd-networkd to communicate with ModemManager
2. a way to start `ModemManager.service` automatically

(I guess that NetworkManager does point 2 itself, but it appears that networkd does not.)

This PR has commits that address both points which I hope can be a starting point to making mobile network connections easy to configure with systemd-networkd. I'm interested to hear any suggestions of different ways of achieving this or how to improve these changes.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests]. **- I ran 2 tests. Both failed. See below.**
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Failing tests

- `nixosTests.networking.networkd` failed with `AssertionError: fou1 exists`
- `nixosTests.networking.networkmanager` failed with `RuntimeError: Shell disconnected`