### PR TITLE
fishPlugins.ros2-fish: init at 0-unstable-2025-04-16

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -79,6 +79,8 @@ lib.makeScope newScope (
 
     pure = callPackage ./pure.nix { };
 
+    ros2-fish = callPackage ./ros2-fish.nix { };
+
     sdkman-for-fish = callPackage ./sdkman-for-fish.nix { };
 
     spark = callPackage ./spark.nix { };

--- a/pkgs/shells/fish/plugins/ros2-fish.nix
+++ b/pkgs/shells/fish/plugins/ros2-fish.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  buildFishPlugin,
+  fetchFromGitHub,
+}:
+buildFishPlugin {
+  pname = "ros2.fish";
+  version = "0-unstable-2025-04-16";
+
+  src = fetchFromGitHub {
+    owner = "kpbaks";
+    repo = "ros2.fish";
+    rev = "2d6d19f3b882f7b5f08707ae9d0a9a3fbc5ec13f";
+    sha256 = "sha256-WWH2eyenMtIPxBs/EZCfag3IfeVZfwUREJYSIbnzFrw=";
+  };
+
+  meta = {
+    description = "Integrates ROS2 with the fish-shell";
+    homepage = "https://github.com/kpbaks/ros2.fish";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tetov ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

"Integrate ROS2 with the fish-shell, and add interactive goodies to make you robotics workflow a little more fluid."

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
