### PR TITLE
obscura: init at 0.1.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6794,6 +6794,12 @@
     githubId = 265220;
     name = "David Leung";
   };
+  dhogenson = {
+    email = "dallin.hogenson@icloud.com";
+    github = "dhogenson";
+    githubId = 167140817;
+    name = "Dallin Hogenson";
+  };
   diadatp = {
     email = "nixpkgs@diadatp.com";
     github = "diadatp";

--- a/pkgs/by-name/ob/obscura/librusty_v8.nix
+++ b/pkgs/by-name/ob/obscura/librusty_v8.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "137.3.0";
+  hashes = {
+    x86_64-linux = "sha256-omgf3lMBir0zZgGPEyYX3VmAAt948VbHvG0v9gi1ZWc=";
+    aarch64-linux = "sha256-42jQy0HBecQ6mQ5OxKVeRN2XYvHTS+FWlqzEQz+KbJI=";
+  };
+in
+stdenv.mkDerivation {
+  name = "librusty_v8-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+    hash =
+      hashes.${stdenv.hostPlatform.system}
+        or (throw "librusty_v8: unsupported platform ${stdenv.hostPlatform.system}");
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    gzip -cd "$src" > "$out"
+    runHook postInstall
+  '';
+
+  meta = {
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames hashes;
+  };
+}

--- a/pkgs/by-name/ob/obscura/librusty_v8.nix
+++ b/pkgs/by-name/ob/obscura/librusty_v8.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "137.3.0";
+  hashes = {
+    x86_64-linux = "0rv5nl4gcbvdpk3mdwbqvw180nfx2wk173q1cqrvv2h1agg1ys52";
+    aarch64-linux = "14kci8zl7i5cjrbf2jyky5i9gpa4bsjw8khfk4xc8yf1875x0s73";
+  };
+in
+stdenv.mkDerivation {
+  name = "librusty_v8-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+    sha256 =
+      hashes.${stdenv.hostPlatform.system}
+        or (throw "librusty_v8: unsupported platform ${stdenv.hostPlatform.system}");
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    gzip -cd "$src" > "$out"
+    runHook postInstall
+  '';
+
+  meta = {
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames hashes;
+  };
+}

--- a/pkgs/by-name/ob/obscura/package.nix
+++ b/pkgs/by-name/ob/obscura/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pkg-config,
+}:
+
+let
+  librusty_v8 = callPackage ./librusty_v8.nix { };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "obscura";
+  __structuredAttrs = true;
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "h4ckf0r0day";
+    repo = "obscura";
+    rev = "v${version}";
+    hash = "sha256-SCK9pDTODUNaTUb2yxe+cGNvQTMErWkFj5ZLu0dXYq8=";
+  };
+
+  cargoHash = "sha256-+q7KeXr69wv3SoJ5qTQOxomCGpA+JdoZ04Hv9jExiZU=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Tests SIGSEGV due to pre-built V8 library incompatibility in the sandbox
+  # Tests segfault due to pre-built V8 binary incompatibility in the sandbox
+  doCheck = false;
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+    RUSTY_V8_ARCHIVE = librusty_v8;
+  };
+
+  meta = with lib; {
+    description = "Headless browser for AI agents and web scraping";
+    homepage = "https://github.com/h4ckf0r0day/obscura";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dhogenson ];
+    mainProgram = "obscura";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ob/obscura/package.nix
+++ b/pkgs/by-name/ob/obscura/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pkg-config,
+  nix-update-script,
+  _experimental-update-script-combinators,
+}:
+
+let
+  librusty_v8 = callPackage ./librusty_v8.nix { };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "obscura";
+  __structuredAttrs = true;
+  version = "0.1.10";
+
+  src = fetchFromGitHub {
+    owner = "h4ckf0r0day";
+    repo = "obscura";
+    rev = "v${version}";
+    hash = "sha256-6IhZhKUlwR06JYTDhQL1Sd1uamVG5PJn4CLxmXyfxEk=";
+  };
+
+  cargoHash = "sha256-db6UEtuncxOUlFzFLdfkk3DyFbEcldxYDKaKPrPS75g=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # Tests crash in Nix sandbox: all obscura-js tests create a V8 isolate
+  # via deno_core::JsRuntime::new(), which loads the pre-built librusty_v8
+  # binary. The sandbox's user namespace + resource limits are incompatible
+  # with V8's initialization.
+  # Basic CLI operations (--help, fetch) don't create an isolate, so work fine.
+  doCheck = false;
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+    RUSTY_V8_ARCHIVE = librusty_v8;
+  };
+
+  passthru = {
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script { })
+      ./update.sh
+    ];
+    inherit librusty_v8;
+  };
+
+  meta = with lib; {
+    description = "Headless browser for AI agents and web scraping";
+    homepage = "https://github.com/h4ckf0r0day/obscura";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dhogenson ];
+    mainProgram = "obscura";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ob/obscura/update.sh
+++ b/pkgs/by-name/ob/obscura/update.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix yq gnugrep gnused git
+set -eu -o pipefail
+
+PACKAGE_DIR=$(dirname "$(readlink --canonicalize-existing "${BASH_SOURCE[0]}")")
+OUTPUT_FILE="$PACKAGE_DIR/librusty_v8.nix"
+
+cd "$PACKAGE_DIR"
+NIXPKGS_ROOT=$(git rev-parse --show-toplevel)
+cd "$NIXPKGS_ROOT"
+VERSION=$(nix-instantiate --raw --eval -E "with import ./. {}; obscura.version")
+CARGO_LOCK=$(curl -sL "https://raw.githubusercontent.com/h4ckf0r0day/obscura/v$VERSION/Cargo.lock")
+NEW_VERSION=$(echo "$CARGO_LOCK" | tomlq -r '.package[] | select(.name == "v8") | .version')
+
+if [ -z "$NEW_VERSION" ]; then
+  echo "Could not find v8 crate in Cargo.lock" >&2
+  exit 1
+fi
+
+CURRENT_VERSION=$(grep 'version =' "$OUTPUT_FILE" | sed -E 's/.*version = "([^"]+)".*/\1/')
+if [ "$CURRENT_VERSION" == "$NEW_VERSION" ]; then
+  echo "librusty_v8 is already at version $NEW_VERSION, nothing to do."
+  exit 0
+fi
+
+TEMP_FILE=$(mktemp)
+cat >"$TEMP_FILE" <<EOF
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+let
+  version = "$NEW_VERSION";
+  hashes = {
+    x86_64-linux = "$(nix-prefetch-url --type sha256 "https://github.com/denoland/rusty_v8/releases/download/v${NEW_VERSION}/librusty_v8_release_x86_64-unknown-linux-gnu.a.gz")";
+    aarch64-linux = "$(nix-prefetch-url --type sha256 "https://github.com/denoland/rusty_v8/releases/download/v${NEW_VERSION}/librusty_v8_release_aarch64-unknown-linux-gnu.a.gz")";
+  };
+in
+stdenv.mkDerivation {
+  name = "librusty_v8-\${version}";
+
+  src = fetchurl {
+    url = "https://github.com/denoland/rusty_v8/releases/download/v\${version}/librusty_v8_release_\${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+    sha256 =
+      hashes.\${stdenv.hostPlatform.system}
+        or (throw "librusty_v8: unsupported platform \${stdenv.hostPlatform.system}");
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+    gzip -cd "\$src" > "\$out"
+    runHook postInstall
+  '';
+
+  meta = {
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames hashes;
+  };
+}
+EOF
+
+mv "$TEMP_FILE" "$OUTPUT_FILE"
+echo "Updated librusty_v8 from $CURRENT_VERSION to $NEW_VERSION."


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `obscura --help` runs successfully
  - `obscura fetch https://example.com --eval "document.title"` outputs `Example Domain`
  - `obscura-worker` binary present
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
