### PR TITLE
moonlight: 2026.3.3 -> 2026.4.0

### DIFF
--- a/pkgs/by-name/mo/moonlight/disable_updates.patch
+++ b/pkgs/by-name/mo/moonlight/disable_updates.patch
@@ -1,5 +1,5 @@
 diff --git i/packages/core-extensions/src/moonbase/host.ts w/packages/core-extensions/src/moonbase/host.ts
-index 6bb7b62..71b57b9 100644
+index ca78483..25716c9 100644
 --- i/packages/core-extensions/src/moonbase/host.ts
 +++ w/packages/core-extensions/src/moonbase/host.ts
 @@ -79,22 +79,9 @@ electron.app.whenReady().then(() => {
@@ -26,7 +26,7 @@ index 6bb7b62..71b57b9 100644
  
        entries.splice(i + 1, 0, {
 diff --git i/packages/core-extensions/src/moonbase/native.ts w/packages/core-extensions/src/moonbase/native.ts
-index 51e347c..a6bdc58 100644
+index 9cccb0c..58e3e06 100644
 --- i/packages/core-extensions/src/moonbase/native.ts
 +++ w/packages/core-extensions/src/moonbase/native.ts
 @@ -39,24 +39,7 @@ export default function getNatives(): MoonbaseNatives {
@@ -56,15 +56,14 @@ index 51e347c..a6bdc58 100644
  
      async updateMoonlight(overrideBranch?: MoonlightBranch) {
 diff --git i/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx w/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-index 49d7fcb..a65b57c 100644
+index a4aee57..ce564bb 100644
 --- i/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
 +++ w/packages/core-extensions/src/moonbase/webpackModules/ui/config/index.tsx
-@@ -107,16 +107,6 @@ function ArrayFormItem({ config }: { config: "repositories" | "devSearchPaths" }
- export default function ConfigPage() {
+@@ -80,14 +80,6 @@ export default function ConfigPage() {
    return (
      <ErrorBoundary>
--      <div className={Margins.marginTop20}>
--        <FormSwitch
+       <Stack direction="vertical" gap={16}>
+-        <Switch
 -          checked={MoonbaseSettingsStore.getExtensionConfigRaw<boolean>("moonbase", "updateChecking", true) ?? true}
 -          onChange={(value: boolean) => {
 -            MoonbaseSettingsStore.setExtensionConfig("moonbase", "updateChecking", value);
@@ -72,7 +71,6 @@ index 49d7fcb..a65b57c 100644
 -          label="Automatic update checking"
 -          description="Checks for updates to moonlight"
 -        />
--      </div>
-       <FormItem title="Repositories">
-         <FormText className={Margins.marginBottom4}>A list of remote repositories to display extensions from</FormText>
-         <ArrayFormItem config="repositories" />
+         <ArrayFormItem
+           label="Repositories"
+           description="A list of remote repositories to display extensions from"

--- a/pkgs/by-name/mo/moonlight/package.nix
+++ b/pkgs/by-name/mo/moonlight/package.nix
@@ -14,13 +14,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "moonlight";
-  version = "2026.3.3";
+  version = "2026.4.0";
 
   src = fetchFromGitHub {
     owner = "moonlight-mod";
     repo = "moonlight";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hGyUoAR0Pv6mkImRDlrnfYAucgJwg2phj6moxewf3aY=";
+    hash = "sha256-jbIdFHPomN0zD2I6UoClofvSNVdOqpf0nM1s5pbn7ew=";
   };
 
   nativeBuildInputs = [
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
-    hash = "sha256-1jGEzTPPlwAFDKPbH92HvYg4rzFrUJLqhZRMNS+H6GI=";
+    hash = "sha256-veZx/b+cvpcRh1xXO8Y34dJtY2cgncqVSYYywb85Geo=";
   };
 
   env = {


### PR DESCRIPTION
Diff: https://github.com/moonlight-mod/moonlight/compare/v2026.3.3...v2026.4.0
Changelog: https://raw.githubusercontent.com/moonlight-mod/moonlight/refs/tags/v2026.4.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
