### PR TITLE
hytale-launcher: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13836,6 +13836,12 @@
     githubId = 32744028;
     keys = [ { fingerprint = "7577 13A4 9609 0C2F 51C4  018C B5C8 89A2 F195 28F6"; } ];
   };
+  karol-broda = {
+    email = "nix@karolbroda.com";
+    github = "karol-broda";
+    githubId = 122811026;
+    name = "Karol Broda";
+  };
   karpfediem = {
     name = "Karpfen";
     github = "karpfediem";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15616,6 +15616,14 @@
     githubId = 591860;
     name = "Lionello Lunesu";
   };
+  liquidnya = {
+    name = "Alice ✨🌙 Luna";
+    github = "liquidnya";
+    githubId = 7364785;
+    email = "alice@liquidnya.dev";
+    matrix = "@liquidnya:matrix.org";
+    keys = [ { fingerprint = "7C2D E075 FA93 D61C C9A7  876F 7966 C19E 32F9 EF06"; } ];
+  };
   lisanna-dettwyler = {
     email = "lisanna.dettwyler@gmail.com";
     github = "lisanna-dettwyler";

--- a/pkgs/by-name/hy/hytale-launcher/package.nix
+++ b/pkgs/by-name/hy/hytale-launcher/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  writeShellApplication,
+
+  coreutils,
+  curl,
+  flatpak,
+  libnotify,
+
+  copyDesktopItems,
+  makeDesktopItem,
+
+  extraEnvironment ? { },
+  ...
+}:
+let
+  environment = {
+    __NV_DISABLE_EXPLICIT_SYNC = "1";
+    WEBKIT_DISABLE_DMABUF_RENDERER = "1";
+    DESKTOP_STARTUP_ID = "com.hypixel.HytaleLauncher";
+  }
+  // extraEnvironment;
+  toFlatpakEnvArg = (var: lib.escapeShellArg "--env=${var.name}=${var.value}");
+in
+writeShellApplication {
+  name = "hytale-launcher";
+
+  runtimeInputs = [
+    coreutils
+    curl
+    flatpak
+    libnotify
+  ];
+
+  text = ''
+    if ! flatpak info --user com.hypixel.HytaleLauncher >/dev/null 2>&1; then
+      notify-send "Hytale Launcher" "[Nix] Installing Hytale Launcher for the first time with Flatpak..." || true
+
+      logs="$(mktemp /tmp/nix-hytale-launcher-XXXXX.log || true)"
+
+      if ! (
+        tmp="$(mktemp /tmp/XXXXX.flatpak)" &&
+          curl -o "$tmp" https://launcher.hytale.com/builds/release/linux/amd64/hytale-launcher-latest.flatpak &&
+          flatpak install --user --noninteractive --bundle "$tmp"
+      ) 2>&1 | tee "$logs"; then
+        notify-send "Hytale Launcher" "[Nix] Installing Hytale Launcher for failed! Logs in $logs"
+        exit 1
+      fi
+    fi
+
+    flatpak run --user \
+      ${lib.concatMapStringsSep " " toFlatpakEnvArg (lib.attrsToList environment)} \
+      com.hypixel.HytaleLauncher
+  '';
+
+  derivationArgs = {
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    nativeBuildInputs = [ copyDesktopItems ];
+    desktopItems = lib.singleton (makeDesktopItem {
+      name = "com.hypixel.HytaleLauncher";
+      desktopName = "Hytale Launcher";
+      genericName = "Launcher for sandbox block game";
+      exec = "hytale-launcher";
+      categories = [ "Game" ];
+      startupWMClass = "com.hypixel.HytaleLauncher";
+    });
+
+    # HACK: writeShellApplication doesn't run all phases by default, so we
+    # inject installPhase in checkPhase...
+    postCheck = "runPhase installPhase";
+
+    meta = {
+      description = "Official launcher for Hytale";
+      longDescription = ''
+        Official launcher for Hytale, an upcoming block-based game from Hypixel Studios.
+
+        NOTE: This package is a simply a script which downloads and installs
+        the Hytale launcher flatpak at *runtime*. From the first install, the
+        launcher version is managed entirely by the Hytale launcher itself,
+        meaning this package is **not reproducible**.
+
+        See discussions on [this pull request](https://github.com/NixOS/nixpkgs/pull/479368)
+        for more context on why this method was chosen.
+      '';
+      homepage = "https://hytale.com";
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [
+        gepbird
+        karol-broda
+        liquidnya
+        dtomvan
+      ];
+      mainProgram = "hytale-launcher";
+      platforms = [ "x86_64-linux" ];
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    };
+  };
+}


### PR DESCRIPTION
This is an alternative to #479368, which is based upon suggestions by @itsliyua @jjsuperpower.

It's the least reproducible solution of them all, as it's basically just an automation for `wget && flatpak install && flatpak run`. But there's been a demand for *some* package for `hytale-launcher`, similar to the way most of steam is downloaded at runtime, due to how upstream distributes its software.

To my understanding this (read: directly installing the official flatpak) is the only way to "package" this for nixpkgs without breaking their license / distribution model.

Built, ran, loaded into a save.

See: https://github.com/NixOS/nixpkgs/pull/479368#issuecomment-4330341381

I added myself as maintainer, since that seems fair as I've now come up with code that I would otherwise not have to maintain.

cc @gepbird @karol-broda @liquidnya for wanting to be maintainers (let me know if you don't want to be a maintainer for this anymore, since it's a really boring derivation now...)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
