### PR TITLE
vmalert: Fail if encountering missing rule paths

### DIFF
--- a/nixos/modules/services/monitoring/vmalert.nix
+++ b/nixos/modules/services/monitoring/vmalert.nix
@@ -25,14 +25,16 @@ let
     in
     attrsOf (either valueType (listOf valueType));
 
+  mkCliVal = value: if isPath value then "${value}" else toString value;
+
   mkLine =
     key: value:
     if value == true then
       "-${key}"
     else if isList value then
-      concatMapStringsSep " " (v: "-${key}=${escapeShellArg (toString v)}") value
+      concatMapStringsSep " " (v: "-${key}=${escapeShellArg (mkCliVal v)}") value
     else
-      "-${key}=${escapeShellArg (toString value)}";
+      "-${key}=${escapeShellArg (mkCliVal value)}";
 
   vmalertName = name: "vmalert" + lib.optionalString (name != "") ("-" + name);
   enabledInstances = lib.filterAttrs (name: conf: conf.enable) config.services.vmalert.instances;


### PR DESCRIPTION
Previously, the vmalert module used toString for interpolating paths. The build process wouldn't attempt to copy the given path into the store; that would then result in hard-to-debug errors when running the vmalert service (it launches, but treats the missing as a non-issue, so you run with no alerting).

Instead, use string interpolation to resolve the file from the given path. This properly fails the build if a missing file is referenced.

This fixes #514178.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
