### PR TITLE
kodi: properly capture kodi.packages to allow for kodi.packages overrides

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -6,16 +6,15 @@ unwrapped.overrideAttrs (oldAttrs: {
   passthru =
     let
       finalKodi = oldAttrs.passthru.kodi;
-      kodiPackages = callPackage ../../../top-level/kodi-packages.nix { kodi = finalKodi; };
     in
     oldAttrs.passthru
     // {
-      packages = kodiPackages;
+      packages = callPackage ../../../top-level/kodi-packages.nix { kodi = finalKodi; };
       withPackages =
         func:
         callPackage ./wrapper.nix {
           kodi = finalKodi;
-          addons = kodiPackages.requiredKodiAddons (func kodiPackages);
+          addons = finalKodi.packages.requiredKodiAddons (func finalKodi.packages);
         };
     };
 })

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -4,12 +4,9 @@
   buildEnv,
   kodi,
   addons,
-  callPackage,
 }:
 
 let
-  kodiPackages = callPackage ../../../top-level/kodi-packages.nix { inherit kodi; };
-
   # linux distros are supposed to provide pillow and pycryptodome
   requiredPythonPath =
     with kodi.pythonPackages;
@@ -26,7 +23,7 @@ let
       addonsWithPythonPath = lib.filter (addon: addon ? pythonPath) addons;
     in
     lib.concatMapStringsSep ":" (
-      addon: "${addon}${kodiPackages.addonDir}/${addon.namespace}/${addon.pythonPath}"
+      addon: "${addon}${kodi.packages.addonDir}/${addon.namespace}/${addon.pythonPath}"
     ) addonsWithPythonPath;
 in
 


### PR DESCRIPTION
The kodi buildEnv wrapper doesn't properly capture kodi's package set. This makes it difficult to add new packages or override existing ones.

Before, trying to mark mediacccde as broken doesn't work and the output hash remains the same:
```
% nix-build -E "(import ./. { }).kodi.withPackages (ps: [ ps.mediacccde ])"
/nix/store/6kbqxvqwizlg42kq8dy6psj5p2g24wlb-kodi-21.3-env
% nix-build -E "(import ./. { overlays = [ (_: super: { kodi = super.kodi.overrideAttrs (oldAttrs: { passthru = oldAttrs.passthru // { packages = oldAttrs.passthru.packages // { mediacccde = oldAttrs.passthru.packages.mediacccde.overrideAttrs (oldAttrs': { meta = oldAttrs'.meta // { broken = true; }; }); }; }; }); }) ]; }).kodi.withPackages (ps: [ ps.mediacccde ])"
/nix/store/6kbqxvqwizlg42kq8dy6psj5p2g24wlb-kodi-21.3-env
%
```
After, without overlay, the output hash remains the same, but when overriding mediacccde as broken, the error appears as expected:
```
% nix-build -E "(import ./. { }).kodi.withPackages (ps: [ ps.mediacccde ])"
/nix/store/6kbqxvqwizlg42kq8dy6psj5p2g24wlb-kodi-21.3-env
% nix-build -E "(import ./. { overlays = [ (_: super: { kodi = super.kodi.overrideAttrs (oldAttrs: { passthru = oldAttrs.passthru // { packages = oldAttrs.passthru.packages // { mediacccde = oldAttrs.passthru.packages.mediacccde.overrideAttrs (oldAttrs': { meta = oldAttrs'.meta // { broken = true; }; }); }; }; }); }) ]; }).kodi.withPackages (ps: [ ps.mediacccde ])"
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'kodi-21.3-env'
         whose name attribute is located at /home/edi/src/nix/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:533:11

       … while evaluating attribute 'chosenOutputs' of derivation 'kodi-21.3-env'
         at /home/edi/src/nix/nixpkgs/pkgs/build-support/buildenv/default.nix:115:9:
          114|
          115|         chosenOutputs = map (drv: {
             |         ^
          116|           paths =

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Refusing to evaluate package 'kodi-media.ccc.de-0.3.0+matrix.1' in /home/edi/src/nix/nixpkgs/pkgs/applications/video/kodi/addons/mediacccde/default.nix:34 because it has problems:
       - broken: This package is broken.

       See also https://nixos.org/manual/nixpkgs/unstable#sec-problems
       To allow evaluation regardless, use:
       - Nixpkgs import: import nixpkgs { config = <below code>; }
       - NixOS: nixpkgs.config = <below code>;
       - nix-* commands: Put below code in ~/.config/nixpkgs/config.nix

         {
           problems.handlers = {
             "media.ccc.de".broken = "warn"; # or "ignore"
           };
         }
%
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
