### PR TITLE
odoo: fix websocket support for real-time connections

### DIFF
--- a/nixos/modules/services/finance/odoo.nix
+++ b/nixos/modules/services/finance/odoo.nix
@@ -46,7 +46,24 @@ in
       };
 
       settings = lib.mkOption {
-        type = format.type;
+        type = lib.types.submodule {
+          options = {
+            options = {
+              workers = lib.mkOption {
+                type = lib.types.ints.unsigned;
+                default = 0;
+                description = "Values above 0 will enable the multi-processing HTTP server, this should be set for production setups. This needs to be set to >0 for real-time connections in the discuss app. For configuration recommendations see <https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html#builtin-server>";
+              };
+              proxy_mode = lib.mkOption {
+                type = lib.types.bool;
+                default = cfg.domain != null;
+                defaultText = "services.odoo.domain != null";
+                description = "Enables the use of X-Forwarded-* headers through Werkzeug’s proxy support. Must be enabled if reverse proxy is used.";
+              };
+            };
+          };
+          freeformType = format.type;
+        };
         default = { };
         description = ''
           Odoo configuration settings. For more details see <https://www.odoo.com/documentation/15.0/administration/install/deploy.html>
@@ -96,7 +113,7 @@ in
           '';
 
           locations = {
-            "/longpolling" = {
+            "/websocket" = {
               proxyPass = "http://odoochat";
             };
 
@@ -127,7 +144,6 @@ in
         );
         settings.options = {
           data_dir = "/var/lib/private/odoo/data";
-          proxy_mode = cfg.domain != null;
           # Disable the database manager by default
           # https://www.odoo.com/documentation/master/administration/on_premise/deploy.html#database-manager-security
           list_db = lib.mkDefault false;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1168,15 +1168,27 @@ in
   octoprint = runTest ./octoprint.nix;
   oddjobd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./oddjobd.nix { };
   odoo17 = runTest {
-    imports = [ ./odoo.nix ];
+    imports = [ ./odoo/single-process.nix ];
+    _module.args.package = pkgs.odoo17;
+  };
+  odoo17-multiprocess = runTest {
+    imports = [ ./odoo/multi-process.nix ];
     _module.args.package = pkgs.odoo17;
   };
   odoo18 = runTest {
-    imports = [ ./odoo.nix ];
+    imports = [ ./odoo/single-process.nix ];
+    _module.args.package = pkgs.odoo18;
+  };
+  odoo18-multiprocess = runTest {
+    imports = [ ./odoo/multi-process.nix ];
     _module.args.package = pkgs.odoo18;
   };
   odoo19 = runTest {
-    imports = [ ./odoo.nix ];
+    imports = [ ./odoo/single-process.nix ];
+    _module.args.package = pkgs.odoo19;
+  };
+  odoo19-multiprocess = runTest {
+    imports = [ ./odoo/multi-process.nix ];
     _module.args.package = pkgs.odoo19;
   };
   oh-my-zsh = runTest ./oh-my-zsh.nix;

--- a/nixos/tests/odoo/multi-process.nix
+++ b/nixos/tests/odoo/multi-process.nix
@@ -1,0 +1,39 @@
+{
+  package,
+  lib,
+  ...
+}:
+{
+  name = "odoo-multi-process";
+  meta.maintainers = with lib.maintainers; [
+    mkg20001
+    xanderio
+  ];
+
+  nodes.server = {
+    services.nginx = {
+      enable = true;
+      recommendedProxySettings = true;
+    };
+
+    services.odoo = {
+      enable = true;
+      package = package;
+      autoInit = true;
+      autoInitExtraFlags = [ "--without-demo=all" ];
+      domain = "localhost";
+      settings.options.workers = 2;
+    };
+  };
+
+  testScript = # python
+    ''
+      server.wait_for_unit("odoo.service")
+      server.wait_until_succeeds(
+        "test $(journalctl -u odoo | grep -o 'Worker WorkerHTTP ([[:digit:]]*) alive' | wc -l) = 2"
+      )
+      server.wait_until_succeeds("curl -s http://localhost:8069/web/database/selector | grep '<title>Odoo</title>'")
+      server.succeed("curl -s http://localhost/web/database/selector | grep '<title>Odoo</title>'")
+      server.succeed("curl http://localhost/web/database/manager | grep 'database manager has been disabled'")
+    '';
+}

--- a/nixos/tests/odoo/single-process.nix
+++ b/nixos/tests/odoo/single-process.nix
@@ -4,8 +4,11 @@
   ...
 }:
 {
-  name = "odoo";
-  meta.maintainers = with lib.maintainers; [ mkg20001 ];
+  name = "odoo-single-process";
+  meta.maintainers = with lib.maintainers; [
+    mkg20001
+    xanderio
+  ];
 
   nodes.server = {
     services.nginx = {

--- a/pkgs/by-name/od/odoo17/package.nix
+++ b/pkgs/by-name/od/odoo17/package.nix
@@ -118,7 +118,7 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     updateScript = ./update.sh;
     tests = {
-      inherit (nixosTests) odoo17;
+      inherit (nixosTests) odoo17 odoo17-multiprocess;
     };
   };
 

--- a/pkgs/by-name/od/odoo17/package.nix
+++ b/pkgs/by-name/od/odoo17/package.nix
@@ -55,6 +55,13 @@ python.pkgs.buildPythonApplication rec {
     }"
   ];
 
+  postPatch = ''
+    # hardcode the location of the unwrapped python scrip, otherwise the websocket
+    # server (called longpoll in codebase) will fail to start.
+    substituteInPlace odoo/service/server.py \
+      --replace-fail 'sys.argv[0]' "'${placeholder "out"}/bin/.odoo-wrapped'"
+  '';
+
   build-system = with python.pkgs; [
     setuptools
   ];

--- a/pkgs/by-name/od/odoo18/package.nix
+++ b/pkgs/by-name/od/odoo18/package.nix
@@ -104,7 +104,7 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     updateScript = ./update.sh;
     tests = {
-      inherit (nixosTests) odoo18;
+      inherit (nixosTests) odoo18 odoo18-multiprocess;
     };
   };
 

--- a/pkgs/by-name/od/odoo18/package.nix
+++ b/pkgs/by-name/od/odoo18/package.nix
@@ -26,6 +26,13 @@ python.pkgs.buildPythonApplication rec {
     hash = "sha256-rNG0He+51DnRT5g1SovGZ9uiE1HWXtcmAybcadBMjY4="; # odoo
   };
 
+  postPatch = ''
+    # hardcode the location of the unwrapped python scrip, otherwise the websocket
+    # server (called longpoll in codebase) will fail to start.
+    substituteInPlace odoo/service/server.py \
+      --replace-fail 'sys.argv[0]' "'${placeholder "out"}/bin/.odoo-wrapped'"
+  '';
+
   makeWrapperArgs = [
     "--prefix PATH : ${
       lib.makeBinPath [

--- a/pkgs/by-name/od/odoo19/package.nix
+++ b/pkgs/by-name/od/odoo19/package.nix
@@ -99,7 +99,7 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     updateScript = ./update.sh;
     tests = {
-      inherit (nixosTests) odoo19;
+      inherit (nixosTests) odoo19 odoo19-multiprocess;
     };
   };
 

--- a/pkgs/by-name/od/odoo19/package.nix
+++ b/pkgs/by-name/od/odoo19/package.nix
@@ -26,6 +26,13 @@ python.pkgs.buildPythonApplication rec {
     hash = "sha256-JsbJ39zPZm4eyRTXkvdCMHwYaA08yUxZXcLglRn3kWs="; # odoo
   };
 
+  postPatch = ''
+    # hardcode the location of the unwrapped python scrip, otherwise the websocket
+    # server (called longpoll in codebase) will fail to start.
+    substituteInPlace odoo/service/server.py \
+      --replace-fail 'sys.argv[0]' "'${placeholder "out"}/bin/.odoo-wrapped'"
+  '';
+
   makeWrapperArgs = [
     "--prefix PATH : ${
       lib.makeBinPath [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current module and packages can support the multi-process web server that odoo recommends in production setups. This also causes the discuss app to fail to establish the websocket connection and display an error message around the window.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
