### PR TITLE
newlisp: change upstream to Debian

### DIFF
--- a/pkgs/by-name/ne/newlisp/package.nix
+++ b/pkgs/by-name/ne/newlisp/package.nix
@@ -6,12 +6,13 @@
   readline,
 }:
 
+# FIXME: The original upstream `www.newlisp.org` does not resolve.
 stdenv.mkDerivation (finalAttrs: {
   pname = "newlisp";
   version = "10.7.5";
 
   src = fetchurl {
-    url = "https://www.newlisp.org/downloads/newlisp-${finalAttrs.version}.tgz";
+    url = "http://deb.debian.org/debian/pool/main/n/newlisp/newlisp_${finalAttrs.version}.orig.tar.gz";
     hash = "sha256-3C0P9lHCsnW8SvOvi6WYUab7bh6t3CCudftgsekBJuw=";
   };
 
@@ -39,9 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       already built in. This includes networking functions, support for
       distributed and multicore processing, and Bayesian statistics.
     '';
-    homepage = "https://www.newlisp.org/";
-    downloadPage = "https://www.newlisp.org/downloads/";
-    changelog = "https://www.newlisp.org/downloads/newlisp-${finalAttrs.version}/doc/CHANGES";
+    downloadPage = "https://packages.debian.org/trixie/source/newlisp";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ rc-zb ];
     mainProgram = "newlisp";


### PR DESCRIPTION
Part of #514132. The original upstream `www.newlisp.org` [does not resolve](https://radar.cloudflare.com/scan/61ab7bae-c727-4d50-96a0-702b35552f73/summary). So I have to change it to the [source archive by Debian](https://packages.debian.org/trixie/source/newlisp).

The file hash does not change, so neither would the program's behavior change, I think.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
