### PR TITLE
attest: init at 0.5.4

### DIFF
--- a/pkgs/by-name/at/attest/package.nix
+++ b/pkgs/by-name/at/attest/package.nix
@@ -1,0 +1,37 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "attest";
+  version = "0.4.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fossable";
+    repo = "attest";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rHlnEbl6Z0Tch7JiF5aNTVgsEZ00sUjfYAMrGTcDAdI=";
+  };
+
+  cargoHash = "sha256-DGrrV2y5Gv0HKk2d+/MB+Kn86hVZdiCNXS5QNFCMqkg=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "attest";
+    description = "Dead simple test framework for the age of AI";
+    homepage = "https://github.com/fossable/attest";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cilki ];
+  };
+})

--- a/pkgs/by-name/at/attest/package.nix
+++ b/pkgs/by-name/at/attest/package.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "attest";
+  version = "0.5.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fossable";
+    repo = "attest";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fc/kzBKuaTIZQd/RD3xWyZfpzP9eMER0FnBgouJVVZM=";
+  };
+
+  cargoHash = "sha256-RN8L5HlYshgmfEqkHAfLAnHZVqWlQ4YDyQXfICg/Dtg=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "attest";
+    description = "Dead simple test framework for the age of AI";
+    homepage = "https://github.com/fossable/attest";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cilki ];
+  };
+})

--- a/pkgs/by-name/at/attest/package.nix
+++ b/pkgs/by-name/at/attest/package.nix
@@ -13,10 +13,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "fossable";
+    owner = "cilki";
     repo = "attest";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-fc/kzBKuaTIZQd/RD3xWyZfpzP9eMER0FnBgouJVVZM=";
+    tag = "3c12213f59cd13ff54fc415ba153c815e8bc1c17";
+    hash = "sha256-c1ibpul1+gGjajqKfbN9ykBhfLCd2BPVcypzQLmSWoM=";
   };
 
   cargoHash = "sha256-RN8L5HlYshgmfEqkHAfLAnHZVqWlQ4YDyQXfICg/Dtg=";


### PR DESCRIPTION
Add simple test framework for CLI applications: https://github.com/fossable/attest

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
