### PR TITLE
lean4: Pin cadical version to 2.1.3 to fix bv_decide

### DIFF
--- a/pkgs/by-name/le/lean4/package.nix
+++ b/pkgs/by-name/le/lean4/package.nix
@@ -6,6 +6,7 @@
   git,
   gmp,
   cadical,
+  makeWrapper,
   pkg-config,
   libuv,
   enableMimalloc ? true,
@@ -13,6 +14,9 @@
   testers,
 }:
 
+let
+  cadical' = cadical.override { version = "2.1.3"; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lean4";
   version = "4.29.1";
@@ -61,13 +65,19 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    makeWrapper
   ];
 
   buildInputs = [
     gmp
     libuv
-    cadical
+    cadical'
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/lean \
+      --prefix PATH : ${cadical'}/bin
+  '';
 
   nativeCheckInputs = [
     git


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Lean4 currently uses cadical 2.1.2 and the update upstream to 3.0.0 is still in progress: https://github.com/leanprover/lean4/pull/7942
Unfortunately, cadical >=2.2.0 currently breaks the `bv_decide` tactic in lean because LRAT proofs are rejected. See https://github.com/arminbiere/cadical/issues/134 for more info.
Since cadical in nixpkgs was updated past 2.1.x, 'bv_decide' no longer works in the nixpkgs distribution of lean4.

A minimum example that breaks with the current version of lean (v4.29.1) in nixpkgs:

```
lean --stdin << 'EOF'
import Std.Tactic.BVDecide
theorem bitvec_InstCombineShift__351 :
    ∀ (X C1 C2 : BitVec 6), (X * C1) <<< C2 = X * (C1 <<< C2) := by
  intros
  bv_decide
EOF
```
results in:
```
<stdin>:5:2: error: Tactic `bv_decide` failed: The LRAT certificate could not be verified; evaluating the following term returned `false`:
  Std.Tactic.BVDecide.Reflect.verifyBVExpr bitvec_InstCombineShift__351._expr_def_1_1
    bitvec_InstCombineShift__351._cert_def_1_1
Error: index out of bounds
backtrace:
0   libleanshared.dylib                 0x0000000114482298 _ZN4leanL15print_backtraceEb + 60
1   libleanshared.dylib                 0x0000000114477a3c _ZN4leanL15lean_panic_implEPKcmb + 176
2   libleanshared.dylib                 0x0000000114478384 lean_array_get_panic + 108
...
```

This PR pins the cadical version in the lean4 derivation to 2.1.3 and wraps the lean binary to force that version in the PATH at runtime. When cadical 3.0.0 support is merged upstream, this should be reverted.

Tested on aarch64-darwin and x86_64-linux.

@hargoniX
@lenianiva

@Coda-Coda
@jthulhu 
@nadja-y

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
