### PR TITLE
rerun: 0.31.3 -> 0.31.4

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -35,7 +35,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
-  version = "0.31.3";
+  version = "0.31.4";
 
   outputs = [
     "out"
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "rerun-io";
     repo = "rerun";
     tag = finalAttrs.version;
-    hash = "sha256-ApGrW3E7r5lulBNB89HCP/WKBtwV7OABueQxqElF6rs=";
+    hash = "sha256-gbN9aplPw+U4liGDU7Z0x+ySfxr+RlyriEkDsIA8gHA=";
   };
 
   # The path in `build.rs` is wrong for some reason, so we patch it to make the passthru tests work
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"rerun_sdk/rerun_cli/rerun"' '"rerun_sdk/rerun"'
   '';
 
-  cargoHash = "sha256-JpYKJ8LRAMTy8TPQ2tk5o9b6Z2sgTkSVwULoCO3fYSk=";
+  cargoHash = "sha256-N5JeZMbGy9FSiluE1MAtvg97dUq3ZoUZdABwORUlWlA=";
 
   cargoBuildFlags = [
     "--package"

--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -37,6 +37,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
   version = "0.31.4";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   outputs = [
     "out"
     "dev"
@@ -83,19 +86,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Note that cargoBuildFeatures reference what buildFeatures is set to in stdenv.mkDerivation,
   # so that user can easily create an overlay to set cargoBuildFeatures to what he needs
   preBuild = ''
-    if [[ " $cargoBuildFeatures " == *" web_viewer "* ]]; then
-      # transform the environment variable that is a space separated list into a comma separated list
-      buildWebViewerFeatures=$(echo $buildWebViewerFeatures | tr ' ' ',')
+    if [[ " ''${cargoBuildFeatures[*]} " == *" web_viewer "* ]]; then
+      # join the bash array into a comma-separated list for cargo's --features flag
+      buildWebViewerFeaturesJoined=$(IFS=,; echo "''${buildWebViewerFeatures[*]}")
       # Create the features option only if there are features to pass
-      buildWebViewerFeaturesCargoOption=""
-      if [[ ! -z "$buildWebViewerFeatures" ]]; then
-        buildWebViewerFeaturesCargoOption="--features $buildWebViewerFeatures"
-        echo "Features passed to the web viewer build: $buildWebViewerFeatures"
+      buildWebViewerFeaturesCargoOption=()
+      if [[ -n "$buildWebViewerFeaturesJoined" ]]; then
+        buildWebViewerFeaturesCargoOption=("--features" "$buildWebViewerFeaturesJoined")
+        echo "Features passed to the web viewer build: $buildWebViewerFeaturesJoined"
       else
         echo "No features will be passed to the web viewer build"
       fi
       echo "Building the wasm web viewer for rerun's web_viewer feature"
-      cargo run -p re_dev_tools -- build-web-viewer --no-default-features $buildWebViewerFeaturesCargoOption --release -g
+      cargo run -p re_dev_tools -- build-web-viewer --no-default-features "''${buildWebViewerFeaturesCargoOption[@]}" --release -g
     else
       echo "web_viewer feature not enabled, skipping web viewer build."
     fi
@@ -159,7 +162,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     while IFS= read -r -d $'\0' path ; do
       elfHasDynamicSection "$path" || continue
-      for dep in $addDlopenRunpaths ; do
+      for dep in "''${addDlopenRunpaths[@]}" ; do
         patchelf "$path" --add-rpath "$dep"
       done
     done < <(

--- a/pkgs/development/python-modules/rerun-sdk/default.nix
+++ b/pkgs/development/python-modules/rerun-sdk/default.nix
@@ -31,6 +31,7 @@
 buildPythonPackage {
   pname = "rerun-sdk";
   pyproject = true;
+  __structuredAttrs = true;
 
   inherit (rerun)
     src


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/rerun-io/rerun/compare/0.31.3...0.31.4
Changelog: https://github.com/rerun-io/rerun/blob/0.31.4/CHANGELOG.md

cc @SomeoneSerge

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test