### PR TITLE
{ettercap,global}: fix changelogs

### DIFF
--- a/pkgs/by-name/et/ettercap/package.nix
+++ b/pkgs/by-name/et/ettercap/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
       analysis.
     '';
     homepage = "https://www.ettercap-project.org/";
-    changelog = "https://github.com/Ettercap/ettercap/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/Ettercap/ettercap/blob/master/CHANGELOG";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ pSub ];

--- a/pkgs/by-name/gl/global/package.nix
+++ b/pkgs/by-name/gl/global/package.nix
@@ -87,8 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
       peterhoeg
     ];
     platforms = lib.platforms.unix;
-    changelog = "https://cvs.savannah.gnu.org/viewvc/global/global/NEWS?view=markup&pathrev=VERSION-${
-      lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
-    }";
+    changelog = "https://www.gnu.org/software/global/whatsnew.html";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

See https://github.com/NixOS/nixpkgs/issues/514132.