### PR TITLE
python3Packages.{langchain,langgraph}*: update

### DIFF
--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -24,19 +24,22 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-anthropic";
-  version = "1.4.0";
+  version = "1.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${finalAttrs.version}";
-    hash = "sha256-nPVmyRvgGWDOANP0NalmX4obl+mMb/LdXtyO60k4zKs=";
+    hash = "sha256-V0unqMEfUTTNOxupBjStWD7JUCn1BQe25RIxSC/i4zI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/partners/anthropic";
 
   build-system = [ hatchling ];
+
+  # Langchain always tracks the latest release of anthropic whether or not it's needed
+  pythonRelaxDeps = [ "anthropic" ];
 
   dependencies = [
     anthropic

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-aws";
-  version = "1.4.4";
+  version = "1.4.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-aws";
     tag = "langchain-aws==${finalAttrs.version}";
-    hash = "sha256-QXWODYzyQTVAAIHL4h2cgEqSBl4lBByoT1+DWMatYWE=";
+    hash = "sha256-ok8rCSzvjKR2Sr6XCdmULWyySkJ4Jdy3+LzKSOzUMlE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/langchain-classic/default.nix
+++ b/pkgs/development/python-modules/langchain-classic/default.nix
@@ -42,14 +42,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-classic";
-  version = "1.0.3";
+  version = "1.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-classic==${finalAttrs.version}";
-    hash = "sha256-vCYdBBN9vU8gWedCxKXnzLzZ5C7pYl3KyECBNAQggto=";
+    hash = "sha256-yIu0P1GJBTEJ/Sq2ZTn7btoLiBgDCaNXJT9/W4maYtg=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/langchain";

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -9,6 +9,7 @@
 
   # dependencies
   jsonpatch,
+  langchain-protocol,
   langsmith,
   packaging,
   pydantic,
@@ -52,6 +53,7 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     jsonpatch
+    langchain-protocol
     langsmith
     packaging
     pydantic

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-core";
-  version = "1.2.27";
+  version = "1.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${finalAttrs.version}";
-    hash = "sha256-WdC43SUVgteNQLNMD+yEkD8TyyCFGXkYTi5moZMEmVo=";
+    hash = "sha256-7ugQnVnq/yW/7NVtqkAB1C3+XjLN3m+GQFKtv5uXw9E=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-fireworks/default.nix
+++ b/pkgs/development/python-modules/langchain-fireworks/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-fireworks";
-  version = "1.1.0";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-fireworks==${version}";
-    hash = "sha256-gLc3pPxQZTm6PU5r1o7mxlnRI8tCeg/w9jkbbfUCSec=";
+    hash = "sha256-8qjF9QYtNneCijGYK8m40NZQIWxCeCLSN6S5jeWfyQE=";
   };
 
   sourceRoot = "${src.name}/libs/partners/fireworks";

--- a/pkgs/development/python-modules/langchain-google-genai/default.nix
+++ b/pkgs/development/python-modules/langchain-google-genai/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-google-genai";
-  version = "4.2.1";
+  version = "4.2.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-google";
     tag = "libs/genai/v${finalAttrs.version}";
-    hash = "sha256-aNmYj5eOWDgHYlSLElwQXQByQg8gHqiybM19JQlkluk=";
+    hash = "sha256-W5JACbNUApJFz8XikKXGMY3XL1zdbaf+u9WmCQymy9M=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/genai";

--- a/pkgs/development/python-modules/langchain-huggingface/default.nix
+++ b/pkgs/development/python-modules/langchain-huggingface/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-huggingface";
-  version = "1.2.1";
+  version = "1.2.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-huggingface==${finalAttrs.version}";
-    hash = "sha256-I6n7UNEbGqlyzT663k7+YpcaB/+rE9RlkqIToupoEyY=";
+    hash = "sha256-jMbFqui0XoKZ15B+5kJAamW5Dasv/JCIZS2KtteRBXg=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/partners/huggingface";

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-openai";
-  version = "1.1.12";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-openai==${finalAttrs.version}";
-    hash = "sha256-lmEnkwX1tL88xHTrQRe96ZCvU5bM6iwzJ46exI+gfSI=";
+    hash = "sha256-EH4TZpo843m6/7oyFUxt4tkmCiCGD5+GFqM0gfgnWVQ=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/partners/openai";

