### PR TITLE
glib: fix MinGW build

### DIFF
--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -9,7 +9,6 @@
   pkg-config,
   perl,
   python3,
-  python3Packages,
   libiconv,
   zlib,
   libffi,
@@ -196,8 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     perl
     python3
-    python3Packages.packaging # mostly used to make meson happy
-    python3Packages.wrapPython # for patchPythonScript
     gettext
     libxslt
   ]
@@ -296,11 +293,6 @@ stdenv.mkDerivation (finalAttrs: {
     for i in $dev/bin/*; do
       moveToOutput "share/bash-completion/completions/''${i##*/}" "$dev"
     done
-  '';
-
-  preFixup = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-    buildPythonPath ${python3Packages.packaging}
-    patchPythonScript "$dev/share/glib-2.0/codegen/utils.py"
   '';
 
   # Move man pages to the same output as their binaries (needs to be

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     finalAttrs.setupHook
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [
+  ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD && !stdenv.hostPlatform.isWindows) [
     libsysprof-capture
   ]
   ++ [
@@ -240,6 +240,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
     "-Dxattr=false"
     "-Dsysprof=disabled" # sysprof-capture does not build on FreeBSD
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isWindows [
+    "-Dsysprof=disabled" # sysprof-capture does not build on Windows
   ];
 
   env = {

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -9,7 +9,6 @@
   pkg-config,
   perl,
   python3,
-  python3Packages,
   libiconv,
   zlib,
   libffi,
@@ -193,8 +192,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     perl
     python3
-    python3Packages.packaging # mostly used to make meson happy
-    python3Packages.wrapPython # for patchPythonScript
     gettext
     libxslt
   ]
@@ -293,11 +290,6 @@ stdenv.mkDerivation (finalAttrs: {
     for i in $dev/bin/*; do
       moveToOutput "share/bash-completion/completions/''${i##*/}" "$dev"
     done
-  '';
-
-  preFixup = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-    buildPythonPath ${python3Packages.packaging}
-    patchPythonScript "$dev/share/glib-2.0/codegen/utils.py"
   '';
 
   # Move man pages to the same output as their binaries (needs to be

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -160,7 +160,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     finalAttrs.setupHook
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD) [
+  ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD && !stdenv.hostPlatform.isWindows) [
     libsysprof-capture
   ]
   ++ [
@@ -237,6 +237,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
     "-Dxattr=false"
     "-Dsysprof=disabled" # sysprof-capture does not build on FreeBSD
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isWindows [
+    "-Dsysprof=disabled" # sysprof-capture does not build on Windows
   ];
 
   env = {

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -77,6 +77,8 @@ let
     &&
       # dtrace support requires sys/sdt.h header
       lib.meta.availableOn stdenv.hostPlatform libsystemtap;
+
+  withSysprofCapture = !stdenv.hostPlatform.isWindows && !stdenv.hostPlatform.isFreeBSD;
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -160,7 +162,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     finalAttrs.setupHook
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isFreeBSD && !stdenv.hostPlatform.isWindows) [
+  ++ lib.optionals withSysprofCapture [
     libsysprof-capture
   ]
   ++ [
@@ -230,16 +232,12 @@ stdenv.mkDerivation (finalAttrs: {
     # FIXME: Fails when linking target glib/tests/libconstructor-helper.so
     # relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
     "-Dtests=${lib.boolToString (!stdenv.hostPlatform.isStatic)}"
-  ]
-  ++ lib.optionals (!lib.meta.availableOn stdenv.hostPlatform elfutils) [
-    "-Dlibelf=disabled"
+    (lib.mesonEnable "libelf" (lib.meta.availableOn stdenv.hostPlatform elfutils))
+    # sysprof-capture does not build on Windows
+    (lib.mesonEnable "sysprof" withSysprofCapture)
   ]
   ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
     "-Dxattr=false"
-    "-Dsysprof=disabled" # sysprof-capture does not build on FreeBSD
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isWindows [
-    "-Dsysprof=disabled" # sysprof-capture does not build on Windows
   ];
 
   env = {


### PR DESCRIPTION
Fix blockers for building `glib` on `mingw-{msvcrt,ucrt}-x86_64`:

- Remove Python `packaging` dependency, which does not build on MinGW hosts and is [no longer used](https://gitlab.gnome.org/GNOME/glib/-/commit/41d34f497661df6f04f6cee9c752ab487629b9dd) by `glib`.

- Disable sysprof because the libsysprof-capture dependency does not build on MinGW hosts (#456657).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
