### PR TITLE
backrest: 1.10.1 -> 1.12.1

### DIFF
--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -1,5 +1,6 @@
 {
   buildGoModule,
+  fetchurl,
   fetchFromGitHub,
   gzip,
   iana-etc,
@@ -16,13 +17,23 @@
 }:
 let
   pname = "backrest";
-  version = "1.10.1";
+  version = "1.12.1";
 
   src = fetchFromGitHub {
     owner = "garethgeorge";
     repo = "backrest";
     tag = "v${version}";
-    hash = "sha256-8WWs7XEVKAc/XmeL+dsw25azfLjUbHKp2MsB6Be14VE=";
+    hash = "sha256-yhhY0aWRwfpAGf3UpzYkRI848Y/kpiCjUyjt3udOmJI=";
+  };
+
+  inlang-plugin-message-format = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js";
+    hash = "sha256-lIZViAHAjrsBgiPFHCBEtsPCP8KowOeJSleIKzT+tso=";
+  };
+
+  inlang-plugin-m-function-matcher = fetchurl {
+    url = "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js";
+    hash = "sha256-hYYvYwV5O1a/2a/lNosJbmP7Kuqzi3eZwFFRe+NJnAs=";
   };
 
   frontend = stdenv.mkDerivation (finalAttrs: {
@@ -36,11 +47,21 @@ let
       pnpm_9
     ];
 
+    postPatch = ''
+      substituteInPlace project.inlang/settings.json \
+        --replace-fail \
+          "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js" \
+          "${inlang-plugin-message-format}" \
+        --replace-fail \
+          "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js" \
+          "${inlang-plugin-m-function-matcher}"
+    '';
+
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
       fetcherVersion = 3;
-      hash = "sha256-9wzPNZxLE0l/AJ8SyE0SkhkBImiibhqJgsG3UrGj3aA=";
+      hash = "sha256-6u+rhN0RwQunufZCJKiogImsmSTZR3tGxJZJhUI/x/0=";
     };
 
     buildPhase = ''
@@ -68,7 +89,8 @@ buildGoModule {
       internal/resticinstaller/resticinstaller.go
   '';
 
-  vendorHash = "sha256-cYqK/sddLI38K9bzCpnomcZOYbSRDBOEru4Y26rBLFw=";
+  vendorHash = "sha256-NC2VohNkU5MKUSguY83/j4Fb1CkZajw3gzHm4qnj5gM=";
+  proxyVendor = true;
 
   nativeBuildInputs = [
     gzip
@@ -106,9 +128,14 @@ buildGoModule {
     # Use restic from nixpkgs, otherwise download fails in sandbox
     export BACKREST_RESTIC_COMMAND="${restic}/bin/restic"
     export HOME=$(pwd)
+    ${gzip}/bin/gzip -c /dev/null > webui/dist/index.html.gz
   ''
-  + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
     export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/services=${iana-etc}/etc/services
+  '';
+
+  postCheck = ''
+    rm webui/dist/index.html.gz
   '';
 
   doCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- updated backrest to `1.12.1`
- upstream changed build system to vite
- upstream uses inglang which [fetches external urls during build](https://github.com/garethgeorge/backrest/blob/v1.12.1/webui/project.inlang/settings.json), so we patch it
- one of the tests requires adding dummy `index.html.gz`, so we do it, [ref](https://github.com/garethgeorge/backrest/blob/9dd08d0f1f51f4e3871dda79af0a293e4b142291/.github/workflows/test.yml#L37)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @iedame