### PR TITLE
Revert "lib/strings.concatLines: call concatStringsSep directly"

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -337,6 +337,7 @@ rec {
 
   /**
     Concatenate a list of strings, adding a newline at the end of each one.
+    Defined as `concatMapStrings (s: s + "\n")`.
 
     # Inputs
 
@@ -360,7 +361,7 @@ rec {
 
     :::
   */
-  concatLines = str: concatStringsSep "\n" str + "\n";
+  concatLines = concatMapStrings (s: s + "\n");
 
   /**
     Given string `s`, replace every occurrence of the string `from` with the string `to`.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -559,6 +559,10 @@ runTests {
     ];
     expected = "a\nb\nc\n";
   };
+  testConcatLinesEmpty = {
+    expr = concatLines [ ];
+    expected = "";
+  };
 
   testMakeIncludePathWithPkgs = {
     expr = (


### PR DESCRIPTION
This reverts commit d7e6988c9b7bd7ada8662752ff654e4fde1a1426.

Fixes #514235

Somehow I didn't catch this problem in the review. :confused: 

Added another commit to make sure the regression doesn't happen again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
