### PR TITLE
{log4shib,opensaml-cpp,shibboleth-sp,xml-security-c,xml-tooling-c}: migrate source to codeberg, adopt, fix build failure

### DIFF
--- a/pkgs/by-name/lo/log4shib/package.nix
+++ b/pkgs/by-name/lo/log4shib/package.nix
@@ -1,18 +1,19 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromCodeberg,
   autoreconfHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "log4shib";
   version = "1.0.9";
 
-  src = fetchgit {
-    url = "https://git.shibboleth.net/git/cpp-log4shib.git";
-    rev = "a1afe19b7b49c32fcb03e6d72809501b8965cf85";
-    sha256 = "06rrc5l6qxlc8abzim2jcxwz2c577qrjqx15cbfqq1zfqagj9hix";
+  src = fetchFromCodeberg {
+    owner = "Shibboleth";
+    repo = "cpp-log4shib";
+    tag = finalAttrs.version;
+    hash = "sha256-PcIkn8LuB4zdYiV0LDM+pzDxeWdS1PiXQox2bGhhORs=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -26,4 +27,4 @@ stdenv.mkDerivation {
     license = lib.licenses.lgpl21;
     homepage = "http://log4cpp.sf.net";
   };
-}
+})

--- a/pkgs/by-name/lo/log4shib/package.nix
+++ b/pkgs/by-name/lo/log4shib/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromCodeberg,
   autoreconfHook,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,6 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ autoreconfHook ];
 
   env.CXXFLAGS = "-std=c++11";
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Forked version of log4cpp that has been created for the Shibboleth project";

--- a/pkgs/by-name/lo/log4shib/package.nix
+++ b/pkgs/by-name/lo/log4shib/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Forked version of log4cpp that has been created for the Shibboleth project";
     mainProgram = "log4shib-config";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drawbu ];
     license = lib.licenses.lgpl21;
     homepage = "http://log4cpp.sf.net";
   };

--- a/pkgs/by-name/op/opensaml-cpp/package.nix
+++ b/pkgs/by-name/op/opensaml-cpp/package.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "samlsign";
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 })

--- a/pkgs/by-name/op/opensaml-cpp/package.nix
+++ b/pkgs/by-name/op/opensaml-cpp/package.nix
@@ -11,6 +11,7 @@
   xml-security-c,
   xml-tooling-c,
   zlib,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-std=c++14";
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     homepage = "https://shibboleth.net/products/opensaml-cpp.html";

--- a/pkgs/by-name/op/opensaml-cpp/package.nix
+++ b/pkgs/by-name/op/opensaml-cpp/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromCodeberg,
   autoreconfHook,
   pkg-config,
   boost,
@@ -17,10 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "opensaml-cpp";
   version = "3.0.1";
 
