### PR TITLE
fluxcd-operator-mcp: add maintainer stealthybox

### DIFF
--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -61,6 +61,7 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       mattfield
+      stealthybox
     ];
     mainProgram = "flux-operator-mcp";
   };


### PR DESCRIPTION
Adding myself as a maintainer for fluxcd-operator-mcp.

I'd like to add myself as a maintainer. I'm a [Flux CD core maintainer](https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS) and want to help keep fluxcd, fluxcd-operator, and fluxcd-operator-mcp up to date.
The pending version bump (0.38.1 -> 0.48.0) is already in #482180.

also see: #514702 #514703