### PR TITLE
wl_shimeji: init at 0-unstable-2026-04-28

### DIFF
--- a/pkgs/by-name/wl/wl_shimeji-unwrapped/package.nix
+++ b/pkgs/by-name/wl/wl_shimeji-unwrapped/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  libarchive,
+  uthash,
+  python3,
+  python3Packages,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wl_shimeji-unwrapped";
+  version = "0-unstable-2026-04-28";
+
+  src = fetchFromGitHub {
+    owner = "CluelessCatBurger";
+    repo = "wl_shimeji";
+    rev = "8ae15cf7e56325b08708e1b8d851baef679962d1";
+    hash = "sha256-UBZXeuZJKGqbEK8Xwjs/Sk6JRktjBu4u6w5NGLjhuCs=";
+    leaveDotGit = true;
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland
+    wayland-protocols
+    wayland-scanner
+    libarchive
+    uthash
+    python3
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  preBuild = ''
+    substituteInPlace ./Makefile \
+    --replace-fail "\$(shell which python3)" "${lib.getExe' python3 "python3"}"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Shimeji reimplementation for Wayland in C.";
+    homepage = "https://github.com/CluelessCatBurger/wl_shimeji";
+    mainProgram = "shimejictl";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ claymorwan ];
+  };
+})

--- a/pkgs/by-name/wl/wl_shimeji/package.nix
+++ b/pkgs/by-name/wl/wl_shimeji/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  symlinkJoin,
+  wl_shimeji-unwrapped,
+  python3,
+  python3Packages,
+}:
+
+let
+  unwrapped = wl_shimeji-unwrapped;
+in
+symlinkJoin {
+  pname = "wl_shimeji";
+  inherit (unwrapped) version;
+
+  paths = [
+    unwrapped
+  ];
+
+  nativeBuildInputs = [
+    python3Packages.wrapPython
+  ];
+
+  pythonInputs = with python3Packages; [
+    pillow
+  ];
+
+  postBuild = ''
+    buildPythonPath "$pythonInputs"
+
+    wrapProgram $out/bin/shimejictl \
+      --prefix PATH : $program_PATH \
+      --set PYTHONHOME ${python3} \
+      --set PYTHONPATH $program_PYTHONPATH
+  '';
+
+  meta = unwrapped.meta // {
+    hydraPlatforms = [ ];
+    priority = (unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Added `wl_shimeji-unwrapped` and its wrapper `wl_shimeji`. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
