### PR TITLE
intel-llvm: support rocm/cuda builds without needing manual --rocm-path/etc.

### DIFF
--- a/pkgs/by-name/in/intel-llvm/package.nix
+++ b/pkgs/by-name/in/intel-llvm/package.nix
@@ -111,7 +111,20 @@ let
         mkdir "$rsrc"
         echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
         ln -s "${lib.getLib self.unwrapped}/lib/clang/${self.llvmMajorVersion}/include" "$rsrc"
-      '';
+      ''
+      + (lib.concatStrings (
+        lib.mapAttrsToList (k: v: ''
+          echo "export ${k}=${v}" >> $out/nix-support/setup-hook
+        '') self.unwrapped.unified-runtime.setupVars
+      ))
+
+      + (lib.optionalString (self.unwrapped.unified-runtime.setupVars ? CUDA_PATH) ''
+        # SYCL CUDA runtime libs (e.g. libonemath_blas_cublas.so) carry DT_NEEDED: libcuda.so.1.
+        # GNU ld resolves transitive DT_NEEDED via -rpath-link, not -L; point it at the stubs.
+        echo "-rpath-link,${self.unwrapped.unified-runtime.setupVars.CUDA_PATH}/lib/stubs" >> $out/nix-support/cc-ldflags
+        # The SYCL CUDA backend discovers libdevice by finding ptxas in PATH.
+        echo "export PATH=${self.unwrapped.unified-runtime.setupVars.CUDA_PATH}/bin''${PATH:+:$PATH}" >> $out/nix-support/setup-hook
+      '');
 
       extraPackages =
         # We need to explicitly link to the dev package to get headers like sycl.hpp

--- a/pkgs/by-name/in/intel-llvm/unified-runtime.nix
+++ b/pkgs/by-name/in/intel-llvm/unified-runtime.nix
@@ -18,6 +18,7 @@
   pkg-config,
   lit,
   filecheck,
+  buildPackages,
   rocmPackages ? { },
   rocmGpuTargets ? lib.optionalString (rocmPackages ? clr.gpuTargets) (
     builtins.concatStringsSep ";" rocmPackages.clr.gpuTargets
@@ -41,10 +42,22 @@ let
     ];
   };
 
+  # Minimal rocm join required at runtime
+  # We pass this to clang in its wrapper later.
+  # This is a separate join from the above because we don't
+  # need to pull in hsakmt and comgr at runtime, only build time.
+  rocmPath = symlinkJoin {
+    name = "rocm-path";
+    paths = with rocmPackages; [
+      clr
+      rocm-device-libs
+    ];
+  };
+
   cudatoolkit_joined = symlinkJoin {
     name = "cuda-merged";
 
-    paths = with cudaPackages; [
+    paths = with buildPackages.cudaPackages; [
       cuda_cudart
       cuda_nvcc
       cuda_nvml_dev.include
@@ -157,6 +170,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CUDAToolkit_CUPTI_INCLUDE_DIR" "${cudatoolkit_joined}/include")
     (lib.cmakeFeature "CUDA_cupti_LIBRARY" "${cudatoolkit_joined}/lib/libcupti.so")
   ];
+
+  passthru.setupVars =
+    lib.optionalAttrs rocmSupport { ROCM_PATH = rocmPath; }
+    // lib.optionalAttrs cudaSupport { CUDA_PATH = cudatoolkit_joined; };
 
   passthru.backends =
     lib.optionals levelZeroSupport [


### PR DESCRIPTION
This PR adds a few lines to `intel-llvm`s wrapper, to allow it to build packages for ROCm/CUDA without needing manually passed `--rocm-path`, etc. flags to find driver libs in Nix' non-standard locations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
