### PR TITLE
[staging] git: fix flaky t7703 on ZFS by ignoring ls -l 'total' line

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -123,6 +123,14 @@ stdenv.mkDerivation (finalAttrs: {
     ./git-sh-i18n.patch
     # Do not search for sendmail in /usr, only in $PATH
     ./git-send-email-honor-PATH.patch
+    # The 'total N' header from ls -l is unstable on ZFS and similar
+    # filesystems, causing spurious failures.
+    # https://github.com/NixOS/nixpkgs/issues/498789
+    (fetchurl {
+      name = "t7703-ignore-ls-total.patch";
+      url = "https://lore.kernel.org/git/20260504101429.340123-1-joerg@thalheim.io/raw";
+      hash = "sha256-44EPfEJ39LjPWjqjFb52EKNaJGzYxZzJaJOis8QnazU=";
+    })
     # Address test failure (new in 2.52.0) caused by `git-gui--askyesno` being
     # installed by `make install`.
     (fetchurl {


### PR DESCRIPTION
t7703-repack-geometric tests 11 and 12, added in upstream 6ce9d558ce (first shipped in 2.53.0), assert that a no-op repack leaves the pack directory untouched by comparing full `ls -l` output. The leading `total N` block-count header is not stable on copy-on-write or compressing filesystems such as ZFS, where delayed allocation can change the reported value between two back-to-back invocations even though the files are byte-identical. This makes gitMinimal's installCheck fail nondeterministically on ZFS-backed builders.

Patch the test to strip that header before comparing. Verified with 20 consecutive runs on ZFS.

Fixes #498789.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
