### PR TITLE
btcli: init at 9.21.0

### DIFF
--- a/pkgs/development/python-modules/async-substrate-interface/default.nix
+++ b/pkgs/development/python-modules/async-substrate-interface/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiosqlite,
+  cyscale,
+  websockets,
+  xxhash,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "async-substrate-interface";
+  version = "2.0.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "async-substrate-interface";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Fd56RgDmi8D4eAx/N6BRB9dEhfYJe8vTsboodPVTXX8=";
+  };
+
+  # On darwin the sandbox isolation is not as strict as on linux,
+  # and we can get permission erros when trying to create/delete arbitrary dirs in /tmp
+  postPatch = lib.optionalString stdenv.isDarwin ''
+    substituteInPlace tests/unit_tests/test_types.py \
+      --replace-fail '/tmp/async-substrate-interface-test-cache' "$(mktemp -d)/cache"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiosqlite
+    cyscale
+    websockets
+    xxhash
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # these tests open a live websocket/subtensor endpoint, unavailable in the build sandbox
+  disabledTestPaths = [
+    "tests/integration_tests"
+    "tests/e2e_tests"
+    "tests/unit_tests/sync/test_block.py"
+  ];
+
+  pythonImportsCheck = [ "async_substrate_interface" ];
+
+  meta = {
+    description = "Modernised py-substrate-interface and associated utils";
+    longDescription = "This project provides an asynchronous interface for interacting with Substrate-based blockchains. It is based on the py-substrate-interface project.";
+    homepage = "https://github.com/latent-to/async-substrate-interface";
+    changelog = "https://github.com/latent-to/async-substrate-interface/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/bittensor-cli/default.nix
+++ b/pkgs/development/python-modules/bittensor-cli/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  aiohttp,
+  async-substrate-interface,
+  backoff,
+  bittensor-drand,
+  bittensor-wallet,
+  cyscale,
+  gitpython,
+  jinja2,
+  netaddr,
+  numpy,
+  packaging,
+  plotille,
+  plotly,
+  pycryptodome,
+  pyyaml,
+  rich,
+  typer,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bittensor-cli";
+  version = "9.21.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "btcli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S4omNwksE2tvGjdXBBOdFRvy1KcHrWt87o2kWIC8Sz0=";
+  };
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    aiohttp
+    async-substrate-interface
+    backoff
+    bittensor-drand
+    bittensor-wallet
+    cyscale
+    gitpython
+    jinja2
+    netaddr
+    numpy
+    packaging
+    plotille
+    plotly
+    pycryptodome
+    pyyaml
+    rich
+    typer
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # e2e tests require a running subtensor node
+  disabledTestPaths = [ "tests/e2e_tests" ];
+
+  pythonImportsCheck = [ "bittensor_cli" ];
+
+  meta = {
+    description = "Bittensor command line tool";
+    homepage = "https://github.com/latent-to/btcli";
+    changelog = "https://github.com/latent-to/btcli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+    mainProgram = "btcli";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1035,6 +1035,8 @@ with pkgs;
 
   auditwheel = with python3Packages; toPythonApplication auditwheel;
 
+  btcli = with python3Packages; toPythonApplication bittensor-cli;
+
   btrsync = with python3Packages; toPythonApplication btrsync;
 
   davinci-resolve-studio = callPackage ../by-name/da/davinci-resolve/package.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1134,6 +1134,8 @@ self: super: with self; {
 
   async-stagger = callPackage ../development/python-modules/async-stagger { };
 
+  async-substrate-interface = callPackage ../development/python-modules/async-substrate-interface { };
+
   async-tiff = callPackage ../development/python-modules/async-tiff { };
 
   async-timeout = callPackage ../development/python-modules/async-timeout { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2120,6 +2120,8 @@ self: super: with self; {
 
   bitstruct = callPackage ../development/python-modules/bitstruct { };
 
+  bittensor-cli = callPackage ../development/python-modules/bittensor-cli { };
+
   bittensor-drand = callPackage ../development/python-modules/bittensor-drand { };
 
   bittensor-wallet = callPackage ../development/python-modules/bittensor-wallet { };


### PR DESCRIPTION
CLI interface for Bittensor

https://github.com/latent-to/btcli

Depends on #514648, ~~#514654~~, ~~#514657~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
