### PR TITLE
CONTRIBUTING.md: establish initial automation/AI/LLM policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -121,6 +121,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
+++ b/.github/ISSUE_TEMPLATE/02_bug_report_darwin.yml
@@ -135,6 +135,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug_report_nixos.yml
@@ -125,6 +125,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/04_build_failure.yml
+++ b/.github/ISSUE_TEMPLATE/04_build_failure.yml
@@ -131,6 +131,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/05_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/05_update_request.yml
@@ -104,6 +104,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/06_module_request.yml
+++ b/.github/ISSUE_TEMPLATE/06_module_request.yml
@@ -79,6 +79,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/07_backport_request.yml
+++ b/.github/ISSUE_TEMPLATE/07_backport_request.yml
@@ -85,6 +85,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/08_documentation_request.yml
+++ b/.github/ISSUE_TEMPLATE/08_documentation_request.yml
@@ -67,6 +67,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
+++ b/.github/ISSUE_TEMPLATE/09_unreproducible_package.yml
@@ -137,6 +137,8 @@ body:
           required: true
         - label: "I assert that I have read the [NixOS Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) and agree to abide by it."
           required: true
+        - label: "I assert that I have read the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy) and that this issue report complies with it."
+          required: true
   - type: "markdown"
     attributes:
       value: |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,12 +27,14 @@ For new packages please briefly describe the package or provide a link to its ho
   - [ ] Module addition: when adding a new NixOS module.
   - [ ] Module update: when the change is significant.
 - [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
+- [ ] Follows the [automation/AI policy].
 
 [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
 [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
 [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
 
 [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
+[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
 [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
 [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
 [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,7 @@ For example, if you make a change to `texlive`, you probably would only check th
 
 #### Meets Nixpkgs contribution standards
 
-The last checkbox is about whether it fits the guidelines in this `CONTRIBUTING.md` file.
+The last two checkboxes are about whether it fits the guidelines in this `CONTRIBUTING.md` file.
 This document details our standards for commit messages, reviews, licensing of contributions, etc...
 Everyone should read and understand these standards before submitting a pull request.
 
@@ -888,3 +888,74 @@ As mentioned previously, it is unfortunately perfectly normal for a PR to sit ar
 
 Please don't blow up situations where progress is happening but is merely not going fast enough for your tastes.
 Honking in a traffic jam will not make you go any faster.
+
+# Automation/AI policy
+
+Every contribution to Nixpkgs and related development venues, including code, documentation, and communication on GitHub and Matrix, must have a **responsible person in the loop** who is accountable for that contribution and reviews it before submission, and must **transparently disclose** any non‐trivial use of automation to produce it, including but not limited to LLM‐based AI tools.
+
+The following sections give more detail.
+
+## Scope
+
+Any use of automated tools to generate non‐trivial amounts of output as part of a contribution, in whole or in part, verbatim or edited, is covered by this policy, except as listed in the Exemptions section.
+Both LLM‐based AI tools and hand‐written automation are covered.
+Contributions include code and documentation in commits, commit messages, pull request summaries and reviews, issue and vulnerability reports, GitHub comments, and Matrix messages.
+The covered venues are the GitHub repositories for Nixpkgs and [related projects](https://github.com/orgs/NixOS/teams/nixpkgs-core/repositories) under the jurisdiction of the Nixpkgs core team, and Matrix rooms that are focused on development of those projects.
+
+## Accountability
+
+Everyone who submits a contribution to Nixpkgs is responsible for it, regardless of the use of automated tooling.
+Before submission, they are expected to establish a reasonable level of understanding of the contribution and belief in its correctness.
+Contributors are expected to be able to answer questions about their contribution and respond to feedback appropriately.
+A contributor submitting a contribution intended for inclusion in Nixpkgs is also responsible for ensuring that it is [appropriately licensed](https://github.com/NixOS/nixpkgs/blob/master/COPYING) and credited, and not encumbered by any incompatible copyright.
+
+When output from automated tooling is used in contributions, a contributor must establish confidence in that output.
+This can be achieved by establishing confidence in the correctness of the tooling’s logic, manual review of the included output, or using further automation to verify the output (e.g. programmatically checking whether a refactor avoids causing rebuilds).
+As the inner workings of LLM‐based AI tools cannot be sufficiently understood at present, only the latter two options are available when those are used.
+When automation is used to verify output, the verification tooling itself must be disclosed and reviewed in line with this policy.
+
+It is not permitted to submit automated contributions without any manual review or intervention, outside of standard community automation.
+Automation without any manual review must not be used as the sole arbiter of whether to merge a change.
+
+## Transparency
+
+All covered use of automated tooling for a contribution must be disclosed as part of that contribution.
+
+In the case of LLM‐based AI tooling used for commits, this **must** be in the form of a Git commit trailer in the format `Assisted-by: AGENT_NAME:MODEL_VERSION`.
+A `Co-authored-by:` trailer does not satisfy this policy.
+
+Any adequate form of disclosure is permitted for other kinds of tooling and contribution.
+Pull request summaries must be disclosed separately to commits.
+
+## Exemptions
+
+The following situations are fully or partially exempt:
+
+* Use of standard deterministic editor/IDE/formatter/text transformation tooling to produce changes that the author manually reviews and understands is exempt, including inline “auto‐completion” (even if LLM‐based) of short, rote snippets of text that do not contribute anything beyond boilerplate the author would have written anyway.
+
+* Use of standard community automation is exempt, such as `nix-update`, the official Nixpkgs CI bots, the @r-ryantm update bot, and the Nixpkgs security tracker bot.
+
+* Use of AI tools for research, testing, debugging, or private review is out of scope, if no substantial amount of their output is included in the resulting contribution.
+  However, if these tools had a significant technical influence on your contribution, you are still responsible for it per the Accountability section, and are expected to disclose this where relevant.
+
+* Use of machine translation is exempt from the requirement to understand the translated output.
+  However, the requirements of appropriate confidence in the original text, responsibility, and disclosure still apply, and you are encouraged to additionally include the original untranslated contribution.
+
+* Use of automation in a contribution clearly marked as not being ready for review (e.g. a draft pull request) is exempt from the requirement for full self‐review, as long as some amount of review has been done and it is expected that the requirements will be met by the time it is marked as ready.
+  This does not waive any other requirement.
+
+* Use of automated tools to develop upstream software packaged inside Nixpkgs is not in scope.
+
+## Enforcement
+
+If you believe that someone is using automation without appropriate disclosure and review, you can politely ask them if that’s the case and point them to this policy as appropriate.
+Please assume good faith and remain civil; it’s not always possible to determine, and it is more likely that someone overlooked this policy than deliberately violated it.
+If you think someone is continuing to break the policy after this, please escalate to the [Nixpkgs core team](https://nixos.org/community/teams/nixpkgs-core/) rather than fighting over it.
+
+Deliberate violations of this policy are considered to break the [Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) clause against “Wasting other people’s time with low quality contributions, including but not limited to LLM and bot spam”.
+If a contribution clearly violates the policy – e.g. the contributor admits it is in violation without working to fix it, or there are AI tool attributions that do not meet our required format – it is acceptable for anyone with technical permissions to close or hide it, pointing to this policy if necessary.
+Repeated violations are grounds for further moderation action.
+
+## Credits
+
+This policy takes inspiration from similar policies in [LLVM](https://llvm.org/docs/AIToolPolicy.html), [Mesa](https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-26.1.0-rc1/docs/submittingpatches.rst?ref_type=tags), [Fedora](https://docs.fedoraproject.org/en-US/council/policy/ai-contribution-policy/), and the [Linux kernel](https://docs.kernel.org/7.0/process/coding-assistants.html), along with [a proposal by the author of Anubis](https://xeiaso.net/notes/2025/assisted-by-footer/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,7 @@ For example, if you make a change to `texlive`, you probably would only check th
 
 #### Meets Nixpkgs contribution standards
 
-The last checkbox is about whether it fits the guidelines in this `CONTRIBUTING.md` file.
+The last two checkboxes are about whether it fits the guidelines in this `CONTRIBUTING.md` file.
 This document details our standards for commit messages, reviews, licensing of contributions, etc...
 Everyone should read and understand these standards before submitting a pull request.
 
@@ -888,3 +888,77 @@ As mentioned previously, it is unfortunately perfectly normal for a PR to sit ar
 
 Please don't blow up situations where progress is happening but is merely not going fast enough for your tastes.
 Honking in a traffic jam will not make you go any faster.
+
+# Automation/AI policy
+
+Every contribution to Nixpkgs and related development venues, including code, documentation, and communication on GitHub and Matrix, must have a **responsible person in the loop** who is accountable for that contribution and reviews it before submission, and must **transparently disclose** any non‐trivial use of automation to produce it, including but not limited to LLM‐based AI tools.
+
+The following sections give more detail.
+
+## Scope
+
+Any use of automated tools to generate non‐trivial amounts of output as part of a contribution, in whole or in part, verbatim or edited, is covered by this policy, except as listed in the Exemptions section.
+Both LLM‐based AI tools and hand‐written automation are covered.
+Contributions include code and documentation in commits, commit messages, pull request summaries and reviews, issue and vulnerability reports, GitHub comments, Matrix messages, and Discourse posts.
+The covered venues are the GitHub repositories for Nixpkgs and [related projects](https://github.com/orgs/NixOS/teams/nixpkgs-core/repositories) under the jurisdiction of the Nixpkgs core team, Matrix rooms that are focused on development of those projects, and Discourse topics about Nixpkgs development.
+
+## Accountability
+
+Everyone who submits a contribution to Nixpkgs is responsible for it, regardless of the use of automated tooling.
+Before submission, they must establish a reasonable level of understanding of the contribution and expectation of its correctness.
+A contributor submitting a contribution intended for inclusion in Nixpkgs is also responsible for ensuring that it is [appropriately licensed](https://github.com/NixOS/nixpkgs/blob/master/COPYING) and credited, and not encumbered by any incompatible copyright.
+
+When output from automated tooling is used in contributions, a contributor must establish confidence in that output.
+This can be achieved by establishing confidence in the correctness of the tooling’s logic, manual review of the included output, or using further automation to verify the output (e.g. programmatically checking whether a refactor avoids causing rebuilds).
+As the inner workings of LLM‐based AI tools cannot be sufficiently understood at present, only the latter two options are available when those are used; vibe coding without review is not permitted.
+When automation is used to verify output, the verification tooling itself must be disclosed and reviewed in line with this policy.
+
+This policy applies equally to any further discussion of a contribution.
+Comments and reviews must separately satisfy the same requirements of understanding, review, and disclosure.
+Contributors are expected to be able to answer questions about their contribution and respond to feedback appropriately, without simply forwarding messages back and forth to automated tools.
+
+It is not permitted to submit automated contributions without any manual review or intervention, outside of standard community automation.
+Automation without any manual review must not be used as the sole arbiter of whether to merge a change.
+
+## Transparency
+
+All covered use of automated tooling for a contribution must be disclosed as part of that contribution.
+
+In the case of LLM‐based AI tooling used for commits, this **must** be in the form of an `Assisted-by:` Git commit trailer, including at least the tool name and the primary model name and version used for the contribution.
+A `Co-authored-by:` trailer does not satisfy this policy.
+
+Any adequate form of disclosure is permitted for other kinds of tooling and contribution.
+Pull request summaries and review comments must be disclosed separately to commits.
+
+## Exemptions
+
+The following situations are fully or partially exempt:
+
+* Use of standard deterministic editor/IDE/formatter/text transformation tooling to produce changes that the author manually reviews and understands is exempt, including inline “auto‐completion” (even if LLM‐based) of short, rote snippets of text that do not contribute anything beyond boilerplate the author would have written anyway.
+
+* Use of standard community automation is exempt, such as `nix-update`, the official Nixpkgs CI bots, the @r-ryantm update bot, other maintainer‐approved bots that run update scripts, and the Nixpkgs security tracker bot.
+
+* Use of AI tools for research, testing, debugging, or private review is out of scope, if no substantial amount of their output is included in the resulting contribution.
+  However, if these tools had a significant technical influence on your contribution, you are still responsible for it per the Accountability section, and are expected to disclose this where relevant.
+
+* Use of machine translation is exempt from the requirement to understand the translated output.
+  However, the requirements of appropriate confidence in the original text, responsibility, and disclosure still apply, and you are encouraged to additionally include the original untranslated contribution.
+
+* Use of automation in a contribution clearly marked as not being ready for merge (e.g. a draft pull request) is exempt from the requirement for full self‐review, as long as some amount of review has been done and it is expected that the requirements will be met by the time it is marked as ready.
+  This does not waive any other requirement.
+
+* Use of automated tools to develop upstream software packaged inside Nixpkgs is not in scope.
+
+## Enforcement
+
+If you believe that someone is using automation without appropriate disclosure and review, you can politely ask them if that’s the case and point them to this policy as appropriate.
+Please assume good faith and remain civil; it’s not always possible to determine, and it is more likely that someone overlooked this policy than deliberately violated it.
+If you think someone is continuing to break the policy after this, please escalate to the [Nixpkgs core team](https://nixos.org/community/teams/nixpkgs-core/) rather than fighting over it.
+
+If a contribution is clearly in violation of the policy (e.g. the contributor admits it was not followed, or there are AI tool attributions that do not meet our required format), it can be closed or hidden, preferably after informing the contributor of the policy and giving them a chance to address the violations.
+Deliberate violations of this policy are considered to break the [Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) clause against “Wasting other people’s time with low quality contributions, including but not limited to LLM and bot spam”.
+Repeated violations are grounds for further moderation action.
+
+## Credits
+
+This policy takes inspiration from similar policies in [LLVM](https://llvm.org/docs/AIToolPolicy.html), [Mesa](https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-26.1.0-rc1/docs/submittingpatches.rst?ref_type=tags), [Fedora](https://docs.fedoraproject.org/en-US/council/policy/ai-contribution-policy/), and the [Linux kernel](https://docs.kernel.org/7.0/process/coding-assistants.html), along with [a proposal by the author of Anubis](https://xeiaso.net/notes/2025/assisted-by-footer/).


### PR DESCRIPTION
The Nixpkgs core team feels it is overdue to establish an official policy on the use of automation for Nixpkgs contributions. The [Code of Conduct](https://github.com/NixOS/.github/blob/master/CODE_OF_CONDUCT.md) has a clause against “Wasting other people’s time with low quality contributions, including but not limited to LLM and bot spam”, but does not define this in detail, and we have seen a large increase in automated contributions over the past months, often without disclosure.

After discussion with the community team bootstrap group and within the Nixpkgs core team, we’ve agreed on submitting this proposed policy for community review.

This is an area where people understandably have strong views, and which goes beyond technical matters to touch on legal and ethical concerns. It’s unlikely we can achieve complete consensus among contributors on the topic, and we’re willing to make judgement calls as necessary for the benefit of Nixpkgs, but we want to start out with a baseline policy that we think can gain strong consensus.

Therefore, we’ve focused on **formalizing existing norms around automated contributions and applying them generally to include LLM‐based AI tools**, ruling out what we think contributors will widely agree are clearly unacceptable cases: **undisclosed use of complex automation, and automated contributions submitted without any manual review or understanding**. The hope is that this will also give us more visibility with which to iterate further as necessary.

The core of the proposed policy is:

> Every contribution to Nixpkgs and related development venues, including code, documentation, and communication on GitHub and Matrix, must have a **responsible person in the loop** who is accountable for that contribution and reviews it before submission, and must **transparently disclose** any non‐trivial use of automation to produce it, including but not limited to LLM‐based AI tools.

See the [rendered version](https://github.com/emilazy/nixpkgs/blob/push-xtnztnzplszo/CONTRIBUTING.md#automationai-policy) of the full policy for easier reading.

This policy takes inspiration from similar policies in [LLVM](https://llvm.org/docs/AIToolPolicy.html), [Mesa](https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-26.1.0-rc1/docs/submittingpatches.rst?ref_type=tags), [Fedora](https://docs.fedoraproject.org/en-US/council/policy/ai-contribution-policy/), and the [Linux kernel](https://docs.kernel.org/7.0/process/coding-assistants.html), along with [a proposal by the author of Anubis](https://xeiaso.net/notes/2025/assisted-by-footer/). We’re also following the Rust project’s [work on a more elaborate, stricter policy](https://github.com/rust-lang/rust-forge/pull/1040).

We’ll leave this pull request open for a public feedback period of **at least two weeks**. We’re happy to hear concerns or suggestions, either on this pull request or [in private](https://nixos.org/community/teams/nixpkgs-core/).

To ensure the discussion stays on track and civil, we’ll be liberally hiding comments that aren’t focused specifically on what Nixpkgs policy should look like, or that restate previously‐raised points. **Please leave each piece of feedback as a separate review comment on specific lines of the diff so that threads of discussion can be kept separate and resolved as needed; use the header line if you have a comment about the policy as a whole.**

## Why cover all automation rather than just LLM‐based AI tools?

We have established norms around how we expect people to disclose, review, and verify automated contributions like treewide refactors. In the past, there have been cases where such changes have been merged without adequate verification and had to be reverted.

We think that formalizing those norms makes sense on its own merits, and that they serve as a good starting point for an AI policy: our expectations for the use of LLM‐based AI tools should clearly be at least as strict as those for more deterministic, reviewable tooling.

## Why not ban LLM‐based tools entirely?

There’s clearly a divide in the community on these tools, with some prominent contributors forgoing them entirely and some using them extensively. As we said in the summary, we’re willing to make judgement calls here for the benefit of Nixpkgs, but only after doing our best to facilitate consensus. We believe that we need to establish a baseline of transparency and accountability before considering whether further steps may be appropriate, and that formalizing existing norms will help with this.

We believe that a maximally hardline policy of banning all use of LLM‐based tools at any stage of any contribution would likely be untenable; we would not want to ban the use of accessibility tools that often use LLMs like machine translation, speech to text, text to speech, and OCR, and declining genuine vulnerability reports solely on the grounds of LLM use during research would be shooting ourselves in the foot. We are not concerned with designing norms around dishonest contributors, but believe any policy will need to strike some kind of balance to be reasonable and enforceable.

We care deeply about the technical quality of Nixpkgs and don’t want a race to the bottom on standards, but believe it should be possible to use these tools without sacrificing rigour. While it may be financially inadvisable, I have seen Claude use to produce trivial version and hash bumps, and clearly in that case there is no meaningful risk to Nixpkgs compared to doing it by hand or with `nix-update`. For a less trivial example, it’s not uncommon for initiatives to be blocked on treewide changes that are tedious to write by hand, but comparatively easy to programatically verify (e.g. checking whether a refactor avoids causing rebuilds); in the past, these have sometimes been accomplished with a combination of naive scripting to handle common cases, and manual busywork to handle the rest. LLM‐based tools show potential to reduce the manual toil for these changes in combination with deterministic verification code.

In terms of copyright, we generally trust that submitted code is unencumbered and licensed appropriately. Cases where there is clear cause for concern are raised and handled as people notice them. LLM output is one of many areas of legal ambiguity around software copyright; too many, sadly, for us to strictly avoid all of them. This shouldn’t be taken as expressing any official project view on the copyright status of LLM output in general – there is clearly LLM output that does not pose a copyright issue (e.g. the aforementioned trivial version bump), and clearly LLM output that is a much greater concern (e.g. eliciting verbatim reproduction of existing code snippets, or using them to rephrase a codebase in an attempt to “launder” its licensing). If anyone spots plagiarism or copyright violation in any contribution, they can point it out and it should be handled appropriately. Of course, the appropriate copyright policy for LLM output may change as regulation and precedent develop.

We understand, however, that many community members have objections to the training and use of LLMs that go beyond matters of technical quality or legal concerns, and don’t intend to dismiss them out of hand. **We would like this policy to be seen as establishing consistent standards based on pre‐existing norms around automation and ruling out the most problematic cases, not as an endorsement by the project, nor necessarily as the final word on the matter.** We hope that transparency requirements will give people choice about which contributions they spend time on in the immediate term, and help facilitate a broader discussion on these topics to inform future work.

## Why require disclosure?

We believe that transparency is the foundation of any effective policy. Establishing a baseline expectation of disclosure is required to enforce any further requirements or prohibitions, and to evaluate whether a policy is working.

We already have an established expectation that people who use scripts to generate large treewide changes disclose this in their contributions, and preferably make efforts to verify and understand the results.

We believe that it’s especially important in the case of LLM‐based tools: they are **particularly good at producing confident and convincing output even when it’s not correct**. While contributors are of course fallible in general, and code review inherently involves applying appropriate scrutiny rather than taking things on faith, we believe that this decoupling between the appearance of confident expert research effort and the correctness of the changes is especially pronounced for LLM output, and has a significant effect on review dynamics. It also decreases the extent to which reviewers can rely on pre‐existing trust in the nominal author.

The fundamental character of interacting with LLM‐based tools is also different – providing extensive feedback on changes from new contributors can usually be expected to help them learn and improve over time, which is not the case for an LLM. Contributors may wish to avoid spending time on this, or adjust their reviews accordingly.

## Why require `Assisted-by:` over `Co-authored-by:`?

Since LLM‐based AI tools use `Co-authored-by:` attribution by default, we think that using a different format will serve as a [brown M&M test](https://en.wikipedia.org/wiki/Van_Halen_test) and assist with triage. A commit that contains such a tool in `Co-authored-by:` but not `Assisted-by:` is, by definition, one that did not follow the policy and can be closed, potentially automatically. It also matches the format standardized on by the Linux kernel and Fedora, and will make it easier to review and query for use of these tools.

## Why require a person in the loop?

We are fundamentally bottlenecked on manual review; there is no benefit to Nixpkgs to the submission of changes *en masse* that we cannot hope to triage. It’s the expected norm that contributors check their contributions before submitting them. A contributor sending automated changes without any review or validation takes up limited triage resources while not contributing anything that someone else with access to the same tooling couldn’t. Since any kind of automation allows changes to be produced much more quickly, requiring oversight ensures that contributions happen at a sustainable pace, and that every contribution is already vouched for by its contributor.

See the LLVM policy’s remarks on [extractive contributions](https://llvm.org/docs/AIToolPolicy.html#extractive-contributions) for thinking that resonates strongly with ours.

We also place trust in maintainers and committers in our own automation, e.g. through the merge bot. Unsupervised automation of changes and reviews subverts the principles behind these mechanisms.

This also mitigates the issues around feedback, by ensuring that there is always *someone* on the other end who can learn from it.

## Why not cover upstream practices for packaged software?

We have been following the discussion about this, but believe that establishing a policy for Nixpkgs itself is the priority. Defining criteria and maintaining data for the entire package set would be a huge undertaking that goes beyond the scope of this proposal. A blanket policy covering packages with any LLM output would be untenable, as we cannot avoid packaging core components like the Linux kernel, LLVM, systemd, and HarfBuzz, and it would likely be very difficult to produce a usable, up‐to‐date system while entirely avoiding all such components.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
