### PR TITLE
writeTextFile: use `installPhase` and `installCheckPhase`, customisable via `derivationArgs`

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -333,6 +333,9 @@ Write a text file to the Nix store.
 
 : Commands to run after generating the file.
 
+  `checkPhase` is deprecated.
+  Use `installCheckPhase` or `preInstallCheck`/`postInstallCheck` in `derivationArgs` instead.
+
   Default: `""`
 
 `meta` (Attribute set, _optional_)
@@ -366,6 +369,31 @@ Write a text file to the Nix store.
 : Extra arguments to pass to the underlying call to `stdenv.mkDerivation`.
 
   Default: `{}`
+
+  Additionally, the following attributes can be passed to `derivatoinArgs`:
+
+  `preInstall`, `postInstall` (String, _optional_)
+
+  : Commands to run before/after file generation.
+
+    `writeTextFile` places its file generation logic inside `installPhase`, surrounded by `runHook preInstall` and `runHook postInstall`.
+
+  : `installCheckPhase`
+
+    This is typically reserved for build helpers derived from `writeTextFile`.
+    Users can place additional checks inside `postInstallCheck` or `preInstallCheck`.
+
+    Default:
+    ```nix
+    ''
+      runHook preInstallCheck
+      runHook postInstallCheck
+    ''
+    ```
+
+  : `preInstallCheck`, `postInstallCheck`
+
+    Additional check commands to run at the beginning/end of `installCheckPhase`.
 
 The resulting store path will include some variation of the name, and it will be a file unless `destination` is used, in which case it will be a directory.
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -139,7 +139,9 @@ rec {
           destination;
         passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
 
-        buildCommand = ''
+        installPhase = ''
+          runHook preInstall
+
           target=$out$destination
           mkdir -p "$(dirname "$target")"
 
@@ -153,6 +155,11 @@ rec {
             chmod +x "$target"
           fi
 
+          runHook postInstall
+        '';
+
+        buildCommand = ''
+          runPhase installPhase
           eval "$checkPhase"
         '';
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -126,7 +126,9 @@ rec {
           n: alt:
           let
             handle =
-              if lib.oldestSupportedReleaseIsAtLeast 2611 then
+              if finalAttrs.passthru.__getDeprecatedCheckPhase-forceThrow then
+                throw
+              else if lib.oldestSupportedReleaseIsAtLeast 2611 then
                 throw
               else if lib.oldestSupportedReleaseIsAtLeast 2605 then
                 lib.warn
@@ -136,7 +138,7 @@ rec {
           in
           lib.optionalString (finalAttrs ? ${n} && finalAttrs.${n} != "" && finalAttrs.${n} != null) (
             handle ''
-              writeTextFile: ${name}: Deprecated ${n} found at ${pos.file}:${toString pos.line}
+              ${finalAttrs.passthru.__getDeprecatedCheckPhase-constructorName}: ${name}: Deprecated ${n} found at ${pos.file}:${toString pos.line}
                 Use ${alt} instead.
             '' finalAttrs.${n}
           );
@@ -206,7 +208,17 @@ rec {
           }
           // meta
           // derivationArgs.meta or { };
-        passthru = passthru // derivationArgs.passthru or { };
+        passthru = {
+          # Configure the checkPhase copatibility layer.
+          # Enable us to test the error-throwing behaviour (and the corresponding mitigations) before turning it on globally.
+          # TODO(@ShamrockLee): Remove after throwing is turned on globally.
+          __getDeprecatedCheckPhase-forceThrow = false;
+          # Facilitate derived build helpers' access to the deprecated checkPhase
+          # TODO(@ShamrockLee) Remove after `checkPhase` is fully deprecated and no longer handled.
+          __getDeprecatedCheckPhase = getDeprecatedPhase "checkPhase" "installCheckPhase";
+        }
+        // passthru
+        // derivationArgs.passthru or { };
       }
       // removeAttrs derivationArgs [
         "passAsFile"

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -160,7 +160,7 @@ rec {
 
         buildCommand = ''
           runPhase installPhase
-          eval "$checkPhase"
+          runPhase checkPhase
         '';
 
         meta =

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -111,14 +111,36 @@ rec {
         text,
         executable ? false,
         destination ? "",
-        checkPhase ? "",
         meta ? { },
         passthru ? { },
         allowSubstitutes ? false,
         preferLocalBuild ? true,
         derivationArgs ? { },
         pos ? builtins.unsafeGetAttrPos "name" args,
+
+        # Deprecated arguments
+        checkPhase ? "",
       }@args:
+      let
+        getDeprecatedPhase =
+          n: alt:
+          let
+            handle =
+              if lib.oldestSupportedReleaseIsAtLeast 2611 then
+                throw
+              else if lib.oldestSupportedReleaseIsAtLeast 2605 then
+                lib.warn
+              else
+                message: val: val;
+            pos = lib.unsafeGetAttrPos n finalAttrs;
+          in
+          lib.optionalString (finalAttrs ? ${n} && finalAttrs.${n} != "" && finalAttrs.${n} != null) (
+            handle ''
+              writeTextFile: ${name}: Deprecated ${n} found at ${pos.file}:${toString pos.line}
+                Use ${alt} instead.
+            '' finalAttrs.${n}
+          );
+      in
       {
         inherit
           pos
@@ -158,9 +180,20 @@ rec {
           runHook postInstall
         '';
 
+        doInstallCheck = derivationArgs.doInstallCheck or true;
+        installCheckPhase = ''
+          runHook preInstallCheck
+          ${lib.replaceStrings [ "runHook preCheck" "runHook postCheck" ] [ "" "" ] (
+            getDeprecatedPhase "checkPhase" "installCheckPhase"
+          )}
+          runHook postInstallCheck
+        '';
+        preInstallCheck = getDeprecatedPhase "preCheck" "preInstallCheck";
+        postInstallCheck = getDeprecatedPhase "postCheck" "postInstallCheck";
+
         buildCommand = ''
           runPhase installPhase
-          runPhase checkPhase
+          runPhase installCheckPhase
         '';
 
         meta =

--- a/pkgs/build-support/trivial-builders/test-overriding.nix
+++ b/pkgs/build-support/trivial-builders/test-overriding.nix
@@ -34,8 +34,19 @@ let
   binCase = case: writeShellScriptBin "test-trivial-overriding-bin-${case}" extglobScript;
 
   # building this derivation would fail without overriding
-  textFileCase = writeTextFile {
-    name = "test-trivial-overriding-text-file";
+  textFileCase-postInstallCheck = writeTextFile {
+    name = "test-trivial-overriding-text-file-postInstallCheck";
+    derivationArgs.postInstallCheck = "false";
+    text = ''
+      #!${runtimeShell}
+      echo success
+    '';
+    executable = true;
+  };
+
+  # building this derivation would fail without overriding
+  textFileCase-deprecated-checkPhase = writeTextFile {
+    name = "test-trivial-overriding-text-file-deprecated-checkPhase";
     checkPhase = "false";
     text = ''
       #!${runtimeShell}
@@ -92,13 +103,16 @@ let
     binSucc = mkCase binCase "succ" true;
     binFail = mkCase binCase "fail" true;
     # Check that we can also override plain writeTextFile
-    textFileSuccess = textFileCase.overrideAttrs (_: {
+    textFilePostInstallCheckSucc = textFileCase-postInstallCheck.overrideAttrs (_: {
+      postInstallCheck = "true";
+    });
+    textFileDeprecatedCheckPhaseSucc = textFileCase-deprecated-checkPhase.overrideAttrs (_: {
       checkPhase = "true";
     });
   };
 
   # `runTest` forces nix to build the script of our test case and
-  # run its `checkPhase` which is our main interest. Additionally
+  # run its `installCheckPhase` which is our main interest. Additionally
   # it executes the script and thus makes sure that extglob also
   # works at run time.
   runTest =

--- a/pkgs/build-support/trivial-builders/test/write-text-file.nix
+++ b/pkgs/build-support/trivial-builders/test/write-text-file.nix
@@ -46,7 +46,7 @@ lib.recurseIntoAttrs {
     name = "weird-names";
     destination = "/etc/${veryWeirdName}";
     text = "passed!";
-    checkPhase = ''
+    derivationArgs.postInstallCheck = ''
       # intentionally hardcode everything here, to make sure
       # Nix does not mess with file paths
 

--- a/pkgs/build-support/trivial-builders/test/write-text-file.nix
+++ b/pkgs/build-support/trivial-builders/test/write-text-file.nix
@@ -11,6 +11,8 @@
 */
 {
   lib,
+  stdenvNoCC,
+  testers,
   runCommand,
   runtimeShell,
   writeTextFile,
@@ -19,6 +21,40 @@ lib.makeExtensible (
   final:
   let
     veryWeirdName = ''here's a name with some "bad" characters, like spaces and quotes'';
+
+    test-checkPhase-expectedBuildLogEntries = [ "writeTextFile is executing checkPhase." ];
+
+    test-checkPhase-sample = writeTextFile {
+      name = "test-writeTextFile-deprecated-checkPhase-compatibility-sample.txt";
+      text = ''
+        This test expects `writeTextFile` to handle the deprecated `checkPhase` argument compatibly.
+      '';
+      checkPhase = ''
+        echo "${lib.concatLines test-checkPhase-expectedBuildLogEntries}"
+        false
+      '';
+    };
+
+    test-checkPhase-samples = {
+      checkPhase = test-checkPhase-sample;
+    }
+    // lib.genAttrs [ "preCheck" "postCheck" ] (
+      phaseName:
+      test-checkPhase-sample.overrideAttrs (previousAttrs: {
+        name = lib.replaceString "checkPhase" phaseName previousAttrs.name;
+        checkPhase = "";
+        ${phaseName} = previousAttrs.checkPhase;
+      })
+    );
+
+    testNoRepeatScriptText = ''
+      REPEATER="repeat-''${REPEATER-}";
+      echo "\$REPEATER is now $REPEATER"
+      if [[ "$REPEATER" != "repeat-" ]]; then
+        echo "ERROR: ''${name-testNoRepeat}: REPEATER is appended more than once."
+        exit 1
+      fi
+    '';
   in
   lib.recurseIntoAttrs {
 
@@ -76,4 +112,68 @@ lib.makeExtensible (
       '';
     };
   }
+
+  // lib.mergeAttrsList (
+    map
+      (
+        phaseName:
+        {
+          "deprecated-${phaseName}-compatibility" = testers.testBuildFailure' {
+            name = "test-writeTextFile-deprecated-${phaseName}-compatibility";
+            drv = test-checkPhase-samples.${phaseName};
+            expectedBuilderLogEntries = test-checkPhase-expectedBuildLogEntries;
+            script = ''
+              set -x
+              diff -u "$failed/result" <(printf "%s" ${lib.escapeShellArg test-checkPhase-sample.text})
+              set +x
+            '';
+          };
+
+          "deprecated-${phaseName}-no-repeat" = writeTextFile (finalAttrs: {
+            name = "test-writeTextFile-deprecated-${phaseName}-no-repeat";
+            text = ''
+              ${finalAttrs.name}
+            '';
+            checkPhase = testNoRepeatScriptText;
+          });
+
+        }
+        //
+          lib.mapAttrs'
+            (n: v: {
+              name = "deprecated-${phaseName}-mitigated-by-${n}";
+              value = test-checkPhase-samples.${phaseName}.overrideAttrs (previousAttrs: {
+                name = "test-writeTextFile-deprecated-${phaseName}-mitigated-by-${n}";
+                ${phaseName} = v;
+                passthru = previousAttrs.passthru or { } // {
+                  __getDeprecatedCheckPhase-forceThrow = true;
+                };
+              });
+            })
+            {
+              null = null;
+              empty-string = "";
+            }
+      )
+      [
+        "checkPhase"
+        "preCheck"
+        "postCheck"
+      ]
+  )
+  // lib.genAttrs' [ "preCheck" "postCheck" ] (
+    phaseName:
+    let
+      previousName = "deprecated-${phaseName}-no-repeat";
+    in
+    {
+      name = previousName + "-with-checkPhase";
+      value = final.${previousName}.overrideAttrs {
+        checkPhase = ''
+          runHook preCheck
+          runHook postCheck
+        '';
+      };
+    }
+  )
 )

--- a/pkgs/build-support/trivial-builders/test/write-text-file.nix
+++ b/pkgs/build-support/trivial-builders/test/write-text-file.nix
@@ -15,62 +15,65 @@
   runtimeShell,
   writeTextFile,
 }:
-let
-  veryWeirdName = ''here's a name with some "bad" characters, like spaces and quotes'';
-in
-lib.recurseIntoAttrs {
+lib.makeExtensible (
+  final:
+  let
+    veryWeirdName = ''here's a name with some "bad" characters, like spaces and quotes'';
+  in
+  lib.recurseIntoAttrs {
 
-  different-exe-name =
-    let
-      pkg = writeTextFile {
-        name = "bar";
-        destination = "/bin/foo";
-        executable = true;
-        text = ''
-          #!${runtimeShell}
-          echo hi
-        '';
-      };
-    in
-    assert pkg.meta.mainProgram == "foo";
-    assert baseNameOf (lib.getExe pkg) == "foo";
-    assert pkg.name == "bar";
-    runCommand "test-writeTextFile-different-exe-name" { } ''
-      PATH="${lib.makeBinPath [ pkg ]}:$PATH"
-      x=$(foo)
-      [[ "$x" == hi ]]
-      touch $out
-    '';
+    different-exe-name =
+      let
+        pkg = writeTextFile {
+          name = "bar";
+          destination = "/bin/foo";
+          executable = true;
+          text = ''
+            #!${runtimeShell}
+            echo hi
+          '';
+        };
+      in
+      assert pkg.meta.mainProgram == "foo";
+      assert baseNameOf (lib.getExe pkg) == "foo";
+      assert pkg.name == "bar";
+      runCommand "test-writeTextFile-different-exe-name" { } ''
+        PATH="${lib.makeBinPath [ pkg ]}:$PATH"
+        x=$(foo)
+        [[ "$x" == hi ]]
+        touch $out
+      '';
 
-  weird-name = writeTextFile {
-    name = "weird-names";
-    destination = "/etc/${veryWeirdName}";
-    text = "passed!";
-    derivationArgs.postInstallCheck = ''
-      # intentionally hardcode everything here, to make sure
-      # Nix does not mess with file paths
+    weird-name = writeTextFile {
+      name = "weird-names";
+      destination = "/etc/${veryWeirdName}";
+      text = "passed!";
+      derivationArgs.postInstallCheck = ''
+        # intentionally hardcode everything here, to make sure
+        # Nix does not mess with file paths
 
-      name="here's a name with some \"bad\" characters, like spaces and quotes"
-      fullPath="$out/etc/$name"
+        name="here's a name with some \"bad\" characters, like spaces and quotes"
+        fullPath="$out/etc/$name"
 
-      if [ -f "$fullPath" ]; then
-        echo "[PASS] File exists!"
-      else
-        echo "[FAIL] File was not created at expected path!"
-        exit 1
-      fi
+        if [ -f "$fullPath" ]; then
+          echo "[PASS] File exists!"
+        else
+          echo "[FAIL] File was not created at expected path!"
+          exit 1
+        fi
 
-      content=$(<"$fullPath")
-      expected="passed!"
+        content=$(<"$fullPath")
+        expected="passed!"
 
-      if [ "$content" = "$expected" ]; then
-        echo "[PASS] Contents match!"
-      else
-        echo "[FAIL] File contents don't match!"
-        echo "       Expected: $expected"
-        echo "       Got:      $content"
-        exit 2
-      fi
-    '';
-  };
-}
+        if [ "$content" = "$expected" ]; then
+          echo "[PASS] Contents match!"
+        else
+          echo "[FAIL] File contents don't match!"
+          echo "       Expected: $expected"
+          echo "       Got:      $content"
+          exit 2
+        fi
+      '';
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Now that `writeTextFile` is based on `stdenvNoCC.mkDerivation` and `lib.extendMkDerivation`, let's bring it closer to other build helpers by using `installPhase` and `installCheckPhase`.

Users can now specify `preInstall`, `postInstall`, `preInstallCheck`, and `postInstallCheck` inside `derivationArgs`.

The `checkPhase` argument is deprecated in favour of `derivationArgs.postInstallCheck` (for users) and `derivationArgs.installCheckPhase` (for derived build helpers).

Still, this PR provides dedicated compatibility layers to ensure full compatibility to these deprecated arguments' direct specification, `finalAttrs`-referencing, and `overrideAttrs`-overriding, and is safe to ship with release-26.05.

This PR deliberately avoid changing downstream build helpers (e.g., `writeText`, `writeScript[Bin]`, `writeShellApplication`, etc.) to minimise the diff. Those build helpers could utilise `finalAttrs.__writeTextFile-getDeprecatedPhase` helper function and `finalAttrs.__writeTextFile-getDeprecatedPhase-constructorName` attribute during their transition, so that we don't have to reinvent the wheel.

Surpases #243023

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
