### PR TITLE
intel-llvm: use --strip-unneeded to reduce NAR size

### DIFF
--- a/pkgs/by-name/in/intel-llvm/unwrapped.nix
+++ b/pkgs/by-name/in/intel-llvm/unwrapped.nix
@@ -135,6 +135,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeBuildType = "Release";
+  # This is to shave a little bit of size off of the final NAR.
+  # Saves about 0.5GiB
+  # Note that the sum of all outputs needs to stay under 4GiB to be cached by Hydra.
+  # To check:
+  #  nix path-info --json --json-format 2 .#intel-llvm.unwrapped{,.lib,.dev,.python} | jq '[.. | .narSize? // empty] | add'
+  stripDebugFlags = [ "--strip-unneeded" ];
 
   patches = [
     # Fix paths so the output can be split properly


### PR DESCRIPTION
`intel-llvm` is ever-so-slightly over the [Hydra size limit of 4GiB](https://github.com/NixOS/infra/blob/8a7701afce13597582b9743a62f22caeee88c871/build/hydra.nix#L116) ([hydra build job](https://hydra.nixos.org/build/326816833#tabs-summary)), at around 4.14GiB.

This PR adds `--strip-unneeded` to shave off a little space, and puts its around at 3.6GiB.
The long term fix here are standalone builds, but those are blocked on upstream at the moment. This is just to get it into cache.

I verified packages built with it still work (e.g. whisper-cpp).

To check size: `nix path-info --json --json-format 2 github:NixOS/nixpkgs/pull/514079/head#intel-llvm.unwrapped{,.lib,.dev,.python} | jq '[.. | .narSize? // empty] | add'`, = 3893915560 ~= 3.63GiB.

I originally thought the limit was per-output, but it's per-derivation, summing all outputs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
