### PR TITLE
inngest: init at 1.34.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6094,6 +6094,11 @@
     github = "Daru-san";
     githubId = 135046711;
   };
+  darwin67 = {
+    github = "darwin67";
+    githubId = 5746693;
+    name = "Darwin";
+  };
   das-g = {
     email = "nixpkgs@raphael.dasgupta.ch";
     github = "das-g";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14160,6 +14160,11 @@
     githubId = 464625;
     name = "Enric Morales";
   };
+  kikos0 = {
+    github = "KiKoS0";
+    githubId = 22998716;
+    name = "Riadh Daghmoura";
+  };
   kilianar = {
     email = "mail@kilianar.de";
     github = "kilianar";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10820,6 +10820,11 @@
     github = "HigherOrderLogic";
     githubId = 73709188;
   };
+  highjeans = {
+    github = "highjeans";
+    githubId = 77588045;
+    name = "Vivan Waghela";
+  };
   hirenashah = {
     email = "hiren@hiren.io";
     github = "hirenashah";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13365,6 +13365,11 @@
     githubId = 5352661;
     name = "James Cleverley-Prance";
   };
+  jpwilliams = {
+    github = "jpwilliams";
+    githubId = 1736957;
+    name = "Jack Williams";
+  };
   jqueiroz = {
     email = "nixos@johnjq.com";
     github = "jqueiroz";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14418,6 +14418,11 @@
     githubId = 464625;
     name = "Enric Morales";
   };
