### PR TITLE
Add podocarp/speedtest_exporter package and module

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -119,6 +119,7 @@ let
         "smartctl"
         "smokeping"
         "snmp"
+        "speedtest"
         "sql"
         "statsd"
         "storagebox"

--- a/nixos/modules/services/monitoring/prometheus/exporters/speedtest.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/speedtest.nix
@@ -15,6 +15,8 @@ let
     ;
 in
 {
+  port = 9798;
+
   extraOpts = {
     serverID = mkOption {
       type = types.int;

--- a/nixos/modules/services/monitoring/prometheus/exporters/speedtest.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/speedtest.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.speedtest;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    optionalString
+    ;
+in
+{
+  extraOpts = {
+    serverID = mkOption {
+      type = types.int;
+      default = -1;
+      description = ''
+        Speedtest.net server ID to run tests against.
+        -1 picks the closest server to your location.
+      '';
+    };
+
+    serverFallback = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If the configured serverID is unavailable, fall back to the closest available server.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-speedtest-exporter}/bin/speedtest_exporter \
+          -listen-address ${cfg.listenAddress} \
+          -port ${toString cfg.port} \
+          -server_id ${toString cfg.serverID} \
+          ${optionalString cfg.serverFallback "-server_fallback"} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
@@ -4,15 +4,15 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   __structuredAttrs = true;
   pname = "prometheus-speedtest-exporter";
-  version = "v1.0.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "podocarp";
     repo = "speedtest_exporter";
-    rev = version;
+    tag = "v${finalAttrs.version}";
     hash = "sha256-n9eunZRssS13mTOeFeZ/PpfSj430DKf3ZRS10hY4Ps8=";
   };
 
@@ -25,4 +25,4 @@ buildGoModule rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ podocarp ];
   };
-}
+})

--- a/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
@@ -1,0 +1,28 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  __structuredAttrs = true;
+  pname = "prometheus-speedtest-exporter";
+  version = "0.0.5-unstable-2026-04-29";
+
+  src = fetchFromGitHub {
+    owner = "podocarp";
+    repo = "speedtest_exporter";
+    rev = "e82be2ecb5d0cbcd5a6a21909afed6991b5d7e00";
+    hash = "sha256-7uy1rVll7YzM9WeQQKKSiI4nblIPADD6h/5z/diCH4E=";
+  };
+
+  vendorHash = "sha256-w113vWnXM4h3zckmj39Qx/oZFaH9Mq0xUSqNxopdQO0=";
+
+  meta = {
+    description = "Speedtest.net Exporter for the Prometheus monitoring system";
+    mainProgram = "speedtest_exporter";
+    homepage = "https://github.com/danopstech/speedtest_exporter";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-speedtest-exporter/package.nix
@@ -4,25 +4,25 @@
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGoModule rec {
   __structuredAttrs = true;
   pname = "prometheus-speedtest-exporter";
-  version = "0.0.5-unstable-2026-04-29";
+  version = "v1.0.0";
 
   src = fetchFromGitHub {
     owner = "podocarp";
     repo = "speedtest_exporter";
-    rev = "e82be2ecb5d0cbcd5a6a21909afed6991b5d7e00";
-    hash = "sha256-7uy1rVll7YzM9WeQQKKSiI4nblIPADD6h/5z/diCH4E=";
+    rev = version;
+    hash = "sha256-n9eunZRssS13mTOeFeZ/PpfSj430DKf3ZRS10hY4Ps8=";
   };
 
-  vendorHash = "sha256-w113vWnXM4h3zckmj39Qx/oZFaH9Mq0xUSqNxopdQO0=";
+  vendorHash = "sha256-HBg44D0CUc4HYCBwGrswnrqG5o5ltA6UT8L0oWetlIc=";
 
   meta = {
     description = "Speedtest.net Exporter for the Prometheus monitoring system";
     mainProgram = "speedtest_exporter";
-    homepage = "https://github.com/danopstech/speedtest_exporter";
+    homepage = "https://github.com/podocarp/speedtest_exporter";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ podocarp ];
   };
 }


### PR DESCRIPTION
Adds the [danopstech/speedtest_exporter](https://github.com/danopstech/speedtest_exporter) package as well as exporter module. I've temporarily pointed it to my fork while waiting for it to be merged, the only change being the addition of a `listenAddress` flag to match the package style with the other exporters.

For testing I just set the module on a live machine and it works
```
curl localhost:9798/metrics
# HELP speedtest_download_speed_Bps Last download speedtest result
# TYPE speedtest_download_speed_Bps gauge
speedtest_download_speed_Bps{redacted}
# HELP speedtest_latency_seconds Measured latency on last speed test
# TYPE speedtest_latency_seconds gauge
speedtest_latency_seconds{redacted}
... ...
```

Note to self: Internally this exporter uses https://github.com/showwin/speedtest-go which does not exist in nixpkgs yet, might be useful to package it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
