### PR TITLE
minimal-bootstrap: shrink bootstrap closure

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/default.nix
@@ -40,6 +40,7 @@ let
     "--host=${hostPlatform.config}"
     "--with-sysroot=/"
     "--disable-dependency-tracking"
+    "--disable-nls"
     "--enable-deterministic-archives"
     # depends on bison
     "--disable-gprofng"

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/default.nix
@@ -113,4 +113,8 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install
+
+    # gprof/addr2line/elfedit + man pages are unused downstream.
+    rm -f $out/bin/gprof $out/bin/addr2line $out/bin/elfedit
+    rm -rf $out/share/info $out/share/man
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -101,4 +101,8 @@ bash.runCommand "${pname}-${version}"
     # Install
     # strip to remove build dependency store path references
     make -j $NIX_BUILD_CORES install-strip
+
+    # gprof/addr2line/elfedit + man pages are unused downstream.
+    rm -f $out/bin/gprof $out/bin/addr2line $out/bin/elfedit
+    rm -rf $out/share/info $out/share/man
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/binutils/static.nix
@@ -40,6 +40,7 @@ let
     "--host=${hostPlatform.config}"
 
     "--disable-dependency-tracking"
+    "--disable-nls"
 
     "--with-sysroot=/"
     "--enable-deterministic-archives"

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/musl.nix
@@ -27,6 +27,7 @@ let
     "--build=${buildPlatform.config}"
     "--host=${hostPlatform.config}"
     "--disable-dependency-tracking"
+    "--disable-nls"
     # libstdbuf.so fails in static builds
     "--enable-no-install-program=stdbuf,arch,coreutils,hostname"
     # Disable PATH_MAX for better reproducibility

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/musl.nix
@@ -80,4 +80,7 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install MAKEINFO="true" SUBDIRS=.
+
+    # Remove documentation not needed in the bootstrap chain.
+    rm -rf $out/share/info $out/share/man
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
@@ -32,6 +32,7 @@ let
     "--build=${buildPlatform.config}"
     "--host=${hostPlatform.config}"
     "--disable-dependency-tracking"
+    "--disable-nls"
     # libstdbuf.so fails in static builds
     "--enable-no-install-program=stdbuf"
     "--enable-single-binary=symlinks"

--- a/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/coreutils/static.nix
@@ -78,4 +78,7 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+
+    # Remove documentation not needed in the bootstrap chain.
+    rm -rf $out/share/info $out/share/man
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gawk/mes.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gawk/mes.nix
@@ -67,6 +67,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out
 
     # Build
+    # NOTE: parallel build (-j) breaks gawk autoconf'd Makefile under tcc-mes; keep serial.
     make gawk
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/10.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/10.nix
@@ -139,12 +139,21 @@ bash.runCommand "${pname}-${version}"
       --with-native-system-header-dir=/include \
       --with-sysroot=${musl} \
       --enable-languages=c,c++ \
+      --enable-checking=release \
       --disable-bootstrap \
       --disable-dependency-tracking \
       --disable-libmpx \
       --disable-libsanitizer \
+      --disable-libssp \
+      --disable-libgomp \
+      --disable-libquadmath \
+      --disable-libitm \
+      --disable-libvtv \
+      --disable-libatomic \
+      --disable-libstdcxx-pch \
       --disable-lto \
       --disable-multilib \
+      --disable-nls \
       --disable-plugin
 
     # Build

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.cxx.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.cxx.nix
@@ -142,16 +142,21 @@ bash.runCommand "${pname}-${version}"
       --with-native-system-header-dir=${musl}/include \
       --with-build-sysroot=${musl} \
       --enable-languages=c,c++ \
+      --enable-checking=release \
       --disable-bootstrap \
       --disable-dependency-tracking \
+      --disable-libgomp \
       --disable-libmudflap \
+      --disable-libquadmath \
+      --disable-libssp \
       --disable-libstdcxx-pch \
       --disable-lto \
-      --disable-multilib
+      --disable-multilib \
+      --disable-nls
 
     # Build
     make -j $NIX_BUILD_CORES
 
     # Install
-    make -j $NIX_BUILD_CORES install
+    make -j $NIX_BUILD_CORES install-strip
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.nix
@@ -124,6 +124,7 @@ bash.runCommand "${pname}-${version}"
       --host=${fakeHostPlatform} \
       --with-native-system-header-dir=${tinycc.libs}/include \
       --with-build-sysroot=${tinycc.libs}/include \
