### PR TITLE
novnc: 1.6.0 -> 1.7.0

### DIFF
--- a/pkgs/by-name/no/novnc/fix-paths.patch
+++ b/pkgs/by-name/no/novnc/fix-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/utils/novnc_proxy b/utils/novnc_proxy
-index 0900f7e..a931763 100755
+index e1efb9f..1540698 100755
 --- a/utils/novnc_proxy
 +++ b/utils/novnc_proxy
 @@ -22,7 +22,7 @@ usage() {
@@ -10,8 +10,8 @@ index 0900f7e..a931763 100755
 +    echo "                          Default: @out@/share/webapps/novnc"
      echo "    --ssl-only            Disable non-https connections."
      echo "                                    "
-     echo "    --record FILE         Record traffic to FILE.session.js"
-@@ -44,7 +44,7 @@ PORT="6080"
+     echo "    --file-only           Disable directory listing in web server."
+@@ -53,7 +53,7 @@ LISTEN="$PORT"
  VNC_DEST="localhost:5900"
  CERT=""
  KEY=""
@@ -19,4 +19,5 @@ index 0900f7e..a931763 100755
 +WEB="@out@/share/webapps/novnc"
  proxy_pid=""
  SSLONLY=""
- RECORD_ARG=""
+ RECORD=""
+

--- a/pkgs/by-name/no/novnc/package.nix
+++ b/pkgs/by-name/no/novnc/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "novnc";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchFromGitHub {
     owner = "novnc";
     repo = "noVNC";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-VYG0p70ZvRzK9IeA+5J95FqF+zWgj/8EcxnVOk+YL9o=";
+    sha256 = "sha256-vObaEjP8ZgA4a4bEYbSBsSTl6CfYa/B7qmghM+iVDnQ=";
   };
 
   patches =
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm755 utils/novnc_proxy "$out/bin/novnc"
     install -dm755 "$out/share/webapps/novnc/"
-    cp -a app core po vendor vnc.html karma.conf.js package.json vnc_lite.html "$out/share/webapps/novnc/"
+    cp -a app core po vendor vnc.html karma.conf.cjs package.json vnc_lite.html "$out/share/webapps/novnc/"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/no/novnc/websockify.patch
+++ b/pkgs/by-name/no/novnc/websockify.patch
@@ -1,13 +1,14 @@
 diff --git a/utils/novnc_proxy b/utils/novnc_proxy
-index 0365c1e..7eba2db 100755
+index e1efb9f..6d79999 100755
 --- a/utils/novnc_proxy
 +++ b/utils/novnc_proxy
-@@ -167,7 +167,7 @@ if [[ -d ${HERE}/websockify ]]; then
+@@ -181,7 +181,7 @@ if [[ -d ${HERE}/websockify ]]; then
  
      echo "Using local websockify at $WEBSOCKIFY"
  else
--    WEBSOCKIFY_FROMSYSTEM=$(which websockify 2>/dev/null)
+-    WEBSOCKIFY_FROMSYSTEM=$(type -P websockify 2>/dev/null)
 +    WEBSOCKIFY_FROMSYSTEM="@websockify@/bin/websockify"
-     WEBSOCKIFY_FROMSNAP=${HERE}/../usr/bin/python2-websockify
      [ -f $WEBSOCKIFY_FROMSYSTEM ] && WEBSOCKIFY=$WEBSOCKIFY_FROMSYSTEM
-     [ -f $WEBSOCKIFY_FROMSNAP ] && WEBSOCKIFY=$WEBSOCKIFY_FROMSNAP
+ 
+     if [ ! -f "$WEBSOCKIFY" ]; then
+


### PR DESCRIPTION
Diff: https://github.com/novnc/noVNC/compare/v1.6.0...v1.7.0
Changelog: https://github.com/novnc/noVNC/releases/tag/v1.7.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
