### PR TITLE
onlykey: fix broken gui

### DIFF
--- a/pkgs/by-name/on/onlykey/package.nix
+++ b/pkgs/by-name/on/onlykey/package.nix
@@ -46,11 +46,43 @@ buildNpmPackage (finalAttrs: {
   # should not break other things.
   npmFlags = [ "--ignore-scripts" ];
 
+  postPatch = ''
+    # NW.js 0.102 in Chrome-packaged-app mode never advances
+    # document.readyState past "loading", so DOMContentLoaded and load
+    # events never fire and the wizard UI never initializes (the window
+    # only shows the page background and the "Last message received"
+    # footer text). Dispatch the events manually after the bottom-of-body
+    # scripts have registered their listeners.
+    substituteInPlace app/app.html \
+      --replace-fail \
+        '<script src="/scripts/dialog-links.js"></script>' \
+        '<script src="/scripts/dialog-links.js"></script>
+    <script>setTimeout(() => { document.dispatchEvent(new Event("DOMContentLoaded")); window.dispatchEvent(new Event("load")); }, 0);</script>'
+
+    # The app should not create autostart entries on first launch.
+    substituteInPlace app/app.js \
+      --replace-fail \
+        "} else if (!localStorage.hasOwnProperty('autoLaunch')) {" \
+        "} else if (false && !localStorage.hasOwnProperty('autoLaunch')) {"
+  '';
+
+  postBuild = ''
+    substituteInPlace build/package.json \
+      --replace-fail '"name": "OnlyKey-dev"' '"name": "OnlyKey"' \
+      --replace-fail '"toolbar": true' '"toolbar": false'
+  '';
+
   installPhase = ''
     runHook preInstall
 
+    rm -rf node_modules
+    npm ci --omit=dev --omit=optional --ignore-scripts
+    rm -rf node_modules/nw
+    rm -f node_modules/.bin/nw
+
     mkdir -p "$out/share"
     cp -r build "$out/share/onlykey"
+    cp -r node_modules "$out/share/onlykey/node_modules"
 
     ln -s "${finalAttrs.desktopItem}/share/applications" "$out/share/applications"
 


### PR DESCRIPTION
Root cause: NW.js 0.102 in Chrome-packaged-app mode never advances document.readyState past loading, so DOMContentLoaded and load events never fire. The previous init(); patch was placed inside the DOMContentLoaded handler, so it never executed.
fixes #386751

Second bug was node modules that needed rebuilding.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
