### PR TITLE
python3Packages.flash-attn: 2.8.2 -> 2.8.3

### DIFF
--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -2,18 +2,26 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  einops,
+
+  # build-system
   ninja,
   setuptools,
-  symlinkJoin,
   torch,
+
+  # dependencies
+  einops,
+
+  # tests
+  pytestCheckHook,
+
+  # passthru
+  flash-attn,
 }:
 
 let
   inherit (torch) cudaCapabilities cudaPackages cudaSupport;
-  inherit (cudaPackages) backendStdenv;
 in
-buildPythonPackage rec {
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "flash-attention";
   version = "2.8.2";
   pyproject = true;
@@ -21,26 +29,29 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Dao-AILab";
     repo = "flash-attention";
-    tag = "v${version}";
-    hash = "sha256-iHxfDh+rGanhymP5F7g8rQcQUlP0oXliVF+y+ur/iJ0=";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
+    hash = "sha256-iHxfDh+rGanhymP5F7g8rQcQUlP0oXliVF+y+ur/iJ0=";
   };
 
   preConfigure = ''
     export MAX_JOBS="$NIX_BUILD_CORES"
-    export NVCC_THREADS="$NIX_BUILD_CORES"
+    export NVCC_THREADS=2
   '';
 
   env = lib.optionalAttrs cudaSupport {
+    FORCE_BUILD = "TRUE";
     FLASH_ATTENTION_SKIP_CUDA_BUILD = "FALSE";
-    CC = "${backendStdenv.cc}/bin/cc";
-    CXX = "${backendStdenv.cc}/bin/c++";
     TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" cudaCapabilities}";
   };
 
   build-system = [
     ninja
     setuptools
+    torch
+  ];
+
+  nativeBuildInputs = [
     cudaPackages.cuda_nvcc
   ];
 
@@ -58,18 +69,27 @@ buildPythonPackage rec {
     torch
   ];
 
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
   # Requires NVIDIA driver.
   doCheck = false;
 
   pythonImportsCheck = [ "flash_attn" ];
+
+  passthru.gpuCheck = flash-attn.overridePythonAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doCheck = true;
+  };
 
   meta = {
     # Upstream requires either CUDA or ROCm. Couldn't get it to work with ROCm for now.
     broken = !cudaSupport;
     description = "Official implementation of FlashAttention and FlashAttention-2";
     homepage = "https://github.com/Dao-AILab/flash-attention/";
-    changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${src.tag}";
+    changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ jherland ];
   };
-}
+})

--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -2,74 +2,152 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  einops,
+
+  # build-system
   ninja,
   setuptools,
-  symlinkJoin,
   torch,
+
+  # dependencies
+  cuda-bindings,
+  einops,
+  nvidia-cutlass-dsl,
+
+  # tests
+  apex,
+  pytestCheckHook,
+  sentencepiece,
+  timm,
+  transformers,
+  writableTmpDirAsHomeHook,
+
+  # passthru
+  flash-attn,
 }:
 
 let
   inherit (torch) cudaCapabilities cudaPackages cudaSupport;
