### PR TITLE
vscode-utils.buildVscode{,Marketplace}Extension: add drv arg `executableConfig` to change the default value of extension config to package's `meta.mainProgram`

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
@@ -1,7 +1,5 @@
 {
   lib,
-  jq,
-  moreutils,
   millet,
   vscode-utils,
 }:
@@ -13,14 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.15.1";
     hash = "sha256-5V5GG7M52ohpS9Zg2TTamEjbWyXH9kllZyy7Oezy4Iw=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."millet.server.path".default = "${millet}/bin/millet-ls"' package.json | sponge package.json
-  '';
+  executableConfig."millet.server.path".package = millet;
   meta = {
     description = "Standard ML support for VS Code";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=azdavis.millet";

--- a/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/azdavis.millet/default.nix
@@ -1,7 +1,5 @@
 {
   lib,
-  jq,
-  moreutils,
   millet,
   vscode-utils,
 }:
@@ -13,14 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.15.2";
     hash = "sha256-mtI4IW+xBIuo11ctTIv5/6LOXVStD3YqSYkIQYJWqmo=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."millet.server.path".default = "${millet}/bin/millet-ls"' package.json | sponge package.json
-  '';
+  executableConfig."millet.server.path".package = millet;
   meta = {
     description = "Standard ML support for VS Code";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=azdavis.millet";

--- a/pkgs/applications/editors/vscode/extensions/b4dm4n.vscode-nixpkgs-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/b4dm4n.vscode-nixpkgs-fmt/default.nix
@@ -1,8 +1,6 @@
 {
   vscode-utils,
-  jq,
   lib,
-  moreutils,
   nixpkgs-fmt,
 }:
 
@@ -13,14 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.0.1";
     hash = "sha256-vz2kU36B1xkLci2QwLpl/SBEhfSWltIDJ1r7SorHcr8=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."nixpkgs-fmt.path".default = "${nixpkgs-fmt}/bin/nixpkgs-fmt"' package.json | sponge package.json
-  '';
+  executableConfig."nixpkgs-fmt.path".package = nixpkgs-fmt;
   meta = {
     license = lib.licenses.mit;
   };

--- a/pkgs/applications/editors/vscode/extensions/biomejs.biome/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/biomejs.biome/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   biome,
-  moreutils,
   vscode-extension-update-script,
 }:
 
@@ -15,10 +13,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-HH+KJYY4J6nuHwQ/+DhEFsJ7P5S97UsNuoc+y7GnE00=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."biome.lsp.bin".oneOf[0].default = "${lib.getExe biome}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."biome.lsp.bin" = {
+    extraJqExpr = ".oneOf[0]";
+    package = biome;
+  };
 
   passthru.updateScript = vscode-extension-update-script {
     extraArgs = [ "--pre-release" ];

--- a/pkgs/applications/editors/vscode/extensions/biomejs.biome/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/biomejs.biome/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   biome,
-  moreutils,
   vscode-extension-update-script,
 }:
 
@@ -15,10 +13,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-6FRrVKDY+E9wuqgeNKArgGn4PDp5ViJsdCPjjwBGbGI=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."biome.lsp.bin".oneOf[0].default = "${lib.getExe biome}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."biome.lsp.bin" = {
+    extraJqExpr = ".oneOf[0]";
+    package = biome;
+  };
 
   passthru.updateScript = vscode-extension-update-script {
     extraArgs = [ "--pre-release" ];

--- a/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/chrischinchilla.vscode-pandoc/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   pandoc,
 }:
 
@@ -13,13 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.7.3";
     hash = "sha256-TGkNYA96mzFtUoM+XPKXJ/AM+hbiLc6Lvk5YDxFUwcI=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    jq '.contributes.configuration.properties."pandoc.executable".default = "${lib.getExe pandoc}"' $out/$installPrefix/package.json | sponge $out/$installPrefix/package.json
-  '';
+  executableConfig."pandoc.executable".package = pandoc;
   meta = {
     description = "Converts Markdown files to pdf, docx, or html files using pandoc";
     homepage = "https://github.com/ChrisChinchilla/vscode-pandoc#readme";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -6,10 +6,8 @@
   config,
   fetchurl,
   jdk,
-  jq,
   lib,
   llvmPackages,
-  moreutils,
   protobuf,
   python3Packages,
   stdenv,
@@ -2759,20 +2757,12 @@ let
             hash = "sha256-83hvz4nqpOxou5tFmiXyuUgWjRnTrOu42R+pRJdNbwU=";
           };
 
-          nativeBuildInputs = [
-            jq
-            moreutils
-          ];
-
           buildInputs = [
             cfn-lint
             pydot
           ];
 
