### PR TITLE
python3Packages.bt-decode: init at 0.8.0

### DIFF
--- a/pkgs/development/python-modules/bt-decode/default.nix
+++ b/pkgs/development/python-modules/bt-decode/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  toml,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bt-decode";
+  version = "0.8.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "bt-decode";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jpCnYKoTVq2NCxE1vZhJzSagXtx43efDSdA5jWsZ95k=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-qj4S1104HaFs6JePwgBjAI/4z7aH71Wq9CDvnSxlXmM=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  dependencies = [ toml ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # these tests compare against bittensor, which is not in nixpkgs
+  disabledTestPaths = [
+    "tests/test_decode_delegate_info.py"
+    "tests/test_decode_neurons.py"
+    "tests/test_decode_stake_info.py"
+    "tests/test_decode_subnet_hyp.py"
+    "tests/test_decode_subnet_info.py"
+  ];
+
+  pythonImportsCheck = [ "bt_decode" ];
+
+  meta = {
+    description = "Fast SCALE decoding of Bittensor data structures";
+    longDescription = "A python wrapper around the rust scale-codec crate for fast scale-decoding of Bittensor data structures.";
+    homepage = "https://github.com/latent-to/bt-decode";
+    changelog = "https://github.com/latent-to/bt-decode/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2343,6 +2343,8 @@ self: super: with self; {
 
   bsuite = callPackage ../development/python-modules/bsuite { };
 
+  bt-decode = callPackage ../development/python-modules/bt-decode { };
+
   bt-proximity = callPackage ../development/python-modules/bt-proximity { };
 
   btchip-python = callPackage ../development/python-modules/btchip-python { };


### PR DESCRIPTION
A python wrapper around the rust scale-codec crate for fast scale-decoding of Bittensor data structures.

https://github.com/latent-to/bt-decode

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
