### PR TITLE
ssh-agent-switcher: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/ss/ssh-agent-switcher/package.nix
+++ b/pkgs/by-name/ss/ssh-agent-switcher/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ssh-agent-switcher";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "jmmv";
     repo = "ssh-agent-switcher";
     tag = "ssh-agent-switcher-${finalAttrs.version}";
-    hash = "sha256-p9W0H25pWDB+GCrwLwuVruX9p8b8kICpp+6I11ym1aw=";
+    hash = "sha256-XAIupGVU8D4tmZXZ3/5lKiHbvBlxgNQXL0T9Htp7Zmo=";
   };
 
-  cargoHash = "sha256-WioA/RjXOAHM9QWl/lxnb7gqzcp76rus7Rv+IfCYceg=";
+  cargoHash = "sha256-dbeUye20E2nQcJPyUCpZT68T95dopgoIlBm8rOoaZ6Y=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Upgrades ssh-agent-switcher to 1.0.2 to, primarily, fix test failures with recent nixpkgs upgrades. There are no code changes otherwise except for some dependency upgrades in Cargo.lock.

Fixes #513032.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
