### PR TITLE
python3Packages.executorch: fix cuda build

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -7,6 +7,8 @@
 
   # nativeBuildInputs
   gitMinimal,
+  # cuda-only:
+  autoPatchelfHook,
 
   # build-system
   certifi,
@@ -46,8 +48,11 @@
   transformers,
   writableTmpDirAsHomeHook,
   yaspin,
+
+  cudaSupport ? torch.cudaSupport,
+  cudaPackages,
 }:
-buildPythonPackage (finalAttrs: {
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "executorch";
   version = "1.2.0";
   pyproject = true;
@@ -107,6 +112,9 @@ buildPythonPackage (finalAttrs: {
     #  Some binaries contain forbidden references to /build/. Check the error above!
     CMAKE_ARGS = lib.concatStringsSep " " [
       (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+
+      # For some cmake-tier reason, cmakeBool does not work here
+      (lib.cmakeFeature "EXECUTORCH_BUILD_CUDA" (if cudaSupport then "ON" else "OFF"))
     ];
   };
 
@@ -122,6 +130,15 @@ buildPythonPackage (finalAttrs: {
 
   nativeBuildInputs = [
     gitMinimal
+  ]
+  ++ lib.optionals cudaSupport [
+    autoPatchelfHook
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_nvrtc
   ];
 
   pythonRemoveDeps = [


### PR DESCRIPTION
## Things done

Fix `python3Packages.executorch` with `cudaSupport`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
