### PR TITLE
groff: Add patch addressing performance regression

### DIFF
--- a/pkgs/by-name/gr/groff/fix-grotty-output-buffer.patch
+++ b/pkgs/by-name/gr/groff/fix-grotty-output-buffer.patch
@@ -1,0 +1,109 @@
+diff --git a/src/devices/grotty/tty.cpp b/src/devices/grotty/tty.cpp
+index be7140e4b..929a4f80d 100644
+--- a/src/devices/grotty/tty.cpp
++++ b/src/devices/grotty/tty.cpp
+@@ -194,11 +194,13 @@ class tty_printer : public printer {
+   int nlines;
+   int cached_v;
+   int cached_vpos;
++  int minline;
+   long curr_fore_idx;
+   long curr_back_idx;
+   bool is_underlining;
+   bool is_boldfacing;
+   bool is_continuously_underlining;
++  bool flushing;
+   PTABLE(schar) tty_colors;
+   void make_underline(int);
+   void make_bold(output_character, int);
+@@ -396,21 +398,39 @@ void tty_printer::add_char(output_character c, int w,
+       fatal("vertical position not a multiple of vertical motion"
+ 	    " quantum");
+     vpos = v / font::vert;
+-    if (vpos > nlines) {
++    if (vpos - minline > nlines) {
+       tty_glyph **old_lines = lines;
+       // If we exceed the previous page length, double the size so that
+       // we don't thrash the allocator.  See Savannah #68145.
+-      int new_nlines = nlines * 2;
+-      lines = new tty_glyph *[new_nlines];
+-      memset(lines, 0, new_nlines * sizeof(tty_glyph *));
+-      memcpy(lines, old_lines, nlines * sizeof(tty_glyph *));
+-      delete[] old_lines;
+-      nlines = new_nlines;
++      // ...however, do not allow buffered output to grow unbounded.
++      // for extremely long unpaginated documents, this buffers the
++      // entire output into memory, leading to poor time-to-first-byte.
++      if (nlines > 10000) { // arbitrary
++        // flush the oldest lines
++        int old_nlines = nlines;
++        nlines = 1000; // arbitrary
++        flushing = true;
++        end_page(0);
++        flushing = false;
++        memmove(&lines[0], &lines[nlines],
++                sizeof(tty_glyph *) * (old_nlines - nlines));
++        memset(&lines[old_nlines - nlines], 0,
++               sizeof(tty_glyph *) * nlines);
++        minline += nlines;
++        nlines = old_nlines;
++      } else {
++        int new_nlines = nlines * 2;
++        lines = new tty_glyph *[new_nlines];
++        memset(lines, 0, new_nlines * sizeof(tty_glyph *));
++        memcpy(lines, old_lines, nlines * sizeof(tty_glyph *));
++        delete[] old_lines;
++        nlines = new_nlines;
++      }
+     }
+     // Note that the first output line corresponds to groff
+     // position font::vert.
+-    if (vpos <= 0) {
+-      error("output above first line discarded");
++    if (vpos <= minline) {
++      error("output above first unflushed line discarded");
+       return;
+     }
+     cached_v = v;
+@@ -430,7 +450,7 @@ void tty_printer::add_char(output_character c, int w,
+   // at each hpos, and otherwise in order of occurrence.
+ 
+   tty_glyph **pp;
+-  for (pp = lines + (vpos - 1); *pp; pp = &(*pp)->next)
++  for (pp = lines + (vpos - 1 - minline); *pp; pp = &(*pp)->next)
+     if ((*pp)->hpos < hpos
+ 	|| ((*pp)->hpos == hpos && (*pp)->order() >= g->order()))
+       break;
+@@ -779,6 +799,8 @@ void tty_printer::begin_page(int)
+ {
+   nlines = default_lines_per_page;
+   lines = new tty_glyph *[nlines];
++  minline = 0;
++  flushing = false;
+   memset(lines, 0, nlines * sizeof(tty_glyph *));
+ }
+ 
+@@ -802,8 +824,11 @@ void tty_printer::end_page(int page_length)
+     error("vertical position at end of page not multiple of vertical"
+ 	  " motion quantum");
+   int lines_per_page = page_length / font::vert;
++  lines_per_page -= minline;
++  if (lines_per_page < 0)
++    lines_per_page = 0;
+   int last_line;
+-  for (last_line = nlines; last_line > 0; last_line--)
++  for (last_line = nlines; !flushing && last_line > 0; last_line--)
+     if (lines[last_line - 1])
+       break;
+ #if 0
+@@ -969,7 +994,9 @@ void tty_printer::end_page(int page_length)
+     for (; last_line < lines_per_page; last_line++)
+       putchar('\n');
+   }
+-  delete[] lines;
++  if (!flushing) {
++    delete[] lines;
++  }
+ }
+ 
+ font *tty_printer::make_font(const char *nm)

--- a/pkgs/by-name/gr/groff/fix-grotty-performance-regression.patch
+++ b/pkgs/by-name/gr/groff/fix-grotty-performance-regression.patch
@@ -1,0 +1,85 @@
+diff --git i/src/devices/grotty/tty.cpp w/src/devices/grotty/tty.cpp
+index 8e69a3b59..bd8767985 100644
+--- i/src/devices/grotty/tty.cpp
++++ w/src/devices/grotty/tty.cpp
+@@ -211,7 +211,7 @@ public:
+   void change_fill_color(const environment * const);
+   void put_char(output_character);
+   void put_color(long, int);
+-  void begin_page(int) { }
++  void begin_page(int);
+   void end_page(int);
+   font *make_font(const char *);
+ };
+@@ -286,17 +286,13 @@ tty_printer::tty_printer() : cached_v(0)
+ 		   &dummy, 5);
+   (void) has_color(0, color::MAX_COLOR_VAL, color::MAX_COLOR_VAL,
+ 		   &dummy, 6);
+-  nlines = 66;
+-  lines = new tty_glyph *[nlines];
+-  for (int i = 0; i < nlines; i++)
+-    lines[i] = 0;
++  begin_page(0 /* dummy */);
+   is_continuously_underlining = false;
+ }
+ 
+ tty_printer::~tty_printer()
+ {
+   current_lineno = 0; // At this point, we've read all the input.
+-  delete[] lines;
+ }
+ 
+ void tty_printer::make_underline(int w)
+@@ -390,12 +386,14 @@ void tty_printer::add_char(output_character c, int w,
+     vpos = v / font::vert;
+     if (vpos > nlines) {
+       tty_glyph **old_lines = lines;
+-      lines = new tty_glyph *[vpos + 1];
++      // If we exceed the previous page length, double the size so that
++      // we don't thrash the allocator.  See Savannah #68145.
++      int new_nlines = nlines * 2;
++      lines = new tty_glyph *[new_nlines];
++      memset(lines, 0, new_nlines * sizeof(tty_glyph *));
+       memcpy(lines, old_lines, nlines * sizeof(tty_glyph *));
+-      for (int i = nlines; i <= vpos; i++)
+-	lines[i] = 0;
+       delete[] old_lines;
+-      nlines = vpos + 1;
++      nlines = new_nlines;
+     }
+     // Note that the first output line corresponds to groff
+     // position font::vert.
+@@ -758,6 +756,16 @@ void tty_printer::put_color(long color_index, int back)
+   }
+ }
+ 
++// We could make this 70 where ISO paper formats are used.
++const int default_lines_per_page = 66;
++
++void tty_printer::begin_page(int)
++{
++  nlines = default_lines_per_page;
++  lines = new tty_glyph *[nlines];
++  memset(lines, 0, nlines * sizeof(tty_glyph *));
++}
++
+ // The possible Unicode combinations for crossing characters.
+ //
+ // '  ' = 0, ' -' = 4, '- ' = 8, '--' = 12,
+@@ -944,6 +952,7 @@ void tty_printer::end_page(int page_length)
+     for (; last_line < lines_per_page; last_line++)
+       putchar('\n');
+   }
++  delete[] lines;
+ }
+ 
+ font *tty_printer::make_font(const char *nm)
+@@ -978,7 +987,7 @@ int main(int argc, char **argv)
+ {
+   program_name = argv[0];
+   static char stderr_buf[BUFSIZ];
+-  if (getenv("GROFF_NO_SGR"))
++  if (getenv("GROFF_NO_SGR") != 0 /* nullptr */)
+     use_overstriking_drawing_scheme = true;
+   setbuf(stderr, stderr_buf);
+   setlocale(LC_CTYPE, "");

--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -54,6 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  patches = [
+    # TODO: Remove when updating to the next release.
+    ./fix-grotty-performance-regression.patch
+  ];
+
   postPatch = ''
     # POSIX_SHELL_PROG gets replaced with a path to the build bash which doesn't get automatically patched by patchShebangs
     substituteInPlace contrib/gdiffmk/gdiffmk.sh \

--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -54,6 +54,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  patches = [
+    # TODO: Remove when updating to the next release.
+    ./fix-grotty-performance-regression.patch
+    # See https://savannah.gnu.org/bugs/index.php?68326
+    ./fix-grotty-output-buffer.patch
+  ];
+
   postPatch = ''
     # POSIX_SHELL_PROG gets replaced with a path to the build bash which doesn't get automatically patched by patchShebangs
     substituteInPlace contrib/gdiffmk/gdiffmk.sh \


### PR DESCRIPTION
Issue #513348 reports a significant performance regression from groff 1.23.0 to groff 1.24.1 when displaying large (~11MB ~380k lines) manpages, e.g. `configuration.nix.5`.

Using the following command `time groff -Tascii -Wall -man configuration.nix.5 >/dev/null` (where configuration.nix.5 is the gunzipped version of `/run/current-system/sw/share/man/man5/configuration.nix.5.gz` copied from one of the community linux-builders) the processing times for the different groff version are as follows:

| groff version | processing time | regression delta
| --- | --- | ---
| 1.23.0 | 3.41s | —
| 1.24.1 | 10.87s | +7.46s
| 1.24.1 + patch proposed in this PR | 4.12s | +0.71s

The issue is known and fixed upstream (see [upstream bug report](https://savannah.gnu.org/bugs/?68145) and [related mailing list thread](https://lists.gnu.org/archive/html/groff/2026-03/msg00087.html))

Unfortunately the upstream commits ([c10be40a3](https://cgit.git.savannah.gnu.org/cgit/groff.git/commit/?id=c10be40a3d2ab6223b2d06c60a3ca9fc452bfa47), [b5ede708b](https://github.com/NixOS/nixpkgs/compare/b5ede708b92afcb581d0271c92a5863a8264a84a), [95d2d0a25](https://github.com/NixOS/nixpkgs/compare/95d2d0a2504e8131a251a9142fd39eca3e453847)) do not apply cleanly onto the 1.24.1 source archive, so I went ahead and created a single custom patch (using `git show $SHA > ${SHA}.patch ; git apply --include='src/devices/grotty/*' ${SHA}.patch`)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
