### PR TITLE
orioledb: init at 17.20

### DIFF
--- a/pkgs/by-name/or/orioledb/extension.nix
+++ b/pkgs/by-name/or/orioledb/extension.nix
@@ -1,0 +1,40 @@
+{
+  curl,
+  fetchFromGitHub,
+  lib,
+  postgresql,
+  postgresqlBuildExtension,
+  postgresqlTestExtension,
+  python3,
+}:
+
+postgresqlBuildExtension (finalAttrs: {
+  pname = "orioledb";
+  # SQL extension version is 1.7, official version is beta15
+  version = "1.7-beta15";
+
+  src = fetchFromGitHub {
+    owner = "orioledb";
+    repo = "orioledb";
+    tag = "beta15";
+    hash = "sha256-ndggHQb/knC1/42k8hCynQGIfEddKMj6PKnA3CcRnno=";
+  };
+
+  buildInputs = postgresql.buildInputs ++ [
+    curl
+  ];
+
+  nativeBuildInputs = [
+    python3
+  ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  meta = {
+    inherit (postgresql.meta) description maintainers;
+    license = lib.licenses.OR [
+      lib.licenses.asl20
+      lib.licenses.postgresql
+    ];
+  };
+})

--- a/pkgs/by-name/or/orioledb/extension.nix
+++ b/pkgs/by-name/or/orioledb/extension.nix
@@ -1,0 +1,46 @@
+{
+  curl,
+  fetchFromGitHub,
+  lib,
+  postgresql,
+  postgresqlBuildExtension,
+  postgresqlTestExtension,
+  python3,
+}:
+
+postgresqlBuildExtension (finalAttrs: {
+  pname = "orioledb";
+  # SQL extension version is 1.8, official version is beta16-pre-3
+  version = "1.8-beta16-pre-3";
+
+  src = fetchFromGitHub {
+    owner = "orioledb";
+    repo = "orioledb";
+    tag = "beta16-pre-3";
+    hash = "sha256-nBLyc9VFETRo75HfBSLmQ13a6Vcc9rlSCp06y/SnDqQ=";
+  };
+
+  buildInputs = postgresql.buildInputs ++ [
+    curl
+  ];
+
+  nativeBuildInputs = [
+    python3
+  ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  meta =
+    # Inheriting maintainers from `postgresql` is only OK to do,
+    # because it's the orioledb-specific fork of PostgreSQL.
+    # Once these patches are upstreamed and the extension can
+    # run on stock PG, this meta section needs to be adjusted.
+    assert postgresql.pname == "orioledb-postgres";
+    {
+      inherit (postgresql.meta) description maintainers;
+      license = lib.licenses.OR [
+        lib.licenses.asl20
+        lib.licenses.postgresql
+      ];
+    };
+})

--- a/pkgs/by-name/or/orioledb/package.nix
+++ b/pkgs/by-name/or/orioledb/package.nix
@@ -1,0 +1,42 @@
+{
+  buildPostgresql,
+  fetchFromGitHub,
+  lib,
+}:
+
+let
+  orioledb-postgres = buildPostgresql rec {
+    pname = "orioledb-postgres";
+    version = "17.18";
+
+    src = fetchFromGitHub {
+      owner = "orioledb";
+      repo = "postgres";
+      tag = "patches17_18";
+      hash = "sha256-GlegSFtRrKIF+gueFWQiZZlCQJmo8Ols13yJzois0Vw=";
+    };
+
+    # Configure extracts the patch version from the git tag. This
+    # is required by the extension build to verify it builds against
+    # the correctly patched postgresql version.
+    postPatch = ''
+      substituteInPlace configure \
+        --replace-fail "git describe --tags --exact-match" "echo '${src.tag}'"
+    '';
+
+    # orioledb seems to have made pg_rewind extensible somehow. For that reason,
+    # there is now a header file in the -dev output for it. Until reported otherwise
+    # we'll just strip that reference to avoid a cycle between outputs.
+    postInstall = ''
+      remove-references-to -t "$dev"  -t "$doc" -t "$man" "$out/bin/pg_rewind"
+    '';
+
+    meta = {
+      description = "Cloud-native storage engine for PostgreSQL";
+      maintainers = [
+        lib.maintainers.wolfgangwalther
+      ];
+    };
+  };
+in
+orioledb-postgres.withPackages (pkgs: [ (pkgs.callPackage ./extension.nix { }) ])

--- a/pkgs/by-name/or/orioledb/package.nix
+++ b/pkgs/by-name/or/orioledb/package.nix
@@ -1,0 +1,50 @@
+{
+  fetchFromGitHub,
+  lib,
+  postgresql_17,
+}:
+
+let
+  orioledb-postgres = postgresql_17.overrideAttrs (
+    finalAttrs: oldAttrs: {
+      pname = "orioledb-postgres";
+      version = "17.20";
+
+      src = fetchFromGitHub {
+        owner = "orioledb";
+        repo = "postgres";
+        tag = "patches17_20";
+        hash = "sha256-3dC00fFpD8fJDKed37oQvILMtA3GKBsWo1GEdUQzXzQ=";
+      };
+
+      # Configure extracts the patch version from the git tag. This
+      # is required by the extension build to verify it builds against
+      # the correctly patched postgresql version.
+      postPatch = oldAttrs.postPatch or "" + ''
+        substituteInPlace configure \
+          --replace-fail "git describe --tags --exact-match" "echo '${finalAttrs.src.tag}'"
+      '';
+
+      # orioledb seems to have made pg_rewind extensible somehow. For that reason,
+      # there is now a header file in the -dev output for it. Until reported otherwise
+      # we'll just strip that reference to avoid a cycle between outputs.
+      postInstall = oldAttrs.postInstall or "" + ''
+        remove-references-to -t "$dev"  -t "$doc" -t "$man" "$out/bin/pg_rewind"
+      '';
+
+      meta = {
+        inherit (oldAttrs.meta)
+          license
+          pkgConfigModules
+          platforms
+          broken
+          ;
+        description = "Cloud-native storage engine for PostgreSQL";
+        maintainers = [
+          lib.maintainers.wolfgangwalther
+        ];
+      };
+    }
+  );
+in
+orioledb-postgres.withPackages (pkgs: [ (pkgs.callPackage ./extension.nix { }) ])

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "14.22";
   rev = "refs/tags/REL_14_22";
   hash = "sha256-0vZEdsrj2WAdXFpZAli5sd0liAfvp9/Os93GjVTy7wk=";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,17 @@
 {
+  fetchFromGitHub,
+  lib,
+}:
+
+rec {
   version = "14.22";
-  rev = "refs/tags/REL_14_22";
-  hash = "sha256-0vZEdsrj2WAdXFpZAli5sd0liAfvp9/Os93GjVTy7wk=";
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    tag = "REL_14_22";
+    hash = "sha256-0vZEdsrj2WAdXFpZAli5sd0liAfvp9/Os93GjVTy7wk=";
+  };
+
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";
@@ -11,5 +21,12 @@
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/dont-use-locale-a-on-musl.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";
       hash = "sha256-fk+y/SvyA4Tt8OIvDl7rje5dLs3Zw+Ln1oddyYzerOo=";
     };
+  };
+
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    changelog = "https://www.postgresql.org/docs/release/${version}/";
+    teams = [ lib.teams.postgres ];
   };
 }

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "14.23";
   rev = "refs/tags/REL_14_23";
   hash = "sha256-fjoboaUhrHFDqusmIXzSS5ZnIpSRHO9+qcqvkchl2dM=";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,11 +1,28 @@
 {
+  fetchFromGitHub,
+  lib,
+}:
+
+rec {
   version = "15.17";
-  rev = "refs/tags/REL_15_17";
-  hash = "sha256-IxvCNJfTbbKT/2dFnNLk3fNUYDaRwHQeeAmvGc1w/OY=";
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    tag = "REL_15_17";
+    hash = "sha256-IxvCNJfTbbKT/2dFnNLk3fNUYDaRwHQeeAmvGc1w/OY=";
+  };
+
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";
       hash = "sha256-fk+y/SvyA4Tt8OIvDl7rje5dLs3Zw+Ln1oddyYzerOo=";
     };
+  };
+
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    changelog = "https://www.postgresql.org/docs/release/${version}/";
+    teams = [ lib.teams.postgres ];
   };
 }

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "15.17";
   rev = "refs/tags/REL_15_17";
   hash = "sha256-IxvCNJfTbbKT/2dFnNLk3fNUYDaRwHQeeAmvGc1w/OY=";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "15.18";
   rev = "refs/tags/REL_15_18";
   hash = "sha256-tw1zzgLXx7Jr4bi8rMKRmTJzOSQFGvrP2nHr9FcVrjs=";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,11 +1,28 @@
 {
+  fetchFromGitHub,
+  lib,
+}:
+
+rec {
   version = "16.13";
-  rev = "refs/tags/REL_16_13";
-  hash = "sha256-Ue117xTq4RMQfq70mnXRBwqJ+IUigW27FvHY7I519ng=";
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    tag = "REL_16_13";
+    hash = "sha256-Ue117xTq4RMQfq70mnXRBwqJ+IUigW27FvHY7I519ng=";
+  };
+
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";
       hash = "sha256-fk+y/SvyA4Tt8OIvDl7rje5dLs3Zw+Ln1oddyYzerOo=";
     };
+  };
+
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    changelog = "https://www.postgresql.org/docs/release/${version}/";
+    teams = [ lib.teams.postgres ];
   };
 }

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "16.13";
   rev = "refs/tags/REL_16_13";
   hash = "sha256-Ue117xTq4RMQfq70mnXRBwqJ+IUigW27FvHY7I519ng=";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "16.14";
   rev = "refs/tags/REL_16_14";
   hash = "sha256-g2+OdB2dGIKBSFJ24Z3Yy7oRAFywNMSVDdWfnsaeJJQ=";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "17.9";
   rev = "refs/tags/REL_17_9";
   hash = "sha256-kmESMgxYL5FsDjg3MLHaginIu6IWMo20kNdOLMM1x4w=";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,11 +1,28 @@
 {
+  fetchFromGitHub,
+  lib,
+}:
+
+rec {
   version = "17.9";
-  rev = "refs/tags/REL_17_9";
-  hash = "sha256-kmESMgxYL5FsDjg3MLHaginIu6IWMo20kNdOLMM1x4w=";
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    tag = "REL_17_9";
+    hash = "sha256-kmESMgxYL5FsDjg3MLHaginIu6IWMo20kNdOLMM1x4w=";
+  };
+
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";
       hash = "sha256-6zjz3OpMx4qTETdezwZxSJPPdOvhCNu9nXvAaU9SwH8=";
     };
+  };
+
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    changelog = "https://www.postgresql.org/docs/release/${version}/";
+    teams = [ lib.teams.postgres ];
   };
 }

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "17.10";
   rev = "refs/tags/REL_17_10";
   hash = "sha256-3ZAqlT3R8ywhNH13oqz2VUbSwpOJ2JaICbxZ29awaMw=";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,11 +1,28 @@
 {
+  fetchFromGitHub,
+  lib,
+}:
+
+rec {
   version = "18.3";
-  rev = "refs/tags/REL_18_3";
-  hash = "sha256-3cu3oyPJ5q6ewv7RFY7Nys5l+10dsQv5f1HNIoYtrO8=";
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    tag = "REL_18_3";
+    hash = "sha256-3cu3oyPJ5q6ewv7RFY7Nys5l+10dsQv5f1HNIoYtrO8=";
+  };
+
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";
       hash = "sha256-6zjz3OpMx4qTETdezwZxSJPPdOvhCNu9nXvAaU9SwH8=";
     };
+  };
+
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    changelog = "https://www.postgresql.org/docs/release/${version}/";
+    teams = [ lib.teams.postgres ];
   };
 }

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "18.3";
   rev = "refs/tags/REL_18_3";
   hash = "sha256-3cu3oyPJ5q6ewv7RFY7Nys5l+10dsQv5f1HNIoYtrO8=";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "18.4";
   rev = "refs/tags/REL_18_4";
   hash = "sha256-Ac/Dqcj8vjcW3my5vsnKaMiQqTq/HPtUzckJ3SMyrfA=";

--- a/pkgs/servers/sql/postgresql/19.nix
+++ b/pkgs/servers/sql/postgresql/19.nix
@@ -1,4 +1,4 @@
-import ./generic.nix {
+{
   version = "19beta1";
   rev = "refs/tags/REL_19_BETA1";
   hash = "sha256-thvbttX8wwGLf5tMJRHl86Xv8OgINzahoqB/AzAdtMI=";

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -22,7 +22,7 @@ let
       version: path:
       let
         attrName = if jitSupport then "${version}_jit" else version;
-        postgresql = import path { inherit self; };
+        postgresql = self.callPackage ./generic.nix (import path // { inherit self; });
         attrValue = if jitSupport then postgresql.withJIT else postgresql.withoutJIT;
       in
       self.lib.nameValuePair attrName attrValue

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -16,13 +16,16 @@ let
     postgresql_18 = ./18.nix;
   };
 
+  buildPostgresql =
+    args: self.callPackage (import ./generic.nix args) { inherit buildPostgresql self; };
+
   mkAttributes =
     jitSupport:
     self.lib.mapAttrs' (
       version: path:
       let
         attrName = if jitSupport then "${version}_jit" else version;
-        postgresql = self.callPackage ./generic.nix (import path // { inherit self; });
+        postgresql = buildPostgresql (import path);
         attrValue = if jitSupport then postgresql.withJIT else postgresql.withoutJIT;
       in
       self.lib.nameValuePair attrName attrValue
@@ -36,5 +39,5 @@ in
   postgresqlVersions = mkAttributes false;
   postgresqlJitVersions = mkAttributes true;
 
-  inherit libpq;
+  inherit buildPostgresql libpq;
 }

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -25,7 +25,7 @@ let
       version: path:
       let
         attrName = if jitSupport then "${version}_jit" else version;
-        postgresql = buildPostgresql (import path);
+        postgresql = buildPostgresql (import path { inherit (self) fetchFromGitHub lib; });
         attrValue = if jitSupport then postgresql.withJIT else postgresql.withoutJIT;
       in
       self.lib.nameValuePair attrName attrValue

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -23,7 +23,7 @@ let
       version: path:
       let
         attrName = if jitSupport then "${version}_jit" else version;
-        postgresql = import path { inherit self; };
+        postgresql = self.callPackage ./generic.nix (import path // { inherit self; });
         attrValue = if jitSupport then postgresql.withJIT else postgresql;
       in
       self.lib.nameValuePair attrName attrValue

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -1,8 +1,9 @@
 # Arguments for buildPostgresql
 {
-  hash,
+  meta,
   muslPatches ? { },
-  rev,
+  pname ? "postgresql",
+  src,
   version,
 }@builderArgs:
 
@@ -171,16 +172,7 @@ let
       stdenv;
 in
 stdenv'.mkDerivation (finalAttrs: {
-  inherit version;
-  pname = "postgresql";
-
-  src = fetchFromGitHub {
-    owner = "postgres";
-    repo = "postgres";
-    # rev, not tag, on purpose: allows updating when new versions
-    # are "stamped" a few days before release (tag).
-    inherit hash rev;
-  };
+  inherit pname src version;
 
   __structuredAttrs = true;
 
@@ -608,11 +600,7 @@ stdenv'.mkDerivation (finalAttrs: {
     };
 
   meta = {
-    homepage = "https://www.postgresql.org";
-    description = "Powerful, open source object-relational database system";
     license = lib.licenses.postgresql;
-    changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
-    teams = [ lib.teams.postgres ];
     pkgConfigModules = [
       "libecpg"
       "libecpg_compat"
@@ -620,7 +608,9 @@ stdenv'.mkDerivation (finalAttrs: {
       "libpq"
     ];
     platforms = lib.platforms.unix;
-
+  }
+  // meta
+  // {
     # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
     # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
     # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
@@ -634,6 +624,7 @@ stdenv'.mkDerivation (finalAttrs: {
     #
     # Note: This is "host canExecute build" on purpose, since this is about the LLVM that is called
     # to do JIT at **runtime**.
-    broken = jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform;
+    broken =
+      meta.broken or false || (jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform);
   };
 })

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -3,6 +3,8 @@
   meta,
   muslPatches ? { },
   pname ? "postgresql",
