### PR TITLE
openbao: patch to allow in-store plugin binaries

### DIFF
--- a/pkgs/by-name/op/openbao/openbao-plugin-path-validation.patch
+++ b/pkgs/by-name/op/openbao/openbao-plugin-path-validation.patch
@@ -1,0 +1,15 @@
+diff --git a/vault/plugin_catalog.go b/vault/plugin_catalog.go
+index 4d22cb2355..d7ad6b2064 100644
+--- a/vault/plugin_catalog.go
++++ b/vault/plugin_catalog.go
+@@ -1101,7 +1101,9 @@ func (c *PluginCatalog) setInternal(ctx context.Context, name string, pluginType
+ 		}
+ 	case false:
+ 		if symAbs != c.directory {
+-			return nil, errors.New("cannot execute files outside of configured plugin directory")
++			if !strings.HasPrefix(symAbs, "/nix/store/") {
++				return nil, errors.New("cannot execute files outside of configured plugin directory")
++			}
+ 		}
+ 	}
+ 

--- a/pkgs/by-name/op/openbao/package.nix
+++ b/pkgs/by-name/op/openbao/package.nix
@@ -27,6 +27,10 @@ buildGoModule (finalAttrs: {
 
   proxyVendor = true;
 
+  patches = [
+    ./openbao-plugin-path-validation.patch
+  ];
+
   subPackages = [ "." ];
 
   tags = lib.optional withHsm "hsm" ++ lib.optional withUi "ui";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a condition into plugin initialization logic to allow plugin binaries to live in store. Fixes #513847.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
