### PR TITLE
ocamlPackages.decoders: fix changelog urls

### DIFF
--- a/pkgs/development/ocaml-modules/decoders-bencode/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-bencode/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Bencode backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-cbor/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-cbor/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "CBOR backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-ezjsonm/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Ezjsonm backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-ezxmlm/default.nix
@@ -27,7 +27,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Ezxmlm backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-jsonaf/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-jsonaf/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Jsonaf backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-jsonm/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Jsonm backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-msgpck/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-msgpck/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Msgpck backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-sexplib/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-sexplib/default.nix
@@ -31,7 +31,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "sexplib backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders-yojson/default.nix
+++ b/pkgs/development/ocaml-modules/decoders-yojson/default.nix
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Yojson backend for decoders";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };

--- a/pkgs/development/ocaml-modules/decoders/default.nix
+++ b/pkgs/development/ocaml-modules/decoders/default.nix
@@ -24,7 +24,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     description = "Elm-inspired decoders for Ocaml";
     homepage = "https://github.com/mattjbray/ocaml-decoders";
-    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/${finalAttrs.version}/CHANGES.md";
+    changelog = "https://github.com/mattjbray/ocaml-decoders/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ infinidoge ];
   };


### PR DESCRIPTION
See #514132

As an aside: Would it be reasonable to `inherit` the metadata from `decoders` so it's set in one place?

Unsure what the best practice is for a bunch of separate-but-bundled packages.

Only a metadata change so no built package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
