### PR TITLE
yaziPlugins.close-and-restore-tab: init at 0-unstable-2026-04-22

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/close-and-restore-tab/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/close-and-restore-tab/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "close-and-restore-tab.yazi";
+  version = "0-unstable-2026-04-22";
+
+  src = fetchFromGitHub {
+    owner = "MasouShizuka";
+    repo = "close-and-restore-tab.yazi";
+    rev = "5047217e59f9c2f4aa5ae15baa92df7b3f724e67";
+    hash = "sha256-bsx6HVdB2CcKXQG+tGxY2T8Ys8TluIe6xWHhOhv4L4I=";
+  };
+
+  meta = {
+    description = "A Yazi plugin that adds the functionality to close and restore tab";
+    homepage = "https://github.com/MasouShizuka/close-and-restore-tab.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nemeott ];
+  };
+}


### PR DESCRIPTION
Added `yaziPlugins.close-and-restore-tab`. Plugin that adds the ability to restore closed tabs. Useful in case you accidentally closed something. [https://github.com/MasouShizuka/close-and-restore-tab.yazi](https://github.com/MasouShizuka/close-and-restore-tab.yazi).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
