### PR TITLE
python3Packages.async-substrate-interface: init at 2.0.4

### DIFF
--- a/pkgs/development/python-modules/async-substrate-interface/default.nix
+++ b/pkgs/development/python-modules/async-substrate-interface/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiosqlite,
+  cyscale,
+  websockets,
+  xxhash,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "async-substrate-interface";
+  version = "2.0.4";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "async-substrate-interface";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3EA3VQ5hfYIepW+03lrkiO4toSEdGHbA515xJznKHn0=";
+  };
+
+  # On darwin the sandbox isolation is not as strict as on linux,
+  # and we can get permission erros when trying to create/delete arbitrary dirs in /tmp
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace tests/unit_tests/test_types.py \
+      --replace-fail '/tmp/async-substrate-interface-test-cache' "$(mktemp -d)/cache"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiosqlite
+    cyscale
+    websockets
+    xxhash
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # these tests open a live websocket/subtensor endpoint, unavailable in the build sandbox
+  disabledTestPaths = [
+    "tests/integration_tests"
+    "tests/e2e_tests"
+    "tests/unit_tests/sync/test_block.py"
+  ];
+
+  pythonImportsCheck = [ "async_substrate_interface" ];
+
+  meta = {
+    description = "Modernised py-substrate-interface and associated utils";
+    longDescription = "This project provides an asynchronous interface for interacting with Substrate-based blockchains. It is based on the py-substrate-interface project.";
+    homepage = "https://github.com/latent-to/async-substrate-interface";
+    changelog = "https://github.com/latent-to/async-substrate-interface/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/cyscale/default.nix
+++ b/pkgs/development/python-modules/cyscale/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  more-itertools,
+  base58,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cyscale";
+  version = "0.3.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "cyscale";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L75xuo4LWfTMs1XYV8zSPtmxqgjWin9wcALDUjz5L1k=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    more-itertools
+    base58
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # test_valid_type_registry_presets walks ../scalecodec/type_registry relative
+  # to the test file, which no longer exists after removing the source package dir
+  disabledTests = [ "test_valid_type_registry_presets" ];
+
+  # remove source package so tests import the installed Cython extensions, not the .pyx sources
+  preCheck = ''
+    rm -rf scalecodec
+  '';
+
+  pythonImportsCheck = [ "scalecodec" ];
+
+  meta = {
+    description = "Cython-accelerated SCALE codec library for Substrate-based blockchains (Polkadot, Kusama, Bittensor, etc.)";
+    longDescription = "A drop-in replacement for py-scale-codec — same scalecodec module name, same public API, compiled with Cython for improved throughput.";
+    homepage = "https://github.com/latent-to/cyscale";
+    changelog = "https://github.com/latent-to/cyscale/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3490,6 +3490,8 @@ self: super: with self; {
 
   cyrtranslit = callPackage ../development/python-modules/cyrtranslit { };
 
+  cyscale = callPackage ../development/python-modules/cyscale { };
+
   cysignals = callPackage ../development/python-modules/cysignals { };
 
   cython = callPackage ../development/python-modules/cython { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1136,6 +1136,8 @@ self: super: with self; {
 
   async-stagger = callPackage ../development/python-modules/async-stagger { };
 
+  async-substrate-interface = callPackage ../development/python-modules/async-substrate-interface { };
+
   async-tiff = callPackage ../development/python-modules/async-tiff { };
 
   async-timeout = callPackage ../development/python-modules/async-timeout { };


### PR DESCRIPTION
Async Substrate Interface provides an asynchronous interface for interacting with [Substrate](https://substrate.io/)-based blockchains. It is based on the [py-substrate-interface](https://github.com/polkascan/py-substrate-interface) project.

https://github.com/latent-to/async-substrate-interface

Depends on ~~#514647~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
