### PR TITLE
retoc: init at 0.1.5

### DIFF
--- a/pkgs/by-name/re/retoc/package.nix
+++ b/pkgs/by-name/re/retoc/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-jevIk0XXQbGMA8M94tti8UuXlpcjagpcPCB7PXKewLE=";
 
   oodleLib = fetchurl {
-    url = "https://github.com/WorkingRobot/OodleUE/raw/refs/heads/main/Engine/Source/Programs/Shared/EpicGames.Oodle/Sdk/2.9.10/linux/lib/liboo2corelinux64.so.9";
+    url = "https://raw.githubusercontent.com/WorkingRobot/OodleUE/a4c95b32ab07c3f35dce7e7c52b0f8cbfd3a7765/Engine/Source/Programs/Shared/EpicGames.Oodle/Sdk/2.9.10/linux/lib/liboo2corelinux64.so.9";
     hash = "sha256-7X6Y9wvhJUqAZE79OuRC/2H4VKL+neuwuXi5UomITpw=";
   };
 
@@ -60,5 +60,6 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [ caniko ];
     mainProgram = "retoc";
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/re/retoc/package.nix
+++ b/pkgs/by-name/re/retoc/package.nix
@@ -11,6 +11,7 @@
 rustPlatform.buildRustPackage rec {
   pname = "retoc";
   version = "0.1.5";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "trumank";

--- a/pkgs/by-name/re/retoc/package.nix
+++ b/pkgs/by-name/re/retoc/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  makeWrapper,
+  rustPlatform,
+  stdenv,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "retoc";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "trumank";
+    repo = "retoc";
+    tag = "v${version}";
+    hash = "sha256-rpDBDViype47oIPfTwlsjRlF9rLDIu3NSGGV46YP8jQ=";
+  };
+
+  cargoHash = "sha256-jevIk0XXQbGMA8M94tti8UuXlpcjagpcPCB7PXKewLE=";
+
+  oodleLib = fetchurl {
+    url = "https://github.com/WorkingRobot/OodleUE/raw/refs/heads/main/Engine/Source/Programs/Shared/EpicGames.Oodle/Sdk/2.9.10/linux/lib/liboo2corelinux64.so.9";
+    hash = "sha256-7X6Y9wvhJUqAZE79OuRC/2H4VKL+neuwuXi5UomITpw=";
+  };
+
+  cargoBuildFlags = [
+    "-p"
+    "retoc_cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "retoc_cli"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    install -Dm444 ${oodleLib} "$out/bin/liboo2corelinux64.so.9"
+    wrapProgram "$out/bin/retoc" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Unreal Engine IoStore CLI packing and unpacking tool";
+    homepage = "https://github.com/trumank/retoc";
+    changelog = "https://github.com/trumank/retoc/releases/tag/v${version}";
+    license = with lib.licenses; [
+      mit
+      unfreeRedistributable
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ caniko ];
+    mainProgram = "retoc";
+  };
+}


### PR DESCRIPTION
Adds `retoc`, a CLI for Unreal Engine IoStore containers (`.utoc`/`.ucas`).

The package includes the Oodle shared library used by retoc's upstream `oodle_loader` path so compressed IoStore containers work from the read-only Nix store. This is why the package is marked with `unfreeRedistributable` and `binaryNativeCode` provenance in addition to the MIT-licensed retoc source.

This branch also defines `passthru.updateScript = nix-update-script { };` for nixpkgs-update automation. Retoc currently tracks GitHub `v${version}` tags; `v0.1.5` is the latest upstream tag, so no custom `extraArgs` or generated version bump is needed.

Local validation performed:

- `NIXPKGS_ALLOW_UNFREE=1 nix build .#retoc --impure`
- `./result/bin/retoc --help`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in pkgs.retoc.meta.platforms'`
- `nix eval --impure --expr 'let pkgs = import ./. { config.allowUnfree = true; }; in pkgs.retoc.updateScript'`
- `NIXPKGS_ALLOW_UNFREE=1 nix-shell maintainers/scripts/update.nix --argstr package retoc --argstr skip-prompt true`
- `./result/bin/retoc list --hash --package --size --path <local Stellar Blade pakchunk0-WindowsNoEditor.utoc>` and confirmed it lists Oodle-compressed IoStore entries such as `SkillTable.uasset`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - `nixpkgs-review-gha` passed for the current head: https://github.com/caniko/nixpkgs-review-gha/actions/runs/25135211235
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

