### PR TITLE
installFonts: make preInstall hook

### DIFF
--- a/pkgs/build-support/setup-hooks/install-fonts.sh
+++ b/pkgs/build-support/setup-hooks/install-fonts.sh
@@ -20,7 +20,7 @@
 # This hook also provides an `installFont` function that can be used to install
 # additional fonts of a particular extension into their respective folder.
 #
-postInstallHooks+=(installFonts)
+preInstallHooks+=(installFonts)
 
 installFont() {
   if (($# != 2)); then

--- a/pkgs/by-name/fi/fira-sans/package.nix
+++ b/pkgs/by-name/fi/fira-sans/package.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     stripRoot = false;
   };
 
-  postInstall = ''
+  preInstall = ''
     rm -r "__MACOSX"
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
this is the current hook ordering
```
Running phase: installPhase
drv preInstall
no Makefile or custom installPhase, doing nothing
drv postInstall
installFonts: hook running
```


```
Running phase: installPhase
drv preInstall
installFonts: hook running
no Makefile or custom installPhase, doing nothing
drv postInstall
```

 and this is as a preInstall hook
done this way, we can use postInstall to manipulate the resulting files from the hook.

this is useful eg. in #513541 

I used `grep -rlZP "postInstall|preInstall" pkgs | xargs -0 grep -l "installFonts"` to find files which may need adjustment due to this, and the only one that ended up changing was fira-sans:
```
pkgs/by-name/lo/lora/package.nix
pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
pkgs/by-name/cm/cm_unicode/package.nix
pkgs/by-name/sn/sniglet/package.nix
pkgs/by-name/eb/eb-garamond/package.nix
pkgs/by-name/fi/fira-code/package.nix
pkgs/by-name/fi/fira-sans/package.nix
pkgs/by-name/ap/apl387/package.nix
pkgs/by-name/br/bront_fonts/package.nix
pkgs/by-name/fa/fantasque-sans-mono/package.nix
pkgs/by-name/xk/xkcd-font/package.nix
pkgs/by-name/xi/xits-math/package.nix
```

leaving as a draft while I think about this
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
