### PR TITLE
[staging] git: fix t7703 on zfs

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -487,8 +487,8 @@ stdenv.mkDerivation (finalAttrs: {
   preInstallCheck = ''
     # Some tests break with high concurrency
     # https://github.com/NixOS/nixpkgs/pull/403237
-    if ((NIX_BUILD_CORES > 32)); then
-      NIX_BUILD_CORES=32
+    if ((NIX_BUILD_CORES > 16)); then
+      NIX_BUILD_CORES=16
     fi
 
     installCheckFlagsArray+=(
@@ -537,6 +537,8 @@ stdenv.mkDerivation (finalAttrs: {
     disable_test t4122-apply-symlink-inside
     disable_test t7513-interpret-trailers
     disable_test t2200-add-update
+    # https://github.com/NixOS/nixpkgs/issues/498789
+    disable_test t7703-repack-geometric
 
     # Fails reproducibly on ZFS on Linux with formD normalization
     disable_test t0021-conversion


### PR DESCRIPTION
The installCheck phase runs prove with up to 32 jobs, under which the test suite has become racy on staging: consecutive rebuilds of the same derivation fail in different scripts (t3451, t4124, t4200, t7703). Lower the cap to 16 to give the tests more headroom.

t7703-repack-geometric keeps failing across runs regardless and is already tracked as flaky in #498789, so skip it explicitly.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
