### PR TITLE
fluxcd: 2.8.5 -> 2.8.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26050,6 +26050,13 @@
     githubId = 26052996;
     name = "Erik Parawell";
   };
+  stealthybox = {
+    email = "leigh@null.net";
+    github = "stealthybox";
+    githubId = 2754700;
+    name = "Leigh Capili";
+    keys = [ { fingerprint = "05E7 89C9 142C DD05 8261  4EF8 5943 2144 444F B382"; } ];
+  };
   steamwalker = {
     email = "steamwalker@xs4all.nl";
     github = "steamwalker";

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "2.8.5";
-  srcHash = "sha256-2Q6l+egcRntGjieXpXz/frGGw4GMhGXxQAUOAZfxBE4=";
-  vendorHash = "sha256-D92vOyTvlpOou/1WHS6xpb4e8igZMQhm4DP7SVSLKPI=";
-  manifestsHash = "sha256-X0Cf8UZufqUWKLxYVjblYNCz5IU/s+mI+h6TpTeks5k=";
+  version = "2.8.6";
+  srcHash = "sha256-pKP4g2pTMYtx/B/Y3ow7tvDdhCSuwbszzeLVXB0W7Bo=";
+  vendorHash = "sha256-VBafft9/AuXaHWvZymy7P9gaSuO8D6IZHfK68Ixp3mI=";
+  manifestsHash = "sha256-h/HR/rJwPWXiuoj9T+LajdsdT4Jo8/EuN+O1I7e9sjI=";
 
   manifests = fetchzip {
     url = "https://github.com/fluxcd/flux2/releases/download/v${version}/manifests.tar.gz";
@@ -82,6 +82,7 @@ buildGoModule rec {
       jlesquembre
       ryan4yin
       SchahinRohani
+      stealthybox
       superherointj
     ];
     mainProgram = "flux";


### PR DESCRIPTION
Upstream release: https://github.com/fluxcd/flux2/releases/tag/v2.8.6

Built and tested on aarch64-linux.

I'd like to add myself as a maintainer. I'm a [Flux CD core maintainer](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS) and want to help keep fluxcd, fluxcd-operator, and fluxcd-operator-mcp up to date.