### PR TITLE
various: inherit missing meta attributes

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/fzf-wrapper/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/fzf-wrapper/default.nix
@@ -11,4 +11,15 @@ vimUtils.buildVimPlugin {
   postInstall = ''
     ln -s ${fzf}/bin/fzf $target/bin/fzf
   '';
+
+  meta = {
+    inherit (fzf.meta)
+      changelog
+      description
+      homepage
+      license
+      platforms
+      ;
+    maintainers = [ ];
+  };
 }

--- a/pkgs/applications/editors/vim/plugins/non-generated/meson/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/meson/default.nix
@@ -6,5 +6,16 @@
 vimUtils.buildVimPlugin {
   inherit (meson) pname version src;
   preInstall = "cd data/syntax-highlighting/vim";
-  meta.maintainers = with lib.maintainers; [ vcunat ];
+
+  meta = {
+    inherit (meson.meta)
+      homepage
+      description
+      mainProgram
+      longDescription
+      license
+      platforms
+      ;
+    maintainers = with lib.maintainers; [ vcunat ];
+  };
 }

--- a/pkgs/applications/editors/vim/plugins/non-generated/tup/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/tup/default.nix
@@ -17,5 +17,16 @@ vimUtils.buildVimPlugin {
     cp "${ftdetect}" vim-plugin/ftdetect/tup.vim
     cd vim-plugin
   '';
-  meta.maintainers = with lib.maintainers; [ enderger ];
+  meta = {
+    inherit (tup.meta)
+      description
+      mainProgram
+      longDescription
+      homepage
+      license
+      platforms
+      broken
+      ;
+    maintainers = with lib.maintainers; [ enderger ];
+  };
 }

--- a/pkgs/by-name/mo/monosat/package.nix
+++ b/pkgs/by-name/mo/monosat/package.nix
@@ -40,12 +40,22 @@ let
       --replace-fail 'defined(__linux__)' '0'
   '';
 
+  meta = {
+    description = "SMT solver for Monotonic Theories";
+    mainProgram = "monosat";
+    platforms = lib.platforms.unix;
+    license = if includeGplCode then lib.licenses.gpl2 else lib.licenses.mit;
+    homepage = "https://github.com/sambayless/monosat";
+    maintainers = [ lib.maintainers.acairncross ];
+  };
+
   core = stdenv.mkDerivation {
     inherit
       pname
       version
       src
       patches
+      meta
       ;
     postPatch = commonPostPatch + ''
       substituteInPlace CMakeLists.txt \
@@ -72,15 +82,6 @@ let
     '';
 
     passthru = { inherit python; };
-
-    meta = {
-      description = "SMT solver for Monotonic Theories";
-      mainProgram = "monosat";
-      platforms = lib.platforms.unix;
-      license = if includeGplCode then lib.licenses.gpl2 else lib.licenses.mit;
-      homepage = "https://github.com/sambayless/monosat";
-      maintainers = [ lib.maintainers.acairncross ];
-    };
   };
 
   python =
@@ -98,6 +99,7 @@ let
         version
         src
         patches
+        meta
         ;
 
       build-system = [

--- a/pkgs/development/python-modules/ua-parser-builtins/default.nix
+++ b/pkgs/development/python-modules/ua-parser-builtins/default.nix
@@ -24,4 +24,14 @@ buildPythonPackage rec {
     pyyaml
     versioningit
   ];
+
+  meta = {
+    inherit (ua-parser.meta)
+      description
+      homepage
+      license
+      changelog
+      ;
+    maintainers = [ ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10526,12 +10526,19 @@ with pkgs;
         };
       };
     }).overrideAttrs
-      {
+      (old: {
         pname = "vim-darwin";
         meta = {
+          inherit (old.meta)
+            description
+            homepage
+            license
+            mainProgram
+            outputsToInstall
+            ;
           platforms = lib.platforms.darwin;
         };
-      };
+      });
 
   vimacs = callPackage ../applications/editors/vim/vimacs.nix { };
 


### PR DESCRIPTION
Continuity of:
- #512901

Adding the meta attributes in packages where no `meta.homepage` have been set.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