-          postInstall = ''
-            cd "$out/$installPrefix"
-            jq '.contributes.configuration.properties."cfnLint.path".default = "${cfn-lint}/bin/cfn-lint"' package.json | sponge package.json
-          '';
+          executableConfig."cfnLint.path".package = cfn-lint;
 
           meta = {
             description = "CloudFormation Linter IDE integration, autocompletion, and documentation";
@@ -4944,17 +4934,9 @@ let
           sha256 = "1nlrijjwc35n1xgb5lgnr4yvlgfcxd0vdj93ip8lv2xi8x1ni5f6";
         };
 
-        nativeBuildInputs = [
-          jq
-          moreutils
-        ];
-
         buildInputs = [ jdk ];
 
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."ltex.java.path".default = "${jdk}"' package.json | sponge package.json
-        '';
+        executableConfig."ltex.java.path".package = jdk;
 
         meta = {
           license = lib.licenses.mpl20;
@@ -5552,14 +5534,10 @@ let
           version = "0.5.5";
           sha256 = "sha256-Em+w3FyJLXrpVAe9N7zsHRoMcpvl+psmG1new7nA8iE=";
         };
-        nativeBuildInputs = [
-          jq
-          moreutils
-        ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties.protoc.properties.path.default = "${protobuf}/bin/protoc"' package.json | sponge package.json
-        '';
+        executableConfig.protoc = {
+          extraJqExpr = ".properties.path";
+          package = protobuf;
+        };
         meta = {
           license = lib.licenses.mit;
         };

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -6,10 +6,8 @@
   config,
   fetchurl,
   jdk,
-  jq,
   lib,
   llvmPackages,
-  moreutils,
   protobuf,
   python3Packages,
   stdenv,
@@ -2781,20 +2779,12 @@ let
             hash = "sha256-83hvz4nqpOxou5tFmiXyuUgWjRnTrOu42R+pRJdNbwU=";
           };
 
-          nativeBuildInputs = [
-            jq
-            moreutils
-          ];
-
           buildInputs = [
             cfn-lint
             pydot
           ];
 
-          postInstall = ''
-            cd "$out/$installPrefix"
-            jq '.contributes.configuration.properties."cfnLint.path".default = "${cfn-lint}/bin/cfn-lint"' package.json | sponge package.json
-          '';
+          executableConfig."cfnLint.path".package = cfn-lint;
 
           meta = {
             description = "CloudFormation Linter IDE integration, autocompletion, and documentation";
@@ -4986,17 +4976,9 @@ let
           sha256 = "1nlrijjwc35n1xgb5lgnr4yvlgfcxd0vdj93ip8lv2xi8x1ni5f6";
         };
 
-        nativeBuildInputs = [
-          jq
-          moreutils
-        ];
-
         buildInputs = [ jdk ];
 
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties."ltex.java.path".default = "${jdk}"' package.json | sponge package.json
-        '';
+        executableConfig."ltex.java.path".package = jdk;
 
         meta = {
           license = lib.licenses.mpl20;
@@ -5594,14 +5576,10 @@ let
           version = "0.5.5";
           sha256 = "sha256-Em+w3FyJLXrpVAe9N7zsHRoMcpvl+psmG1new7nA8iE=";
         };
-        nativeBuildInputs = [
-          jq
-          moreutils
-        ];
-        postInstall = ''
-          cd "$out/$installPrefix"
-          jq '.contributes.configuration.properties.protoc.properties.path.default = "${protobuf}/bin/protoc"' package.json | sponge package.json
-        '';
+        executableConfig.protoc = {
+          extraJqExpr = ".properties.path";
+          package = protobuf;
+        };
         meta = {
           license = lib.licenses.mit;
         };

--- a/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
@@ -2,9 +2,7 @@
   lib,
   vscode-utils,
   vscode-extension-update-script,
-  jq,
   harper,
-  moreutils,
   ...
 }:
 
@@ -16,15 +14,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-nK97C9ZYSI6dh4w1ntDP0mbmv6ez3pyAfv/4D30I2sA=";
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."harper.path".default = "${harper}/bin/harper-ls"' package.json | sponge package.json
-  '';
+  executableConfig."harper.path".package = harper;
   passthru.updateScript = vscode-extension-update-script { };
 
   meta = {

--- a/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
@@ -2,9 +2,7 @@
   lib,
   vscode-utils,
   vscode-extension-update-script,
-  jq,
   harper,
-  moreutils,
   ...
 }:
 
@@ -21,16 +19,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-/brjx/yY4JLLboI6dLwF/eyX7yhRyMlohhGNFGIrm54=";
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
+  executableConfig."harper.path".package = harper;
 
   postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."harper.path".default = "${lib.getExe harper}"' package.json | sponge package.json
