### PR TITLE
vscode-extensions.anthropic.claude-code: use platform-specific VSIXs

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -1,22 +1,38 @@
 {
   lib,
-  claude-code,
+  stdenvNoCC,
   vscode-utils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
-  mktplcRef = {
-    name = "claude-code";
-    publisher = "anthropic";
-    version = "2.1.119";
-    hash = "sha256-/KqOJ8dvv6PhQJyfuOFEgKx6U8hH/WoUnocmWxsLLUk=";
-  };
-
-  postInstall = ''
-    mkdir -p "$out/$installPrefix/resources/native-binary"
-    rm -f "$out/$installPrefix/resources/native-binary/claude"*
-    ln -s "${claude-code}/bin/claude" "$out/$installPrefix/resources/native-binary/claude"
-  '';
+  mktplcRef =
+    let
+      sources = {
+        "x86_64-linux" = {
+          arch = "linux-x64";
+          hash = "sha256-w4kUYNnQW4KkIlzxnTASTBFxL3m3/NBwBET7/8ealIY=";
+        };
+        "aarch64-linux" = {
+          arch = "linux-arm64";
+          hash = "sha256-ZsVR7Qajv78A0+UfR+DqaUZyV1FFRjNs2+vJInboh6U=";
+        };
+        "x86_64-darwin" = {
+          arch = "darwin-x64";
+          hash = "sha256-8zvhF5cs1XOGa/l2M27K2Mv2cgusNy51glFZf1OVdWI=";
+        };
+        "aarch64-darwin" = {
+          arch = "darwin-arm64";
+          hash = "sha256-Csb9F6HGWAgvPDjtsu35gjtGCuDLu0WQD1NNX/+S7F8=";
+        };
+      };
+    in
+    {
+      name = "claude-code";
+      publisher = "anthropic";
+      version = "2.1.119";
+    }
+    // sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");
 
   meta = {
     description = "Harness the power of Claude Code without leaving your IDE";
@@ -25,5 +41,11 @@ vscode-utils.buildVscodeMarketplaceExtension {
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ xiaoxiangmoe ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 }


### PR DESCRIPTION
The marketplace ships a separate VSIX per target platform, each bundling the matching `claude` native binary. Switch to the standard nixpkgs platform-specific pattern via `mktplcRef.arch`, and drop the `claude-code` input plus the `postInstall` symlink.

The previous mechanism (#478565) fetches an unqualified VSIX and replaces its bundled `claude` with a symlink to the `claude-code` package. This risks extension/CLI version drift, and the marketplace serves different per-platform artifacts for the unqualified URL, so the fixed-output hash fails on platforms other than the one it was originally computed on.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
