### PR TITLE
tpm-trust: init at 0.4.1

### DIFF
--- a/pkgs/by-name/tp/tpm-trust/package.nix
+++ b/pkgs/by-name/tp/tpm-trust/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  buildGo125Module,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGo125Module (finalAttrs: {
+  pname = "tpm-trust";
+  version = "0.4.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "loicsikidi";
+    repo = "tpm-trust";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hhcIO+Od5Hhzm9evRlBHIicj+rivFn1H647mCKMq048=";
+  };
+
+  vendorHash = "sha256-MKUZ87Ketw29cyCa/7fVcQmlsJa8shwz4gHT3mhRaco=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.builtBy=nix"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd tpm-trust \
+      --bash <($out/bin/tpm-trust completion bash) \
+      --zsh <($out/bin/tpm-trust completion zsh) \
+      --fish <($out/bin/tpm-trust completion fish)
+  '';
+
+  meta = {
+    description = "Validate TPM authenticity by checking its Endorsement Key certificate against manufacturer root certificates";
+    homepage = "https://github.com/loicsikidi/tpm-trust";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ thillux ];
+    mainProgram = "tpm-trust";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
tpm-trust is a tool which can be used
to check verify if a TPM from the major
vendors present a valid endorsement certificate.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