-  src = fetchgit {
-    url = "https://git.shibboleth.net/git/cpp-opensaml.git";
-    rev = finalAttrs.version;
-    sha256 = "0ms3sqmwqkrqb92d7jy2hqwnz5yd7cbrz73n321jik0jilrwl5w8";
+  src = fetchFromCodeberg {
+    owner = "Shibboleth";
+    repo = "cpp-opensaml";
+    tag = finalAttrs.version;
+    hash = "sha256-iBfKM40SzCiDGHacnxc7zZdvOYbCy9NEWjhPzCvWQ1c=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/op/opensaml-cpp/package.nix
+++ b/pkgs/by-name/op/opensaml-cpp/package.nix
@@ -39,7 +39,10 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  configureFlags = [ "--with-xmltooling=${xml-tooling-c}" ];
+  configureFlags = [
+    "--with-xmltooling=${xml-tooling-c}"
+    "--with-boost=${boost.dev}"
+  ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-std=c++14";
 

--- a/pkgs/by-name/op/opensaml-cpp/package.nix
+++ b/pkgs/by-name/op/opensaml-cpp/package.nix
@@ -11,6 +11,7 @@
   xml-security-c,
   xml-tooling-c,
   zlib,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,6 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-std=c++14";
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     homepage = "https://shibboleth.net/products/opensaml-cpp.html";

--- a/pkgs/by-name/op/opensaml-cpp/package.nix
+++ b/pkgs/by-name/op/opensaml-cpp/package.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "samlsign";
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 })

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromCodeberg,
   fetchpatch,
   autoreconfHook,
   boost,
@@ -19,10 +19,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "shibboleth-sp";
   version = "3.0.4.1";
 
-  src = fetchgit {
-    url = "https://git.shibboleth.net/git/cpp-sp.git";
-    rev = finalAttrs.version;
-    sha256 = "1qb4dbz5gk10b9w1rf6f4vv7c2wb3a8bfzif6yiaq96ilqad7gdr";
+  src = fetchFromCodeberg {
+    owner = "Shibboleth";
+    repo = "cpp-sp";
+    tag = finalAttrs.version;
+    hash = "sha256-ub3TFKbRJKyiNy5+t5Aaiwt29ibOuBx4WiDMV/5qZOE=";
   };
 
   # Upgrade to Clang 19 (and thereby LLVM19) causes `std::char_traits` to now be present,
@@ -34,13 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
   patches = lib.optionals (stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "19") [
     (fetchpatch {
       name = "char-traits-ambig-1";
-      url = "https://git.shibboleth.net/view/?p=cpp-sp.git;a=blobdiff_plain;f=shibsp/util/IPRange.cpp;h=532cf9e94c915667c091d127c696979f63939eb5;hp=d6f00bc36ea25997817a2308314bcdbea572936f;hb=49cd05fa6d9935a45069fa555db7a26ca77d23db;hpb=293ff2ab6454b0946b3b03719efa132bff461f1f";
+      url = "https://codeberg.org/Shibboleth/cpp-sp/commit/49cd05fa6d9935a45069fa555db7a26ca77d23db.diff";
       hash = "sha256-ZF0jsZJoHaxaPPjVbT6Wlq+wjyPQLTnEKcUxONji/hE=";
     })
 
     (fetchpatch {
       name = "char-traits-ambig-2";
-      url = "https://git.shibboleth.net/view/?p=cpp-sp.git;a=blobdiff_plain;f=shibsp/util/IPRange.cpp;h=da954870eb03c7cd054ecc5c52a6c1f011787760;hp=354010d5f5e533262cb385ea16756df53fe0c241;hb=793663a67aaa4e9a4aa9172728d924f8cec45cf6;hpb=a43814935030930c49b7a08f5515b861906525c7";
+      url = "https://codeberg.org/Shibboleth/cpp-sp/commit/793663a67aaa4e9a4aa9172728d924f8cec45cf6.diff";
+      includes = [ "shibsp/util/IPRange.cpp" ];
       hash = "sha256-4iGwCGpGwAkriOwQmh5AgvHLX1o39NuQ2l4sAJbD2bc=";
     })
   ];

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-xmltooling=${xml-tooling-c}"
     "--with-saml=${opensaml-cpp}"
     "--with-fastcgi"
+    "--with-boost=${boost.dev}"
     "CXXFLAGS=-std=c++14"
   ];
 

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -13,6 +13,7 @@
   xercesc,
   xml-security-c,
   xml-tooling-c,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -71,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     homepage = "https://shibboleth.net/products/service-provider.html";

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -80,6 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Enables SSO and Federation web applications written with any programming language or framework";
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 })

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -81,6 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Enables SSO and Federation web applications written with any programming language or framework";
     platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 })

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -69,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-saml=${opensaml-cpp}"
     "--with-boost=${boost.dev}"
     "--with-fastcgi"
+    "--with-boost=${boost.dev}"
     "CXXFLAGS=-std=c++14"
   ];
 

--- a/pkgs/by-name/sh/shibboleth-sp/package.nix
+++ b/pkgs/by-name/sh/shibboleth-sp/package.nix
@@ -13,6 +13,7 @@
   xercesc,
   xml-security-c,
   xml-tooling-c,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -72,6 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     homepage = "https://shibboleth.net/products/service-provider.html";

