### PR TITLE
envio: 0.6.1 -> 0.7.0; add nix-update-script

### DIFF
--- a/pkgs/by-name/en/envio/package.nix
+++ b/pkgs/by-name/en/envio/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.1";
 
   src = fetchFromGitHub {
-    owner = "envio-cli";
+    owner = "humblepenguinn";
     repo = "envio";
     rev = "v${finalAttrs.version}";
     hash = "sha256-je0DBoBIayFK//Aija5bnO/2z+hxNWgVkwOgxMyq5s4=";
@@ -36,8 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://envio-cli.github.io/home";
-    changelog = "https://github.com/envio-cli/envio/blob/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/humblepenguinn/envio/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Modern and secure CLI tool for managing environment variables";
     mainProgram = "envio";
     longDescription = ''

--- a/pkgs/by-name/en/envio/package.nix
+++ b/pkgs/by-name/en/envio/package.nix
@@ -1,25 +1,28 @@
 {
+  stdenv,
   lib,
   fetchFromGitHub,
   installShellFiles,
   gpgme,
+  dbus,
   libgpg-error,
   pkg-config,
   rustPlatform,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "envio";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "humblepenguinn";
     repo = "envio";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-je0DBoBIayFK//Aija5bnO/2z+hxNWgVkwOgxMyq5s4=";
+    hash = "sha256-uiuJ3yFuU5S0e6SrD1C4tU5Ve/VBoGmyclbokESDZAw=";
   };
 
-  cargoHash = "sha256-stb5BZ77yBUjP6p3yfdgtN6fkE7wWU6A+sPAmc8YZD0=";
+  cargoHash = "sha256-eECjTnqjy38jA5kHddPaBZaZ/1ErHB7uQPbZYNFBcSU=";
 
   nativeBuildInputs = [
     pkg-config
@@ -29,11 +32,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     libgpg-error
     gpgme
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
   ];
 
   postInstall = ''
     installManPage man/*.1
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/humblepenguinn/envio/blob/v${finalAttrs.version}/CHANGELOG.md";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* 0.6.1 -> 0.7.0 update
* add nix-update-script
* fix meta.changelog url

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