-
-    rm ./bin/harper-ls
+    rm "$out/$installPrefix"/bin/harper-ls
   '';
 
   passthru.updateScript = vscode-extension-update-script { };

--- a/pkgs/applications/editors/vscode/extensions/eugleo.magic-racket/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/eugleo.magic-racket/default.nix
@@ -1,7 +1,5 @@
 {
   lib,
-  jq,
-  moreutils,
   racket,
   vscode-utils,
 }:
@@ -13,15 +11,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.8.0";
     hash = "sha256-yWmJFLXktsJDEDwHO8ZCXQBTw8j5bOv6TXEOO/V8mZs=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."magicRacket.general.racketPath".default = "${racket}/bin/racket"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."magicRacket.general.racoPath".default = "${racket}/bin/raco"' package.json | sponge package.json
-  '';
+  executableConfig = {
+    "magicRacket.general.racketPath".package = racket;
+    "magicRacket.general.racoPath".package = lib.getExe' racket "raco";
+  };
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/evzen-wybitul.magic-racket/changelog";
     description = "Best coding experience for Racket in VS Code";

--- a/pkgs/applications/editors/vscode/extensions/foxundermoon.shell-format/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/foxundermoon.shell-format/default.nix
@@ -1,7 +1,5 @@
 {
-  jq,
   lib,
-  moreutils,
   shfmt,
   vscode-utils,
 }:
@@ -14,15 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-kfpRByJDcGY3W9+ELBzDOUMl06D/vyPlN//wPgQhByk=";
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."shellformat.path".default = "${shfmt}/bin/shfmt"' package.json | sponge package.json
-  '';
+  executableConfig."shellformat.path".package = shfmt;
 
   meta = {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format";

--- a/pkgs/applications/editors/vscode/extensions/hashicorp.terraform/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/hashicorp.terraform/default.nix
@@ -1,8 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
+  buildPackages,
   terraform-ls,
   vscode-extension-update-script,
 }:
@@ -17,7 +16,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   postInstall = ''
     cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration[0].properties."terraform.languageServer.path".default = "${terraform-ls}/bin/terraform-ls"' package.json | ${lib.getExe' moreutils "sponge"} package.json