+  postPatch ? "",
+  postInstall ? "",
   src,
   version,
 }@builderArgs:
@@ -438,7 +440,8 @@ stdenv'.mkDerivation (finalAttrs: {
   + lib.optionalString (atLeast "15" && stdenv'.hostPlatform.isStatic) ''
     substituteInPlace src/interfaces/libpq/Makefile \
       --replace-fail "echo 'libpq must not be calling any function which invokes exit'; exit 1;" "echo;"
-  '';
+  ''
+  + postPatch;
 
   postInstall = ''
     moveToOutput "bin/ecpg" "$dev"
@@ -509,7 +512,8 @@ stdenv'.mkDerivation (finalAttrs: {
   + lib.optionalString tclSupport ''
     moveToOutput "lib/*pltcl*" "$pltcl"
     moveToOutput "share/postgresql/extension/*pltcl*" "$pltcl"
-  '';
+  ''
+  + postInstall;
 
   postFixup = lib.optionalString stdenv'.hostPlatform.isGnu ''
     # initdb needs access to "locale" command from glibc.

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -39,7 +39,6 @@ let
       removeReferencesTo,
 
       # passthru
-      buildEnv,
       buildPackages,
       newScope,
       nixosTests,
@@ -585,10 +584,7 @@ let
             in
             import ./ext.nix newSelf newSuper;
 
-          withPackages = postgresqlWithPackages {
-            inherit buildEnv lib makeBinaryWrapper;
-            postgresql = this;
-          };
+          withPackages = self.callPackage ./wrapper.nix { postgresql = this; };
 
           pg_config = buildPackages.callPackage ./pg_config.nix {
             inherit (finalAttrs) finalPackage;
@@ -640,74 +636,6 @@ let
         broken = jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform;
       };
     });
-
-  postgresqlWithPackages =
-    {
-      postgresql,
-      buildEnv,
-      lib,
-      makeBinaryWrapper,
-    }:
-    f:
-    let
-      installedExtensions = f postgresql.pkgs;
-      recurse = postgresqlWithPackages {
-        inherit
-          buildEnv
-          lib
-          makeBinaryWrapper
-          postgresql
-          ;
-      };
-      finalPackage = buildEnv {
-        pname = "${postgresql.pname}-and-plugins";
-        inherit (postgresql) version;
-        paths = installedExtensions ++ [
-          # consider keeping in-sync with `postBuild` below
-          postgresql
-          postgresql.man # in case user installs this into environment
-        ];
-
-        pathsToLink = [
-          "/"
-          "/bin"
-          "/share/postgresql/extension"
-          # Unbreaks Omnigres' build system
-          "/share/postgresql/timezonesets"
-          "/share/postgresql/tsearch_data"
-        ];
-
-        nativeBuildInputs = [ makeBinaryWrapper ];
-        postBuild =
-          let
-            args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-          in
-          ''
-            wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
-          '';
-
-        passthru = {
-          inherit installedExtensions;
-          inherit (postgresql)
-            pkgs
-            psqlSchema
-            ;
-
-          pg_config = postgresql.pg_config.override {
-            outputs = {
-              out = finalPackage;
-              man = finalPackage;
-            };
-          };
-
-          withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
-          withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
-
-          withPackages = f': recurse (ps: installedExtensions ++ f' ps);
-        };
-      };
-    in
-    finalPackage;
 
 in
 # passed by <major>.nix

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -155,7 +155,6 @@
 let
   atLeast = lib.versionAtLeast version;
   olderThan = lib.versionOlder version;
-  lz4Enabled = atLeast "14";
   zstdEnabled = atLeast "15";
 
   dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
@@ -264,7 +263,7 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals icuSupport [ icu ]
   ++ lib.optionals jitSupport [ llvmPackages.llvm ]
-  ++ lib.optionals lz4Enabled [ lz4 ]
+  ++ [ lz4 ]
   ++ lib.optionals zstdEnabled [ zstd ]
   ++ lib.optionals systemdSupport [ systemdLibs ]
   ++ lib.optionals uringSupport [ liburing ]
@@ -338,7 +337,7 @@ stdenv'.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals (withBlocksize != null) [ "--with-blocksize=${toString withBlocksize}" ]
     ++ lib.optionals (withWalBlocksize != null) [ "--with-wal-blocksize=${toString withWalBlocksize}" ]
-    ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+    ++ [ "--with-lz4" ]
     ++ lib.optionals zstdEnabled [ "--with-zstd" ]
     ++ lib.optionals uringSupport [ "--with-liburing" ]
     ++ lib.optionals curlSupport [ "--with-libcurl" ]

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -1,3 +1,12 @@
+# Arguments for buildPostgresql
+{
+  hash,
+  muslPatches ? { },
+  rev,
+  version,
+}@builderArgs:
+
+# Arguments to callPackage
 {
   # utils
   stdenv,
@@ -5,12 +14,6 @@
   fetchurl,
   lib,
   replaceVars,
-
-  # source specification
-  hash,
-  muslPatches ? { },
-  rev,
-  version,
 
   # runtime dependencies
   darwin,
@@ -37,6 +40,7 @@
 
   # passthru
   buildPackages,
+  buildPostgresql,
   newScope,
   nixosTests,
   self,
@@ -146,7 +150,7 @@
   # Uring
   uringSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform liburing,
   liburing,
-}@args:
+}@packageArgs:
 let
   atLeast = lib.versionAtLeast version;
   olderThan = lib.versionOlder version;
@@ -549,7 +553,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   passthru =
     let
-      this = self.callPackage ./generic.nix args;
+      this = (buildPostgresql builderArgs).override packageArgs;
     in
     {
       inherit dlSuffix;

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -1,645 +1,635 @@
+{
+  # utils
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  replaceVars,
+
+  # source specification
+  hash,
+  muslPatches ? { },
+  rev,
+  version,
+
+  # runtime dependencies
+  darwin,
+  freebsd,
+  glibc,
+  libuuid,
+  libxml2,
+  lz4,
+  openssl,
+  readline,
+  tzdata,
+  zlib,
+  zstd,
+
+  # build dependencies
+  bison,
+  docbook-xsl-nons,
+  docbook_xml_dtd_45,
+  flex,
+  libxslt,
+  makeBinaryWrapper,
+  pkg-config,
+  removeReferencesTo,
+
+  # passthru
+  buildPackages,
+  newScope,
+  nixosTests,
+  self,
+  testers,
+
+  # Block size
+  # Changing the block size will break on-disk database compatibility. See:
+  # https://www.postgresql.org/docs/current/install-make.html#CONFIGURE-OPTION-WITH-BLOCKSIZE
+  withBlocksize ? null,
+  withWalBlocksize ? null,
+
+  # bonjour
+  bonjourSupport ? false,
+
+  # Curl
+  curlSupport ?
+    lib.versionAtLeast version "18"
+    && lib.meta.availableOn stdenv.hostPlatform curl
+    # Building statically fails with:
+    # configure: error: library 'curl' does not provide curl_multi_init
+    # https://www.postgresql.org/message-id/487dacec-6d8d-46c0-a36f-d5b8c81a56f1%40technowledgy.de
+    && !stdenv.hostPlatform.isStatic,
+  curl,
+
+  # GSSAPI
+  gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic,
+  libkrb5,
+
+  # icu
+  # Building with icu in pkgsStatic gives tons of "undefined reference" errors like this:
+  #   /nix/store/452lkaak37d3mzzn3p9ak7aa3wzhdqaj-icu4c-74.2-x86_64-unknown-linux-musl/lib/libicuuc.a(chariter.ao):
+  #    (.data.rel.ro._ZTIN6icu_7417CharacterIteratorE[_ZTIN6icu_7417CharacterIteratorE]+0x0):
+  #    undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
+  icuSupport ? !stdenv.hostPlatform.isStatic,
+  icu,
+
+  # JIT
+  jitSupport ?
+    stdenv.hostPlatform.canExecute stdenv.buildPlatform
+    # Building with JIT in pkgsStatic fails like this:
+    #   fatal error: 'stdio.h' file not found
+    && !stdenv.hostPlatform.isStatic,
+  llvmPackages,
+  nukeReferences,
+  overrideCC,
+
+  # LDAP
+  ldapSupport ? false,
+  openldap,
+
+  # NLS
+  nlsSupport ? false,
+  gettext,
+
+  # NUMA
+  numaSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform numactl,
+  numactl,
+
+  # PAM
+  pamSupport ?
+    lib.meta.availableOn stdenv.hostPlatform linux-pam
+    # Building with linux-pam in pkgsStatic gives a few "undefined reference" errors like this:
+    #   /nix/store/3s55icpsbc36sgn7sa8q3qq4z6al6rlr-linux-pam-static-x86_64-unknown-linux-musl-1.6.1/lib/libpam.a(pam_audit.o):
+    #     in function `pam_modutil_audit_write':(.text+0x571):
+    #     undefined reference to `audit_close'
+    && !stdenv.hostPlatform.isStatic,
+  linux-pam,
+
+  # PL/Perl
+  perlSupport ?
+    lib.meta.availableOn stdenv.hostPlatform perl
+    # Building with perl in pkgsStatic gives this error:
+    #   configure: error: cannot build PL/Perl because libperl is not a shared library
+    && !stdenv.hostPlatform.isStatic
+    # configure tries to call the perl executable for the version
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  perl,
+
+  # PL/Python
+  pythonSupport ?
+    lib.meta.availableOn stdenv.hostPlatform python3
+    # Building with python in pkgsStatic gives this error:
+    #  checking how to link an embedded Python application... configure: error: could not find shared library for Python
+    && !stdenv.hostPlatform.isStatic
+    # configure tries to call the python executable
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  python3,
+
+  # PL/Tcl
+  tclSupport ?
+    lib.meta.availableOn stdenv.hostPlatform tcl
+    # tcl is broken in pkgsStatic
+    && !stdenv.hostPlatform.isStatic
+    # configure fails with:
+    #   configure: error: file 'tclConfig.sh' is required for Tcl
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  tcl,
+
+  # SELinux
+  selinuxSupport ? false,
+  libselinux,
+
+  # Systemd
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdLibs,
+
+  # Uring
+  uringSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform liburing,
+  liburing,
+}@args:
 let
+  atLeast = lib.versionAtLeast version;
+  olderThan = lib.versionOlder version;
+  lz4Enabled = atLeast "14";
+  zstdEnabled = atLeast "15";
 
-  generic =
-    # utils
-    {
-      stdenv,
-      fetchFromGitHub,
-      fetchurl,
-      lib,
-      replaceVars,
+  dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
 
-      # source specification
-      hash,
-      muslPatches ? { },
-      rev,
-      version,
+  stdenv' =
+    if !stdenv.cc.isClang then
+      overrideCC llvmPackages.stdenv (
+        llvmPackages.stdenv.cc.override {
+          # LLVM bintools are not used by default, but are needed to make -flto work below.
+          bintools = buildPackages."llvmPackages_${lib.versions.major llvmPackages.release_version}".bintools;
+        }
+      )
+    else
+      stdenv;
+in
+stdenv'.mkDerivation (finalAttrs: {
+  inherit version;
+  pname = "postgresql";
 
-      # runtime dependencies
-      darwin,
-      freebsd,
-      glibc,
-      libuuid,
-      libxml2,
-      lz4,
-      openssl,
-      readline,
-      tzdata,
-      zlib,
-      zstd,
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    # rev, not tag, on purpose: allows updating when new versions
+    # are "stamped" a few days before release (tag).
+    inherit hash rev;
+  };
 
-      # build dependencies
-      bison,
-      docbook-xsl-nons,
-      docbook_xml_dtd_45,
-      flex,
-      libxslt,
-      makeBinaryWrapper,
-      pkg-config,
-      removeReferencesTo,
+  __structuredAttrs = true;
 
-      # passthru
-      buildPackages,
-      newScope,
-      nixosTests,
-      self,
-      testers,
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+    "lib"
+    "man"
+  ]
+  ++ lib.optionals jitSupport [ "jit" ]
+  ++ lib.optionals perlSupport [ "plperl" ]
+  ++ lib.optionals pythonSupport [ "plpython3" ]
+  ++ lib.optionals tclSupport [ "pltcl" ];
 