--- a/pkgs/development/python-modules/langchain-protocol/default.nix
+++ b/pkgs/development/python-modules/langchain-protocol/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "langchain-protocol";
+  version = "0.0.12";
+  pyproject = true;
+
+  # Not available vis Github yet; required by langchain-core
+  src = fetchPypi {
+    pname = "langchain_protocol";
+    inherit (finalAttrs) version;
+    hash = "sha256-XhTENCkKcFyVEP2xqD7PdWGl5uDf0FOTCt6A26BpJp8=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [
+    "langchain_protocol"
+  ];
+
+  meta = {
+    description = "Python bindings for the LangChain agent streaming protocol";
+    homepage = "https://pypi.org/project/langchain-protocol";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+})

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-tests";
-  version = "1.1.6";
+  version = "1.1.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${finalAttrs.version}";
-    hash = "sha256-W+uJy0t6awNwMpMHEftHV8tDliEhvL/g8V2ZJPWeYk8=";
+    hash = "sha256-zesNbesiLMayvlVrU6NagmE2+o0l6ozwZlOGqvyGpnQ=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/standard-tests";

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -21,14 +21,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-text-splitters";
-  version = "1.1.1";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-text-splitters==${finalAttrs.version}";
-    hash = "sha256-I5eMc/E7sCxEQG8+jw3E/M4uB7adKU5IMHRsS6pacsA=";
+    hash = "sha256-AiRl8N2V2UfYLZfqxM8DHZmT76rH19I1gFyOYc/mpYY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/text-splitters";

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langgraph-checkpoint";
-  version = "4.0.2";
+  version = "4.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpoint==${finalAttrs.version}";
-    hash = "sha256-k0V+/kZlpMttgVId+mLgEMvK+l20NEmf8S1ylPWjjsU=";
+    hash = "sha256-zdl/WpzNLr3QmQqi2rvFl4dDzy0BRqMRv7I0GUp9Feg=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/checkpoint";

--- a/pkgs/development/python-modules/langgraph-prebuilt/default.nix
+++ b/pkgs/development/python-modules/langgraph-prebuilt/default.nix
@@ -32,14 +32,14 @@
 # It exists so the langgraph team can iterate on it without having to rebuild langgraph.
 buildPythonPackage (finalAttrs: {
   pname = "langgraph-prebuilt";
-  version = "1.0.9";
+  version = "1.0.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "prebuilt==${finalAttrs.version}";
-    hash = "sha256-B9ntvj6qoKd63W/cPkevtfHbv8XUxmkaWupxURA8C68=";
+    hash = "sha256-J899GIBdXHjZVMwZlnn5GH52/TNjzLukc4Xp/qc8NOM=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/prebuilt";

--- a/pkgs/development/python-modules/langgraph-runtime-inmem/default.nix
+++ b/pkgs/development/python-modules/langgraph-runtime-inmem/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langgraph-runtime-inmem";
-  version = "0.27.3";
+  version = "0.28.0";
   pyproject = true;
 
   # Not available in any repository
   src = fetchPypi {
     pname = "langgraph_runtime_inmem";
     inherit (finalAttrs) version;
-    hash = "sha256-jylX7GXEJFJr5pBxCnD2W/kG3dkqS9IFS7VhyPlErJE=";
+    hash = "sha256-4CU2UItcFU8YokJAZjr3wjifQ8tPu6yZWicXtM/kDS8=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -41,14 +41,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "langgraph";
-  version = "1.1.6";
+  version = "1.1.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = finalAttrs.version;
-    hash = "sha256-9YuvzPmyNOfx8AolUaY8XFeYUpWRmudtLEAUadRUAqY=";
+    hash = "sha256-J899GIBdXHjZVMwZlnn5GH52/TNjzLukc4Xp/qc8NOM=";
   };
 
   postgresqlTestSetupPost = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8478,6 +8478,8 @@ self: super: with self; {
 
   langchain-perplexity = callPackage ../development/python-modules/langchain-perplexity { };
 
+  langchain-protocol = callPackage ../development/python-modules/langchain-protocol { };
+
   langchain-tests = callPackage ../development/python-modules/langchain-tests { };
 
   langchain-text-splitters = callPackage ../development/python-modules/langchain-text-splitters { };


### PR DESCRIPTION
*  python3Packages.langchain-anthropic: 1.4.0 -> 1.4.1
*  python3Packages.langgraph-prebuilt: 1.0.9 -> 1.0.12
*  python3Packages.langgraph-runtime-inmem: 0.27.3 -> 0.28.0
*  python3Packages.langgraph-checkpoint: 4.0.2 -> 4.0.3
*  python3Packages.langgraph: 1.1.6 -> 1.1.10
*  python3Packages.langchain-huggingface: 1.2.1 -> 1.2.2
*  python3Packages.langchain-google-genai: 4.2.1 -> 4.2.2
*  python3Packages.langchain-fireworks: 1.1.0 -> 1.2.0
*  python3Packages.langchain-classic: 1.0.3 -> 1.0.4
*  python3Packages.langchain-aws: 1.4.4 -> 1.4.5
*  python3Packages.langchain-openai: 1.1.12 -> 1.2.0
*  python3Packages.langchain-tests: 1.1.6 -> 1.1.7
*  python3Packages.langchain-core: 1.2.27 -> 1.3.1
*  python3Packages.langchain-text-splitters: 1.1.1 -> 1.1.2
*  python3Packages.langchain-protocol: init at 0.0.12

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
