### PR TITLE
roots: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27712,6 +27712,12 @@
     githubId = 9853194;
     name = "Philipp Bartsch";
   };
+  tnmt = {
+    email = "s@tnmt.info";
+    github = "tnmt";
+    githubId = 56112;
+    name = "Shinya Tsunematsu";
+  };
   toast = {
     name = "Toast";
     github = "toast003";

--- a/pkgs/by-name/ro/roots/package.nix
+++ b/pkgs/by-name/ro/roots/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "roots";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "roots";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ACMRfWY/lhc3C/KVhuUyS1rgkSHGWPxZrmYt+pXupJI=";
+  };
+
+  vendorHash = "sha256-uxcT5VzlTCxxnx09p13mot0wVbbas/otoHdg7QSDt4E=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/k1LoW/roots/version.Version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for exploring multiple root directories such as those in a monorepo project";
+    homepage = "https://github.com/k1LoW/roots";
+    changelog = "https://github.com/k1LoW/roots/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "roots";
+    maintainers = with lib.maintainers; [ tnmt ];
+  };
+})

--- a/pkgs/by-name/ro/roots/package.nix
+++ b/pkgs/by-name/ro/roots/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,6 +26,9 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X github.com/k1LoW/roots/version.Version=${finalAttrs.version}"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ro/roots/package.nix
+++ b/pkgs/by-name/ro/roots/package.nix
@@ -9,6 +9,8 @@ buildGoModule (finalAttrs: {
   pname = "roots";
   version = "0.4.1";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "k1LoW";
     repo = "roots";

--- a/pkgs/by-name/ro/roots/package.nix
+++ b/pkgs/by-name/ro/roots/package.nix
@@ -38,6 +38,12 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool for exploring multiple root directories such as those in a monorepo project";
+    longDescription = ''
+      roots discovers root directories of projects (those containing files
+      like package.json, go.mod, or Cargo.toml) and prints their paths.
+      It is useful for locating each subproject in a monorepo and feeding
+      the results into other tools.
+    '';
     homepage = "https://github.com/k1LoW/roots";
     changelog = "https://github.com/k1LoW/roots/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ro/roots/package.nix
+++ b/pkgs/by-name/ro/roots/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildGoModule,
+  callPackage,
   fetchFromGitHub,
   nix-update-script,
   versionCheckHook,
@@ -30,7 +31,10 @@ buildGoModule (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.monorepo-detection = callPackage ./test.nix { roots = finalAttrs.finalPackage; };
+  };
 
   meta = {
     description = "Tool for exploring multiple root directories such as those in a monorepo project";

--- a/pkgs/by-name/ro/roots/package.nix
+++ b/pkgs/by-name/ro/roots/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "roots";
+  version = "0.4.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "roots";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ACMRfWY/lhc3C/KVhuUyS1rgkSHGWPxZrmYt+pXupJI=";
+  };
+
+  vendorHash = "sha256-uxcT5VzlTCxxnx09p13mot0wVbbas/otoHdg7QSDt4E=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/k1LoW/roots/version.Version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.monorepo-detection = callPackage ./test.nix { roots = finalAttrs.finalPackage; };
+  };
+
+  meta = {
+    description = "Tool for exploring multiple root directories such as those in a monorepo project";
+    longDescription = ''
+      roots discovers root directories of projects (those containing files
+      like package.json, go.mod, or Cargo.toml) and prints their paths.
+      It is useful for locating each subproject in a monorepo and feeding
+      the results into other tools.
+    '';
+    homepage = "https://github.com/k1LoW/roots";
+    changelog = "https://github.com/k1LoW/roots/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "roots";
+    maintainers = with lib.maintainers; [ tnmt ];
+  };
+})

--- a/pkgs/by-name/ro/roots/test.nix
+++ b/pkgs/by-name/ro/roots/test.nix
@@ -1,0 +1,17 @@
+{ runCommand, roots }:
+
+runCommand "roots-monorepo-detection"
+  {
+    nativeBuildInputs = [ roots ];
+  }
+  ''
+    mkdir -p repo/packages/foo repo/packages/bar
+    touch repo/go.mod repo/packages/foo/package.json repo/packages/bar/Cargo.toml
+    cd repo
+    output=$(roots)
+    echo "$output"
+    grep -qE '/repo$' <<< "$output"
+    grep -qE '/repo/packages/foo$' <<< "$output"
+    grep -qE '/repo/packages/bar$' <<< "$output"
+    touch $out
+  ''


### PR DESCRIPTION
## Description of changes

Adds `roots`, a CLI tool for exploring multiple root directories (such as those in a monorepo project containing `package.json`, `go.mod`, `Cargo.toml`, etc.).

Upstream: https://github.com/k1LoW/roots
License: MIT

```console
$ roots
/path/to/repo
/path/to/repo/packages/foo
/path/to/repo/packages/bar
```

Maintainer: @tnmt (new maintainer entry added in this PR).

This contribution, including the package expression, the `test.nix` derivation, and earlier revisions of this PR description, was authored with assistance from Claude Code (Claude Opus 4.7). The output was reviewed, built, and tested locally before submission, and the commit carries an `Assisted-by:` trailer as required by the [automation/AI policy].

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test