### PR TITLE
otpclient: 4.2.0 -> 5.1.1; libcotp: 3.1.1 -> 4.1.0

### DIFF
--- a/pkgs/by-name/li/libcotp/package.nix
+++ b/pkgs/by-name/li/libcotp/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcotp";
-  version = "3.1.1";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "paolostivanin";
     repo = "libcotp";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-5Jjk8uby1QjvU7TraTTTp+29Yh5lzbCvlorfPbGvciM=";
+    sha256 = "sha256-Ut7ySOgmMb8PnNxiabqvpVSIyGrBJK6sR12Pp7L5o2Y=";
   };
 
   postPatch = lib.optionalString stdenv.cc.isClang ''

--- a/pkgs/by-name/li/libcotp/package.nix
+++ b/pkgs/by-name/li/libcotp/package.nix
@@ -6,24 +6,21 @@
   pkg-config,
   libgcrypt,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcotp";
-  version = "3.1.1";
+  version = "4.1.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "paolostivanin";
     repo = "libcotp";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-5Jjk8uby1QjvU7TraTTTp+29Yh5lzbCvlorfPbGvciM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iNmCQHAl2LIkdJiVByc9CWiJSTo1HIz5Ma5Xjo2n9mA=";
   };
 
-  postPatch = lib.optionalString stdenv.cc.isClang ''
-    substituteInPlace CMakeLists.txt \
-      --replace "add_link_options(-Wl," "# add_link_options(-Wl,"
-  '';
-
   buildInputs = [ libgcrypt ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -32,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "C library that generates TOTP and HOTP";
     homepage = "https://github.com/paolostivanin/libcotp";
+    changelog = "https://github.com/paolostivanin/libcotp/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ alexbakker ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ot/otpclient/package.nix
+++ b/pkgs/by-name/ot/otpclient/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "otpclient";
-  version = "4.2.0";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "paolostivanin";
     repo = "otpclient";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KGtASCc07NGdjvQ8tIrnQIaEeld9H6z3odytKd8c5aQ=";
+    hash = "sha256-aT1EnfjIHP516l3ucNV9xPCl2vDjHh6+Dhp9Z1EaG68=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ot/otpclient/package.nix
+++ b/pkgs/by-name/ot/otpclient/package.nix
@@ -4,30 +4,32 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  gtk3,
+  gtk4,
   wrapGAppsHook3,
   jansson,
   libgcrypt,
-  libzip,
+  libadwaita,
   libpng,
   libcotp,
-  protobuf,
+  glib,
   protobufc,
   qrencode,
   libsecret,
   libuuid,
   zbar,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "otpclient";
-  version = "4.2.0";
+  version = "5.1.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "paolostivanin";
     repo = "otpclient";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KGtASCc07NGdjvQ8tIrnQIaEeld9H6z3odytKd8c5aQ=";
+    hash = "sha256-sKXxujzHNQUZj9XloQLsZR12ZhyiY+512FOqgkTrxyQ=";
   };
 
   nativeBuildInputs = [
@@ -37,15 +39,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    gtk3
+    gtk4
+    glib
+    libadwaita
     jansson
     libcotp
     libgcrypt
     libpng
     libsecret
     libuuid
-    libzip
-    protobuf
     protobufc
     qrencode
     zbar
@@ -54,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Highly secure and easy to use OTP client written in C/GTK that supports both TOTP and HOTP";
     homepage = "https://github.com/paolostivanin/OTPClient";
-    changelog = "https://github.com/paolostivanin/OTPClient/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/paolostivanin/OTPClient/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ alexbakker ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
supersedes/closes: #493669

otpclient: 4.2.0 -> 5.1.1

Diff: https://github.com/paolostivanin/OTPClient/compare/v4.2.0...v5.1.1

libcotp: 3.1.1 -> 4.1.0

Diff: https://github.com/paolostivanin/libcotp/compare/v3.1.1...v4.1.0

Changelogs:

- https://github.com/paolostivanin/libcotp/releases/tag/v4.1.0
- https://github.com/paolostivanin/libcotp/releases/tag/v4.0.1
- https://github.com/paolostivanin/libcotp/releases/tag/v4.0.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
