### PR TITLE
buildpack: 0.37.0 -> 0.40.3

### DIFF
--- a/pkgs/by-name/bu/buildpack/package.nix
+++ b/pkgs/by-name/bu/buildpack/package.nix
@@ -8,20 +8,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "pack";
-  version = "0.37.0";
+  version = "0.40.3";
 
   src = fetchFromGitHub {
     owner = "buildpacks";
     repo = "pack";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QCN0UvWa5u9XX5LvY3yD8Xz2s1XzZUg/WXnAfWwZnY0=";
+    hash = "sha256-KKgF05oJDgMQExJtsAc6weor4OxUZl4xNIFY0VoQfs4=";
   };
 
-  vendorHash = "sha256-W8FTk2eJYaTE9gCRwrT+mDhda/ZZeCytqQ9vvVZZHSQ=";
+  vendorHash = "sha256-sRITmNcCwJw4aXLv/wKYOTZai95YY/DY87F4P2+7b5A=";
 
   nativeBuildInputs = [ installShellFiles ];
 
-  subPackages = [ "cmd/pack" ];
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Update to 0.40.3

This changes go submodule organization upstream. We need to build ./ now instead of cmd/pack.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
