### PR TITLE
python3Packages.bittorrent-drand: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/bittensor-drand/default.nix
+++ b/pkgs/development/python-modules/bittensor-drand/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bittensor-drand";
+  version = "1.3.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "bittensor-drand";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0GizpmKGWbDjWCIAF1kPdz2sjn8B/e0qSIHmDqlDzZc=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-JasDf3qXzB6ddp1NjC+xtozsggwyk2nQbRw/Lbt02Kg=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # remove source package so tests import the installed Rust extension, not the stub __init__.py
+  preCheck = ''
+    rm -rf bittensor_drand
+  '';
+
+  # All tests in test_commit_reveal.py and most in test_all_functions.py call
+  # the live drand network beacon, which is unavailable in the build sandbox.
+  disabledTests = [
+    "test_get_latest_round"
+    "test_encrypt_and_decrypt"
+    "test_encrypt_at_round_and_decrypt"
+    "test_get_signature_for_round"
+    "test_decrypt_with_signature"
+    "test_batch_decryption_optimization"
+    "test_get_encrypted_commitment"
+    "test_get_encrypted_commit"
+    "test_get_encrypted_commits"
+  ];
+
+  pythonImportsCheck = [ "bittensor_drand" ];
+
+  meta = {
+    description = "Bittensor drand integration for commit-reveal";
+    homepage = "https://github.com/latent-to/bittensor-drand";
+    changelog = "https://github.com/latent-to/bittensor-drand/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2110,6 +2110,8 @@ self: super: with self; {
 
   bitstruct = callPackage ../development/python-modules/bitstruct { };
 
+  bittensor-drand = callPackage ../development/python-modules/bittensor-drand { };
+
   bitvavo-aio = callPackage ../development/python-modules/bitvavo-aio { };
 
   bitvector-for-humans = callPackage ../development/python-modules/bitvector-for-humans { };


### PR DESCRIPTION
https://github.com/latent-to/bittensor-drand

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
