### PR TITLE
go: use uplosi as tester instead of athens

### DIFF
--- a/pkgs/development/compilers/go/tests.nix
+++ b/pkgs/development/compilers/go/tests.nix
@@ -9,11 +9,11 @@
   runCommand,
   bintools,
   # A package with CGO_ENABLED=0
-  athens,
+  uplosi,
 }:
 let
   skopeo' = skopeo.override { buildGoModule = buildGoModule; };
-  athens' = athens.override { buildGoModule = buildGoModule; };
+  uplosi' = uplosi.override { buildGoModule = buildGoModule; };
   expectedCgoEnabledType = "DYN";
   expectedCgoDisabledType = "EXE";
 in
@@ -24,7 +24,7 @@ in
     command = "go version";
     version = "go${go.version}";
   };
-  athens = testers.testVersion { package = athens'; };
+  uplosi = testers.testVersion { package = uplosi'; };
 }
 # bin type tests assume ELF file + linux-specific exe types
 // lib.optionalAttrs stdenv.hostPlatform.isLinux {
@@ -41,13 +41,13 @@ in
       exit 1
     fi
   '';
-  athens-bin-type = runCommand "athens-bin-type" { meta.broken = stdenv.hostPlatform.isStatic; } ''
-    bin="${lib.getExe athens'}"
+  uplosi-bin-type = runCommand "uplosi-bin-type" { meta.broken = stdenv.hostPlatform.isStatic; } ''
+    bin="${lib.getExe uplosi'}"
     ${lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
       # For CGO_ENABLED=0 the internal linker should be used, except
       # for cross where we rely on external linking by default
-      if ${lib.getExe' bintools "readelf"} -p .comment ${lib.getExe athens'} | grep -Fq "GCC: (GNU)"; then
-        echo "${lib.getExe athens'} has a GCC .comment, but it should have used the internal go linker"
+      if ${lib.getExe' bintools "readelf"} -p .comment ${lib.getExe uplosi'} | grep -Fq "GCC: (GNU)"; then
+        echo "${lib.getExe uplosi'} has a GCC .comment, but it should have used the internal go linker"
         exit 1
       fi
     ''}


### PR DESCRIPTION
athens currently pins Go 1.26, making it unusable for the test.

fixes https://github.com/NixOS/nixpkgs/pull/510665#issuecomment-4330399033

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
