### PR TITLE
pomerium: 0.32.4 -> 0.32.6

### DIFF
--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -18,15 +18,15 @@ let
 in
 buildGoModule rec {
   pname = "pomerium";
-  version = "0.32.4";
+  version = "0.32.6";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256-XTj0ZLPRe8I3a5be0oRTxRUuT2wHnbsms7wIvLUg9ms=";
+    hash = "sha256-VwmjuXlYsh2dGKf7ux8DyLZec7xMISuQ7SSb9+LwzfU=";
   };
 
-  vendorHash = "sha256-EYXmeS4jtueI9FwVQdMlsYX3CSRGH9Dft0Syf88nf7o=";
+  vendorHash = "sha256-b4H7gAMG7DXEbvkZFsoEZrKpuvPW0vkfv1qqBPBaGAM=";
 
   ui = buildNpmPackage {
     pname = "pomerium-ui";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Pomerium [v0.32.6](https://github.com/pomerium/pomerium/releases/tag/v0.32.6)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

```sh
./result/bin/pomerium --version
pomerium version pomerium: v0.32.6-nixpkgs
envoy: 1.36.5+429dc716720106e02a1221426742cfefe5513111de8c430ebba17e6f2b062dbf
```
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
