### PR TITLE
frr: 10.5.3 -> 10.6.0

### DIFF
--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -31,7 +31,8 @@
   readline,
   rtrlib,
   protobufc,
-  zeromq,
+  sqlite,
+  lua53Packages,
 
   # tests
   net-tools,
@@ -80,13 +81,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "frr";
-  version = "10.5.3";
+  version = "10.6.0";
 
   src = fetchFromGitHub {
     owner = "FRRouting";
     repo = "frr";
     rev = "frr-${finalAttrs.version}";
-    hash = "sha256-nVXoRApW8EZtP1HiGJ5JBJaoQXVISfPK2k+xmCtdVH0=";
+    hash = "sha256-o0h9adGvb9FEcAMYrjrjTb7MMozdXriOsK6fE0fGjss=";
   };
 
   # Without the std explicitly set, we may run into abseil-cpp
@@ -119,7 +120,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     readline
     rtrlib
-    zeromq
+    lua53Packages.lua
+    sqlite
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libcap
@@ -148,11 +150,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   configureFlags = [
+    "--disable-zeromq"
     "--disable-silent-rules"
     "--enable-configfile-mask=0640"
     "--enable-group=frr"
     "--enable-logfile-mask=0640"
     "--enable-multipath=${toString numMultipath}"
+    "--enable-config-rollbacks"
+    "--enable-scripting"
     "--enable-user=frr"
     "--enable-vty-group=frrvty"
     "--localstatedir=/var"


### PR DESCRIPTION
Changelog: https://github.com/FRRouting/frr/releases/tag/frr-10.6.0

While there, recheck config flags and dependencies:
- ZeroMQ prevents tests from completion and is also disabled by ArchLinux.
- Scripting with Lua and Config rollbacks seem to be useful features, so enable them from now on.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
