### PR TITLE
pear-desktop: added cjk-sans font

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15549,6 +15549,12 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  LodWKobku = {
+    email = "lodwkobku@gmail.com";
+    github = "LodWKobku";
+    githubId = 101132529;
+    name = "LodWKobku";
+  };
   logan-barnett = {
     email = "logustus+nixpkgs@gmail.com";
     github = "LoganBarnett";

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -130,6 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       aacebedo
       SuperSandro2000
+      LodWKobku
     ];
     mainProgram = "pear-desktop";
     platforms = [

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -12,7 +12,7 @@
   pnpmConfigHook,
   makeDesktopItem,
   nix-update-script,
-  noto-fonts-cjk-sans, 
+  noto-fonts-cjk-sans,
   writeText,
 }:
 

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -12,7 +12,20 @@
   pnpmConfigHook,
   makeDesktopItem,
   nix-update-script,
+  noto-fonts-cjk-sans, 
+  writeText,
 }:
+
+let
+  pearFontsConf = writeText "pear-desktop-fonts.conf" ''
+    <?xml version="1.0"?>
+    <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+    <fontconfig>
+      <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+      <dir>${noto-fonts-cjk-sans}/share/fonts</dir>
+    </fontconfig>
+  '';
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pear-desktop";
   version = "3.11.0";
@@ -99,6 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
       --add-flags $out/share/pear-desktop/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set-default FONTCONFIG_FILE ${pearFontsConf} \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0


### PR DESCRIPTION
In pear-desktop package, I configured FONTCONFIG_FILE to added cjk-sans font. This is necessary because without it Mandarin, Japanese and other characters are invisable

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
