### PR TITLE
nixos/firefly-iii{,-data-importer}: don't run as nginx group

### DIFF
--- a/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
+++ b/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
@@ -84,11 +84,12 @@ in
 
     group = lib.mkOption {
       type = lib.types.str;
-      default = if cfg.enableNginx then "nginx" else defaultGroup;
-      defaultText = "If `services.firefly-iii-data-importer.enableNginx` is true then `nginx` else ${defaultGroup}";
+      default = defaultGroup;
       description = ''
-        Group under which firefly-iii-data-importer runs. It is best to set this to the group
-        of whatever webserver is being used as the frontend.
+        Group under which firefly-iii-data-importer runs.
+        While this also changes which group has access to the phpfpm socket,
+        changing {option}`services.firefly-iii-data-importer.poolConfig."listen.group"`
+        is preferred.
       '';
     };
 
@@ -149,6 +150,9 @@ in
       default = { };
       defaultText = lib.literalExpression ''
         {
+          "listen.mode" = "0660";
+          "listen.owner" = if config.services.firefly-iii-data-importer.enableNginx then config.services.nginx.user else config.services.firefly-iii-data-importer.user;
+          "listen.group" = if config.services.firefly-iii-data-importer.enableNginx then config.services.nginx.group else config.services.firefly-iii-data-importer.group;
           "pm" = "dynamic";
           "pm.max_children" = 32;
           "pm.start_servers" = 2;
@@ -201,9 +205,9 @@ in
         log_errors = on
       '';
       settings = {
-        "listen.mode" = "0660";
-        "listen.owner" = user;
-        "listen.group" = group;
+        "listen.mode" = lib.mkDefault "0660";
+        "listen.owner" = lib.mkDefault (if cfg.enableNginx then config.services.nginx.user else user);
+        "listen.group" = lib.mkDefault (if cfg.enableNginx then config.services.nginx.group else group);
         "pm" = lib.mkDefault "dynamic";
         "pm.max_children" = lib.mkDefault 32;
         "pm.start_servers" = lib.mkDefault 2;

--- a/nixos/modules/services/web-apps/firefly-iii.nix
+++ b/nixos/modules/services/web-apps/firefly-iii.nix
@@ -93,11 +93,12 @@ in
 
     group = lib.mkOption {
       type = lib.types.str;
-      default = if cfg.enableNginx then "nginx" else defaultGroup;
-      defaultText = "If `services.firefly-iii.enableNginx` is true then `nginx` else ${defaultGroup}";
+      default = defaultGroup;
       description = ''
-        Group under which firefly-iii runs. It is best to set this to the group
-        of whatever webserver is being used as the frontend.
+        Group under which firefly-iii runs.
+        While this also changes which group has access to the phpfpm socket,
+        changing {option}`services.firefly-iii.poolConfig."listen.group"`
+        is preferred.
       '';
     };
 
@@ -151,6 +152,9 @@ in
       default = { };
       defaultText = ''
         {
+          "listen.mode" = "0660";
+          "listen.owner" = if config.services.firefly-iii.enableNginx then config.services.nginx.user else config.services.firefly-iii.user;
+          "listen.group" = if config.services.firefly-iii.enableNginx then config.services.nginx.group else config.services.firefly-iii.group;
           "pm" = "dynamic";
           "pm.max_children" = 32;
           "pm.start_servers" = 2;
@@ -295,8 +299,8 @@ in
       '';
       settings = {
         "listen.mode" = lib.mkDefault "0660";
-        "listen.owner" = lib.mkDefault user;
-        "listen.group" = lib.mkDefault group;
+        "listen.owner" = lib.mkDefault (if cfg.enableNginx then config.services.nginx.user else user);
+        "listen.group" = lib.mkDefault (if cfg.enableNginx then config.services.nginx.group else group);
         "pm" = lib.mkDefault "dynamic";
         "pm.max_children" = lib.mkDefault 32;
         "pm.start_servers" = lib.mkDefault 2;


### PR DESCRIPTION
There is no need to run the php-fpm process with the `nginx` group, as phpfpm supports setting the user/group of the socket instead. This reduces the attack surface for the service (e.g., firefly can no longer read from other `nginx`-owned sockets).

Additionally, stops hardcoding the nginx group and instead uses `config.services.nginx.group` (which was the main motivation for this PR).
See #510765 for a similar change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
