### PR TITLE
lib/strings.concatLines: call concatStringsSep directly v2

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -337,7 +337,6 @@ rec {
 
   /**
     Concatenate a list of strings, adding a newline at the end of each one.
-    Defined as `concatMapStrings (s: s + "\n")`.
 
     # Inputs
 
@@ -361,7 +360,7 @@ rec {
 
     :::
   */
-  concatLines = concatMapStrings (s: s + "\n");
+  concatLines = lines: optionalString (lines != [ ]) (concatStringsSep "\n" lines + "\n");
 
   /**
     Given string `s`, replace every occurrence of the string `from` with the string `to`.


### PR DESCRIPTION
Follow up to:
- https://github.com/NixOS/nixpkgs/pull/506077
- https://github.com/NixOS/nixpkgs/pull/514350

Re-applies the original commit, re-worked to also handle empty lists.

Theoretically, this should be more performant; we avoid calling `map` on an empty list, and we avoid handling per-line concatenation in nix (`concatStringsSep` is a C++ primeop).

@hsjobeki's tests, added in https://github.com/NixOS/nixpkgs/pull/514350, are passing.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    - `nix-build lib/tests/release.nix`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
