### PR TITLE
openshadinglanguage: unpin llvm, cleanup, adopt

### DIFF
--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
+    (lib.cmakeBool "USE_QT" false)
+
     # Build system implies llvm-config and llvm-as are in the same directory.
     # Override defaults.
     (lib.cmakeFeature "LLVM_BC_GENERATOR" "${clang}/bin/clang++")

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -1,6 +1,5 @@
 {
   bison,
-  boost,
   cmake,
   fetchFromGitHub,
   flex,
@@ -19,7 +18,6 @@
 }:
 
 let
-  boost_static = boost.override { enableStatic = true; };
   inherit (llvmPackages) clang libclang llvm;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -34,10 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    (lib.cmakeBool "ENABLE_RTTI" true)
-    (lib.cmakeBool "USE_BOOST_WAVE" true)
-    (lib.cmakeFeature "Boost_ROOT" "${boost}")
-
     # Build system implies llvm-config and llvm-as are in the same directory.
     # Override defaults.
     (lib.cmakeFeature "LLVM_BC_GENERATOR" "${clang}/bin/clang++")
@@ -62,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost_static
     hexdump
     libclang
     llvm

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Advanced shading language for production GI renderers";
     homepage = "http://openshadinglanguage.org";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.amarshall ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "LLVM_DIRECTORY" "${llvm}")
   ];
 
-  prePatch = ''
+  postPatch = ''
     substituteInPlace src/cmake/modules/FindLLVM.cmake \
       --replace-fail "NO_DEFAULT_PATH" ""
   '';

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -4,6 +4,7 @@
   cmake,
   fetchFromGitHub,
   flex,
+  hexdump,
   lib,
   libxml2,
   llvmPackages,
@@ -14,7 +15,6 @@
   python3Packages,
   robin-map,
   stdenv,
-  util-linux,
   zlib,
 }:
 
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     boost_static
+    hexdump
     libclang
     llvm
     openexr
@@ -71,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     pugixml
     python3Packages.pybind11
     robin-map
-    util-linux # needed just for hexdump
     zlib
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -34,15 +34,15 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    "-DBoost_ROOT=${boost}"
-    "-DUSE_BOOST_WAVE=ON"
-    "-DENABLE_RTTI=ON"
+    (lib.cmakeBool "ENABLE_RTTI" true)
+    (lib.cmakeBool "USE_BOOST_WAVE" true)
+    (lib.cmakeFeature "Boost_ROOT" "${boost}")
 
     # Build system implies llvm-config and llvm-as are in the same directory.
     # Override defaults.
-    "-DLLVM_DIRECTORY=${llvm}"
-    "-DLLVM_CONFIG=${llvm.dev}/bin/llvm-config"
-    "-DLLVM_BC_GENERATOR=${clang}/bin/clang++"
+    (lib.cmakeFeature "LLVM_BC_GENERATOR" "${clang}/bin/clang++")
+    (lib.cmakeFeature "LLVM_CONFIG" "${llvm.dev}/bin/llvm-config")
+    (lib.cmakeFeature "LLVM_DIRECTORY" "${llvm}")
   ];
 
   prePatch = ''

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -6,7 +6,7 @@
   flex,
   lib,
   libxml2,
-  llvmPackages_19,
+  llvmPackages,
   openexr,
   openimageio,
   partio,
@@ -20,7 +20,7 @@
 
 let
   boost_static = boost.override { enableStatic = true; };
-  inherit (llvmPackages_19) clang libclang llvm;
+  inherit (llvmPackages) clang libclang llvm;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openshadinglanguage";


### PR DESCRIPTION
See individual commits for details. Fixes `blender.passthru.tests.render` and should fix https://github.com/NixOS/nixpkgs/issues/508671.

## Things done

Tested via Blender

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
