### PR TITLE
python3Packages.tree-sitter-zeek: 0.2.12 -> 0.2.13; zeekscript: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "zeekscript";
-  version = "1.3.3";
+  version = "1.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "zeekscript";
     tag = "v${version}";
-    hash = "sha256-uNVmY+yJy/4H/zRGqg68Pop2TcwZgsrT46cdx3bhKIo=";
+    hash = "sha256-icc5mMhl/MK0+0fLYJG07wqWaKKX2QFcpD1IIvdmASw=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];

--- a/pkgs/by-name/ze/zeekscript/package.nix
+++ b/pkgs/by-name/ze/zeekscript/package.nix
@@ -2,7 +2,6 @@
   lib,
   python3,
   fetchFromGitHub,
-  writeScript,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -13,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "zeekscript";
-    rev = "065edacf0321dd9a0cdd64285b93dec954bf448e";
+    tag = "v${version}";
     hash = "sha256-uNVmY+yJy/4H/zRGqg68Pop2TcwZgsrT46cdx3bhKIo=";
   };
 
@@ -35,19 +34,6 @@ python3.pkgs.buildPythonApplication rec {
   pythonImportsCheck = [
     "zeekscript"
   ];
-
-  passthru.updateScript = writeScript "update-${pname}" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p git common-updater-scripts
-    tmpdir="$(mktemp -d)"
-    git clone "${src.gitRepoUrl}" "$tmpdir"
-    pushd "$tmpdir"
-    newVersion=$(cat VERSION)
-    newRevision=$(git log -s -n 1 --pretty='format:%H' VERSION)
-    popd
-    rm -rf "$tmpdir"
-    update-source-version "${pname}" "$newVersion" --rev="$newRevision"
-  '';
 
   meta = {
     description = "Zeek script formatter and analyzer";

--- a/pkgs/development/python-modules/tree-sitter-zeek/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-zeek/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "tree-sitter-zeek";
-  version = "0.2.12";
+  version = "0.2.13";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zeek";
     repo = "tree-sitter-zeek";
     tag = "v${version}";
-    hash = "sha256-BWrzPMsUgbIvdWsafTtXApmGGr7Sdpb382iqhM8Etqk=";
+    hash = "sha256-okm65ls/38PnzHpfdNT1McouaZ1r1dBflXcGUzaM9Z0=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
- **python3Packages.tree-sitter-zeek: 0.2.12 -> 0.2.13**
  Diff: https://github.com/zeek/tree-sitter-zeek/compare/v0.2.12...v0.2.13
- **zeekscript: switch rev to tag**
  As a bonus, this also allows removal of the custom update script.
- **zeekscript: 1.3.3 -> 1.3.4**
  Changelog: https://github.com/zeek/zeekscript/blob/refs/tags/v1.3.4/CHANGES
  Diff: https://github.com/zeek/zeekscript/compare/v1.3.3...v1.3.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
