### PR TITLE
cc-wrapper: fix `import std` support with Clang + LLVM libc++

### DIFF
--- a/pkgs/build-support/cc-wrapper/clang-scan-deps-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/clang-scan-deps-wrapper.sh
@@ -15,7 +15,7 @@ buildcpath() {
     esac
     shift
   done
-  echo $path${after:+':'}$after
+  printf "%s" "$path${after:+':'}$after"
 }
 
 buildcpluspath() {
@@ -33,7 +33,7 @@ buildcpluspath() {
     esac
     shift
   done
-  echo $path${after:+':'}$after
+  printf "%s" "$path${after:+':'}$after"
 }
 
 export C_INCLUDE_PATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \

--- a/pkgs/build-support/cc-wrapper/clang-scan-deps-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/clang-scan-deps-wrapper.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+buildcpath() {
+  local path after
+  while (( $# )); do
+    case $1 in
+        -isystem)
+            shift
+            path=$path${path:+':'}$1
+            ;;
+        -idirafter)
+            shift
+            after=$after${after:+':'}$1
+            ;;
+    esac
+    shift
+  done
+  echo $path${after:+':'}$after
+}
+
+buildcpluspath() {
+  local path after
+  while (( $# )); do
+    case $1 in
+        -isystem|-cxx-isystem)
+            shift
+            path=$path${path:+':'}$1
+            ;;
+        -idirafter)
+            shift
+            after=$after${after:+':'}$1
+            ;;
+    esac
+    shift
+  done
+  echo $path${after:+':'}$after
+}
+
+export C_INCLUDE_PATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                        $(<@out@/nix-support/libc-cflags))
+
+export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpluspath ${NIX_CFLAGS_COMPILE} \
+                                                                                          $(<@out@/nix-support/libcxx-cxxflags) \
+                                                                                          $(<@out@/nix-support/libc-cflags))
+
+exec @prog@ "$@"

