### PR TITLE
stm32cubeide{,_1_19_0}: init at 2.1.1/1.19.0

### DIFF
--- a/pkgs/by-name/st/stm32cubeide/generic.nix
+++ b/pkgs/by-name/st/stm32cubeide/generic.nix
@@ -1,0 +1,374 @@
+{
+  lib,
+  stdenv,
+  src,
+  version,
+  basename,
+  autoPatchelfHook,
+  makeWrapper,
+  copyDesktopItems,
+  udevCheckHook,
+  gnutar,
+  unzip,
+  makeDesktopItem,
+  stlinkServerVersion,
+  stlinkUdevVersion,
+  jlinkUdevVersion,
+
+  # Core libraries
+  glib,
+  gtk3,
+  gdk-pixbuf,
+  pango,
+  cairo,
+  atk,
+  zlib,
+  freetype,
+  fontconfig,
+  libx11,
+  libxrender,
+  libxtst,
+  libxi,
+  libxext,
+  libxrandr,
+  libxcursor,
+  libxcomposite,
+  libxdamage,
+  libxfixes,
+  libxinerama,
+  libxxf86vm,
+  libxcb,
+  libxau,
+  libxdmcp,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxcb-wm,
+  libxkbcommon,
+  dbus,
+  dbus-glib,
+
+  # Wayland support
+  wayland,
+
+  # OpenGL
+  libGL,
+  libGLU,
+  mesa,
+
+  # USB support (for debugging probes)
+  libusb1,
+  hidapi,
+
+  # Ncurses (mentioned in installer)
+  ncurses5,
+
+  # For GDB
+  expat,
+  python3,
+
+  # SSL/crypto
+  openssl,
+
+  # Additional libraries
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  cups,
+  udev,
+  nspr,
+  nss,
+
+  # For CubeProgrammer
+  pcsclite,
+  xercesc,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stm32cubeide";
+  inherit version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    copyDesktopItems
+    gnutar
+    unzip
+  ];
+
+  nativeInstallCheckInputs = [
+    udevCheckHook
+  ];
+  doInstallCheck = true;
+
+  buildInputs = [
+    # Core libraries
+    glib
+    gtk3
+    gdk-pixbuf
+    pango
+    cairo
+    atk
+    zlib
+    freetype
+    fontconfig
+    libx11
+    libxrender
+    libxtst
+    libxi
+    libxext
+    libxrandr
+    libxcursor
+    libxcomposite
+    libxdamage
+    libxfixes
+    libxinerama
+    libxxf86vm
+    libxcb
+    libxau
+    libxdmcp
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxcb-wm
+    libxkbcommon
+    dbus
+    dbus-glib
+
+    # Wayland support
+    wayland
+
+    # OpenGL
+    libGL
+    libGLU
+    mesa
+
+    # USB support (for debugging probes)
+    libusb1
+    hidapi
+
+    # Ncurses (mentioned in installer)
+    ncurses5
+
+    # For GDB
+    stdenv.cc.cc.lib
+    expat
+    python3
+
+    # SSL/crypto
+    openssl
+
+    # Additional libraries
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    cups
+    udev
+    nspr
+    nss
+
+    # For CubeProgrammer
+    pcsclite
+    xercesc
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    mkdir source
+    cd source
+    unzip $src
+    bash ${basename}.sh --noexec --target .
+
+    runHook postUnpack
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Extract the main tarball
+    mkdir -p $out/opt/stm32cubeide
+    tar -xzf ${basename}.tar.gz -C $out/opt/stm32cubeide --strip-components=0
+
+    # Create bin directory
+    mkdir -p $out/bin
+
+    # Create wrapper script for the main IDE
+    makeWrapper $out/opt/stm32cubeide/stm32cubeide $out/bin/stm32cubeide \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
+      --set GTK_THEME "Adwaita"
+
+    # Also create wayland-compatible wrapper (still uses x11 backend)
+    makeWrapper $out/opt/stm32cubeide/stm32cubeide $out/bin/stm32cubeide_wayland \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
+      --set GDK_BACKEND x11 \
+      --set GTK_THEME "Adwaita"
+
+    # Create wrapper for headless build
+    if [ -f $out/opt/stm32cubeide/headless-build.sh ]; then
+      makeWrapper $out/opt/stm32cubeide/headless-build.sh $out/bin/stm32cubeide-headless \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}"
+    fi
+
+    # Copy icon
+    mkdir -p $out/share/pixmaps
+    mkdir -p $out/share/icons/hicolor/stm32cubeide/apps
+    if [ -f $out/opt/stm32cubeide/icon.xpm ]; then
+      cp $out/opt/stm32cubeide/icon.xpm $out/share/pixmaps/stm32cubeide.xpm
+      cp $out/opt/stm32cubeide/icon.xpm $out/share/icons/hicolor/stm32cubeide/apps/stm32cubeide.xpm
+    fi
+
+    # Install stlink-server from the separate package
+    mkdir -p $out/opt/stlink-server
+    bash st-stlink-server.${stlinkServerVersion}-linux-amd64.install.sh \
+      --noexec --target $out/opt/stlink-server
+
+    if [ -f $out/opt/stlink-server/stlink-server ]; then
+      chmod +x $out/opt/stlink-server/stlink-server
+      makeWrapper $out/opt/stlink-server/stlink-server $out/bin/stlink-server \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libusb1 ]}"
+    fi
+
+    # install the various udev rules
+    mkdir udev
+    bash segger-jlink-udev-rules-${jlinkUdevVersion}-linux-noarch.sh --noexec --target udev
+    bash st-stlink-udev-rules-${stlinkUdevVersion}-linux-noarch.sh --noexec --target udev
+    mkdir -p $out/lib/udev/rules.d
+    # Remove group specifications for a group that doesn't exist
+    substituteInPlace udev/49-stlinkv*.rules --replace-fail "GROUP=\"plugdev\", " ""
+    cp udev/49-stlinkv*.rules udev/99-jlink.rules $out/lib/udev/rules.d/
+
+    runHook postInstall
+  '';
+
+  # autoPatchelfHook settings
+  autoPatchelfIgnoreMissingDeps = [
+    # These are bundled with the application
+    "libjli.so"
+    "libSTLinkUSBDriver.so"
+    "libhsmp11.so"
+    "libPreparation.so.1"
+    # Bundled Qt6 (for CubeProgrammer)
+    "libQt6Core.so.6"
+    "libQt6DBus.so.6"
+    "libQt6Gui.so.6"
+    "libQt6Network.so.6"
+    "libQt6OpenGL.so.6"
+    "libQt6Qml.so.6"
+    "libQt6SerialPort.so.6"
+    "libQt6Widgets.so.6"
+    "libQt6XcbQpa.so.6"
+    "libQt6Xml.so.6"
+    "libQt6EglFSDeviceIntegration.so.6"
+    "libQt6WaylandEglClientHwIntegration.so.6"
+    "libQt6WaylandClient.so.6"
+    # Bundled Qt4 (for JLink tools)
+    "libQtCore.so.4"
+    "libQtGui.so.4"
+    # Bundled JLink
+    "libjlinkarm.so"
+    "libjlinkarm.so.8"
+    # Optional FFmpeg plugins for JRE (not needed for IDE)
+    "libavformat-ffmpeg.so.56"
+    "libavcodec-ffmpeg.so.56"
+    "libavformat.so.54"
+    "libavcodec.so.54"
+    "libavformat.so.56"
+    "libavcodec.so.56"
+    "libavformat.so.57"
+    "libavcodec.so.57"
+    "libavformat.so.58"
+    "libavcodec.so.58"
+    "libavformat.so.59"
+    "libavcodec.so.59"
+    "libavformat.so.60"
+    "libavcodec.so.60"
+    # xerces versioned lib (we have 3.3, it wants 3.2)
+    "libxerces-c-3.2.so"
+  ];
+
+  # Set rpath for bundled libraries to find each other
+  postFixup = ''
+    # Fix the CubeProgrammer tools to find their bundled libs
+    CUBEPROG_DIR=$(find $out/opt/stm32cubeide/plugins -type d -name "com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.linux64_*" | head -1)
+    if [ -n "$CUBEPROG_DIR" ]; then
+      patchelf --set-rpath "$CUBEPROG_DIR/tools/lib:${lib.makeLibraryPath finalAttrs.buildInputs}" \
+        $CUBEPROG_DIR/tools/bin/STM32_Programmer_CLI || true
+    fi
+
+    # Fix JLink tools to find their bundled libs
+    JLINK_DIR=$(find $out/opt/stm32cubeide/plugins -type d -name "com.st.stm32cube.ide.mcu.externaltools.jlink.linux64_*" | head -1)
+    if [ -n "$JLINK_DIR" ]; then
+      for bin in $JLINK_DIR/tools/bin/JLink*; do
+        if [ -f "$bin" ] && [ -x "$bin" ]; then
+          patchelf --set-rpath "$JLINK_DIR/tools/bin:${lib.makeLibraryPath finalAttrs.buildInputs}" "$bin" || true
+        fi
+      done
+    fi
+
+    # Fix the bundled JRE
+    JRE_DIR=$(find $out/opt/stm32cubeide/plugins -type d -name "com.st.stm32cube.ide.jre.linux64_*" | head -1)
+    if [ -n "$JRE_DIR" ] && [ -d "$JRE_DIR/jre" ]; then
+      for bin in $JRE_DIR/jre/bin/*; do
+        if [ -f "$bin" ] && [ -x "$bin" ]; then
+          patchelf --set-rpath "$JRE_DIR/jre/lib:$JRE_DIR/jre/lib/server:${lib.makeLibraryPath finalAttrs.buildInputs}" "$bin" || true
+        fi
+      done
+      for lib in $JRE_DIR/jre/lib/*.so $JRE_DIR/jre/lib/server/*.so; do
+        if [ -f "$lib" ]; then
+          patchelf --set-rpath "$JRE_DIR/jre/lib:$JRE_DIR/jre/lib/server:${lib.makeLibraryPath finalAttrs.buildInputs}" "$lib" || true
+        fi
+      done
+    fi
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "stm32cubeide";
+      comment = "Integrated Development Environment for STM32";
+      genericName = "STM32 IDE";
+      desktopName = "STM32CubeIDE ${version}";
+      exec = "stm32cubeide %F";
+      icon = "stm32cubeide";
+      terminal = false;
+      startupNotify = true;
+      categories = [
+        "Development"
+        "IDE"
+        "Electronics"
+      ];
+      mimeTypes = [ "application/x-stm32cubeide" ];
+    })
+    (makeDesktopItem {
+      name = "stm32cubeide_wayland";
+      comment = "Integrated Development Environment for STM32 (Wayland compatibility with X11)";
+      genericName = "STM32 IDE";
+      desktopName = "STM32CubeIDE ${version} (Wayland Compat)";
+      exec = "stm32cubeide_wayland %F";
+      icon = "stm32cubeide";
+      terminal = false;
+      startupNotify = true;
+      categories = [
+        "Development"
+        "IDE"
+        "Electronics"
+      ];
+      mimeTypes = [ "application/x-stm32cubeide" ];
+    })
+  ];
+
+  meta = {
+    description = "Integrated Development Environment for STM32 microcontrollers";
+    homepage = "https://www.st.com/en/development-tools/stm32cubeide.html";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ sempiternal-aurora ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/st/stm32cubeide/package.nix
+++ b/pkgs/by-name/st/stm32cubeide/package.nix
@@ -1,0 +1,45 @@
+{
+  callPackage,
+  requireFile,
+  lib,
+  version ? "2.1.1",
+  source ? null,
+  versionInfo ? null,
+}:
+
+let
+  versions = import ./versions.nix;
+
+  versionStrings =
+    (builtins.attrNames versions)
+    # assume that if they are passing their own versionInfo
+    # that it is for the version they specify
+    ++ lib.optional (versionInfo != null) version;
+
+  selected = lib.defaultTo (versions.${version}) versionInfo;
+  basename = "st-stm32cubeide_${version}_${selected.buildNumber}_${selected.date}_${selected.time}_amd64";
+
+  defaultSource = requireFile {
+    name = "${basename}.sh.zip";
+    message = ''
+      This nix expression requires that ${basename}.sh.zip is
+      already part of the store. Download it from
+      https://www.st.com/en/development-tools/stm32cubeide.html
+      (it's the generic linux version) and then add it to the
+      store with:
+      $ nix store add --mode flat ${basename}.sh.zip
+      or
+      $ nix-store --add-fixed sha256 ${basename}.sh.zip
+    '';
+    inherit (selected) hash;
+  };
+in
+
+assert lib.asserts.assertOneOf "version" version versionStrings;
+
+callPackage ./generic.nix {
+  inherit version basename;
+  inherit (selected) stlinkServerVersion jlinkUdevVersion stlinkUdevVersion;
+
+  src = lib.defaultTo defaultSource source;
+}

--- a/pkgs/by-name/st/stm32cubeide/versions.nix
+++ b/pkgs/by-name/st/stm32cubeide/versions.nix
@@ -1,0 +1,79 @@
+{
+  "2.1.1" = {
+    buildNumber = "28236";
+    date = "20260312";
+    time = "0043";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "9.24";
+    stlinkUdevVersion = "1.0.3-3";
+
+    hash = "sha256-Pqns+1IJ/aZI4EW+oTIMhzZY8qTnlZk4GnG85ddnNfs=";
+  };
+  "2.1.0" = {
+    buildNumber = "27993";
+    date = "20260219";
+    time = "1630";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "9.14a";
+    stlinkUdevVersion = "1.0.3-3";
+
+    hash = "sha256-mLlJndPOCqHuLnbayh0fE9jpNOeHaFM7iYKsYwNWeMw=";
+  };
+  "2.0.0" = {
+    buildNumber = "26820";
+    date = "20251114";
+    time = "1348";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "8.80";
+    stlinkUdevVersion = "1.0.3-2";
+
+    hash = "sha256-pkMa8svF3zHBYd3xupgkB5w7Lf85nH98H3o9ZHNDt+Q=";
+  };
+  "1.19.0" = {
+    buildNumber = "25607";
+    date = "20250703";
+    time = "0907";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "8.38_fixed";
+    stlinkUdevVersion = "1.0.3-2";
+
+    hash = "sha256-+jeXv7+ywRhgQAIl7aFCnRzhbVJZPlW6JICvGLacPG0=";
+  };
+  "1.18.1" = {
+    buildNumber = "24813";
+    date = "20250409";
+    time = "2138";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "8.12c_final";
+    stlinkUdevVersion = "1.0.3-2";
+
+    hash = "sha256-asdu5tNaDSy9bcFN7Q+jLxeIVlyGa53SjLp8YlDY1U8=";
+  };
+  "1.18.0" = {
+    buildNumber = "24413";
+    date = "20250227";
+    time = "1633";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "8.12c_final";
+    stlinkUdevVersion = "1.0.3-2";
+
+    hash = "sha256-jsdHk66/BJtEk2RwZf4ohFJSLfs3gbSqzIZPTgCcWuI=";
+  };
+  "1.17.0" = {
+    buildNumber = "23558";
+    date = "20241125";
+    time = "2245";
+
+    stlinkServerVersion = "2.1.1-1";
+    jlinkUdevVersion = "8.10d";
+    stlinkUdevVersion = "1.0.3-2";
+
+    hash = "sha256-eDxCZpXe8YSlApQUn6kpsZqcqpea6l4jRh2N9VKDxzI=";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3134,6 +3134,8 @@ with pkgs;
     isDesktopVariant = true;
   };
 
+  stm32cubeide_1_19_0 = stm32cubeide.override { version = "1.19.0"; };
+
   stm32loader = with python3Packages; toPythonApplication stm32loader;
 
   solc-select = with python3Packages; toPythonApplication solc-select;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Package `stm32cubeide` for use in `nixpkgs`. Goes along with `stm32cubemx`, which we already have here. Source for the project requires agreeing to a EULA, and providing an name/email to st, so I have built it to use `pkgs.requireFile` like mathematica does. A few things I'm unsure about, which is why I'm leaving this as a draft for now:
- I'm not sure how functional the actual IDE is. Going to be using it for the next few weeks, so I'll bug test it and see how it goes. Don't think it'll be ready in time for feature freeze sadly.
- Not sure what the maintenance burden will be in keeping all these versions of the IDE will be. 
  - Right now, the st-link server version is the same as the latest stm32cubeide version, but for all of the stm32cubeide versions I've packaged here.
  - I think this is just a coincidence, as the current st-link server version seems to have been around since `2024` at the very least, but I'm not 100% confident. 
  - Basically, I'm worried they'll rebuild all recent versions of the software when a new stm32cubeide release comes out, and I don't want to re-download 8 1GB files every time a new version comes out.
- Further, with the versions, do we need more than latest 2.x and 1.x versions?
  - I originally got them all based on what mathematica does, but they have more reason to do it there, as software version is tied directly to licences
  - It doesn't really seem like we'd need more than stm32cubeide, and stm32cubeide1?
    - Not quite sure on the name for the second one there.
- Also worth considering, do we want to create a separate derivation for stlink-server?
  - It seems like it can be used without stm32cubeide, and does have a separate upstream download link.
  - I don't think it's really necessary right now, and will cause users of stm32cubeide to have to provide 2 different files to the nix-store, one of which is redundant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
