### PR TITLE
fork-cleaner: cleanup

### DIFF
--- a/pkgs/by-name/fo/fork-cleaner/package.nix
+++ b/pkgs/by-name/fo/fork-cleaner/package.nix
@@ -29,7 +29,7 @@ buildGoModule {
   meta = {
     description = "Quickly clean up unused forks on your GitHub account";
     homepage = "https://github.com/caarlos0/fork-cleaner";
-    changelog = "https://github.com/caarlos0/fork-cleaner/releases/tag/${version}";
+    changelog = "https://github.com/caarlos0/fork-cleaner/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ isabelroses ];
     mainProgram = "fork-cleaner";

--- a/pkgs/by-name/fo/fork-cleaner/package.nix
+++ b/pkgs/by-name/fo/fork-cleaner/package.nix
@@ -13,7 +13,7 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "caarlos0";
     repo = "fork-cleaner";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-Io/IOJYa9qDCTTf6vQvZeco1iEDV7crnvzR539QDz40=";
   };
 

--- a/pkgs/by-name/fo/fork-cleaner/package.nix
+++ b/pkgs/by-name/fo/fork-cleaner/package.nix
@@ -19,10 +19,6 @@ buildGoModule {
 
   vendorHash = "sha256-+OlrXYjBiXtbMf/IRzj06J1yq2XdlQk54lnJtCmqymw=";
 
-  # allowGoReference adds the flag `-trimpath` which is also denoted by, fork-cleaner goreleaser config
-  #  <https://github.com/caarlos0/fork-cleaner/blob/645345bf97d751614270de4ade698ddbc53509c1/goreleaser.yml#L38>
-  allowGoReference = true;
-
   ldflags = [
     "-s"
     "-w"


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/issues/514132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
