### PR TITLE
1password-gui: 8.12.8 -> 8.12.12

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.12.8",
+      "version": "8.12.12",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.8.x64.tar.gz",
-          "hash": "sha256-WMApavYGR4TX1/gx8yjzaI0SHf1CEC+Ay9nAyxCOLs0="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.12.x64.tar.gz",
+          "hash": "sha256-tdhuBJeCXbepDN6Z9Yqs6gE5lMUh72sOJuQSv4Qoj1M="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.8.arm64.tar.gz",
-          "hash": "sha256-Uqt44otc40/v7/f90r2BS0yK1TuctOO0VUcWGhjv0pI="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.12.arm64.tar.gz",
+          "hash": "sha256-RNwZOqr29aLgNJYH/66TFEKCK3AVBhk+qnSax+Y7Dl4="
         }
       }
     },
     "darwin": {
-      "version": "8.12.8",
+      "version": "8.12.12",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.8-x86_64.zip",
-          "hash": "sha256-w4gfs8Ctpe73TNaXebwUoa0cEOuZfiBUWN+qngSNcj4="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.12-x86_64.zip",
+          "hash": "sha256-6vVMkra7T4kVRrVn8QexBMRkHDrUoZXP/eALyBPYPow="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.8-aarch64.zip",
-          "hash": "sha256-tT7VG6KlIv4Q+UtG9pzkyBRnISzvAdrqOeO8zdlZPb4="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.12-aarch64.zip",
+          "hash": "sha256-IqMw4dgMhHkzjMVbmZy/h3li74JZxbY8D4COeMEg+1o="
         }
       }
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
