### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 2 to fetcherVersion = 3 (part 1)

### DIFF
--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
       prePnpmInstall
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 2;
-    hash = "sha256-DFoIq5+cKqnmWLJ6CHhfdQEAGjvpu72qb1CSWaExODI=";
+    fetcherVersion = 3;
+    hash = "sha256-1kdXt0Wc/ON//hwBYozRSMAyKQqEfSMfOI7XJyd9MBc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bu/bumpp/package.nix
+++ b/pkgs/by-name/bu/bumpp/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-rI0DhnncVWd4Wp5pvTnL8IerXbFDwJzkhC4uIe6WJto=";
+    fetcherVersion = 3;
+    hash = "sha256-nIj4S5BWTaw3RVNIxbla8Q31wvK67Of6psx5wX9ID+E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cd/cdxgen/package.nix
+++ b/pkgs/by-name/cd/cdxgen/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 2;
-    hash = "sha256-o5pNgn+ZqaEfsWO97jXkRyPH+0pffR6TBZcF6nApWVg=";
+    fetcherVersion = 3;
+    hash = "sha256-o7u/ZZS/5PgOtWd07zO4a01mUWZowUTL+JDJ2442mGc=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ch/changelogen/package.nix
+++ b/pkgs/by-name/ch/changelogen/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-UKSIfn2iR8Ydk9ViGCgWtspZr1FjTeW49UMwTcL57UA=";
+    fetcherVersion = 3;
+    hash = "sha256-S+GxeljcPj/MzBkleVNgaRa8D4kmHrKwwVqakmB5sAw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/co/coc-cmake/package.nix
+++ b/pkgs/by-name/co/coc-cmake/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_8;
-    fetcherVersion = 2;
-    hash = "sha256-wQ9dcqY7BVXc7wpsHlYNpc7utL1+MkdTCu77Wh8+QWc=";
+    fetcherVersion = 3;
+    hash = "sha256-h/ND/665MpcPaDIR1Bb5iPrHmoNysr9vuFk1I0fFP34=";
   };
 
   pnpmWorkspaces = [ "coc-cmake" ];

--- a/pkgs/by-name/co/conventional-changelog-cli/package.nix
+++ b/pkgs/by-name/co/conventional-changelog-cli/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-vOZnVCz5lFdVD2qmlHdTRxzuEjpR3W/rXfzvjvdOh9E=";
+    fetcherVersion = 3;
+    hash = "sha256-O91ypnycBwkfLSruezx9E5CrytguBdtmvgVhKFjUzvM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cs/cspell/package.nix
+++ b/pkgs/by-name/cs/cspell/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 2;
-    hash = "sha256-EKnczZ/7O2ZMaSlIFfLk9WXyf/ubynhmecs+IyIoTHw=";
+    fetcherVersion = 3;
+    hash = "sha256-eQ9KiRSwWmfhCinYVP4ulQdAG6SOd9yyyOUWSwc5TV8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/de/deadlock-mod-manager/package.nix
+++ b/pkgs/by-name/de/deadlock-mod-manager/package.nix
@@ -77,9 +77,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 2;
+    fetcherVersion = 3;
     sourceRoot = "source";
-    hash = "sha256-fFcKyqAo/HpGBaEJMk6Lq0FafNXrGu9z9nHnav5d6Hg=";
+    hash = "sha256-6lMTvlkIeM9kkbFhHzS9jJsHk2bVZWZs6GPgn+X3Rss=";
   };
 
   patches = [

--- a/pkgs/by-name/de/deltachat-desktop/package.nix
+++ b/pkgs/by-name/de/deltachat-desktop/package.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 2;
-    hash = "sha256-+Mxf/D66EoE/axKg5+TSaLFPSpUEDZNtSNH4zklxV5s=";
+    fetcherVersion = 3;
+    hash = "sha256-UZ6/OTUtIiOA1D5PanY4aS+VCBNj/AIbIGYe1eibGMQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/e-/e-search/package.nix
+++ b/pkgs/by-name/e-/e-search/package.nix
@@ -71,8 +71,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     nativeBuildInputs = [ gitMinimal ];
     pnpm = pnpm';
-    fetcherVersion = 2;
-    hash = "sha256-q0+6vkDZdcDXwsTxby2RuQUYTgEnxGx1CeXROSrG9lU=";
+    fetcherVersion = 3;
+    hash = "sha256-gP/0WeVp+Y8QgPmAmbFt+cInX6+4oxPIYlwFpSh2hPQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ga/garage-webui/package.nix
+++ b/pkgs/by-name/ga/garage-webui/package.nix
@@ -33,8 +33,8 @@ buildGoModule (finalAttrs: {
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs') pname version src;
       pnpm = pnpm_9;
-      fetcherVersion = 2;
-      hash = "sha256-8eQhR/fuDFNL8W529Ev7piCaseVaFahgZJQk3AJA3ng=";
+      fetcherVersion = 3;
+      hash = "sha256-z/Y9q/SE2c/KYzIOAfATlprjr6NjmmUHQB+ZbO39OK4=";
     };
 
     buildPhase = ''


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 2` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 2` produces an unpacked pnpm store. Version 3 produces a single zstd-compressed tarball, which is more reproducible and avoids touching individual store files at fixup time.

Split across four PRs to keep each one reviewable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md