### PR TITLE
idescriptor: 0.2.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/id/idescriptor/package.nix
+++ b/pkgs/by-name/id/idescriptor/package.nix
@@ -2,11 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   buildGoModule,
   nix-update-script,
   copyDesktopItems,
   makeDesktopItem,
+  cargo,
   cmake,
+  corrosion,
   pkg-config,
   avahi-compat,
   ffmpeg,
@@ -25,17 +28,33 @@
   pugixml,
   qt6,
   lxqt,
+  rustPlatform,
+  rustc,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "idescriptor";
-  version = "0.3.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "iDescriptor";
     repo = "iDescriptor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tBTAJqXDqWAqrxQlEEi2kDcVqrB6WrBquxvKV2dkpQ4=";
+    hash = "sha256-AN3CVR9WWa9cG6C6q+hiDyTomT+RebHC1ghr6XyEtAo=";
     fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/iDescriptor/iDescriptor/commit/fc73e3146dc4884cf9bc1f7879574ac832cc21e6.patch";
+      hash = "sha256-WqEpSY/fhbsMv0bgU2Ak5japUdohaN7zsNG1BbxJnKs=";
+    })
+  ];
+
+  cargoRoot = "src/rust";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src cargoRoot;
+    hash = "sha256-PJhMb+lMiu8ubOYVX8YVkQzeQMbBO+i6NQhvuyrCujk=";
   };
 
   ipatool-go-modules =
@@ -50,15 +69,19 @@ stdenv.mkDerivation (finalAttrs: {
     }).goModules;
 
   nativeBuildInputs = [
+    cargo
     cmake
     copyDesktopItems
     pkg-config
     go
     qt6.wrapQtAppsHook
+    rustPlatform.cargoSetupHook
+    rustc
   ];
 
   buildInputs = [
     avahi-compat
+    corrosion
     ffmpeg
     libheif
     libimobiledevice
@@ -83,9 +106,17 @@ stdenv.mkDerivation (finalAttrs: {
     lxqt.qtermwidget
   ];
 
+  cxx-qt-cmake = fetchFromGitHub {
+    owner = "kdab";
+    repo = "cxx-qt-cmake";
+    tag = "0.8.1";
+    hash = "sha256-kXSIU71iHn+SSGikGoNeMbBpSrDJ6hwhnHslmskm8nY=";
+  };
+
   cmakeFlags = [
     "-DPACKAGE_MANAGER_MANAGED=ON"
     "-DPACKAGE_MANAGER_HINT=nixpkgs"
+    "-DFETCHCONTENT_SOURCE_DIR_CXXQT=${finalAttrs.cxx-qt-cmake}"
   ];
 
   preConfigure = ''


### PR DESCRIPTION
Failing build: https://r.ryantm.com/log/idescriptor/2026-04-21.log

Changelogs: https://github.com/iDescriptor/iDescriptor/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
