### PR TITLE
nixos/vnstat: add RFC-42 settings and NixOS test

### DIFF
--- a/nixos/modules/services/monitoring/vnstat.nix
+++ b/nixos/modules/services/monitoring/vnstat.nix
@@ -6,16 +6,31 @@
 }:
 let
   cfg = config.services.vnstat;
+  settingsFormat = pkgs.formats.keyValue { };
 in
 {
   options.services.vnstat = {
     enable = lib.mkEnableOption "update of network usage statistics via vnstatd";
     package = lib.mkPackageOption pkgs "vnstat" { };
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = settingsFormat.type; };
+      default = { };
+      description = ''
+        Configuration for vnstat. Refer to
+        [https://humdi.net/vnstat/man/vnstat.conf.html](https://humdi.net/vnstat/man/vnstat.conf.html)
+        or {manpage}`vnstat.conf(5)` for more information.
+      '';
+      example = {
+        AlwaysAddNewInterfaces = 1;
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ cfg.package ];
+
+    environment.etc."vnstat.conf".source = settingsFormat.generate "vnstat.conf" cfg.settings;
 
     users = {
       groups.vnstatd = { };

--- a/nixos/modules/services/monitoring/vnstat.nix
+++ b/nixos/modules/services/monitoring/vnstat.nix
@@ -74,4 +74,8 @@ in
       };
     };
   };
+
+  meta = {
+    maintainers = with lib.maintainers; [ hmenke ];
+  };
 }

--- a/nixos/modules/services/monitoring/vnstat.nix
+++ b/nixos/modules/services/monitoring/vnstat.nix
@@ -6,16 +6,31 @@
 }:
 let
   cfg = config.services.vnstat;
+  settingsFormat = pkgs.formats.keyValue { };
 in
 {
   options.services.vnstat = {
     enable = lib.mkEnableOption "update of network usage statistics via vnstatd";
     package = lib.mkPackageOption pkgs "vnstat" { };
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = settingsFormat.type; };
+      default = { };
+      description = ''
+        Configuration for vnstat. Refer to
+        [https://humdi.net/vnstat/man/vnstat.conf.html]
+        or {manpage}`vnstat.conf(5)` for more information.
+      '';
+      example = {
+        AlwaysAddNewInterfaces = 1;
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ cfg.package ];
+
+    environment.etc."vnstat.conf".source = settingsFormat.generate "vnstat.conf" cfg.settings;
 
     users = {
       groups.vnstatd = { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1755,6 +1755,7 @@ in
   vikunja = runTest ./vikunja.nix;
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };
+  vnstat = runTest ./vnstat.nix;
   vscode-remote-ssh = handleTestOn [ "x86_64-linux" ] ./vscode-remote-ssh.nix { };
   vscodium = import ./vscodium.nix { inherit runTest; };
   vsftpd = runTest ./vsftpd.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1844,6 +1844,7 @@ in
   };
   virtualbox = handleTestOn [ "x86_64-linux" ] ./virtualbox.nix { };
   vm-variant = handleTest ./vm-variant.nix { };
+  vnstat = runTest ./vnstat.nix;
   vscode-remote-ssh = handleTestOn [ "x86_64-linux" ] ./vscode-remote-ssh.nix { };
   vscodium = import ./vscodium.nix { inherit runTest; };
   vsftpd = runTest ./vsftpd.nix;

--- a/nixos/tests/vnstat.nix
+++ b/nixos/tests/vnstat.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+{
+  name = "vnstat";
+  meta.maintainers = with lib.maintainers; [ hmenke ];
+
+  nodes.machine = {
+    services.vnstat = {
+      enable = true;
+      settings = {
+        AlwaysAddNewInterfaces = 1;
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("vnstat.service")
+
+    machine.succeed("vnstat --iflist")
+    machine.succeed("ip link add dummy0 type dummy")
+    machine.succeed("ip link set dummy0 up")
+    machine.wait_until_succeeds("vnstat --iflist | grep -F dummy0", timeout=10)
+  '';
+}

--- a/nixos/tests/vnstat.nix
+++ b/nixos/tests/vnstat.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+{
+  name = "vnstat";
+  meta.maintainers = with lib.maintainers; [ hmenke ];
+
+  containers.machine = {
+    services.vnstat = {
+      enable = true;
+      settings = {
+        AlwaysAddNewInterfaces = 1;
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("vnstat.service")
+
+    machine.succeed("vnstat --iflist")
+    machine.fail("vnstat -i dummy0")
+    machine.succeed("ip link add dummy0 type dummy")
+    machine.succeed("ip link set dummy0 up")
+    machine.wait_until_succeeds("vnstat -i dummy0", timeout=10)
+  '';
+}

--- a/pkgs/by-name/vn/vnstat/package.nix
+++ b/pkgs/by-name/vn/vnstat/package.nix
@@ -7,6 +7,7 @@
   ncurses,
   sqlite,
   check,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [ check ];
 
   doCheck = true;
+
+  passthru.tests = { inherit (nixosTests) vnstat; };
 
   meta = {
     description = "Console-based network statistics utility for Linux";

--- a/pkgs/by-name/vn/vnstat/package.nix
+++ b/pkgs/by-name/vn/vnstat/package.nix
@@ -7,6 +7,7 @@
   ncurses,
   sqlite,
   check,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
   checkInputs = [ check ];
 
   doCheck = true;
+
+  passthru.tests = { inherit (nixosTests) vnstat; };
 
   meta = {
     description = "Console-based network statistics utility for Linux";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