-  inherit (cudaPackages) backendStdenv;
+  inherit (cudaPackages.flags) dropDots;
+
+  self = buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
+    pname = "flash-attention";
+    version = "2.8.3";
+    pyproject = true;
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "Dao-AILab";
+      repo = "flash-attention";
+      tag = "v${finalAttrs.version}";
+      fetchSubmodules = true;
+      hash = "sha256-6I1O4E5K5IdbpzrXFHK06QVcOE8zuVkFE338ffk6N8M=";
+    };
+
+    patches = [
+      # cutlass.utils.ampere_helpers was removed from nvidia-cutlass-dsl, this patch is a workaround.
+      ./drop-cutlass-ampere-utils.patch
+    ];
+
+    preConfigure = ''
+      export MAX_JOBS="$NIX_BUILD_CORES"
+      export NVCC_THREADS=2
+    '';
+
+    env = lib.optionalAttrs cudaSupport {
+      FORCE_BUILD = "TRUE";
+      FLASH_ATTENTION_SKIP_CUDA_BUILD = "FALSE";
+
+      # 8.0;9.0;12.0
+      TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
+      # 80;90;120
+      FLASH_ATTN_CUDA_ARCHS = lib.strings.concatMapStringsSep ";" dropDots cudaCapabilities;
+    };
+
+    build-system = [
+      ninja
+      setuptools
+      torch
+    ];
+
+    nativeBuildInputs = [
+      cudaPackages.cuda_nvcc
+    ];
+
+    buildInputs = [
+      cudaPackages.cuda_cccl # <thrust/*>
+      cudaPackages.libcublas # cublas_v2.h
+      cudaPackages.libcurand # curand.h
+      cudaPackages.libcusolver # cusolverDn.h
+      cudaPackages.libcusparse # cusparse.h
+      cudaPackages.cuda_cudart # cuda_runtime.h cuda_runtime_api.h
+    ];
+
+    dependencies = [
+      # Used in flash_attn/cute/interface.py
+      cuda-bindings
+
+      einops
+      nvidia-cutlass-dsl
+      torch
+    ];
+
+    pythonImportsCheck = [ "flash_attn" ];
+
+    nativeCheckInputs = [
+      apex
+      pytestCheckHook
+      sentencepiece
+      timm
+      transformers
+      writableTmpDirAsHomeHook
+    ];
+
+    enabledTestPaths = [
+      "tests/"
+    ];
+
+    disabledTestPaths = [
+      # `fused_dense_lib` and `dropout_layer_norm` live under csrc/ as standalone Python packages
+      # with their own setup.py; the top-level setup.py does not build them, and they are not
+      # shipped on PyPI either.
+      "tests/ops/test_dropout_layer_norm.py"
+      "tests/ops/test_fused_dense.py"
+      "tests/ops/test_fused_dense_parallel.py"
+
+      # Imports `RotaryEmbedding` from `transformers.models.gpt_neox.modeling_gpt_neox`, which
+      # upstream transformers has since removed.
+      "tests/layers/test_rotary.py"
+
+      # Tests the ROCm composable_kernel backend; we only build the CUDA backend.
+      "tests/test_flash_attn_ck.py"
+
+      # Module-name collision with tests/test_flash_attn.py (both import as
+      # `test_flash_attn`). Disable the CUTE-DSL variant and keep the tests that
+      # exercise the C++ extension we actually build.
+      "tests/cute/test_flash_attn.py"
+    ];
+
+    preCheck = ''
+      rm -rf flash_attn
+    '';
+
+    # Tests require access to a physical GPU
+    doCheck = false;
+
+    passthru.gpuCheck = self.overridePythonAttrs {
+      requiredSystemFeatures = [ "cuda" ];
+      doCheck = true;
+    };
+
+    meta = {
+      # Upstream requires either CUDA or ROCm. Couldn't get it to work with ROCm for now.
+      broken = !cudaSupport;
+      description = "Official implementation of FlashAttention and FlashAttention-2";
+      homepage = "https://github.com/Dao-AILab/flash-attention/";
+      changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${finalAttrs.src.tag}";
+      license = lib.licenses.bsd3;
+      maintainers = with lib.maintainers; [ jherland ];
+    };
+  });
 in
-buildPythonPackage rec {
-  pname = "flash-attention";
-  version = "2.8.2";
-  pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "Dao-AILab";
-    repo = "flash-attention";
-    tag = "v${version}";
-    hash = "sha256-iHxfDh+rGanhymP5F7g8rQcQUlP0oXliVF+y+ur/iJ0=";
-    fetchSubmodules = true;
-  };
-
-  preConfigure = ''
-    export MAX_JOBS="$NIX_BUILD_CORES"
-    export NVCC_THREADS="$NIX_BUILD_CORES"
-  '';
-
-  env = lib.optionalAttrs cudaSupport {
-    FLASH_ATTENTION_SKIP_CUDA_BUILD = "FALSE";
-    CC = "${backendStdenv.cc}/bin/cc";
-    CXX = "${backendStdenv.cc}/bin/c++";
-    TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" cudaCapabilities}";
-  };
-
-  build-system = [
-    ninja
-    setuptools
-    cudaPackages.cuda_nvcc
-  ];
-
-  buildInputs = [
-    cudaPackages.cuda_cccl # <thrust/*>
-    cudaPackages.libcublas # cublas_v2.h
-    cudaPackages.libcurand # curand.h
-    cudaPackages.libcusolver # cusolverDn.h
-    cudaPackages.libcusparse # cusparse.h
-    cudaPackages.cuda_cudart # cuda_runtime.h cuda_runtime_api.h
-  ];
-
-  dependencies = [
-    einops
-    torch
-  ];
-
-  # Requires NVIDIA driver.
-  doCheck = false;
-
-  pythonImportsCheck = [ "flash_attn" ];
-
-  meta = {
-    # Upstream requires either CUDA or ROCm. Couldn't get it to work with ROCm for now.
-    broken = !cudaSupport;
-    description = "Official implementation of FlashAttention and FlashAttention-2";
-    homepage = "https://github.com/Dao-AILab/flash-attention/";
-    changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${src.tag}";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ jherland ];
-  };
-}
+self

