### PR TITLE
python3Packages.siphashc: fetch sources from GitHub, fix changelog

### DIFF
--- a/pkgs/development/python-modules/siphashc/default.nix
+++ b/pkgs/development/python-modules/siphashc/default.nix
@@ -1,20 +1,22 @@
 {
   lib,
-  fetchPypi,
+  fetchFromGitHub,
   buildPythonPackage,
   setuptools,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "siphashc";
   version = "2.7";
   pyproject = true;
   build-system = [ setuptools ];
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-ppRNc3aM9So6g0LunBka2UBFWQAvck9E4Ot6sOC96jM=";
+  src = fetchFromGitHub {
+    owner = "WeblateOrg";
+    repo = "siphashc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Rj+0oIlGs2Xs2TTN0PIwcVUlTgd1AZITC8xBf/Hn31Q=";
   };
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -24,8 +26,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python c-module for siphash";
     homepage = "https://github.com/WeblateOrg/siphashc";
-    changelog = "https://github.com/WeblateOrg/siphashc/blob/${version}/CHANGES.rst";
+    changelog = "https://github.com/WeblateOrg/siphashc/blob/${finalAttrs.src.tag}/CHANGES.rst";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ erictapen ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
