### PR TITLE
efitools: patch invalid make argument

### DIFF
--- a/pkgs/by-name/ef/efitools/objcopy-output-target.patch
+++ b/pkgs/by-name/ef/efitools/objcopy-output-target.patch
@@ -1,0 +1,15 @@
+Use --output-target instead of --target in objcopy invocation.
+Newer binutils dropped support for --target as an output format specifier.
+
+Bug-Debian: https://bugs.debian.org/1122408
+--- a/Make.rules
++++ b/Make.rules
+@@ -26,7 +26,7 @@
+ LDSCRIPT	= elf_$(ARCH)_efi.lds
+ LDFLAGS		+= -shared -Bsymbolic $(CRTOBJS) -L $(CRTPATH) -L /usr/lib -L /usr/lib64 -T $(LDSCRIPT)
+ LOADLIBES	= -lefi -lgnuefi $(shell $(CC) $(ARCH3264) -print-libgcc-file-name)
+-FORMAT		= --target=efi-app-$(ARCH)
++FORMAT		= --output-target=efi-app-$(ARCH)
+ OBJCOPY		= objcopy
+ MYGUID		= 11111111-2222-3333-4444-123456789abc
+ INSTALL		= install

--- a/pkgs/by-name/ef/efitools/package.nix
+++ b/pkgs/by-name/ef/efitools/package.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Fix build with gcc15
     ./remove-redundant-bool.patch
+
+    # https://bugs.debian.org/1122408
+    ./objcopy-output-target.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Added a patch to change the `--target` argument to `--output-target` to unblock the failing build: 

* Issue: https://github.com/NixOS/nixpkgs/issues/512925
* Failing hydra build: https://hydra.nixos.org/build/326971536

```
error: Cannot build '/nix/store/76j4hyqy0bmi5992wbxv7gyhblcqh46v-efitools-1.9.2.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/fp5azn4663r0c1akcxcb38474kmg7vlg-efitools-1.9.2
       Last 25 log lines:
       > gcc -I/build/source/include/ -I/nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/include/efi/ -I/nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/include/efi//x86_64 -I/nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/include/efi//protocol -O2 -g  -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check -DGNU_EFI_USE_MS_ABI -DEFI_FUNCTION_WRAPPER -mno-red-zone -DCONFIG_x86_64 -c variables.c -o variables.o
       > ar rcv lib-efi.a simple_file.efi.o pecoff.efi.o guid.efi.o sha256.efi.o console.efi.o execute.efi.o configtable.efi.o shell.efi.o security_policy.efi.o shim_protocol.efi.o pkcs7verify.efi.o variables.o
       > a - simple_file.efi.o
       > a - pecoff.efi.o
       > a - guid.efi.o
       > a - sha256.efi.o
       > a - console.efi.o
       > a - execute.efi.o
       > a - configtable.efi.o
       > a - shell.efi.o
       > a - security_policy.efi.o
       > a - shim_protocol.efi.o
       > a - pkcs7verify.efi.o
       > a - variables.o
       > make[1]: Leaving directory '/build/source/lib'
       > gcc -I/build/source/include/ -I/nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/include/efi/ -I/nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/include/efi//x86_64 -I/nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/include/efi//protocol -O2 -g  -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check -DGNU_EFI_USE_MS_ABI -DEFI_FUNCTION_WRAPPER -mno-red-zone -DCONFIG_x86_64 -c HelloWorld.c -o HelloWorld.o
       > ld -nostdlib -shared -Bsymbolic /nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/lib//crt0-efi-x86_64.o -L /nix/store/11fhr4wrlx2qwh9b3q2a2x5inkannwkl-gnu-efi-4.0.2/lib/ -L /usr/lib -L /usr/lib64 -T elf_x86_64_efi.lds HelloWorld.o lib/lib-efi.a -o HelloWorld.so -lefi -lgnuefi /nix/store/sanx9fg8mry8mq92zhlm5qvb83qlxrlx-gcc-15.2.0/lib/gcc/x86_64-unknown-linux-gnu/15.2.0/libgcc.a
       > # check we have no undefined symbols
       > nm -D HelloWorld.so | grep ' U ' && exit 1 || exit 0
       > objcopy -j .text -j .sdata -j .data -j .dynamic -j .dynsym \
       >            -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
       >      -j .reloc --target=efi-app-x86_64 HelloWorld.so HelloWorld.efi
       > objcopy: HelloWorld.so: file format not recognized
       > make: *** [Make.rules:55: HelloWorld.efi] Error 1
       > rm HelloWorld.o

```

