### PR TITLE
snouty: 0.3.5 -> 0.4.2

### DIFF
--- a/pkgs/by-name/sn/snouty/package.nix
+++ b/pkgs/by-name/sn/snouty/package.nix
@@ -5,22 +5,24 @@
   installShellFiles,
   pkg-config,
   openssl,
+  podman,
+  writableTmpDirAsHomeHook,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "snouty";
-  version = "0.3.5";
+  version = "0.3.6";
 
   src = fetchFromGitHub {
     owner = "antithesishq";
     repo = "snouty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lE0SHk2pkWPAMRI8seBhP4lMVyruhF8DKW/LSRkqcRw=";
+    hash = "sha256-08F2NKPqeLcdVoD29hupmcMjwge74FRLG+tZoLYbqb8=";
   };
 
-  cargoHash = "sha256-b5FVhF+MVexf8ZV3+pUomzCA8fq1Un0g51aLg1muxRM=";
+  cargoHash = "sha256-0u9auWAGjJNp2patIAAxQ3pI0a2w+UFRDxDv3tTBwb8=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -38,6 +40,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       $releaseDir/build/snouty-*/out/snouty.{bash,fish} \
       --zsh $releaseDir/build/snouty-*/out/_snouty
   '';
+
+  nativeCheckInputs = [
+    podman
+    writableTmpDirAsHomeHook
+  ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "version";

--- a/pkgs/by-name/sn/snouty/package.nix
+++ b/pkgs/by-name/sn/snouty/package.nix
@@ -41,6 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --zsh $releaseDir/build/snouty-*/out/_snouty
   '';
 
+  useNextest = true;
+
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
     podman

--- a/pkgs/by-name/sn/snouty/package.nix
+++ b/pkgs/by-name/sn/snouty/package.nix
@@ -5,22 +5,24 @@
   installShellFiles,
   pkg-config,
   openssl,
+  writableTmpDirAsHomeHook,
+  podman,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "snouty";
-  version = "0.3.5";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "antithesishq";
     repo = "snouty";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lE0SHk2pkWPAMRI8seBhP4lMVyruhF8DKW/LSRkqcRw=";
+    hash = "sha256-LDcGeRiDYUKDrQZ8pXrRhPFLS0tE16wtgJ8AN3gIVd0=";
   };
 
-  cargoHash = "sha256-b5FVhF+MVexf8ZV3+pUomzCA8fq1Un0g51aLg1muxRM=";
+  cargoHash = "sha256-IYprp5XEc2DSGWmf9IOKAHfnMX8JbmUWgvKK+CoA1i8=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -38,6 +40,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       $releaseDir/build/snouty-*/out/snouty.{bash,fish} \
       --zsh $releaseDir/build/snouty-*/out/_snouty
   '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    podman
+  ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "version";


### PR DESCRIPTION
https://github.com/antithesishq/snouty/compare/v0.3.5...v0.4.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
