### PR TITLE
python3Packages.nixl: override pkgs.nixl with the proper python interpreter

### DIFF
--- a/pkgs/by-name/ni/nixl/package.nix
+++ b/pkgs/by-name/ni/nixl/package.nix
@@ -9,7 +9,7 @@
   meson,
   ninja,
   pkg-config,
-  python3,
+  python3Packages,
 
   # buildInputs
   abseil-cpp,
@@ -20,7 +20,6 @@
   libfabric,
   liburing,
   numactl,
-  python3Packages,
   taskflow,
   ucx,
 
@@ -87,7 +86,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    python3
+    python3Packages.python
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_nvcc

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11136,7 +11136,9 @@ self: super: with self; {
 
   nix-prefetch-github = callPackage ../development/python-modules/nix-prefetch-github { };
 
-  nixl = callPackage ../development/python-modules/nixl { inherit (pkgs) nixl; };
+  nixl = callPackage ../development/python-modules/nixl {
+    nixl = pkgs.nixl.override { python3Packages = self; };
+  };
 
   nixpkgs-plugin-update = callPackage ../development/python-modules/nixpkgs-plugin-update { };
 


### PR DESCRIPTION
## Things done

Currently, all `python3XPackages.nixl` depend on the same `python313` (instead of `python3X`).
Follow up of #512187.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
