### PR TITLE
Ginac with gcc

### DIFF
--- a/pkgs/by-name/gi/ginac/ginac-example-test.nix
+++ b/pkgs/by-name/gi/ginac/ginac-example-test.nix
@@ -1,0 +1,32 @@
+{
+  runCommand,
+  gccStdenv,
+  cln,
+  ginac
+}:
+runCommand "ginac-example-test"
+  {
+    nativeBuildInputs = [ gccStdenv.cc ginac cln ];
+  }
+  ''
+    echo "
+      #include <iostream>
+      #include <ginac/ginac.h>
+      using namespace std;
+      using namespace GiNaC;
+
+      int main() {
+        symbol x(\"x\"), y(\"y\");
+        ex poly;
+
+        for (int i=0; i<3; ++i) {
+          poly += factorial(i+16)*pow(x,i)*pow(y,2-i);
+        }
+
+        cout << poly << endl;
+        return 0;
+      }" > hello.cc
+    c++ -lginac -lcln hello.cc -o hello
+    ./hello
+    mkdir $out
+  ''

--- a/pkgs/by-name/gi/ginac/package.nix
+++ b/pkgs/by-name/gi/ginac/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   gccStdenv,
+  callPackage,
   fetchurl,
   cln,
   pkg-config,
@@ -35,6 +36,8 @@ gccStdenv.mkDerivation (finalAttrs: {
   '';
 
   configureFlags = [ "--disable-rpath" ];
+
+  passthru.tests.example = callPackage ./ginac-example-test.nix { ginac = finalAttrs.finalPackage; };
 
   meta = {
     description = "GiNaC C++ library for symbolic manipulations";

--- a/pkgs/by-name/gi/ginac/package.nix
+++ b/pkgs/by-name/gi/ginac/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  gccStdenv,
   fetchurl,
   cln,
   pkg-config,
@@ -9,7 +10,7 @@
   python3,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "ginac";
   version = "1.8.10";
 


### PR DESCRIPTION
On Darwin the stdenv uses clang, which builds binaries that crash with example inputs, `SIGSEGV (Address boundary error)`. Ginac documentation says "We used GCC for development so if you have a different compiler you are on your own." Switching to always using gcc aligns the derivation with the build instructions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