--- a/pkgs/by-name/xm/xml-security-c/package.nix
+++ b/pkgs/by-name/xm/xml-security-c/package.nix
@@ -7,6 +7,7 @@
   xalanc,
   xercesc,
   openssl,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     xercesc
     openssl
   ];
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     homepage = "https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/3726671873/Santuario";

--- a/pkgs/by-name/xm/xml-security-c/package.nix
+++ b/pkgs/by-name/xm/xml-security-c/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromCodeberg,
   autoreconfHook,
   pkg-config,
   xalanc,
@@ -13,9 +13,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xml-security-c";
   version = "3.0.0";
 
-  src = fetchgit {
-    url = "https://git.shibboleth.net/git/cpp-xml-security";
-    rev = finalAttrs.version;
+  src = fetchFromCodeberg {
+    owner = "Shibboleth";
+    repo = "cpp-xml-security";
+    tag = finalAttrs.version;
     hash = "sha256-D60JtD4p9ERh6sowvwBHtE9XWVm3D8saooagDvA6ZtQ=";
   };
 

--- a/pkgs/by-name/xm/xml-security-c/package.nix
+++ b/pkgs/by-name/xm/xml-security-c/package.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ Implementation of W3C security standards for XML";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ drawbu ];
   };
 })

--- a/pkgs/by-name/xm/xml-tooling-c/package.nix
+++ b/pkgs/by-name/xm/xml-tooling-c/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromCodeberg,
   autoreconfHook,
   pkg-config,
   boost,
@@ -16,8 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xml-tooling-c";
   version = "3.3.0";
 
-  src = fetchgit {
-    url = "https://git.shibboleth.net/git/cpp-xmltooling.git";
+  src = fetchFromCodeberg {
+    owner = "Shibboleth";
+    repo = "cpp-xmltooling";
     tag = finalAttrs.version;
     hash = "sha256-czmBu7ThDwq+x7FahgZDMHqid8jeUNnTuKMI/Fj4IIw=";
   };

--- a/pkgs/by-name/xm/xml-tooling-c/package.nix
+++ b/pkgs/by-name/xm/xml-tooling-c/package.nix
@@ -10,6 +10,7 @@
   log4shib,
   xercesc,
   xml-security-c,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -44,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-std=c++14";
 
   enableParallelBuilding = true;
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Low-level library that provides a high level interface to XML processing for OpenSAML 2";


### PR DESCRIPTION
The https://git.shibboleth.net git forge has been replaced by Codeberg and is no longer reachable. 
The hashes have not changed, neither for the sources nor the patches, so this commit should be a no-op.

<details>
  <summary> `opensaml-cpp` was failing, but this is not new, so not related to the migration. </summary>

```
$ hydra-check --arch=x86_64-linux opensaml-cpp
Build Status for nixpkgs.opensaml-cpp.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.opensaml-cpp.x86_64-linux
✖ (Failed)             opensaml-cpp-3.0.1  2026-04-23  https://hydra.nixos.org/build/326842806
✖ (Failed)             opensaml-cpp-3.0.1  2026-04-10  https://hydra.nixos.org/build/324268931
✖ (Failed)             opensaml-cpp-3.0.1  2026-03-16  https://hydra.nixos.org/build/322161363
✖ (Failed)             opensaml-cpp-3.0.1  2026-02-13  https://hydra.nixos.org/build/319759816
✖ (Failed)             opensaml-cpp-3.0.1  2026-01-07  https://hydra.nixos.org/build/317884143
✖ (Failed)             opensaml-cpp-3.0.1  2025-12-17  https://hydra.nixos.org/build/314210973
✖ (Failed)             opensaml-cpp-3.0.1  2025-11-14  https://hydra.nixos.org/build/313195249
✖ (Failed)             opensaml-cpp-3.0.1  2025-11-11  https://hydra.nixos.org/build/310422086
✖ (Failed)             opensaml-cpp-3.0.1  2025-10-15  https://hydra.nixos.org/build/310138384
✖ (Dependency failed)  opensaml-cpp-3.0.1  2025-10-10  https://hydra.nixos.org/build/308861554
```
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
