### PR TITLE
home-assistant-custom-lovelace-modules.light-entity-card: fix meta.changelog, intel-graphics-compiler: fix meta.changelog, python314Packages.protobuf: remove myself from maintainers

### DIFF
--- a/pkgs/by-name/in/intel-graphics-compiler/package.nix
+++ b/pkgs/by-name/in/intel-graphics-compiler/package.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "LLVM-based compiler for OpenCL targeting Intel Gen graphics hardware";
     homepage = "https://github.com/intel/intel-graphics-compiler";
-    changelog = "https://github.com/intel/intel-graphics-compiler/releases/tag/${version}";
+    changelog = "https://github.com/intel/intel-graphics-compiler/releases/tag/v${version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ SuperSandro2000 ];

--- a/pkgs/development/python-modules/protobuf/5.nix
+++ b/pkgs/development/python-modules/protobuf/5.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     homepage = "https://developers.google.com/protocol-buffers/";
     changelog = "https://github.com/protocolbuffers/protobuf/releases/v${version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/light-entity-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/light-entity-card/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "light-entity-card";
   version = "6.3.1";
 
   src = fetchFromGitHub {
     owner = "ljmerza";
     repo = "light-entity-card";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Y25jtbKJNTVi6XUHntm2AtIzuht96/o5l+uScwEE9So=";
   };
 
@@ -31,8 +31,8 @@ buildNpmPackage rec {
   meta = {
     description = "Control any light or switch entity";
     homepage = "https://github.com/ljmerza/light-entity-card";
-    changelog = "https://github.com/ljmerza/light-entity-card/releases/tag/${version}";
+    changelog = "https://github.com/ljmerza/light-entity-card/releases/tag/${finalAttrs.src.tag}";
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
see #514132


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
