### PR TITLE
perry: init at 0.5.345

### DIFF
--- a/pkgs/by-name/pe/perry/package.nix
+++ b/pkgs/by-name/pe/perry/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenvNoCC,
+  deno,
+  gtk4,
+  makeBinaryWrapper,
+  clang,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "perry";
+  version = "0.5.345";
+
+  src = fetchFromGitHub {
+    owner = "PerryTS";
+    repo = "perry";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mgqk/savFP8FB3SN4IPqCV1bljJXT2gXDUAV01C4Tw8=";
+  };
+
+  cargoHash = "sha256-eE0f2P0ldSIeuJ0OzrtCbaRHNsg/g8ENT2TMbGWFLRw=";
+
+  cargoTestFlags = [
+    "--workspace"
+    "--exclude"
+    "perry-ui-ios"
+    "--exclude"
+    "perry-ui-visionos"
+    "--exclude"
+    "perry-ui-tvos"
+    "--exclude"
+    "perry-ui-watchos"
+    "--exclude"
+    "perry-ui-gtk4"
+    "--exclude"
+    "perry-ui-android"
+    "--exclude"
+    "perry-ui-windows"
+  ];
+
+  env.RUSTY_V8_ARCHIVE = deno.librusty_v8;
+
+  buildInputs = lib.optionals stdenvNoCC.isLinux [ gtk4 ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/${finalAttrs.meta.mainProgram} \
+      --prefix PATH : ${lib.makeBinPath [ clang ]} \
+      --prefix LD_LIBRARY_PATH : $out/lib
+    rm -f $out/bin/styling-matrix
+  '';
+
+  __structuredAttrs = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Native TypeScript compiler written in Rust";
+    homepage = "https://www.perryts.com";
+    downloadPage = "https://github.com/PerryTS/perry/releases";
+    changelog = "https://github.com/PerryTS/perry/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode # librusty_v8.a
+    ];
+    mainProgram = "perry";
+    hydraPlatforms = lib.lists.remove "x86_64-darwin" lib.platforms.all;
+  };
+})


### PR DESCRIPTION
init [perry](https://github.com/PerryTS/perry)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
