### PR TITLE
angrr: 0.2.3 -> 0.2.6

### DIFF
--- a/nixos/modules/services/misc/angrr.nix
+++ b/nixos/modules/services/misc/angrr.nix
@@ -27,6 +27,16 @@ let
         keep-latest-n = 5;
         keep-booted-system = true;
         keep-current-system = true;
+        keep-n-per-bucket = [
+          {
+            bucket-window = "1 day";
+            bucket-amount = 7;
+          }
+          {
+            bucket-window = "1 week";
+            bucket-amount = 4;
+          }
+        ];
       };
       user = {
         enable = false;
@@ -198,6 +208,13 @@ let
           Whether to keep the last booted system generation. Only useful for system profiles.
         '';
       };
+      keep-n-per-bucket = lib.mkOption {
+        type = with lib.types; listOf (submodule keepNPerBucketOptions);
+        default = [ ];
+        description = ''
+          Specify a list of rules having n, bucket-window, and bucket-amount attributes.
+        '';
+      };
     };
   };
   filterOptions = {
@@ -214,6 +231,31 @@ let
         default = [ ];
         description = ''
           Extra command-line arguments pass to the external filter program.
+        '';
+      };
+    };
+  };
+  keepNPerBucketOptions = {
+    freeformType = toml.type;
+    options = {
+      n = lib.mkOption {
+        type = lib.types.int;
+        default = 1;
+        description = ''
+          Retain n generations every bucket-window duration for bucket-amount buckets.
+        '';
+      };
+      bucket-window = lib.mkOption {
+        type = lib.types.str;
+        description = ''
+          The duration of the bucket window.
+        '';
+      };
+      bucket-amount = lib.mkOption {
+        type = lib.types.int;
+        default = 1;
+        description = ''
+          The number of buckets to keep.
         '';
       };
     };
@@ -236,7 +278,6 @@ in
 {
   meta.maintainers = pkgs.angrr.meta.maintainers;
   imports = [
-    (lib.mkRemovedOptionModule [ "services" "angrr" "period" ] configFileMigrationMsg)
     (lib.mkRemovedOptionModule [ "services" "angrr" "removeRoot" ] configFileMigrationMsg)
     (lib.mkRemovedOptionModule [ "services" "angrr" "ownedOnly" ] configFileMigrationMsg)
   ];
@@ -265,6 +306,15 @@ in
         default = [ ];
         description = ''
           Extra command-line arguments pass to angrr.
+        '';
+      };
+      period = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          If set, it configures {option}`services.angrr.settings` to a preset that
+          monitor .direnv, results, system, and user profiles,
+          retaining GC roots that are younger than the specified period.
         '';
       };
       settings = lib.mkOption {
@@ -371,6 +421,38 @@ in
         programs.direnv.direnvrcExtra = lib.mkIf direnvCfg.autoUse ''
           _angrr_auto_use "$@"
         '';
+      })
+
+      # When period is set, configure a preset retention policy
+      # Users can still override settings via services.angrr.settings
+      (lib.mkIf (cfg.period != null) {
+        services.angrr.settings = {
+          temporary-root-policies = {
+            direnv = {
+              path-regex = "/\\.direnv/";
+              period = cfg.period;
+            };
+            result = {
+              path-regex = "/result[^/]*$";
+              period = cfg.period;
+            };
+          };
+          profile-policies = {
+            system = {
+              profile-paths = [ "/nix/var/nix/profiles/system" ];
+              keep-since = cfg.period;
+              keep-booted-system = true;
+              keep-current-system = true;
+            };
+            user = {
+              profile-paths = [
+                "~/.local/state/nix/profiles/profile"
+                "/nix/var/nix/profiles/per-user/root/profile"
+              ];
+              keep-since = cfg.period;
+            };
+          };
+        };
       })
     ]
   );

--- a/nixos/tests/angrr.nix
+++ b/nixos/tests/angrr.nix
@@ -95,7 +95,7 @@ in
     machine.succeed("su normal --command 'nix build /run/current-system --out-link /tmp/result-user-auto-gc-root-2'")
 
     machine.systemctl("start nix-gc.service")
-    # Not auto gc root will be removed
+    # No auto gc root will be removed
     machine.succeed("readlink /tmp/result-root-auto-gc-root-1")
     machine.succeed("readlink /tmp/result-root-auto-gc-root-2")
     machine.succeed("readlink /tmp/result-user-auto-gc-root-1")

--- a/pkgs/by-name/an/angrr/package.nix
+++ b/pkgs/by-name/an/angrr/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "angrr";
-  version = "0.2.3";
+  version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "linyinfeng";
     repo = "angrr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8UrQ9e+gx7AR6ASNX94P2K3SvNOzvR98U3ub/odqybM=";
+    hash = "sha256-bEQuCXxZpalfn4pLoc//aTiEzbnie9CYPBBCS6HCTbI=";
   };
 
-  cargoHash = "sha256-pVFIsFIdOIgBilBRYtGZdjVOyaERrfiJJT2WT/YoXeQ=";
+  cargoHash = "sha256-kgbaEgjEqnY4hCcNRcc6mSssqi4xlmGl3qotDhGdsBA=";
 
   buildAndTestSubdir = "angrr";
 

--- a/pkgs/by-name/an/angrr/package.nix
+++ b/pkgs/by-name/an/angrr/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "angrr";
-  version = "0.2.3";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "linyinfeng";
     repo = "angrr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8UrQ9e+gx7AR6ASNX94P2K3SvNOzvR98U3ub/odqybM=";
+    hash = "sha256-Sj7aaKC7rtIzIz3UiVfmLjr4O7hWXrEC3wkKaPra/3A=";
   };
 
-  cargoHash = "sha256-pVFIsFIdOIgBilBRYtGZdjVOyaERrfiJJT2WT/YoXeQ=";
+  cargoHash = "sha256-LspQncUrWfou41G37L3O1GbeiaoQpAC/RAu3EAPVrRU=";
 
   buildAndTestSubdir = "angrr";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: <https://github.com/linyinfeng/angrr/releases/tag/v0.2.4>.
Changelog: <https://github.com/linyinfeng/angrr/releases/tag/v0.2.5>.
Changelog: <https://github.com/linyinfeng/angrr/releases/tag/v0.2.6>.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package angrr --package angrr.tests --package nixosTests.angrr`
Commit: `e8cb691e0e3d1e6e49bb5ea3bec6e4f11ca25266`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 test built:</summary>
  <ul>
    <li>nixosTests.angrr</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>angrr</li>
    <li>angrr.tests.version</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
