### PR TITLE
kapow: 1.5.10 -> 1.7.0

### DIFF
--- a/pkgs/by-name/ka/kapow/package.nix
+++ b/pkgs/by-name/ka/kapow/package.nix
@@ -1,28 +1,30 @@
 {
   lib,
   stdenv,
+  cmake,
   fetchFromGitHub,
-  libsForQt5,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kapow";
-  version = "1.5.10";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "gottcode";
     repo = "kapow";
     rev = "v${finalAttrs.version}";
-    sha256 = "1fz9fb4w21ax8hjs6dwfn2410ig4lqvzdlijq0jcj3jbgxd4i1gw";
+    hash = "sha256-IWkvAXDcWodrV23/wv3GEQXWdNcaIZDsU3LUtxsD+cA=";
   };
 
   nativeBuildInputs = [
-    libsForQt5.qmake
-    libsForQt5.qttools
-    libsForQt5.wrapQtAppsHook
+    cmake
+    qt6.qmake
+    qt6.qttools
+    qt6.wrapQtAppsHook
   ];
 
-  buildInputs = [ libsForQt5.qtbase ];
+  buildInputs = [ qt6.qtbase ];
 
   meta = {
     description = "Punch clock to track time spent on projects";

--- a/pkgs/by-name/ka/kapow/package.nix
+++ b/pkgs/by-name/ka/kapow/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Punch clock to track time spent on projects";
     mainProgram = "kapow";
     homepage = "https://gottcode.org/kapow/";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tbutter ];
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;
   };


### PR DESCRIPTION
Update kapow to 1.7.0

Update qt5 to qt6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
