### PR TITLE
vim: 9.2.0340 -> 9.2.0341

### DIFF
--- a/pkgs/applications/editors/vim/common.nix
+++ b/pkgs/applications/editors/vim/common.nix
@@ -4,7 +4,7 @@
   stdenv,
 }:
 rec {
-  version = "9.2.0340";
+  version = "9.2.0341";
 
   outputs = [
     "out"


### PR DESCRIPTION
## Summary

Bumps vim to v9.2.0341 which includes the revert of upstream commit [`86ae6858a`](https://github.com/vim/vim/commit/86ae6858a) that introduced a breaking change in `jjdescription.vim` syntax.

## Problem

The `jjdescription.vim` syntax file in nixpkgs' vim package causes errors when editing `.jjdescription` files:

```
Error detected while processing BufRead Autocommands for "*"..Syntax
Autocommands for "*"..function <SNR>7_SynSet[25]..script .../jjdescription.vim:
line   27:
E110: Missing ')'
```

## Root Cause

- Upstream vim commit [`86ae6858a`](https://github.com/vim/vim/commit/86ae6858a) added a new feature with incompatible syntax (`get(g:, expr + 1)`) that doesn't work in Vim 9.2 base
- The commit was reverted in [`86dcb1878`](https://github.com/vim/vim/commit/86dcb1878) (included in v9.2.0341+)
- nixpkgs uses vim 9.2.0340 which has the buggy version

## Fix

Update vim to version 9.2.0341 which contains the revert commit.

---

*AI disclosure: issue identified and fixed using MiniMax M2.5 Free through OpenCode.*