### PR TITLE
grype: 0.108.0 -> 0.111.1

### DIFF
--- a/pkgs/by-name/gr/grype/0001-test_helpers-redact-support-nix.patch
+++ b/pkgs/by-name/gr/grype/0001-test_helpers-redact-support-nix.patch
@@ -1,0 +1,35 @@
+diff --git a/grype/presenter/internal/test_helpers.go b/grype/presenter/internal/test_helpers.go
+index 2bfafbc2..6e70ed87 100644
+--- a/grype/presenter/internal/test_helpers.go
++++ b/grype/presenter/internal/test_helpers.go
+@@ -1,6 +1,7 @@
+ package internal
+ 
+ import (
++	"os"
+ 	"regexp"
+ 	"testing"
+ 
+@@ -92,8 +93,21 @@ func Redact(s []byte) []byte {
+ 	cycloneDxBomRefPattern := regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+ 	tempDirPattern := regexp.MustCompile(`/tmp/[^"]+`)
+ 	macTempDirPattern := regexp.MustCompile(`/var/folders/[^"]+`)
++	// nix build dir isn't always /build so we'll identify it by $TMP
++	nixDir := os.Getenv("TMP")
++	if nixDir == "" {
++		panic("missing $TMP for identifying nix build dir")
++	}
++	end := regexp.QuoteMeta(nixDir)
++	pattern := `[^"]+`
++	// add slash prefix to pattern only if required
++	// don't use strings lib to reduce chance of merge conflicts above
++	if end[len(end)-1] != '/' {
++		pattern = "/" + pattern
++	}
++	nixBuildDirPattern := regexp.MustCompile(end + pattern)
+ 
+-	for _, pattern := range []*regexp.Regexp{serialPattern, rfc3339Pattern, refPattern, uuidPattern, cycloneDxBomRefPattern, tempDirPattern, macTempDirPattern} {
++	for _, pattern := range []*regexp.Regexp{serialPattern, rfc3339Pattern, refPattern, uuidPattern, cycloneDxBomRefPattern, tempDirPattern, macTempDirPattern, nixBuildDirPattern} {
+ 		s = pattern.ReplaceAll(s, []byte(""))
+ 	}
+ 	return s

--- a/pkgs/by-name/gr/grype/package.nix
+++ b/pkgs/by-name/gr/grype/package.nix
@@ -7,17 +7,18 @@
   installShellFiles,
   openssl,
   net-tools,
+  zstd,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "grype";
-  version = "0.108.0";
+  version = "0.111.1";
 
   src = fetchFromGitHub {
     owner = "anchore";
     repo = "grype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5TYQKLVl3iM1Litp86n0aAaj3p2yKA1fbJ6bduIjfp8=";
+    hash = "sha256-eAiExxvLFkHsmslfhhbQG0ogaSMF9eOeCq0u2wUimp0=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -32,7 +33,7 @@ buildGoModule (finalAttrs: {
 
   proxyVendor = true;
 
-  vendorHash = "sha256-8LVpcSjWdGwYv8CMuMZyaHC9+wMJNPDSNV6a8VsmA0M=";
+  vendorHash = "sha256-rsdZt+xKjIJpWS5pYx8A+ryY1D2WIKquKjsQBkxToUQ=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -40,6 +41,7 @@ buildGoModule (finalAttrs: {
     git
     openssl
     net-tools
+    zstd
   ];
 
   subPackages = [ "cmd/grype" ];
@@ -70,7 +72,7 @@ buildGoModule (finalAttrs: {
     unset ldflags
 
     # patch utility script
-    patchShebangs grype/db/v5/distribution/test-fixtures/tls/generate-x509-cert-pair.sh
+    patchShebangs grype/db/v5/distribution/testdata/tls/generate-x509-cert-pair.sh
 
     # FIXME: these tests fail when building with Nix
     substituteInPlace test/cli/config_test.go \

--- a/pkgs/by-name/gr/grype/package.nix
+++ b/pkgs/by-name/gr/grype/package.nix
@@ -14,6 +14,9 @@ buildGoModule (finalAttrs: {
   pname = "grype";
   version = "0.111.1";
 
+  # required for tests
+  __darwinAllowLocalNetworking = true;
+
   src = fetchFromGitHub {
     owner = "anchore";
     repo = "grype";
@@ -34,6 +37,12 @@ buildGoModule (finalAttrs: {
   proxyVendor = true;
 
   vendorHash = "sha256-rsdZt+xKjIJpWS5pYx8A+ryY1D2WIKquKjsQBkxToUQ=";
+
+  patches = [
+    # several test golden files have unstable paths based on the platform
+    # this patch adjusts the `Redact` helper to also work for builds by nix.
+    ./0001-test_helpers-redact-support-nix.patch
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -73,52 +82,37 @@ buildGoModule (finalAttrs: {
 
     # patch utility script
     patchShebangs grype/db/v5/distribution/testdata/tls/generate-x509-cert-pair.sh
-
-    # FIXME: these tests fail when building with Nix
-    substituteInPlace test/cli/config_test.go \
-      --replace-fail "Test_configLoading" "Skip_configLoading"
-    substituteInPlace test/cli/db_providers_test.go \
-      --replace-fail "TestDBProviders" "SkipDBProviders"
-    substituteInPlace grype/presenter/cyclonedx/presenter_test.go \
-      --replace-fail "TestCycloneDxPresenterDir" "SkipCycloneDxPresenterDir" \
-      --replace-fail "Test_CycloneDX_Valid" "Skip_CycloneDX_Valid"
-
-    # remove tests that depend on docker
-    substituteInPlace test/cli/cmd_test.go \
-      --replace-fail "TestCmd" "SkipCmd"
-    substituteInPlace grype/pkg/provider_test.go \
-      --replace-fail "TestSyftLocationExcludes" "SkipSyftLocationExcludes"
-    substituteInPlace test/cli/cmd_test.go \
-      --replace-fail "Test_descriptorNameAndVersionSet" "Skip_descriptorNameAndVersionSet"
-
-    # remove tests that depend on git
-    substituteInPlace test/cli/db_validations_test.go \
-      --replace-fail "TestDBValidations" "SkipDBValidations"
-    substituteInPlace test/cli/registry_auth_test.go \
-      --replace-fail "TestRegistryAuth" "SkipRegistryAuth"
-    substituteInPlace test/cli/sbom_input_test.go \
-      --replace-fail "TestSBOMInput_FromStdin" "SkipSBOMInput_FromStdin" \
-      --replace-fail "TestSBOMInput_AsArgument" "SkipSBOMInput_AsArgument"
-    substituteInPlace test/cli/subprocess_test.go \
-      --replace-fail "TestSubprocessStdin" "SkipSubprocessStdin"
-    substituteInPlace grype/internal/packagemetadata/names_test.go \
-      --replace-fail "TestAllNames" "SkipAllNames"
-    substituteInPlace test/cli/version_cmd_test.go \
-      --replace-fail "TestVersionCmdPrintsToStdout" "SkipVersionCmdPrintsToStdout"
-    substituteInPlace grype/presenter/sarif/presenter_test.go \
-      --replace-fail "Test_SarifIsValid" "SkipTest_SarifIsValid"
-    substituteInPlace test/cli/config_test.go \
-      --replace-fail "Test_dpkgUseCPEsForEOLEnvVar" "SkipTest_dpkgUseCPEsForEOLEnvVar" \
-      --replace-fail "Test_rpmUseCPEsForEOLEnvVar" "SkipTest_rpmUseCPEsForEOLEnvVar"
-
-    # May fail on NixOS, probably due bug in how syft handles tmpfs.
-    # See https://github.com/anchore/grype/issues/1822
-    substituteInPlace grype/distro/distro_test.go \
-      --replace-fail "Test_NewDistroFromRelease_Coverage" "SkipTest_NewDistroFromRelease_Coverage"
-
-    # segfault
-    rm grype/db/v5/namespace/cpe/namespace_test.go
   '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # depend on docker
+        "TestCmd"
+        "TestSyftLocationExcludes"
+        "Test_descriptorNameAndVersionSet"
+        # depend on .git
+        "Test_configLoading"
+        "TestDBProviders"
+        "TestDBValidations"
+        "TestRegistryAuth"
+        "TestRegistryAuthRedactions"
+        "TestSBOMInput_FromStdin"
+        "TestSBOMInput_AsArgument"
+        "TestSubprocessStdin"
+        "TestAllNames"
+        "TestVersionCmdPrintsToStdout"
+        "Test_SarifIsValid"
+        "Test_dpkgUseCPEsForEOLEnvVar"
+        "Test_rpmUseCPEsForEOLEnvVar"
+      ]
+      ++ lib.optionals stdenv.isDarwin [
+        # fails to generate x509 certificate
+        # cat: /etc/ssl/openssl.cnf: Operation not permitted
+        "Test_defaultHTTPClientHasCert"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd grype \


### PR DESCRIPTION
- **grype: 0.108.0 -> 0.111.1**
  - Diff: https://github.com/anchore/grype/compare/v0.108.0...v0.111.1
  - Changelog: https://github.com/anchore/grype/releases/tag/v0.111.1
- **grype: cleanup test skipping**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
