### PR TITLE
python3Packages.enocean-async: 0.4.2 -> 0.13.5

### DIFF
--- a/pkgs/development/python-modules/enocean-async/default.nix
+++ b/pkgs/development/python-modules/enocean-async/default.nix
@@ -3,16 +3,16 @@
   fetchFromGitHub,
   fetchpatch,
   lib,
-  pyserial-asyncio-fast,
   pytest-asyncio,
   pytestCheckHook,
   pythonOlder,
+  serialx,
   setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "enocean-async";
-  version = "0.4.2";
+  version = "0.13.5";
   pyproject = true;
 
   disabled = pythonOlder "3.14";
@@ -21,13 +21,13 @@ buildPythonPackage (finalAttrs: {
     owner = "henningkerstan";
     repo = "enocean-async";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-VBBZwNPBgJ9rXUaAVtRzgdebeDtfJCt7R1zOu3Eom80=";
+    hash = "sha256-D0ocHDr75cwPK7Ci3sq+I1bk/152m2dL+jXgGBNQjMc=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    pyserial-asyncio-fast
+    serialx
   ];
 
   pythonImportsCheck = [ "enocean_async" ];
@@ -35,11 +35,6 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
-  ];
-
-  disabledTestPaths = [
-    # tests have broken imports, fixed in 0.12.4
-    "tests/test_eep.py"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/henningkerstan/enocean-async/compare/v0.4.2...v0.13.5

Changelog: https://github.com/henningkerstan/enocean-async/blob/v0.13.5/CHANGELOG.md

also see https://github.com/NixOS/nixpkgs/issues/514132
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
