### PR TITLE
phylophlan: cleanup the nix declaration

### DIFF
--- a/pkgs/by-name/ph/phylophlan/package.nix
+++ b/pkgs/by-name/ph/phylophlan/package.nix
@@ -8,60 +8,63 @@
   diamond,
   python3Packages,
 }:
-let
-  finalAttrs = {
-    pname = "phylophlan";
-    version = "3.2.1";
-    pyproject = true;
 
-    src = fetchFromGitHub {
-      owner = "biobakery";
-      repo = "phylophlan";
-      tag = finalAttrs.version;
-      hash = "sha256-rPTEdu0W3LD27tDIWCOQ3K+RJuj97I9aEeYFdM77jOs=";
-    };
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "phylophlan";
+  version = "3.2.1";
+  pyproject = true;
 
-    build-system = with python3Packages; [ setuptools ];
+  src = fetchFromGitHub {
+    owner = "biobakery";
+    repo = "phylophlan";
+    tag = finalAttrs.version;
+    hash = "sha256-rPTEdu0W3LD27tDIWCOQ3K+RJuj97I9aEeYFdM77jOs=";
+  };
 
-    # It has no tests
-    doCheck = false;
+  build-system = with python3Packages; [ setuptools ];
 
-    dependencies = with python3Packages; [
-      biopython
-      dendropy
-      matplotlib
-      numpy
-      pandas
-      seaborn
-      distutils
-      requests
-      scipy
-      tqdm
-    ];
+  # It has no tests
+  doCheck = false;
 
+  dependencies = with python3Packages; [
+    biopython
+    dendropy
+    matplotlib
+    numpy
+    pandas
+    seaborn
+    distutils
+    requests
+    scipy
+    tqdm
+  ];
+
+  preFixup = ''
     # Minimum needed external tools
     # See https://github.com/biobakery/phylophlan/wiki#dependencies
-    propagatedBuildInputs = [
-      raxml
-      mafft
-      trimal
-      blast
-      diamond
-    ];
+    makeWrapperArgs+=(--prefix PATH : ${
+      lib.makeBinPath [
+        raxml
+        mafft
+        trimal
+        blast
+        diamond
+      ]
+    }
+    )
+  '';
 
-    postInstall = ''
-      # Not revelant in this context
-      rm -f $out/bin/phylophlan_write_default_configs.sh
-    '';
+  postInstall = ''
+    # Not revelant in this context
+    rm -f $out/bin/phylophlan_write_default_configs.sh
+  '';
 
-    meta = {
-      homepage = "https://github.com/biobakery/phylophlan";
-      description = "Precise phylogenetic analysis of microbial isolates and genomes from metagenomes";
-      changelog = "https://github.com/biobakery/phylophlan/releases";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ theobori ];
-      mainProgram = "phylophlan";
-    };
+  meta = {
+    homepage = "https://github.com/biobakery/phylophlan";
+    description = "Precise phylogenetic analysis of microbial isolates and genomes from metagenomes";
+    changelog = "https://github.com/biobakery/phylophlan/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theobori ];
+    mainProgram = "phylophlan";
   };
-in
-python3Packages.buildPythonApplication finalAttrs
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR add some changes for cleaning up the phylohplan nix declaration. Now using function argument instead of a `let` block and using `wrapProgram` in the `preFixup` phase instead of the `propagatedBuildInputs` attribute.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
