### PR TITLE
rsonpath: 0.9.1-unstable-2024-11-15 -> 0.10.0

### DIFF
--- a/pkgs/by-name/rs/rsonpath/package.nix
+++ b/pkgs/by-name/rs/rsonpath/package.nix
@@ -2,25 +2,20 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  unstableGitUpdater,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rsonpath";
-  version = "0.9.1-unstable-2024-11-15";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "rsonquery";
     repo = "rsonpath";
-    rev = "979e6374a68747dfba7b87b61bbe77951f749659";
-    hash = "sha256-YQCbkdv7PRf5hVXAGUg6DrtaCLIyS9nUGXsl8XHpKZU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Lh58U5A4EeD+tQ3CZNE7YabwGIJ14Cv5dqbJ64JYNDk=";
   };
 
-  passthru.updateScript = unstableGitUpdater {
-    tagPrefix = "v";
-  };
-
-  cargoHash = "sha256-9pSn0f0VWsBg1z1UYGRtMb1z23htRm7qLmO80zvSjN8=";
+  cargoHash = "sha256-w1AODL95+O0jhzXvNrL9I+i2+jcZX3SvJDKrLWkI7c8=";
 
   cargoBuildFlags = [ "-p=rsonpath" ];
   cargoTestFlags = finalAttrs.cargoBuildFlags;
@@ -28,9 +23,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Experimental JSONPath engine for querying massive streamed datasets";
     homepage = "https://github.com/v0ldek/rsonpath";
-    changelog = "https://github.com/v0ldek/rsonpath/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/v0ldek/rsonpath/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     mainProgram = "rq";
   };
 })


### PR DESCRIPTION
Update to 0.10.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
