### PR TITLE
lightway: 0-unstable-2026-04-10 -> 0-unstable-2026-04-24

### DIFF
--- a/pkgs/by-name/li/lightway/package.nix
+++ b/pkgs/by-name/li/lightway/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "lightway";
-  version = "0-unstable-2026-04-10";
+  version = "0-unstable-2026-04-24";
 
   src = fetchFromGitHub {
     owner = "expressvpn";
     repo = "lightway";
-    rev = "72a924935df9db641e7f4fe28cbeafaead59014f";
-    hash = "sha256-tygK2CQmbbynJiwGkMvYzt2dHoE17DCJeqD+jlai/m8=";
+    rev = "8e0940f047ee72db5daa1fb7c3bb82bc89e0f1d9";
+    hash = "sha256-OFMAEw613aIGG7N5LBAGbVrpkqMUBi7lUy7jm5tZowc=";
   };
 
-  cargoHash = "sha256-NdVOphyBW5sflv5jZPV/ShfAJXb3ZOyDRctmn/2JY38=";
+  cargoHash = "sha256-gY8KokOtdBT7Vq+lGn2sk4/o3A0TypEqv09TVJqaZjc=";
 
   cargoBuildFlags = lib.cli.toCommandLineGNU { } {
     package = [


### PR DESCRIPTION
Bumps the vendored wolfSSL to 5.9.1, thus fixing a bunch of CVEs.

Diff: https://github.com/expressvpn/lightway/compare/72a924935df9db641e7f4fe28cbeafaead59014f...8e0940f047ee72db5daa1fb7c3bb82bc89e0f1d9

(cherry picked from commit 0ed8424ca33155a261aa2f462e82dd2a21aa49af)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