+  kikos0 = {
+    github = "KiKoS0";
+    githubId = 22998716;
+    name = "Riadh Daghmoura";
+  };
   kilianar = {
     email = "mail@kilianar.de";
     github = "kilianar";

--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm,
+  pnpmConfigHook,
+  nodejs_20,
+  stdenv,
+  testers,
+  writeShellScript,
+  gh,
+  nix-update,
+  common-updater-scripts,
+}:
+let
+  version = "1.18.0";
+
+  src = fetchFromGitHub {
+    owner = "inngest";
+    repo = "inngest";
+    tag = "v${version}";
+    hash = "sha256-r7SvSFYyoe4PMZ7MtM9aJa1yE9mV5HSGYiO/PagYMz4=";
+  };
+
+  website = fetchFromGitHub {
+    owner = "inngest";
+    repo = "website";
+    rev = "159c0ac611e85ec85ffe0a8c8bf2c4a0330bdb38";
+    hash = "sha256-EkTIv8jgcqzurz2M7PC6Kfh6x2Zxu7UmIhpTjlj8o88=";
+  };
+
+  inngest-ui = stdenv.mkDerivation (finalAttrs: {
+    inherit version src;
+    pname = "inngest-ui";
+
+    nativeBuildInputs = [
+      nodejs_20
+      pnpm
+      pnpmConfigHook
+    ];
+
+    pnpmDeps =
+      (fetchPnpmDeps {
+        inherit (finalAttrs) pname version src;
+        sourceRoot = "${finalAttrs.src.name}/ui";
+        fetcherVersion = 3;
+        hash = "sha256-K7PPrv7ZkcoZCS1IqCIqeBgac0vlZNaBztXS2vJ0vAk=";
+      }).overrideAttrs
+        (old: {
+          env = (old.env or { }) // {
+            npm_config_manage_package_manager_versions = "false";
+          };
+        });
+    pnpmRoot = "ui";
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm --filter dev-server-ui build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/dist
+      cp -r ui/apps/dev-server-ui/dist/. $out/dist/
+      runHook postInstall
+    '';
+  });
+in
+buildGoModule (finalAttrs: {
+  inherit version src;
+  pname = "inngest";
+
+  __structuredAttrs = true;
+
+  vendorHash = null;
+
+  preBuild = ''
+    cp -r ${inngest-ui}/dist/. ./pkg/devserver/static/
+    cp -r ${website}/. ./internal/embeddocs/website/
+  '';
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/inngest
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/inngest/inngest/pkg/inngest/version.Version=${version}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd/" ];
+
+  passthru = {
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = writeShellScript "update-inngest" ''
+      set -euo pipefail
+      # exclude beta/rc tags before picking highest semver
+      latest=$(${lib.getExe gh} release list --repo inngest/inngest \
+        --json tagName --jq '.[].tagName' \
+        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -V | tail -1 | tr -d 'v')
+      ${lib.getExe nix-update} inngest --version "$latest"
+      websiteRev=$(${lib.getExe gh} api \
+        "repos/inngest/inngest/contents/internal/embeddocs/website?ref=v$latest" \
+        --jq '.sha')
+      ${common-updater-scripts}/bin/update-source-version inngest "$latest" "" \
+        --source-key="website" --rev="$websiteRev" --ignore-same-version || true
+    '';
+  };
+
+  meta = {
+    description = "CLI and dev server for Inngest durable workflows";
+    homepage = "https://github.com/inngest/inngest";
+    changelog = "https://github.com/inngest/inngest/releases/tag/v${version}";
+    license = lib.licenses.sspl;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [
+      darwin67
+      highjeans
+      jpwilliams
+      kikos0
+    ];
+    mainProgram = "inngest";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -14,13 +14,13 @@
   common-updater-scripts,
 }:
 let
-  version = "1.18.0";
+  version = "1.19.1";
 
   src = fetchFromGitHub {
     owner = "inngest";
     repo = "inngest";
     tag = "v${version}";
-    hash = "sha256-r7SvSFYyoe4PMZ7MtM9aJa1yE9mV5HSGYiO/PagYMz4=";
+    hash = "sha256-EDSlcfo22qyUR445UjtJ+dxUlLEep5ypcUBT/mYtvCQ=";
   };
 
   website = fetchFromGitHub {

--- a/pkgs/by-name/in/inngest/package.nix
+++ b/pkgs/by-name/in/inngest/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm_10,
+  pnpmConfigHook,
+  nodejs,
+  stdenv,
+  testers,
+}:
+let
+  version = "1.34.0";
+  websiteRev = "159c0ac611e85ec85ffe0a8c8bf2c4a0330bdb38";
+
+  src = fetchFromGitHub {
+    owner = "inngest";
+    repo = "inngest";
+    tag = "v${version}";
+    hash = "sha256-DMJEhgKj2glNtJmsLc3oyDZr5H/COFLrcogcgaYiLjU=";
+  };
+
+  website = fetchFromGitHub {
+    owner = "inngest";
+    repo = "website";
+    rev = websiteRev;
+    hash = "sha256-EkTIv8jgcqzurz2M7PC6Kfh6x2Zxu7UmIhpTjlj8o88=";
+  };
+
+  ui = stdenv.mkDerivation (finalAttrs: {
+    inherit version src;
+    pname = "inngest-ui";
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_10
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      pnpm = pnpm_10;
+      sourceRoot = "${finalAttrs.src.name}/ui";
+      fetcherVersion = 4;
+      hash = "sha256-bt/7cpN9EXf2CZFRAaybr7pgJyInV0fdUy7Rv/UcT/I=";
+    };
+    pnpmRoot = "ui";
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm --filter dev-server-ui build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/dist
+      cp -r ui/apps/dev-server-ui/dist/. $out/dist/
+      runHook postInstall
+    '';
+  });
+in
+buildGoModule (finalAttrs: {
+  inherit version src;
+  pname = "inngest";
+
+  __structuredAttrs = true;
+
+  vendorHash = null;
+
+  preBuild = ''
+    cp -r ${ui}/dist/. ./pkg/devserver/static/
+    cp -r ${website}/. ./internal/embeddocs/website/
+  '';
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/inngest
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/inngest/inngest/pkg/inngest/version.Version=${version}"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [ "cmd" ];
+
+  passthru = {
+    inherit ui website websiteRev;
+    tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "CLI and dev server for Inngest durable workflows";
+    homepage = "https://github.com/inngest/inngest";
+    changelog = "https://github.com/inngest/inngest/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.sspl;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    maintainers = with lib.maintainers; [ kikos0 ];
+    mainProgram = "inngest";
+    platforms = lib.lists.remove "x86_64-darwin" lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/in/inngest/update.sh
+++ b/pkgs/by-name/in/inngest/update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p gh jq
+# shellcheck shell=bash
+set -euo pipefail
+
+nixpkgs="$(pwd)"
+cd "$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")"
+
+nix_attr() { nix eval --json --impure --expr "(import $nixpkgs {}).$1" | jq -r; }
+
+update_hash() {
+  old_hash="$(nix_attr "$1.outputHash")"
+  new_hash="$(nix-build --impure --expr "let src = (import $nixpkgs {}).$1; in (src.overrideAttrs or (f: src // f src)) (_: { outputHash = \"\"; outputHashAlgo = \"sha256\"; })" 2>&1 | tr -s ' ' | grep -Po "got: \K.+$")" || true
+  sed -i "s|${old_hash}|${new_hash}|g" package.nix
+  echo "$1: $old_hash -> $new_hash"
+}
+
+latest=$(gh api repos/inngest/inngest/releases/latest --jq '.tag_name' | tr -d 'v')
+current=$(nix_attr inngest.version)
+
+if [[ "$current" == "$latest" ]]; then
+  echo "inngest is already up to date: $current"
+  exit 0
+fi
+
+echo "Updating inngest $current -> $latest"
+
+sed -i "s|version = \"${current}\"|version = \"${latest}\"|" package.nix
+update_hash inngest.src
+
+old_lock=$(gh api "repos/inngest/inngest/contents/ui/pnpm-lock.yaml?ref=v${current}" --jq '.sha')
+new_lock=$(gh api "repos/inngest/inngest/contents/ui/pnpm-lock.yaml?ref=v${latest}" --jq '.sha')
+if [[ "$old_lock" != "$new_lock" ]]; then
+  update_hash inngest.ui.pnpmDeps
+else
+  echo "pnpm lockfile unchanged, skipping"
+fi
+
+new_rev=$(gh api "repos/inngest/inngest/contents/internal/embeddocs/website?ref=v${latest}" --jq '.sha')
+old_rev=$(nix_attr inngest.websiteRev)
+if [[ "$old_rev" != "$new_rev" ]]; then
+  sed -i "s|${old_rev}|${new_rev}|" package.nix
+  update_hash inngest.website
+else
+  echo "website unchanged, skipping"
+fi


### PR DESCRIPTION
Adds [inngest](https://github.com/inngest/inngest) to nixpkgs, superseding #414522 (outdated version) and #512002 (closed in favor of #414522 because it source builds)

---

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [x] Package tests at `passthru.tests` (`testVersion` passes)
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files (`inngest --version`, `inngest dev` MCP endpoint verified)
- Nixpkgs Release Notes — N/A (new package)
- NixOS Release Notes — N/A (no module)
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md
