### PR TITLE
python3Packages.chipwhisperer: mark broken

### DIFF
--- a/pkgs/development/python-modules/chipwhisperer/default.nix
+++ b/pkgs/development/python-modules/chipwhisperer/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
 
   # build
-  pythonAtLeast,
   setuptools,
   setuptools-scm,
   cython,
@@ -15,7 +14,6 @@
   ecpy,
   fastdtw,
   libusb1,
-  numpy,
   pyserial,
   tqdm,
 
@@ -108,5 +106,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/newaetech/chipwhisperer/releases/tag/${version}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.krishnans2006 ];
+    broken = true; # Requires NumPy 1.26.4 (unsupported by nixpkgs)
   };
 }


### PR DESCRIPTION
The package requires (the unsupported) NumPy 1.26.4, and using relaxed deps causes test and functionality errors. Hopefully, once upstream migrates to NumPy 2.0, this can be re-packaged.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
