### PR TITLE
python3Packages.zha-quirks: 1.1.1 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "1.1.1";
+  version = "1.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     tag = version;
-    hash = "sha256-GxNxc+cu3wBjz/1VF2+0DJ/PBTLlJKm0ncgzeaw5Fxw=";
+    hash = "sha256-mDcvVwqzSmszaJDahzkRNteiO4C/eU+BqTdBpWj5yGw=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Trivial version bump.

Diff: https://github.com/zigpy/zha-device-handlers/compare/1.1.1...1.2.0
Changelog: https://github.com/zigpy/zha-device-handlers/releases/tag/1.2.0

Resolves #514757.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at \`passthru.tests\`. (4753 upstream pytest tests pass during build.)
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran \`nixpkgs-review\` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in \`./result/bin/\` (library package — \`pythonImportsCheck\` passes).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.

## Automation/AI disclosure

In line with the proposed [Automation/AI policy in #514587](https://github.com/NixOS/nixpkgs/pull/514587):

- This trivial version + hash bump was produced with the assistance of an LLM-based AI tool (Claude, model \`claude-opus-4-7\`) running \`nix-update python3Packages.zha-quirks --version 1.2.0 --commit\`.
- I (the human author, @typedrat) reviewed the diff, verified the upstream tag exists, ran \`nix-build -A python3Packages.zha-quirks\` locally on x86_64-linux, and confirmed the upstream test suite passes before submission.
- The commit carries an \`Assisted-by:\` trailer as suggested by the proposed policy.