### PR TITLE
lychee: 0.23.0 -> 0.24.1

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -129,6 +129,13 @@ It has two modes:
 
   Example: `{ "include_verbatim" = true; }`
 
+`extraArgs` (list of strings, optional) {#tester-lycheeLinkCheck-param-extraArgs}
+
+: Extra command line arguments to pass to the `lychee` invocation.
+  These are passed in both the offline (build) and [`online`](#tester-lycheeLinkCheck-return) modes.
+
+  Example: `[ "--format" "json" ]`
+
 `lychee` (derivation, optional) {#tester-lycheeLinkCheck-param-lychee}
 
 : The `lychee` package to use.

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -37,6 +37,7 @@ let
       remap ? { },
       lychee ? deps.lychee,
       extraConfig ? { },
+      extraArgs ? [ ],
     }:
     stdenv.mkDerivation (finalAttrs: {
       name = "lychee-link-check";
@@ -47,6 +48,7 @@ let
         cacert
       ];
       configFile = (formats.toml { }).generate "lychee.toml" finalAttrs.passthru.config;
+      inherit extraArgs;
 
       # These can be overridden with overrideAttrs if needed.
       passthru = {
@@ -69,13 +71,13 @@ let
             site=${finalAttrs.site}
             configFile=${finalAttrs.configFile}
             echo Checking links on $site
-            exec lychee --config $configFile $site "$@"
+            exec lychee --config $configFile ${lib.escapeShellArgs extraArgs} $site "$@"
           '';
         };
       };
       buildCommand = ''
         echo Checking internal links on $site
-        lychee --offline --config $configFile $site
+        lychee --offline --config $configFile "''${extraArgs[@]}" $site
         touch $out
       '';
     });

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -51,7 +51,7 @@ let
       passthru = {
         inherit lychee remap;
         config = {
-          include_fragments = true;
+          include_fragments = "full";
         }
         // lib.optionalAttrs (finalAttrs.passthru.remap != { }) {
           remap = mapAttrsToList (

--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -40,6 +40,7 @@ let
     }:
     stdenv.mkDerivation (finalAttrs: {
       name = "lychee-link-check";
+      __structuredAttrs = true;
       inherit site;
       nativeBuildInputs = [
         finalAttrs.passthru.lychee

--- a/pkgs/by-name/ly/lychee/package.nix
+++ b/pkgs/by-name/ly/lychee/package.nix
@@ -16,7 +16,7 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lychee";
-  version = "0.23.0";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "lycheeverse";
@@ -31,10 +31,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
           '("cargo:rustc-env=GIT_DATE={}", "'$GIT_DATE'")'
       rm -rf $out/.git
     '';
-    hash = "sha256-Rfdys16a4N6B3NsmPsB3OpKjLGElFYvd4UtiRipy8iQ=";
+    hash = "sha256-lknj0uTIWYwDm3PA/Q8paVxRn+B9qvfllYUjnp7I4jI=";
   };
 
-  cargoHash = "sha256-5KL/PmBSU8xkOE9/w7uUBkJSOBPsj3Z4o/2VmzA/f3Q=";
+  cargoHash = "sha256-ivLx48qbagjw5zGkYC+ygK83p8q110iEn2YEfUjTFHs=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -45,6 +45,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postFixup = lib.optionalString canRun ''
     ${lychee} --generate man > lychee.1
     installManPage lychee.1
+
+    installShellCompletion --cmd lychee \
+      --bash <(${lychee} --generate complete-bash) \
+      --fish <(${lychee} --generate complete-fish) \
+      --zsh <(${lychee} --generate complete-zsh)
   '';
 
   cargoTestFlags = [

--- a/pkgs/by-name/ly/lychee/tests/fail-emptyDirectory.nix
+++ b/pkgs/by-name/ly/lychee/tests/fail-emptyDirectory.nix
@@ -2,6 +2,7 @@
   runCommand,
   testers,
   emptyDirectory,
+  jq,
 }:
 let
   sitePkg = runCommand "site" { } ''
@@ -19,14 +20,30 @@ let
       # cannot check URI: InvalidUrlRemap("The remapping pattern must produce a valid URL, but it is not: /nix/store/4d0ix...empty-directory/foo
       "https://example.com" = emptyDirectory;
     };
+    extraArgs = [
+      "--format"
+      "json"
+      "--output"
+      "${placeholder "out"}"
+    ];
   };
 
   failure = testers.testBuildFailure check;
 in
-runCommand "link-check-fail" { inherit failure; } ''
-  # The details of the message might change, but we have to make sure the
-  # correct error is reported, so that we know it's not something else that
-  # went wrong.
-  grep 'empty-directory/foo.*Cannot find file' $failure/testBuildFailure.log >/dev/null
-  touch $out
-''
+runCommand "link-check-fail"
+  {
+    nativeBuildInputs = [ jq ];
+    inherit failure;
+  }
+  ''
+    # The details of the message might change, but we have to make sure the
+    # correct error is reported, so that we know it's not something else that
+    # went wrong.
+    jq -e '.error_map | to_entries[] | .value[] | select(.url | test("empty-directory/foo")) | .status.text | test("File not found")' $failure/result > /dev/null || {
+      echo Lychee output:
+      jq . $failure/result
+      echo 'Did not find expected error in JSON output. Adjust test if behavior is acceptable. It should find the broken link to non-existent `foo`.'
+      exit 1
+    }
+    touch $out
+  ''

--- a/pkgs/by-name/ly/lychee/tests/network.nix
+++ b/pkgs/by-name/ly/lychee/tests/network.nix
@@ -14,10 +14,21 @@ let
   check = config.node.pkgs.testers.lycheeLinkCheck {
     site = sitePkg;
   };
+  checkJson = config.node.pkgs.testers.lycheeLinkCheck {
+    site = sitePkg;
+    extraArgs = [
+      "--format"
+      "json"
+    ];
+  };
 in
 {
   name = "testers-lychee-link-check-run";
-  nodes.client = { ... }: { };
+  nodes.client =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.jq ];
+    };
   nodes.example = {
     networking.firewall.allowedTCPPorts = [ 80 ];
     services.nginx = {
@@ -67,5 +78,13 @@ in
     client.succeed("""
         ${lib.getExe check.online}
     """)
+
+    # EXTRA ARGS CASE: verify extraArgs are passed through to online wrapper
+
+    with subtest("extraArgs are passed to the online wrapper"):
+        client.succeed("""
+            ${lib.getExe checkJson.online} --output /tmp/lychee.json
+            jq -e .total /tmp/lychee.json
+        """)
   '';
 }

--- a/pkgs/by-name/ly/lychee/tests/network.nix
+++ b/pkgs/by-name/ly/lychee/tests/network.nix
@@ -55,31 +55,29 @@ in
         curl --fail -v http://example
     """)
 
-    # FAILURE CASE
+    # TEST CASES
 
-    client.succeed("""
-        exec 1>&2
-        r=0
-        ${lib.getExe check.online} || {
-          r=$?
-        }
-        if [[ $r -ne 2 ]]; then
-            echo "lycheeLinkCheck unexpected exit code $r"
-            exit 1
-        fi
-    """)
+    with subtest("online check detects broken links"):
+        client.succeed("""
+            exec 1>&2
+            r=0
+            ${lib.getExe check.online} || {
+              r=$?
+            }
+            if [[ $r -ne 2 ]]; then
+                echo "lycheeLinkCheck unexpected exit code $r"
+                exit 1
+            fi
+        """)
 
-    # SUCCESS CASE
+    with subtest("online check succeeds when links are fixed"):
+        example.succeed("""
+            echo '<h1>foo</h1>' > /var/www/example/foo.html
+        """)
 
-    example.succeed("""
-        echo '<h1>foo</h1>' > /var/www/example/foo.html
-    """)
-
-    client.succeed("""
-        ${lib.getExe check.online}
-    """)
-
-    # EXTRA ARGS CASE: verify extraArgs are passed through to online wrapper
+        client.succeed("""
+            ${lib.getExe check.online}
+        """)
 
     with subtest("extraArgs are passed to the online wrapper"):
         client.succeed("""


### PR DESCRIPTION
Update to lychee v0.24.1. This replaces #513078.

Note that I wasn't able to test the shell completions yet.
How would I be able to test if shell completions work as expected?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
