### PR TITLE
linuxPackages.nvidia_x11.persistenced: clean up and fix cross-compilation

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -4,6 +4,7 @@ nvidia_x11: sha256:
   stdenv,
   lib,
   fetchFromGitHub,
+  buildPackages,
   m4,
   pkg-config,
   addDriverRunpath,
@@ -26,6 +27,8 @@ stdenv.mkDerivation {
     NIX_LDFLAGS = toString [ "-ltirpc" ];
   };
 
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   nativeBuildInputs = [
     m4
     pkg-config
@@ -36,7 +39,12 @@ stdenv.mkDerivation {
     libtirpc
   ];
 
-  makeFlags = [ "DATE=true" ];
+  makeFlags = [
+    "DATE=true"
+    "DO_STRIP="
+    "HOST_CC=\$(CC_FOR_BUILD)"
+    "HOST_LD=\$(LD_FOR_BUILD)"
+  ];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -5,9 +5,9 @@ nvidia_x11: sha256:
   lib,
   fetchFromGitHub,
   m4,
-  glibc,
-  libtirpc,
   pkg-config,
+  addDriverRunpath,
+  libtirpc,
 }:
 
 stdenv.mkDerivation {
@@ -21,23 +21,22 @@ stdenv.mkDerivation {
     inherit sha256;
   };
 
-  env = {
-    LIBRARY_PATH = "${glibc}/lib";
+  env = lib.optionalAttrs (lib.versionOlder nvidia_x11.persistencedVersion "450.51") {
     NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
+    NIX_LDFLAGS = toString [ "-ltirpc" ];
   };
-  NIX_LDFLAGS = [ "-ltirpc" ];
 
   nativeBuildInputs = [
     m4
     pkg-config
+    addDriverRunpath
   ];
 
   buildInputs = [
     libtirpc
-    stdenv.cc.cc.lib
   ];
 
-  makeFlags = nvidia_x11.passthru.mod.makeFlags ++ [ "DATE=true" ];
+  makeFlags = [ "DATE=true" ];
 
   installFlags = [ "PREFIX=$(out)" ];
 
@@ -47,8 +46,7 @@ stdenv.mkDerivation {
     cp $out/{bin,origBin}/nvidia-persistenced
     patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 $out/origBin/nvidia-persistenced
 
-    patchelf --set-rpath "$(patchelf --print-rpath $out/bin/nvidia-persistenced):${nvidia_x11}/lib" \
-      $out/bin/nvidia-persistenced
+    addDriverRunpath $out/bin/nvidia-persistenced
   '';
 
   meta = {


### PR DESCRIPTION
- explicit flags are only required for `<450.51` where persistenced switched to pkg-config
- Use `addDriverRunpath` and link to the runtime driver, not a specific driver. (Removes dependency)
- Skip stripping during make (stdenv fixUp will handle it)
- Fix cross-compilation by specifying bintools for the host.

Verified the following derivations:
- `linuxPackages.nvidiaPackages.production.persistenced`
- `pkgsCross.aarch64-multiplatform.linuxPackages.nvidiaPackages.production.persistenced`
- `linuxPackages.nvidiaPackages.legacy_340.persistenced`
- `pkgsi686Linux.linuxPackages.nvidiaPackages.legacy_340.persistenced`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
