### PR TITLE
nixos/dunst: fix config format

### DIFF
--- a/nixos/modules/services/desktops/dunst.nix
+++ b/nixos/modules/services/desktops/dunst.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  toml = pkgs.formats.toml { };
+  gitIni = pkgs.formats.gitIni { };
   cfg = config.services.dunst;
 in
 {
@@ -22,7 +22,7 @@ in
     };
 
     settings = lib.mkOption {
-      type = toml.type;
+      type = gitIni.type;
       default = { };
       description = "Dunst configuration, see dunst(5)";
       example = lib.literalExpression ''
@@ -69,7 +69,7 @@ in
 
     environment = {
       systemPackages = [ cfg.package ];
-      etc."xdg/dunst/dunstrc".source = toml.generate "dunstrc" cfg.settings;
+      etc."xdg/dunst/dunstrc".source = gitIni.generate "dunstrc" cfg.settings;
     };
 
     services.dbus.packages = [ cfg.package ];


### PR DESCRIPTION
dunst expects config values to be double quoted, toml uses singe quotes, ini does not uses quotes at all

Upstream dust even calls it file for the config parser. `ini.c`: https://github.com/dunst-project/dunst/blob/master/src/ini.c

First sentence from `man 5 dunst`:
> The configuration is divided into sections in an ini-like format.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
