### PR TITLE
python3Packages.pamqp: 3.3.0 -> 4.0.0

### DIFF
--- a/pkgs/development/python-modules/aio-pika/default.nix
+++ b/pkgs/development/python-modules/aio-pika/default.nix
@@ -1,67 +1,39 @@
 {
   lib,
-  aiomisc-pytest,
   aiormq,
   buildPythonPackage,
-  docker,
   fetchFromGitHub,
-  pamqp,
-  poetry-core,
-  pytestCheckHook,
-  shortuuid,
-  testcontainers,
-  wrapt,
+  uv-build,
   yarl,
 }:
 
 buildPythonPackage rec {
   pname = "aio-pika";
-  version = "9.5.8";
+  version = "9.6.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mosquito";
     repo = "aio-pika";
     tag = version;
-    hash = "sha256-0jVxgU+r/d2n4YO5/YAZrZUWDCAlZldBshCGpcEV/sQ=";
+    hash = "sha256-N5MjFIolMRTTn4aV1NskBwonB/8FSuEZETumUrAa02Y=";
   };
 
-  build-system = [ poetry-core ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.26,<0.10.0" uv_build
+  '';
+
+  build-system = [ uv-build ];
 
   dependencies = [
     aiormq
     yarl
   ];
 
-  nativeCheckInputs = [
-    aiomisc-pytest
-    docker
-    pamqp
-    pytestCheckHook
-    shortuuid
-    testcontainers
-    wrapt
-  ];
-
-  disabledTests = [
-    # Tests attempt to connect to a RabbitMQ server
-    "test_connection_interleave"
-    "test_connection_happy_eyeballs_delay"
-    "test_robust_connection_interleave"
-    "test_robust_connection_happy_eyeballs_delay"
-  ];
-
-  disabledTestPaths = [
-    # Tests attempt to connect to a RabbitMQ server
-    "tests/test_amqp.py"
-    "tests/test_amqp_robust.py"
-    "tests/test_amqp_robust_proxy.py"
-    "tests/test_amqps.py"
-    "tests/test_master.py"
-    "tests/test_memory_leak.py"
-    "tests/test_rpc.py"
-    "tests/test_types.py"
-  ];
+  # Tests require running a RabbitMQ server.
+  # They rely on having AMQP_URL set or running Docker.
+  doCheck = false;
 
   pythonImportsCheck = [ "aio_pika" ];
 

--- a/pkgs/development/python-modules/aiormq/default.nix
+++ b/pkgs/development/python-modules/aiormq/default.nix
@@ -1,44 +1,41 @@
 {
   lib,
-  aiomisc-pytest,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
   pamqp,
+  uv-build,
   yarl,
-  poetry-core,
 }:
 
 buildPythonPackage rec {
   pname = "aiormq";
-  version = "6.9.2";
+  version = "9.6.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mosquito";
     repo = "aiormq";
     tag = version;
-    hash = "sha256-ApwL3okhpc3Dtq4bfWCCnoikyRx+4zPI9XtJ+qPKQdg=";
+    hash = "sha256-GFeOwjSQ1+nxP9hgNoELoEInTmhhO0JnNeoe2qfWNcg=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "uv_build>=0.10.4,<0.11.0" uv_build
+  '';
 
   pythonRelaxDeps = [ "pamqp" ];
 
-  build-system = [ poetry-core ];
+  build-system = [ uv-build ];
 
   dependencies = [
     pamqp
     yarl
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  checkInputs = [ aiomisc-pytest ];
-
-  # Tests attempt to connect to a RabbitMQ server
-  disabledTestPaths = [
-    "tests/test_channel.py"
-    "tests/test_connection.py"
-  ];
+  # Tests require running a RabbitMQ server.
+  # They rely on having AMQP_URL set or running Docker.
+  doCheck = false;
 
   pythonImportsCheck = [ "aiormq" ];
 

--- a/pkgs/development/python-modules/pamqp/default.nix
+++ b/pkgs/development/python-modules/pamqp/default.nix
@@ -2,12 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
+  hatchling,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
-  version = "3.3.0";
+  version = "4.0.0";
   pname = "pamqp";
 
   pyproject = true;
@@ -15,11 +15,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "gmr";
     repo = "pamqp";
-    rev = version;
-    hash = "sha256-0vjiPBLd8afnATjmV2sINsBd4j7L544u5DA3jLiLSsY=";
+    tag = version;
+    hash = "sha256-0rRVbzC5G+lH6Okvw8PtoPZKD8LlobAGYvDEIDw0aFo=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ hatchling ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/gmr/pamqp/blob/${src.rev}/docs/changelog.rst";
+    changelog = "https://github.com/gmr/pamqp/blob/${src.tag}/docs/changelog.rst";
     description = "RabbitMQ Focused AMQP low-level library";
     homepage = "https://github.com/gmr/pamqp";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
Diff: https://github.com/gmr/pamqp/compare/3.3.0...4.0.0

Changelog: https://github.com/gmr/pamqp/blob/4.0.0/docs/changelog.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
