### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 2 to fetcherVersion = 3 (part 2)

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/eamodio.gitlens/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/eamodio.gitlens/default.nix
@@ -26,8 +26,8 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      fetcherVersion = 2;
-      hash = "sha256-mr5GwwfuNoLhKM5bAhNAO3j0ow4FcyZhvQlVnAENoyg=";
+      fetcherVersion = 3;
+      hash = "sha256-Yuxuqr1BiviSw+dGNHLs2jAy8ADlBvRks6Kmy7FmCMw=";
     };
 
     postPatch = ''

--- a/pkgs/by-name/gi/gitbutler/package.nix
+++ b/pkgs/by-name/gi/gitbutler/package.nix
@@ -58,8 +58,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-0WLgtidG8hqTkXY3heu+m3VoqQD/kGMlTmLb0qAS8sQ=";
+    fetcherVersion = 3;
+    hash = "sha256-eRiFA5lXpPHQwlyFmKMx1zmHH2zLCHB+3s708g6srg4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10_29_2;
-    fetcherVersion = 2;
-    hash = "sha256-uK3CNyPewUVAmqBJq1WMCrNeMP5I18BEBkZIBP0qPsI=";
+    fetcherVersion = 3;
+    hash = "sha256-0iTvrIe5PVj99ePWt8rn+laikdJ5TaNQ8GZGHyUTTQI=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;

--- a/pkgs/by-name/im/immich-kiosk/package.nix
+++ b/pkgs/by-name/im/immich-kiosk/package.nix
@@ -33,8 +33,8 @@ buildGoModule rec {
       ;
     pnpm = pnpm_9;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-ELIbM+tWOGntv8XmNvRZ/Q2iSRq0g9Kv5LnkwLPisPM=";
-    fetcherVersion = 2;
+    hash = "sha256-8iKug4zsX3u0vS68osKRW6iOP+A3OdjI3yxNPIJaQqM=";
+    fetcherVersion = 3;
   };
 
   # Frontend is in a subdirectory

--- a/pkgs/by-name/mc/mcporter/package.nix
+++ b/pkgs/by-name/mc/mcporter/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-OJhlpKwRCE7IqstwIzj1dBJMbMyPVA/w3RVnYfjz764=";
+    fetcherVersion = 3;
+    hash = "sha256-aYBd1+QkME+q2LkZRnlxHEbIQz38k+N64YSS+NOu0QU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/meshtastic-web/package.nix
+++ b/pkgs/by-name/me/meshtastic-web/package.nix
@@ -36,8 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    fetcherVersion = 2;
-    hash = "sha256-p8AdAYqaHoKaWirNy9uPLs/kRDVNDcXBJQ1y29MVAA0=";
+    fetcherVersion = 3;
+    hash = "sha256-yUdPrZAnCsxIiF++SxTm1VuVAEKIzTsp2qd/WcCPOcQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mg/mgrep/package.nix
+++ b/pkgs/by-name/mg/mgrep/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-qNsYMp25OAbbv+K7qvNRB+7QzzrgtrKQkUoe9IMIR5c=";
+    fetcherVersion = 3;
+    hash = "sha256-T1mbRDBLU4SjZSgqyKgusZe5UV9hI+/bAmBYoAWcWtQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -59,8 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 2;
-    hash = "sha256-GVzU5YQe7GHn2ddpaGPyLLmhOv5Fy33RL+gBLl3Oyis=";
+    fetcherVersion = 3;
+    hash = "sha256-iMS+sFDnGShOQfFQjGtj4+7McqMQvfE8KK1MV/jPC2s=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ni/ni/package.nix
+++ b/pkgs/by-name/ni/ni/package.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-BoQO6oTctvRAzHUw6dsOSV5w7uLzrnD1+KmP9irG0Z4=";
+    fetcherVersion = 3;
+    hash = "sha256-I/jf6nlsKQFrYLO15f+CWdPPdEpVDDMBQodLsbG4sqw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/nr/nrm/package.nix
+++ b/pkgs/by-name/nr/nrm/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-PENYS5xO2LwT3+TGl/wU2r0ALEj/JQfbkpf/0MJs0uw=";
+    fetcherVersion = 3;
+    hash = "sha256-DvhUXkh9Ijuik9uWzPOtM1idSNSaJxDiRHWpUMepf3U=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ox/oxfmt/package.nix
+++ b/pkgs/by-name/ox/oxfmt/package.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 2;
-    hash = "sha256-vcTdeNh5+hzqzB9PXpRBeY+aG9LjbtaEfRkDWxIsIIc=";
+    fetcherVersion = 3;
+    hash = "sha256-fomJmm0GXIClng63wql3hCo1Pf4CbVUiEtbvAv9DPIo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 2` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 2` produces an unpacked pnpm store. Version 3 produces a single zstd-compressed tarball, which is more reproducible and avoids touching individual store files at fixup time.

Split across four PRs to keep each one reviewable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md