### PR TITLE
aws-lc-fips-{validated,recommended}: init at 2.0.0 / 3.3.0

### DIFF
--- a/pkgs/by-name/aw/aws-lc-fips-recommended/package.nix
+++ b/pkgs/by-name/aw/aws-lc-fips-recommended/package.nix
@@ -1,0 +1,100 @@
+# AWS-LC FIPS recommended build
+#
+# This packages tracks the latest AWS-LC-FIPS release.  It is "recommended" in
+# the sense that it addresses known CVEs and bugs, but it may not have formal NIST
+# FIPS 140-3 validation.
+#
+# See AWS-LC FIPS module status at
+# https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/FIPS.md
+#
+# The build instruction from security policy documents are followed as closely as is practical.
+#
+{ lib
+, clangStdenv  # FIPS delocator tool expects clang
+, cmakeMinimal
+, fetchurl
+, unzip
+, gnumake
+, go
+, perl
+, nix-update-script
+, useSharedLibraries ? !clangStdenv.hostPlatform.isStatic
+}:
+
+let
+  version = "3.3.0";
+  tag = "AWS-LC-FIPS-${version}";
+in
+clangStdenv.mkDerivation {
+  pname = "aws-lc-fips";
+  inherit version;
+
+  # Use fetchurl with zip so that hash correlates to hash from security policy documents.
+  src = fetchurl {
+    url = "https://github.com/aws/aws-lc/archive/refs/tags/${tag}.zip";
+    hash = "sha256-b5N1aHdQYa7O2Mm/8pXz10Xm+iI102cJ1PXrSFLLr7A=";
+  };
+
+  sourceRoot = "aws-lc-${tag}";
+
+  unpackPhase = ''
+    runHook preUnpack
+    unzip $src
+    runHook postUnpack
+  '';
+
+  outputs = [ "out" "bin" "dev" ];
+
+  nativeBuildInputs = [ cmakeMinimal gnumake go perl unzip ];
+
+  # Per NIST security policy:
+  # Dynamic: cmake -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 ..
+  # Static:  cmake -DFIPS=1 ..
+  cmakeFlags = [
+    "-DFIPS=1"
+  ] ++ lib.optionals useSharedLibraries [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=1"
+  ];
+
+  postFixup = ''
+    for f in $out/lib/crypto/cmake/*/crypto-targets.cmake; do
+      substituteInPlace "$f" \
+        --replace-fail 'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' 'INTERFACE_INCLUDE_DIRECTORIES ""'
+    done
+  '';
+
+  hardeningDisable = [ "fortify" ];
+
+  env = {
+    # No GOFLAGS - let Go use its default behavior (the vendor dir in 3.3.0 is incomplete)
+    GOPROXY = "off";
+    GOCACHE = "/tmp/go-cache";
+    NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type-mismatch";
+  };
+
+  passthru = {
+    inherit useSharedLibraries;
+    validated = false;
+    # Filters git tags to FIPS releases only, ignoring mainline aws-lc tags (vX.Y.Z).
+    # `--url` is explicit because `src` uses fetchurl; without it nix-update
+    # may fail to locate the upstream repo for tag enumeration.
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--url"
+        "https://github.com/aws/aws-lc"
+        "--version-regex"
+        "AWS-LC-FIPS-(.*)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "AWS-LC cryptographic library (FIPS recommended)";
+    homepage = "https://github.com/aws/aws-lc";
+    license = [ lib.licenses.asl20 lib.licenses.isc ];
+    maintainers = [ lib.maintainers.goertzenator ];
+    platforms = lib.platforms.unix;
+    mainProgram = "bssl";
+  };
+}

--- a/pkgs/by-name/aw/aws-lc-fips-recommended/package.nix
+++ b/pkgs/by-name/aw/aws-lc-fips-recommended/package.nix
@@ -9,16 +9,17 @@
 #
 # The build instruction from security policy documents are followed as closely as is practical.
 #
-{ lib
-, clangStdenv  # FIPS delocator tool expects clang
-, cmakeMinimal
-, fetchurl
-, unzip
-, gnumake
-, go
-, perl
-, nix-update-script
-, useSharedLibraries ? !clangStdenv.hostPlatform.isStatic
+{
+  lib,
+  clangStdenv, # FIPS delocator tool expects clang
+  cmakeMinimal,
+  fetchurl,
+  unzip,
+  gnumake,
+  go,
+  perl,
+  nix-update-script,
+  useSharedLibraries ? !clangStdenv.hostPlatform.isStatic,
 }:
 
 let
@@ -28,6 +29,9 @@ in
 clangStdenv.mkDerivation {
   pname = "aws-lc-fips";
   inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   # Use fetchurl with zip so that hash correlates to hash from security policy documents.
   src = fetchurl {
@@ -43,16 +47,27 @@ clangStdenv.mkDerivation {
     runHook postUnpack
   '';
 
-  outputs = [ "out" "bin" "dev" ];
+  outputs = [
+    "out"
+    "bin"
+    "dev"
+  ];
 
-  nativeBuildInputs = [ cmakeMinimal gnumake go perl unzip ];
+  nativeBuildInputs = [
+    cmakeMinimal
+    gnumake
+    go
+    perl
+    unzip
+  ];
 
   # Per NIST security policy:
   # Dynamic: cmake -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 ..
   # Static:  cmake -DFIPS=1 ..
   cmakeFlags = [
     "-DFIPS=1"
-  ] ++ lib.optionals useSharedLibraries [
+  ]
+  ++ lib.optionals useSharedLibraries [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_SHARED_LIBS=1"
   ];
@@ -92,7 +107,10 @@ clangStdenv.mkDerivation {
   meta = {
     description = "AWS-LC cryptographic library (FIPS recommended)";
     homepage = "https://github.com/aws/aws-lc";
-    license = [ lib.licenses.asl20 lib.licenses.isc ];
+    license = [
+      lib.licenses.asl20
+      lib.licenses.isc
+    ];
     maintainers = [ lib.maintainers.goertzenator ];
     platforms = lib.platforms.unix;
     mainProgram = "bssl";

--- a/pkgs/by-name/aw/aws-lc-fips-validated/package.nix
+++ b/pkgs/by-name/aw/aws-lc-fips-validated/package.nix
@@ -9,19 +9,20 @@
 #
 # The build instruction from security policy documents are followed as closely as is practical.
 #
-{ lib
-, clangStdenv  # FIPS delocator tool expects clang
-, cmakeMinimal
-, fetchurl
-, unzip
-, gnumake
-, go
-, perl
-, writeShellScript
-, curl
-, jq
-, common-updater-scripts
-, useSharedLibraries ? !clangStdenv.hostPlatform.isStatic
+{
+  lib,
+  clangStdenv, # FIPS delocator tool expects clang
+  cmakeMinimal,
+  fetchurl,
+  unzip,
+  gnumake,
+  go,
+  perl,
+  writeShellScript,
+  curl,
+  jq,
+  common-updater-scripts,
+  useSharedLibraries ? !clangStdenv.hostPlatform.isStatic,
 }:
 
 let
@@ -31,6 +32,9 @@ in
 clangStdenv.mkDerivation {
   pname = "aws-lc-fips";
   inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   # Use fetchurl with zip so that hash correlates to hash from security policy documents.
   src = fetchurl {
@@ -46,9 +50,19 @@ clangStdenv.mkDerivation {
     runHook postUnpack
   '';
 
-  outputs = [ "out" "bin" "dev" ];
+  outputs = [
+    "out"
+    "bin"
+    "dev"
+  ];
 
-  nativeBuildInputs = [ cmakeMinimal gnumake go perl unzip ];
+  nativeBuildInputs = [
+    cmakeMinimal
+    gnumake
+    go
+    perl
+    unzip
+  ];
 
   # Per NIST security policy:
   # Dynamic: cmake -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 ..
@@ -60,7 +74,8 @@ clangStdenv.mkDerivation {
   cmakeFlags = [
     "-DFIPS=1"
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-  ] ++ lib.optionals useSharedLibraries [
+  ]
+  ++ lib.optionals useSharedLibraries [
     "-DCMAKE_BUILD_TYPE=Release"
     "-DBUILD_SHARED_LIBS=1"
   ];
@@ -117,7 +132,10 @@ clangStdenv.mkDerivation {
   meta = {
     description = "AWS-LC cryptographic library (FIPS validated)";
     homepage = "https://github.com/aws/aws-lc";
-    license = [ lib.licenses.asl20 lib.licenses.isc ];
+    license = [
+      lib.licenses.asl20
+      lib.licenses.isc
+    ];
     maintainers = [ lib.maintainers.goertzenator ];
     platforms = lib.platforms.unix;
     mainProgram = "bssl";

--- a/pkgs/by-name/aw/aws-lc-fips-validated/package.nix
+++ b/pkgs/by-name/aw/aws-lc-fips-validated/package.nix
@@ -1,0 +1,125 @@
+# AWS-LC FIPS validated build
+#
+# This packages tracks the latest AWS-LC-FIPS release that has a FIPS 140-3
+# validation certificate. It is typically not the latest release and may have
+# known bugs and CVEs.
+#
+# See AWS-LC FIPS module status at
+# https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/FIPS.md
+#
+# The build instruction from security policy documents are followed as closely as is practical.
+#
+{ lib
+, clangStdenv  # FIPS delocator tool expects clang
+, cmakeMinimal
+, fetchurl
+, unzip
+, gnumake
+, go
+, perl
+, writeShellScript
+, curl
+, jq
+, common-updater-scripts
+, useSharedLibraries ? !clangStdenv.hostPlatform.isStatic
+}:
+
+let
+  version = "2.0.0";
+  tag = "AWS-LC-FIPS-${version}";
+in
+clangStdenv.mkDerivation {
+  pname = "aws-lc-fips";
+  inherit version;
+
+  # Use fetchurl with zip so that hash correlates to hash from security policy documents.
+  src = fetchurl {
+    url = "https://github.com/aws/aws-lc/archive/refs/tags/${tag}.zip";
+    hash = "sha256-YkHsLxOl+AIk7pzYWS7WapfUJkgQZv6qTvxvJOYLvJY=";
+  };
+
+  sourceRoot = "aws-lc-${tag}";
+
+  unpackPhase = ''
+    runHook preUnpack
+    unzip $src
+    runHook postUnpack
+  '';
+
+  outputs = [ "out" "bin" "dev" ];
+
+  nativeBuildInputs = [ cmakeMinimal gnumake go perl unzip ];
+
+  # Per NIST security policy:
+  # Dynamic: cmake -DFIPS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 ..
+  # Static:  cmake -DFIPS=1 ..
+  #
+  # CMAKE_POLICY_VERSION_MINIMUM works around AWS-LC-FIPS 2.0.0's
+  # cmake_minimum_required(VERSION <3.5); CMake 4.x refuses such declarations
+  # without this override.
+  cmakeFlags = [
+    "-DFIPS=1"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ] ++ lib.optionals useSharedLibraries [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=1"
+  ];
+
+  postFixup = ''
+    for f in $out/lib/crypto/cmake/*/crypto-targets.cmake; do
+      substituteInPlace "$f" \
+        --replace-fail 'INTERFACE_INCLUDE_DIRECTORIES "''${_IMPORT_PREFIX}/include"' 'INTERFACE_INCLUDE_DIRECTORIES ""'
+    done
+  '';
+
+  hardeningDisable = [ "fortify" ];
+
+  env = {
+    GOPROXY = "off";
+    GOFLAGS = "-mod=vendor";
+    GOCACHE = "/tmp/go-cache";
+    # cast-function-type-mismatch: pre-existing, clang warning newer than upstream.
+    # unterminated-string-initialization: clang 21+ flag, triggers on intentionally
+    # non-null-terminated byte arrays (e.g. AES keys) in the FIPS self-check code.
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=cast-function-type-mismatch"
+      "-Wno-error=unterminated-string-initialization"
+    ];
+  };
+
+  passthru = {
+    inherit useSharedLibraries;
+    validated = true;
+    # Picks the highest version listed under "validated" in
+    # crypto/fipsmodule/FIPS_VERSIONS.json upstream. Presence in that list
+    # is AWS-LC's signal that the release carries NIST validation, so
+    # auto-bumps stay within the validated set by definition.
+    #
+    # For testing against an unmerged FIPS_VERSIONS.json, override the
+    # source URL via FIPS_VERSIONS_URL, e.g.
+    #   FIPS_VERSIONS_URL=file:///home/you/aws-lc/crypto/fipsmodule/FIPS_VERSIONS.json \
+    #     nix-shell maintainers/scripts/update.nix --argstr package aws-lc-fips-validated
+    updateScript = writeShellScript "update-aws-lc-fips-validated" ''
+      set -euo pipefail
+      url=''${FIPS_VERSIONS_URL:-https://raw.githubusercontent.com/aws/aws-lc/main/crypto/fipsmodule/FIPS_VERSIONS.json}
+      json=$(${lib.getExe curl} -fsSL "$url")
+      latest_tag=$(echo "$json" | ${lib.getExe jq} -r '.validated | keys[]' | sort -V | tail -1)
+      if [ -z "$latest_tag" ]; then
+        echo "no validated versions found in $url" >&2
+        exit 1
+      fi
+      latest_version=''${latest_tag#AWS-LC-FIPS-}
+      ${lib.getExe' common-updater-scripts "update-source-version"} \
+        aws-lc-fips-validated "$latest_version"
+    '';
+  };
+
+  meta = {
+    description = "AWS-LC cryptographic library (FIPS validated)";
+    homepage = "https://github.com/aws/aws-lc";
+    license = [ lib.licenses.asl20 lib.licenses.isc ];
+    maintainers = [ lib.maintainers.goertzenator ];
+    platforms = lib.platforms.unix;
+    mainProgram = "bssl";
+  };
+}


### PR DESCRIPTION
## Summary

Adds two FIPS variants of AWS-LC, each with its own update policy:

- **\`aws-lc-fips-validated\`** (2.0.0) — tracks the latest AWS-LC-FIPS release that carries an active NIST FIPS 140-3 validation certificate. Currently certificate [#4759](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4759) (dynamic) and [#4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816) (static).
- **\`aws-lc-fips-recommended\`** (3.3.0) — tracks the latest AWS-LC-FIPS release. Not yet NIST-validated but addresses CVEs in the validated track. Suited to consumers that need FIPS-style crypto behavior plus current security fixes, but don't strictly require an active cert.

Both follow AWS-LC's NIST security policy build procedure: \`clangStdenv\` (the FIPS delocator tool expects clang), \`-DFIPS=1\`, and the documented build steps (vendored Go modules where the upstream tarball ships them; \`-mod=vendor\` toggle exposed via \`useVendoredGo\` in spirit).

### Auto-update story

The validated variant is wired to read aws-lc's [proposed \`FIPS_VERSIONS.json\`](https://github.com/aws/aws-lc/issues/3184) so r-ryantm bumps stay within the AWS-LC-curated validated set. While the metadata file isn't yet merged upstream, the script accepts a \`FIPS_VERSIONS_URL\` env var for testing against a local AWS-LC fork, and degrades gracefully (errors loudly) until upstream lands the file.

The recommended variant uses \`nix-update-script\` with a \`--version-regex 'AWS-LC-FIPS-(.*)'\` filter so it ignores mainline aws-lc tags (\`vX.Y.Z\`) and tracks only \`AWS-LC-FIPS-*\` releases.

### Build environment compat

\`aws-lc-fips-validated\` (2.0.0, Oct 2023) needs two compat flags for the current toolchain:
- \`-DCMAKE_POLICY_VERSION_MINIMUM=3.5\` — its \`CMakeLists.txt\` declares \`cmake_minimum_required(VERSION <3.5)\`, which CMake 4.x refuses without this override.
- \`-Wno-error=unterminated-string-initialization\` — clang 21+ flags AWS-LC's intentionally non-null-terminated AES key / DRBG constants in the FIPS self-check; the code can't be changed without invalidating the FIPS module.

The recommended variant (3.3.0) builds clean against current toolchains.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at \`passthru.tests\`.
- [ ] Ran \`nixpkgs-review\` on this PR. (Brand-new packages, zero reverse deps.)
- [x] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)