### PR TITLE
php85Extensions.grpc: unbreak for PHP 8.5

### DIFF
--- a/pkgs/development/php-packages/grpc/default.nix
+++ b/pkgs/development/php-packages/grpc/default.nix
@@ -27,6 +27,5 @@ buildPecl {
     homepage = "https://github.com/grpc/grpc/tree/master/src/php/ext/grpc";
     license = lib.licenses.asl20;
     teams = [ lib.teams.php ];
-    broken = lib.versionAtLeast php.version "8.5";
   };
 }


### PR DESCRIPTION
grpc 1.80.0 supports PHP 8.5. Remove the `broken = lib.versionAtLeast php.version "8.5"` flag.

The `broken` flag was added in https://github.com/NixOS/nixpkgs/pull/481104 when PHP 8.5 was initialized at 8.5.2, at which point grpc was still on 1.76.0 and used `zend_exception_get_default()` which was removed in PHP 8.5.

The C library was updated to 1.80.0 in https://github.com/NixOS/nixpkgs/pull/505044 which includes the PHP 8.5 compatibility fix.