### PR TITLE
Firefox: 150.0 -> 150.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,2057 @@
 {
-  version = "150.0";
+  version = "150.0.1";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ach/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ach/firefox-150.0.1.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "6fda3549eeb58d2c0abee981f03cec5abdf0a99031d82be368ab11268791cf28";
+      sha256 = "8df967bb0baa0dcc1e16e6b9d36654068fa263839af105e04103bddd9a3b3cb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/af/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/af/firefox-150.0.1.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "2f564c698f6d287b2574d00380886119ba3ec088f622ebccc08e83799ecdbcaa";
+      sha256 = "e0bd056bc365ea58b008cacafbaddb4af0eea7f025aeb5a980144513f5be3dbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/an/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/an/firefox-150.0.1.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "d91484977a311430e8d883b2de04338d07b166ba1244b215e5a7e3c4381a9e08";
+      sha256 = "d29cfd51a2881834bdb4878d774cd29134f1b3d86f781853b57a1368337c16a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ar/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ar/firefox-150.0.1.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "069c5001055811f1c6e26c80d1b6b94b0d1944d29774ce294863a075bc30610f";
+      sha256 = "9953650bfb2a9da5cae6950c5649ce4ee1a1891da53a3ce94c0739039c61e620";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ast/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ast/firefox-150.0.1.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "46c58edf509744ae7b2b66fa8b9ccc35b596bb46b19fe36d72c0cfd5df147ecd";
+      sha256 = "557ddda3f673963872057b7b87438150dcab1ec707ab4a98620e5d9dd4ed4bb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/az/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/az/firefox-150.0.1.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "aee9472480d653b17ca70a27bd02d5809c686eea855c083707f4f97e20fa9e04";
+      sha256 = "b054f3f119b2cdcc2acd69d2b1595ffc51385aefa8066a887de9567e3431b7cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/be/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/be/firefox-150.0.1.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "f337bbece77ab7a80a2379d7d937f4b07c33143f33c067586b6b8b9a7a036bcd";
+      sha256 = "dc2681e0b390ee722ac3d9b8af4afc31d8ada28b5e65af2486cb08a3c85f3eee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/bg/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/bg/firefox-150.0.1.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "bc93a3c89dd4ddaeca71ab29f60fb0f03d4c575829fb6f008d5d3f768c822483";
+      sha256 = "398974bcd5c80e513db99e8d282a1c0acaff3596123f0af161de6082a989e492";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/bn/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/bn/firefox-150.0.1.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "5498489c48848ae28416d859951faed4ab176a2f7c1578f28b3d2d59631e6c53";
+      sha256 = "8ed8814129d7e2a2e15a90d6e9eb089e2b57061ad3f8085c0b2c86b21c9809ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/br/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/bo/firefox-150.0.1.tar.xz";
+      locale = "bo";
+      arch = "linux-x86_64";
+      sha256 = "4dd922931156b14ddada8dad36c14c3d046d388d2314e9720f6671a4a6ff4adf";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/bqi/firefox-150.0.1.tar.xz";
+      locale = "bqi";
+      arch = "linux-x86_64";
+      sha256 = "f5a959afa143a3c5576944758c1c6595498345a76cc12f0d649f68025d35f870";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/br/firefox-150.0.1.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e37a97e0235c36028bd43e4358bc50a8c64819ea9d28b889dd550afab6f06396";
+      sha256 = "a10ebb49d0f1a551a8c956d3232c351769533eed0c433ac00b075ff3ed932600";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/bs/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/brx/firefox-150.0.1.tar.xz";
+      locale = "brx";
+      arch = "linux-x86_64";
+      sha256 = "2a557041f621c371be99762f31816fbc87fa6a9413f2ba148d8076c064038034";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/bs/firefox-150.0.1.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "6e8b7aa778e3423c10c26de2eacddc5fd1adb50f97c90ba5fda3379a1ed74f92";
+      sha256 = "986f07ce957f704a1c5711755bf052aa694df87998eb265ac8ce68bb59acd9f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ca-valencia/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ca-valencia/firefox-150.0.1.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "26fb6c5c4018bb318e65ce8545dd1470a76f5865d42b341c7009ec7961f1170a";
+      sha256 = "f0db798b7e2b2d5459fdba9ab143e72c151577e8416108c8df1f168fd72b37e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ca/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ca/firefox-150.0.1.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "fa1688801bd1fd16771bd31d457c70b02b15d493f709e37dc947e26f642d7f75";
+      sha256 = "128abfe1d356d6ef07202ca992c415f0b8a3b2cf319c68245272209b2752d6ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/cak/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/cak/firefox-150.0.1.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "5334bc92c4912b4500311c8ddcb149abed21ab74a8bb7a91213a3690c43a130a";
+      sha256 = "e068e8371fd28a6feaa7829cc27d853c256a6cf64c03f37521e0ac51f6ef4862";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/cs/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ckb/firefox-150.0.1.tar.xz";
+      locale = "ckb";
+      arch = "linux-x86_64";
+      sha256 = "1bf8bcf2e8dafd46719d0b52539661ce9309bee9d1b014d221b3029e8a4041f4";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/cs/firefox-150.0.1.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "0deaf31785fec9f5212a81ca7908525283205783b3670c41fc669e1288006eb4";
+      sha256 = "15201a284b7c4b3c7fef023ec6041c7fb0749e93e72bad0ab33cb2cb7ffa98e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/cy/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/cy/firefox-150.0.1.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "b19fd410e899ce9e2ed41667e0ea7500d9c6a3eb20579a45563bd7bc7afad21a";
+      sha256 = "b4b101b4df576e53abd7ddc44f6d845d485148864b09ef58c15c72f69d1bf9af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/da/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/da/firefox-150.0.1.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "bc609f518235a115c6b64c67e3cbc805098cc2a4c4b19352e951c8e60316e733";
+      sha256 = "75d1a8fe304e8e4fe2209571de9917806e56d5ef2dcf4beb0e70034464141453";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/de/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/de/firefox-150.0.1.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "5991544d554bdad4e1d485fba3e3d1bd86909bacf42afe2c794bb7cedf5192de";
+      sha256 = "ec9a6c64811db82b51b003d6f9c61719be185a2ab102be753d54886902bb0b97";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/dsb/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/dsb/firefox-150.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "0925ac61578aff7ada7c5d4ce94e4bee685a4487b3930e55817325f1b21c38a1";
+      sha256 = "702f2b853c8dd9d6b851792740796903a5b471b2be7d6dce514825a3330c7054";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/el/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/el/firefox-150.0.1.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "ce06c587a2b86fa73e7e8cd93427a74498fbec28ee2603bfbf048c9962931cd0";
+      sha256 = "24291afc0c758a2823406ef48b66f7ce82f051bf1cb77bec54f605a5f7f18d12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/en-CA/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/en-CA/firefox-150.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "7187c727aacc8b462c340bc3d68d4e2c78c53a0db6e92efdf1d3a3eb770bcdd9";
+      sha256 = "563445823374ac3a4b2d7a35902e7c8bca507590fb49bf51fc7289cb58466af0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/en-GB/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/en-GB/firefox-150.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "04802f87d51633e593682c3a67ffe5ad2278d8aefba0a7a963b1aadaf78bb2f8";
+      sha256 = "927bf825b1f72d36e28fdc9ebc04ebd79cc86265f2c4739891ba69a2f80babcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/en-US/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/en-US/firefox-150.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "2ff987e94bfa6ed51f53d6b4baa7f0f8ec3fc26c4c47bd9f86c70d11aa0fbd60";
+      sha256 = "83871560c3d3514d3b5bdd196cd258dde23d53f5d3d89d266765bd7e8306b895";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/eo/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/eo/firefox-150.0.1.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "1983fb4d167646ec7a9c9320de1b37e4f0042fd24c890848b84a304df13e0e68";
+      sha256 = "e5b4e12d05e99bde29fc96566efc4d039d1fca07d4b257f1c0ba36b9a64d88d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-AR/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/es-AR/firefox-150.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "bc2e4b24152c6a2f9b2a29e9a4c7dae698f803ba2cc841a39e318a4e04f95575";
+      sha256 = "7b1914eee5c0155f95a93bfb53e641240889ffe707423abcbb130c34c6a6c6a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-CL/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/es-CL/firefox-150.0.1.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "0f11ee090d0927239847c22de8e4e8fde5426cb0f48ab5c40bb4819a6d0dfa9b";
+      sha256 = "29c6efef9868b0383338af0afba7ee623e1f06155a8e47a86dc6229418b399e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-ES/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/es-ES/firefox-150.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "cd604a866aa7f8e6086d70690671281f975d20206edbfde19f1c153d82d52081";
+      sha256 = "ce1fa5fcef78563a4d2921f600f91b378b0c81ed22b167eef0b503a274752a20";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/es-MX/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/es-MX/firefox-150.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "00250676a87308cf1cb0260fd300c3d3abaebbaa01bb58952bced085496bb94b";
+      sha256 = "f31252190c4fccaea01b328a1a4a73837ae7060180ac5d610ea0cb53c028533d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/et/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/et/firefox-150.0.1.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "e6effc06ee1998a7842e3459ef87d0eb41813239df1a638b19e25cee690f4545";
+      sha256 = "b7862bdecc8492c76d110971d28da8de194cd38b0351a286fb71506f88474032";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/eu/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/eu/firefox-150.0.1.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "b55c891191869c9b38cc8abdacc73fa46f6f400571247fda0e11351d4eecb8e6";
+      sha256 = "d9686a806b870adf51f512589b23649e66a94e59a66689b0fed69dfef62844c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fa/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/fa/firefox-150.0.1.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "8565e9302d61fe53db0aa93b54c77c2e5fa01668a0749f2180d4a2877bd436da";
+      sha256 = "bc48fd47694ab1040d7880c9dedb3461f3f87c95493a0571cf4b314c8297d1c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ff/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ff/firefox-150.0.1.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "9cdf2a235b2900f5773abeff59d929a787576fc76e8b0f8bfbf199d8d3493c86";
+      sha256 = "a93365446a506e1453c6815d8ad8913208c11390df7d60d8fdb38636e73c9044";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fi/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/fi/firefox-150.0.1.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "ff8901eb6714133cbbcf8cc0cac83b253686d82e9dbff693538d10a577dbbe17";
+      sha256 = "84379104f44ace79de75ae0b65b09d63a7bc519b57a00135925d38f177ddd290";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/fr/firefox-150.0.1.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e5993ec9c373df0e3e738f00e3914fdf727b00e3b15a0ed4892e5d1416f30eff";
+      sha256 = "8ace62c3c41df014135d2f598a7e9cbfc8efa0836d0489fc4f12ed8bc5e5b820";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fur/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/fur/firefox-150.0.1.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "25dec1f12105b87d9ec64847b97b3d66610ca10bfdefa1b0d6c9e94ccd5f1e06";
+      sha256 = "f9704f4587d080b3938b03468cfda8d9f8028f57d4ddfaff9f222622fac841c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/fy-NL/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/fy-NL/firefox-150.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "13bd01d13edc2a63d334d184adff5b5f58014e50e97c5dfc747f7c22865f67a4";
+      sha256 = "aa04c83b25a9d09f6bb7d10b95fa03b6ca9219e2c1697e3085882edb9c2b0015";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ga-IE/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ga-IE/firefox-150.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "fc08eb3c9f3e0554a8b449502a91b53562b9a1b90e9bbbe3f5ec7a69835a075c";
+      sha256 = "a63ad6d692a605f7382bbd8a39d8496b9dab813573f33697d26b8c696e453b7b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gd/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/gd/firefox-150.0.1.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "f93f7c51e96248b8f4bc342f887e698c2a8300c635dc188e243a92344bf9a40c";
+      sha256 = "7a97768ea9326f844b00f63e716ebd87b8fa4304cb949f3be6c2d0ff3b44d829";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/gl/firefox-150.0.1.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "94df516061208f827856132baab2f21a3e3099066ca324358586c5de2b8d64d2";
+      sha256 = "9421edf800c0b68c057a0bffef4071d1e76affb06d06c97f04c0429ef6825bea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gn/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/gn/firefox-150.0.1.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "fcdd1c0a2ea34e49c82e71b15ff6246fcc94c0a822ec857d20d84ed1194a2426";
+      sha256 = "12a62535360280796c6eb4f22c6745c16a0d45a8e473728da5d0763898bb97d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/gu-IN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/gu-IN/firefox-150.0.1.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "9aa1360317b7a730c5bfbaca9fd4271170299ae7d86d01352a0fe90fd6af7567";
+      sha256 = "b9b93f9ba1c1ac8e83a605ee5cb26482362024cfea5a198efd265add2470692d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/he/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/he/firefox-150.0.1.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "96b935a94a0e57cef008b0fc72de9fa46328ad47aa12eb1f348a51b684588c4f";
+      sha256 = "92f907d375d8d43b4226047b3326c00884a03bcc012b7f385c1fbea8417fb275";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hi-IN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/hi-IN/firefox-150.0.1.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "ab8d3295c74c407cb923035f070b3dd8a8f102e7968b0786010b31c105f0ff61";
+      sha256 = "82ad07e69ab74b7256d6a623033c8e8a8c5c8c4015c59b605a876fd1fbdb8260";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/hr/firefox-150.0.1.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "c07894fc729efd289a16c75bd9791bf9b45da02582aa6b16b1575f215c87baa3";
+      sha256 = "c8655f3a8b8829419a82bc63f9eade478fce4f0643b6a7e65c76e0fd63de209f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hsb/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/hsb/firefox-150.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "7639cb516533ce99038691116edc6ef571192e74f1458850de438c1cd6591239";
+      sha256 = "57d39bd2c7969b1b7de9864d8ced6f14bdbfa231fc18a7c3a5be6a54cd1e392a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hu/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/hu/firefox-150.0.1.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "9b8a83bef86262ecaa8f0c52cd8f6ea24c37307aa4e757b4e467039cbb91ec6b";
+      sha256 = "9a3ceffe953e4e935e68295a67d933073d368d07addc54b40f745709ddfdadb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/hy-AM/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/hy-AM/firefox-150.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "034f14b74c65117fe19191da9a48862cfb4b43dc3d96bccba7c52c413af72b82";
+      sha256 = "a66233ddeb1ad03a1f5a14134480cbcaa64e3f58e3f30ab9fcc40bb2fb681868";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ia/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/hye/firefox-150.0.1.tar.xz";
+      locale = "hye";
+      arch = "linux-x86_64";
+      sha256 = "be4bb38c9b57ab42e055a1d2c167307c656473c4296d6f2c435e1bf81a1393a3";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ia/firefox-150.0.1.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "0c99d8783d83621cd75d74ec91b1917aaa7649030c94848af74eeca85fba4f95";
+      sha256 = "57f5feab33ae6be40c363b805785aa9e6c1b9aa8082ba600e34bad04cefb7162";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/id/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/id/firefox-150.0.1.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7836898dd1569518d1e11f872e90b161072f786b0df1ef0a6e561066e48e4fba";
+      sha256 = "b1e7bdd4631f50e5b1910a850fae113415997563bfc4ad981cfb5f29bcaf3105";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/is/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/is/firefox-150.0.1.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "9a3425105dc9cae3c61c9c66099d8db45ebdafca3b24ba61a6ae3d9a8367aabc";
+      sha256 = "036ea67243ce666c54086d0e219bb063217f2e8321ab1dfcbf2e7690fefb353d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/it/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/it/firefox-150.0.1.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "c46f185b9357b62d4ed2d5f1fd4abc3d88174c72b97846eae87d8a7e0ac149e8";
+      sha256 = "00f38bb2ec48dec5a202774b4c50440b06b9936726922850d3663e641a09c927";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ja/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ja/firefox-150.0.1.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "86f16a1bc7e8dd1e54ff4abac9684c4380eab88ef55c45b056107aad33c197ff";
+      sha256 = "56faf471236f66aa4739287885d458324d91c715407dceaddc24bcd30d752394";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ka/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ka/firefox-150.0.1.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "711bf219c8271cebbadf735510e06f64732f96a3e82e9f02031c1b4c45210473";
+      sha256 = "e16ce6b7994cf29fc875c70eba04c6aa6172a1d508455a9e48298f942bdf7b31";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/kab/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/kab/firefox-150.0.1.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "9e808d0b0433fcaeca0f046bf3504d174afdcb51ca7fcce13cf8d5445dafaeb0";
+      sha256 = "1a6c584963332e16c55db5b16f6acaf27847a56696a3c7d3057f139fd1fbe6e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/kk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/kk/firefox-150.0.1.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "e39c684b53088922e06f291e36360d8b7668854e7ccb090897e3c4d6afea2120";
+      sha256 = "fbd12f3014207ef7c0e4dc5c7b116eb69bd9305afd7da4e1e0535ad4237d7565";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/km/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/km/firefox-150.0.1.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "27755aaf765e65cbc3813aa780390586db75d0a54e0bf30d9b39c5457efece30";
+      sha256 = "f65d60e0d21ed87e061a1668575ce54c90699ab06decf42b0acf1c6dfa799099";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/kn/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/kn/firefox-150.0.1.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "59365d692e939a83ee409db0c593200ca5721f3c0c37dc15fd305ff9f4cad8a4";
+      sha256 = "979b78ba65f70f875f2364aa0d3621fa965a54c42e5520e2a34ef03fd80a7c02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ko/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ko/firefox-150.0.1.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f9b40208d5d782d823caf658b3527778fd569c4beffceebeac0e593fd72ea846";
+      sha256 = "d1f7142a6bca24b26d1ede360c8e2013376e300117a10054f7a2cbaef4bd236a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/lij/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/lij/firefox-150.0.1.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "8d92d909dcf6fb2096cdf174c38fd22343b735bd406f1bd7b70ebe2ace40780b";
+      sha256 = "bf4fca76941f2b92288a79be529c6d8daae42d00dfa1509cbf0b1c4acd546f88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/lt/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/lo/firefox-150.0.1.tar.xz";
+      locale = "lo";
+      arch = "linux-x86_64";
+      sha256 = "5849e07330a477098364863d114fde1fd54fa97460183443514f0beef386b2de";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/lt/firefox-150.0.1.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "2ed3230c2989218674b5c5c454e6be6db02aa53a51171f80b710a8854364ea4b";
+      sha256 = "b3295000050b405dc8131c79a5e7c6f4ac63157bba554dc270227a0d0e1d12c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/lv/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ltg/firefox-150.0.1.tar.xz";
+      locale = "ltg";
+      arch = "linux-x86_64";
+      sha256 = "62a0d117c718d07f2f63e5976fa5ef01a98147e0d066cf8e1c7961b095f7ad86";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/lv/firefox-150.0.1.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3cae4a5fee6856fc8d26f9f331e6209c92e368e7d8e0cca116493da5257d1e88";
+      sha256 = "4cbab42225c919b21dc7ba624bcac999188d3a7452f237ff0594653f0fc9b103";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/mk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/meh/firefox-150.0.1.tar.xz";
+      locale = "meh";
+      arch = "linux-x86_64";
+      sha256 = "3900f5657d5655d73ceffb15a9f912cf16e5abdc9c2ea51a8e437c2ab7decb4a";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/mk/firefox-150.0.1.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "4e983c39616f2a0a903f18c7b9c724d3ee30e284b91a2197346d5ef9b89333c4";
+      sha256 = "ab45fc250423d23da2f0f80abbac28abdfdca22239f629d11d8527c566f36865";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/mr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ml/firefox-150.0.1.tar.xz";
+      locale = "ml";
+      arch = "linux-x86_64";
+      sha256 = "26b8e74037fee5ef9b88a8b1fd042f8efa3909f41c2a90f7b3503376f75f0910";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/mr/firefox-150.0.1.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "018c79ec6dd8d80aaf025260ee1f0fa436d1f273a0450401b5582d325d15e808";
+      sha256 = "e720a7acde548cdc4ed45a3a6a1a633b81b523579d03af314e67943e6f6f326c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ms/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ms/firefox-150.0.1.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "fd6e53060243b54d02cf15f83ae6b6a1fd74387e32c3a872e06287e4e67e7214";
+      sha256 = "ef2e8232de91b87581572c33b4cb9dea2e197f325cbc1c389da20b08fd9025fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/my/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/my/firefox-150.0.1.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "66be74d223804ea70759e21f67388c506459b1e5dabcb99ea4c6940d8437bd5f";
+      sha256 = "f7c6592ad7b8edab343de438ddc756b1031439d5fe0be44ffae7c41bd3abf490";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/nb-NO/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/nb-NO/firefox-150.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "881700e587a36b40c3a363e721b7a8b6bc8525bfac3ef0bc0bd32c4ae55eadb6";
+      sha256 = "e76c556b97bd5e70f098b88678ce85ea80da9afe5f63f7214d18bca2678264f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ne-NP/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ne-NP/firefox-150.0.1.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "612e84a33109f3be70ebf5806d23aa82abfb1e2ee1be26be8871dcc834ef5e90";
+      sha256 = "bfcc08764cd5ae2c5afe6a8796f0fd8248c65fc8378248b23d7cdd8177478d9c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/nl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/nl/firefox-150.0.1.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "8cf72e25578ef232d111fde5dc233be761467b3ccf9089d356724a202a4af507";
+      sha256 = "a38d38a5115cfdd3b8a6af0f3a227c41b81ff1df989a8f7eaedb1a8ea5c3a76d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/nn-NO/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/nn-NO/firefox-150.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "d8b7b4c09f69d8b4f72bf65efb38c1a6fd2cbb7a5e1d628c7747d53f1b752cd3";
+      sha256 = "69399f4217d4bacfc317b76c2d98e35ec1db8792f74a48e48a78ffce79cf7562";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/oc/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/oc/firefox-150.0.1.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "d85c3edbdb601e4b2f185da27dd87a5c991edd57d7093eae0ea504e8c895014b";
+      sha256 = "71acefaa84fc651a0244976c9861a98595abf7f5372e242b8e76aff6b10fdb82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pa-IN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/pa-IN/firefox-150.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "0b1606b64d0b712a7844cd98f51c271400c409a02875fced5830407cf6e24eb0";
+      sha256 = "3ad8da6f8b29e0523383ab75b0312b11a316ff3b7a7e7fc53482f899b7e75cca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/pl/firefox-150.0.1.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "e2e48642bcf8b73ae19be2212f4c5faecea12d90ab03467f9ce778a02ac54f92";
+      sha256 = "4dc09fb01345cf5e4e6a38f2977821e0bca4ecac57ea6ab37069e89325489fad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pt-BR/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/pt-BR/firefox-150.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "d2c9dc14be5395be1e99782644a0dd69cd381bd0558ba905e59842baf2d9fd77";
+      sha256 = "7e178f959ed18806149625c05d64a3867b71c36d327defe3bafa4f1a294d2dbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/pt-PT/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/pt-PT/firefox-150.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "78ca0c4486fd2b5f36e74fb75de94be6be3ae9863283fc40c098dde7bd056ae5";
+      sha256 = "0fd02b1e54dcbfdf33e20d078d3ab9e252e2f7be9f4cf6b4ab2a6e84e7ba673a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/rm/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/rm/firefox-150.0.1.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "5fdcc6ea08da8d9539bdb6b058370880b8387d8b724663e692ac69a70ae1688d";
+      sha256 = "8f3a004e64a884e6e6adc71bc1958e4bb0624f1ddf9641b595a9aad77a78a103";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ro/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ro/firefox-150.0.1.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ccbd22c2e0a5b42b0a7385e5d18f1f4318f9aee45db45e979f66606b5b38cde1";
+      sha256 = "39d91e36bd820f514b1555c7efc4119e178be0bfc50d7d80cbd235dc79fa3f88";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ru/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ru/firefox-150.0.1.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "12fa20208db2048f35cda8c868103dcee372fec4fa111fa46e135aaab7d4a556";
+      sha256 = "3ea866bea819fe2924b31c2d230864ded8e79c520efe5a0077807d40d6ff1f8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sat/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sat/firefox-150.0.1.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "719e550ad69aced566f63f2863f5f8f1fd2dd5e7f1bb31606eeee830d151760e";
+      sha256 = "108a14c809facc50001caa056ac5662a01a71920b879eb04f64e71199b9c679c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sc/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sc/firefox-150.0.1.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "cd215721dba4cf36b00eaf5a3bf29af623c7f86b21e6f4abe54b0f00f6a52214";
+      sha256 = "af53472a3e87aadf764521da7c8de117bd05d99df70d40b1d7e7ccde6b77de5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sco/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/scn/firefox-150.0.1.tar.xz";
+      locale = "scn";
+      arch = "linux-x86_64";
+      sha256 = "1487280795ec63cf95df8aa086ce47f344db0e68114eb3c0d1bb7e9d6952b324";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sco/firefox-150.0.1.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "434a248ede9771a58f7315585609b659287dacfd2f077b3b7726f17d3f32817b";
+      sha256 = "f2892f2af3fc11a9850cbc3cd35efea9303631265b83af5df4c9b491a7725cbd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/si/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/si/firefox-150.0.1.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "9eea0ae86f75db6996f5bd2030f5edff11e9071f294ff4bac39cbf1405cab6bd";
+      sha256 = "22b3677a751ec0ecfbba034727ee3422c455e06b3c4bf1689c6078d5bf4f5621";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sk/firefox-150.0.1.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "76393f918ffbf5697ac29eb5548545ac3f81d26d1fd126d434eef22037525c9e";
+      sha256 = "be838c44417a55bda3daa5b32d1319f366659c84f718bbd47877e7aeaae4b4c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/skr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/skr/firefox-150.0.1.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "47b2a99f38081ecaebd470c9c92c3764dc22a0d5e8a5b5d1ebd3ef8a5778c6ed";
+      sha256 = "116eabc0df45208024ad748dccd0560d402ef0e07120668cf38f460752dacf93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sl/firefox-150.0.1.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "58fb7c5d61b347c1ecb6273f95345fc45adf3cc82951faa3a6704fe0d97475db";
+      sha256 = "1d9cd0ee1d9c1ee32836dfd2528df34b20b58a6f7b048ac992856239b6c9f45a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/son/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/son/firefox-150.0.1.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "d3eff42279227c045c0c5deeecc2955c316639a1c624d2f431be9eb8dc208981";
+      sha256 = "d664e04da60898edc227eb6c978c94d09d9c704186ab11c7f1b3d069d371ee0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sq/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sq/firefox-150.0.1.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "01223c61da469892fee98effddd3d8c862f2037e1fe0f9a063c0f8d54ca45f66";
+      sha256 = "1809114fcc1f39a7cf5fba17c7cdb7c388d7db200140e72e43eb68cf51e56ede";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sr/firefox-150.0.1.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "7341c99e41b96ae73b3eca82aaed9a53d9d7f93148511598a340f2df2c5f1bd7";
+      sha256 = "721c182205e4117a8d361e1b7b01e5544b6883c08c55baa0228ee220414fbd00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/sv-SE/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/sv-SE/firefox-150.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "534c40d3b5187ea53514457b74c84e9221fe0e59b7a9c7a543ebb00f2c6b0ebc";
+      sha256 = "47f22dc1ea086df633dbc2cbc4e758a6cbc9d54b01e0c90904a3d0d4cf4b3d79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/szl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/szl/firefox-150.0.1.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "89059713ba528500e256bf36b59b3b29b518e2fe6a1cce387765b5668d377899";
+      sha256 = "f87f2c5233d5ae337c0e7e495636b40279fa94c5d193b0f1f81dd3457e7a9e29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ta/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ta/firefox-150.0.1.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "819e223804e6bf19269556a603f5e1de22864973aeb6c02b07dbf5883bddec65";
+      sha256 = "c1b15e4ee9698f76104efbff260cd74a3ce94a6511f4f4c3117291dbbb624309";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/te/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/te/firefox-150.0.1.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "d0d619885daa8b580cceb419267b213bcb428f240cf33b5cddbb56a371b7b5a2";
+      sha256 = "dd0dc5f8dd74e75104054f1f654adaefcac5bae0f1c41bf516c4962e9d9aa9f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/tg/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/tg/firefox-150.0.1.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "de0a569e50ea10f2581292f91c87b6c9e589c8eaaa925a9154d3c99ef2970fa2";
+      sha256 = "1d304edba33e9dca7e72905593de1d3e14ebbd56602ba43c00450e9a13cd34a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/th/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/th/firefox-150.0.1.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "e24b9a1c30995b3edcea1c62eeaa16d24fe51a917dfd5d77bbb4f28a88298316";
+      sha256 = "73ca92e278c3eaf6598a76679f47b6efc4d617686247ba1fe2f19acdd30668ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/tl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/tl/firefox-150.0.1.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "572e70a6f3f5095c00ef5c5381f4ed3d686f0cda2b754dd80b2b7f475e36b882";
+      sha256 = "fa1fcddcb3f1d87d326f05613de3a99ab3d4f445b4b14245c5ea4e308020fc70";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/tr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/tr/firefox-150.0.1.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "491929752bf6aad4637418779679e09fd4c11831c5c9ae8e5ebe54ec07524bac";
+      sha256 = "e3f709f5180be6086baf6ecaa3aaeb1acf0760ab37ae7a31b733ab0b974b5848";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/trs/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/trs/firefox-150.0.1.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "38ff7c7e4e0296a8774c2fd51b68c966f9c0a9d2b80cb66f3ece90f0b9f3c2b5";
+      sha256 = "aae7fdb048cc4bc752070183d24db7acd19f41545e4dff1448274d161a72dbb1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/uk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/uk/firefox-150.0.1.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "477afc4e02ce89b72e999237d36f2088e89abdb9a6e6afb199e1a4ede58d48ee";
+      sha256 = "acb0a8a039bb68c7dcf7447c2166c3b38b0adc8d2b06647cb88fb8cdacb5265c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/ur/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/ur/firefox-150.0.1.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "ff286564a782108c772c8b050464499f08b97e40c108ebbde703de5c539b240e";
+      sha256 = "4203ffc02c641c0418b32a542c3e17ee79b37cfe0f84daa6c5be1222dd078916";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/uz/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/uz/firefox-150.0.1.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "88178214e9aa0e4e00b6c7bab3651efe4bf9fbc552b2e3a5fe6374aa4d9c3f79";
+      sha256 = "49c275a012b480aee408f3f4e344f2e7c94e1944dfa897ff12e957ad2faaea68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/vi/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/vi/firefox-150.0.1.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "7f8823ed0456189dc3ee7e42ecc605c3445fdab99a82aacb9ce6d7ed5ad9d15b";
+      sha256 = "b899bef5925fe50e87d9b035ef4f74b9346fcee88d8a71da56aafec924abfb5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/xh/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/wo/firefox-150.0.1.tar.xz";
+      locale = "wo";
+      arch = "linux-x86_64";
+      sha256 = "81d19e8b73c5400067b6c10d822389227b362ba8e0b4a5f259ad5180d44e8e53";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/xh/firefox-150.0.1.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "8988a0e5547a5039bdafd01193e3159d96757a36630420f7d5f2ee6e350df329";
+      sha256 = "93550d5d0fc22862165f7ea6be56866184c0e9682ddd78fe9c2e39bb8ee91429";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/zh-CN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/zh-CN/firefox-150.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "c4ec491f484bf7ee35e91f89e297a943b785ab2d657de3e1352320b7de967b01";
+      sha256 = "6e636a89f9b8b5843a0771be51019cbed3e423b54ccf5343f571afa10c55bdbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-x86_64/zh-TW/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-x86_64/zh-TW/firefox-150.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "dd81e74e904f74b72247f56d92b180bfe8fecec5732f76d3650ebbd5d8051944";
+      sha256 = "ae716b38a97120a13bc0d83a1eb8645ba7e172ae7a6e9bb154923ad42d195650";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ach/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ach/firefox-150.0.1.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "bfb5d97c838501a93f4a8148ecc00de102a51f8d2bfb2019da7e331ea9fbd7b5";
+      sha256 = "910dd87259210daba781325b2e50c546ead88bb15f94f7e516f5c8bc52038acd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/af/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/af/firefox-150.0.1.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "f2e2444bce5853d147ebfd62b6663b626207964a3cb34558865a27aa9a499cc7";
+      sha256 = "dbe844fe5cc2f8584bc066ccb3edca2d1114730155802ac3b43d6e2c7bfa916d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/an/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/an/firefox-150.0.1.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "773d7793172b12ca5ef9931bfdfe45527332b8214a47aa8cce7cec056b9e5ba5";
+      sha256 = "459950fdeae20b8ea1ba5eb33a34fcfb68e1dde611e37432acbbfa5d35d2b412";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ar/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ar/firefox-150.0.1.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "fe2c2721d91dfbf210b2f965abd49ffa0853a9f3ffb7245e09d4b5c432977608";
+      sha256 = "908d14dc45cfebaf9ad6109640931d325cb7f3dd3ebcda18e367f762114f2ddb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ast/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ast/firefox-150.0.1.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "3d2a9d32b4b65c9d820c7369acf38abd7601fafb2762c8450666bf14cb60fb62";
+      sha256 = "b138b3ae317e1af4846a348428752a5f3d81133bb3ca7d0cb4cac78a671455e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/az/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/az/firefox-150.0.1.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "d85d3df76c17e39520f81fbeb763c73ed5f8208a40d91aec2fe73e4b4ef8bd73";
+      sha256 = "8d05dc93c246be985255edcff836b3a4dcb00c5e4d18ebb5ddf90b2b0245ed04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/be/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/be/firefox-150.0.1.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "ff61b2f17609e9088765a8c2c27c73aefe679ab364178be923e9bd79e7e82c64";
+      sha256 = "700cdb0e00e83b606158fd7a3008e3df758af53131f525a1f2c61128d3c57559";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/bg/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/bg/firefox-150.0.1.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "24d052f7057bd679445abdadf3594ee298913b25d7b6d037c46a4a3d817c2580";
+      sha256 = "fad7345dc157a279a45c14f5cf6ae5375ec647718bb407647ad05c4481c32829";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/bn/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/bn/firefox-150.0.1.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "d6753fb7c487243faa6767c30d459c69a2c5b922f0b448efe31e17a0f7228050";
+      sha256 = "3634edd19c446c4a0467f8f3854ddf7a81e30656aeaf9d4561ab0c653d5b6089";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/br/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/bo/firefox-150.0.1.tar.xz";
+      locale = "bo";
+      arch = "linux-aarch64";
+      sha256 = "b8105ebcf2d955572f7a36bf9a03f4c05d63a11df83baec3496769dfe97acdc7";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/bqi/firefox-150.0.1.tar.xz";
+      locale = "bqi";
+      arch = "linux-aarch64";
+      sha256 = "44fc51ff937c71ce644bfef7a942731b2a47ee66a34bf24d9438588cb8b224e5";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/br/firefox-150.0.1.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "01c695d79b76c7b688dbdce4c7be454562b048900a6170ce1831f644cdb2649d";
+      sha256 = "6d2bf509548feeace1904f6e0d9fdf035372777062c4f1c84c085875b7224d17";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/bs/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/brx/firefox-150.0.1.tar.xz";
+      locale = "brx";
+      arch = "linux-aarch64";
+      sha256 = "b935ea946b2f6955a4302cd22a204538ae96e674aafb217f2bc26c2d7da7c828";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/bs/firefox-150.0.1.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "53ef34e6bde6bd751dfca50e833ce7662cbd916c1202885f560cf0880fb05d4e";
+      sha256 = "e3e9d0e21b157948294403b1714c07d1cbdbb5254b2f1032d032784b28ddb80d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ca-valencia/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ca-valencia/firefox-150.0.1.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "169695d4ac628ff56655e37dfce77dafb7f4d52f02f76dfd9791b2ceacf5faff";
+      sha256 = "32610991c8831417b8df60b57f01743692809fe439833b99e6579738720988e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ca/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ca/firefox-150.0.1.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "54ecf88b598f7a0ff1f75a575b09ab6ce210eaf606b85be137282c301fc9a0e2";
+      sha256 = "111f8191b7584db3e84ccfb1138c36dd11a385bf00281b99f74e5ed32aaa1a95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/cak/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/cak/firefox-150.0.1.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "7d68e7c8307f72b14f588f35f7ea8d4570d28e07c1a779c025be01a8b54a7ab5";
+      sha256 = "e81a113824976a5a9eeb531e91040e1b7c904a66fc480b013ea6f409a171041b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/cs/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ckb/firefox-150.0.1.tar.xz";
+      locale = "ckb";
+      arch = "linux-aarch64";
+      sha256 = "579f0f3bd781d8cade5be3e5b3b4826b3ff65135cded7e24395a11d6bcc274d1";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/cs/firefox-150.0.1.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "1d0d62000802d037a2386f5375bfcb924ec7830c9822390ccf18097dde958a99";
+      sha256 = "03e7b4241c6ba9bb91ce71702d7affa989e9c505ac9cd79d78ed392f4a394a55";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/cy/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/cy/firefox-150.0.1.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "96afc930c806785ef41a37bd6fe1c52746289efb311eaba17af187c76e8aaf88";
+      sha256 = "c7f966b86291160687e79c105d1d3f5203386112e171511d80d065a663b05bd7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/da/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/da/firefox-150.0.1.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "0519613f94868e1a0a6e07d646c0ff0ca606a6b1d7c850d7f4496f774fa86353";
+      sha256 = "4b8cc62221236e8d698505ec650bc42cf6bd08fbe8f8537d5ce6d703a1a45836";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/de/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/de/firefox-150.0.1.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "f6cc63dee1b96ed41d60934e002a44a4a16da79f15c06297fba10f13abcc7d13";
+      sha256 = "607fe83aaa513237cca04bab5425c97911fc34d89a53fdcc13f53b1a7e5c9e53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/dsb/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/dsb/firefox-150.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "692524f3a8df532855c2880ac2e4bba10637d79cfec3e687664afc285d919c20";
+      sha256 = "b0223639f7373c0cc5b675e89e31a77d9f59b7c559da49cf866a16919a79f508";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/el/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/el/firefox-150.0.1.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "8c33b155683938adb80db55ea6a6db6df233382d38c75f99288653c2a00fe2c4";
+      sha256 = "3c97360ac2afeb34cb15dfb5755d7c89b320f69deb1564bc4ac07d3c3958a141";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/en-CA/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/en-CA/firefox-150.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "df7400d44670569befe8695660885e42ffb31a4eaee7e3c822bf01ddcdcce39d";
+      sha256 = "493a0a53f94c3a964a471d4b72163babf2ba456dcbf983cb1b53dc3063ae0fb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/en-GB/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/en-GB/firefox-150.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "ab5c228fea3531abaaa5f80b25cae5fddb56e8f94f795d44985319e1510625aa";
+      sha256 = "0bf22734ba59b5bfe8bfe7115688c7bff15f7a145b94245b0f2e929a2d7f9af3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/en-US/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/en-US/firefox-150.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "9e6e2974ddfa840544caf26efda765c4988931bf2ada85c6b107500cd916cee7";
+      sha256 = "518c3bcfe5b859a2fe0405f9fc9ac4271072dd68f3164629c4ecc14729ed9c7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/eo/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/eo/firefox-150.0.1.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "c70bd558e0566d7c42467a7c950ff3df8a8db4d7ebedcc987464d48fa56def5f";
+      sha256 = "e4a4eb335a85640bf9723e0a63aa66713cc96aaa55696e43de887b6355b3fe80";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-AR/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/es-AR/firefox-150.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "967de64c73a667ac467fa94a821f50c0cf18993353a1882cf6f297a9d894d5ce";
+      sha256 = "78873ac54608fd436220415e225be4d6ef37229cc0af116164f927aca3b430c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-CL/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/es-CL/firefox-150.0.1.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "30bcbb562ff20cf4d6d69a22507efe1882e6afb76580cd73c770b41df81cf996";
+      sha256 = "add480f9e15598a1cbed863aa7acf4c76ff703a9fd56c6695394561e231d4ede";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-ES/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/es-ES/firefox-150.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "95b6502bb5c79a86790444e9047ebfbcc0da1bfd4a139b1118af9a3d6034c803";
+      sha256 = "48cb9dedceb524023bc70145d685259a3e743b117fa7a7743aeebff2a07937f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/es-MX/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/es-MX/firefox-150.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "d14341b9dbdf69bd26f7020aea990e7b1260798b2126edb12f26130112ec676f";
+      sha256 = "096731da41334f1ec3112fa5b07b0c5335c358fe932155b78736eb05f56d8edf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/et/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/et/firefox-150.0.1.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "090fdb54b57196bfe50d95703fd891fc45e5b61a71f01d9f387a4ea090cf185b";
+      sha256 = "790eb765d8a1ad0d50d03c82a35345a65a7ab5ba0f0c71bf1ed249f0bd65d2e6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/eu/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/eu/firefox-150.0.1.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "17f09f54c040a86218503a963871e9009ec91ff808cb83544de76978b74e32a0";
+      sha256 = "19bdb6d0b9e28572440c1eb9cada15cf7b129e366781fb90de8087c8ea58f8bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fa/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/fa/firefox-150.0.1.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "2ba0a879cb17e11cdd40f4db120b6c4ce96ef3534427603055224600f3e0eea4";
+      sha256 = "b23b79cef42c1daf3b190e14bdc7b52eb9bdde17a19dfc0bc36074ffe9868d73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ff/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ff/firefox-150.0.1.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "968a570398cd970f1884b49e17aa2ed245f59b70f9c7d3c807ec7f75259d5e43";
+      sha256 = "d8726f896933022054b95bbc29da0a616d1094528bb1c1a77d1bd54ec57aa8f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fi/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/fi/firefox-150.0.1.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "e7f8a50883183b11cdbbee3ec3f31b8efa72571a0e5235a13ced94a756d98ff5";
+      sha256 = "76a5db7fe2709e68074e80823151eaaddd7460e29fab797bf657c2b9db023fac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/fr/firefox-150.0.1.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "b8abb61dd340aff2d0812e3fe22b128ccacaba4acc8e2c670df99627af5c09b9";
+      sha256 = "574c9aa9e8806cd4bb60f86503be11a0ee6914a1f0710433717fce0c880352f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fur/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/fur/firefox-150.0.1.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "37877b40446d443941f174d26735b50c8b3680e33fac023e97632c056533f586";
+      sha256 = "46239042deb73913442236ab5c49b1486d996078710fe537ae73ed11ad1d4b1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/fy-NL/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/fy-NL/firefox-150.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "15e36db60b6b31648163dc8f740c6fc91373daa8d39ce573bb3c51bd22aa86db";
+      sha256 = "efcf678e26f400072f3976004c44c0d9236bbfe6fe0a42f335d1ba2faf4d728a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ga-IE/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ga-IE/firefox-150.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "80e113f41aba04d445315c3d27766e107e27b01598451eb7f293b7f1a176adb3";
+      sha256 = "80260ae606e9656c85ac24ea9404ac5cde7e88b531f26fa904c3c70268698e28";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gd/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/gd/firefox-150.0.1.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "50e0a2530aae063cd0928e6d1123eefb275c722b81b29649cdae2a2a9f5f59f2";
+      sha256 = "31e77e7c5b4ec9303bf46af168a53bb360249ed87cd1f18095e50d1750dab150";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/gl/firefox-150.0.1.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "35f9737a3576583e0c3f70df8d7deb96918648b35722bc87e82eae86054ddf25";
+      sha256 = "b3189d324834fd21107a82fde12bd2be0e4dfd29017328fff6a276af8322a118";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gn/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/gn/firefox-150.0.1.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "beed54e00bef3e35625583175a338d652e09764df312752403a7b3d7402c1d33";
+      sha256 = "9c3283d98b8716d6a2a11261eccba29d6cec6dcb7b8f4e190ecdced7e6dd7262";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/gu-IN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/gu-IN/firefox-150.0.1.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "b85e6dddf1c4d854502724c6f661da6dc28c2f15504ff0509299ae75feae97fd";
+      sha256 = "bb6b2b8cc620e328deb9dcff90e671c5cafe702b19fafbc9af81764429ed07b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/he/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/he/firefox-150.0.1.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "815f9e01499dbb83df62380bee2ed0b5a6bee368f00a51cb14e178465135e3a9";
+      sha256 = "55b9954cfde56434b8c0dab9e76c409246cc66f6a9dc69ed0d42d7da93a6cae8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hi-IN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/hi-IN/firefox-150.0.1.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "ccb8169a407e548ec662e2149bcd848fc19b8bb6fb7559afff412456c3fb1596";
+      sha256 = "2ec0590056f85476199e9f61a4a59e297f53a4793aad749bc88e5479a6bbb5cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/hr/firefox-150.0.1.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "66e17b54c9ca0275dcc0dc17a57b64eac0360587f4d80caaf5a8f904bd9f3fbc";
+      sha256 = "bfb02b878e13f4a1d98b9631659a07ae075a607bc328c3ee5aa5ac86bd42f6d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hsb/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/hsb/firefox-150.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "001ab0ccbfe3fdbc6b057664d02929dc3ebc4e9567684749f05f483cb3ebf369";
+      sha256 = "e6d5e54117250e22c6c2329a4b8c98546d65cb27797c9a42f69cfc92c72cdb1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hu/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/hu/firefox-150.0.1.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "16babc87894317efe88d6234762b6f0c14db62323b20987abcb95d9f639f32bb";
+      sha256 = "3903debfd0638dda86b13d27c92585fa3e8fdbb750366d77d83bbe1f6b29b29e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/hy-AM/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/hy-AM/firefox-150.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "419d551fca7fc4066303b980e7fff9585f7115270fbbadab3f487b559e88170a";
+      sha256 = "624f032b814ba01334ec52727bf9cbd3805cf94488994f0e1076ebeca21e8bbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ia/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/hye/firefox-150.0.1.tar.xz";
+      locale = "hye";
+      arch = "linux-aarch64";
+      sha256 = "ffc537707535c9a19ae66ac684c4792882da0986eac643d118614c67bb3eed10";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ia/firefox-150.0.1.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "d6bddb0e06ebb26dad4fbec0589c550c0a4644133ae915a801419b8c5083e5dd";
+      sha256 = "51f84bf0c6cf4c8783553d113ce079153225e3df8c0c45462e3df70af4b31b79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/id/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/id/firefox-150.0.1.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "02da44560c02c186417906254dd427213aac0f923c17499a89cdb169832069e8";
+      sha256 = "7613525439e39b7275887b6dcd100b7bf2d3b9fb4ee0c43525974376b1040243";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/is/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/is/firefox-150.0.1.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "acc08d39f248b5b799aa5f2631eaea6a0778157887fb5c0926ff42e7b1145b8b";
+      sha256 = "c2a85e67d6bee9d9149badc4489a4d70a8716e278819e03379c309471ed93ef5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/it/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/it/firefox-150.0.1.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "96f389427893b009b4b00c0426d7c1e44f4edfe4f85c954665798273dd24cf6c";
+      sha256 = "b2847b5bd62d3551c6cea210fed3a42f67c44ea500d1d007b574f8958aa8759a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ja/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ja/firefox-150.0.1.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "a28a5dc44c81b8d7bbb36e8529ec12b9eb93a4dbbb315e510591f57df70e431d";
+      sha256 = "56620a77759b736c554a3f825b8d8e643e8d943e5330a4b2d378a6ec618a8f9a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ka/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ka/firefox-150.0.1.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "e749135cafc5505f32832b36053a7c1179d3b10ecd00bf22856855e1aa595385";
+      sha256 = "11b0d303dcd30bbcff1e918446cb0e2134ff58adf33f8836e53ba743832ebe36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/kab/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/kab/firefox-150.0.1.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "56289ea469839fb14e1755b807c8590fdfec417e3ba3e167977d0a775d47ddfa";
+      sha256 = "d2ef86d352a2a9ac56f25368f9174a152b781305055725e796118e2600b86a3f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/kk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/kk/firefox-150.0.1.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "cf264d6c21e67632ee81eb808a52b624a3a994c6b6075aa93be0fc8cf8867d5a";
+      sha256 = "b143536df5ed2798a836306c3bc677490050f37a11b1027a03b061c136e36e4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/km/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/km/firefox-150.0.1.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "fd96e17527b863213e311ee9e3221b64c6dc44db4465d926afc17cde37970f37";
+      sha256 = "e4d4285bd3ec06cc6183957d7c21374661945575bbf89815fab92211b1f4f142";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/kn/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/kn/firefox-150.0.1.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "7a47e0e8cf8917bc9626dc0ba59ef7425be9cbcdf54e2b31954402d1cc3988d9";
+      sha256 = "3d62a8980af44837d04946fecb786869583951887804791496ed9b407388df1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ko/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ko/firefox-150.0.1.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "a90d9216e1112bb9639f536e6752e8a7f0afc5f19748e4544140096b4b7d1bee";
+      sha256 = "7c3013343f1d52b2345983452bda56dab05460f374dddd03e1d198ee92d537de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/lij/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/lij/firefox-150.0.1.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "c9868c2d93656facbef63bd0267870ca145efb0860063870b13c011debcc0570";
+      sha256 = "71211c4c8dee826dae432f77d7d26e4da19c939714890b11abcd628c9443bcad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/lt/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/lo/firefox-150.0.1.tar.xz";
+      locale = "lo";
+      arch = "linux-aarch64";
+      sha256 = "e78b38500aff29d791eef802e7bd328f9b961d53c276ea625cb36156126df70a";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/lt/firefox-150.0.1.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "8fc2b840950ad2593876794170575af91c04ad334552404f5460a5d006e9d594";
+      sha256 = "d88dc2b7e1331de2ef82a6960020b7a0f27dcf8fb4c9de4de199c66ba6fc51b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/lv/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ltg/firefox-150.0.1.tar.xz";
+      locale = "ltg";
+      arch = "linux-aarch64";
+      sha256 = "45086a95b8166412ab51a8db6446c540b9dab49a779eea8656e010a5d31fca4c";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/lv/firefox-150.0.1.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "a534d5e8e12e57a3b288ca1b12be61fb270da791f6ccd33938233eb1c0f3fc07";
+      sha256 = "2bbf06086aab432fd384416da0d5ca872df102bc88d9006ddd83dd6757c5ef3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/mk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/meh/firefox-150.0.1.tar.xz";
+      locale = "meh";
+      arch = "linux-aarch64";
+      sha256 = "7b7fe732cf7246d11b2fe5c889546abfec1649e06cac3df3212c36a65e5edc87";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/mk/firefox-150.0.1.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "101f937a0a64cc4aeb71ecc0b76334bdcf3c4bc41bc2923a845df89e1b1e4475";
+      sha256 = "3bd132654564c9d6da1fe962bb4ffa24db04e0c5cc10909312bd892bdee805f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/mr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ml/firefox-150.0.1.tar.xz";
+      locale = "ml";
+      arch = "linux-aarch64";
+      sha256 = "c2a533d488c0b1a41380aab5e8adf24bf4d228f2c3bf9105a5ca06ae598e13bc";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/mr/firefox-150.0.1.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "e9f8226415d5aa07faf0a9493d247c98f20ac1cfd64ad45dffa5b101470f266c";
+      sha256 = "584cb5c0ce829333b8789c5c0e3b0b92e360528525d1b7b26095e9aa7451ade7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ms/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ms/firefox-150.0.1.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "4860eaef1ffcc84c776645d46d09d05f792b5c939447b5e5cae5015080cba254";
+      sha256 = "a0e657870a6727167b9d09ca64a290240ad70603dd1f00041c98567cde2ac79f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/my/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/my/firefox-150.0.1.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "365b05ab1bb379d6fe3a7d47f4cad780fd06e8e4cf2d97be8b454e557b549f5d";
+      sha256 = "0be94e433659efa1195fbbd7cc3dda57a27ad792d6f27fcc3fbb4ef568c6ba24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/nb-NO/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/nb-NO/firefox-150.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "26da7d07de34b248bf31b46456be7db188819782de4be81c3102936ce7a7c147";
+      sha256 = "13a7c44869ad992b3b5e5d96bd728da805c008ddd6911a9a0b02080c0043b1ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ne-NP/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ne-NP/firefox-150.0.1.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "f18c403279ab4355f3c3af7df37917ddee15cf12d5702ee3631416094e34e29e";
+      sha256 = "239cb386656b0b399a28fd255e5e8f87dd8cf88494ae6d2d68e9bffddd8aff82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/nl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/nl/firefox-150.0.1.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "3af9e6a79b151deb9edbe20637b484763682ce129e19c62bf64d75c1c8b3e3b3";
+      sha256 = "7d8b35934fbede88f8fe419db69823fae84ec0fe76b975ac0b91684148fdb1d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/nn-NO/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/nn-NO/firefox-150.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "ced05bce994800f362e23305269324bff93363f6971a6fb3dcd50fd6695b46a6";
+      sha256 = "8a5cb9d59f364915ccfa2422cf0b89eeb0cea0955e6104634f982c7e6c03a0d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/oc/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/oc/firefox-150.0.1.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "001a3236dc3221693f00ccf7d3ef9a772a9f85e956086113f2d5ec00097764be";
+      sha256 = "c79e5e732756d38f55b41ad41292b094c24f39d6babd3b49650ca9fbd71b8606";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pa-IN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/pa-IN/firefox-150.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "ed8e49b3bad3263620c3335079c72bd01c12b5ec19bf5d2a3ee2501cc9bdfc3d";
+      sha256 = "6e8f56c5b989333fb0a38bc4cda2cad8822b622dcc46614a634f4e508973f631";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/pl/firefox-150.0.1.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "3b1518027b323cfdfdc4bb95f66bd75dc43ce387a75fade39f8cdcd789483f55";
+      sha256 = "9552d9903201258af9ae36a7e83b33593280ebb560e2c43e03b0210fcc0aec5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pt-BR/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/pt-BR/firefox-150.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "07decb7d696a9cecf4130352c77bdacf23fd0c7b486889fa40f5cf1faff22b5d";
+      sha256 = "aa0a2910705bf3ad409289403a2a53c99f050020e233c94055dc9256b7a81dbe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/pt-PT/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/pt-PT/firefox-150.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "cb011d2ba53d7eaf9d8065fbcf8a0a599ebd46d63a140af48aa68be90e2e89b8";
+      sha256 = "9c779f7c6ba13d77878cf5d3677bd8a079f30cfc69c9f140a6f4d6a31dc3ec5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/rm/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/rm/firefox-150.0.1.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "059036333a669b2e332bd1c91f8462f8f2c9197dd200686c93e8bc9c98d9a3e1";
+      sha256 = "f90c9cd8cd7d8adbc235fc6b8c7bb009e91101473f4a2e722d4746b29534daca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ro/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ro/firefox-150.0.1.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "dc0424e5288f25cf15e9dde77d21ee8b4819f2f3efcfb1a7f9759db38de69435";
+      sha256 = "b5cfb3ceee3ff68a831f4251fe653ec080b3921656814b4c8f034058ba8ead9f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ru/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ru/firefox-150.0.1.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "acc30078a9be326d58972b4ec86abde7d829309915f573ff930d07453497bde0";
+      sha256 = "72c877dc903a52d2375348a16fad7ded617ba199016d6f22aada1f28c5035b62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sat/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sat/firefox-150.0.1.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "64fe33329ccf4e46a7c83eba9ace506fb0f1eaa77f84e4fe0fe2a4b79adafe04";
+      sha256 = "ac17c01232d386ae52eaa504f05b70a22db1dfcbdf463e1020b5351e07265a9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sc/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sc/firefox-150.0.1.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "6865e09f8ac77bcb4f07f9adbb6d8db55d265d60bddd589c8fffd74fe08b88c0";
+      sha256 = "a7809ab6f568896beb07b1ad7106ac6f514af736a40b5d91fe351968c421bdaa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sco/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/scn/firefox-150.0.1.tar.xz";
+      locale = "scn";
+      arch = "linux-aarch64";
+      sha256 = "e6d09b48c3ab312504f932319b4b0fb5389ac282be44221db222837f129bd3fc";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sco/firefox-150.0.1.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "aa391d7766f94b938e70c1b25c6a94e37c89d0ff9dae04b194aa9f9cb05c6bce";
+      sha256 = "139aedbb5d6293fd939ab84a9bc45980987a1e7015d0696d66bb76dd726cee44";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/si/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/si/firefox-150.0.1.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "6724d82646c653cefeadf1170ed0e137541631536d282a7e11ccfd0066f17dbf";
+      sha256 = "7c78c58f7ff019fbd9ae99fdd71085511f8469b47624bb9794b5a19c96c92373";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sk/firefox-150.0.1.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "c660a9a3fc60a8dec171931f8dc42eab78f2e8eac052ad38b234f27c1cdaaf69";
+      sha256 = "015c865fcd5ce8cb3da3bc055146ad1e3d84ac2ba034dad8db1cf5c40458ea93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/skr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/skr/firefox-150.0.1.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "c4c02f3a144f70bd0ee2e9ad112e523bd5962253afbf72b7c672cbacb09f7f69";
+      sha256 = "0886595e8ae4776a83ddcddd6c2d8bf2257f8fc7b37693b3a517c66d154527c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sl/firefox-150.0.1.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "5734549558ace1c969ed2e2b4375a08f8869b25ab560d706bb60ddb4193590c9";
+      sha256 = "96541bb42b73f27162a85b9318ced66dacee185b2d76831416453859eebd82cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/son/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/son/firefox-150.0.1.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "a5d560cea663dc82152ab9bcf7d2733396254c02dd7308709d74264553e1ae15";
+      sha256 = "84f42c1c8a6b28408dc19b9c8153d1e8b4e2f578d60b5dec175250015ab41dd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sq/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sq/firefox-150.0.1.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "3eb5c4b583205380c13eb99c13df361db7adb46324ab37e4405b892f5c923d21";
+      sha256 = "6ffeb766f19b53763691e902f6a01584720a248b52cbe08bdb530ba7f9c65971";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sr/firefox-150.0.1.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "83b9a7cc9b19d82771f29f2fc2f20e76b04c0778d51644a3ab38223d46c51c2f";
+      sha256 = "ba6d4769fe30ca2c6dafbb9d9acb18defe2c2b7c48bb80a9d7a7579d23b236ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/sv-SE/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/sv-SE/firefox-150.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "d60f17565af94a7bac9b4188a036844b170a2183d1adb9323cc0e297121007d9";
+      sha256 = "9f3b81e42d918cb964c6ecd5887658704d8192fcec57123edea739ae617cd02c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/szl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/szl/firefox-150.0.1.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "0ab6422102620f7a2f8a3109e4a1ad7cefcba8692c3ab561cc218b71134fbe16";
+      sha256 = "9deb181dcc5d6bf24c2e14cc690cd867a7c3ffa6589899a7bd98021137c0da36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ta/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ta/firefox-150.0.1.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "7e6b81fe4bf32f20d6d63b624cfbbdc4534ad39908b9057ee7ec18d90fa0f006";
+      sha256 = "00987b9eedef78a5611860970d54c567cf441f333b1fe2d8a279b0babf1cdc85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/te/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/te/firefox-150.0.1.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "5c66682d957e02c9f93eb248bdec5787a2397099b1ec63d5bfe62e15fee8a616";
+      sha256 = "68a41103ae728f3bddc4632814fb4e9cc37d338ac171903b8fc51c18e6610d4d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/tg/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/tg/firefox-150.0.1.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "6151d4822fb5085e2743ace099c3fb5b06b11b10e9aaf48cd100da19e452701e";
+      sha256 = "48db88f96b0bd6719005a1e240988955b85489662957f77752e283d8eef8f5ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/th/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/th/firefox-150.0.1.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "de1cccee3e3f2734e011dde3aa4c564fefa43a493fa682b631c4f7a81c15260a";
+      sha256 = "18bb5d344710cf0a66d23fd221c55fab6c80932e4023301dcee928d48362cf91";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/tl/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/tl/firefox-150.0.1.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "816f2620046c878db2f2d91ba859b8db6657dfab0f48bf12f9956247edb43ced";
+      sha256 = "a1a8beaf1a316e38282c0f1478f6b6e82ab84a341a88c0edc8e446f53b201839";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/tr/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/tr/firefox-150.0.1.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "c3e21bed21f1d8ded7b8f67fb6a5b971aaedf982358cc2adaa1d22830cd3d4b6";
+      sha256 = "1cff2234f98902f95688bbd91411d65fd577164413c6de781d34c2275d74a517";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/trs/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/trs/firefox-150.0.1.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "2e34b768fb5ade0ded463a23278e779f726dc8a98ba50640b4c11d1dd9f439cb";
+      sha256 = "3c07eafec76bf6fd6a4f50476fe81b4eae905175c05365b97107e835c2b2051e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/uk/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/uk/firefox-150.0.1.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "2d3668f7dd2250b87d3568ea9a24fd9d56eece1087f0933bb41754f39f1d563e";
+      sha256 = "bd182a49930c4627bd2ca3f83eba539fa176a5061bc7b3187991b7d068b5406c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/ur/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/ur/firefox-150.0.1.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "f5b1c24d9d01ad2aa80d83312cb5a149bbb60aa08213ab53cafbb6c5c816055d";
+      sha256 = "0554f5d004570663b78e171eb009bbaa94683adec2af2516c2dfa0646737f0d9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/uz/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/uz/firefox-150.0.1.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "6185d107063cb3d37dd57b9931cbd7880c6119bf85c381aa90115fa2b4c69d6b";
+      sha256 = "efa72ea250f4d8db45e13f6a609c46ee2fa6f86aa13c577292f169ed9c5788eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/vi/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/vi/firefox-150.0.1.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "97a3ec310672fcb164205418b4a5d253a7e8b7c45798022233f4296c24f77e5f";
+      sha256 = "3d16128d05374def7a12783a323d0ceb7ae0f547c981d81227a951155437a706";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/xh/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/wo/firefox-150.0.1.tar.xz";
+      locale = "wo";
+      arch = "linux-aarch64";
+      sha256 = "aef236467b43f37f98e867c4f75ab0da3d7d96149eaf323b8a8c9209a4305b7e";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/xh/firefox-150.0.1.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "04ff21fad2cbf864fe975706f955f98bed94a731aefa9c50e04804471ba961b6";
+      sha256 = "d6bb489a2d1cacb4ef1f1d43b04ec8c4edc4b4ab1d7bd734824b93279a39f47d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/zh-CN/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/zh-CN/firefox-150.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "b2c97b5d0b1c84fd75f52c7480b262c2f6ce9a951ad30f8ce6c985f6f78b91d8";
+      sha256 = "055524b16616bc351b18cb9d3307adf1f78887fe3f2e1f686149d04809cdeee7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/linux-aarch64/zh-TW/firefox-150.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/linux-aarch64/zh-TW/firefox-150.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "91ed18bc6d5d9d9422f07f51b0c2e5e231431facb2871d413b5da61cc4119fa6";
+      sha256 = "7d7b833febb3d1d60d62bf54a26cb6a47406b3bfb1b0f8e72657e220a2335b6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ach/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ach/Firefox%20150.0.1.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "e2f99ffde15698e329db9e7fc0ba6cf50179f5b4246b0af824c694e861c8859d";
+      sha256 = "c2518f81742075eaf16f2630799397c7627f1e1df8d79f93c81cbbcc33a409a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/af/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/af/Firefox%20150.0.1.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "f36f2dd4c98d0cad0edd619c2e7aec22f7a86893f79407e96fd49b9b309f1a8b";
+      sha256 = "e9a78ec3e57ae2c56dca47597a452fb68d8f8f16aa10dbccf1dbb334b6c09064";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/an/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/an/Firefox%20150.0.1.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "dfa35cf323f25d1eb7ee8e95fd4ce1a28d1201e1082af5782ee53a6e2831472f";
+      sha256 = "c883a4c46ddf15d287afe2067dae819071bd3d4ec8f88d01685d3d4903567cd6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ar/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ar/Firefox%20150.0.1.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "afeec7930073b35949ed52303b3efcb0874f7ece39c697f89aaa78d4c36bad82";
+      sha256 = "567d0bdd4dec097d078e1d88d04148585bb4d35257a1cce2a47bdeff33e807e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ast/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ast/Firefox%20150.0.1.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "59611ab660fd04204462ecd7c0f5378539cb32ea65ad9bf009837a52a79c742f";
+      sha256 = "ec991c807d01840f7f9e45701b682158d64850e70328337b8e1e28169d7b3831";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/az/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/az/Firefox%20150.0.1.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "ad3573544a5856de13c62b2fe44351d6dd72f7d4a620492d6d5095fa495fca31";
+      sha256 = "80c669b37157511082d2d08e9280fe0a187868a09ecd1cc98834117c6bf73151";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/be/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/be/Firefox%20150.0.1.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "2745f823e387caa1a511a0e4a9480ad00413eb97ca1ff775113f4f0cf4da4d15";
+      sha256 = "815d972f549f82b81159f001fb9a68815256d1517c5104b1707c1220850e3532";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/bg/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/bg/Firefox%20150.0.1.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "1566dfe0d417ea0b5fe474454f6ace8a30e673d61f940bb4e2f522e77ec21e64";
+      sha256 = "cc03e352f0e17a1788b017b70cf4f473fa4fa0000855ed84c796ac581d8447a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/bn/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/bn/Firefox%20150.0.1.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "509e9b7f2a205bdc985413e963aca3d56e32fceff571e1d290fc47d218838b91";
+      sha256 = "3d6b15cfc2383396b409701b21dc57420fffefa8966d760145cc748d7329f3f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/br/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/bo/Firefox%20150.0.1.dmg";
+      locale = "bo";
+      arch = "mac";
+      sha256 = "e28d2a4485e5a030a89319e6e09fc5d3f8f6957b8eaddd6fcb0b469bb1fb17f5";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/bqi/Firefox%20150.0.1.dmg";
+      locale = "bqi";
+      arch = "mac";
+      sha256 = "10c37d15762fd6850fed848415faad8d53652e0386c78d35d33e0adc2db5f1e0";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/br/Firefox%20150.0.1.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "3046278dcc38b3454e8946797669d742b845f435fbed655309205dca6d4bcfb2";
+      sha256 = "265115a1802bf1ad659a38452204125df68fe5d840c5020b1e2a6b9e373ada96";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/bs/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/brx/Firefox%20150.0.1.dmg";
+      locale = "brx";
+      arch = "mac";
+      sha256 = "b9c3b988b55270a39ddce604ede130c3919f09128da5ff5749ccab95806c7d98";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/bs/Firefox%20150.0.1.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "05e4a787bf8a8778035b9ada4a31fcf3bd03bb6178592ce47782baa7caa876ec";
+      sha256 = "91e872c8e38fab0a20defe160d485ba12552403eaf0dfae1d536c35e06a80ecb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ca-valencia/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ca-valencia/Firefox%20150.0.1.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "913bcc960aebfb8bec9553308cb2e016bb9c1fe01a82f5440425480844f49717";
+      sha256 = "fad07a890ddcab9835a48cab50df18563ce25250d046ec61a5d09d55a29e9dd9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ca/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ca/Firefox%20150.0.1.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "a7efad433f593638bf2c8c9e72fb1f8bf57850ae2349638bbdec0c4180bbce3c";
+      sha256 = "e53369cfcff306e4a4e3343a5982c120108b168c0d80b0ca0915f536fb35cd01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/cak/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/cak/Firefox%20150.0.1.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "318b0df6f127c4f064304f3b26a708592d1c47a03c61d20f66661eba747eb2b6";
+      sha256 = "090adb887dd541a165ee8a6a6e4be79ee96eb491e3d96e5504795304b6f5e5ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/cs/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ckb/Firefox%20150.0.1.dmg";
+      locale = "ckb";
+      arch = "mac";
+      sha256 = "bec340f210f21848a3c8862500ae349ec65ff3ac62de9ac64607f4c76ce44d66";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/cs/Firefox%20150.0.1.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "071bf4034d1e1a7a1dccb90bec227ee4789a58500db939990c984e823a3c73a0";
+      sha256 = "01079e246026659b3c2da4e1b66141d5c597117f37e2719b409d1f595d7947fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/cy/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/cy/Firefox%20150.0.1.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "f62445587949d8e6d0ffbbc13d16be51be48b1bd1cbd947f05b7b73e94d1cbda";
+      sha256 = "7ef6d16950f8fad526606e6589bd2cba94c4da692aad3be717b113bb209eb6ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/da/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/da/Firefox%20150.0.1.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "0bba3653fa7789ea14f51d16152fc9289b9a12ecb0a375da18fa2cbc738471c1";
+      sha256 = "78c6684b85e8b3f4ad6bfc8da763782e06cf1e9018f996ef623c464dd1c02d25";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/de/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/de/Firefox%20150.0.1.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "ab4a318fc950826e7e2d174c42c36f4d5f7311199dbebdc48ee5a0e0f8e2354d";
+      sha256 = "f0d6f01a6819fc6ec3c7472372c322b387d00eb7ed3408a89d864d1a73d75631";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/dsb/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/dsb/Firefox%20150.0.1.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "2945d491b0aaf17f86e4b6e63a28d089246cb2cd0b0fa900cda1a73b1ed92837";
+      sha256 = "ad8b5d6bbb429b40761e71dca6636108c38143a5a35abce3399b55179fa0b99c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/el/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/el/Firefox%20150.0.1.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "3bcb364362142750d764812c2d86077cf87b592c4a72baccbb1a18e8de6c09c0";
+      sha256 = "218149aecc7f2b0c03b16d115aea8b71ab083c004c8e172189e07002f5c1aea7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/en-CA/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/en-CA/Firefox%20150.0.1.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "088bdd837a5771b4aed7686f2e847867a5a1534bbcb983eac6ffac954ec1c079";
+      sha256 = "9afc261a0c5e2f9807b9263dbc9a7da516a44e1e259c4a785c8d4df2f424d5f0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/en-GB/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/en-GB/Firefox%20150.0.1.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "59ce8018013a9a647c91bffa9c0637821524b677ceb78542b983d6bc88c41649";
+      sha256 = "129f84a7f63d0f1774d747fe74203422a83c38350ca915bdc74ddc81df4b22ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/en-US/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/en-US/Firefox%20150.0.1.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "203667ff6b0920f89973d477b1394d99b4b78807a613914c97bb1b3200e6da1b";
+      sha256 = "4221ec4972cb385042354b25940728e5eb7ececce7c95d2ec3f83d2323673d6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/eo/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/eo/Firefox%20150.0.1.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "e6fec1759803d73fc22797cf99334f1eac4da522dbae4ec8b06abe6747880d34";
+      sha256 = "a91efa6dc567a9f927fc018d8f35cd28f35938eea18276c036c1304ef768b943";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-AR/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/es-AR/Firefox%20150.0.1.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "8752226080d09bdc42bfd8b91ed7e694159401837b5aa3218fd595872d3dd926";
+      sha256 = "a5b719c37ed2602359f9de55d76afd032d71292ce366e6aee7da34c3089c52b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-CL/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/es-CL/Firefox%20150.0.1.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "406bfe67e7d92a3b365a314bfce1453c937d950cce47924eff577e924e28557c";
+      sha256 = "6682776a4062713cc117bd136a0336ddba951d79c53ed994b49d4a80eabfb272";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-ES/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/es-ES/Firefox%20150.0.1.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "0a14361560e5393d41f805bbcbac2dc24c3da16d218a18ca042d7913a552c679";
+      sha256 = "95594f5f6ede6be45cb6b41dbac1637c43efbcefd36b47bd34d350aee1d35fd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/es-MX/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/es-MX/Firefox%20150.0.1.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "4a6b627fc6804ed5a6fa4d797cf203690461d9cdb7faa6671ec11314114e867f";
+      sha256 = "98222582878630d280e889403a7f120339c5932904602cd538c758accec2719c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/et/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/et/Firefox%20150.0.1.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "bd970085f5a9825ec8f4d96c9370a7b89a098f3812e8de27498ba497ea687499";
+      sha256 = "9036fa35657a551940f2a630be91f954b7c22ea2200b91a3cbc103ae57787a68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/eu/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/eu/Firefox%20150.0.1.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "520f5732ca766b542c43e8fe520ce5b9e709b66b60d3cf71d36c5565a7f0a9f9";
+      sha256 = "f23ac467f480cc92bd1a32dc0d9385daf7cca1817c05b41a99707f8f6ac27ec4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fa/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/fa/Firefox%20150.0.1.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "6d082bca5b04d9951d9bacc89b1b33f08758c695058a8adc3814c1a362f9520b";
+      sha256 = "1979583c9084856c9ddb41faf699166dd134549e5a880dc6189b07602540a40c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ff/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ff/Firefox%20150.0.1.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "16bb5c8740943579fdb32e82d5ff2b8498fde6251afd2778acfca74a8fe74b45";
+      sha256 = "a54b68ea9b7e365d66400cfce048fc8967e81dd9ba3f88c9dddbcd0ab8f12263";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fi/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/fi/Firefox%20150.0.1.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "4119a5949a8602cd3d472342f63b0d9aeb0707e509b07db6aca8ec01aae09220";
+      sha256 = "3b744401a99db610e7d656435f584e81a5ef2a460b85c71a559777fbe2c1083d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fr/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/fr/Firefox%20150.0.1.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "cdacb332809c8c1862ccb1623031a296357ba6a53d288403445be93ca319a62f";
+      sha256 = "0ea7b30b41db56ad0faf5167019555d22fd526dc59c2591321398a7c12d9f3ac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fur/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/fur/Firefox%20150.0.1.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "82f6933e7e04e434904d7e7bc473097200ef071b8c1f59456c0f9f01afa9bef9";
+      sha256 = "3540e96329ef85636112a66a375081f67c67d99243eb7b8606aeb89b45a495a5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/fy-NL/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/fy-NL/Firefox%20150.0.1.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "dfc61dba9a4cd772be21c656e04da55ff6eed85adfe38d7cd752d139de7d813e";
+      sha256 = "176d78af8e7d7d91aef342ee7e49df1806fd60f5cbf21627b6a625583885f9d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ga-IE/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ga-IE/Firefox%20150.0.1.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "5ac1ec34a95244839f896b5d9e9f3b89b4276a5ef660880f7ccdf5466938dbfb";
+      sha256 = "4b268ecc43e3c88fe81f4ee16d186dd91d41a26c79cdb69d0eb42fca20603e6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gd/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/gd/Firefox%20150.0.1.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "a5fe8008b3406793d673100d7d0ec6785a8c878015c11e9c064496547013c204";
+      sha256 = "d6860f98e4ed711b075d32f21a66dfd60aaa1c5fd25660c862b06691d45f9f73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gl/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/gl/Firefox%20150.0.1.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "7a2fa34d2526f047b3649b480e0d5046a46a8fdbdfe05a393bcd3b513ec416d0";
+      sha256 = "227b89b5785598db1edf8b6099ab92d6bf460725fc93abd7c2afce1155879ef1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gn/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/gn/Firefox%20150.0.1.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "b6d7bc020d2551632c0063528a35bd9c71dceaf437703f25676663b34e5a9030";
+      sha256 = "ca7b15b96a45b1209e332f3182e2440088a63d206154542a69b0f94822ce1fe3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/gu-IN/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/gu-IN/Firefox%20150.0.1.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "deced77571f57a83661c4ebe430bb945ad5135a3137524bee7cdfb39c9837150";
+      sha256 = "33ad8602102ba910bb699e008c2b3dbe1fe7dcea8d176aa074be6dc5e4d2b4cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/he/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/he/Firefox%20150.0.1.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "147b97dbe732977acbc792956f82cc954d5891ba22717a533fc429f3061c1a07";
+      sha256 = "e7651ce1935ec3dc560429a8b883f2a181efd4b01d0c91986aeb7ca65f49ec80";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hi-IN/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/hi-IN/Firefox%20150.0.1.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "2625dc7f5959adbc72391e20abd839f6f0bd12b1a0a9d6775e0d270dd43f5f03";
+      sha256 = "cb9dbb3ca3a1d7dcb4ba8e425ee8d0445236fc4163f503bfeb8dc000daad407d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hr/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/hr/Firefox%20150.0.1.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "7d1bcc51e2660c132fb880dc2678cc7c4342ec891177f25dc33206e1bf78182a";
+      sha256 = "f68d0e7950c7ea00b0621951a5e98162c7722b5c4fcf127a53704a989ee8ee93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hsb/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/hsb/Firefox%20150.0.1.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "b63fc4a6ce0bfb1af6d7698b0ecd0dedbb3f79b4cbb5b4037b04eaf566a41aab";
+      sha256 = "b8f76b886d5678dd0391399cb0da049f5a3615c0621235501ecc3ef11bd2f476";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hu/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/hu/Firefox%20150.0.1.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "48629e9ae8212e03f2d9aa7c6d9bfc531218db350076161ae99808b9abf9069f";
+      sha256 = "8026c72dbcdd0b81782f05707f43b37a75ee15a60ed1a490d69d7f17d860f44f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/hy-AM/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/hy-AM/Firefox%20150.0.1.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "249bc6e8fa8e2a46e00d13552d0ea4be0117a608f8d2a70578cbd2372465da22";
+      sha256 = "bf7f92dca25bfd91e7b5f4148b8e745dd4b37482bc5ec07a527b18d634359f46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ia/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/hye/Firefox%20150.0.1.dmg";
+      locale = "hye";
+      arch = "mac";
+      sha256 = "99b8c1127a5473c7aa4788806cce2c8b557158b13c87d66f075b50bb72e8a369";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ia/Firefox%20150.0.1.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "8f223ce9c7f32ca477bb9f1bc340e572ea2310f97ca0a04c02cbb811c17ec2b4";
+      sha256 = "bd70ef1f71281a9cd9e10a344652403a12d58311ccac0278e48c2323a3c48a29";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/id/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/id/Firefox%20150.0.1.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "bcb61e41d888ab6de6854086cbe1bbe3701a8709a48b84170264ab6576aebb73";
+      sha256 = "80995a7ee82bf576a850dbdcb79d9950b9cbdd6dc797072646d2913b02292dff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/is/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/is/Firefox%20150.0.1.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "79becad3d33edd9beb8ea1bf7dd20320b359020815fb41f07181a3e11c95fb20";
+      sha256 = "9cce4f5520c014cc6f248abfa99672dc6bc9ffd484e7535fc4c53f8de9e4845a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/it/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/it/Firefox%20150.0.1.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "6ef5871c8951a69ff4f013f6c69d360d613fa01563318b08d98f079b7070b461";
+      sha256 = "cfba534a808acb011bbc5d5597fa0faaa13bd5f2c8ebe8777926211cc48a74ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ja-JP-mac/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ja-JP-mac/Firefox%20150.0.1.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "48d16cfd50ac3101e248c6c3a61d029a5573284bf47baea329427e7338b54685";
+      sha256 = "ce9ba0877ca07b14dbc8447637ab5fe543e7352d3eb334180794374326235a5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ka/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ka/Firefox%20150.0.1.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "e0b956a354597d8f4e258f12193476bda64d3e3853528c9a28e3e3573abe64f1";
+      sha256 = "234e6fec77e8e59c7bc31d2c10fe88ce223ace6ce9f7a2d99334202bcdf1d6e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/kab/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/kab/Firefox%20150.0.1.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "975021e54d958973ed42c9f51067f083885534b44701c4f27d671bfbffd929b9";
+      sha256 = "1d98a7597b449c1cf78ead0fd074522a11d31cc400a77c3169a6344178cfbc83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/kk/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/kk/Firefox%20150.0.1.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "832e6b87e2543d88ca3fa737e12cee984572eddba6dbd9a641a1452809259c84";
+      sha256 = "713b74d9de35b634cfe6786a828f44824b67806e3366117fa4bca0d15b1f99a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/km/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/km/Firefox%20150.0.1.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "bd9ebf1c384f0f50738eae6a2eea9fed6dc4f9044ac040a01acf6e9a7f7e6b85";
+      sha256 = "60a1ed56bbce21d3e4e8aa6f10f1dd52f49d42dd8882e5564bc38c2f07baa2b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/kn/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/kn/Firefox%20150.0.1.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "2223200b5fd4e96bef71c619255e4431f0162782ce71f4dfc7e0969d6273be10";
+      sha256 = "203220d6f154b887abe35353d1c4b257e76f9e07d648091d1d6d07fd9970c5e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ko/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ko/Firefox%20150.0.1.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "78e4bf62066f0608a218baf53ab0eae7e0c9214f335e7cb1a38072afb567513d";
+      sha256 = "42ad6d86cbec0471a71487f1eaa4abd9e652a708d5f372f10838c6f263f5a12d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/lij/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/lij/Firefox%20150.0.1.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "ac4a69804ac2938a4756774180f0cf56d4587757cef872b8d825502d2f1965fb";
+      sha256 = "c91d3a5d6c6e89865766e3fa6a5f8d266327775e8511620ca94dac482522a60e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/lt/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/lo/Firefox%20150.0.1.dmg";
+      locale = "lo";
+      arch = "mac";
+      sha256 = "18e69fb04a70af32460bd0cd16d2f1fa26264adaa75be372625700d92e8ddbac";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/lt/Firefox%20150.0.1.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "60a74fcf7a1d7ba9f7eb1cd27360ec32c45016c9c0c9c70dd8d73ceb5fe1d994";
+      sha256 = "cba75728c41dce858e6df6f079f930c9545efcffbffa5ed941bffb757db73f36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/lv/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ltg/Firefox%20150.0.1.dmg";
+      locale = "ltg";
+      arch = "mac";
+      sha256 = "f59c199a9cae7517b2321f215e8b45acfd21cc31f6aa6013d6322e903228fb92";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/lv/Firefox%20150.0.1.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "aadbaab1bd91fbd442b8827591250ef5cff9040c21fd97d4285ba5d81d4457d8";
+      sha256 = "187119046ddbd6659f5fd6c64c5cd3a1e2ce4d82753c8e11f32c5f2e54b6b566";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/mk/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/meh/Firefox%20150.0.1.dmg";
+      locale = "meh";
+      arch = "mac";
+      sha256 = "0717720e48246523513df9a7af59080acfe238b04de5284a4ae3536dc66057d6";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/mk/Firefox%20150.0.1.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "cee675f21a7d2ebf2f402270aee057ed8f0ce0092da12ae7cdd0fc85e3b18758";
+      sha256 = "730f901596e01172902e790c01b808dd1c8451e2b32597d12e39201b146e319d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/mr/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ml/Firefox%20150.0.1.dmg";
+      locale = "ml";
+      arch = "mac";
+      sha256 = "5de15615b7ef2d142b16c75034227e8810820cc5e810ea3c2030b3dbeee78df6";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/mr/Firefox%20150.0.1.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "8868a5d395347301c55c5f78f697a1bb52de47253b7245589f34fe464c9a1c40";
+      sha256 = "0d71ad1a2ca07f2c7448e81dc7d25fad30ef169eaf075f6053099668308c7ad5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ms/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ms/Firefox%20150.0.1.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "750bc64c2ab827826aed35b6da9cca647399e3294df2cf630f5cc636d5da61bf";
+      sha256 = "f96944452b3dfc3444ce52019aa039716e911c4a7432154bca5a9b6fbbddc0b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/my/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/my/Firefox%20150.0.1.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "038b6bcbb2721c70cfd33cdf879e83f8e5fb307c7c9cbec8ce907fb6e617730d";
+      sha256 = "8ec34d7c59ceb09a85c44e69339c649874cd0c13d3c3fb0ebc3c7f516f32a8f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/nb-NO/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/nb-NO/Firefox%20150.0.1.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "bc8935903eeea49bd45e8275f03e9e740c592e5a8169dce577dba14c1d1732a1";
+      sha256 = "178fed09b47d686a3f1cc8b49a9aeb0716d3a386cf300b096f6ff1259662677f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ne-NP/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ne-NP/Firefox%20150.0.1.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "811c118292c752ad5fe1d1f253c47ed2d7f25c23d82eaaa4b20d19b5d0ced135";
+      sha256 = "2fad9a1283c1388bc8409ff09ef51d85f35c3e94e93d4f1209eeeac7ee9dd7c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/nl/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/nl/Firefox%20150.0.1.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "41c818ea0b92df3e600c3c645f818645aa2e456f40734663fd9281b0732c4c51";
+      sha256 = "b98841b24abc26bda166f47756c91e18b779ae772dc498d173d0496b07bff636";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/nn-NO/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/nn-NO/Firefox%20150.0.1.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "3184e233f39b648dd7580262ef66591180a92ce9e1596989f195ab5e4e2cda61";
+      sha256 = "fee8e673d778c2f5a31422cc24db010a3eef70a56f0281e794fbfd24b52257e4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/oc/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/oc/Firefox%20150.0.1.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "c53ccceb610e24be9130fdbf4f603d7010a9dac35e5d914842ea4f676ddc3e74";
+      sha256 = "e5fc44dad1c91d43fa110370771602e67729a5968d3dea3e8d14733bf6a95eef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pa-IN/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/pa-IN/Firefox%20150.0.1.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "0b99e9868f1a8881fddc1cba7e22ed997edc2df4d719a3dc5641cbcab0def7ee";
+      sha256 = "7b204e5d1ce67ccc4874b8e3612f21de7b2b38ff211ecbff0d0532fa27569879";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pl/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/pl/Firefox%20150.0.1.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "02d38b35d439946e1cc06e341b82206a36face5a98d699ef4d525aa43ceb782a";
+      sha256 = "7dfd2b8f893e320ff60f6c841f39cbfd79e55e551f04338bf1cecbb2f2de3163";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pt-BR/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/pt-BR/Firefox%20150.0.1.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "ee872bc7eccb06694ebb40dac937c56968b25a33d11ffffe9b1792fb304dc4f3";
+      sha256 = "bf3cd9091da8ca07c81bdf40659d9a1ea36513cceb9dad064fb832fdfaba1afd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/pt-PT/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/pt-PT/Firefox%20150.0.1.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "8d44bb2dd36833035935bb29fd2006da070dd61b3017e1db3da950908eeeabfb";
+      sha256 = "4854d3b9fbab99e8665e46471b93c670c479feb72610d6464e6fdc045795bce2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/rm/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/rm/Firefox%20150.0.1.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "ecec9f55bfd0f42466eab33a9dacfa936188e82418a38ad41becf76ec26f4190";
+      sha256 = "73231634123b3c65eac7a58765408b10803f3bcf717feba31113cef3867c65e0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ro/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ro/Firefox%20150.0.1.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "e6ca0b18792b55afd20aba6014cd2678fc091d6e772760a2ff14e2d39e1f6ab3";
+      sha256 = "05e53fa5b5e8177c26ee80a1fbda1890b4786ca263112a64059885004021b921";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ru/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ru/Firefox%20150.0.1.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "f009ae9bfd40cb6cf6a52ea952cd63c363acd1133fa80bb2536aff48412709fe";
+      sha256 = "d9ecff067f59b72d09a21424fbb47ac1ea7c5cfa28439dd3dc8de13415d2afb0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sat/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sat/Firefox%20150.0.1.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "c6e6eed4908b8ee44d8c9d5726c93b19ed6a4c9d931b4a9caae9de842ff899b3";
+      sha256 = "d2f2e07a1401197ec19e5cebf0e8ee146429acb41287be6c555b7e20e3ac18ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sc/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sc/Firefox%20150.0.1.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "451744f61ac1bfd93fd3faf09f7a7570ee828a70191ab5290717cc28ae1e2c37";
+      sha256 = "af044d75600b326856de2b96df71f5029534614cb3b348cff831c431151d23d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sco/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/scn/Firefox%20150.0.1.dmg";
+      locale = "scn";
+      arch = "mac";
+      sha256 = "f31813be578e7ea4ef71ef4db382491b37dbad190d2d6764514acc5edb20988f";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sco/Firefox%20150.0.1.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "3f7dd6d01c68ca4cae050e44ede5b870341e66e5ff90156ff9ab083edb5605cd";
+      sha256 = "ee43e020caf91f2dfee081ffe041b0931cb8993c6c6d3d9e637001ce98151a76";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/si/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/si/Firefox%20150.0.1.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "ddab892764e2019cfe657a794188808f6167bff7c32357a671a057aa0dc63e8e";
+      sha256 = "fe18a56b01250a295e73da07dbd5c4dffcaed63079d24458794c6c318ecc3c71";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sk/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sk/Firefox%20150.0.1.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "afccb64c6be439428912bb49f880c3491bd8666cfecd7ad26fcd2d410fdf1a24";
+      sha256 = "836e6fb298c7652775dbde8b326ca9290c17e4d1ccb8882cec7b099a3b991b86";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/skr/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/skr/Firefox%20150.0.1.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "e765f6c3844f21111f249a79610837d56237b99419bba3ee17c9b145ec35d396";
+      sha256 = "55f11b8de296808cf29906452074cd077b442fdaf6d6cf83570fbfd9e46a7dab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sl/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sl/Firefox%20150.0.1.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "f621e3fd3e525d52758a4f43537176e740e1fd90207da8eab0215fecb01600d5";
+      sha256 = "47d9b4c35e5e9652f7f89ee23478cabc3f4c0c2e5240692eaa06ea3082d4a5d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/son/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/son/Firefox%20150.0.1.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "b2ae31affc04473ee6174b7cb08d49bda96e968d2918e363ea9c3ecdcdfcc420";
+      sha256 = "cdc6253145b79f98c9565c9480b132d00e3040e734ab6bf05535817b0c32e62b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sq/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sq/Firefox%20150.0.1.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "5d921780265bf24a565fee901b2c41aecedc87ad53f7410dd14265c5cae9fb9f";
+      sha256 = "51a2e17ce3a891ed97ff2c3d33b860594467282e79191c1811d522513e0a2d6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sr/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sr/Firefox%20150.0.1.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "8c867b4e486d8b9753b4201f8a939c31710fc6bb315eacc5a079d89f2626d4ca";
+      sha256 = "230ca74cefa96cfccb1e827ca95dbe0fbb7e691af2f20f0eea6656dafcedf6b8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/sv-SE/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/sv-SE/Firefox%20150.0.1.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "c70e230922d4ae6ae8f4ab5e73d4b38a11c74c6fccb14782d58ba19ae1bd5e4f";
+      sha256 = "4a352287203afbf0b48f65178a96c510e4d20e77d82c5e664c7ae4635e380a3c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/szl/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/szl/Firefox%20150.0.1.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "3b33c959100bf3856ed18c3985e39fc044376c1eb8d96a8313a3813468810574";
+      sha256 = "8cf05c5f74a0223008c816592cf6409ea564addc30536d3cedaf7ef24d2fe036";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ta/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ta/Firefox%20150.0.1.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "db395f1b99caa216113dbc504a109c4e4b8c59e644d7652c54064aced8bd4735";
+      sha256 = "0e2c1a570b51a36ed18d24872a2956c73cf7efdb1698436bad78aa2f28cabd8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/te/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/te/Firefox%20150.0.1.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "800c86a587c6414d0e102d92dcd2e9e41919c6ce6fccc9a63cf0e02edf72b2d4";
+      sha256 = "2e6d6b13d894096c8b3a9b509954c73fd21781a1d68feaa20915107068a15ccc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/tg/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/tg/Firefox%20150.0.1.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "756a3e76cdba1e34455b7ac3c637020232f7099918b804bce489258d0a621dfe";
+      sha256 = "f4eeacae46aae68850828458e0e86ffca9bfee716735dabf853acb3d8118f571";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/th/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/th/Firefox%20150.0.1.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "dad99883df22810004a23231b3c0bf261742de0ae8300a5a347334c295c59303";
+      sha256 = "8785e060463c7901d96d10bb69383efbd7d288820cccd0b52b24bba2078e9df5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/tl/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/tl/Firefox%20150.0.1.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "afc55a8ec60c36b98d4729a99567af1e9174088c9e886b8c1699395ef94840f4";
+      sha256 = "50bc2996c1a2d0b882b46b0a0ad453ceb514ada7e8f9f17cd4041b3b50ec8e6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/tr/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/tr/Firefox%20150.0.1.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "567a203a8372b78ee0b8d1a8a2ae38834bd5bc33ff0c75a547dd3d766588c6e3";
+      sha256 = "fbd033e40a0f870d7a471a56c563323ba56d6136a9594176023f307173ce3635";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/trs/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/trs/Firefox%20150.0.1.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "7fbb43a8fc8830a3de6618c36861cd4ae31263df065663be4b3de78720911636";
+      sha256 = "8011f29a2b5e610c040cce3ddb7ed57bd8f9f35a121ff51a9e5c4ae6cc42ec2f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/uk/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/uk/Firefox%20150.0.1.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "a1e99a73327e9cc5dc910a85f859d4a8d17ee56db837926195432832936bf338";
+      sha256 = "12dc63014ac7b506ada38021c32fa3f014f3f532c5580df00a521a2e2efd191e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/ur/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/ur/Firefox%20150.0.1.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "dea1ca0d4db9cf690a0fc0cd09e54d61c3348331edb6b53708993ce7c9c33c41";
+      sha256 = "3d7c494e14425a9988816083fda6de822b74bdf13358278c2fda704855a6a23c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/uz/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/uz/Firefox%20150.0.1.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "1a711465583bec0d94dad20da45d3c78b068b117bfa5602e3b69dc9c6da25a96";
+      sha256 = "7d3dcf3ff39d043b700212ab6bcbb10562596fb655b1c1b3949f3d2811159477";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/vi/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/vi/Firefox%20150.0.1.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "22c6a53d890f66b01e47965f9ce9a0db22c71c0d722ad336bcf5dce930a4600d";
+      sha256 = "7335573a841a00ca790854c9fafcf151b813e4d496afec447c23558e5463e2d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/xh/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/wo/Firefox%20150.0.1.dmg";
+      locale = "wo";
+      arch = "mac";
+      sha256 = "0089bf8dcd9bcce824975b6b2d24e17ad6e1881c84248815a99452e8e3e0f24a";
+    }
+    {
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/xh/Firefox%20150.0.1.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "253552c147b314f419c6a7ada0512e357b91b69331f817709d57849d543acffb";
+      sha256 = "138cc152b5c1a87e29840222729b505958a4bb5a65659ddf0cbc3e789d0ad7c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/zh-CN/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/zh-CN/Firefox%20150.0.1.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "858c6f75ed5c40e062dac3267d2e7b559af6f0618206a1f9b3be841bee6f4882";
+      sha256 = "11b9671aca9071f24c22af18d6dc822c6185829818b27fba28f61df1e59d6d4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/150.0/mac/zh-TW/Firefox%20150.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/150.0.1/mac/zh-TW/Firefox%20150.0.1.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "45360816b33a3e30eac95e845e9aa5bcb9f012f19fbae2aca3a8b80b74c2d4ae";
+      sha256 = "7aa5f608da115a55c5589554315710f877c8a289c82e9ff2f460330f9552cfbe";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "150.0";
+  version = "150.0.1";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "77e8eae86e7b17c33933fdea6d3b5fbe73e6613949e62c13d9ed3e593e7ba0b50701fa97fc7d56a278961d2e1cdb2902244c30a1020790091b0ae2f0cb1b4e71";
+    sha512 = "b3710e1b35002312bf248e822681039b75ec1196f8d014c88b0377c9b06f34780469152a98ad967440a51a4a0ca45418ba6239438f869ae564cc82c023645179";
   };
 
   meta = {


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/150.0.1/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