+    ${lib.getExe buildPackages.jq} '.contributes.configuration[0].properties."terraform.languageServer.path".default = "${terraform-ls}/bin/terraform-ls"' package.json | ${lib.getExe' buildPackages.moreutils "sponge"} package.json
   '';
 
   passthru.updateScript = vscode-extension-update-script {

--- a/pkgs/applications/editors/vscode/extensions/jackmacwindows.craftos-pc/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jackmacwindows.craftos-pc/default.nix
@@ -1,9 +1,7 @@
 {
   vscode-utils,
   craftos-pc,
-  jq,
   lib,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -13,24 +11,16 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "1.2.3";
     hash = "sha256-QoLMefSmownw9AEem0jx1+BF1bcolHYpiqyPKQNkdiQ=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-
-    jq -e '
-      .contributes.configuration.properties."craftos-pc.executablePath.linux".default =
-        "${lib.meta.getExe craftos-pc}" |
-      .contributes.configuration.properties."craftos-pc.executablePath.mac".default =
-        "${lib.meta.getExe craftos-pc}" |
-      .contributes.configuration.properties."craftos-pc.executablePath.windows".default =
-        "${lib.meta.getExe craftos-pc}"
-    ' \
-    < package.json \
-    | sponge package.json
-  '';
+  executableConfig =
+    lib.genAttrs
+      [
+        "craftos-pc.executablePath.linux"
+        "craftos-pc.executablePath.linux"
+        "craftos-pc.executablePath.windows"
+      ]
+      (_: {
+        package = craftos-pc;
+      });
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/jackmacwindows.craftos-pc/changelog";
     description = "Visual Studio Code extension for opening a CraftOS-PC window";

--- a/pkgs/applications/editors/vscode/extensions/jebbs.plantuml/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jebbs.plantuml/default.nix
@@ -2,8 +2,6 @@
   lib,
   vscode-utils,
   plantuml,
-  jq,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -13,15 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2.18.1";
     hash = "sha256-o4FN/vUEK53ZLz5vAniUcnKDjWaKKH0oPZMbXVarDng=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."plantuml.java".default = "${plantuml}/bin/plantuml"' package.json | sponge package.json
-  '';
-
+  executableConfig."plantuml.java".package = plantuml;
   meta = {
     description = "Visual Studio Code extension for supporting Rich PlantUML";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml";

--- a/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
@@ -1,9 +1,9 @@
 {
   alejandra,
-  jq,
   lib,
-  moreutils,
   vscode-utils,
+  jq,
+  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -13,21 +13,13 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "1.0.0";
     hash = "sha256-COlEjKhm8tK5XfOjrpVUDQ7x3JaOLiYoZ4MdwTL8ktk=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
+  executableConfig."alejandra.program".package = alejandra;
   postInstall = ''
     cd "$out/$installPrefix"
-
-    jq -e '
-      .contributes.configuration.properties."alejandra.program".default =
-        "${alejandra}/bin/alejandra" |
+    ${lib.getExe jq} -e '
       .contributes.configurationDefaults."alejandra.program" =
-        "${alejandra}/bin/alejandra"
-    ' \
-    < package.json \
-    | sponge package.json
+        "${lib.getExe alejandra}"
+    ' package.json | ${lib.getExe' moreutils "sponge"} package.json
   '';
   meta = {
     description = "Uncompromising Nix Code Formatter";

--- a/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/kamadorueda.alejandra/default.nix
@@ -2,8 +2,7 @@
   alejandra,
   lib,
   vscode-utils,
-  jq,
-  moreutils,
+  buildPackages,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -16,10 +15,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
   executableConfig."alejandra.program".package = alejandra;
   postInstall = ''
     cd "$out/$installPrefix"
-    ${lib.getExe jq} -e '
+    ${lib.getExe buildPackages.jq} -e '
       .contributes.configurationDefaults."alejandra.program" =
         "${lib.getExe alejandra}"
-    ' package.json | ${lib.getExe' moreutils "sponge"} package.json
+    ' package.json | ${lib.getExe' buildPackages.moreutils "sponge"} package.json
   '';
   meta = {
     description = "Uncompromising Nix Code Formatter";

--- a/pkgs/applications/editors/vscode/extensions/mads-hartmann.bash-ide-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/mads-hartmann.bash-ide-vscode/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   shfmt,
   shellcheck,
 }:
@@ -14,17 +12,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "1.43.0";
     hash = "sha256-IpJCzoYZ+L39HqBts487E00RfVnZhLa9wUYs2FIV9pQ=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq -e '
-      .contributes.configuration.properties."bashIde.shellcheckPath".default = "${lib.getExe shellcheck}" |
-      .contributes.configuration.properties."bashIde.shfmt.path".default = "${lib.getExe shfmt}"
-    ' package.json | sponge package.json
-  '';
+  executableConfig = {
+    "bashIde.shellcheckPath".package = shellcheck;
+    "bashIde.shfmt.path".package = shfmt;
+  };
   meta = {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.kamadorueda ];

--- a/pkgs/applications/editors/vscode/extensions/mkhl.direnv/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/mkhl.direnv/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   direnv,
 }:
 
@@ -13,14 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.17.0";
     hash = "sha256-9sFcfTMeLBGw2ET1snqQ6Uk//D/vcD9AVsZfnUNrWNg=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq -e '.contributes.configuration.properties."direnv.path.executable".default = "${lib.getExe direnv}"' package.json | sponge package.json
-  '';
+  executableConfig."direnv.path.executable".package = direnv;
   meta = {
     description = "direnv support for Visual Studio Code";
     license = lib.licenses.bsd0;

--- a/pkgs/applications/editors/vscode/extensions/mkhl.shfmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/mkhl.shfmt/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   shfmt,
-  moreutils,
 }:
 vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
@@ -13,10 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-Mff3ZpxnLp/cEB17T0KGZ4GWG8jN4VxrfR/wIEi2ouM=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."shfmt.executablePath".default = "${lib.getExe shfmt}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."shfmt.executablePath".package = shfmt;
 
   meta = {
     description = "Extension uses shfmt to provide a formatter for shell script documents";

--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -1,7 +1,5 @@
 {
-  jq,
   lib,
-  moreutils,
   tinymist,
   vscode-utils,
 }:
@@ -14,17 +12,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-R4tlQgtQaXIT6qiBg1RqQB0Usnsj0Ijs2Bhn2J1CQq4=";
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
   buildInputs = [ tinymist ];
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."tinymist.serverPath".default = "${lib.getExe tinymist}"' package.json | sponge package.json
-  '';
+  executableConfig."tinymist.serverPath".package = tinymist;
 
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/myriad-dreamin.tinymist/changelog";

--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -1,7 +1,5 @@
 {
-  jq,
   lib,
-  moreutils,
   tinymist,
   vscode-utils,
 }:
@@ -17,17 +15,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
   __structuredAttrs = true;
   strictDeps = true;
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
   buildInputs = [ tinymist ];
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."tinymist.serverPath".default = "${lib.getExe tinymist}"' package.json | sponge package.json
-  '';
+  executableConfig."tinymist.serverPath".package = tinymist;
 
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/myriad-dreamin.tinymist/changelog";

--- a/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   python3,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -14,10 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-oTXy0Vjd0s7ZYZzr36ILQOJm4BW9Qd7y8fGbnhkaD1Y=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."scheme-fmt.pythonPath".default = "${lib.getExe python3}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."scheme-fmt.pythonPath".package = python3;
 
   meta = {
     description = "Formats Scheme source code";

--- a/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/oliver-ni.scheme-fmt/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   vscode-utils,
-  buildPackages,
   python3,
 }:
 
@@ -13,10 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-oTXy0Vjd0s7ZYZzr36ILQOJm4BW9Qd7y8fGbnhkaD1Y=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe buildPackages.jq} '.contributes.configuration.properties."scheme-fmt.pythonPath".default = "${lib.getExe python3}"' package.json | ${lib.getExe' buildPackages.moreutils "sponge"} package.json
-  '';
+  executableConfig."scheme-fmt.pythonPath".package = python3;
 
   meta = {
     description = "Formats Scheme source code";

--- a/pkgs/applications/editors/vscode/extensions/prince781.vala/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prince781.vala/default.nix
@@ -2,8 +2,6 @@
   lib,
   vala-language-server,
   vscode-utils,
-  jq,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -14,15 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-LJJDKhwzbGznyiXeB8SYir3LOM7/quYhGae1m4X/s3M=";
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."vala.languageServerPath".default = "${lib.getExe vala-language-server}"' package.json | sponge package.json
-  '';
+  executableConfig."vala.languageServerPath".package = vala-language-server;
 
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/prince781.vala/changelog";

--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -1,13 +1,12 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   languageserver ? rPackages.languageserver,
   R,
   radian,
-
   rPackages,
+  jq,
+  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -17,17 +16,18 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2.8.8";
     hash = "sha256-mt2bes7aHcAHLMngSLW/zI3kSIzNKALqX+g0UXo84uI=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
+  executableConfig = {
+    "r.rpath.mac".package = R;
+    "r.rpath.linux".package = R;
+    "r.rterm.mac".package = radian;
+    "r.rterm.linux".package = radian;
+  };
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."r.rpath.mac".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rpath.linux".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rterm.mac".default = "${lib.getExe radian}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rterm.linux".default = "${lib.getExe radian}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.libPaths".default = [ "${languageserver}/library" ]' package.json | sponge package.json
+    ${lib.getExe jq} -e '
+      .contributes.configuration.properties."r.libPaths" =
+        [ "${languageserver}/library" ]
+    ' package.json | ${lib.getExe' moreutils "sponge"} package.json
   '';
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/REditorSupport.r/changelog";

--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -1,13 +1,12 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   languageserver ? rPackages.languageserver,
   R,
   radian,
-
   rPackages,
+  jq,
+  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -17,17 +16,18 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2.8.8";
     hash = "sha256-mt2bes7aHcAHLMngSLW/zI3kSIzNKALqX+g0UXo84uI=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
+  executableConfig = {
+    "r.rpath.mac".package = R;
+    "r.rpath.linux".package = R;
+    "r.rterm.mac".package = radian;
+    "r.rterm.linux".package = radian;
+  };
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."r.rpath.mac".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rpath.linux".default = "${lib.getExe' R "R"}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rterm.mac".default = "${lib.getExe radian}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.rterm.linux".default = "${lib.getExe radian}"' package.json | sponge package.json
-    jq '.contributes.configuration.properties."r.libPaths".default = [ "${languageserver}/library" ]' package.json | sponge package.json
+    ${lib.getExe jq} -e '
+      .contributes.configuration.properties."r.libPaths".default =
+        [ "${languageserver}/library" ]
+    ' package.json | ${lib.getExe' moreutils "sponge"} package.json
   '';
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/REditorSupport.r/changelog";

--- a/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/reditorsupport.r/default.nix
@@ -5,8 +5,7 @@
   R,
   radian,
   rPackages,
-  jq,
-  moreutils,
+  buildPackages,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -24,10 +23,10 @@ vscode-utils.buildVscodeMarketplaceExtension {
   };
   postInstall = ''
     cd "$out/$installPrefix"
-    ${lib.getExe jq} -e '
+    ${lib.getExe buildPackages.jq} -e '
       .contributes.configuration.properties."r.libPaths".default =
         [ "${languageserver}/library" ]
-    ' package.json | ${lib.getExe' moreutils "sponge"} package.json
+    ' package.json | ${lib.getExe' buildPackages.moreutils "sponge"} package.json
   '';
   meta = {
     changelog = "https://marketplace.visualstudio.com/items/REditorSupport.r/changelog";

--- a/pkgs/applications/editors/vscode/extensions/release-candidate.vscode-scheme-repl/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/release-candidate.vscode-scheme-repl/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   chez,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -14,10 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-Pfy0aJXq8I53o5mG4dfzyqsyLQX0bs+phBgN46yU/Yw=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."chezScheme.schemePath" = "${lib.getExe' chez "scheme"}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."chezScheme.schemePath".package = chez;
 
   meta = {
     description = "Uses REPL for autocompletions and to evaluate expressions";

--- a/pkgs/applications/editors/vscode/extensions/tecosaur.latex-utilities/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tecosaur.latex-utilities/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   texlivePackages,
 }:
 
@@ -14,18 +12,9 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
     hash = "sha256-GsbHzFcN56UbcaqFN9s+6u/KjUBn8tmks2ihK0pg3Ds=";
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
   buildInputs = [ texlivePackages.texcount ];
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    echo -n ${finalAttrs.version} > VERSION
-    jq '.contributes.configuration.properties."latex-utilities.countWord.path".default = "${texlivePackages.texcount}/bin/texcount"' package.json | sponge package.json
-  '';
+  executableConfig."latex-utilities.countWord.path".package = texlivePackages.texcount;
 
   meta = {
     description = "Add-on to the Visual Studio Code extension LaTeX Workshop";

--- a/pkgs/applications/editors/vscode/extensions/tekumara.typos-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tekumara.typos-vscode/default.nix
@@ -1,8 +1,6 @@
 {
   stdenv,
-  jq,
   lib,
-  moreutils,
   typos-lsp,
   vscode-utils,
   vscode-extension-update-script,
@@ -42,17 +40,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
     inherit (extInfo) hash arch;
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
   buildInputs = [ typos-lsp ];
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."typos.path".default = "${lib.getExe typos-lsp}"' package.json | sponge package.json
-  '';
+  executableConfig."typos.path".package = typos-lsp;
 
   passthru.updateScript = vscode-extension-update-script { };
 

--- a/pkgs/applications/editors/vscode/extensions/tekumara.typos-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tekumara.typos-vscode/default.nix
@@ -1,8 +1,6 @@
 {
   stdenv,
-  jq,
   lib,
-  moreutils,
   typos-lsp,
   vscode-utils,
   vscode-extension-update-script,
@@ -42,17 +40,9 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
     inherit (extInfo) hash arch;
   };
 
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-
   buildInputs = [ typos-lsp ];
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."typos.path".default = "${lib.getExe typos-lsp}"' package.json | sponge package.json
-  '';
+  executableConfig."typos.path".package = typos-lsp;
 
   passthru.updateScript = vscode-extension-update-script { };
 

--- a/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
@@ -1,7 +1,5 @@
 {
-  jq,
   lib,
-  moreutils,
   shellcheck,
   vscode-utils,
 }:
@@ -13,14 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.39.3";
     sha256 = "sha256-A87dG+bBNCMZ8ERDGpVJIP7lXL8rfRely2Uo/ZMsgVI=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."shellcheck.executablePath".default = "${shellcheck}/bin/shellcheck"' package.json | sponge package.json
-  '';
+  executableConfig."shellcheck.executablePath".package = shellcheck;
   meta = {
     description = "Integrates ShellCheck into VS Code, a linter for Shell scripts";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck";

--- a/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/timonwong.shellcheck/default.nix
@@ -1,7 +1,5 @@
 {
-  jq,
   lib,
-  moreutils,
   shellcheck,
   vscode-utils,
 }:
@@ -13,14 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "0.39.5";
     sha256 = "sha256-8f9LGmNE8ilPYZmbJpmmAx9DkKJXbQzAia11rM3wTec=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."shellcheck.executablePath".default = "${shellcheck}/bin/shellcheck"' package.json | sponge package.json
-  '';
+  executableConfig."shellcheck.executablePath".package = shellcheck;
   meta = {
     description = "Integrates ShellCheck into VS Code, a linter for Shell scripts";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck";

--- a/pkgs/applications/editors/vscode/extensions/tsyesika.guile-scheme-enhanced/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tsyesika.guile-scheme-enhanced/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   guile,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -14,10 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-uoHYfbLeANHnMB7OgDQPfIIlNN7LgERS9zQfa+QIk0M=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."guileScheme.guileREPLCommand".default = "${lib.getExe' guile "guile"}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."guileScheme.guileREPLCommand".package = guile;
 
   meta = {
     description = "Better experience for working with scheme";

--- a/pkgs/applications/editors/vscode/extensions/tsyesika.guile-scheme-enhanced/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/tsyesika.guile-scheme-enhanced/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
   vscode-utils,
-  jq,
   guile,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -14,10 +12,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-uoHYfbLeANHnMB7OgDQPfIIlNN7LgERS9zQfa+QIk0M=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."guileScheme.guileREPLCommand".default = "${lib.getExe' guile "guile"}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig."guileScheme.guileREPLCommand".package = "guile";
 
   meta = {
     description = "Better experience for working with scheme";

--- a/pkgs/applications/editors/vscode/extensions/ufo5260987423.magic-scheme/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ufo5260987423.magic-scheme/default.nix
@@ -1,11 +1,9 @@
 {
   lib,
   vscode-utils,
-  jq,
   akkuPackages,
   chez,
   akku,
-  moreutils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
@@ -16,10 +14,11 @@ vscode-utils.buildVscodeMarketplaceExtension {
     hash = "sha256-ibEdsw/ulr+cagB90uALDbSsQV18dPULANCdnjPvhuI=";
   };
 
-  postInstall = ''
-    cd "$out/$installPrefix"
-    ${lib.getExe jq} '.contributes.configuration.properties."magicScheme.scheme-langserver.serverPath".default = "${lib.getExe' akkuPackages.scheme-langserver "scheme-langserver"}" | .contributes.configuration.properties."magicScheme.scheme.path".default = "${lib.getExe' chez "scheme"}" | .contributes.configuration.properties."magicScheme.akku.path".default = "${lib.getExe akku}"' package.json | ${lib.getExe' moreutils "sponge"} package.json
-  '';
+  executableConfig = {
+    "magicScheme.scheme-langserver.serverPath".package = akkuPackages.scheme-langserver;
+    "magicScheme.scheme.path".package = chez;
+    "magicScheme.akku.path".package = akku;
+  };
 
   meta = {
     description = "Adds support for Scheme(r6rs standard)";

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -7,8 +7,8 @@
   vscode,
   unzip,
   makeSetupHook,
-  writeScript,
   jq,
+  moreutils,
   vscode-extension-update-script,
 }:
 let
@@ -22,6 +22,7 @@ let
     constructDrv = stdenv.mkDerivation;
     excludeDrvArgNames = [
       "vscodeExtUniqueId"
+      "executableConfig"
     ];
     extendDrvArgs =
       finalAttrs:
@@ -32,6 +33,7 @@ let
         vscodeExtPublisher,
         vscodeExtName,
         vscodeExtUniqueId,
+        executableConfig ? { },
         configurePhase ? ''
           runHook preConfigure
           runHook postConfigure
@@ -82,6 +84,34 @@ let
 
             runHook postInstall
           '';
+
+        postInstall =
+          let
+            jqExprs = lib.concatMapAttrsStringSep "| " (
+              executableConfigKey:
+              {
+                package,
+                extraJqExpr ? "",
+              }:
+              # https://code.visualstudio.com/api/references/contribution-points
+              ''
+                .contributes."configuration.properties"."${executableConfigKey}"${extraJqExpr}.default = "${
+                  if lib.isDerivation package then lib.getExe package else package
+                }"
+              ''
+            ) executableConfig;
+            original = args.postInstall or "";
+          in
+          if executableConfig == { } then
+            original
+          else
+            original
+            + ''
+              cd "$out/$installPrefix"
+              ${lib.getExe jq} -e '
+                ${jqExprs}' package.json |
+              ${lib.getExe' moreutils "sponge"} package.json
+            '';
       };
   };
 
@@ -93,6 +123,7 @@ let
     excludeDrvArgNames = [
       "mktplcRef"
       "vsix"
+      "executableConfig"
     ];
     extendDrvArgs =
       finalAttrs:
@@ -101,6 +132,7 @@ let
         src ? null,
         vsix ? null,
         mktplcRef,
+        executableConfig ? { },
         ...
       }:
       assert "" == name;
@@ -112,6 +144,7 @@ let
         vscodeExtPublisher = mktplcRef.publisher;
         vscodeExtName = mktplcRef.name;
         vscodeExtUniqueId = "${mktplcRef.publisher}.${mktplcRef.name}";
+        inherit executableConfig;
       };
   };
 

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -8,8 +8,8 @@
   buildPackages,
   unzip,
   makeSetupHook,
-  writeScript,
   jq,
+  moreutils,
   vscode-extension-update-script,
 }:
 let
@@ -24,6 +24,7 @@ let
     constructDrv = stdenv.mkDerivation;
     excludeDrvArgNames = [
       "vscodeExtUniqueId"
+      "executableConfig"
     ];
     extendDrvArgs =
       finalAttrs:
@@ -34,6 +35,7 @@ let
         vscodeExtPublisher,
         vscodeExtName,
         vscodeExtUniqueId,
+        executableConfig ? { },
         configurePhase ? ''
           runHook preConfigure
           runHook postConfigure
@@ -84,6 +86,34 @@ let
 
             runHook postInstall
           '';
+
+        postInstall =
+          let
+            jqExprs = lib.concatMapAttrsStringSep "| " (
+              executableConfigKey:
+              {
+                package,
+                extraJqExpr ? "",
+              }:
+              # https://code.visualstudio.com/api/references/contribution-points
+              ''
+                .contributes."configuration.properties"."${executableConfigKey}"${extraJqExpr}.default = "${
+                  if lib.isDerivation package then lib.getExe package else package
+                }"
+              ''
+            ) executableConfig;
+            original = args.postInstall or "";
+          in
+          if executableConfig == { } then
+            original
+          else
+            original
+            + ''
+              cd "$out/$installPrefix"
+              ${lib.getExe jq} -e '
+                ${jqExprs}' package.json |
+              ${lib.getExe' moreutils "sponge"} package.json
+            '';
       };
   };
 
@@ -95,6 +125,7 @@ let
     excludeDrvArgNames = [
       "mktplcRef"
       "vsix"
+      "executableConfig"
     ];
     extendDrvArgs =
       finalAttrs:
@@ -103,6 +134,7 @@ let
         src ? null,
         vsix ? null,
         mktplcRef,
+        executableConfig ? { },
         ...
       }:
       assert "" == name;
@@ -114,6 +146,7 @@ let
         vscodeExtPublisher = mktplcRef.publisher;
         vscodeExtName = mktplcRef.name;
         vscodeExtUniqueId = "${mktplcRef.publisher}.${mktplcRef.name}";
+        inherit executableConfig;
       };
   };
 

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -9,7 +9,6 @@
   unzip,
   makeSetupHook,
   jq,