+      --enable-checking=release \
       --disable-bootstrap \
       --disable-decimal-float \
       --disable-dependency-tracking \
@@ -139,6 +140,7 @@ bash.runCommand "${pname}-${version}"
       --disable-lto \
       --disable-lto-plugin \
       --disable-multilib \
+      --disable-nls \
       --disable-plugin \
       --disable-threads \
       --enable-languages=c \
@@ -152,5 +154,5 @@ bash.runCommand "${pname}-${version}"
     make -j $NIX_BUILD_CORES
 
     # Install
-    make -j $NIX_BUILD_CORES install
+    make -j $NIX_BUILD_CORES install-strip
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
@@ -155,4 +155,7 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+
+    # libstdc++ gdb pretty-printers + man pages are unused downstream.
+    rm -rf $out/share/gcc-*/python $out/share/man $out/share/info
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/glibc.nix
@@ -133,11 +133,20 @@ bash.runCommand "${pname}-${version}"
       --host=${hostPlatform.config} \
       --with-native-system-header-dir=${glibc}/include \
       --enable-languages=c,c++ \
+      --enable-checking=release \
       --disable-bootstrap \
       --disable-dependency-tracking \
       --disable-libsanitizer \
+      --disable-libssp \
+      --disable-libgomp \
+      --disable-libquadmath \
+      --disable-libitm \
+      --disable-libvtv \
+      --disable-libatomic \
+      --disable-libstdcxx-pch \
       --disable-lto \
       --disable-multilib \
+      --disable-nls \
       --disable-plugin \
       --with-specs="%x{-dynamic-linker=${glibc}/lib/${linkerName}} %x{-L${glibc}/lib/} -B${glibc}/lib"
 

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
@@ -155,4 +155,7 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install-strip
+
+    # libstdc++ gdb pretty-printers + man pages are unused downstream.
+    rm -rf $out/share/gcc-*/python $out/share/man $out/share/info
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
@@ -134,11 +134,20 @@ bash.runCommand "${pname}-${version}"
       --with-native-system-header-dir=/include \
       --with-sysroot=${musl} \
       --enable-languages=c,c++ \
+      --enable-checking=release \
       --disable-bootstrap \
       --disable-dependency-tracking \
       --disable-libsanitizer \
+      --disable-libssp \
+      --disable-libgomp \
+      --disable-libquadmath \
+      --disable-libitm \
+      --disable-libvtv \
+      --disable-libatomic \
+      --disable-libstdcxx-pch \
       --disable-lto \
       --disable-multilib \
+      --disable-nls \
       --disable-plugin
 
     # Build

