### PR TITLE
leshade: init at 2.4.7

### DIFF
--- a/pkgs/by-name/le/leshade/package.nix
+++ b/pkgs/by-name/le/leshade/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  qt6,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "leshade";
+  version = "2.4.7";
+  __structuredAttrs = true;
+
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Ishidawg";
+    repo = "LeShade";
+    tag = finalAttrs.version;
+    hash = "sha256-whv+pTi7b1yrRP4TIrbj7JKDF3jGmDFviQwm70gu6EQ=";
+  };
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwayland
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pyside6
+    certifi
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PYTHONPATH"
+    ":"
+    (placeholder "out" + "/share/leshade")
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  postInstall = ''
+    rm $out/bin/leshade
+    cp $out/share/leshade/main.py $out/bin/leshade
+    chmod +x $out/bin/leshade
+
+    substituteInPlace $out/share/applications/leshade.desktop \
+      --replace-fail "Icon=io.github.ishidawg.LeShade" "Icon=leshade"
+  '';
+
+  meta = {
+    description = "ReShade manager for Linux";
+    mainProgram = "leshade";
+    homepage = "https://github.com/Ishidawg/LeShade";
+    changelog = "https://github.com/Ishidawg/LeShade/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ amadejkastelic ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This PR adds LeShade, a ReShade manager for Linux. https://github.com/Ishidawg/LeShade

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
