### PR TITLE
gdk-pixbuf: fixup after the last update

### DIFF
--- a/pkgs/by-name/gd/gdk-pixbuf/package.nix
+++ b/pkgs/by-name/gd/gdk-pixbuf/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchurl,
+  fetchpatch,
   nixosTests,
   fixDarwinDylibNames,
   meson,
@@ -46,6 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Move installed tests to a separate output
     ./installed-tests-path.patch
+
+    # Fix loading of xpm module if built-in
+    # https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/267
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/62b8f9fd0bb3b862823cd34afce4b389fbd27569.patch";
+      hash = "sha256-ECEIt8lq/jBtDdBetErKpap2PWGav10vqCXKCpIQSyA=";
+    })
   ];
 
   # gdk-pixbuf-thumbnailer is not wrapped therefore strictDeps will work
@@ -83,6 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/gdk-pixbuf2/-/work_items/13
+    "-Dlegacy_xpm=enabled"
     "-Dgio_sniffing=false"
     "-Dandroid=disabled"
     "-Dglycin=disabled"


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/507383#issuecomment-4328244662

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
