### PR TITLE
zig: add each phase to pre*Hook if they have been defined

### DIFF
--- a/pkgs/development/compilers/zig/setup-hook.sh
+++ b/pkgs/development/compilers/zig/setup-hook.sh
@@ -4,18 +4,20 @@
 readonly zigDefaultCpuFlag=@zig_default_cpu_flag@
 readonly zigDefaultOptimizeFlag=@zig_default_optimize_flag@
 
+function zigConfigureHook {
+  ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+  export ZIG_GLOBAL_CACHE_DIR
+}
+
 function zigConfigurePhase {
   runHook preConfigure
 
-  ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
-  export ZIG_GLOBAL_CACHE_DIR
+  zigConfigureHook
 
   runHook postConfigure
 }
 
-function zigBuildPhase {
-  runHook preBuild
-
+function zigBuildHook {
   local buildCores=1
 
   # Parallel building is enabled by default.
@@ -36,13 +38,17 @@ function zigBuildPhase {
 
   echoCmd 'zig build flags' "${flagsArray[@]}"
   TERM=dumb zig build "${flagsArray[@]}" --verbose
+}
+
+function zigBuildPhase {
+  runHook preBuild
+
+  zigBuildHook
 
   runHook postBuild
 }
 
-function zigCheckPhase {
-  runHook preCheck
-
+function zigCheckHook {
   local buildCores=1
 
   # Parallel building is enabled by default.
@@ -63,13 +69,17 @@ function zigCheckPhase {
 
   echoCmd 'zig check flags' "${flagsArray[@]}"
   TERM=dumb zig build test "${flagsArray[@]}" --verbose
+}
+
+function zigCheckPhase {
+  runHook preCheck
+
+  zigCheckHook
 
   runHook postCheck
 }
 
-function zigInstallPhase {
-  runHook preInstall
-
+function zigInstallHook {
   local buildCores=1
 
   # Parallel building is enabled by default.
@@ -98,21 +108,44 @@ function zigInstallPhase {
   echoCmd 'zig install flags' "${flagsArray[@]}"
   TERM=dumb zig build install "${flagsArray[@]}" --verbose
 
+}
+
+function zigInstallPhase {
+  runHook preInstall
+
+  zigInstallHook
+
   runHook postInstall
 }
 
-if [ -z "${dontUseZigConfigure-}" ] && [ -z "${configurePhase-}" ]; then
-  configurePhase=zigConfigurePhase
+if [ -z "${dontUseZigConfigure-}" ]; then
+    if [ -z "${configurePhase-}" ]; then
+        configurePhase=zigConfigurePhase
+    else
+        preConfigureHooks+=(zigConfigureHook)
+    fi
 fi
 
-if [ -z "${dontUseZigBuild-}" ] && [ -z "${buildPhase-}" ]; then
-  buildPhase=zigBuildPhase
+if [ -z "${dontUseZigBuild-}" ]; then
+    if [ -z "${buildPhase-}" ]; then
+        buildPhase=zigBuildPhase
+    else
+        preBuildHooks+=(zigBuildHook)
+    fi
 fi
 
-if [ -z "${dontUseZigCheck-}" ] && [ -z "${checkPhase-}" ]; then
-  checkPhase=zigCheckPhase
+if [ -z "${dontUseZigCheck-}" ]; then
+    if [ -z "${checkPhase-}" ]; then
+        checkPhase=zigCheckPhase
+    else
+        preCheckHooks+=(zigCheckHook)
+    fi
 fi
 
-if [ -z "${dontUseZigInstall-}" ] && [ -z "${installPhase-}" ]; then
-  installPhase=zigInstallPhase
+if [ -z "${dontUseZigInstall-}" ]; then
+    if [ -z "${installPhase-}" ]; then
+        installPhase=zigInstallPhase
+    else
+        preInstallHooks+=(zigInstallHook)
+    fi
 fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
In current zig hook, if a phase has been defined, it is omit, and each zig phase is defined with runHook, so it is really hard to reuse the predefined zig phase.

This change is inspired by #334476.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
