### PR TITLE
dillo: 3.2.0 -> 3.3.0, add update script

### DIFF
--- a/pkgs/by-name/di/dillo/package.nix
+++ b/pkgs/by-name/di/dillo/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   autoreconfHook,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   fltk_1_3,
   libjpeg,
   libpng,
@@ -12,6 +12,7 @@
   pkg-config,
   stdenv,
   which,
+  nix-update-script,
   # Configurable options
   tlsLibrary ? "libressl",
 }:
@@ -27,13 +28,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dillo";
-  version = "3.2.0";
+  version = "3.3.0";
 
-  src = fetchFromGitHub {
-    owner = "dillo-browser";
+  src = fetchFromCodeberg {
+    owner = "dillo";
     repo = "dillo";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9nJq20iW8/UI3GgXWje+46WDSu3/omd1PN/uTlYCOac=";
+    hash = "sha256-MzfY5Wyrt7ChTxp+BPNuDG10D8CefhgHjuaSvAiquZI=";
   };
 
   nativeBuildInputs = [
@@ -58,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://dillo-browser.github.io/";


### PR DESCRIPTION
From here on, dillo migrated from Github to a self-hosted git source and using Codeberg as an official mirror.
Reference: https://git.dillo-browser.org/dillo/about/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
