### PR TITLE
python3Packages.pynzbgetapi: remove broken changelog URL

### DIFF
--- a/pkgs/development/python-modules/pynzbgetapi/default.nix
+++ b/pkgs/development/python-modules/pynzbgetapi/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
   meta = {
     description = "Basic Python NZBGet API client";
     homepage = "https://github.com/voltron4lyfe/pynzbgetapi";
-    changelog = "https://github.com/voltron4lyfe/pynzbgetapi/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.jamiemagee ];
   };


### PR DESCRIPTION
Upstream has not tagged or released 0.4.0 on GitHub (latest tag is `0.3.0`, latest release is `0.2.0`), so no changelog page exists for this version.

Part of #514132.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
