### PR TITLE
aws-lc: restore postFixup dropped in 1.65.0 bump

### DIFF
--- a/pkgs/by-name/aw/aws-lc/package.nix
+++ b/pkgs/by-name/aw/aws-lc/package.nix
@@ -54,6 +54,20 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
+  # AWS-LC's generated *-targets.cmake files hardcode _IMPORT_PREFIX to $out
+  # and set INTERFACE_INCLUDE_DIRECTORIES to "$out/include", but headers live
+  # in $dev/include under multi-output splitting. Clear the broken claim so
+  # consumers fall back to stdenv's normal include-path propagation via
+  # buildInputs (which correctly resolves to $dev/include).
+  postFixup = ''
+    for f in $out/lib/{crypto,ssl}/cmake/*/*-targets.cmake; do
+      substituteInPlace "$f" \
+        --replace-fail \
+          'INTERFACE_INCLUDE_DIRECTORIES "\$<\$<BOOL:1>:>;''${_IMPORT_PREFIX}/include"' \
+          'INTERFACE_INCLUDE_DIRECTORIES ""'
+    done
+  '';
+
   __darwinAllowLocalNetworking = true;
 
   passthru = {


### PR DESCRIPTION
## Summary

Commit 6ff493e7a8c3 (\`aws-lc: 1.56.0 -> 1.65.0\`) silently dropped \`postFixup\` along with the version bump — no mention in the commit message. The hook was clearing a broken \`INTERFACE_INCLUDE_DIRECTORIES\` that AWS-LC bakes into its generated \`*-targets.cmake\` files: \`_IMPORT_PREFIX\` is hardcoded to \`\$out\`, but headers live in \`\$dev/include\` under multi-output splitting, so consumers using \`find_dependency(LibCrypto)\` fail to locate them.

The fix updates the substitution pattern to match AWS-LC's current cmake output format, which prepends a generator expression (\`\$<\$<BOOL:1>:>;\`) that didn't exist in older releases. That change in upstream output is almost certainly why the original \`--replace-fail\` was silently aborting and the bump's author removed the hook rather than investigating.

This unblocks downstream CMake consumers of aws-lc, including s2n-tls's \`aws-lc\` crypto backend (see #s2n-tls-backends companion PR).

The fix also covers \`ssl-targets.cmake\` (same defect, same fix) so future consumers of \`AWS::ssl\` don't hit the same wall.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at \`passthru.tests\`.
- [ ] Ran \`nixpkgs-review\` on this PR. Deferred to OfBorg.
- [x] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)