### PR TITLE
stdenv/check-meta: various performance cleanups

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -368,7 +368,7 @@ rec {
   availableOn =
     platform: pkg:
     ((!pkg ? meta.platforms) || any (platformMatch platform) pkg.meta.platforms)
-    && all (elem: !platformMatch platform elem) (pkg.meta.badPlatforms or [ ]);
+    && ((!pkg ? meta.badPlatforms) || !(any (platformMatch platform) pkg.meta.badPlatforms));
 
   /**
     Mapping of SPDX ID to the attributes in lib.licenses.

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -403,9 +403,12 @@ let
   # Along with a boolean flag for each reason
   checkValidity =
     attrs:
+    if !attrs ? meta then
+      null
+    else
     # Check meta attribute types first, to make sure it is always called even when there are other issues
     # Note that this is not a full type check and functions below still need to by careful about their inputs!
-    if checkMeta && metaInvalid (attrs.meta or { }) then
+    if checkMeta && metaInvalid attrs.meta then
       {
         reason = "unknown-meta";
         msg = "has an invalid meta attrset:${

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -37,7 +37,7 @@ let
     ;
 
   inherit (lib.meta)
-    availableOn
+    platformMatch
     cpeFullVersionWithVendor
     ;
 
@@ -122,7 +122,14 @@ let
 
   isMarkedBroken = attrs: attrs.meta.broken or false;
 
-  hasUnsupportedPlatform = pkg: !(availableOn hostPlatform pkg);
+  # Logical inversion of meta.availableOn for hostPlatform
+  hasUnsupportedPlatform =
+    let
+      anyHostPlatform = any (platformMatch hostPlatform);
+    in
+    pkg:
+    pkg ? meta.platforms && !(anyHostPlatform pkg.meta.platforms)
+    || pkg ? meta.badPlatforms && anyHostPlatform pkg.meta.badPlatforms;
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -181,7 +181,6 @@ let
     attrs:
     attrs ? meta.sourceProvenance
     && any (t: !t.isSource) attrs.meta.sourceProvenance
-    && !allowNonSource
     && !allowNonSourcePredicate attrs;
 
   showLicenseOrSourceType =
@@ -436,7 +435,7 @@ let
         msg = "has a blocklisted license (‘${showLicense attrs.meta.license}’)";
         remediation = "";
       }
-    else if hasDeniedNonSourceProvenance attrs then
+    else if !allowNonSource && hasDeniedNonSourceProvenance attrs then
       {
         reason = "non-source";
         msg = "contains elements not built from source (‘${showSourceType attrs.meta.sourceProvenance}’)";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -392,14 +392,11 @@ let
   metaInvalid = meta: !metaType.verify meta;
 
   checkOutputsToInstall =
-    if checkMeta then
-      attrs:
-      let
-        actualOutputs = attrs.outputs or [ "out" ];
-      in
-      any (output: !elem output actualOutputs) (attrs.meta.outputsToInstall or [ ])
-    else
-      attrs: false;
+    attrs:
+    let
+      actualOutputs = attrs.outputs or [ "out" ];
+    in
+    any (output: !elem output actualOutputs) (attrs.meta.outputsToInstall or [ ]);
 
   # Check if a derivation is valid, that is whether it passes checks for
   # e.g brokenness or license.
@@ -423,7 +420,7 @@ let
       }
 
     # --- Put checks that cannot be ignored here ---
-    else if checkOutputsToInstall attrs then
+    else if checkMeta && checkOutputsToInstall attrs then
       {
         reason = "broken-outputs";
         msg = "has invalid meta.outputsToInstall";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -81,20 +81,16 @@ let
 
   hasListedLicense =
     assert areLicenseListsValid;
-    list:
-    if list == [ ] then
-      attrs: false
-    else
-      attrs:
-      attrs ? meta.license
-      && (
-        if isList attrs.meta.license then
-          any (l: elem l list) attrs.meta.license
-        else if attrs.meta.license ? "licenseType" then
-          lib.licenses.containsLicenses list attrs.meta.license
-        else
-          elem attrs.meta.license list
-      );
+    list: attrs:
+    attrs ? meta.license
+    && (
+      if isList attrs.meta.license then
+        any (l: elem l list) attrs.meta.license
+      else if attrs.meta.license ? "licenseType" then
+        lib.licenses.containsLicenses list attrs.meta.license
+      else
+        elem attrs.meta.license list
+    );
 
   hasAllowlistedLicense = hasListedLicense allowlist;
 
@@ -428,13 +424,13 @@ let
       }
 
     # --- Put checks that can be ignored here ---
-    else if hasDeniedUnfreeLicense attrs && !(hasAllowlistedLicense attrs) then
+    else if hasDeniedUnfreeLicense attrs && !(allowlist != [ ] && hasAllowlistedLicense attrs) then
       {
         reason = "unfree";
         msg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
         remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate" attrs);
       }
-    else if hasBlocklistedLicense attrs then
+    else if blocklist != [ ] && hasBlocklistedLicense attrs then
       {
         reason = "blocklisted";
         msg = "has a blocklisted license (‘${showLicense attrs.meta.license}’)";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -388,10 +388,11 @@ let
       identifiers = attrs;
     };
 
-  metaInvalid = if config.checkMeta then meta: !metaType.verify meta else meta: false;
+  checkMeta = config.checkMeta;
+  metaInvalid = meta: !metaType.verify meta;
 
   checkOutputsToInstall =
-    if config.checkMeta then
+    if checkMeta then
       attrs:
       let
         actualOutputs = attrs.outputs or [ "out" ];
@@ -412,7 +413,7 @@ let
     attrs:
     # Check meta attribute types first, to make sure it is always called even when there are other issues
     # Note that this is not a full type check and functions below still need to by careful about their inputs!
-    if metaInvalid (attrs.meta or { }) then
+    if checkMeta && metaInvalid (attrs.meta or { }) then
       {
         reason = "unknown-meta";
         msg = "has an invalid meta attrset:${

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -384,7 +384,6 @@ let
     };
 
   checkMeta = config.checkMeta;
-  metaInvalid = meta: !metaType.verify meta;
 
   checkOutputsToInstall =
     attrs:
@@ -408,7 +407,7 @@ let
     else
     # Check meta attribute types first, to make sure it is always called even when there are other issues
     # Note that this is not a full type check and functions below still need to by careful about their inputs!
-    if checkMeta && metaInvalid attrs.meta then
+    if checkMeta && !metaType.verify attrs.meta then
       {
         reason = "unknown-meta";
         msg = "has an invalid meta attrset:${

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -387,10 +387,13 @@ let
 
   checkOutputsToInstall =
     attrs:
-    let
-      actualOutputs = attrs.outputs or [ "out" ];
-    in
-    any (output: !elem output actualOutputs) (attrs.meta.outputsToInstall or [ ]);
+    attrs.meta ? outputsToInstall
+    && (
+      let
+        actualOutputs = attrs.outputs or [ "out" ];
+      in
+      !all (output: elem output actualOutputs) attrs.meta.outputsToInstall
+    );
 
   # Check if a derivation is valid, that is whether it passes checks for
   # e.g brokenness or license.

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -81,13 +81,17 @@ let
 
   hasListedLicense =
     assert areLicenseListsValid;
-    list: attrs:
+    list:
+    let
+      containsListLicenses = lib.licenses.containsLicenses list;
+    in
+    attrs:
     attrs ? meta.license
     && (
       if isList attrs.meta.license then
         any (l: elem l list) attrs.meta.license
       else if attrs.meta.license ? "licenseType" then
-        lib.licenses.containsLicenses list attrs.meta.license
+        containsListLicenses attrs.meta.license
       else
         elem attrs.meta.license list
     );


### PR DESCRIPTION
My journey through key files continues! The profiler sent me to `assertValidity` and `checkValidity` by extension as performance-critical. Most of this boils down to performing checks in a different order - `config.checkMeta` is false by default, yet we were only checking whether it was false _after_ the record typecheck.  We can also avoid a lot of checks if a derivation doesn't set `meta` at all.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
