### PR TITLE
swagger-typescript-api: 13.6.5 -> 13.7.2

### DIFF
--- a/pkgs/by-name/sw/swagger-typescript-api/package.nix
+++ b/pkgs/by-name/sw/swagger-typescript-api/package.nix
@@ -9,10 +9,10 @@
 }:
 let
   pname = "swagger-typescript-api";
-  version = "13.6.5";
+  version = "13.7.2";
 
   node-modules-hash = {
-    "x86_64-linux" = "sha256-N19ocmrqQ8SpDNhmpCNC1wdWGrkBXCdio+ZfEXceaUA=";
+    "x86_64-linux" = "sha256-1Wy9RWNvMmxSY72Qcam/jCVwurGk4ms9PTR5tt6t03I=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -22,12 +22,17 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "acacode";
     repo = "swagger-typescript-api";
     rev = "v${version}";
-    hash = "sha256-DAgE88JBJLNkg9WOO2qVI2dpdfNFvvBIcy++S/PX2NY=";
+    hash = "sha256-2sAE3wD/vUjaxvlhfrBRSErB3PsjQfi4UAcc4tU0le4=";
   };
 
   node_modules = stdenv.mkDerivation {
     inherit (finalAttrs) src version;
     pname = "${pname}-node_modules";
+
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
 
     nativeBuildInputs = [
       bun
@@ -35,6 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
     dontConfigure = true;
+    # Prevent patchShebangs from rewriting node_modules/.bin shebangs to store
+    # paths, which would make this fixed-output derivation's output hash unstable.
+    dontPatchShebangs = true;
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
