### PR TITLE
 pythonPackages.googletrans: Remove changelog URL from googletrans metadata

### DIFF
--- a/pkgs/development/python-modules/googletrans/default.nix
+++ b/pkgs/development/python-modules/googletrans/default.nix
@@ -28,7 +28,6 @@ buildPythonPackage rec {
   meta = {
     description = "Library to interact with Google Translate API";
     homepage = "https://py-googletrans.readthedocs.io";
-    changelog = "https://github.com/ssut/py-googletrans/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ unode ];
     mainProgram = "translate";


### PR DESCRIPTION
Upstream does not provide a reliable changelog source for all versions.
It was exceptionally done for [release 4.0.0](https://github.com/ssut/py-googletrans/releases/tag/v4.0.0) but no other since.

Fixes 404 in changelog URL reported in #514132