### PR TITLE
netbox: 4.5.7 -> 4.7.9

### DIFF
--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -393,7 +393,7 @@ in
                 ${lib.concatStringsSep " " cfg.gunicornArgs}
             '';
             PrivateTmp = true;
-            TimeoutStartSec = lib.mkDefault "5min";
+            TimeoutStartSec = lib.mkDefault "10min";
           };
         };
 

--- a/pkgs/by-name/ne/netbox_4_5/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   python3,
+  fetchpatch2,
   plugins ? _ps: [ ],
   nixosTests,
   nix-update-script,
@@ -28,6 +29,12 @@ py.pkgs.buildPythonApplication rec {
 
   patches = [
     ./custom-static-root.patch
+    # TODO: check if change is applied upstream before upgrading to NetBox v4.6
+    (fetchpatch2 {
+      name = "upgrade-django-tables2-v3.0.patch";
+      url = "https://github.com/netbox-community/netbox/commit/d57346d9f0eef8126eafcd5033ea43864faeaf0d.patch";
+      hash = "sha256-6/wdd8wDVT4eqDKMNx8tmoPTDvw8OE7atf9nzg3LZzk=";
+    })
   ];
 
   dependencies =

--- a/pkgs/by-name/ne/netbox_4_5/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/package.nix
@@ -16,14 +16,14 @@ let
 in
 py.pkgs.buildPythonApplication rec {
   pname = "netbox";
-  version = "4.5.7";
+  version = "4.5.9";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "netbox-community";
     repo = "netbox";
     tag = "v${version}";
-    hash = "sha256-8oOlDtTVeKDlaWt3JDy9wc1oUTTJPSoHd5O3YxbE50g=";
+    hash = "sha256-S8/2ZLYhYKBEpz3EGTyQPAPexX4se3MnmaH5aStVEj0=";
   };
 
   patches = [


### PR DESCRIPTION
Changelog: https://github.com/netbox-community/netbox/blob/v4.5.9/docs/release-notes/version-4.5.md

Also fixes #512843, and increase the start timeout.

Some plugins might have to be patched for django-tables2 v3.0, but I don't have time to investigate right now. This PR fixes the main NetBox, at least.

Superseeds #512432

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `9bdc55cfb71dc8a74c57ec4bc97d024c6c799a84`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 39 packages built:</summary>
  <ul>
    <li>netbox</li>
    <li>python313Packages.netbox-attachments</li>
    <li>python313Packages.netbox-attachments.dist</li>
    <li>python313Packages.netbox-bgp</li>
    <li>python313Packages.netbox-bgp.dist</li>
    <li>python313Packages.netbox-contract</li>
    <li>python313Packages.netbox-contract.dist</li>
    <li>python313Packages.netbox-documents</li>
    <li>python313Packages.netbox-documents.dist</li>
    <li>python313Packages.netbox-floorplan-plugin</li>
    <li>python313Packages.netbox-floorplan-plugin.dist</li>
    <li>python313Packages.netbox-interface-synchronization</li>
    <li>python313Packages.netbox-interface-synchronization.dist</li>
    <li>python313Packages.netbox-napalm-plugin</li>
    <li>python313Packages.netbox-napalm-plugin.dist</li>
    <li>python313Packages.netbox-plugin-prometheus-sd</li>
    <li>python313Packages.netbox-plugin-prometheus-sd.dist</li>
    <li>python313Packages.netbox-qrcode</li>
    <li>python313Packages.netbox-qrcode.dist</li>
    <li>python313Packages.netbox-reorder-rack</li>
    <li>python313Packages.netbox-reorder-rack.dist</li>
    <li>python313Packages.netbox-routing</li>
    <li>python313Packages.netbox-routing.dist</li>
    <li>python313Packages.netbox-topology-views</li>
    <li>python313Packages.netbox-topology-views.dist</li>
    <li>python314Packages.netbox-bgp</li>
    <li>python314Packages.netbox-bgp.dist</li>
    <li>python314Packages.netbox-documents</li>
    <li>python314Packages.netbox-documents.dist</li>
    <li>python314Packages.netbox-interface-synchronization</li>
    <li>python314Packages.netbox-interface-synchronization.dist</li>
    <li>python314Packages.netbox-plugin-prometheus-sd</li>
    <li>python314Packages.netbox-plugin-prometheus-sd.dist</li>
    <li>python314Packages.netbox-qrcode</li>
    <li>python314Packages.netbox-qrcode.dist</li>
    <li>python314Packages.netbox-reorder-rack</li>
    <li>python314Packages.netbox-reorder-rack.dist</li>
    <li>python314Packages.netbox-routing</li>
    <li>python314Packages.netbox-routing.dist</li>
  </ul>
</details>
