### PR TITLE
lib/filesystem: remove absolute path literals

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -201,7 +201,7 @@ in
         in
         if builtins.length matches != 0 then
           { inherit path matches; }
-        else if path == /. then
+        else if toString path == "/" then
           null
         else
           go (dirOf path);
@@ -211,7 +211,7 @@ in
           base = baseNameOf file;
           type = (builtins.readDir parent).${base} or null;
         in
-        file == /. || type == "directory";
+        toString file == "/" || type == "directory";
     in
     go (if isDir then file else parent);
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Absolute path literals are not portable.
Nix complains about the changed lines if the option `lint-absolute-path-literals` is set to `warn`.

`lint-absolute-path-literals` Option Documentation:
https://nix.dev/manual/nix/2.34/command-ref/conf-file.html#conf-lint-absolute-path-literals

I'm making several PRs to Nixpkgs to resolve all instances of this issue.

Relevant Discussion:
[Remove All Absolute Path Literals From Nixpkgs](https://discourse.nixos.org/t/remove-all-absolute-path-literals-from-nixpkgs/77245/8)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