-  moreutils,
   vscode-extension-update-script,
 }:
 let
@@ -110,9 +109,9 @@ let
             original
             + ''
               cd "$out/$installPrefix"
-              ${lib.getExe jq} -e '
+              ${lib.getExe buildPackages.jq} -e '
                 ${jqExprs}' package.json |
-              ${lib.getExe' moreutils "sponge"} package.json
+              ${lib.getExe' buildPackages.moreutils "sponge"} package.json
             '';
       };
   };

--- a/pkgs/applications/editors/vscode/extensions/yzane.markdown-pdf/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/yzane.markdown-pdf/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   ungoogled-chromium,
 }:
 
@@ -13,13 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2.0.1";
     hash = "sha256-XykOUbCiTVtfmp5H9UC4gFPBxmrIJR7jv9VvLljOSM0=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    jq '.contributes.configuration.properties."markdown-pdf.executablePath".default = "${lib.getExe ungoogled-chromium}"' $out/$installPrefix/package.json | sponge $out/$installPrefix/package.json
-  '';
+  executableConfig."markdown-pdf.executablePath".package = ungoogled-chromium;
   meta = {
     description = "Converts Markdown files to pdf, html, png or jpeg files";
     homepage = "https://github.com/yzane/vscode-markdown-pdf#readme";

--- a/pkgs/applications/editors/vscode/extensions/yzane.markdown-pdf/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/yzane.markdown-pdf/default.nix
@@ -1,8 +1,6 @@
 {
   lib,
   vscode-utils,
-  jq,
-  moreutils,
   ungoogled-chromium,
 }:
 
@@ -13,13 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     version = "2.1.0";
     hash = "sha256-3N4de2jgLbBlDGouFU7XoH4ElL9En9+2ZprMqoL03/E=";
   };
-  nativeBuildInputs = [
-    jq
-    moreutils
-  ];
-  postInstall = ''
-    jq '.contributes.configuration.properties."markdown-pdf.executablePath".default = "${lib.getExe ungoogled-chromium}"' $out/$installPrefix/package.json | sponge $out/$installPrefix/package.json
-  '';
+  executableConfig."markdown-pdf.executablePath".package = ungoogled-chromium;
   meta = {
     description = "Converts Markdown files to pdf, html, png or jpeg files";
     homepage = "https://github.com/yzane/vscode-markdown-pdf#readme";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- vscode-utils.buildVscode{,Marketplace}Extension: add drv arg `executableConfig` to change the default value of extension config to package's `meta.mainProgram`
- vscode-extensions.*: replace using `jq | sponge` to change the default value of extension config with package binary to drv arg `executableConfig` of `vscode-utils.buildVscodeMarketplaceExtension`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
