### PR TITLE
treewide changelogs fixes

### DIFF
--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
       primarily intended for automatic, unattended downloading of podcasts.
     '';
     homepage = "https://castget.johndal.com/";
-    changelog = "https://github.com/mlj/castget/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mlj/castget/blob/${finalAttrs.src.rev}/CHANGES.md";
     maintainers = with lib.maintainers; [ doronbehar ];
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ca/castget/package.nix
+++ b/pkgs/by-name/ca/castget/package.nix
@@ -19,14 +19,14 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "castget";
   # Using unstable version since it doesn't require `ronn`, see:
-  # https://github.com/mlj/castget/commit/e97b179227b4fc7e2e2bc5a373933624c0467daa
-  version = "2.0.1-unstable-2025-01-25";
+  # https://github.com/mlj/castget/commit/218734296e2efc53071e0dbd3c4d59930b571aae
+  version = "2.0.1-unstable-2026-02-04";
 
   src = fetchFromGitHub {
     owner = "mlj";
     repo = "castget";
-    rev = "e97b179227b4fc7e2e2bc5a373933624c0467daa";
-    hash = "sha256-3t/N8JO36wjHuzIdWNstRWphC/ZR6KkZX0l9yKarS7c=";
+    rev = "218734296e2efc53071e0dbd3c4d59930b571aae";
+    hash = "sha256-GEfsGOTBkorPWLGP3eNbuiGFwDUgb4Gu6ykyS3/RNOg=";
   };
 
   # without this, the build fails because of an encoding issue with the manual page.

--- a/pkgs/by-name/yu/yudit/package.nix
+++ b/pkgs/by-name/yu/yudit/package.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Free Unicode plain-text editor for Unix-like systems";
     homepage = "https://www.yudit.org/";
-    changelog = "https://www.yudit.org/download/CHANGELOG.TXT";
     mainProgram = "yudit";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ doronbehar ];

--- a/pkgs/development/python-modules/crate/default.nix
+++ b/pkgs/development/python-modules/crate/default.nix
@@ -67,7 +67,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/crate/crate-python";
     description = "Python client library for CrateDB";
-    changelog = "https://github.com/crate/crate-python/blob/${version}/CHANGES.txt";
+    changelog = "https://github.com/crate/crate-python/blob/${version}/CHANGES.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ doronbehar ];
   };

--- a/pkgs/development/python-modules/guidata/default.nix
+++ b/pkgs/development/python-modules/guidata/default.nix
@@ -113,7 +113,12 @@ buildPythonPackage rec {
   meta = {
     description = "Python library generating graphical user interfaces for easy dataset editing and display";
     homepage = "https://github.com/PlotPyStack/guidata";
-    changelog = "https://github.com/PlotPyStack/guidata/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/PlotPyStack/guidata/blob/master/doc/release_notes/release_${lib.versions.major version}.${
+      lib.pipe version [
+        lib.versions.minor
+        (lib.fixedWidthString 2 "0")
+      ]
+    }.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ doronbehar ];
   };

--- a/pkgs/development/python-modules/plotpy/default.nix
+++ b/pkgs/development/python-modules/plotpy/default.nix
@@ -117,7 +117,12 @@ buildPythonPackage rec {
   meta = {
     description = "Curve and image plotting tools for Python/Qt applications";
     homepage = "https://github.com/PlotPyStack/PlotPy";
-    changelog = "https://github.com/PlotPyStack/PlotPy/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/PlotPyStack/PlotPy/blob/master/doc/release_notes/release_${lib.versions.major version}.${
+      lib.pipe version [
+        lib.versions.minor
+        (lib.fixedWidthString 2 "0")
+      ]
+    }.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ doronbehar ];
   };


### PR DESCRIPTION
A fix of all my maintained packages, per:

- https://github.com/NixOS/nixpkgs/issues/514132

Changes include:

- **castget: fix changelog url**
- **python31{3,4}.pkgs.crate: fix changelog url**
- **python31{3,4}.pkgs.plotpy: fix changelog URL**
- **python31{3,4}.pkgs.guidata: fix changelog URL**
- **yudit: remove gone meta.changelog address**

## Things done


- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
