### PR TITLE
python3Packages.lupa: fix lua module

### DIFF
--- a/pkgs/development/python-modules/lupa/default.nix
+++ b/pkgs/development/python-modules/lupa/default.nix
@@ -7,11 +7,6 @@
   cython,
   setuptools,
 
-  # nativeBuildInputs
-  pkg-config,
-
-  # buildInputs
-  luajit,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "lupa";
@@ -22,24 +17,16 @@ buildPythonPackage (finalAttrs: {
     owner = "scoder";
     repo = "lupa";
     tag = "lupa-${finalAttrs.version}";
-    hash = "sha256-JlKxisVd0sbLcmVjzyFEkbUDAornAoCWekpASl6qeY4=";
+    # Lua sources are vendored as submodules under third-party/.
+    # They are needed so that setup.py builds properly named backend
+    # modules (e.g. lua51, lua54, luajit21) expected by consumers like fakeredis.
+    fetchSubmodules = true;
+    hash = "sha256-XLBUQ1TrzWWST9RJdMTnpsceldDNzidnL82bixLhSRA=";
   };
 
   build-system = [
     cython
     setuptools
-  ];
-
-  nativeBuildInputs = [
-    pkg-config
-  ];
-
-  env = {
-    LUPA_NO_BUNDLE = "true";
-  };
-
-  buildInputs = [
-    luajit
   ];
 
   pythonImportsCheck = [ "lupa" ];


### PR DESCRIPTION
## Things done

Follow up of https://github.com/NixOS/nixpkgs/pull/513748
Turns out using the system-provided `lua` interpreter does not play well with consumers (e.g. fakeredis).
This broke `optuna` for instance.

Let's switch to letting `lupa` fetch the `lua` it wants.

Fixes #514622

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
