### PR TITLE
python3.pkgs.pyqt6: 6.9.0 -> 6.11.0

### DIFF
--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchzip,
+  fetchPypi,
   pkg-config,
   dbus,
   lndir,
@@ -29,14 +29,10 @@ buildPythonPackage (finalAttrs: {
   version = "6.9.0";
   pyproject = true;
 
-  # It looks like a stable release, but is it? Who knows.
-  # It's not on PyPI proper yet, at least, and the current
-  # actually-released version does not build with Qt 6.9,
-  # so we kinda have to use it.
-  # "ffs smdh fam" - K900
-  src = fetchzip {
-    url = "https://web.archive.org/web/20250406083944/https://www.riverbankcomputing.com/pypi/packages/PyQt6/pyqt6-6.9.0.tar.gz";
-    hash = "sha256-UZSbz6MqdNtl2r4N8uvgNjQ+28KCzNFb5yFqPcooT5E=";
+  src = fetchPypi {
+    pname = "pyqt6";
+    inherit (finalAttrs) version;
+    hash = "sha256-ao/4480YMRu32Tf310HnhwQK5/9HznUcKKlMXN3BtOY=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -24,7 +24,7 @@
   withPdf ? true,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyqt6";
   version = "6.9.0";
   pyproject = true;
@@ -66,7 +66,7 @@ buildPythonPackage rec {
     EOF
 
     substituteInPlace pyproject.toml \
-      --replace-fail 'version = "${version}"' 'version = "${lib.versions.pad 3 version}"'
+      --replace-fail 'version = "${finalAttrs.version}"' 'version = "${lib.versions.pad 3 finalAttrs.version}"'
   '';
 
   enableParallelBuilding = true;
@@ -166,4 +166,4 @@ buildPythonPackage rec {
     inherit (mesa.meta) platforms;
     maintainers = with lib.maintainers; [ LunNova ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -26,13 +26,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyqt6";
-  version = "6.9.0";
+  version = "6.11.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "pyqt6";
     inherit (finalAttrs) version;
-    hash = "sha256-ao/4480YMRu32Tf310HnhwQK5/9HznUcKKlMXN3BtOY=";
+    hash = "sha256-Rd1gqmmXbeGRi1zta057aiWr0qkZ7O9f1YJuzHZxiIk=";
   };
 
   patches = [


### PR DESCRIPTION
It is a good practice to make PyQt6's version match that of Qt itself.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test