-      # Block size
-      # Changing the block size will break on-disk database compatibility. See:
-      # https://www.postgresql.org/docs/current/install-make.html#CONFIGURE-OPTION-WITH-BLOCKSIZE
-      withBlocksize ? null,
-      withWalBlocksize ? null,
+  outputChecks = {
+    out = {
+      disallowedReferences = [
+        "dev"
+        "doc"
+        "man"
+      ]
+      ++ lib.optionals jitSupport [ "jit" ];
+      disallowedRequisites = [
+        stdenv'.cc
+        llvmPackages.llvm.out
+        llvmPackages.llvm.lib
+      ]
+      ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+    };
 
-      # bonjour
-      bonjourSupport ? false,
-
-      # Curl
-      curlSupport ?
-        lib.versionAtLeast version "18"
-        && lib.meta.availableOn stdenv.hostPlatform curl
-        # Building statically fails with:
-        # configure: error: library 'curl' does not provide curl_multi_init
-        # https://www.postgresql.org/message-id/487dacec-6d8d-46c0-a36f-d5b8c81a56f1%40technowledgy.de
-        && !stdenv.hostPlatform.isStatic,
-      curl,
-
-      # GSSAPI
-      gssSupport ? with stdenv.hostPlatform; !isWindows && !isStatic,
-      libkrb5,
-
-      # icu
-      # Building with icu in pkgsStatic gives tons of "undefined reference" errors like this:
-      #   /nix/store/452lkaak37d3mzzn3p9ak7aa3wzhdqaj-icu4c-74.2-x86_64-unknown-linux-musl/lib/libicuuc.a(chariter.ao):
-      #    (.data.rel.ro._ZTIN6icu_7417CharacterIteratorE[_ZTIN6icu_7417CharacterIteratorE]+0x0):
-      #    undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
-      icuSupport ? !stdenv.hostPlatform.isStatic,
-      icu,
-
-      # JIT
-      jitSupport ?
-        stdenv.hostPlatform.canExecute stdenv.buildPlatform
-        # Building with JIT in pkgsStatic fails like this:
-        #   fatal error: 'stdio.h' file not found
-        && !stdenv.hostPlatform.isStatic,
-      llvmPackages,
-      nukeReferences,
-      overrideCC,
-
-      # LDAP
-      ldapSupport ? false,
-      openldap,
-
-      # NLS
-      nlsSupport ? false,
-      gettext,
-
-      # NUMA
-      numaSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform numactl,
-      numactl,
-
-      # PAM
-      pamSupport ?
-        lib.meta.availableOn stdenv.hostPlatform linux-pam
-        # Building with linux-pam in pkgsStatic gives a few "undefined reference" errors like this:
-        #   /nix/store/3s55icpsbc36sgn7sa8q3qq4z6al6rlr-linux-pam-static-x86_64-unknown-linux-musl-1.6.1/lib/libpam.a(pam_audit.o):
-        #     in function `pam_modutil_audit_write':(.text+0x571):
-        #     undefined reference to `audit_close'
-        && !stdenv.hostPlatform.isStatic,
-      linux-pam,
-
-      # PL/Perl
-      perlSupport ?
-        lib.meta.availableOn stdenv.hostPlatform perl
-        # Building with perl in pkgsStatic gives this error:
-        #   configure: error: cannot build PL/Perl because libperl is not a shared library
-        && !stdenv.hostPlatform.isStatic
-        # configure tries to call the perl executable for the version
-        && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-      perl,
-
-      # PL/Python
-      pythonSupport ?
-        lib.meta.availableOn stdenv.hostPlatform python3
-        # Building with python in pkgsStatic gives this error:
-        #  checking how to link an embedded Python application... configure: error: could not find shared library for Python
-        && !stdenv.hostPlatform.isStatic
-        # configure tries to call the python executable
-        && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-      python3,
-
-      # PL/Tcl
-      tclSupport ?
-        lib.meta.availableOn stdenv.hostPlatform tcl
-        # tcl is broken in pkgsStatic
-        && !stdenv.hostPlatform.isStatic
-        # configure fails with:
-        #   configure: error: file 'tclConfig.sh' is required for Tcl
-        && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-      tcl,
-
-      # SELinux
-      selinuxSupport ? false,
-      libselinux,
-
-      # Systemd
-      systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-      systemdLibs,
-
-      # Uring
-      uringSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform liburing,
-      liburing,
-    }@args:
-    let
-      atLeast = lib.versionAtLeast version;
-      olderThan = lib.versionOlder version;
-      lz4Enabled = atLeast "14";
-      zstdEnabled = atLeast "15";
-
-      dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
-
-      stdenv' =
-        if !stdenv.cc.isClang then
-          overrideCC llvmPackages.stdenv (
-            llvmPackages.stdenv.cc.override {
-              # LLVM bintools are not used by default, but are needed to make -flto work below.
-              bintools = buildPackages."llvmPackages_${lib.versions.major llvmPackages.release_version}".bintools;
-            }
-          )
-        else
-          stdenv;
-    in
-    stdenv'.mkDerivation (finalAttrs: {
-      inherit version;
-      pname = "postgresql";
-
-      src = fetchFromGitHub {
-        owner = "postgres";
-        repo = "postgres";
-        # rev, not tag, on purpose: allows updating when new versions
-        # are "stamped" a few days before release (tag).
-        inherit hash rev;
-      };
-
-      __structuredAttrs = true;
-
-      outputs = [
+    lib = {
+      disallowedReferences = [
         "out"
         "dev"
         "doc"
-        "lib"
         "man"
       ]
-      ++ lib.optionals jitSupport [ "jit" ]
-      ++ lib.optionals perlSupport [ "plperl" ]
-      ++ lib.optionals pythonSupport [ "plpython3" ]
-      ++ lib.optionals tclSupport [ "pltcl" ];
+      ++ lib.optionals jitSupport [ "jit" ];
+      disallowedRequisites = [
+        stdenv'.cc
+        llvmPackages.llvm.out
+        llvmPackages.llvm.lib
+      ]
+      ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+    };
 
-      outputChecks = {
-        out = {
-          disallowedReferences = [
-            "dev"
-            "doc"
-            "man"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-            llvmPackages.llvm.lib
-          ]
-          ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
+    doc = {
+      disallowedReferences = [
+        "out"
+        "dev"
+        "man"
+      ]
+      ++ lib.optionals jitSupport [ "jit" ];
+    };
 
-        lib = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "doc"
-            "man"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-            llvmPackages.llvm.lib
-          ]
-          ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
+    man = {
+      disallowedReferences = [
+        "out"
+        "dev"
+        "doc"
+      ]
+      ++ lib.optionals jitSupport [ "jit" ];
+    };
+  }
+  // lib.optionalAttrs jitSupport {
+    jit = {
+      disallowedReferences = [
+        "dev"
+        "doc"
+        "man"
+      ];
+      disallowedRequisites = [
+        stdenv'.cc
+        llvmPackages.llvm.out
+      ]
+      ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+    };
+  };
 
-        doc = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "man"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-        };
+  strictDeps = true;
 
