### PR TITLE
ideviceinstaller: 1.1.1+date=2023-04-30 -> 1.2.0

### DIFF
--- a/pkgs/by-name/id/ideviceinstaller/package.nix
+++ b/pkgs/by-name/id/ideviceinstaller/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
+  gitUpdater,
   usbmuxd,
   libimobiledevice,
   libzip,
@@ -11,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ideviceinstaller";
-  version = "1.1.1+date=2023-04-30";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "ideviceinstaller";
-    rev = "71ec5eaa30d2780c2614b6b227a2229ea3aeb1e9";
-    hash = "sha256-YsQwAlt71vouYJzXl0P7b3fG/MfcwI947GtvN4g3/gM=";
+    tag = finalAttrs.version;
+    hash = "sha256-V4zJ85wF3jjBlWOY+oxo6veNeiSHVAUBipmokzhRgaI=";
   };
 
   nativeBuildInputs = [
@@ -39,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
   preAutoreconf = ''
     export RELEASE_VERSION=${finalAttrs.version}
   '';
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://github.com/libimobiledevice/ideviceinstaller";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Update
- Add update script
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
