### PR TITLE
liquidsoap: 2.4.2 → 2.4.4

### DIFF
--- a/pkgs/by-name/li/liquidsoap/package.nix
+++ b/pkgs/by-name/li/liquidsoap/package.nix
@@ -11,13 +11,13 @@
   bubblewrap,
   curl,
   dune,
-  ffmpeg_6-full,
+  ffmpeg_8-full,
   yt-dlp,
   runtimePackages ? [
     awscli2
     bubblewrap
     curl
-    ffmpeg_6-full
+    ffmpeg_8-full
     yt-dlp
   ],
 }:
@@ -26,13 +26,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "liquidsoap";
-  version = "2.4.2";
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "liquidsoap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ViJlG+AUncL37mltlFFXVho98Up11qZI3wwSnrd9C8g=";
+    hash = "sha256-uRqYyxLF6PuSDvbL77qn2PvttqqM9S00BjcaKUFxlQw=";
   };
 
   postPatch = ''
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    dune build
+    dune build --release @install
 
     runHook postBuild
   '';
@@ -87,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     libjpeg
 
     # Mandatory dependencies
+    ocamlPackages.domain_shims
     ocamlPackages.dtools
     ocamlPackages.duppy
     ocamlPackages.mm

--- a/pkgs/development/ocaml-modules/ffmpeg/base.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/base.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub }:
 
 rec {
-  version = "1.2.8";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-ffmpeg";
     tag = "v${version}";
-    hash = "sha256-wQvpbvAAg4tybAFdGq0O9vfCc0v2iPFk04Q3zgTwa7Y=";
+    hash = "sha256-qGXuE+wHNuy24jeuGpvMlYIQw7N5g6tXMa7r0pwXVX0=";
   };
 
   meta = {


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
