### PR TITLE
qemu: Add Canokey and Ceph support by default in the full QEMU package

### DIFF
--- a/nixos/tests/systemd-initrd-luks-fido2.nix
+++ b/nixos/tests/systemd-initrd-luks-fido2.nix
@@ -1,14 +1,11 @@
 {
   lib,
-  pkgs,
-  hostPkgs,
   ...
 }:
 {
   name = "systemd-initrd-luks-fido2";
 
-  qemu.package = hostPkgs.qemu_test.override { canokeySupport = true; };
-
+  # Non minimal QEMU contains Canokey by default now.
   nodes.machine =
     { pkgs, config, ... }:
     {

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -90,7 +90,7 @@
   liburing,
   fuseSupport ? stdenv.hostPlatform.isLinux && !minimal,
   fuse3,
-  canokeySupport ? false,
+  canokeySupport ? !minimal,
   canokey-qemu,
   u2fEmuSupport ? false,
   libu2f-emu,

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -67,7 +67,7 @@
   usbredir,
   xenSupport ? false,
   xen,
-  cephSupport ? false,
+  cephSupport ? !minimal,
   ceph,
   glusterfsSupport ? false,
   glusterfs,


### PR DESCRIPTION
## Things done

Canokey QEMU is now repaired and has been updated last month.
Turning it on because Canokey is really convenient.

Ceph is also enabled as it's expected and very hard to debug if you do not have it and you run e.g. Incus which is packaged in NixOS.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
