### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 2 to fetcherVersion = 3 (part 3)

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rooveterinaryinc.roo-cline/default.nix
@@ -25,8 +25,8 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      fetcherVersion = 2;
-      hash = "sha256-kQjxcqHEClQtG6x2QM1/zixN6rvcEivX8vicNydDdOw=";
+      fetcherVersion = 3;
+      hash = "sha256-t2sPuhn8xdk6hGfmViPGG+5TAhtBBOMYNoOb6DlPzws=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -80,8 +80,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit pnpm;
       inherit (finalAttrs) pname version src;
-      fetcherVersion = 2;
-      hash = "sha256-pG7olcBq5P52CvZYLqUjb+RwxjbQbSotlS50pvgm7WQ=";
+      fetcherVersion = 3;
+      hash = "sha256-HO+IDNB3NXWgvV0cvZ5zx46JuXv6Tgroz+YfVump5MA=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10_29_2;
-    fetcherVersion = 2;
-    hash = "sha256-xZQ8rnLGD0ZxxUUPLHmNJ6mA+lnUHCTBvtJTiIPxaZU=";
+    fetcherVersion = 3;
+    hash = "sha256-BHxieFMMUFbHJHWu8spz0z803kx+kwJ99oYkDpm6a58=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -74,8 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 2;
-    hash = "sha256-tCp5qLZVo93H8VIToU3mkmwNsVXOAd1IEsL6RlazPXo=";
+    fetcherVersion = 3;
+    hash = "sha256-k/2ya08JaTEt+dr5xfw1ordwENGm17YFyfKGFej5fdc=";
   };
 
   patches = [

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 2;
-    hash = "sha256-gDffEtUWqSWbwr4S0HZIPTvSrXDvl/q2Y5QuA+U6Ndk=";
+    fetcherVersion = 3;
+    hash = "sha256-ldxhP+I455PEfBrkJIlHudNvAsI4EN34ZkQXMBciOo4=";
   };
 
   env.COREPACK_ENABLE_STRICT = 0;

--- a/pkgs/by-name/se/serve/package.nix
+++ b/pkgs/by-name/se/serve/package.nix
@@ -23,8 +23,8 @@ buildNpmPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 2;
-    hash = "sha256-IJMu0XHwEn2TZP/He79FFGl/PeXOCTD51lIgmImpyKo=";
+    fetcherVersion = 3;
+    hash = "sha256-N5oasGilHECndJZYdRHZFvAa4aYwmPtOTBZtcty4g/k=";
   };
 
   nativeBuildInputs = [ pnpm_9 ];

--- a/pkgs/by-name/sh/shadcn/package.nix
+++ b/pkgs/by-name/sh/shadcn/package.nix
@@ -30,8 +30,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 2;
-    hash = "sha256-clTcaTar7m2jEX9cMPtSPeBtt17LaMzlwlLXhPKc+kk=";
+    fetcherVersion = 3;
+    hash = "sha256-OESxer0YIbWql3NgdhvUhgMW4wc0nIyUYRESjmM1A1s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sh/shopify-cli/package.nix
+++ b/pkgs/by-name/sh/shopify-cli/package.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-5rghSHGigsw193OJLiVegjNs1qDj+sCq1KJ1J8oPnrA=";
+    fetcherVersion = 3;
+    hash = "sha256-gwEVlvr8hxgyCsGjxjz1UkbDZYYq1iukKTPJ7JHdo2U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       ;
     inherit pnpm;
-    fetcherVersion = 2;
-    hash = "sha256-PTfZopse+9RS7qh0miLu3duYlWDfifZS254tZKqgxKk=";
+    fetcherVersion = 3;
+    hash = "sha256-NaKI2369TlF8DDMy6Q3RUqb2B2/T756Zd6gu4ATz/yc=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/by-name/sv/svelte-check/package.nix
+++ b/pkgs/by-name/sv/svelte-check/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    fetcherVersion = 2;
-    hash = "sha256-3bsY31sp5hjTYhRiZniAMVb3kZ1EqOlbyOvljU8jHlY=";
+    fetcherVersion = 3;
+    hash = "sha256-43AIkVzpcq/Y+QO2k7pkr6CN340idXJEpie0gVdxra8=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 2` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 2` produces an unpacked pnpm store. Version 3 produces a single zstd-compressed tarball, which is more reproducible and avoids touching individual store files at fixup time.

Split across four PRs to keep each one reviewable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md