### PR TITLE
xen: 4.20.2 -> 4.20.3

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -173,7 +173,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xen";
-  version = "4.20.2";
+  version = "4.20.3";
 
   # This attribute can be overriden to correct the file paths in
   # `passthru` when building an unstable Xen.
@@ -186,28 +186,28 @@ stdenv.mkDerivation (finalAttrs: {
 
     (replaceVars ./0002-scripts-external-executable-calls.patch scriptDeps)
 
-    # XSA #477
+    # XSA #483
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa477.patch";
-      hash = "sha256-c9i61GvHPiLwMGvd+5IKgUwyu/NPub+mtnxUPHW/HhI=";
+      url = "https://xenbits.xenproject.org/xsa/xsa483.patch";
+      hash = "sha256-pZkSQKAjEIa/EHlCa2hD+3kofzpVHtFxcdp/TiWu9i8=";
     })
 
-    # XSA #479
+    # XSA #484
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa479.patch";
-      hash = "sha256-2o6RYyT4Nrg1le6BUOQ3AwedorCvxvKao2uMYWrUV1Y=";
+      url = "https://xenbits.xenproject.org/xsa/xsa484.patch";
+      hash = "sha256-6zkTBHKfpAK2poSycEFSb3pE9pDpZwBxAe5Jf862j+U=";
     })
 
-    # XSA #480
+    # XSA #486
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa480.patch";
-      hash = "sha256-mHoY+Y8klwLYOo4LZCwYcNsB1BcBbSa1nQOn3NueDdI=";
+      url = "https://xenbits.xenproject.org/xsa/xsa486.patch";
+      hash = "sha256-8EC1lv2JAYqchX5sHbO3NbP7haEyu1V0/72KwALG+BA=";
     })
 
-    # XSA #481
+    # XSA #488
     (fetchpatch {
-      url = "https://xenbits.xenproject.org/xsa/xsa481.patch";
-      hash = "sha256-QpRXS4rFuML2TawH7yhUmg8U4C1ATt4xiLLs91duuO8=";
+      url = "https://xenbits.xenproject.org/xsa/xsa488-4.20.patch";
+      hash = "sha256-QttKWdmWC6Zn5k2hd6RIMCpLWv71HB/A9mCbDP+i8to=";
     })
 
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
@@ -228,8 +228,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xen-project";
     repo = "xen";
-    tag = "RELEASE-4.20.2";
-    hash = "sha256-ZDPjsEAEH5bW0156MVvOKUeqg+mwdce0GFdUTBH39Qc=";
+    tag = "RELEASE-4.20.3";
+    hash = "sha256-+qTHIsDD2A5lVwmpJ7artnzdviT1XN05CYeu7JFxfqc=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Plus XSAs 483, 484, 486 and 488. See https://xenbits.xenproject.org/xsa.

Builds and runs on my systems, most changes are with AMD CPUs which I can no longer test, but this kind of Xen update is historically extremely stable and shouldn't cause problems.

Please be forewarned that my availability is currently limited, but I'll do my best to get this merged soon if it needs any changes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
