### PR TITLE
nixos/stage-1: Fix inconsistency with fonts and no earlySetup

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -189,9 +189,6 @@ in
             "/etc/kbd/keymaps" = lib.mkIf (!cfg.earlySetup) {
               source = "${consoleEnv config.boot.initrd.systemd.package.kbd}/share/keymaps";
             };
-            "/etc/kbd/consolefonts" = lib.mkIf (!cfg.earlySetup && cfg.font != null) {
-              source = "${consoleEnv config.boot.initrd.systemd.package.kbd}/share/consolefonts";
-            };
           };
           boot.initrd.systemd.additionalUpstreamUnits = [
             "systemd-vconsole-setup.service"

--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -23,10 +23,12 @@ let
       '';
 
   # Sadly, systemd-vconsole-setup doesn't support binary keymaps.
-  vconsoleConf = pkgs.writeText "vconsole.conf" ''
-    KEYMAP=${cfg.keyMap}
-    ${lib.optionalString (cfg.font != null) "FONT=${cfg.font}"}
-  '';
+  vconsoleConf =
+    withFont:
+    pkgs.writeText "vconsole.conf" ''
+      KEYMAP=${cfg.keyMap}
+      ${lib.optionalString (withFont && cfg.font != null) "FONT=${cfg.font}"}
+    '';
 
   consoleEnv =
     kbd:
@@ -163,7 +165,7 @@ in
 
           # Let systemd-vconsole-setup.service do the work of setting up the
           # virtual consoles.
-          environment.etc."vconsole.conf".source = vconsoleConf;
+          environment.etc."vconsole.conf".source = vconsoleConf true;
           # Provide kbd with additional packages.
           environment.etc.kbd.source = "${consoleEnv pkgs.kbd}/share";
 
@@ -180,7 +182,7 @@ in
           );
 
           boot.initrd.systemd.contents = {
-            "/etc/vconsole.conf".source = vconsoleConf;
+            "/etc/vconsole.conf".source = vconsoleConf cfg.earlySetup;
             # Add everything if we want full console setup...
             "/etc/kbd" = lib.mkIf cfg.earlySetup {
               source = "${consoleEnv config.boot.initrd.systemd.package.kbd}/share";
@@ -198,7 +200,7 @@ in
             "${config.boot.initrd.systemd.package.kbd}/bin/setfont"
             "${config.boot.initrd.systemd.package.kbd}/bin/loadkeys"
           ]
-          ++ lib.optionals (cfg.font != null && lib.hasPrefix builtins.storeDir cfg.font) [
+          ++ lib.optionals (cfg.font != null && cfg.earlySetup && lib.hasPrefix builtins.storeDir cfg.font) [
             "${cfg.font}"
           ]
           ++ lib.optionals (lib.hasPrefix builtins.storeDir cfg.keyMap) [
@@ -213,7 +215,7 @@ in
             description = "Reset console on configuration changes";
             wantedBy = [ "multi-user.target" ];
             restartTriggers = [
-              vconsoleConf
+              (config.environment.etc."vconsole.conf".source)
               (consoleEnv pkgs.kbd)
             ];
             reloadIfChanged = true;

--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -23,10 +23,12 @@ let
       '';
 
   # Sadly, systemd-vconsole-setup doesn't support binary keymaps.
-  vconsoleConf = pkgs.writeText "vconsole.conf" ''
-    KEYMAP=${cfg.keyMap}
-    ${lib.optionalString (cfg.font != null) "FONT=${cfg.font}"}
-  '';
+  vconsoleConf =
+    withFont:
+    pkgs.writeText "vconsole.conf" ''
+      KEYMAP=${cfg.keyMap}
+      ${lib.optionalString (withFont && cfg.font != null) "FONT=${cfg.font}"}
+    '';
 
   consoleEnv =
     kbd:
@@ -163,7 +165,7 @@ in
 
           # Let systemd-vconsole-setup.service do the work of setting up the
           # virtual consoles.
-          environment.etc."vconsole.conf".source = vconsoleConf;
+          environment.etc."vconsole.conf".source = vconsoleConf true;
           # Provide kbd with additional packages.
           environment.etc.kbd.source = "${consoleEnv pkgs.kbd}/share";
 
@@ -180,7 +182,7 @@ in
           );
 
           boot.initrd.systemd.contents = {
-            "/etc/vconsole.conf".source = vconsoleConf;
+            "/etc/vconsole.conf".source = vconsoleConf cfg.earlySetup;
             # Add everything if we want full console setup...
             "/etc/kbd" = lib.mkIf cfg.earlySetup {
               source = "${consoleEnv config.boot.initrd.systemd.package.kbd}/share";
@@ -213,7 +215,7 @@ in
             description = "Reset console on configuration changes";
             wantedBy = [ "multi-user.target" ];
             restartTriggers = [
-              vconsoleConf
+              (config.environment.etc."vconsole.conf".source)
               (consoleEnv pkgs.kbd)
             ];
             reloadIfChanged = true;


### PR DESCRIPTION
`earlySetup` has to be `true` for fonts to be included in the initrd, so we should not have the `FONT=` line in `/etc/vconsole.conf` when they won't be there to set up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