After patch:
```

❯ nix build path:/home/goose/repositories/nixpkgs#efitools && ls result/bin/
 cert-to-efi-hash-list   efi-readvar     efitool-mkusb   hash-to-efi-sig-list   sign-efi-sig-list
 cert-to-efi-sig-list    efi-updatevar   flash-var       sig-list-to-certs

```

Run without arguments:
```
nixpkgs on master ································································································································23:26:59
❯ result/bin/efitool-mkusb --help
Usage result/bin/efitool-mkusb: key_dir efi_dir output_image_file

nixpkgs on master ····························································································································✘ 1 23:27:04
❯ result/bin/efi-readvar
Variable PK, length 1301
PK: List 0, type X509
    Signature 0, size 1273, owner 47d3686b-03a1-41fb-bc8f-2ffd77bbbd5e
        Subject:
            C=Platform Key, CN=Platform Key
        Issuer:
            C=Platform Key, CN=Platform Key
Variable KEK, length 2876
KEK: List 0, type X509
    Signature 0, size 1288, owner 47d3686b-03a1-41fb-bc8f-2ffd77bbbd5e
        Subject:
            C=Key Exchange Key, CN=Key Exchange Key
        Issuer:
            C=Key Exchange Key, CN=Key Exchange Key
KEK: List 1, type X509
    Signature 0, size 1532, owner 77fa9abd-0359-4d32-bd60-28f4e78f784b
        Subject:
            C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation KEK CA 2011
        Issuer:
            C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root
Variable db, length 4443
db: List 0, type X509
    Signature 0, size 1272, owner 47d3686b-03a1-41fb-bc8f-2ffd77bbbd5e
        Subject:
            C=Database Key, CN=Database Key
        Issuer:
            C=Database Key, CN=Database Key
db: List 1, type X509
    Signature 0, size 1572, owner 77fa9abd-0359-4d32-bd60-28f4e78f784b
        Subject:
            C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation UEFI CA 2011
        Issuer:
            C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Corporation Third Party Marketplace Root
db: List 2, type X509
    Signature 0, size 1515, owner 77fa9abd-0359-4d32-bd60-28f4e78f784b
        Subject:
            C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Windows Production PCA 2011
        Issuer:
            C=US, ST=Washington, L=Redmond, O=Microsoft Corporation, CN=Microsoft Root Certificate Authority 2010
Variable dbx has no entries
Variable MokList has no entries

nixpkgs on master ································································································································23:27:16
❯ result/bin/efi-updatevar
Usage: result/bin/efi-updatevar: [-a] [-e] [-d <list>[-<entry>]] [-k <key>] [-g <guid>] [-b <file>|-f <file>|-c file] <var>

nixpkgs on master ····························································································································✘ 1 23:27:24
❯ result/bin/cert-to-efi-hash-list
Usage: result/bin/cert-to-efi-hash-list [-g <guid>][-t <timestamp>][-s <hash>] <crt file> <efi sig list file>

nixpkgs on master ····························································································································✘ 1 23:27:28
❯ result/bin/cert-to-efi-sig-list

nixpkgs on master ····························································································································✘ 1 23:27:32
❯ result/bin/flash-var
Usage: result/bin/flash-var: [-l] [-g <owner guid>] [-t <timestamp>] <flashfile> <var> <varcontentfile>

nixpkgs on master ····························································································································✘ 1 23:27:36
❯ result/bin/hash-to-efi-sig-list
Usage: result/bin/hash-to-efi-sig-list efi-binary [efi-binary ...] efi-signature-list

nixpkgs on master ····························································································································✘ 1 23:27:40
❯ result/bin/sign-efi-sig-list
Usage: result/bin/sign-efi-sig-list [-r] [-m] [-a] [-g <guid>] [-o] [-t <timestamp>] [-i <infile>] [-c <crt file>] [-k <key file>] [-e <engine>] <var> <efi sig list file> <output file>

nixpkgs on master ····························································································································✘ 1 23:27:45
❯ result/bin/sig-list-to-certs
Usage: result/bin/sig-list-to-certs <efi sig list file> <cert file base name>
```

