### PR TITLE
blender: cleanup

### DIFF
--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -281,6 +281,7 @@ stdenv'.mkDerivation (finalAttrs: {
     (opensubdiv.override { inherit cudaSupport; })
     onetbb
     openvdb
+    openxr-loader
     potrace
     pugixml
     python3
@@ -304,7 +305,6 @@ stdenv'.mkDerivation (finalAttrs: {
         libxrender
         libxxf86vm
         openal
-        openxr-loader
       ]
     else
       [
@@ -314,7 +314,6 @@ stdenv'.mkDerivation (finalAttrs: {
         apple-sdk_15
         brotli
         llvmPackages.openmp
-        openxr-loader
       ]
   )
   ++ lib.optionals stdenv.hostPlatform.isAarch64 [ sse2neon ]

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -1,5 +1,4 @@
 {
-  SDL,
   addDriverRunpath,
   alembic,
   apple-sdk_15,
@@ -15,8 +14,8 @@
   cudaSupport ? config.cudaSupport,
   dbus,
   embree,
-  fetchzip,
   fetchFromGitHub,
+  fetchzip,
   ffmpeg_7,
   fftw,
   fftwFloat,
@@ -27,16 +26,11 @@
   jackaudioSupport ? false,
   jemalloc,
   lib,
-  libGL,
-  libGLU,
-  libx11,
-  libxext,
-  libxi,
-  libxrender,
-  libxxf86vm,
   libdecor,
   libepoxy,
   libffi,
+  libGL,
+  libGLU,
   libharu,
   libjack2,
   libjpeg,
@@ -46,13 +40,18 @@
   libspnav,
   libtiff,
   libwebp,
+  libx11,
+  libxext,
+  libxi,
   libxkbcommon,
+  libxrender,
+  libxxf86vm,
   llvmPackages,
   makeWrapper,
   manifold,
   mesa,
   nix-update-script,
-  openUsdSupport ? !stdenv.hostPlatform.isDarwin,
+  onetbb,
   openal,
   opencollada-blender,
   opencolorio,
@@ -62,6 +61,7 @@
   openjpeg,
   openpgl,
   opensubdiv,
+  openUsdSupport ? !stdenv.hostPlatform.isDarwin,
   openvdb,
   openxr-loader,
   pkg-config,
@@ -72,11 +72,11 @@
   rocmSupport ? config.rocmSupport,
   rubberband,
   runCommand,
+  SDL,
   shaderc,
   spaceNavSupport ? stdenv.hostPlatform.isLinux,
   sse2neon,
   stdenv,
-  onetbb,
   vulkan-headers,
   vulkan-loader,
   wayland,
@@ -184,7 +184,6 @@ stdenv'.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_CYCLES_EMBREE" embreeSupport)
     (lib.cmakeBool "WITH_CYCLES_OSL" true)
     (lib.cmakeBool "WITH_CYCLES_PARALLEL_DEVICE_KERNEL_BUILD" true)
-    (lib.cmakeBool "WITH_SYSTEM_GLOG" true)
     (lib.cmakeBool "WITH_HYDRA" openUsdSupport)
     (lib.cmakeBool "WITH_INSTALL_PORTABLE" false)
     (lib.cmakeBool "WITH_JACK" jackaudioSupport)
@@ -197,6 +196,7 @@ stdenv'.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_PYTHON_INSTALL_NUMPY" false)
     (lib.cmakeBool "WITH_PYTHON_INSTALL_REQUESTS" false)
     (lib.cmakeBool "WITH_STRICT_BUILD_OPTIONS" true)
+    (lib.cmakeBool "WITH_SYSTEM_GLOG" true)
     (lib.cmakeBool "WITH_USD" openUsdSupport)
 
     # Blender supplies its own FindAlembic.cmake (incompatible with the Alembic-supplied config file)
@@ -279,8 +279,8 @@ stdenv'.mkDerivation (finalAttrs: {
     openjpeg
     openpgl
     (opensubdiv.override { inherit cudaSupport; })
-    openvdb
     onetbb
+    openvdb
     potrace
     pugixml
     python3
@@ -455,10 +455,10 @@ stdenv'.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl2Plus ] ++ lib.optional cudaSupport nvidiaCudaRedist;
 
     platforms = [
+      "aarch64-darwin"
       "aarch64-linux"
       "x86_64-darwin"
       "x86_64-linux"
-      "aarch64-darwin"
     ];
     maintainers = with lib.maintainers; [
       amarshall

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -183,6 +183,7 @@ stdenv'.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_CYCLES_DEVICE_OPTIX" cudaSupport)
     (lib.cmakeBool "WITH_CYCLES_EMBREE" embreeSupport)
     (lib.cmakeBool "WITH_CYCLES_OSL" true)
+    (lib.cmakeBool "WITH_CYCLES_PARALLEL_DEVICE_KERNEL_BUILD" true)
     (lib.cmakeBool "WITH_SYSTEM_GLOG" true)
     (lib.cmakeBool "WITH_HYDRA" openUsdSupport)
     (lib.cmakeBool "WITH_INSTALL_PORTABLE" false)

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -213,9 +213,7 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals waylandSupport [
     (lib.cmakeBool "WITH_GHOST_WAYLAND" true)
-    (lib.cmakeBool "WITH_GHOST_WAYLAND_DBUS" true)
     (lib.cmakeBool "WITH_GHOST_WAYLAND_DYNLOAD" false)
-    (lib.cmakeBool "WITH_GHOST_WAYLAND_LIBDECOR" true)
   ]
   ++ lib.optionals stdenv.cc.isClang [
     (lib.cmakeFeature "PYTHON_LINKFLAGS" "") # Clang doesn't support "-export-dynamic"

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -451,8 +451,6 @@ stdenv'.mkDerivation (finalAttrs: {
   meta = {
     description = "3D Creation/Animation/Publishing System";
     homepage = "https://www.blender.org";
-    # They comment two licenses: GPLv2 and Blender License, but they
-    # say: "We've decided to cancel the BL offering for an indefinite period."
     # OptiX, enabled with cudaSupport, is non-free.
     license = with lib.licenses; [ gpl2Plus ] ++ lib.optional cudaSupport nvidiaCudaRedist;
 

--- a/pkgs/by-name/bl/blender/wrapper.nix
+++ b/pkgs/by-name/bl/blender/wrapper.nix
@@ -15,15 +15,12 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
   installPhase = ''
-    mkdir $out/{share/applications,bin} -p
-    sed 's/Exec=blender/Exec=${finalAttrs.finalPackage.pname}/g' $src/share/applications/blender.desktop > $out/share/applications/${finalAttrs.finalPackage.pname}.desktop
-    cp -r $src/share/blender $out/share
-    cp -r $src/share/doc $out/share
-    cp -r $src/share/icons $out/share
+    mkdir $out/bin -p
+    cp -r $src/share $out/share
 
     buildPythonPath "''${pythonPath[*]}"
 
-    makeWrapper ${blender}/bin/blender $out/bin/${finalAttrs.finalPackage.pname} \
+    makeWrapper ${blender}/bin/blender $out/bin/blender \
       --prefix PATH : $program_PATH \
       --prefix PYTHONPATH : $program_PYTHONPATH
   '';


### PR DESCRIPTION
See individual commits for details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
