### PR TITLE
kata-runtime: 3.21.0 -> 3.29.0

### DIFF
--- a/pkgs/by-name/ka/kata-runtime/kata-images.nix
+++ b/pkgs/by-name/ka/kata-runtime/kata-images.nix
@@ -17,8 +17,8 @@ let
 
   imageHash =
     {
-      "x86_64-linux" = "sha256-roS2pGO00ORN+xxNU3/uqJG9RzhVqf8gCkt8EJJbY/g=";
-      "aarch64-linux" = "sha256-AuK5a2Qtd176B91+vSsEFwuWICpe8wcGTbXoE7B8b20=";
+      "x86_64-linux" = "sha256-sHPFf5DKsLjCiCG6PSjCEFcEtzESOxsVD162Ui/nCRc=";
+      "aarch64-linux" = "sha256-43P2MIMfE6+kB4/Ehe0NHmZhcd0/5Tnzj9vml5NxNWk=";
     }
     ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 

--- a/pkgs/by-name/ka/kata-runtime/package.nix
+++ b/pkgs/by-name/ka/kata-runtime/package.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "3.21.0";
+  version = "3.29.0";
 
   kata-images = callPackage ./kata-images.nix { inherit version; };
 
@@ -34,7 +34,7 @@ buildGoModule rec {
     owner = "kata-containers";
     repo = "kata-containers";
     rev = version;
-    hash = "sha256-gOPabvimKzP7U1/BRzjKPDKE0MHnhKI4j0WZPM6ZTSA=";
+    hash = "sha256-AjGqKJVrcfHLY0NosBWFOgKC3eiU9hsFXQsU+LM8XME=";
   };
 
   sourceRoot = "${src.name}/src/runtime";


### PR DESCRIPTION
This should close #420414 by picking up the upstream fix https://github.com/kata-containers/kata-containers/pull/12754, which landed in 3.29.0. See https://github.com/kata-containers/kata-containers/releases/tag/3.29.0.

CC @dinvlad @HeroBrine1st


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
