### PR TITLE
[Backport 25.11] wayle: init at 0.2.3

### DIFF
--- a/pkgs/by-name/wa/wayle/package.nix
+++ b/pkgs/by-name/wa/wayle/package.nix
@@ -24,7 +24,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wayle";
-  version = "0.2.1";
+  version = "0.2.3";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -33,10 +33,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "wayle-rs";
     repo = "wayle";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YzDrvCTPuCOCkq0A79IHP+LYZ7ev3IpmWkk6sHuwDts=";
+    hash = "sha256-K4ItGV7kTZrm3uqHeN/hSZjKzkQpSn+nan3509FYUQw=";
   };
 
-  cargoHash = "sha256-KYYuB2TsHmHqYDXggWbj6HI0iZ0bepdMVDSQcocfXj4=";
+  cargoHash = "sha256-omCcKXYouS9qPdhVINJC2mAjI7uG0M9MH14BN/4Zegs=";
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/by-name/wa/wayle/package.nix
+++ b/pkgs/by-name/wa/wayle/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  copyDesktopItems,
+  fetchFromGitHub,
+  fftw,
+  glib,
+  gtk4-layer-shell,
+  gtksourceview5,
+  installShellFiles,
+  libpulseaudio,
+  libxkbcommon,
+  makeDesktopItem,
+  nix-update-script,
+  pipewire,
+  pixman,
+  pkg-config,
+  rustPackages_1_94,
+  stdenv,
+  udev,
+  wrapGAppsHook4,
+}:
+let
+  inherit (rustPackages_1_94) rustPlatform;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wayle";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "wayle-rs";
+    repo = "wayle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YzDrvCTPuCOCkq0A79IHP+LYZ7ev3IpmWkk6sHuwDts=";
+  };
+
+  cargoHash = "sha256-KYYuB2TsHmHqYDXggWbj6HI0iZ0bepdMVDSQcocfXj4=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    glib
+    installShellFiles
+    pkg-config
+    rustPlatform.bindgenHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4-layer-shell.dev
+    gtksourceview5
+    # Not sure why ".dev" is needed here, but CMake doesn't find libxkbcommon otherwise
+    libxkbcommon.dev
+    pixman
+    udev
+
+    # for generating libcava bindings
+    fftw.dev
+    libpulseaudio
+    pipewire.dev
+  ];
+
+  cargoBuildFlags = [
+    "--bin=wayle"
+    "--bin=wayle-settings"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkFlags = [
+    # GTK4 failed to initialize (requires GUI?)
+    "--skip=tests::css_loads_into_gtk4"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    cp -r resources/icons "$out/share"
+    cp resources/wayle-settings.svg "$out/share/icons/hicolor/scalable/apps"
+  '';
+
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      # bash
+      ''
+        installShellCompletion --cmd wayle \
+          --bash <($out/bin/wayle completions bash) \
+          --fish <($out/bin/wayle completions fish) \
+          --zsh <($out/bin/wayle completions zsh)
+      '';
+
+  preFixup = ''
+    # so wayle could access wayle-settings binary
+    gappsWrapperArgs+=( --suffix PATH : $out/bin )
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.wayle.settings.desktop";
+      type = "Application";
+      desktopName = "Wayle Settings";
+      genericName = "Shell Settings";
+      comment = "Configure the Wayle desktop shell";
+      exec = "wayle-settings";
+      icon = "wayle-settings";
+      terminal = false;
+      categories = [
+        "Settings"
+        "DesktopSettings"
+        "GTK"
+      ];
+      keywords = [
+        "wayle"
+        "settings"
+        "shell"
+        "bar"
+        "wayland"
+        "config"
+      ];
+      startupNotify = true;
+      startupWMClass = "com.wayle.settings";
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland Elements - A compositor agnostic shell with extensive customization";
+    homepage = "https://github.com/wayle-rs/wayle/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ perchun ];
+    mainProgram = "wayle";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This is a simple backport of #503416 and #514090

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
(cherry-picked from 70946db)