--- a/pkgs/build-support/cc-wrapper/clang-scan-deps-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/clang-scan-deps-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! @shell@
 
 buildcpath() {
   local path after
@@ -15,7 +15,7 @@ buildcpath() {
     esac
     shift
   done
-  printf "%s" "$path${after:+':'}$after"
+  printf "%s" "$path${after:+:}$after"
 }
 
 buildcpluspath() {
@@ -33,7 +33,7 @@ buildcpluspath() {
     esac
     shift
   done
-  printf "%s" "$path${after:+':'}$after"
+  printf "%s" "$path${after:+:}$after"
 }
 
 export C_INCLUDE_PATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -554,6 +554,10 @@ stdenvNoCC.mkDerivation {
     elif [ -e $ccPath/cpp${exeSuffix} ]; then
       wrap ${targetPrefix}cpp $wrapper $ccPath/cpp${exeSuffix}
     fi
+
+    if [ -e $ccPath/clang-scan-deps${exeSuffix} ]; then
+      wrap ${targetPrefix}clang-scan-deps ${./clang-scan-deps-wrapper.sh} $ccPath/clang-scan-deps${exeSuffix}
+    fi
   ''
 
   # No need to wrap gnat, gnatkr, gnatname or gnatprep; we can just symlink them in

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -770,6 +770,7 @@ stdenvNoCC.mkDerivation {
     ''
     + optionalString (libcxx.isLLVM or false) ''
       include -cxx-isystem "${getDev libcxx}/include/c++/v1" >> $out/nix-support/libcxx-cxxflags
+      echo "-B${getLib libcxx}/lib" >> $out/nix-support/libcxx-cxxflags
       echo "-stdlib=libc++" >> $out/nix-support/libcxx-ldflags
     ''
     # GCC NG friendly libc++

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -556,6 +556,14 @@ stdenvNoCC.mkDerivation {
     fi
   ''
 
+  # This is used by C++20 modules support in cmake.
+  + optionalString isClang ''
+    if [ -e $ccPath/clang-scan-deps${exeSuffix} ]; then
+      export clang="$out"
+      wrap ${targetPrefix}clang-scan-deps ${../../development/compilers/llvm/common/clang-tools/wrapper} $ccPath/clang-scan-deps${exeSuffix}
+    fi
+  ''
+
   # No need to wrap gnat, gnatkr, gnatname or gnatprep; we can just symlink them in
   + optionalString cc.langAda or false ''
     for cmd in gnatbind gnatchop gnatclean gnatlink gnatls gnatmake; do

--- a/pkgs/development/compilers/llvm/common/clang-tools/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang-tools/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   runCommand,
   writeText,
+  runtimeShell,
   clang-unwrapped,
   clang,
   libcxxClang,
@@ -17,6 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = lib.getVersion clang-unwrapped;
   dontUnpack = true;
   clang = if enableLibcxx then libcxxClang else clang;
+  shell = runtimeShell;
 
   installPhase = ''
     runHook preInstall
@@ -38,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       fi
 
       cp $toolPath $out/bin/$toolName-unwrapped
+      export prog="$out/bin/$toolName-unwrapped"
       substituteAll ${./wrapper} $out/bin/$toolName
       chmod +x $out/bin/$toolName
     done

--- a/pkgs/development/compilers/llvm/common/clang-tools/wrapper
+++ b/pkgs/development/compilers/llvm/common/clang-tools/wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! @shell@
 
 buildcpath() {
   local path after
@@ -15,7 +15,7 @@ buildcpath() {
     esac
     shift
   done
-  echo $path${after:+':'}$after
+  printf "%s" "$path${after:+:}$after"
 }
 
 buildcpluspath() {
@@ -33,7 +33,7 @@ buildcpluspath() {
     esac
     shift
   done
-  echo $path${after:+':'}$after
+  printf "%s" "$path${after:+:}$after"
 }
 
 # When user passes `--query-driver`, avoid extending `CPATH` et al, since we
@@ -55,4 +55,4 @@ if [ "$extendcpath" = true ]; then
                                                                                             $(<@clang@/nix-support/libc-cflags))
 fi
 
-@out@/bin/$(basename $0)-unwrapped "$@"
+exec @prog@ "$@"


### PR DESCRIPTION
Fixes two issues that prevented C++23 `import std` from working in nixpkgs with Clang + LLVM libc++. In particular, this resolves CMake build failures caused by `clang-scan-deps` being invoked without the correct libc++ include paths — a breakage that silently affects any C++20 package declaring `cmake_minimum_required(VERSION 4.0)` or later in standard `stdenv`.

Closes #370217, Closes #452260

---
## Problem 1: `libc++.modules.json` not found

CMake locates `libc++.modules.json` by running:

```
clang++ --print-file-name=libc++.modules.json
```

Without `-B${getLib libcxx}/lib` in the wrapper, the libc++ lib directory is absent from the search path used by `--print-file-name`, so `libc++.modules.json` cannot be located. Adding `-B${getLib libcxx}/lib` makes the directory discoverable to this lookup.

**Fix:** add `-B${getLib libcxx}/lib` to `nix-support/libcxx-cxxflags` when wrapping with LLVM libc++. This also supersedes the manual workaround via `NIX_CFLAGS_COMPILE` described in #370217.

## Problem 2: `clang-scan-deps` is not wrapped

CMake invokes `clang-scan-deps` to scan `std.cppm` for dependencies. The cc-wrapper setup-hook puts the unwrapped compiler's `bin/` on `PATH`, so the unwrapped `clang-scan-deps` is picked up directly — without any libc++ include paths — and fails to discover the stdlib, causing the scan to fail. The workaround has been to add `clang-tools` to `nativeBuildInputs` (#452260), but this is wrong for two reasons:

1. **Wrong package.** `clang-scan-deps` is a build tool invoked automatically by CMake — it is not a developer tool. Placing it in `clang-tools` forces every C++20 CMake package to explicitly pull in a developer-tool collection just to get basic compilation working.

2. **Silently breaks all affected C++20 packages.** CMake 4.0+ automatically invokes `clang-scan-deps` when both `cmake_minimum_required(VERSION 4.0)` or later is declared and a C++20 target is present. Every such package silently fails in standard `stdenv` unless `clang-tools` is manually added.
Reproducer ([source](https://github.com/gen740/nixpkgs-fails-on-cxx20)): `nix build github:gen740/nixpkgs-fails-on-cxx20`

**Fix:** wrap `clang-scan-deps` in cc-wrapper using the same wrapper script as `clang-tools`, so it can discover the stdlib.

---


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test