### PR TITLE
python3Packages.cyclopts: 4.10.2 -> 4.16.0

### DIFF
--- a/pkgs/development/python-modules/cyclopts/default.nix
+++ b/pkgs/development/python-modules/cyclopts/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cyclopts";
-  version = "4.10.2";
+  version = "4.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BrianPugh";
     repo = "cyclopts";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vlsjhBfI08QMQ8FzM+BogAXbukHhnr4aD8ZmZVicCv0=";
+    hash = "sha256-yCq2G4NrjNhLrJR7FQpJVDoVqtUlBuh/xfWTHSYYdkg=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/cyclopts/default.nix
+++ b/pkgs/development/python-modules/cyclopts/default.nix
@@ -1,35 +1,41 @@
 {
   lib,
+  stdenv,
   attrs,
   buildPythonPackage,
   docstring-parser,
   fetchFromGitHub,
+  bash,
+  fish,
   hatch-vcs,
   hatchling,
   markdown,
   mkdocs,
+  pexpect,
   pydantic,
   pymdown-extensions,
+  pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
   pyyaml,
-  rich-rst,
   rich,
+  rich-rst,
   sphinx,
   syrupy,
   trio,
+  zsh,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "cyclopts";
-  version = "4.10.2";
+  version = "4.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BrianPugh";
     repo = "cyclopts";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vlsjhBfI08QMQ8FzM+BogAXbukHhnr4aD8ZmZVicCv0=";
+    hash = "sha256-tDDYVqhjvTRQ0rTvib4ek49zEnEefkKoq1t/3C/PRlQ=";
   };
 
   build-system = [
@@ -47,7 +53,6 @@ buildPythonPackage (finalAttrs: {
   optional-dependencies = {
     trio = [ trio ];
     yaml = [ pyyaml ];
-    docs = [ sphinx ];
     mkdocs = [
       mkdocs
       markdown
@@ -56,32 +61,45 @@ buildPythonPackage (finalAttrs: {
   };
 
   nativeCheckInputs = [
+    pexpect
     pydantic
+    pytest-cov-stub
     pytest-mock
     pytestCheckHook
     syrupy
+
+    # integrations
+    sphinx
+    bash
+    fish
+    zsh
   ]
   ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   pythonImportsCheck = [ "cyclopts" ];
 
   disabledTests = [
-    # Test requires bash
-    "test_positional_not_treated_as_command"
     # Building docs
     "build_succeeds"
-  ];
-
-  disabledTestPaths = [
-    # Tests requires sphinx
-    "tests/test_sphinx_ext.py"
-  ];
+    # https://github.com/BrianPugh/cyclopts/issues/820
+    "test_behavior[fish-literal-positional]"
+    "test_behavior[fish-multi-positional-second]"
+    "test_behavior[fish-equals-form-option-value]"
+    "test_behavior[fish-multi-positional-third]"
+  ]
+  # https://github.com/BrianPugh/cyclopts/issues/821
+  ++ lib.lists.optional (
+    stdenv.hostPlatform.system == "aarch64-linux"
+  ) "test_collection_option_repeats";
 
   meta = {
     description = "Module to create CLIs based on Python type hints";
     homepage = "https://github.com/BrianPugh/cyclopts";
     changelog = "https://github.com/BrianPugh/cyclopts/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      PerchunPak
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

meta.description: Intuitive, easy CLIs based on Python type hints
meta.homepage: https://github.com/BrianPugh/cyclopts

Aside from upgrading the package, I have also enabled tests for completions in different shells (bash, zsh, fish)

Changelogs:
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.11.0
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.11.1
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.11.2
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.12.0
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.13.0
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.14.0
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.14.1
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.15.0
- https://github.com/BrianPugh/cyclopts/releases/tag/v4.16.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
