### PR TITLE
[Backport staging-25.11] libraw: 0.21.4 -> 0.22.1

### DIFF
--- a/pkgs/by-name/li/libraw/package.nix
+++ b/pkgs/by-name/li/libraw/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libraw";
-  version = "0.21.4";
+  version = "0.21.5b";
 
   src = fetchFromGitHub {
     owner = "LibRaw";
     repo = "LibRaw";
     tag = finalAttrs.version;
-    hash = "sha256-JAGIM7A9RbK22F8KczRcb+29t4fDDXzoCA3a4s/z6Q8=";
+    hash = "sha256-CE7XB61bnjRhy0Ww2Q3pvvSJMobHHta5jn4F/i/oOEE=";
   };
 
   outputs = [

--- a/pkgs/by-name/li/libraw/package.nix
+++ b/pkgs/by-name/li/libraw/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libraw";
-  version = "0.21.5b";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "LibRaw";
     repo = "LibRaw";
     tag = finalAttrs.version;
-    hash = "sha256-CE7XB61bnjRhy0Ww2Q3pvvSJMobHHta5jn4F/i/oOEE=";
+    hash = "sha256-B2+LcdC6FqKryiu8t0wBifrESTAyz/+wDQhcGj7myhE=";
   };
 
   outputs = [

--- a/pkgs/by-name/li/libraw/package.nix
+++ b/pkgs/by-name/li/libraw/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libraw";
-  version = "0.22.0";
+  version = "0.22.1";
 
   src = fetchFromGitHub {
     owner = "LibRaw";
     repo = "LibRaw";
     tag = finalAttrs.version;
-    hash = "sha256-B2+LcdC6FqKryiu8t0wBifrESTAyz/+wDQhcGj7myhE=";
+    hash = "sha256-1Q2u9v1yOzXchUGvZvbLKk506xATjMb421H2sBZURZs=";
   };
 
   outputs = [


### PR DESCRIPTION
See:

 - https://github.com/NixOS/nixpkgs/pull/473842
 - https://github.com/NixOS/nixpkgs/pull/483482
 - https://github.com/NixOS/nixpkgs/pull/509738

Namely, the last PR had the security label, and an automatic backport was [tried to be made](https://github.com/NixOS/nixpkgs/pull/509738#issuecomment-4301611609).

With the tip of this branch (targeting 25.11 directly, not staging), this was checked using

```
 $ nix-build --attr libraw.tests
```

This addresses:

 - [0.21.5b](https://github.com/LibRaw/LibRaw/blob/e082a6e54497959d758c9fa94c12b0c3bad3c3aa/Changelog.txt#L3-L15)
     - (The CVEs listed are for 0.21.4, not 0.21.5)
 - [0.22.0](https://github.com/LibRaw/LibRaw/blob/b860248a89d9082b8e0a1e202e516f46af9adb29/Changelog.txt#L36-L318)
    - (No listed security fixes)
 - [0.22.1](https://github.com/LibRaw/LibRaw/blob/b860248a89d9082b8e0a1e202e516f46af9adb29/Changelog.txt#L1-L34)
     - CVE-2026-20884
     - CVE-2026-20889
     - CVE-2026-20911
     - CVE-2026-21413
     - CVE-2026-24450
     - CVE-2026-24660

[0.22.1 is also stated to handle](https://seclists.org/oss-sec/2026/q2/102) CVE-2026-5342 and CVE-2026-5318 (duplicate/independent reports).

cc @dotlambda who merged the last upgrade PR, and @PhiliPdB who authored the last upgrade PR.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
