### PR TITLE
python3Packages.sseclient-py: fix changelog URL

### DIFF
--- a/pkgs/development/python-modules/sseclient-py/default.nix
+++ b/pkgs/development/python-modules/sseclient-py/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Pure-Python Server Side Events (SSE) client";
     homepage = "https://github.com/mpetazzoni/sseclient";
-    changelog = "https://github.com/mpetazzoni/sseclient/releases/tag/sseclient-py-${finalAttrs.src.tag}";
+    changelog = "https://github.com/mpetazzoni/sseclient/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jamiemagee ];
   };


### PR DESCRIPTION
The `src.tag` attribute already contains the `sseclient-py-` prefix, so the constructed URL doubled it (`…/tag/sseclient-py-sseclient-py-1.9.0`) and 404'd.

Verified the fixed URL resolves:

```
$ curl -fsI https://github.com/mpetazzoni/sseclient/releases/tag/sseclient-py-1.9.0
HTTP/2 200
```

Part of #514132.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
