### PR TITLE
python3Packages.bittorrent-wallet: init at 4.0.1

### DIFF
--- a/pkgs/development/python-modules/bittensor-wallet/default.nix
+++ b/pkgs/development/python-modules/bittensor-wallet/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  libsodium,
+  libiconv,
+  pytestCheckHook,
+  ansible-vault-rw,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bittensor-wallet";
+  version = "4.0.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "btwallet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L774RPoasixvW+0Z4WuJ6eLuazLQscckRU++VCAiFug=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-ETr7XhSmUTqtWDGzJMq5ijaLL8+tqmLJa/ngmzwWiFg=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ]);
+
+  buildInputs = [
+    openssl
+    libsodium
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ansible-vault-rw
+    setuptools # ansible_vault uses pkg_resources at import time
+  ];
+
+  # tests hardcode /tmp/tests_wallets; /tmp is shared across builds on Darwin
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    walletTestPath=$(mktemp -d)
+    sed -i "s|/tmp/tests_wallets|$walletTestPath/tests_wallets|g" tests/test_wallet.py tests/test_keypair.py
+  '';
+
+  preCheck = ''
+    # remove source package so tests import the installed Rust extension
+    rm -rf bittensor_wallet
+    # ansible-vault writes to HOME
+    export HOME=$(mktemp -d)
+  '';
+
+  # test_common_calls.py requires bittensor and substrateinterface, which are not in nixpkgs.
+  disabledTestPaths = [ "tests/test_common_calls.py" ];
+
+  pythonImportsCheck = [ "bittensor_wallet" ];
+
+  meta = {
+    description = "Bittensor wallet implementation";
+    homepage = "https://github.com/latent-to/btwallet";
+    changelog = "https://github.com/latent-to/btwallet/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/development/python-modules/bittensor-wallet/default.nix
+++ b/pkgs/development/python-modules/bittensor-wallet/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  libsodium,
+  libiconv,
+  pytestCheckHook,
+  ansible-vault-rw,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bittensor-wallet";
+  version = "4.0.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "latent-to";
+    repo = "btwallet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L774RPoasixvW+0Z4WuJ6eLuazLQscckRU++VCAiFug=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-ETr7XhSmUTqtWDGzJMq5ijaLL8+tqmLJa/ngmzwWiFg=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ]);
+
+  buildInputs = [
+    openssl
+    libsodium
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ansible-vault-rw
+    setuptools
+  ];
+
+  # On darwin /tmp accesses are restricted inside the nix sandbox.
+  # mock_wallet is part of the installed package and used by downstream packages' tests,
+  # so it has to resolve a writable path at runtime.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace bittensor_wallet/mock/wallet_mock.py \
+      --replace-fail 'import os' $'import os\nimport tempfile' \
+      --replace-fail '"/tmp/mock_wallet"' 'tempfile.gettempdir() + "/mock_wallet"'
+  '';
+
+  preCheck = ''
+    # remove source package so tests import the installed Rust extension
+    rm -rf bittensor_wallet
+    # ansible-vault writes to HOME
+    export HOME=$(mktemp -d)
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    walletTestPath=$(mktemp -d)
+    sed -i "s|/tmp/tests_wallets|$walletTestPath/tests_wallets|g" tests/test_wallet.py tests/test_keypair.py
+  '';
+
+  # test_common_calls.py requires bittensor, which depends on this package, which'd create a circular dependency
+  disabledTestPaths = [ "tests/test_common_calls.py" ];
+
+  pythonImportsCheck = [ "bittensor_wallet" ];
+
+  meta = {
+    description = "Bittensor wallet implementation";
+    homepage = "https://github.com/latent-to/btwallet";
+    changelog = "https://github.com/latent-to/btwallet/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilyanni ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2110,6 +2110,8 @@ self: super: with self; {
 
   bitstruct = callPackage ../development/python-modules/bitstruct { };
 
+  bittensor-wallet = callPackage ../development/python-modules/bittensor-wallet { };
+
   bitvavo-aio = callPackage ../development/python-modules/bitvavo-aio { };
 
   bitvector-for-humans = callPackage ../development/python-modules/bitvector-for-humans { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2122,6 +2122,8 @@ self: super: with self; {
 
   bittensor-drand = callPackage ../development/python-modules/bittensor-drand { };
 
+  bittensor-wallet = callPackage ../development/python-modules/bittensor-wallet { };
+
   bitvavo-aio = callPackage ../development/python-modules/bitvavo-aio { };
 
   bitvector-for-humans = callPackage ../development/python-modules/bitvector-for-humans { };


### PR DESCRIPTION
Bittensor Wallet Python SDK library

https://github.com/latent-to/btwallet

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
