### PR TITLE
rpcs3: update `meta.license`

### DIFF
--- a/pkgs/by-name/rp/rpcs3/package.nix
+++ b/pkgs/by-name/rp/rpcs3/package.nix
@@ -176,7 +176,25 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       ilian
     ];
-    license = lib.licenses.gpl2Only;
+    license = [
+      lib.licenses.gpl2Only
+      # Uses wolfSSL, which changed its licence from
+      # `GPL-2.0-or-later` to `GPL-3.0-or-later`, which is incompatible
+      # with RPCS3’s `GPL-2.0-only`. They have a “GPLv2 exception list”
+      # (<https://github.com/wolfSSL/wolfssl/blob/v5.9.1-stable/LICENSING>),
+      # but this is dubious; either the exception likely negates the
+      # licence change by letting you take wolfSSL out of a
+      # `GPL-2.0-only` combination and redistribute it under those
+      # terms, negating the licence change entirely, or else it doesn’t
+      # allow distribution of the combination under the `GPL-2.0-only`
+      # at all and therefore would still constitute a licence
+      # violation to redistribute.
+      #
+      # We use `lib.licenses.unfree` to represent this awkward
+      # situation and keep Hydra from building the package.
+      lib.licenses.gpl3Plus
+      lib.licenses.unfree
+    ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"


### PR DESCRIPTION
Partial manual backport of https://github.com/NixOS/nixpkgs/pull/504471. The updates don’t build on 25.11.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
