### PR TITLE
minimal-bootstrap: trim python and glibc closure further

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/glibc/default.nix
@@ -115,4 +115,5 @@ bash.runCommand "${pname}-${version}"
 
     # localedef + iconv() are never invoked downstream of this glibc
     rm -rf $out/share/i18n $out/lib/gconv $out/share/locale
+    rm -rf $out/bin $out/sbin
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/python/default.nix
@@ -115,4 +115,17 @@ bash.runCommand "${pname}-${version}"
       ! -name 'math*' \
       ! -name 'select*' \
       -delete
+
+    rm -rf \
+      $out/lib/python*/ensurepip \
+      $out/lib/python*/idlelib \
+      $out/lib/python*/site-packages \
+      $out/lib/python*/test \
+      $out/lib/python*/tkinter \
+      $out/lib/python*/turtledemo \
+      $out/share/man
+
+    rm -f $out/bin/idle* $out/bin/pip*
+    find $out/lib/python* -type d -name __pycache__ -prune -exec rm -rf {} +
+    strip --strip-unneeded $out/bin/python${lib.versions.majorMinor version} $out/lib/python*/lib-dynload/*.so || true
   ''


### PR DESCRIPTION
Follow-up to #513872, shaving more unused content from the minimal-bootstrap Python and glibc outputs.

Across the measured bootstrap derivations, total self-size drops from **608.6 MB to 536.3 MB (−11.9 %)** and total closure size drops from **1114.7 MB to 888.9 MB (−20.3 %)**.

Python already builds without test modules, ensurepip, or a static libpython. This additionally removes installed Python trees that are not used by the bootstrap chain (`ensurepip`, `idlelib`, `site-packages`, `test`, `tkinter`, `turtledemo`, manpages, `pip*`/`idle*` entry points, and `__pycache__` directories), then strips the interpreter and extension modules.

The glibc side removes `$out/bin` and `$out/sbin` after install. The bootstrap chain consumes glibc headers and libraries; these helper programs are not used by downstream stages.

Measured against `36d5b9325f41 python3Packages.joserfc: disable failing tests (#514243)`.

| derivation | self before | self after | closure before | closure after |
|---|---:|---:|---:|---:|
| python | 88.8 MB | 18.9 MB | 346.6 MB | 125.7 MB |
| gcc46-cxx | 47.3 MB | 47.3 MB | 76.2 MB | 76.2 MB |
| gcc46 | 22.2 MB | 22.2 MB | 46.4 MB | 46.4 MB |
| binutils | 36.6 MB | 36.6 MB | 67.9 MB | 67.9 MB |
| binutils-static | 24.3 MB | 24.3 MB | 44.9 MB | 44.9 MB |
| gcc-latest | 138.8 MB | 138.8 MB | 176.8 MB | 176.8 MB |
| gcc-glibc | 134.5 MB | 134.5 MB | 199.6 MB | 197.1 MB |
| gcc10 | 96.0 MB | 96.0 MB | 129.3 MB | 129.3 MB |
| glibc | 20.3 MB | 17.8 MB | 27.0 MB | 24.5 MB |

<details>
<summary>Replicating the measurements</summary>

Measurements use decimal MB. For each output, self-size is `du -sb` on the output path and closure size is `nix path-info --closure-size`.

```bash
attrs=(
  minimal-bootstrap.python
  minimal-bootstrap.gcc46-cxx
  minimal-bootstrap.gcc46
  minimal-bootstrap.binutils
  minimal-bootstrap.binutils-static
  minimal-bootstrap.gcc-latest
  minimal-bootstrap.glibc
  minimal-bootstrap.gcc-glibc
  minimal-bootstrap.gcc10
)

measure() {
  for attr in "${attrs[@]}"; do
    out=$(nix-build --no-out-link -A "$attr")
    self=$(du -sb "$out" | awk '{print $1}')
    closure=$(nix path-info --closure-size "$out" | awk '{print $2}')
    printf '%s\t%s\t%s\t%s\n' "$attr" "$self" "$closure" "$out"
  done
}

git checkout 36d5b9325f41
measure > /tmp/minimal-bootstrap-before.tsv

git checkout siraben/bootstrap-closure-python
measure > /tmp/minimal-bootstrap-after.tsv
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