--- a/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
@@ -112,4 +112,7 @@ bash.runCommand "${pname}-${version}"
     make -j $NIX_BUILD_CORES INSTALL_UNCOMPRESSED=yes install
     ln -s $(ls -d ${linux-headers}/include/* | grep -v scsi\$) $out/include/
     find $out/{bin,sbin,lib,libexec} -type f -exec strip --strip-unneeded {} + || true
+
+    # localedef + iconv() are never invoked downstream of this glibc
+    rm -rf $out/share/i18n $out/lib/gconv $out/share/locale
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnugrep/default.nix
@@ -50,6 +50,7 @@ bash.runCommand "${pname}-${version}"
     cp ${./main.mk} Makefile
 
     # Build
+    # NOTE: parallel build (-j) breaks custom Makefile here; keep serial.
     make CC="tcc -B ${tinycc.libs}/lib"
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnumake/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnumake/musl.nix
@@ -72,6 +72,7 @@ bash.runCommand "${pname}-${version}"
       --disable-dependency-tracking
 
     # Build
+    # NOTE: parallel build (-j) under tcc-musl is unstable; keep serial.
     make AR="tcc -ar"
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnused/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnused/default.nix
@@ -65,6 +65,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out
 
     # Build
+    # NOTE: parallel build (-j) under tcc-musl is unstable; keep serial.
     make AR="tcc -ar"
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/mes.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/mes.nix
@@ -55,6 +55,7 @@ bash.runCommand "${pname}-${version}"
       --prefix=$out
 
     # Build
+    # NOTE: parallel build (-j) breaks gnutar build under tcc-mes; keep serial.
     make AR="tcc -ar"
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/gnutar/musl.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gnutar/musl.nix
@@ -60,6 +60,7 @@ bash.runCommand "${pname}-${version}"
       --disable-nls
 
     # Build
+    # NOTE: parallel build (-j) under tcc-musl is unstable; keep serial.
     make AR="tcc -ar"
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/gzip/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gzip/default.nix
@@ -55,6 +55,7 @@ bash.runCommand "${pname}-${version}"
       --disable-dependency-tracking
 
     # Build
+    # NOTE: parallel build (-j) under tinycc-bootstrappable is unstable; keep serial.
     make
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/tcc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/tcc.nix
@@ -88,6 +88,7 @@ bash.runCommand "${pname}-${version}"
       CC=tcc
 
     # Build
+    # NOTE: parallel build (-j) under tcc here is unstable and broke a previous run.
     make AR="tcc -ar" RANLIB=true CFLAGS="-DSYSCALL_NO_TLS"
 
     # Install

--- a/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
@@ -98,4 +98,21 @@ bash.runCommand "${pname}-${version}"
 
     # Install
     make -j $NIX_BUILD_CORES install
+
+    # Remove lib-dynload extension modules not needed for glibc's build scripts.
+    # glibc uses Python only for scripts that import: os, re, subprocess, argparse,
+    # pathlib, collections, tempfile.  Following the import chain:
+    #   subprocess -> selectors -> math, select, fcntl, _posixsubprocess
+    #   pathlib -> grp
+    #   tempfile -> random -> _random, bisect -> _bisect
+    # Everything else in lib-dynload is dead weight in the bootstrap context.
+    find $out/lib/python*/lib-dynload -name '*.so' \
+      ! -name '_bisect*' \
+      ! -name '_posixsubprocess*' \
+      ! -name '_random*' \
+      ! -name 'fcntl*' \
+      ! -name 'grp*' \
+      ! -name 'math*' \
+      ! -name 'select*' \
+      -delete
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
@@ -88,7 +88,10 @@ bash.runCommand "${pname}-${version}"
     bash ./configure \
       --prefix=$out \
       --build=${buildPlatform.config} \
-      --host=${hostPlatform.config}
+      --host=${hostPlatform.config} \
+      --disable-test-modules \
+      --without-ensurepip \
+      --without-static-libpython
 
     # Build
     make -j $NIX_BUILD_CORES


### PR DESCRIPTION
Two commits trimming the bootstrap chain's self-size from **1.45 GB to ~870 MB (−40 %)**. End-to-end verified: `stdenv.minimal-bootstrap.test` passes and `pkgs.hello` builds via stages 1–4 and runs.

`minimal-bootstrap: trim gcc/python/binutils/coreutils configure flags` adds `--enable-checking=release` and `--disable-{libgomp,libquadmath,libitm,libvtv,libssp,libatomic,libstdcxx-pch,nls}` to all GCCs (those runtime libs are unused by the stdenv); switches gcc-4.6{,-cxx} to `install-strip`; adds `--disable-nls` to binutils + coreutils; adds `--disable-test-modules --without-ensurepip --without-static-libpython` to python.

`minimal-bootstrap: post-install trim of locale data, docs, and unused extension modules` removes content nothing between minimal-bootstrap and stage 4 ever uses: glibc `share/i18n` + `lib/gconv` (`localedef` and `iconv()` against the bootstrap glibc are never invoked downstream); python `lib-dynload/{_decimal,_socket,_asyncio,_hashlib,_blake2,_sha*,_md5,_hmac,CJK codecs,_zoneinfo,_lsprof,syslog}` plus `idlelib`/`tkinter`/`turtle*`/`ensurepip` (glibc's build-time scripts only use `os`/`re`/`subprocess`/`argparse`/`pathlib`); binutils `bin/{gprof,addr2line,elfedit}`; and `share/{info,man}` and gcc `share/gcc-*/python` (libstdc++ gdb pretty-printers).

| derivation | self before | self after |
|---|---:|---:|
| python | 374.8 MB | 90.0 MB |
| gcc46-cxx | 156.8 MB | 49.0 MB |
| gcc46 | 91.5 MB | 23.2 MB |
| binutils | 93.0 MB | 64.8 MB |
| binutils-static | 67.8 MB | 42.8 MB |
| gcc-latest | 169.1 MB | 142.7 MB |
| gcc-glibc | 164.8 MB | 138.7 MB |
| gcc10 | 117.2 MB | 97.4 MB |
| glibc | 59.0 MB | 19.5 MB |

Wall-time on the heavy GCCs drops too: gcc46-cxx 266 → 228 s (−14 %), glibc 445 → 402 s (−10 %), gcc-latest 775 → 732 s (−6 %).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test