### PR TITLE
shairport-sync: 5.0.2 -> 5.0.4

### DIFF
--- a/pkgs/by-name/sh/shairport-sync/package.nix
+++ b/pkgs/by-name/sh/shairport-sync/package.nix
@@ -23,6 +23,7 @@
   libao,
   libsoundio,
   mosquitto,
+  nix-update-script,
   pipewire,
   soxr,
   alac,
@@ -43,7 +44,7 @@
   enableMqttClient ? true,
   enableDbus ? stdenv.hostPlatform.isLinux,
   enableSoxr ? true,
-  enableAlac ? true,
+  enableAlac ? !enableAirplay2, # airplay2 build uses ffmpeg for alac
   enableConvolution ? true,
   enableLibdaemon ? false,
   enableTinySVCmDNS ? true,
@@ -55,13 +56,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shairport-sync";
-  version = "5.0.2";
+  version = "5.0.4";
 
   src = fetchFromGitHub {
     repo = "shairport-sync";
     owner = "mikebrady";
     tag = finalAttrs.version;
-    hash = "sha256-tmnAVO9XpVNOwS8ze/23v4TV5Gq+goaVNnA9INf17wk=";
+    hash = "sha256-7/QB0lvpjZnGXo4vjKSYogjhi66S/QRRpypsqEMLGj0=";
   };
 
   nativeBuildInputs = [
@@ -140,6 +141,11 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optional enableAirplay2 "--with-airplay-2";
 
   strictDeps = true;
+
+  passthru.updateScript = nix-update-script {
+    # ignore -dev tagged releases
+    extraArgs = [ "--version-regex=^([0-9\\.]+)$" ];
+  };
 
   meta = {
     homepage = "https://github.com/mikebrady/shairport-sync";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

airplay2 builds no longer support apple alac. This was seen as a build failure in the ryantm PR linked to close.

```
configure: error: the Apple ALAC Decoder (deprecated) can not be used in AirPlay 2
```

Closes #513365

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
