### PR TITLE
gping: fix ipv6 use

### DIFF
--- a/pkgs/by-name/gp/gping/package.nix
+++ b/pkgs/by-name/gp/gping/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch,
   installShellFiles,
   iputils,
   versionCheckHook,
@@ -21,6 +22,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-F0QBL7tCCdjnavClqrw8yYxFrY8y4f8h/gcHSpEqBiM=";
+
+  patches = [
+    # Fix use of ipv6 addrs by using ping -6 not ping6
+    (fetchpatch {
+      url = "https://github.com/orf/gping/pull/546.patch";
+      hash = "sha256-b3Nv+mobPUcgREaNvn7cXra24PgEUe60yE/kOPTQEos=";
+    })
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gp/gping/package.nix
+++ b/pkgs/by-name/gp/gping/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
+  fetchpatch,
   installShellFiles,
   iputils,
   versionCheckHook,
@@ -21,6 +22,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-F0QBL7tCCdjnavClqrw8yYxFrY8y4f8h/gcHSpEqBiM=";
+
+  patches = [
+    (fetchpatch {
+      name = "fix-ipv6-addrs-by-using-ping-dash-6.patch";
+      # https://github.com/orf/gping/pull/546
+      url = "https://github.com/orf/gping/commit/7ef8e1ddec847681c5ef3d4a010a0ad3a7aebab0.patch";
+      hash = "sha256-b3Nv+mobPUcgREaNvn7cXra24PgEUe60yE/kOPTQEos=";
+    })
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION

**Description:**
Adds a patch to use `ping -6` instead of `ping6`.

**Backstory:**
`gping` hardcodes the use of `ping6`, which was deprecated from `iputils` in 2015. Some distributions (Debian/Ubuntu) create a symlink from `ping6` to `ping` to maintain backwards compatibility. NixOS does not provide this symlink, causing `nix run nixpkgs#gping -- 2620:fe::fe` to fail with a "cannot find ping6" error.

**Closes:** #499471

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
