### PR TITLE
python3Packages.cyscale: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/cyscale/default.nix
+++ b/pkgs/development/python-modules/cyscale/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  more-itertools,
+  base58,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cyscale";
+  version = "0.3.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "cyscale";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L75xuo4LWfTMs1XYV8zSPtmxqgjWin9wcALDUjz5L1k=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    more-itertools
+    base58
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # test_valid_type_registry_presets walks ../scalecodec/type_registry relative
+  # to the test file, which no longer exists after removing the source package dir
+  disabledTests = [ "test_valid_type_registry_presets" ];
+
+  # remove source package so tests import the installed Cython extensions, not the .pyx sources
+  preCheck = ''
+    rm -rf scalecodec
+  '';
+
+  pythonImportsCheck = [ "scalecodec" ];
+
+  meta = {
+    description = "Cython-accelerated SCALE codec library for Substrate-based blockchains (Polkadot, Kusama, Bittensor, etc.)";
+    longDescription = "A drop-in replacement for py-scale-codec — same scalecodec module name, same public API, compiled with Cython for improved throughput.";
+    homepage = "https://github.com/latent-to/cyscale";
+    changelog = "https://github.com/latent-to/cyscale/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3490,6 +3490,8 @@ self: super: with self; {
 
   cyrtranslit = callPackage ../development/python-modules/cyrtranslit { };
 
+  cyscale = callPackage ../development/python-modules/cyscale { };
+
   cysignals = callPackage ../development/python-modules/cysignals { };
 
   cython = callPackage ../development/python-modules/cython { };


### PR DESCRIPTION
Cython-accelerated [SCALE codec](https://docs.substrate.io/reference/scale-codec/) library for Substrate-based blockchains (Polkadot, Kusama, Bittensor, etc.).

https://github.com/latent-to/cyscale/tree/master

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