--- a/pkgs/development/python-modules/flash-attn/drop-cutlass-ampere-utils.patch
+++ b/pkgs/development/python-modules/flash-attn/drop-cutlass-ampere-utils.patch
@@ -1,0 +1,62 @@
+diff --git a/flash_attn/cute/ampere_helpers.py b/flash_attn/cute/ampere_helpers.py
+index 839f407..9f74824 100644
+--- a/flash_attn/cute/ampere_helpers.py
++++ b/flash_attn/cute/ampere_helpers.py
+@@ -5,6 +5,15 @@ import cutlass
+ import cutlass.cute as cute
+ 
+ 
++# Max dynamic shared memory per SM, in bytes (architectural max minus 1 KB reserved for the driver).
++# Mirrors the values previously exposed by cutlass.utils.ampere_helpers, which was removed in nvidia-cutlass-dsl 4.3.
++SMEM_CAPACITY = {
++    "sm80": (164 - 1) * 1024,
++    "sm86": (100 - 1) * 1024,
++    "sm89": (100 - 1) * 1024,
++}
++
++
+ def get_smem_layout_atom(dtype: Type[cutlass.Numeric], k_dim: int) -> cute.ComposedLayout:
+     dtype_byte = cutlass.const_expr(dtype.width // 8)
+     bytes_per_row = cutlass.const_expr(k_dim * dtype_byte)
+diff --git a/flash_attn/cute/flash_bwd.py b/flash_attn/cute/flash_bwd.py
+index 79f5ee8..be008b1 100644
+--- a/flash_attn/cute/flash_bwd.py
++++ b/flash_attn/cute/flash_bwd.py
+@@ -11,7 +11,6 @@ import cuda.bindings.driver as cuda
+ import cutlass
+ import cutlass.cute as cute
+ from cutlass.cute.nvgpu import cpasync, warp
+-import cutlass.utils.ampere_helpers as sm80_utils_basic
+ 
+ from flash_attn.cute import ampere_helpers as sm80_utils
+ from flash_attn.cute import utils
+@@ -125,7 +124,7 @@ class FlashAttentionBackwardSm80:
+         smem_usage_V = n_block_size * head_dim_v * 2
+         smem_usage_QV = (smem_usage_Q + smem_usage_V) if not V_in_regs else max(smem_usage_Q, smem_usage_V)
+         smem_usage = smem_usage_QV + smem_usage_dO + smem_usage_K
+-        smem_capacity = sm80_utils_basic.SMEM_CAPACITY["sm80"]
++        smem_capacity = sm80_utils.SMEM_CAPACITY["sm80"]
+         if smem_usage > smem_capacity:
+             return False
+         return True
+diff --git a/flash_attn/cute/flash_fwd.py b/flash_attn/cute/flash_fwd.py
+index ddd5cfc..cf5ac81 100644
+--- a/flash_attn/cute/flash_fwd.py
++++ b/flash_attn/cute/flash_fwd.py
+@@ -16,7 +16,6 @@ import cutlass
+ import cutlass.cute as cute
+ from cutlass import const_expr
+ from cutlass.cute.nvgpu import cpasync, warp, warpgroup
+-import cutlass.utils.ampere_helpers as sm80_utils_basic
+ import cutlass.utils.hopper_helpers as sm90_utils_basic
+ 
+ from flash_attn.cute import ampere_helpers as sm80_utils
+@@ -127,7 +126,7 @@ class FlashAttentionForwardBase:
+         smem_usage_QV = (smem_usage_Q + smem_usage_V) if not Q_in_regs else max(smem_usage_Q, smem_usage_V)
+         smem_usage = smem_usage_QV + smem_usage_K
+         # TODO: sm86 and sm89
+-        smem_capacity = sm80_utils_basic.SMEM_CAPACITY["sm80"]
++        smem_capacity = sm80_utils.SMEM_CAPACITY["sm80"]
+         if smem_usage > smem_capacity:
+             return False
+         # Check if twice the block size is divisible by the number of threads


### PR DESCRIPTION
## Things done

Diff: https://github.com/Dao-AILab/flash-attention/compare/v2.8.2...v2.8.3
Changelog: https://github.com/Dao-AILab/flash-attention/releases/tag/v2.8.3

Fixes #508320.

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
