### PR TITLE
arelle: 2.38.7 -> 2.39.10

### DIFF
--- a/pkgs/development/python-modules/arelle/default.nix
+++ b/pkgs/development/python-modules/arelle/default.nix
@@ -52,14 +52,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arelle${lib.optionalString (!gui) "-headless"}";
-  version = "2.38.7";
+  version = "2.39.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Arelle";
     repo = "Arelle";
     tag = finalAttrs.version;
-    hash = "sha256-9ARMEXqoiBuAnj8hRrA1PqArmTMmRMP1BwASekOTQoc=";
+    hash = "sha256-oMZZCmZyUfCP3qe3FMHmR9IbmtDcKLS5NHmnWQJ8TZQ=";
   };
 
   outputs = [
@@ -69,7 +69,7 @@ buildPythonPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace pyproject.toml --replace-fail \
-        'requires = ["setuptools>=80.9,<81", "wheel>=0.45,<1", "setuptools_scm[toml]>=9.2,<10"]' \
+        'requires = ["setuptools>=82,<83", "wheel>=0.46,<0.47", "setuptools_scm>=10.0,<11.0"]' \
         'requires = ["setuptools", "wheel", "setuptools_scm[toml]"]'
   '';
 


### PR DESCRIPTION
Update to 2.39.10
Fix substitution for new version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
