### PR TITLE
taco: unstable-2022-08-02 -> 0-unstable-2025-04-14

### DIFF
--- a/pkgs/by-name/ta/taco/package.nix
+++ b/pkgs/by-name/ta/taco/package.nix
@@ -6,11 +6,10 @@
   python3,
   llvmPackages,
   enablePython ? false,
-  python ? python3,
 }:
 
 let
-  pyEnv = python.withPackages (
+  pyEnv = python3.withPackages (
     p: with p; [
       numpy
       scipy
@@ -21,17 +20,17 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "taco";
-  version = "unstable-2022-08-02";
+  version = "0-unstable-2025-04-14";
 
   src = fetchFromGitHub {
     owner = "tensor-compiler";
     repo = "taco";
-    rev = "2b8ece4c230a5f0f0a74bc6f48e28edfb6c1c95e";
+    rev = "0e79acb56cb5f3d1785179536256e206790b2a9e";
     fetchSubmodules = true;
-    hash = "sha256-PnBocyRLiLALuVS3Gkt/yJeslCMKyK4zdsBI8BFaTSg=";
+    hash = "sha256-mdT6ZLxtJ7fqyjRqdWf6+RltvMy7YDr9AEnJtnaDmTw=";
   };
 
-  src-new-pybind11 = python.pkgs.pybind11.src;
+  src-new-pybind11 = python3.pkgs.pybind11.src;
 
   postPatch = ''
     rm -rf python_bindings/pybind11/*
@@ -45,6 +44,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace apps/tensor_times_vector/CMakeLists.txt --replace-fail \
       "cmake_minimum_required(VERSION 2.8.12)" \
       "cmake_minimum_required(VERSION 3.5)"
+
+    # Newer pybind11 typing wrappers require a single concrete lambda return type.
+    substituteInPlace python_bindings/src/pytaco.cpp --replace-fail \
+      'm.def("get_parallel_schedule", [](){' \
+      'm.def("get_parallel_schedule", []() -> py::tuple {'
   '';
 
   # Remove test cases from cmake build as they violate modern C++ expectations
@@ -62,8 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional enablePython "-DPYTHON=ON";
 
   postInstall = lib.strings.optionalString enablePython ''
-    mkdir -p $out/${python.sitePackages}
-    cp -r lib/pytaco $out/${python.sitePackages}/.
+    mkdir -p $out/${python3.sitePackages}
+    cp -r lib/pytaco $out/${python3.sitePackages}/.
   '';
 
   # The standard CMake test suite fails a single test of the CLI interface.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19039,7 +19039,6 @@ self: super: with self; {
 
   taco = toPythonModule (
     pkgs.taco.override {
-      inherit (self) python;
       enablePython = true;
     }
   );


### PR DESCRIPTION
Fixes the broken Taco build by updating to the latest commit and fixing a pybind incompatibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
