### PR TITLE
Add siebenmann/zfs_exporter package and related module

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -131,6 +131,7 @@ let
         "v2ray"
         "varnish"
         "wireguard"
+        "zfs-siebenmann"
         "zfs"
       ]
       (

--- a/nixos/modules/services/monitoring/prometheus/exporters/zfs-siebenmann.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/zfs-siebenmann.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.zfs-siebenmann;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    optionalString
+    ;
+in
+{
+  port = 9700;
+
+  extraOpts = {
+    pools = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      description = ''
+        Name of the pool(s) to collect, repeat for multiple pools (default: all pools).
+      '';
+    };
+
+    depth = mkOption {
+      type = types.int;
+      default = 1;
+      description = ''
+        Depth of the vdev tree to report on.
+        0 is the pool, 1 is top level vdevs, 2 is devices too.
+      '';
+    };
+
+    fullPath = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Report the full path of disks.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    # needs zpool
+    path = [ config.boot.zfs.package ];
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-siebenmann-zfs-exporter}/bin/zfs_exporter \
+          --listen-addr ${cfg.listenAddress}:${toString cfg.port} \
+          --depth ${toString cfg.depth} \
+          ${optionalString cfg.fullPath "--fullpath"} \
+          ${concatStringsSep " " (map (p: "--pool=${p}") cfg.pools)} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+      ProtectClock = false;
+      PrivateDevices = false;
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-siebenmann-zfs-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-siebenmann-zfs-exporter/package.nix
@@ -1,0 +1,28 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  __structuredAttrs = true;
+  pname = "prometheus-siebenmann-zfs-exporter";
+  version = "unstable-2022-08-17";
+
+  src = fetchFromGitHub {
+    owner = "siebenmann";
+    repo = "zfs_exporter";
+    rev = "c5f18cb0d470c24dbd2c12553a87d0aca3ddc50b";
+    hash = "sha256-FBFjzsoRiU48616CsxkP2lVSGO3qgLYBjOrtROzhgSY=";
+  };
+
+  vendorHash = "sha256-YjEK/nKqoMch0UygoCkk8mAclRFhsjodFVHhN49zeW4=";
+
+  meta = {
+    description = "ZFS Exporter for the Prometheus monitoring system (Siebenmann/cks-upstream variant)";
+    mainProgram = "zfs_exporter";
+    homepage = "https://github.com/siebenmann/zfs_exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ podocarp ];
+  };
+}


### PR DESCRIPTION
Adds [siebenmann/zfs_exporter](https://github.com/siebenmann/zfs_exporter). This is different from the currently existing exporter in `services.prometheus.exporters.zfs`, and different from the zfs module in the node_exporter. Notably, it exposes some performance related metrics that were removed by zfs upstream (https://github.com/prometheus/node_exporter/issues/2068).

Also, I don't know what to name it, maybe someone can come up with a better name.

## Things done

Regarding testing, I deployed it on a running system using the module and I have physically checked that it does export.
```
  services.prometheus.exporters = {
    zfs-siebenmann = {
      enable = true;
      port = 9100;
    };
  };

```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
