### PR TITLE
php.extensions.pdo_sqlsrv, php.extensions.sqlsrv: 5.10.1/5.12.0 -> 5.13.0

### DIFF
--- a/pkgs/development/php-packages/pdo_sqlsrv/default.nix
+++ b/pkgs/development/php-packages/pdo_sqlsrv/default.nix
@@ -6,22 +6,21 @@
   unixodbc,
   php,
 }:
-
 buildPecl {
   pname = "pdo_sqlsrv";
 
-  version = "5.10.1";
-  sha256 = "sha256-x4VBlqI2vINQijRvjG7x35mbwh7rvYOL2wUTIV4GKK0=";
+  version = "5.13.0";
+  sha256 = "sha256-76hZvMSNl/JSaNvevx2yXyVhDX+jaz7pEHPByZQR4kw=";
 
-  internalDeps = [ php.extensions.pdo ];
+  internalDeps = [php.extensions.pdo];
 
-  buildInputs = [ unixodbc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+  buildInputs = [unixodbc] ++ lib.optionals stdenv.hostPlatform.isDarwin [libiconv];
 
   meta = {
     description = "Microsoft Drivers for PHP for SQL Server";
     license = lib.licenses.mit;
     homepage = "https://github.com/Microsoft/msphpsql";
-    teams = [ lib.teams.php ];
+    teams = [lib.teams.php];
     broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/pdo_sqlsrv/default.nix
+++ b/pkgs/development/php-packages/pdo_sqlsrv/default.nix
@@ -12,15 +12,15 @@ buildPecl {
   version = "5.13.0";
   sha256 = "sha256-76hZvMSNl/JSaNvevx2yXyVhDX+jaz7pEHPByZQR4kw=";
 
-  internalDeps = [php.extensions.pdo];
+  internalDeps = [ php.extensions.pdo ];
 
-  buildInputs = [unixodbc] ++ lib.optionals stdenv.hostPlatform.isDarwin [libiconv];
+  buildInputs = [ unixodbc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   meta = {
     description = "Microsoft Drivers for PHP for SQL Server";
     license = lib.licenses.mit;
     homepage = "https://github.com/Microsoft/msphpsql";
-    teams = [lib.teams.php];
+    teams = [ lib.teams.php ];
     broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/sqlsrv/default.nix
+++ b/pkgs/development/php-packages/sqlsrv/default.nix
@@ -5,19 +5,18 @@
   unixodbc,
   libiconv,
 }:
-
 buildPecl {
   pname = "sqlsrv";
 
-  version = "5.12.0";
-  sha256 = "sha256-qeu4gLKlWNPWaE9uaALFPFv/pJ4e5g0Uc6cST8nLcq0=";
+  version = "5.13.0";
+  sha256 = "sha256-MdbCg1oFp7btDw3bZ1VsqRRlKlelccJokfAtitmbflw=";
 
-  buildInputs = [ unixodbc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+  buildInputs = [unixodbc] ++ lib.optionals stdenv.hostPlatform.isDarwin [libiconv];
 
   meta = {
     description = "Microsoft Drivers for PHP for SQL Server";
     license = lib.licenses.mit;
     homepage = "https://github.com/Microsoft/msphpsql";
-    teams = [ lib.teams.php ];
+    teams = [lib.teams.php];
   };
 }

--- a/pkgs/development/php-packages/sqlsrv/default.nix
+++ b/pkgs/development/php-packages/sqlsrv/default.nix
@@ -11,12 +11,12 @@ buildPecl {
   version = "5.13.0";
   sha256 = "sha256-MdbCg1oFp7btDw3bZ1VsqRRlKlelccJokfAtitmbflw=";
 
-  buildInputs = [unixodbc] ++ lib.optionals stdenv.hostPlatform.isDarwin [libiconv];
+  buildInputs = [ unixodbc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   meta = {
     description = "Microsoft Drivers for PHP for SQL Server";
     license = lib.licenses.mit;
     homepage = "https://github.com/Microsoft/msphpsql";
-    teams = [lib.teams.php];
+    teams = [ lib.teams.php ];
   };
 }


### PR DESCRIPTION
Updated PHP SQL Server driver pacakges to the latest version to support the latest versions of PHP

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