nixpkgs-review:
```
nixpkgs on master ·················································23:22:10
❯ nix run nixpkgs#nixpkgs-review -- wip
disabling binary cache 'https://cache.flakehub.com' for 60 seconds
warning:
         … during download of 'https://cache.flakehub.com/nix-cache-info'

         warning: unable to download 'https://cache.flakehub.com/nix-cache-info': HTTP error 401

         response body:

         {"code":401,"error":"Unauthorized","message":"Unauthorized.","request_id":"019dd62f-cefe-7360-b062-201d72cd9244"}
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (22/22), done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 12 (delta 9), reused 2 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (12/12), 1.78 KiB | 1.78 MiB/s, done.
Resolving deltas: 100% (9/9), completed with 9 local objects.
From https://github.com/NixOS/nixpkgs
 * [new branch]                master     -> refs/nixpkgs-review/0
$ git worktree prune
$ git worktree add /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d-dirty/nixpkgs f46fb76b8c8fc8887b3832789745db59f23631ad
Preparing worktree (detached HEAD f46fb76b8c8f)
Updating files: 100% (52233/52233), done.
HEAD is now at f46fb76b8c8f protonmail-desktop: 1.12.1 -> 1.13.0 (#511258)
Local evaluation for computing rebuilds
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d-dirty/nixpkgs nixpkgs-overlays=/tmp/tmpy6v0p3o6 -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
warning: experimental feature 'no-url-literals' has been stabilized and renamed; use 'lint-url-literals = fatal' setting instead
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
  nix build path:/home/goose/repositories/nixpkgs#efitools && ls result/$ git --no-pager diff --no-ext-diff --src-prefix=a/ --dst-prefix=b/
No diff detected, stopping review...
$ git worktree remove -f /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d-dirty/nixpkgs

nixpkgs on master ······················································································································· ⏱ 2m41s 23:25:08
❯ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree prune
$ git worktree add /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs f46fb76b8c8fc8887b3832789745db59f23631ad
Preparing worktree (detached HEAD f46fb76b8c8f)
Updating files: 100% (52233/52233), done.
HEAD is now at f46fb76b8c8f protonmail-desktop: 1.12.1 -> 1.13.0 (#511258)
Local evaluation for computing rebuilds
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs nixpkgs-overlays=/tmp/nix-shell-303647-3945457670/tmpiyygp7_k -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
warning: experimental feature 'no-url-literals' has been stabilized and renamed; use 'lint-url-literals = fatal' setting instead
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
$ git merge --no-commit --no-ff 90c83aa341bbb8f354c452411239e7e9d94eb21d
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs nixpkgs-overlays=/tmp/nix-shell-303647-3945457670/tmpiyygp7_k -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
warning: experimental feature 'no-url-literals' has been stabilized and renamed; use 'lint-url-literals = fatal' setting instead
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
--------- Impacted packages on 'x86_64-linux' ---------
1 package updated:
efitools

warning: experimental feature 'no-url-literals' has been stabilized and renamed; use 'lint-url-literals = fatal' setting instead
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
$ nom build --file /nix/store/fhmj33ni9rc3irlj5jd80kxfx76dgnch-nixpkgs-review-3.7.0/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix --extra-experimental-features 'nix-command no-url-literals' --nix-path 'nixpkgs=/home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs nixpkgs-overlays=/tmp/nix-shell-303647-3945457670/tmpiyygp7_k' --no-allow-import-from-derivation --no-link --keep-going --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-303647-3945457670/tmpx6br6ljz.nix --argstr attrs-path /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/attrs.nix
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
┏━ Dependency Graph:
┃ ✔ review-shell
┣━━━ Builds
┗━ ∑ ⏵ 0 │ ✔ 1 │ ⏸ 0 │ Finished at 23:35:11 after 3s
--------- Report for 'x86_64-linux' ---------
1 package built:
efitools

Logs can be found under:
/home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/logs

warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
warning: 
[efitools-x86_64-linux.log](https://github.com/user-attachments/files/27183166/efitools-x86_64-linux.log)
unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
disabling binary cache 'https://cache.flakehub.com' for 60 seconds
warning: unable to download 'https://cache.flakehub.com/nix-cache-info': HTTP error 401

         response body:

         {"code":401,"error":"Unauthorized","message":"Unauthorized.","request_id":"019dd63b-729b-7082-a602-9074cdae80c7"}
$ /etc/profiles/per-user/goose/bin/nom-shell --argstr local-system x86_64-linux --argstr nixpkgs-path /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs --argstr nixpkgs-config-path /tmp/nix-shell-303647-3945457670/tmpx6br6ljz.nix --argstr attrs-path /home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/attrs.nix --nix-path 'nixpkgs=/home/goose/.local/cache/nixpkgs-review/rev-90c83aa341bbb8f354c452411239e7e9d94eb21d/nixpkgs nixpkgs-overlays=/tmp/nix-shell-303647-3945457670/tmpiyygp7_k' /nix/store/fhmj33ni9rc3irlj5jd80kxfx76dgnch-nixpkgs-review-3.7.0/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix
warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'
[efitools-x86_64-linux.log](https://github.com/user-attachments/files/27183180/efitools-x86_64-linux.log)

warning: unknown setting 'eval-cores'
warning: unknown setting 'lazy-trees'

warning: unknown setting 'eval-cores'
```

attached efitools-x86_64-linux.log

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
