### PR TITLE
kotlin-lsp: init at 262.4739.0

### DIFF
--- a/pkgs/by-name/ko/kotlin-lsp/package.nix
+++ b/pkgs/by-name/ko/kotlin-lsp/package.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  darwin,
+  fixDarwinDylibNames,
+  unar,
+  versionCheckHook,
+  zlib,
+}:
+
+let
+  system = stdenv.hostPlatform.system;
+
+  archiveFile =
+    version:
+    {
+      "x86_64-linux" = "kotlin-server-${version}.tar.gz";
+      "aarch64-linux" = "kotlin-server-${version}-aarch64.tar.gz";
+      "x86_64-darwin" = "kotlin-server-${version}.sit";
+      "aarch64-darwin" = "kotlin-server-${version}-aarch64.sit";
+    }
+    .${system} or (throw "kotlin-lsp does not support ${system}");
+  archiveHash =
+    {
+      "x86_64-linux" = "sha256-RpcREMm4ozYM4/31Q3Rn9MRH2tN61z2/gdZK9neeQQU=";
+      "aarch64-linux" = "sha256-YlhwrgkcbQ3uJVFNVFxwim6lDXy7UVSq8aqRI8z/M4s=";
+      "x86_64-darwin" = "sha256-bwbv56EPlLnIoCjE7+tsfhdp9HoB7ft0RQrPMKtWZeQ=";
+      "aarch64-darwin" = "sha256-G3RXQ84irZJoGhvDsQRoA+lCpuHzbgT7ha6aQDNKLx4=";
+    }
+    .${system} or (throw "kotlin-lsp does not support ${system}");
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kotlin-lsp";
+  version = "262.4739.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${finalAttrs.version}/${archiveFile finalAttrs.version}";
+    hash = archiveHash;
+  };
+
+  # Add support for .sit archive using unar
+  preUnpack = lib.optionalString stdenv.isDarwin ''
+    _tryUnar() {
+      if ! [[ "$curSrc" =~ \.sit$ ]]; then return 1; fi
+      ${lib.getExe unar} "$curSrc"
+    }
+    unpackCmdHooks+=(_tryUnar)
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # Stripping breaks the binary on Darwin (code signing issues)
+  dontStrip = stdenv.isDarwin;
+
+  # (on Linux only) X11/Wayland/sound/font libs are GUI-only backends in the bundled JBR;
+  # the LSP server itself runs headless so these are safe to ignore.
+  autoPatchelfIgnoreMissingDeps = [
+    "libasound.so.2"
+    "libc.musl-x86_64.so.1"
+    "libfreetype.so.6"
+    "libwayland-client.so.0"
+    "libwayland-cursor.so.0"
+    "libX11.so.6"
+    "libXext.so.6"
+    "libXi.so.6"
+    "libXrender.so.1"
+    "libXtst.so.6"
+    "libxkbcommon.so.0"
+  ];
+  nativeBuildInputs = (
+    lib.optionals stdenv.isLinux [ autoPatchelfHook ]
+    ++ lib.optionals stdenv.isDarwin [
+      fixDarwinDylibNames
+      unar
+      darwin.autoSignDarwinBinariesHook
+    ]
+  );
+
+  buildInputs = [
+    # for native JNI libs (rocksdbjni, filewatcher),
+    stdenv.cc.cc.lib # libgcc_s.so.1, libstdc++.so.6
+    # for the bundled JBR (libjli, libzip, libinstrument, etc.)
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install the vendored JBR (JetBrains Runtime) tree under $out/share/kotlin-lsp.
+    # The `product-info.json` must sit in a parent directory of `intellij-server` binary.
+    mkdir -p $out/share/kotlin-lsp
+    cp -r bin jbr lib modules plugins product-info.json build.txt $out/share/kotlin-lsp/
+
+    mkdir -p $out/bin
+    ln -s ../share/kotlin-lsp/bin/intellij-server $out/bin/kotlin-lsp
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Official Kotlin LSP, by JetBrains";
+    longDescription = ''
+      Pre-alpha official Kotlin support for editors using the Language Server Protocol.
+      The server is based on IntelliJ IDEA and the IntelliJ IDEA Kotlin Plugin.
+      Supports JVM Kotlin Gradle projects out of the box, with Maven and other build
+      systems also supported.
+    '';
+    homepage = "https://github.com/Kotlin/kotlin-lsp";
+    changelog = "https://github.com/Kotlin/kotlin-lsp/releases/tag/kotlin-lsp%2Fv${finalAttrs.version}";
+    maintainers = with lib.maintainers; [
+      bew
+      eveeifyeve
+    ];
+    license = with lib.licenses; [
+      asl20
+      # NOTE: @2026-04 the LSP source code is not public
+      unfreeRedistributable
+    ];
+    platforms = lib.platforms.darwin ++ [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    sourceProvenance = [
+      lib.sourceTypes.binaryNativeCode
+      lib.sourceTypes.binaryBytecode
+    ];
+    mainProgram = "kotlin-lsp";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've tested `kotlin-lsp` on my NixOS (x86_64) and my work mac (aarch64), both in Neovim, it seems to work well!

Build with `NIXPKGS_ALLOW_UNFREE=1 nix build .#kotlin-lsp --impure`

Replaces #435169 & #492163, improving them by:
- fixing the license
- avoid depending on X11/Wayland packages (the lsp is headless, it has no need for graphical stuff!)
- does not use the deprecated `kotlin-lsp.sh` launcher, but properly wraps the `intellij-server` as instructed in upstream project
- adding support for `.sit` archives used for MacOS (👉 should I move the unpack hook out of the package?)
- adding version check to ensure the binary works in `installCheck` phase


---
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
