### PR TITLE
nuget-to-json: don't add packages with only contentHash

### DIFF
--- a/pkgs/by-name/nu/nuget-to-json/nuget-to-json.sh
+++ b/pkgs/by-name/nu/nuget-to-json/nuget-to-json.sh
@@ -61,9 +61,9 @@ done
                 continue
             fi
 
-            # packages in the nix store should have an empty metadata file
+            # packages in the nix store should have a metadata file without 'version' (see createNupkgMetadata)
             # packages installed with 'dotnet tool' may be missing 'source'
-            used_source="$(jq -r 'if has("source") then .source elif has("contentHash") then "__unknown" else "" end' "$version"/.nupkg.metadata)"
+            used_source="$(jq -r 'if has("source") then .source elif has("version") then "__unknown" else "" end' "$version"/.nupkg.metadata)"
             found=false
 
             if [[ -z "$used_source" || -d "$used_source" ]]; then


### PR DESCRIPTION
Fixes: bfc94a6c9e64bffc75e3d936413209c42b3b7923

This problem was found here: https://github.com/NixOS/nixpkgs/pull/511950#pullrequestreview-4174007868

I've tested regenerating a bunch of deps files from various packages, and haven't found any problems.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
