### PR TITLE
Update cocogitto metadata

### DIFF
--- a/pkgs/by-name/co/cocogitto/package.nix
+++ b/pkgs/by-name/co/cocogitto/package.nix
@@ -36,6 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   meta = {
+    changelog = "https://github.com/cocogitto/cocogitto/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Set of cli tools for the conventional commit and semver specifications";
     mainProgram = "cog";
     homepage = "https://docs.cocogitto.io/";

--- a/pkgs/by-name/co/cocogitto/package.nix
+++ b/pkgs/by-name/co/cocogitto/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Set of cli tools for the conventional commit and semver specifications";
     mainProgram = "cog";
-    homepage = "https://github.com/oknozor/cocogitto";
+    homepage = "https://docs.cocogitto.io/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ gs-101 ];
   };


### PR DESCRIPTION
I added a link to [cocogitto](https://github.com/cocogitto/cocogitto)'s [changelog](https://github.com/cocogitto/cocogitto/blob/7.0.0/CHANGELOG.md) and updated it's homepage:

https://github.com/oknozor/cocogitto -> https://docs.cocogitto.io/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test