### PR TITLE
cudaPackages.cuda_crt: do not patch math headers on >=13.2

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_crt.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_crt.nix
@@ -2,6 +2,7 @@
   lib,
   backendStdenv,
   buildRedist,
+  cudaOlder,
   glibc,
 }:
 buildRedist {
@@ -11,10 +12,11 @@ buildRedist {
   outputs = [ "out" ];
 
   # Fix compatibility with glibc 2.42:
-  # CUDA >= 13.0 fixed sinpi/cospi (using __NV_IEC_60559_FUNCS_EXCEPTION_SPECIFIER), but
-  # rsqrt/rsqrtf in math_functions.h still lack noexcept, conflicting with glibc 2.42's
-  # declarations.
-  postInstall = lib.optionalString (lib.versionAtLeast glibc.version "2.42") ''
+  # - CUDA >= 13.0 fixed sinpi/cospi (using __NV_IEC_60559_FUNCS_EXCEPTION_SPECIFIER), but
+  #   rsqrt/rsqrtf in math_functions.h still lack noexcept, conflicting with glibc 2.42's
+  #   declarations.
+  # - CUDA >= 13.2 fixed rsqrt/rsqrtf as well (using _NV_RSQRT_SPECIFIER).
+  postInstall = lib.optionalString (cudaOlder "13.2" && lib.versionAtLeast glibc.version "2.42") ''
     nixLog "Patching math_functions.h rsqrt signatures to match glibc's ones"
     substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.h" \
       --replace-fail \


### PR DESCRIPTION
## Things done

Fixes `cudaPackages_13_2.cuda_crt`.

cc @NixOS/cuda-maintainers.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
