### PR TITLE
yet-another-monochrome-icon-set: init at 1.3.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27272,6 +27272,11 @@
     githubId = 57180880;
     name = "Ansh Tyagi";
   };
+  therealglh = {
+    github = "TheRealGLH";
+    githubId = 10632069;
+    name = "Martijn Daniels";
+  };
   therealgramdalf = {
     email = "gramdalftech@gmail.com";
     github = "TheRealGramdalf";

--- a/pkgs/by-name/ye/yet-another-monochrome-icon-set/package.nix
+++ b/pkgs/by-name/ye/yet-another-monochrome-icon-set/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  plasma5Packages,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "yet-another-monochrome-icon-set";
+  version = "1.3.7";
+
+  src = fetchzip {
+    url = "https://bitbucket.org/dirn-typo/yet-another-monochrome-icon-set/get/82cc7fe71231d6dd48c8d497f76f41471fa47c20.zip";
+    hash = "sha256-OBlREiChDzTyyrA+CjPmjvzypzHYbZK6vMFrgrBQdzE=";
+    stripRoot = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    themeDir="$out/share/icons/yet-another-monochrome-icon-set"
+    mkdir -p "$themeDir"
+    cp -R ./* "$themeDir/"
+    test -f "$themeDir/index.theme"
+    runHook postInstall
+  '';
+
+  propagatedBuildInputs = [
+    plasma5Packages.breeze-icons
+  ];
+
+  meta = {
+    description = "Monochrome icon theme for KDE Plasma desktops";
+    homepage = "https://store.kde.org/p/2303161";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.therealglh ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A basic icon theme package intended for KDE Plasma:

https://store.kde.org/p/2303161

I want to add that this is my first attempt at packaging something for Nix, though I've used this package directly in my personal setup already and it seems to work fine there.

If there's anything that would need to be changed or improved, I'd be happy to do so.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
