### PR TITLE
gui-for-singbox: 1.21.0 -> 1.23.2, migrate to fetcherVersion = 3

### DIFF
--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -18,13 +18,13 @@
 
 let
   pname = "gui-for-singbox";
-  version = "1.21.0";
+  version = "1.23.2";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.SingBox";
     tag = "v${version}";
-    hash = "sha256-IGsH8QHoj2CvrSEc9eIisxySXQkjPSDBXsCPOXqANVM=";
+    hash = "sha256-CEJ0yzF2smBlLgZ4EH5UWV4Pc4vA2ZH80TjoudUKWZM=";
   };
 
   metaCommon = {
@@ -53,8 +53,8 @@ let
         sourceRoot
         ;
       pnpm = pnpm_10;
-      fetcherVersion = 2;
-      hash = "sha256-dWqwEnXPT+5N+36szm4AF1ChM9M6UJltct+EtQAofGQ=";
+      fetcherVersion = 3;
+      hash = "sha256-m9Rmc9Ww4jb2aQ+RXOwF71daZ6puspdMM/xidnk/YHs=";
     };
 
     buildPhase = ''
@@ -91,7 +91,7 @@ buildGo126Module {
       --subst-var out
   '';
 
-  vendorHash = "sha256-EeIxt0BzSaZh1F38btUXN9kAvj12nlqEerVgWVGkiuk=";
+  vendorHash = "sha256-9uWrctbQ+vujb1Q8zT7Bv7rVyNY1rCM577c9caOKRNo=";
 
   nativeBuildInputs = [
     autoPatchelfHook


### PR DESCRIPTION
Upstream deleted the v1.21.0 tag, leaving the package unbuildable (the source fetch returned 404). Bump to the latest tag `v1.23.2` and migrate `fetchPnpmDeps` from `fetcherVersion = 2` to `fetcherVersion = 3` in the same change. Source, pnpm deps, and Go vendor hashes regenerated.

Builds and runs on x86_64-linux.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md