### PR TITLE
befunge-tools: init at 0-unstable-2025-08-02

### DIFF
--- a/pkgs/by-name/be/befunge-tools/package.nix
+++ b/pkgs/by-name/be/befunge-tools/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  unstableGitUpdater,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "befunge-tools";
+  version = "0-unstable-2025-08-02";
+
+  src = fetchFromGitHub {
+    owner = "esoterra";
+    repo = "befunge-tools";
+    rev = "a345da9a72670154dfc3de105d7a8297665430c7";
+    hash = "sha256-zhLcZ3+4XaVbFqouHDUSiZ7CSdM0T/PPfqayl6W1elE=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-aylH69J7ISDzBfp7zyC1SUH205+Du75r1TDGnoU/kww=";
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp -r programs $out/share/
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "A collection of command line tools for executing, analyzing, and visualizing Befunge code";
+    homepage = "https://github.com/esoterra/befunge-tools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ julm ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
> Befunge Tools - bft
> A collection of command line tools for executing, analyzing, and visualizing Befunge code. 

https://github.com/esoterra/befunge-tools
https://www.youtube.com/watch?v=aTY-uq-cSf8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
