### PR TITLE
anytype: fix desktop entry wrapper

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29792,6 +29792,12 @@
     githubId = 5629059;
     name = "Xavier Lambein";
   };
+  xmnlz = {
+    name = "xmnlz";
+    github = "xmnlz";
+    githubId = 63904972;
+    email = "lemmeq9+nixos@gmail.com";
+  };
   xnaveira = {
     email = "xnaveira@gmail.com";
     github = "xnaveira";

--- a/pkgs/by-name/an/anytype/0003-remove-desktop-entry.patch
+++ b/pkgs/by-name/an/anytype/0003-remove-desktop-entry.patch
@@ -1,0 +1,15 @@
+diff --git a/electron/js/util.js b/electron/js/util.js
+index da18f41ad0..bb07ec9f21 100644
+--- a/electron/js/util.js
++++ b/electron/js/util.js
+@@ -314,7 +314,9 @@ class Util {
+ 		if (!is.linux) {
+ 			return;
+ 		};
+-
++		// NixOS: desktop entries are managed by the package, avoid 
++		// writing user-local anytype.desktop which goes stale on updates
++		return;
+ 		const { execFile } = require('child_process');
+ 		const home = process.env.HOME || '';
+ 		const dataHome = process.env.XDG_DATA_HOME || path.join(home, '.local', 'share');

--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -57,6 +57,7 @@ buildNpmPackage (finalAttrs: {
   patches = [
     ./0001-feat-update-Disable-auto-checking-for-updates-and-updating-manually.patch
     ./0002-remove-grpc-devtools.patch
+    ./0003-remove-desktop-entry.patch
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/an/anytype/package.nix
+++ b/pkgs/by-name/an/anytype/package.nix
@@ -139,6 +139,7 @@ buildNpmPackage (finalAttrs: {
       autrimpo
       adda
       kira-bruneau
+      xmnlz
     ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Anytype creates its own `~/.local/share/applications/anytype.desktop`, which overrides the desktop file shipped by nixpkgs. The generated entry uses runtime paths that become invalid after updates or garbage collection, causing launches from desktop environments to fail.

This patch disables the in-app desktop entry generation so the desktop entry provided by nixpkgs is always used instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test