### PR TITLE
nixos/goatcounter: Always run with `-automigrate` flag

### DIFF
--- a/nixos/modules/services/web-apps/goatcounter.nix
+++ b/nixos/modules/services/web-apps/goatcounter.nix
@@ -59,6 +59,7 @@ in
           [
             (lib.getExe cfg.package)
             "serve"
+            "-automigrate"
             "-listen"
             "${cfg.address}:${toString cfg.port}"
           ]


### PR DESCRIPTION
This is mentioned by upstream to ensure migrations are always performed automatically on upgrade:
https://github.com/arp242/goatcounter#updating

Prevents goatcounter silently failing on some API endpoints after upgrade:

```
Apr 27 19:03:01 triglav goatcounter[549050]: Apr 27 17:03:01  ERROR cron: cron.emailReports: get users: zdb.Select: missing column "seen_up
dates_at" in type string
Apr 27 19:03:01 triglav goatcounter[549050]:                                 email_reports.go:94    zgo.at/goatcounter/v2/cron.reportUsers
Apr 27 19:03:01 triglav goatcounter[549050]:                                 email_reports.go:25    zgo.at/goatcounter/v2/cron.emailReports
Apr 27 19:03:01 triglav goatcounter[549050]:                                 cron.go:64             zgo.at/goatcounter/v2/cron.Start.func1
Apr 27 19:03:01 triglav goatcounter[549050]:                         
Apr 27 19:03:01 triglav goatcounter[549050]:                         stacktrace =
Apr 27 19:03:01 triglav goatcounter[549050]:                                 log.go:127     zgo.at/goatcounter/v2/log.(*Logger).Error
Apr 27 19:03:01 triglav goatcounter[549050]:                                 cron.go:66     zgo.at/goatcounter/v2/cron.Start.func1
Apr 27 19:03:01 triglav goatcounter[549050]:                                 bgrun.go:209   zgo.at/bgrun.(*Runner).run.func1
Apr 27 19:03:01 triglav goatcounter[549050]:                         stacktrace =
Apr 27 19:03:01 triglav goatcounter[549050]:                                 email_reports.go:27    zgo.at/goatcounter/v2/cron.emailReports
Apr 27 19:03:01 triglav goatcounter[549050]:                                 cron.go:64             zgo.at/goatcounter/v2/cron.Start.func1
Apr 27 19:03:01 triglav goatcounter[549050]:                         location   = /build/source/cron/cron.go:66
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@bhankas