### PR TITLE
massren: 1.5.6 -> 1.5.7

### DIFF
--- a/pkgs/by-name/ma/massren/package.nix
+++ b/pkgs/by-name/ma/massren/package.nix
@@ -2,29 +2,20 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "massren";
-  version = "1.5.6";
+  version = "1.5.7";
 
   src = fetchFromGitHub {
     owner = "laurent22";
     repo = "massren";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-17y+vmspvZKKRRaEwzP3Zya4r/z+2aSGG6oNZiA8D64=";
+    hash = "sha256-PjF7ani4NdM0Avz0/4D04CZLdvkQHg91E/eFoDXD6ks=";
   };
 
   vendorHash = null;
-
-  patches = [
-    # Add Go Modules support
-    (fetchpatch {
-      url = "https://github.com/laurent22/massren/commit/83df215b6e112d1ec375b08d8c44dadc5107155d.patch";
-      hash = "sha256-FMTmUrv6zGq11vexUirAuK3H6r78RtoipqyWoh+pzrs=";
-    })
-  ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
https://github.com/laurent22/massren/releases/tag/v1.5.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
