### PR TITLE
[Backport release-25.11] drupal: 11.2.8 -> 11.2.11

### DIFF
--- a/pkgs/by-name/dr/drupal/package.nix
+++ b/pkgs/by-name/dr/drupal/package.nix
@@ -8,17 +8,17 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "drupal";
-  version = "11.2.8";
+  version = "11.2.11";
 
   src = fetchFromGitLab {
     domain = "git.drupalcode.org";
     owner = "project";
     repo = "drupal";
     tag = finalAttrs.version;
-    hash = "sha256-y561aeENxRMEFS0i2gMnTtSFfgQwCEM//tdiE3ub3Yc=";
+    hash = "sha256-rdcjcibX6tblmtme9GDhe4xCsMsy7z/TXsqr9hjJg6A=";
   };
 
-  vendorHash = "sha256-filBjabfUnqL4o1Oh3OC+EoyFrVI6xvFbWEyPZKsZ+Q=";
+  vendorHash = "sha256-eQWXb+DrDO7Nm4bz/+aWbtzgozAOsUizsvjHWSQELlE=";
   composerNoPlugins = false;
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a security update for Drupal from 11.2.8 to 11.2.11.

The release notes for this upgrade are listed here: https://www.drupal.org/project/drupal/releases/11.2.11

This commit is not cherry picked because the Ryantm upgrade bot is tracking the 11.3.x series of releases, and although that is suitable for the unstable branch, it makes more sense for the stable branch to stay on the 11.2.x series until NixOS 26.05 is released.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
