### PR TITLE
vcluster: 0.31.0 -> 0.33.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23497,6 +23497,13 @@
     githubId = 53882428;
     name = "Erik Rodriguez";
   };
+  roehrijn = {
+    email = "jan.roehrich@loft.sh";
+    github = "roehrijn";
+    githubId = 2474078;
+    name = "Jan Roehrich";
+    keys = [ { fingerprint = "21C1 F506 455E 95B4 EB39  D566 BAE1 2FF6 0C8A 97F2"; } ];
+  };
   rogarb = {
     email = "rogarb@rgarbage.fr";
     github = "rogarb";

--- a/pkgs/by-name/vc/vcluster/package.nix
+++ b/pkgs/by-name/vc/vcluster/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "vcluster";
-  version = "0.31.0";
+  version = "0.33.2";
 
   src = fetchFromGitHub {
     owner = "loft-sh";
     repo = "vcluster";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yGvKZ70+x+PQiTCB8MxUplymlQLm9iT+ryBHFF1a/Os=";
+    hash = "sha256-17nJa4xM4+D1v85x2rHFtGU0C+Gi8nph7Q8JRHYXBP4=";
   };
 
   vendorHash = null;
@@ -57,6 +57,7 @@ buildGoModule (finalAttrs: {
     mainProgram = "vcluster";
     maintainers = with lib.maintainers; [
       qjoly
+      roehrijn
     ];
   };
 })


### PR DESCRIPTION
Bumps `vcluster` from 0.31.0 to 0.33.2 (latest stable upstream release).

Changelogs:
- https://github.com/loft-sh/vcluster/releases/tag/v0.32.0
- https://github.com/loft-sh/vcluster/releases/tag/v0.32.1
- https://github.com/loft-sh/vcluster/releases/tag/v0.32.2
- https://github.com/loft-sh/vcluster/releases/tag/v0.33.0
- https://github.com/loft-sh/vcluster/releases/tag/v0.33.1
- https://github.com/loft-sh/vcluster/releases/tag/v0.33.2

No CLI/UX breakage relevant to the packaged subcommand (`cmd/vclusterctl`) across these releases.

Also adds `roehrijn` as a co-maintainer (in a separate `maintainers: add roehrijn` commit, signed by the listed GPG key, per `maintainers/README.md`). I'm an upstream maintainer of `loft-sh/vcluster` and will keep the package current.

`nixpkgs-review wip` was not run locally — `nix-env -qaP`-based eval consumes >24 GB on this machine (well-known issue). Since `vcluster` is a leaf binary, the rebuild surface should be small; ofborg / GitHub Actions eval will cover it. Happy to run `nixpkgs-review pr <num>` after this PR is opened (which reuses the CI eval result) if a reviewer requests it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test