### PR TITLE
sp800-90b-entropyassessment: fix build with jsoncpp 1.9.7 & cleanup maintainers

### DIFF
--- a/pkgs/by-name/sp/sp800-90b-entropyassessment/package.nix
+++ b/pkgs/by-name/sp/sp800-90b-entropyassessment/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.nistSoftware;
     maintainers = with lib.maintainers; [
-      orichter
       thillux
     ];
   };

--- a/pkgs/by-name/sp/sp800-90b-entropyassessment/package.nix
+++ b/pkgs/by-name/sp/sp800-90b-entropyassessment/package.nix
@@ -30,7 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace "-march=native" ""
+      --replace-fail "-march=native" "" \
+      --replace-fail "-std=c++11" "-std=c++17"
   '';
 
   sourceRoot = "${finalAttrs.src.name}/cpp";


### PR DESCRIPTION
This package failed to build after the bump of jsoncpp to 1.9.7 because string_view code paths are now used instead of e.g. operator[](const char*). Fix this by using C++17.

While there cleanup maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
