### PR TITLE
python3Packages.google-cloud-firestore: switch to github

### DIFF
--- a/pkgs/development/python-modules/google-cloud-firestore/default.nix
+++ b/pkgs/development/python-modules/google-cloud-firestore/default.nix
@@ -2,7 +2,7 @@
   lib,
   aiounittest,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   freezegun,
   google-api-core,
   google-cloud-core,
@@ -16,6 +16,7 @@
   pythonOlder,
   pyyaml,
   setuptools,
+  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -23,11 +24,14 @@ buildPythonPackage (finalAttrs: {
   version = "2.27.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "google_cloud_firestore";
-    inherit (finalAttrs) version;
-    hash = "sha256-VjPLFk71bKbHOoB4IhkaVqmPbxDnaXjE8usZeuAzg9I=";
+  src = fetchFromGitHub {
+    owner = "googleapis";
+    repo = "google-cloud-python";
+    tag = "google-cloud-firestore-v${finalAttrs.version}";
+    hash = "sha256-hdUT4SRPOL+ArpU4RcsNCUCV3UCW3vQgwtHuxJiyZeU=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/google-cloud-firestore";
 
   build-system = [ setuptools ];
 
@@ -78,10 +82,17 @@ buildPythonPackage (finalAttrs: {
     "google.cloud.firestore_admin_v1"
   ];
 
+  updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "google-cloud-firestore-v(.*)"
+    ];
+  };
+
   meta = {
     description = "Google Cloud Firestore API client library";
-    homepage = "https://github.com/googleapis/python-firestore";
-    changelog = "https://github.com/googleapis/python-firestore/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-firestore";
+    changelog = "https://github.com/googleapis/google-cloud-python/tree/${finalAttrs.src.tag}/packages/google-cloud-firestore/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ sarahec ];
   };


### PR DESCRIPTION
1. Migrate from PyPi to github
2. Fixup changelog link (Tracking #514132)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
