### PR TITLE
init: solder at 0.2.0

### DIFF
--- a/pkgs/by-name/so/solder/package.nix
+++ b/pkgs/by-name/so/solder/package.nix
@@ -1,0 +1,37 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "solder";
+  version = "0.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fossable";
+    repo = "solder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N1nggPClY4PjhvsgEQV+AVL8Ri74eXz1p/GFCPu+cbc=";
+  };
+
+  cargoHash = "sha256-au9bo7llYS8PiZvfNDC6w7HsURShKwBW9HUm12qUY30=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "solder";
+    description = "Fuse shared libraries into ELFs";
+    homepage = "https://github.com/fossable/solder";
+    license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cilki ];
+  };
+})


### PR DESCRIPTION
Add new package for merging shared libraries post-link: https://github.com/fossable/solder

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
