### PR TITLE
zsh: fix sigsuspend probe under autoconf 2.73 / C23

### DIFF
--- a/pkgs/by-name/zs/zsh/fix-sigsuspend-probe-c23.patch
+++ b/pkgs/by-name/zs/zsh/fix-sigsuspend-probe-c23.patch
@@ -1,0 +1,17 @@
+Prototype the K&R handler so the probe still compiles under -std=gnu23
+(selected by autoconf 2.73). Upstream removed the probe in 8dd271fdec52,
+which does not apply against 5.9 with the PCRE backports.
+
+https://github.com/NixOS/nixpkgs/issues/513543
+--- a/configure.ac
++++ b/configure.ac
+@@ -2334,8 +2334,7 @@ if test x$signals_style = xPOSIX_SIGNALS; then
+ #include <signal.h>
+ #include <unistd.h>
+ int child=0;
+-void handler(sig)
+-    int sig;
++void handler(int sig)
+ {if(sig==SIGCHLD) child=1;}
+ int main() {
+     struct sigaction act;

--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -63,6 +63,9 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-bl1PG9Zk1wK+2mfbCBhD3OEpP8HQboqEO8sLFqX8DmA=";
       excludes = [ "ChangeLog" ];
     })
+    # autoconf 2.73 picks -std=gnu23, breaking the K&R sigsuspend probe and
+    # causing $(...) hangs. Drop with the next zsh release.
+    ./fix-sigsuspend-probe-c23.patch
   ]
   ++ lib.optionals stdenv.cc.isGNU [
     # Fixes compilation with gcc >= 14.


### PR DESCRIPTION
autoconf 2.73 makes AC_PROG_CC pick -std=gnu23, which rejects the K&R handler in the zsh_cv_sys_sigsuspend probe. The compile failure flips the probe to "no", defines BROKEN_POSIX_SIGSUSPEND, and the resulting racy pause() fallback hangs $(...) on a lost SIGCHLD.

Upstream dropped the probe in 8dd271fdec52; that does not apply on 5.9 with the PCRE backports here, so just prototype the handler.

Fixes #513543
Fixes #513019


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