-        man = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "doc"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
+  buildInputs = [
+    zlib
+    readline
+    openssl
+    libxml2
+    libuuid
+  ]
+  ++ lib.optionals icuSupport [ icu ]
+  ++ lib.optionals jitSupport [ llvmPackages.llvm ]
+  ++ lib.optionals lz4Enabled [ lz4 ]
+  ++ lib.optionals zstdEnabled [ zstd ]
+  ++ lib.optionals systemdSupport [ systemdLibs ]
+  ++ lib.optionals uringSupport [ liburing ]
+  ++ lib.optionals curlSupport [ curl ]
+  ++ lib.optionals numaSupport [ numactl ]
+  ++ lib.optionals gssSupport [ libkrb5 ]
+  ++ lib.optionals pamSupport [ linux-pam ]
+  ++ lib.optionals perlSupport [ perl ]
+  ++ lib.optionals ldapSupport [ openldap ]
+  ++ lib.optionals selinuxSupport [ libselinux ]
+  ++ lib.optionals nlsSupport [ gettext ];
+
+  nativeBuildInputs = [
+    bison
+    docbook-xsl-nons
+    docbook_xml_dtd_45
+    flex
+    libxml2
+    libxslt
+    makeBinaryWrapper
+    perl
+    pkg-config
+    removeReferencesTo
+  ]
+  ++ lib.optionals jitSupport [
+    llvmPackages.llvm.dev
+    nukeReferences
+  ];
+
+  enableParallelBuilding = true;
+
+  separateDebugInfo = true;
+
+  buildFlags = [ "world" ];
+
+  env = {
+    # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
+    # into all binaries. However, almost no binaries actually use those paths. The following
+    # flags will remove unused sections from all shared libraries and binaries - including
+    # those paths. This avoids a lot of circular dependency problems with different outputs,
+    # and allows splitting them cleanly.
+    CFLAGS = "-fdata-sections -ffunction-sections -flto";
+
+    # This flag was introduced upstream in:
+    # https://github.com/postgres/postgres/commit/b6c7cfac88c47a9194d76f3d074129da3c46545a
+    # It causes errors when linking against libpq.a in pkgsStatic:
+    #   undefined reference to `pg_encoding_to_char'
+    # Unsetting the flag fixes it. The upstream reasoning to introduce it is about the risk
+    # to have initdb load a libpq.so from a different major version and how to avoid that.
+    # This doesn't apply to us with Nix.
+    NIX_CFLAGS_COMPILE = "-UUSE_PRIVATE_ENCODING_FUNCS";
+  }
+  // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
+  // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }
+  // lib.optionalAttrs tclSupport { TCLSH = "${lib.getBin tcl}/bin/tclsh"; };
+
+  configureFlags =
+    let
+      inherit (lib) withFeature;
+    in
+    [
+      "--with-openssl"
+      "--with-libxml"
+      (withFeature icuSupport "icu")
+      "--sysconfdir=/etc"
+      "--with-system-tzdata=${tzdata}/share/zoneinfo"
+      "--enable-debug"
+      (lib.optionalString systemdSupport "--with-systemd")
+      (if stdenv.hostPlatform.isFreeBSD then "--with-uuid=bsd" else "--with-uuid=e2fs")
+      (withFeature perlSupport "perl")
+    ]
+    ++ lib.optionals (withBlocksize != null) [ "--with-blocksize=${toString withBlocksize}" ]
+    ++ lib.optionals (withWalBlocksize != null) [ "--with-wal-blocksize=${toString withWalBlocksize}" ]
+    ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+    ++ lib.optionals zstdEnabled [ "--with-zstd" ]
+    ++ lib.optionals uringSupport [ "--with-liburing" ]
+    ++ lib.optionals curlSupport [ "--with-libcurl" ]
+    ++ lib.optionals numaSupport [ "--with-libnuma" ]
+    ++ lib.optionals gssSupport [ "--with-gssapi" ]
+    ++ lib.optionals pythonSupport [ "--with-python" ]
+    ++ lib.optionals jitSupport [ "--with-llvm" ]
+    ++ lib.optionals pamSupport [ "--with-pam" ]
+    # This can be removed once v17 is removed. v18+ ships with it.
+    ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16" && olderThan "18") [
+      "LDFLAGS_EX_BE=-Wl,-export_dynamic"
+    ]
+    # some version of this flag is required in all cross configurations
+    # since it cannot be automatically detected
+    ++
+      lib.optionals
+        (
+          (!stdenv'.hostPlatform.isDarwin)
+          && (!(stdenv'.buildPlatform.canExecute stdenv.hostPlatform))
+          && atLeast "16"
+        )
+        [
+          "LDFLAGS_EX_BE=-Wl,--export-dynamic"
+        ]
+    ++ lib.optionals ldapSupport [ "--with-ldap" ]
+    ++ lib.optionals tclSupport [ "--with-tcl" ]
+    ++ lib.optionals selinuxSupport [ "--with-selinux" ]
+    ++ lib.optionals nlsSupport [ "--enable-nls" ]
+    ++ lib.optionals bonjourSupport [ "--with-bonjour" ];
+
+  patches = [
+    (
+      if atLeast "16" then
+        ./patches/relative-to-symlinks-16+.patch
+      else
+        ./patches/relative-to-symlinks.patch
+    )
+    (
+      if atLeast "15" then
+        ./patches/empty-pg-config-view-15+.patch
+      else
+        ./patches/empty-pg-config-view.patch
+    )
+    ./patches/less-is-more.patch
+    ./patches/paths-for-split-outputs.patch
+    ./patches/paths-with-postgresql-suffix.patch
+
+    (replaceVars ./patches/locale-binary-path.patch {
+      locale = "${
+        if stdenv.hostPlatform.isDarwin then
+          darwin.adv_cmds
+        else if stdenv.hostPlatform.isFreeBSD then
+          freebsd.locale
+        else
+          lib.getBin stdenv.cc.libc
+      }/bin/locale";
+    })
+  ]
+  ++ lib.optionals stdenv'.hostPlatform.isMusl (
+    # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
+    map fetchurl (lib.attrValues muslPatches)
+  )
+  ++ lib.optionals stdenv'.hostPlatform.isLinux [
+    ./patches/socketdir-in-run-13+.patch
+  ]
+  ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
+    ./patches/export-dynamic-darwin-15-.patch
+  ];
+
+  installTargets = [ "install-world" ];
+
+  postPatch = ''
+    substituteInPlace "src/Makefile.global.in" --subst-var out
+    substituteInPlace "src/common/config_info.c" --subst-var dev
+    cat ${./pg_config.env.mk} >> src/common/Makefile
+  ''
+  # This test always fails on hardware with >1 NUMA node: the sysfs
+  # dirs providing information about the topology are hidden in the sandbox,
+  # so postgres assumes there's only a single node `0`. However,
+  # the test checks on which NUMA nodes the allocated pages are which is >1
+  # on such hardware. This in turn triggers a safeguard in the view
+  # which breaks the test.
+  # Manual tests confirm that the testcase behaves properly outside of the
+  # Nix sandbox.
+  + lib.optionalString (atLeast "18") ''
+    substituteInPlace src/test/regress/parallel_schedule \
+      --replace-fail numa ""
+  ''
+  # This check was introduced upstream to prevent calls to "exit" inside libpq.
+  # However, this doesn't work reliably with static linking, see this and following:
+  # https://postgr.es/m/flat/20210703001639.GB2374652%40rfd.leadboat.com#52584ca4bd3cb9dac376f3158c419f97
+  # Thus, disable the check entirely, as it would currently fail with this:
+  # > libpq.so.5.17:                  U atexit
+  # > libpq.so.5.17:                  U pthread_exit
+  # > libpq must not be calling any function which invokes exit
+  # Don't mind the fact that this checks libpq.**so** in pkgsStatic - that's correct, since PostgreSQL
+  # still needs a shared library internally.
+  + lib.optionalString (atLeast "15" && stdenv'.hostPlatform.isStatic) ''
+    substituteInPlace src/interfaces/libpq/Makefile \
+      --replace-fail "echo 'libpq must not be calling any function which invokes exit'; exit 1;" "echo;"
+  '';
+
+  postInstall = ''
+    moveToOutput "bin/ecpg" "$dev"
+    moveToOutput "lib/pgxs" "$dev"
+  ''
+  + lib.optionalString (stdenv'.buildPlatform.canExecute stdenv'.hostPlatform) ''
+    mkdir -p "$dev/nix-support"
+    "$out/bin/pg_config" > "$dev/nix-support/pg_config.expected"
+  ''
+  + ''
+      rm "$out/bin/pg_config"
+      make -C src/common pg_config.env
+      substituteInPlace src/common/pg_config.env \
+        --replace-fail "$out" "@out@" \
+        --replace-fail "$man" "@man@"
+      install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
+
+    # postgres exposes external symbols get_pkginclude_path and similar. Those
+    # can't be stripped away by --gc-sections/LTO, because they could theoretically
+    # be used by dynamically loaded modules / extensions. To avoid circular dependencies,
+    # references to -dev, -doc and -man are removed here. References to -lib must be kept,
+    # because there is a realistic use-case for extensions to locate the /lib directory to
+    # load other shared modules.
+    remove-references-to -t "$dev" -t "$doc" -t "$man" "$out/bin/postgres"
+  ''
+  + lib.optionalString (!stdenv'.hostPlatform.isStatic) ''
+    if [ -z "''${dontDisableStatic:-}" ]; then
+      # Remove static libraries in case dynamic are available.
+      for i in $lib/lib/*.a; do
+        name="$(basename "$i")"
+        ext="${stdenv'.hostPlatform.extensions.sharedLibrary}"
+        if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
+          rm "$i"
+        fi
+      done
+    fi
+  ''
+  + ''
+    # The remaining static libraries are libpgcommon.a, libpgport.a and related.
+    # Those are only used when building e.g. extensions, so go to $dev.
+    moveToOutput "lib/*.a" "$dev"
+  ''
+  + lib.optionalString jitSupport ''
+    # In the case of JIT support, prevent useless dependencies on header files
+    find "$out/lib" -iname '*.bc' -type f -exec nuke-refs '{}' +
+
+    # Stop lib depending on the -dev output of llvm
+    remove-references-to -t ${llvmPackages.llvm.dev} "$out/lib/llvmjit${dlSuffix}"
+
+    moveToOutput "lib/bitcode" "$jit"
+    moveToOutput "lib/llvmjit*" "$jit"
+  ''
+  + lib.optionalString stdenv'.hostPlatform.isDarwin ''
+    # The darwin specific Makefile for PGXS contains a reference to the postgres
+    # binary. Some extensions (here: postgis), which are able to set bindir correctly
+    # to their own output for installation, will then fail to find "postgres" during linking.
+    substituteInPlace "$dev/lib/pgxs/src/Makefile.port" \
+      --replace-fail '-bundle_loader $(bindir)/postgres' "-bundle_loader $out/bin/postgres"
+  ''
+  + lib.optionalString perlSupport ''
+    moveToOutput "lib/*plperl*" "$plperl"
+    moveToOutput "share/postgresql/extension/*plperl*" "$plperl"
+  ''
+  + lib.optionalString pythonSupport ''
+    moveToOutput "lib/*plpython3*" "$plpython3"
+    moveToOutput "share/postgresql/extension/*plpython3*" "$plpython3"
+  ''
+  + lib.optionalString tclSupport ''
+    moveToOutput "lib/*pltcl*" "$pltcl"
+    moveToOutput "share/postgresql/extension/*pltcl*" "$pltcl"
+  '';
+
+  postFixup = lib.optionalString stdenv'.hostPlatform.isGnu ''
+    # initdb needs access to "locale" command from glibc.
+    wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
+  '';
+
+  # Running tests as "install check" to work around SIP issue on macOS:
+  # https://www.postgresql.org/message-id/flat/4D8E1BC5-BBCF-4B19-8226-359201EA8305%40gmail.com
+  # Also see <nixpkgs>/doc/stdenv/platform-notes.chapter.md
+  doCheck = false;
+  doInstallCheck =
+    !(stdenv'.hostPlatform.isStatic)
+    &&
+      # Tests currently can't be run on darwin, because of a Nix bug:
+      # https://github.com/NixOS/nix/issues/12548
+      # https://git.lix.systems/lix-project/lix/issues/691
+      # The error appears as this in the initdb logs:
+      #   FATAL:  could not create shared memory segment: Cannot allocate memory
+      # Don't let yourself be fooled when trying to remove this condition: Running
+      # the tests works fine most of the time. But once the tests (or any package using
+      # postgresqlTestHook) fails on the same machine for a few times, enough IPC objects
+      # will be stuck around, and any future builds with the tests enabled *will* fail.
+      !(stdenv'.hostPlatform.isDarwin)
+    &&
+      # Regression tests currently fail in pkgsMusl because of a difference in EXPLAIN output.
+      !(stdenv'.hostPlatform.isMusl)
+    &&
+      # Modifying block sizes is expected to break regression tests.
+      # https://www.postgresql.org/message-id/E1TJOeZ-000717-Lg%40wrigleys.postgresql.org
+      (withBlocksize == null && withWalBlocksize == null);
+  installCheckTarget = "check-world";
+
+  passthru =
+    let
+      this = self.callPackage ./generic.nix args;
+    in
+    {
+      inherit dlSuffix;
+
+      psqlSchema = lib.versions.major version;
+
+      withJIT = if jitSupport then this.withPackages (_: [ this.jit ]) else null;
+      withoutJIT = this;
+
+      pkgs =
+        let
+          scope = {
+            inherit
+              jitSupport
+              pythonSupport
+              perlSupport
+              tclSupport
+              ;
+            inherit (llvmPackages) llvm;
+            postgresql = this;
+            stdenv = stdenv';
+            postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
+            postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
+          };
+          newSelf = self // scope;
+          newSuper = {
+            callPackage = newScope (scope // this.pkgs);
+          };
+        in
+        import ./ext.nix newSelf newSuper;
+
+      withPackages = self.callPackage ./wrapper.nix { postgresql = this; };
+
+      pg_config = buildPackages.callPackage ./pg_config.nix {
+        inherit (finalAttrs) finalPackage;
+        outputs = {
+          out = lib.getOutput "out" finalAttrs.finalPackage;
+          man = lib.getOutput "man" finalAttrs.finalPackage;
         };
+      };
+
+      tests = {
+        postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
+        postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
+        postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
+        postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
+        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       }
       // lib.optionalAttrs jitSupport {
-        jit = {
-          disallowedReferences = [
-            "dev"
-            "doc"
-            "man"
-          ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-          ]
-          ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
+        postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
       };
+    };
 
-      strictDeps = true;
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    license = lib.licenses.postgresql;
+    changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
+    teams = [ lib.teams.postgres ];
+    pkgConfigModules = [
+      "libecpg"
+      "libecpg_compat"
+      "libpgtypes"
+      "libpq"
+    ];
+    platforms = lib.platforms.unix;
 
-      buildInputs = [
-        zlib
-        readline
-        openssl
-        libxml2
-        libuuid
-      ]
-      ++ lib.optionals icuSupport [ icu ]
-      ++ lib.optionals jitSupport [ llvmPackages.llvm ]
-      ++ lib.optionals lz4Enabled [ lz4 ]
-      ++ lib.optionals zstdEnabled [ zstd ]
-      ++ lib.optionals systemdSupport [ systemdLibs ]
-      ++ lib.optionals uringSupport [ liburing ]
-      ++ lib.optionals curlSupport [ curl ]
-      ++ lib.optionals numaSupport [ numactl ]
-      ++ lib.optionals gssSupport [ libkrb5 ]
-      ++ lib.optionals pamSupport [ linux-pam ]
-      ++ lib.optionals perlSupport [ perl ]
-      ++ lib.optionals ldapSupport [ openldap ]
-      ++ lib.optionals selinuxSupport [ libselinux ]
-      ++ lib.optionals nlsSupport [ gettext ];
-
-      nativeBuildInputs = [
-        bison
-        docbook-xsl-nons
-        docbook_xml_dtd_45
-        flex
-        libxml2
-        libxslt
-        makeBinaryWrapper
-        perl
-        pkg-config
-        removeReferencesTo
-      ]
-      ++ lib.optionals jitSupport [
-        llvmPackages.llvm.dev
-        nukeReferences
-      ];
-
-      enableParallelBuilding = true;
-
-      separateDebugInfo = true;
-
-      buildFlags = [ "world" ];
-
-      env = {
-        # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
-        # into all binaries. However, almost no binaries actually use those paths. The following
-        # flags will remove unused sections from all shared libraries and binaries - including
-        # those paths. This avoids a lot of circular dependency problems with different outputs,
-        # and allows splitting them cleanly.
-        CFLAGS = "-fdata-sections -ffunction-sections -flto";
-
-        # This flag was introduced upstream in:
-        # https://github.com/postgres/postgres/commit/b6c7cfac88c47a9194d76f3d074129da3c46545a
-        # It causes errors when linking against libpq.a in pkgsStatic:
-        #   undefined reference to `pg_encoding_to_char'
-        # Unsetting the flag fixes it. The upstream reasoning to introduce it is about the risk
-        # to have initdb load a libpq.so from a different major version and how to avoid that.
-        # This doesn't apply to us with Nix.
-        NIX_CFLAGS_COMPILE = "-UUSE_PRIVATE_ENCODING_FUNCS";
-      }
-      // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
-      // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }
-      // lib.optionalAttrs tclSupport { TCLSH = "${lib.getBin tcl}/bin/tclsh"; };
-
-      configureFlags =
-        let
-          inherit (lib) withFeature;
-        in
-        [
-          "--with-openssl"
-          "--with-libxml"
-          (withFeature icuSupport "icu")
-          "--sysconfdir=/etc"
-          "--with-system-tzdata=${tzdata}/share/zoneinfo"
-          "--enable-debug"
-          (lib.optionalString systemdSupport "--with-systemd")
-          (if stdenv.hostPlatform.isFreeBSD then "--with-uuid=bsd" else "--with-uuid=e2fs")
-          (withFeature perlSupport "perl")
-        ]
-        ++ lib.optionals (withBlocksize != null) [ "--with-blocksize=${toString withBlocksize}" ]
-        ++ lib.optionals (withWalBlocksize != null) [ "--with-wal-blocksize=${toString withWalBlocksize}" ]
-        ++ lib.optionals lz4Enabled [ "--with-lz4" ]
-        ++ lib.optionals zstdEnabled [ "--with-zstd" ]
-        ++ lib.optionals uringSupport [ "--with-liburing" ]
-        ++ lib.optionals curlSupport [ "--with-libcurl" ]
-        ++ lib.optionals numaSupport [ "--with-libnuma" ]
-        ++ lib.optionals gssSupport [ "--with-gssapi" ]
-        ++ lib.optionals pythonSupport [ "--with-python" ]
-        ++ lib.optionals jitSupport [ "--with-llvm" ]
-        ++ lib.optionals pamSupport [ "--with-pam" ]
-        # This can be removed once v17 is removed. v18+ ships with it.
-        ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16" && olderThan "18") [
-          "LDFLAGS_EX_BE=-Wl,-export_dynamic"
-        ]
-        # some version of this flag is required in all cross configurations
-        # since it cannot be automatically detected
-        ++
-          lib.optionals
-            (
-              (!stdenv'.hostPlatform.isDarwin)
-              && (!(stdenv'.buildPlatform.canExecute stdenv.hostPlatform))
-              && atLeast "16"
-            )
-            [
-              "LDFLAGS_EX_BE=-Wl,--export-dynamic"
-            ]
-        ++ lib.optionals ldapSupport [ "--with-ldap" ]
-        ++ lib.optionals tclSupport [ "--with-tcl" ]
-        ++ lib.optionals selinuxSupport [ "--with-selinux" ]
-        ++ lib.optionals nlsSupport [ "--enable-nls" ]
-        ++ lib.optionals bonjourSupport [ "--with-bonjour" ];
-
-      patches = [
-        (
-          if atLeast "16" then
-            ./patches/relative-to-symlinks-16+.patch
-          else
-            ./patches/relative-to-symlinks.patch
-        )
-        (
-          if atLeast "15" then
-            ./patches/empty-pg-config-view-15+.patch
-          else
-            ./patches/empty-pg-config-view.patch
-        )
-        ./patches/less-is-more.patch
-        ./patches/paths-for-split-outputs.patch
-        ./patches/paths-with-postgresql-suffix.patch
-
-        (replaceVars ./patches/locale-binary-path.patch {
-          locale = "${
-            if stdenv.hostPlatform.isDarwin then
-              darwin.adv_cmds
-            else if stdenv.hostPlatform.isFreeBSD then
-              freebsd.locale
-            else
-              lib.getBin stdenv.cc.libc
-          }/bin/locale";
-        })
-      ]
-      ++ lib.optionals stdenv'.hostPlatform.isMusl (
-        # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
-        map fetchurl (lib.attrValues muslPatches)
-      )
-      ++ lib.optionals stdenv'.hostPlatform.isLinux [
-        ./patches/socketdir-in-run-13+.patch
-      ]
-      ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
-        ./patches/export-dynamic-darwin-15-.patch
-      ];
-
-      installTargets = [ "install-world" ];
-
-      postPatch = ''
-        substituteInPlace "src/Makefile.global.in" --subst-var out
-        substituteInPlace "src/common/config_info.c" --subst-var dev
-        cat ${./pg_config.env.mk} >> src/common/Makefile
-      ''
-      # This test always fails on hardware with >1 NUMA node: the sysfs
-      # dirs providing information about the topology are hidden in the sandbox,
-      # so postgres assumes there's only a single node `0`. However,
-      # the test checks on which NUMA nodes the allocated pages are which is >1
-      # on such hardware. This in turn triggers a safeguard in the view
-      # which breaks the test.
-      # Manual tests confirm that the testcase behaves properly outside of the
-      # Nix sandbox.
-      + lib.optionalString (atLeast "18") ''
-        substituteInPlace src/test/regress/parallel_schedule \
-          --replace-fail numa ""
-      ''
-      # This check was introduced upstream to prevent calls to "exit" inside libpq.
-      # However, this doesn't work reliably with static linking, see this and following:
-      # https://postgr.es/m/flat/20210703001639.GB2374652%40rfd.leadboat.com#52584ca4bd3cb9dac376f3158c419f97
-      # Thus, disable the check entirely, as it would currently fail with this:
-      # > libpq.so.5.17:                  U atexit
-      # > libpq.so.5.17:                  U pthread_exit
-      # > libpq must not be calling any function which invokes exit
-      # Don't mind the fact that this checks libpq.**so** in pkgsStatic - that's correct, since PostgreSQL
-      # still needs a shared library internally.
-      + lib.optionalString (atLeast "15" && stdenv'.hostPlatform.isStatic) ''
-        substituteInPlace src/interfaces/libpq/Makefile \
-          --replace-fail "echo 'libpq must not be calling any function which invokes exit'; exit 1;" "echo;"
-      '';
-
-      postInstall = ''
-        moveToOutput "bin/ecpg" "$dev"
-        moveToOutput "lib/pgxs" "$dev"
-      ''
-      + lib.optionalString (stdenv'.buildPlatform.canExecute stdenv'.hostPlatform) ''
-        mkdir -p "$dev/nix-support"
-        "$out/bin/pg_config" > "$dev/nix-support/pg_config.expected"
-      ''
-      + ''
-          rm "$out/bin/pg_config"
-          make -C src/common pg_config.env
-          substituteInPlace src/common/pg_config.env \
-            --replace-fail "$out" "@out@" \
-            --replace-fail "$man" "@man@"
-          install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
-
-        # postgres exposes external symbols get_pkginclude_path and similar. Those
-        # can't be stripped away by --gc-sections/LTO, because they could theoretically
-        # be used by dynamically loaded modules / extensions. To avoid circular dependencies,
-        # references to -dev, -doc and -man are removed here. References to -lib must be kept,
-        # because there is a realistic use-case for extensions to locate the /lib directory to
-        # load other shared modules.
-        remove-references-to -t "$dev" -t "$doc" -t "$man" "$out/bin/postgres"
-      ''
-      + lib.optionalString (!stdenv'.hostPlatform.isStatic) ''
-        if [ -z "''${dontDisableStatic:-}" ]; then
-          # Remove static libraries in case dynamic are available.
-          for i in $lib/lib/*.a; do
-            name="$(basename "$i")"
-            ext="${stdenv'.hostPlatform.extensions.sharedLibrary}"
-            if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
-              rm "$i"
-            fi
-          done
-        fi
-      ''
-      + ''
-        # The remaining static libraries are libpgcommon.a, libpgport.a and related.
-        # Those are only used when building e.g. extensions, so go to $dev.
-        moveToOutput "lib/*.a" "$dev"
-      ''
-      + lib.optionalString jitSupport ''
-        # In the case of JIT support, prevent useless dependencies on header files
-        find "$out/lib" -iname '*.bc' -type f -exec nuke-refs '{}' +
-
-        # Stop lib depending on the -dev output of llvm
-        remove-references-to -t ${llvmPackages.llvm.dev} "$out/lib/llvmjit${dlSuffix}"
-
-        moveToOutput "lib/bitcode" "$jit"
-        moveToOutput "lib/llvmjit*" "$jit"
-      ''
-      + lib.optionalString stdenv'.hostPlatform.isDarwin ''
-        # The darwin specific Makefile for PGXS contains a reference to the postgres
-        # binary. Some extensions (here: postgis), which are able to set bindir correctly
-        # to their own output for installation, will then fail to find "postgres" during linking.
-        substituteInPlace "$dev/lib/pgxs/src/Makefile.port" \
-          --replace-fail '-bundle_loader $(bindir)/postgres' "-bundle_loader $out/bin/postgres"
-      ''
-      + lib.optionalString perlSupport ''
-        moveToOutput "lib/*plperl*" "$plperl"
-        moveToOutput "share/postgresql/extension/*plperl*" "$plperl"
-      ''
-      + lib.optionalString pythonSupport ''
-        moveToOutput "lib/*plpython3*" "$plpython3"
-        moveToOutput "share/postgresql/extension/*plpython3*" "$plpython3"
-      ''
-      + lib.optionalString tclSupport ''
-        moveToOutput "lib/*pltcl*" "$pltcl"
-        moveToOutput "share/postgresql/extension/*pltcl*" "$pltcl"
-      '';
-
-      postFixup = lib.optionalString stdenv'.hostPlatform.isGnu ''
-        # initdb needs access to "locale" command from glibc.
-        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
-      '';
-
-      # Running tests as "install check" to work around SIP issue on macOS:
-      # https://www.postgresql.org/message-id/flat/4D8E1BC5-BBCF-4B19-8226-359201EA8305%40gmail.com
-      # Also see <nixpkgs>/doc/stdenv/platform-notes.chapter.md
-      doCheck = false;
-      doInstallCheck =
-        !(stdenv'.hostPlatform.isStatic)
-        &&
-          # Tests currently can't be run on darwin, because of a Nix bug:
-          # https://github.com/NixOS/nix/issues/12548
-          # https://git.lix.systems/lix-project/lix/issues/691
-          # The error appears as this in the initdb logs:
-          #   FATAL:  could not create shared memory segment: Cannot allocate memory
-          # Don't let yourself be fooled when trying to remove this condition: Running
-          # the tests works fine most of the time. But once the tests (or any package using
-          # postgresqlTestHook) fails on the same machine for a few times, enough IPC objects
-          # will be stuck around, and any future builds with the tests enabled *will* fail.
-          !(stdenv'.hostPlatform.isDarwin)
-        &&
-          # Regression tests currently fail in pkgsMusl because of a difference in EXPLAIN output.
-          !(stdenv'.hostPlatform.isMusl)
-        &&
-          # Modifying block sizes is expected to break regression tests.
-          # https://www.postgresql.org/message-id/E1TJOeZ-000717-Lg%40wrigleys.postgresql.org
-          (withBlocksize == null && withWalBlocksize == null);
-      installCheckTarget = "check-world";
-
-      passthru =
-        let
-          this = self.callPackage generic args;
-        in
-        {
-          inherit dlSuffix;
-
-          psqlSchema = lib.versions.major version;
-
-          withJIT = if jitSupport then this.withPackages (_: [ this.jit ]) else null;
-          withoutJIT = this;
-
-          pkgs =
-            let
-              scope = {
-                inherit
-                  jitSupport
-                  pythonSupport
-                  perlSupport
-                  tclSupport
-                  ;
-                inherit (llvmPackages) llvm;
-                postgresql = this;
-                stdenv = stdenv';
-                postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
-                postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
-              };
-              newSelf = self // scope;
-              newSuper = {
-                callPackage = newScope (scope // this.pkgs);
-              };
-            in
-            import ./ext.nix newSelf newSuper;
-
-          withPackages = self.callPackage ./wrapper.nix { postgresql = this; };
-
-          pg_config = buildPackages.callPackage ./pg_config.nix {
-            inherit (finalAttrs) finalPackage;
-            outputs = {
-              out = lib.getOutput "out" finalAttrs.finalPackage;
-              man = lib.getOutput "man" finalAttrs.finalPackage;
-            };
-          };
-
-          tests = {
-            postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
-            postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
-            postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
-            postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
-            pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-          }
-          // lib.optionalAttrs jitSupport {
-            postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
-          };
-        };
-
-      meta = {
-        homepage = "https://www.postgresql.org";
-        description = "Powerful, open source object-relational database system";
-        license = lib.licenses.postgresql;
-        changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
-        teams = [ lib.teams.postgres ];
-        pkgConfigModules = [
-          "libecpg"
-          "libecpg_compat"
-          "libpgtypes"
-          "libpq"
-        ];
-        platforms = lib.platforms.unix;
-
-        # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
-        # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
-        # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
-        # host-platform.
-        #
-        # I managed to get a cross-build with JIT support working with
-        # `depsBuildBuild = [ llvmPackages.clang ] ++ buildInputs`, but considering that the
-        # resulting LLVM IR isn't platform-independent this doesn't give you much.
-        # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
-        # a query, postgres would coredump with `Illegal instruction`.
-        #
-        # Note: This is "host canExecute build" on purpose, since this is about the LLVM that is called
-        # to do JIT at **runtime**.
-        broken = jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform;
-      };
-    });
-
-in
-# passed by <major>.nix
-versionArgs:
-# passed by default.nix
-{ self, ... }@defaultArgs:
-self.callPackage generic (defaultArgs // versionArgs)
+    # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
+    # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
+    # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
+    # host-platform.
+    #
+    # I managed to get a cross-build with JIT support working with
+    # `depsBuildBuild = [ llvmPackages.clang ] ++ buildInputs`, but considering that the
+    # resulting LLVM IR isn't platform-independent this doesn't give you much.
+    # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
+    # a query, postgres would coredump with `Illegal instruction`.
+    #
+    # Note: This is "host canExecute build" on purpose, since this is about the LLVM that is called
+    # to do JIT at **runtime**.
+    broken = jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform;
+  };
+})

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -1,608 +1,598 @@
+{
+  # utils
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  replaceVars,
+
+  # source specification
+  hash,
+  muslPatches ? { },
+  rev,
+  version,
+
+  # runtime dependencies
+  darwin,
+  freebsd,
+  glibc,
+  libuuid,
+  libxml2,
+  lz4,
+  openssl,
+  readline,
+  tzdata,
+  zlib,
+  zstd,
+
+  # build dependencies
+  bison,
+  docbook-xsl-nons,
+  docbook_xml_dtd_45,
+  flex,
+  libxslt,
+  makeBinaryWrapper,
+  pkg-config,
+  removeReferencesTo,
+
+  # passthru
+  buildPackages,
+  newScope,
+  nixosTests,
+  self,
+  testers,
+
+  # Block size
+  # Changing the block size will break on-disk database compatibility. See:
+  # https://www.postgresql.org/docs/current/install-make.html#CONFIGURE-OPTION-WITH-BLOCKSIZE
+  withBlocksize ? null,
+  withWalBlocksize ? null,
+
+  # bonjour
+  bonjourSupport ? false,
+
+  # Curl
+  curlSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform curl,
+  curl,
+
+  # GSSAPI
+  gssSupport ? with stdenv.hostPlatform; !isWindows,
+  libkrb5,
+
+  # icu
+  icuSupport ? true,
+  icu,
+
+  # JIT
+  jitSupport ? stdenv.hostPlatform.canExecute stdenv.buildPlatform,
+  llvmPackages,
+  nukeReferences,
+  overrideCC,
+
+  # LDAP
+  ldapSupport ? false,
+  openldap,
+
+  # NLS
+  nlsSupport ? false,
+  gettext,
+
+  # NUMA
+  numaSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform numactl,
+  numactl,
+
+  # PAM
+  pamSupport ? lib.meta.availableOn stdenv.hostPlatform linux-pam,
+  linux-pam,
+
+  # PL/Perl
+  perlSupport ?
+    lib.meta.availableOn stdenv.hostPlatform perl
+    # configure tries to call the perl executable for the version
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  perl,
+
+  # PL/Python
+  pythonSupport ?
+    lib.meta.availableOn stdenv.hostPlatform python3
+    # configure tries to call the python executable
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  python3,
+
+  # PL/Tcl
+  tclSupport ?
+    lib.meta.availableOn stdenv.hostPlatform tcl
+    # configure fails with:
+    #   configure: error: file 'tclConfig.sh' is required for Tcl
+    && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  tcl,
+
+  # SELinux
+  selinuxSupport ? false,
+  libselinux,
+
+  # Systemd
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdLibs,
+
+  # Uring
+  uringSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform liburing,
+  liburing,
+}@args:
 let
+  atLeast = lib.versionAtLeast version;
+  olderThan = lib.versionOlder version;
+  lz4Enabled = atLeast "14";
+  zstdEnabled = atLeast "15";
 
-  generic =
-    # utils
-    {
-      stdenv,
-      fetchFromGitHub,
-      fetchurl,
-      lib,
-      replaceVars,
+  dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
 
-      # source specification
-      hash,
-      muslPatches ? { },
-      rev,
-      version,
+  stdenv' =
+    if !stdenv.cc.isClang then
+      overrideCC llvmPackages.stdenv (
+        llvmPackages.stdenv.cc.override {
+          # LLVM bintools are not used by default, but are needed to make -flto work below.
+          bintools = buildPackages."llvmPackages_${lib.versions.major llvmPackages.release_version}".bintools;
+        }
+      )
+    else
+      stdenv;
+in
+stdenv'.mkDerivation (finalAttrs: {
+  inherit version;
+  pname = "postgresql";
 
-      # runtime dependencies
-      darwin,
-      freebsd,
-      glibc,
-      libuuid,
-      libxml2,
-      lz4,
-      openssl,
-      readline,
-      tzdata,
-      zlib,
-      zstd,
+  src = fetchFromGitHub {
+    owner = "postgres";
+    repo = "postgres";
+    # rev, not tag, on purpose: allows updating when new versions
+    # are "stamped" a few days before release (tag).
+    inherit hash rev;
+  };
 
-      # build dependencies
-      bison,
-      docbook-xsl-nons,
-      docbook_xml_dtd_45,
-      flex,
-      libxslt,
-      makeBinaryWrapper,
-      pkg-config,
-      removeReferencesTo,
+  __structuredAttrs = true;
 
-      # passthru
-      buildPackages,
-      newScope,
-      nixosTests,
-      self,
-      testers,
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+    "lib"
+    "man"
+  ]
+  ++ lib.optionals jitSupport [ "jit" ]
+  ++ lib.optionals perlSupport [ "plperl" ]
+  ++ lib.optionals pythonSupport [ "plpython3" ]
+  ++ lib.optionals tclSupport [ "pltcl" ];
 
-      # Block size
-      # Changing the block size will break on-disk database compatibility. See:
-      # https://www.postgresql.org/docs/current/install-make.html#CONFIGURE-OPTION-WITH-BLOCKSIZE
-      withBlocksize ? null,
-      withWalBlocksize ? null,
+  outputChecks = {
+    out = {
+      disallowedReferences = [
+        "dev"
+        "doc"
+        "man"
+      ]
+      ++ lib.optionals jitSupport [ "jit" ];
+      disallowedRequisites = [
+        stdenv'.cc
+        llvmPackages.llvm.out
+        llvmPackages.llvm.lib
+      ]
+      ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+    };
 
-      # bonjour
-      bonjourSupport ? false,
-
-      # Curl
-      curlSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform curl,
-      curl,
-
-      # GSSAPI
-      gssSupport ? with stdenv.hostPlatform; !isWindows,
-      libkrb5,
-
-      # icu
-      icuSupport ? true,
-      icu,
-
-      # JIT
-      jitSupport ? stdenv.hostPlatform.canExecute stdenv.buildPlatform,
-      llvmPackages,
-      nukeReferences,
-      overrideCC,
-
-      # LDAP
-      ldapSupport ? false,
-      openldap,
-
-      # NLS
-      nlsSupport ? false,
-      gettext,
-
-      # NUMA
-      numaSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform numactl,
-      numactl,
-
-      # PAM
-      pamSupport ? lib.meta.availableOn stdenv.hostPlatform linux-pam,
-      linux-pam,
-
-      # PL/Perl
-      perlSupport ?
-        lib.meta.availableOn stdenv.hostPlatform perl
-        # configure tries to call the perl executable for the version
-        && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-      perl,
-
-      # PL/Python
-      pythonSupport ?
-        lib.meta.availableOn stdenv.hostPlatform python3
-        # configure tries to call the python executable
-        && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-      python3,
-
-      # PL/Tcl
-      tclSupport ?
-        lib.meta.availableOn stdenv.hostPlatform tcl
-        # configure fails with:
-        #   configure: error: file 'tclConfig.sh' is required for Tcl
-        && stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-      tcl,
-
-      # SELinux
-      selinuxSupport ? false,
-      libselinux,
-
-      # Systemd
-      systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-      systemdLibs,
-
-      # Uring
-      uringSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform liburing,
-      liburing,
-    }@args:
-    let
-      atLeast = lib.versionAtLeast version;
-      olderThan = lib.versionOlder version;
-      lz4Enabled = atLeast "14";
-      zstdEnabled = atLeast "15";
-
-      dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
-
-      stdenv' =
-        if !stdenv.cc.isClang then
-          overrideCC llvmPackages.stdenv (
-            llvmPackages.stdenv.cc.override {
-              # LLVM bintools are not used by default, but are needed to make -flto work below.
-              bintools = buildPackages."llvmPackages_${lib.versions.major llvmPackages.release_version}".bintools;
-            }
-          )
-        else
-          stdenv;
-    in
-    stdenv'.mkDerivation (finalAttrs: {
-      inherit version;
-      pname = "postgresql";
-
-      src = fetchFromGitHub {
-        owner = "postgres";
-        repo = "postgres";
-        # rev, not tag, on purpose: allows updating when new versions
-        # are "stamped" a few days before release (tag).
-        inherit hash rev;
-      };
-
-      __structuredAttrs = true;
-
-      outputs = [
+    lib = {
+      disallowedReferences = [
         "out"
         "dev"
         "doc"
-        "lib"
         "man"
       ]
-      ++ lib.optionals jitSupport [ "jit" ]
-      ++ lib.optionals perlSupport [ "plperl" ]
-      ++ lib.optionals pythonSupport [ "plpython3" ]
-      ++ lib.optionals tclSupport [ "pltcl" ];
-
-      outputChecks = {
-        out = {
-          disallowedReferences = [
-            "dev"
-            "doc"
-            "man"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-            llvmPackages.llvm.lib
-          ]
-          ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
-
-        lib = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "doc"
-            "man"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-            llvmPackages.llvm.lib
-          ]
-          ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
-
-        doc = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "man"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-        };
-
-        man = {
-          disallowedReferences = [
-            "out"
-            "dev"
-            "doc"
-          ]
-          ++ lib.optionals jitSupport [ "jit" ];
-        };
-      }
-      // lib.optionalAttrs jitSupport {
-        jit = {
-          disallowedReferences = [
-            "dev"
-            "doc"
-            "man"
-          ];
-          disallowedRequisites = [
-            stdenv'.cc
-            llvmPackages.llvm.out
-          ]
-          ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
-        };
-      };
-
-      strictDeps = true;
-
-      buildInputs = [
-        zlib
-        readline
-        openssl
-        libxml2
-        libuuid
+      ++ lib.optionals jitSupport [ "jit" ];
+      disallowedRequisites = [
+        stdenv'.cc
+        llvmPackages.llvm.out
+        llvmPackages.llvm.lib
       ]
-      ++ lib.optionals icuSupport [ icu ]
-      ++ lib.optionals jitSupport [ llvmPackages.llvm ]
-      ++ lib.optionals lz4Enabled [ lz4 ]
-      ++ lib.optionals zstdEnabled [ zstd ]
-      ++ lib.optionals systemdSupport [ systemdLibs ]
-      ++ lib.optionals uringSupport [ liburing ]
-      ++ lib.optionals curlSupport [ curl ]
-      ++ lib.optionals numaSupport [ numactl ]
-      ++ lib.optionals gssSupport [ libkrb5 ]
-      ++ lib.optionals pamSupport [ linux-pam ]
-      ++ lib.optionals perlSupport [ perl ]
-      ++ lib.optionals ldapSupport [ openldap ]
-      ++ lib.optionals selinuxSupport [ libselinux ]
-      ++ lib.optionals nlsSupport [ gettext ];
+      ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+    };
 
-      nativeBuildInputs = [
-        bison
-        docbook-xsl-nons
-        docbook_xml_dtd_45
-        flex
-        libxml2
-        libxslt
-        makeBinaryWrapper
-        perl
-        pkg-config
-        removeReferencesTo
+    doc = {
+      disallowedReferences = [
+        "out"
+        "dev"
+        "man"
       ]
-      ++ lib.optionals jitSupport [
-        llvmPackages.llvm.dev
-        nukeReferences
+      ++ lib.optionals jitSupport [ "jit" ];
+    };
+
+    man = {
+      disallowedReferences = [
+        "out"
+        "dev"
+        "doc"
+      ]
+      ++ lib.optionals jitSupport [ "jit" ];
+    };
+  }
+  // lib.optionalAttrs jitSupport {
+    jit = {
+      disallowedReferences = [
+        "dev"
+        "doc"
+        "man"
       ];
+      disallowedRequisites = [
+        stdenv'.cc
+        llvmPackages.llvm.out
+      ]
+      ++ (map lib.getDev (builtins.filter (drv: drv ? "dev") finalAttrs.buildInputs));
+    };
+  };
 
-      enableParallelBuilding = true;
+  strictDeps = true;
 
-      separateDebugInfo = true;
+  buildInputs = [
+    zlib
+    readline
+    openssl
+    libxml2
+    libuuid
+  ]
+  ++ lib.optionals icuSupport [ icu ]
+  ++ lib.optionals jitSupport [ llvmPackages.llvm ]
+  ++ lib.optionals lz4Enabled [ lz4 ]
+  ++ lib.optionals zstdEnabled [ zstd ]
+  ++ lib.optionals systemdSupport [ systemdLibs ]
+  ++ lib.optionals uringSupport [ liburing ]
+  ++ lib.optionals curlSupport [ curl ]
+  ++ lib.optionals numaSupport [ numactl ]
+  ++ lib.optionals gssSupport [ libkrb5 ]
+  ++ lib.optionals pamSupport [ linux-pam ]
+  ++ lib.optionals perlSupport [ perl ]
+  ++ lib.optionals ldapSupport [ openldap ]
+  ++ lib.optionals selinuxSupport [ libselinux ]
+  ++ lib.optionals nlsSupport [ gettext ];
 
-      buildFlags = [ "world" ];
+  nativeBuildInputs = [
+    bison
+    docbook-xsl-nons
+    docbook_xml_dtd_45
+    flex
+    libxml2
+    libxslt
+    makeBinaryWrapper
+    perl
+    pkg-config
+    removeReferencesTo
+  ]
+  ++ lib.optionals jitSupport [
+    llvmPackages.llvm.dev
+    nukeReferences
+  ];
 
-      env = {
-        # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
-        # into all binaries. However, almost no binaries actually use those paths. The following
-        # flags will remove unused sections from all shared libraries and binaries - including
-        # those paths. This avoids a lot of circular dependency problems with different outputs,
-        # and allows splitting them cleanly.
-        CFLAGS = "-fdata-sections -ffunction-sections -flto";
+  enableParallelBuilding = true;
 
-        # This flag was introduced upstream in:
-        # https://github.com/postgres/postgres/commit/b6c7cfac88c47a9194d76f3d074129da3c46545a
-        # It causes errors when linking against libpq.a in pkgsStatic:
-        #   undefined reference to `pg_encoding_to_char'
-        # Unsetting the flag fixes it. The upstream reasoning to introduce it is about the risk
-        # to have initdb load a libpq.so from a different major version and how to avoid that.
-        # This doesn't apply to us with Nix.
-        NIX_CFLAGS_COMPILE = "-UUSE_PRIVATE_ENCODING_FUNCS";
-      }
-      // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
-      // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }
-      // lib.optionalAttrs tclSupport { TCLSH = "${lib.getBin tcl}/bin/tclsh"; };
+  separateDebugInfo = true;
 
-      configureFlags =
-        let
-          inherit (lib) withFeature;
-        in
+  buildFlags = [ "world" ];
+
+  env = {
+    # libpgcommon.a and libpgport.a contain all paths returned by pg_config and are linked
+    # into all binaries. However, almost no binaries actually use those paths. The following
+    # flags will remove unused sections from all shared libraries and binaries - including
+    # those paths. This avoids a lot of circular dependency problems with different outputs,
+    # and allows splitting them cleanly.
+    CFLAGS = "-fdata-sections -ffunction-sections -flto";
+
+    # This flag was introduced upstream in:
+    # https://github.com/postgres/postgres/commit/b6c7cfac88c47a9194d76f3d074129da3c46545a
+    # It causes errors when linking against libpq.a in pkgsStatic:
+    #   undefined reference to `pg_encoding_to_char'
+    # Unsetting the flag fixes it. The upstream reasoning to introduce it is about the risk
+    # to have initdb load a libpq.so from a different major version and how to avoid that.
+    # This doesn't apply to us with Nix.
+    NIX_CFLAGS_COMPILE = "-UUSE_PRIVATE_ENCODING_FUNCS";
+  }
+  // lib.optionalAttrs perlSupport { PERL = lib.getExe perl; }
+  // lib.optionalAttrs pythonSupport { PYTHON = lib.getExe python3; }
+  // lib.optionalAttrs tclSupport { TCLSH = "${lib.getBin tcl}/bin/tclsh"; };
+
+  configureFlags =
+    let
+      inherit (lib) withFeature;
+    in
+    [
+      "--with-openssl"
+      "--with-libxml"
+      (withFeature icuSupport "icu")
+      "--sysconfdir=/etc"
+      "--with-system-tzdata=${tzdata}/share/zoneinfo"
+      "--enable-debug"
+      (lib.optionalString systemdSupport "--with-systemd")
+      (if stdenv.hostPlatform.isFreeBSD then "--with-uuid=bsd" else "--with-uuid=e2fs")
+      (withFeature perlSupport "perl")
+    ]
+    ++ lib.optionals (withBlocksize != null) [ "--with-blocksize=${toString withBlocksize}" ]
+    ++ lib.optionals (withWalBlocksize != null) [ "--with-wal-blocksize=${toString withWalBlocksize}" ]
+    ++ lib.optionals lz4Enabled [ "--with-lz4" ]
+    ++ lib.optionals zstdEnabled [ "--with-zstd" ]
+    ++ lib.optionals uringSupport [ "--with-liburing" ]
+    ++ lib.optionals curlSupport [ "--with-libcurl" ]
+    ++ lib.optionals numaSupport [ "--with-libnuma" ]
+    ++ lib.optionals gssSupport [ "--with-gssapi" ]
+    ++ lib.optionals pythonSupport [ "--with-python" ]
+    ++ lib.optionals jitSupport [ "--with-llvm" ]
+    ++ lib.optionals pamSupport [ "--with-pam" ]
+    # This can be removed once v17 is removed. v18+ ships with it.
+    ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16" && olderThan "18") [
+      "LDFLAGS_EX_BE=-Wl,-export_dynamic"
+    ]
+    # some version of this flag is required in all cross configurations
+    # since it cannot be automatically detected
+    ++
+      lib.optionals
+        (
+          (!stdenv'.hostPlatform.isDarwin)
+          && (!(stdenv'.buildPlatform.canExecute stdenv.hostPlatform))
+          && atLeast "16"
+        )
         [
-          "--with-openssl"
-          "--with-libxml"
-          (withFeature icuSupport "icu")
-          "--sysconfdir=/etc"
-          "--with-system-tzdata=${tzdata}/share/zoneinfo"
-          "--enable-debug"
-          (lib.optionalString systemdSupport "--with-systemd")
-          (if stdenv.hostPlatform.isFreeBSD then "--with-uuid=bsd" else "--with-uuid=e2fs")
-          (withFeature perlSupport "perl")
+          "LDFLAGS_EX_BE=-Wl,--export-dynamic"
         ]
-        ++ lib.optionals (withBlocksize != null) [ "--with-blocksize=${toString withBlocksize}" ]
-        ++ lib.optionals (withWalBlocksize != null) [ "--with-wal-blocksize=${toString withWalBlocksize}" ]
-        ++ lib.optionals lz4Enabled [ "--with-lz4" ]
-        ++ lib.optionals zstdEnabled [ "--with-zstd" ]
-        ++ lib.optionals uringSupport [ "--with-liburing" ]
-        ++ lib.optionals curlSupport [ "--with-libcurl" ]
-        ++ lib.optionals numaSupport [ "--with-libnuma" ]
-        ++ lib.optionals gssSupport [ "--with-gssapi" ]
-        ++ lib.optionals pythonSupport [ "--with-python" ]
-        ++ lib.optionals jitSupport [ "--with-llvm" ]
-        ++ lib.optionals pamSupport [ "--with-pam" ]
-        # This can be removed once v17 is removed. v18+ ships with it.
-        ++ lib.optionals (stdenv'.hostPlatform.isDarwin && atLeast "16" && olderThan "18") [
-          "LDFLAGS_EX_BE=-Wl,-export_dynamic"
-        ]
-        # some version of this flag is required in all cross configurations
-        # since it cannot be automatically detected
-        ++
-          lib.optionals
-            (
-              (!stdenv'.hostPlatform.isDarwin)
-              && (!(stdenv'.buildPlatform.canExecute stdenv.hostPlatform))
-              && atLeast "16"
-            )
-            [
-              "LDFLAGS_EX_BE=-Wl,--export-dynamic"
-            ]
-        ++ lib.optionals ldapSupport [ "--with-ldap" ]
-        ++ lib.optionals tclSupport [ "--with-tcl" ]
-        ++ lib.optionals selinuxSupport [ "--with-selinux" ]
-        ++ lib.optionals nlsSupport [ "--enable-nls" ]
-        ++ lib.optionals bonjourSupport [ "--with-bonjour" ]
-        # Configure needs a little help to find `nm` when cross-compiling.
-        ++ lib.optionals (atLeast "19") [ "NM=${stdenv'.cc}/bin/${stdenv'.cc.targetPrefix}nm" ];
+    ++ lib.optionals ldapSupport [ "--with-ldap" ]
+    ++ lib.optionals tclSupport [ "--with-tcl" ]
+    ++ lib.optionals selinuxSupport [ "--with-selinux" ]
+    ++ lib.optionals nlsSupport [ "--enable-nls" ]
+    ++ lib.optionals bonjourSupport [ "--with-bonjour" ]
+    # Configure needs a little help to find `nm` when cross-compiling.
+    ++ lib.optionals (atLeast "19") [ "NM=${stdenv'.cc}/bin/${stdenv'.cc.targetPrefix}nm" ];
 
-      patches = [
-        (
-          if atLeast "16" then
-            ./patches/relative-to-symlinks-16+.patch
-          else
-            ./patches/relative-to-symlinks.patch
-        )
-        (
-          if atLeast "15" then
-            ./patches/empty-pg-config-view-15+.patch
-          else
-            ./patches/empty-pg-config-view.patch
-        )
-        ./patches/less-is-more.patch
-        ./patches/paths-for-split-outputs.patch
-        ./patches/paths-with-postgresql-suffix.patch
+  patches = [
+    (
+      if atLeast "16" then
+        ./patches/relative-to-symlinks-16+.patch
+      else
+        ./patches/relative-to-symlinks.patch
+    )
+    (
+      if atLeast "15" then
+        ./patches/empty-pg-config-view-15+.patch
+      else
+        ./patches/empty-pg-config-view.patch
+    )
+    ./patches/less-is-more.patch
+    ./patches/paths-for-split-outputs.patch
+    ./patches/paths-with-postgresql-suffix.patch
 
-        (replaceVars ./patches/locale-binary-path.patch {
-          locale = "${
-            if stdenv.hostPlatform.isDarwin then
-              darwin.adv_cmds
-            else if stdenv.hostPlatform.isFreeBSD then
-              freebsd.locale
-            else
-              lib.getBin stdenv.cc.libc
-          }/bin/locale";
-        })
-      ]
-      ++ lib.optionals stdenv'.hostPlatform.isMusl (
-        # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
-        map fetchurl (lib.attrValues muslPatches)
-      )
-      ++ lib.optionals stdenv'.hostPlatform.isLinux [
-        ./patches/socketdir-in-run-13+.patch
-      ]
-      ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
-        ./patches/export-dynamic-darwin-15-.patch
-      ];
+    (replaceVars ./patches/locale-binary-path.patch {
+      locale = "${
+        if stdenv.hostPlatform.isDarwin then
+          darwin.adv_cmds
+        else if stdenv.hostPlatform.isFreeBSD then
+          freebsd.locale
+        else
+          lib.getBin stdenv.cc.libc
+      }/bin/locale";
+    })
+  ]
+  ++ lib.optionals stdenv'.hostPlatform.isMusl (
+    # Using fetchurl instead of fetchpatch on purpose: https://github.com/NixOS/nixpkgs/issues/240141
+    map fetchurl (lib.attrValues muslPatches)
+  )
+  ++ lib.optionals stdenv'.hostPlatform.isLinux [
+    ./patches/socketdir-in-run-13+.patch
+  ]
+  ++ lib.optionals (stdenv'.hostPlatform.isDarwin && olderThan "16") [
+    ./patches/export-dynamic-darwin-15-.patch
+  ];
 
-      installTargets = [ "install-world" ];
+  installTargets = [ "install-world" ];
 
-      postPatch = ''
-        substituteInPlace "src/Makefile.global.in" --subst-var out
-        substituteInPlace "src/common/config_info.c" --subst-var dev
-        cat ${./pg_config.env.mk} >> src/common/Makefile
-      ''
-      # This test always fails on hardware with >1 NUMA node: the sysfs
-      # dirs providing information about the topology are hidden in the sandbox,
-      # so postgres assumes there's only a single node `0`. However,
-      # the test checks on which NUMA nodes the allocated pages are which is >1
-      # on such hardware. This in turn triggers a safeguard in the view
-      # which breaks the test.
-      # Manual tests confirm that the testcase behaves properly outside of the
-      # Nix sandbox.
-      + lib.optionalString (atLeast "18") ''
-        substituteInPlace src/test/regress/parallel_schedule \
-          --replace-fail numa ""
-      '';
+  postPatch = ''
+    substituteInPlace "src/Makefile.global.in" --subst-var out
+    substituteInPlace "src/common/config_info.c" --subst-var dev
+    cat ${./pg_config.env.mk} >> src/common/Makefile
+  ''
+  # This test always fails on hardware with >1 NUMA node: the sysfs
+  # dirs providing information about the topology are hidden in the sandbox,
+  # so postgres assumes there's only a single node `0`. However,
+  # the test checks on which NUMA nodes the allocated pages are which is >1
+  # on such hardware. This in turn triggers a safeguard in the view
+  # which breaks the test.
+  # Manual tests confirm that the testcase behaves properly outside of the
+  # Nix sandbox.
+  + lib.optionalString (atLeast "18") ''
+    substituteInPlace src/test/regress/parallel_schedule \
+      --replace-fail numa ""
+  '';
 
-      postInstall = ''
-        moveToOutput "bin/ecpg" "$dev"
-        moveToOutput "lib/pgxs" "$dev"
-      ''
-      + lib.optionalString (stdenv'.buildPlatform.canExecute stdenv'.hostPlatform) ''
-        mkdir -p "$dev/nix-support"
-        "$out/bin/pg_config" > "$dev/nix-support/pg_config.expected"
-      ''
-      + ''
-          rm "$out/bin/pg_config"
-          make -C src/common pg_config.env
-          substituteInPlace src/common/pg_config.env \
-            --replace-fail "$out" "@out@" \
-            --replace-fail "$man" "@man@"
-          install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
+  postInstall = ''
+    moveToOutput "bin/ecpg" "$dev"
+    moveToOutput "lib/pgxs" "$dev"
+  ''
+  + lib.optionalString (stdenv'.buildPlatform.canExecute stdenv'.hostPlatform) ''
+    mkdir -p "$dev/nix-support"
+    "$out/bin/pg_config" > "$dev/nix-support/pg_config.expected"
+  ''
+  + ''
+      rm "$out/bin/pg_config"
+      make -C src/common pg_config.env
+      substituteInPlace src/common/pg_config.env \
+        --replace-fail "$out" "@out@" \
+        --replace-fail "$man" "@man@"
+      install -D src/common/pg_config.env "$dev/nix-support/pg_config.env"
 
-        # postgres exposes external symbols get_pkginclude_path and similar. Those
-        # can't be stripped away by --gc-sections/LTO, because they could theoretically
-        # be used by dynamically loaded modules / extensions. To avoid circular dependencies,
-        # references to -dev, -doc and -man are removed here. References to -lib must be kept,
-        # because there is a realistic use-case for extensions to locate the /lib directory to
-        # load other shared modules.
-        remove-references-to -t "$dev" -t "$doc" -t "$man" "$out/bin/postgres"
+    # postgres exposes external symbols get_pkginclude_path and similar. Those
+    # can't be stripped away by --gc-sections/LTO, because they could theoretically
+    # be used by dynamically loaded modules / extensions. To avoid circular dependencies,
+    # references to -dev, -doc and -man are removed here. References to -lib must be kept,
+    # because there is a realistic use-case for extensions to locate the /lib directory to
+    # load other shared modules.
+    remove-references-to -t "$dev" -t "$doc" -t "$man" "$out/bin/postgres"
 
-        if [ -z "''${dontDisableStatic:-}" ]; then
-          # Remove static libraries in case dynamic are available.
-          for i in $lib/lib/*.a; do
-            name="$(basename "$i")"
-            ext="${stdenv'.hostPlatform.extensions.sharedLibrary}"
-            if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
-              rm "$i"
-            fi
-          done
+    if [ -z "''${dontDisableStatic:-}" ]; then
+      # Remove static libraries in case dynamic are available.
+      for i in $lib/lib/*.a; do
+        name="$(basename "$i")"
+        ext="${stdenv'.hostPlatform.extensions.sharedLibrary}"
+        if [ -e "$lib/lib/''${name%.a}$ext" ] || [ -e "''${i%.a}$ext" ]; then
+          rm "$i"
         fi
+      done
+    fi
 
-        # The remaining static libraries are libpgcommon.a, libpgport.a and related.
-        # Those are only used when building e.g. extensions, so go to $dev.
-        moveToOutput "lib/*.a" "$dev"
-      ''
-      + lib.optionalString jitSupport ''
-        # In the case of JIT support, prevent useless dependencies on header files
-        find "$out/lib" -iname '*.bc' -type f -exec nuke-refs '{}' +
+    # The remaining static libraries are libpgcommon.a, libpgport.a and related.
+    # Those are only used when building e.g. extensions, so go to $dev.
+    moveToOutput "lib/*.a" "$dev"
+  ''
+  + lib.optionalString jitSupport ''
+    # In the case of JIT support, prevent useless dependencies on header files
+    find "$out/lib" -iname '*.bc' -type f -exec nuke-refs '{}' +
 
-        # Stop lib depending on the -dev output of llvm
-        remove-references-to -t ${llvmPackages.llvm.dev} "$out/lib/llvmjit${dlSuffix}"
+    # Stop lib depending on the -dev output of llvm
+    remove-references-to -t ${llvmPackages.llvm.dev} "$out/lib/llvmjit${dlSuffix}"
 
-        moveToOutput "lib/bitcode" "$jit"
-        moveToOutput "lib/llvmjit*" "$jit"
-      ''
-      + lib.optionalString stdenv'.hostPlatform.isDarwin ''
-        # The darwin specific Makefile for PGXS contains a reference to the postgres
-        # binary. Some extensions (here: postgis), which are able to set bindir correctly
-        # to their own output for installation, will then fail to find "postgres" during linking.
-        substituteInPlace "$dev/lib/pgxs/src/Makefile.port" \
-          --replace-fail '-bundle_loader $(bindir)/postgres' "-bundle_loader $out/bin/postgres"
-      ''
-      + lib.optionalString perlSupport ''
-        moveToOutput "lib/*plperl*" "$plperl"
-        moveToOutput "share/postgresql/extension/*plperl*" "$plperl"
-      ''
-      + lib.optionalString pythonSupport ''
-        moveToOutput "lib/*plpython3*" "$plpython3"
-        moveToOutput "share/postgresql/extension/*plpython3*" "$plpython3"
-      ''
-      + lib.optionalString tclSupport ''
-        moveToOutput "lib/*pltcl*" "$pltcl"
-        moveToOutput "share/postgresql/extension/*pltcl*" "$pltcl"
-      '';
+    moveToOutput "lib/bitcode" "$jit"
+    moveToOutput "lib/llvmjit*" "$jit"
+  ''
+  + lib.optionalString stdenv'.hostPlatform.isDarwin ''
+    # The darwin specific Makefile for PGXS contains a reference to the postgres
+    # binary. Some extensions (here: postgis), which are able to set bindir correctly
+    # to their own output for installation, will then fail to find "postgres" during linking.
+    substituteInPlace "$dev/lib/pgxs/src/Makefile.port" \
+      --replace-fail '-bundle_loader $(bindir)/postgres' "-bundle_loader $out/bin/postgres"
+  ''
+  + lib.optionalString perlSupport ''
+    moveToOutput "lib/*plperl*" "$plperl"
+    moveToOutput "share/postgresql/extension/*plperl*" "$plperl"
+  ''
+  + lib.optionalString pythonSupport ''
+    moveToOutput "lib/*plpython3*" "$plpython3"
+    moveToOutput "share/postgresql/extension/*plpython3*" "$plpython3"
+  ''
+  + lib.optionalString tclSupport ''
+    moveToOutput "lib/*pltcl*" "$pltcl"
+    moveToOutput "share/postgresql/extension/*pltcl*" "$pltcl"
+  '';
 
-      postFixup = lib.optionalString stdenv'.hostPlatform.isGnu ''
-        # initdb needs access to "locale" command from glibc.
-        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
-      '';
+  postFixup = lib.optionalString stdenv'.hostPlatform.isGnu ''
+    # initdb needs access to "locale" command from glibc.
+    wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
+  '';
 
-      # Running tests as "install check" to work around SIP issue on macOS:
-      # https://www.postgresql.org/message-id/flat/4D8E1BC5-BBCF-4B19-8226-359201EA8305%40gmail.com
-      # Also see <nixpkgs>/doc/stdenv/platform-notes.chapter.md
-      doCheck = false;
-      doInstallCheck =
-        # Tests currently can't be run on darwin, because of a Nix bug:
-        # https://github.com/NixOS/nix/issues/12548
-        # https://git.lix.systems/lix-project/lix/issues/691
-        # The error appears as this in the initdb logs:
-        #   FATAL:  could not create shared memory segment: Cannot allocate memory
-        # Don't let yourself be fooled when trying to remove this condition: Running
-        # the tests works fine most of the time. But once the tests (or any package using
-        # postgresqlTestHook) fails on the same machine for a few times, enough IPC objects
-        # will be stuck around, and any future builds with the tests enabled *will* fail.
-        !(stdenv'.hostPlatform.isDarwin)
-        &&
-          # Regression tests currently fail in pkgsMusl because of a difference in EXPLAIN output.
-          !(stdenv'.hostPlatform.isMusl)
-        &&
-          # Modifying block sizes is expected to break regression tests.
-          # https://www.postgresql.org/message-id/E1TJOeZ-000717-Lg%40wrigleys.postgresql.org
-          (withBlocksize == null && withWalBlocksize == null);
-      installCheckTarget = "check-world";
+  # Running tests as "install check" to work around SIP issue on macOS:
+  # https://www.postgresql.org/message-id/flat/4D8E1BC5-BBCF-4B19-8226-359201EA8305%40gmail.com
+  # Also see <nixpkgs>/doc/stdenv/platform-notes.chapter.md
+  doCheck = false;
+  doInstallCheck =
+    # Tests currently can't be run on darwin, because of a Nix bug:
+    # https://github.com/NixOS/nix/issues/12548
+    # https://git.lix.systems/lix-project/lix/issues/691
+    # The error appears as this in the initdb logs:
+    #   FATAL:  could not create shared memory segment: Cannot allocate memory
+    # Don't let yourself be fooled when trying to remove this condition: Running
+    # the tests works fine most of the time. But once the tests (or any package using
+    # postgresqlTestHook) fails on the same machine for a few times, enough IPC objects
+    # will be stuck around, and any future builds with the tests enabled *will* fail.
+    !(stdenv'.hostPlatform.isDarwin)
+    &&
+      # Regression tests currently fail in pkgsMusl because of a difference in EXPLAIN output.
+      !(stdenv'.hostPlatform.isMusl)
+    &&
+      # Modifying block sizes is expected to break regression tests.
+      # https://www.postgresql.org/message-id/E1TJOeZ-000717-Lg%40wrigleys.postgresql.org
+      (withBlocksize == null && withWalBlocksize == null);
+  installCheckTarget = "check-world";
 
-      passthru = {
-        inherit dlSuffix;
+  passthru = {
+    inherit dlSuffix;
 
-        psqlSchema = lib.versions.major version;
+    psqlSchema = lib.versions.major version;
 
-        withJIT =
-          if jitSupport then
-            finalAttrs.finalPackage.withPackages (_: [ finalAttrs.finalPackage.jit ])
-          else
-            null;
-        withoutJIT = finalAttrs.finalPackage.withPackages (_: [ ]);
+    withJIT =
+      if jitSupport then
+        finalAttrs.finalPackage.withPackages (_: [ finalAttrs.finalPackage.jit ])
+      else
+        null;
+    withoutJIT = finalAttrs.finalPackage.withPackages (_: [ ]);
 
-        pkgs =
-          let
-            scope = {
-              inherit
-                jitSupport
-                pythonSupport
-                perlSupport
-                tclSupport
-                ;
-              inherit (llvmPackages) llvm;
-              postgresql = finalAttrs.finalPackage;
-              stdenv = stdenv';
-              postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
-              postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
-            };
-            newSelf = self // scope;
-            newSuper = {
-              callPackage = newScope (scope // finalAttrs.finalPackage.pkgs);
-            };
-          in
-          import ./ext.nix newSelf newSuper;
-
-        withPackages = self.callPackage ./wrapper.nix { postgresql = finalAttrs.finalPackage; };
-
-        pg_config = buildPackages.callPackage ./pg_config.nix {
-          inherit (finalAttrs) finalPackage;
-          outputs = {
-            out = lib.getOutput "out" finalAttrs.finalPackage;
-            man = lib.getOutput "man" finalAttrs.finalPackage;
-          };
+    pkgs =
+      let
+        scope = {
+          inherit
+            jitSupport
+            pythonSupport
+            perlSupport
+            tclSupport
+            ;
+          inherit (llvmPackages) llvm;
+          postgresql = finalAttrs.finalPackage;
+          stdenv = stdenv';
+          postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
+          postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
         };
-
-        tests = {
-          postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
-          postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
-          postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
-          postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
-          pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-        }
-        // lib.optionalAttrs jitSupport {
-          postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
+        newSelf = self // scope;
+        newSuper = {
+          callPackage = newScope (scope // finalAttrs.finalPackage.pkgs);
         };
+      in
+      import ./ext.nix newSelf newSuper;
+
+    withPackages = self.callPackage ./wrapper.nix { postgresql = finalAttrs.finalPackage; };
+
+    pg_config = buildPackages.callPackage ./pg_config.nix {
+      inherit (finalAttrs) finalPackage;
+      outputs = {
+        out = lib.getOutput "out" finalAttrs.finalPackage;
+        man = lib.getOutput "man" finalAttrs.finalPackage;
       };
+    };
 
-      meta = {
-        homepage = "https://www.postgresql.org";
-        description = "Powerful, open source object-relational database system";
-        license = lib.licenses.postgresql;
-        changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
-        teams = [ lib.teams.postgres ];
-        pkgConfigModules = [
-          "libecpg"
-          "libecpg_compat"
-          "libpgtypes"
-          "libpq"
-        ];
-        platforms = lib.platforms.unix;
+    tests = {
+      postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
+      postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
+      postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
+      postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    }
+    // lib.optionalAttrs jitSupport {
+      postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
+    };
+  };
 
-        broken =
-          # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
-          # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
-          # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
-          # host-platform.
-          #
-          # I managed to get a cross-build with JIT support working with
-          # `depsBuildBuild = [ llvmPackages.clang ] ++ buildInputs`, but considering that the
-          # resulting LLVM IR isn't platform-independent this doesn't give you much.
-          # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
-          # a query, postgres would coredump with `Illegal instruction`.
-          #
-          # Note: This is "host canExecute build" on purpose, since this is about the LLVM that is called
-          # to do JIT at **runtime**.
-          (jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform)
-          # While PostgreSQL claims to support static builds, it does not do so in a way that
-          # would work properly and consistently in pkgsStatic. The server heavily depends on
-          # the ability to load shared modules at runtime, but dlopen() is stubbed out in static
-          # musl builds. The important part is, that the separate libpq package builds in pkgsStatic.
-          || stdenv.hostPlatform.isStatic;
-      };
-    });
+  meta = {
+    homepage = "https://www.postgresql.org";
+    description = "Powerful, open source object-relational database system";
+    license = lib.licenses.postgresql;
+    changelog = "https://www.postgresql.org/docs/release/${finalAttrs.version}/";
+    teams = [ lib.teams.postgres ];
+    pkgConfigModules = [
+      "libecpg"
+      "libecpg_compat"
+      "libpgtypes"
+      "libpq"
+    ];
+    platforms = lib.platforms.unix;
 
-in
-# passed by <major>.nix
-versionArgs:
-# passed by default.nix
-{ self, ... }@defaultArgs:
-self.callPackage generic (defaultArgs // versionArgs)
+    broken =
+      # JIT support doesn't work with cross-compilation. It is attempted to build LLVM-bytecode
+      # (`%.bc` is the corresponding `make(1)`-rule) for each sub-directory in `backend/` for
+      # the JIT apparently, but with a $(CLANG) that can produce binaries for the build, not the
+      # host-platform.
+      #
+      # I managed to get a cross-build with JIT support working with
+      # `depsBuildBuild = [ llvmPackages.clang ] ++ buildInputs`, but considering that the
+      # resulting LLVM IR isn't platform-independent this doesn't give you much.
+      # In fact, I tried to test the result in a VM-test, but as soon as JIT was used to optimize
+      # a query, postgres would coredump with `Illegal instruction`.
+      #
+      # Note: This is "host canExecute build" on purpose, since this is about the LLVM that is called
+      # to do JIT at **runtime**.
+      (jitSupport && !stdenv.hostPlatform.canExecute stdenv.buildPlatform)
+      # While PostgreSQL claims to support static builds, it does not do so in a way that
+      # would work properly and consistently in pkgsStatic. The server heavily depends on
+      # the ability to load shared modules at runtime, but dlopen() is stubbed out in static
+      # musl builds. The important part is, that the separate libpq package builds in pkgsStatic.
+      || stdenv.hostPlatform.isStatic;
+  };
+})

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -39,7 +39,6 @@ let
       removeReferencesTo,
 
       # passthru
-      buildEnv,
       buildPackages,
       newScope,
       nixosTests,
@@ -542,10 +541,7 @@ let
           in
           import ./ext.nix newSelf newSuper;
 
-        withPackages = postgresqlWithPackages {
-          inherit buildEnv lib makeBinaryWrapper;
-          postgresql = finalAttrs.finalPackage;
-        };
+        withPackages = self.callPackage ./wrapper.nix { postgresql = finalAttrs.finalPackage; };
 
         pg_config = buildPackages.callPackage ./pg_config.nix {
           inherit (finalAttrs) finalPackage;
@@ -603,77 +599,6 @@ let
           || stdenv.hostPlatform.isStatic;
       };
     });
-
-  postgresqlWithPackages =
-    {
-      postgresql,
-      buildEnv,
-      lib,
-      makeBinaryWrapper,
-    }:
-    f:
-    let
-      installedExtensions = f postgresql.pkgs;
-      recurse = postgresqlWithPackages {
-        inherit
-          buildEnv
-          lib
-          makeBinaryWrapper
-          postgresql
-          ;
-      };
-      finalPackage = buildEnv {
-        pname = "${postgresql.pname}-and-plugins";
-        inherit (postgresql) version;
-        paths = installedExtensions ++ [
-          # consider keeping in-sync with `postBuild` below
-          postgresql
-          postgresql.man # in case user installs this into environment
-        ];
-
-        pathsToLink = [
-          "/"
-          "/bin"
-          "/share/postgresql/extension"
-          # Unbreaks Omnigres' build system
-          "/share/postgresql/timezonesets"
-          "/share/postgresql/tsearch_data"
-        ];
-
-        derivationArgs = {
-          strictDeps = true;
-          nativeBuildInputs = [ makeBinaryWrapper ];
-          postBuild =
-            let
-              args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
-            in
-            ''
-              wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
-            '';
-        };
-
-        passthru = {
-          inherit installedExtensions;
-          inherit (postgresql)
-            pkgs
-            psqlSchema
-            ;
-
-          pg_config = postgresql.pg_config.override {
-            outputs = {
-              out = finalPackage;
-              man = finalPackage;
-            };
-          };
-
-          withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
-          withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
-
-          withPackages = f': recurse (ps: installedExtensions ++ f' ps);
-        };
-      };
-    in
-    finalPackage;
 
 in
 # passed by <major>.nix

--- a/pkgs/servers/sql/postgresql/wrapper.nix
+++ b/pkgs/servers/sql/postgresql/wrapper.nix
@@ -1,0 +1,68 @@
+{
+  buildEnv,
+  callPackage,
+  lib,
+  makeBinaryWrapper,
+  postgresql,
+}:
+f:
+let
+  installedExtensions = f postgresql.pkgs;
+  recurse = import ./wrapper.nix {
+    # explicitly listed in case they were overridden
+    inherit
+      buildEnv
+      callPackage
+      lib
+      makeBinaryWrapper
+      postgresql
+      ;
+  };
+in
+buildEnv (finalAttrs: {
+  pname = "${postgresql.pname}-and-plugins";
+  inherit (postgresql) version;
+  paths = installedExtensions ++ [
+    # consider keeping in-sync with `postBuild` below
+    postgresql
+    postgresql.man # in case user installs this into environment
+  ];
+
+  pathsToLink = [
+    "/"
+    "/bin"
+    "/share/postgresql/extension"
+    # Unbreaks Omnigres' build system
+    "/share/postgresql/timezonesets"
+    "/share/postgresql/tsearch_data"
+  ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  postBuild =
+    let
+      args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+    in
+    ''
+      wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+    '';
+
+  passthru = {
+    inherit installedExtensions;
+    inherit (postgresql)
+      pkgs
+      psqlSchema
+      ;
+
+    pg_config = postgresql.pg_config.override {
+      outputs = {
+        out = finalAttrs.finalPackage;
+        man = finalAttrs.finalPackage;
+      };
+    };
+
+    withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
+    withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
+
+    withPackages = f': recurse (ps: installedExtensions ++ f' ps);
+  };
+})

--- a/pkgs/servers/sql/postgresql/wrapper.nix
+++ b/pkgs/servers/sql/postgresql/wrapper.nix
@@ -1,0 +1,71 @@
+{
+  buildEnv,
+  callPackage,
+  lib,
+  makeBinaryWrapper,
+  postgresql,
+}:
+f:
+let
+  installedExtensions = f postgresql.pkgs;
+  recurse = import ./wrapper.nix {
+    # explicitly listed in case they were overridden
+    inherit
+      buildEnv
+      callPackage
+      lib
+      makeBinaryWrapper
+      postgresql
+      ;
+  };
+in
+buildEnv (finalAttrs: {
+  pname = "${postgresql.pname}-and-plugins";
+  inherit (postgresql) version;
+  paths = installedExtensions ++ [
+    # consider keeping in-sync with `postBuild` below
+    postgresql
+    postgresql.man # in case user installs this into environment
+  ];
+
+  pathsToLink = [
+    "/"
+    "/bin"
+    "/share/postgresql/extension"
+    # Unbreaks Omnigres' build system
+    "/share/postgresql/timezonesets"
+    "/share/postgresql/tsearch_data"
+  ];
+
+  derivationArgs = {
+    strictDeps = true;
+    nativeBuildInputs = [ makeBinaryWrapper ];
+    postBuild =
+      let
+        args = lib.concatMap (ext: ext.wrapperArgs or [ ]) installedExtensions;
+      in
+      ''
+        wrapProgram "$out/bin/postgres" ${lib.concatStringsSep " " args}
+      '';
+  };
+
+  passthru = {
+    inherit installedExtensions;
+    inherit (postgresql)
+      pkgs
+      psqlSchema
+      ;
+
+    pg_config = postgresql.pg_config.override {
+      outputs = {
+        out = finalAttrs.finalPackage;
+        man = finalAttrs.finalPackage;
+      };
+    };
+
+    withJIT = recurse (_: installedExtensions ++ [ postgresql.jit ]);
+    withoutJIT = recurse (_: lib.remove postgresql.jit installedExtensions);
+
+    withPackages = f': recurse (ps: installedExtensions ++ f' ps);
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8259,6 +8259,7 @@ with pkgs;
   };
 
   inherit (import ../servers/sql/postgresql pkgs)
+    buildPostgresql
     postgresqlVersions
     postgresqlJitVersions
     libpq


### PR DESCRIPTION
I want to package [`orioledb`](https://www.orioledb.com/), which is an [extension](https://github.com/orioledb/orioledb) that needs a [patched version of postgresql](https://github.com/orioledb/postgres). In other words, I need to package a postgresql fork.

The first thing I tried downstream was something like `(postgresql.overrideAttrs { src = ... orioledb/postgres ... }).withPackages (pkgs: pkgs.callPackage (... orioledb/orioledb ...))`. Unfortunately that doesn't work, because `withPackages` looses `overrideAttrs`. We tried to fix that in #488692, but failed - the interactions between `withPackages` and overriding are more complicated.

I tried a few different things to fix that, ~~but ultimately failed with all of them. So I went this way: We're now exposing a separate `buildPostgresql` function, which can be used to call the generic builder. Also added `orioledb` as an example of its usage.~~

(more text in the commits!)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
