### PR TITLE
prometheus-tibber-exporter: 3.10.0 -> 3.10.2

### DIFF
--- a/pkgs/by-name/pr/prometheus-tibber-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-tibber-exporter/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "prometheus-tibber-exporter";
-  version = "3.10.0";
+  version = "3.10.2";
 
   src = fetchFromGitHub {
     owner = "terjesannum";
     repo = "tibber-exporter";
     tag = "tibber-exporter-${finalAttrs.version}";
-    hash = "sha256-Ndg2BxWdL5DKa2eHjY0rIdrfJ+SJlzvOUZDtWUBSR6g=";
+    hash = "sha256-by7/c2a/8jM4ShoeQnYC+L+EVLk2NwQoRTAMiZZcMn0=";
     leaveDotGit = true;
     postFetch = ''
       cd "$out"
@@ -37,9 +37,14 @@ buildGoModule (finalAttrs: {
     "-X github.com/prometheus/common/version.BuildUser=nix@nixpkgs"
   ];
 
-  vendorHash = "sha256-JTJTapsqBj0FO2Gcx8O1eWJf9hMbeWzjtO0HYcDdzQo=";
+  vendorHash = "sha256-rjM2M9auiyFvGcq/D8N5YPoFOPeC9r1Y1JPssT7nvew=";
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "tibber-exporter-(.*)"
+    ];
+  };
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
Diff: https://github.com/terjesannum/tibber-exporter/compare/tibber-exporter-3.10.1...tibber-exporter-3.10.2

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
