### PR TITLE
fishPlugins.hydro: add HigherOrderLogic as maintainer; add update script

### DIFF
--- a/pkgs/shells/fish/plugins/hydro.nix
+++ b/pkgs/shells/fish/plugins/hydro.nix
@@ -19,6 +19,6 @@ buildFishPlugin {
     description = "Ultra-pure, lag-free prompt with async Git status";
     homepage = "https://github.com/jorgebucaran/hydro";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ higherorderlogic ];
   };
 }

--- a/pkgs/shells/fish/plugins/hydro.nix
+++ b/pkgs/shells/fish/plugins/hydro.nix
@@ -2,6 +2,7 @@
   lib,
   buildFishPlugin,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
 buildFishPlugin {
@@ -14,6 +15,8 @@ buildFishPlugin {
     rev = "24bb2375e3cb29c71ab790c8cfe98b9069de80c3";
     hash = "sha256-8ixve1ws80q5jNdKoooL25Lk7qopVitCMVTucW490fU=";
   };
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Ultra-pure, lag-free prompt with async Git status";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add myself as maintainer, also add update script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
