### PR TITLE
zon2nix: 0.1.3-unstable-2025-03-20 -> 0.1.3-unstable-2025-04-13

### DIFF
--- a/pkgs/by-name/zo/zon2nix/package.nix
+++ b/pkgs/by-name/zo/zon2nix/package.nix
@@ -2,23 +2,25 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  zig_0_14,
+  zig_0_16,
   nix,
 }:
-
+let
+  zig = zig_0_16;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "zon2nix";
-  version = "0.1.3-unstable-2025-03-20";
+  version = "0.1.3-unstable-2026-04-13";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "zon2nix";
-    rev = "2360e358c2107860dadd340f88b25d260b538188";
-    hash = "sha256-89hYzrzQokQ+HUOd3g4epP9jdajaIoaMG81SrCNCqqU=";
+    rev = "d1e1762ce1e5d4df3b65a0d45421b6fb7b99cf92";
+    hash = "sha256-LzmPWG0cEhQS3+NDg/5KRgsUJHygllTK9lvDJJI/o+U=";
   };
 
   nativeBuildInputs = [
-    zig_0_14
+    zig
   ];
 
   zigBuildFlags = [
@@ -38,6 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       RossComputerGuy
     ];
-    inherit (zig_0_14.meta) platforms;
+    inherit (zig.meta) platforms;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
