### PR TITLE
python3Packages.scalecodec: init at 1.2.12

### DIFF
--- a/pkgs/development/python-modules/scalecodec/default.nix
+++ b/pkgs/development/python-modules/scalecodec/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  more-itertools,
+  base58,
+  requests,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scalecodec";
+  version = "1.2.12";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "JAMdotTech";
+    repo = "py-scale-codec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e6SDVivkVZjL84kcvkPs+5S2iD79+p+dGjhUWuS50Fc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    more-itertools
+    base58
+    requests
+  ];
+
+  # setup.py reads version from TRAVIS_TAG env var
+  env.TRAVIS_TAG = finalAttrs.src.tag;
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "scalecodec" ];
+
+  meta = {
+    description = "Python SCALE Codec Library";
+    longDescription = "Substrate uses a lightweight and efficient encoding and decoding program to optimize how data is sent and received over the network. The program used to serialize and deserialize data is called the SCALE codec, with SCALE being an acronym for Simple Concatenated Aggregate Little-Endian.";
+    homepage = "https://github.com/JAMdotTech/py-scale-codec";
+    changelog = "https://github.com/JAMdotTech/py-scale-codec/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/scalecodec/default.nix
+++ b/pkgs/development/python-modules/scalecodec/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  more-itertools,
+  base58,
+  requests,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scalecodec";
+  version = "1.2.12";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "JAMdotTech";
+    repo = "py-scale-codec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e6SDVivkVZjL84kcvkPs+5S2iD79+p+dGjhUWuS50Fc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    more-itertools
+    base58
+    requests
+  ];
+
+  # setup.py reads version from TRAVIS_TAG env var
+  env.TRAVIS_TAG = finalAttrs.src.tag;
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "scalecodec" ];
+
+  meta = {
+    description = "Python SCALE Codec Library";
+    longDescription = ''
+      Substrate uses a lightweight and efficient encoding and decoding program to optimize how data is sent and received over the network.
+      The program used to serialize and deserialize data is called the SCALE codec, with SCALE being an acronym for Simple Concatenated Aggregate Little-Endian.
+    '';
+    homepage = "https://github.com/JAMdotTech/py-scale-codec";
+    changelog = "https://github.com/JAMdotTech/py-scale-codec/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17315,6 +17315,8 @@ self: super: with self; {
 
   scalar-fastapi = callPackage ../development/python-modules/scalar-fastapi { };
 
+  scalecodec = callPackage ../development/python-modules/scalecodec { };
+
   scalene = callPackage ../development/python-modules/scalene { };
 
   scales = callPackage ../development/python-modules/scales { };


### PR DESCRIPTION
 Python SCALE-Codec implementation

https://github.com/JAMdotTech/py-scale-codec

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
