### PR TITLE
{libsForQt5,qt6Packages}.accounts-qt: Adopt, modernise

### DIFF
--- a/pkgs/development/libraries/accounts-qt/default.nix
+++ b/pkgs/development/libraries/accounts-qt/default.nix
@@ -2,21 +2,27 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  testers,
   gitUpdater,
+  dbus-test-runner,
   doxygen,
   glib,
+  graphviz,
   libaccounts-glib,
   pkg-config,
   qmake,
   qtbase,
-  wrapQtAppsHook,
+  qttools,
+  writableTmpDirAsHomeHook,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "accounts-qt";
   version = "1.17";
 
-  # pinned to fork with Qt6 support
   src = fetchFromGitLab {
     owner = "accounts-sso";
     repo = "libaccounts-qt";
@@ -24,32 +30,91 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-mPZgD4r7vlUP6wklvZVknGqTXZBckSOtNzK7p6e2qSA=";
   };
 
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  postPatch =
+    # Don't install test binary. Not useful, and it has ref to /build.
+    ''
+      substituteInPlace tests/tst_libaccounts.pro \
+        --replace-fail 'include( ../common-installs-config.pri )' '# include( ../common-installs-config.pri )'
+    ''
+    # Let Nix do the timeout.
+    + ''
+      substituteInPlace tests/accountstest.sh \
+        --replace-fail 'dbus-test-runner -m 180' 'dbus-test-runner -m 0'
+    ''
+    # We're installing headers to dev output
+    + ''
+      substituteInPlace Accounts/AccountsQt*Config.cmake.in \
+        --replace-fail 'set(ACCOUNTSQT_INCLUDE_DIRS $${INSTALL_PREFIX}' 'set(ACCOUNTSQT_INCLUDE_DIRS $${NIX_OUTPUT_DEV}'
+    ''
+    # qhelpgenerator isn't on PATH w/ Qt6
+    + ''
+      substituteInPlace doc/doxy.conf \
+        --replace-fail \
+          '= qhelpgenerator' \
+          '= ${if withQt6 then "${qttools}/libexec" else "${lib.getDev qttools}/bin"}/qhelpgenerator'
+    '';
+
+  # QMake
+  strictDeps = false;
+
+  nativeBuildInputs = [
+    doxygen
+    graphviz
+    pkg-config
+    qmake
+    writableTmpDirAsHomeHook # to stop doxygen from complaining
+  ];
+
   propagatedBuildInputs = [
     glib
     libaccounts-glib
   ];
-  buildInputs = [ qtbase ];
-  nativeBuildInputs = [
-    doxygen
-    pkg-config
-    qmake
-    wrapQtAppsHook
+
+  nativeCheckInputs = [
+    dbus-test-runner
   ];
 
-  # remove forbidden references to /build
-  preFixup = ''
-    patchelf --shrink-rpath --allowed-rpath-prefixes "$NIX_STORE" "$out"/bin/*
+  # Library
+  dontWrapQtApps = true;
+
+  # Configure *now*
+  postConfigure = ''
+    make qmake_all
   '';
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "VERSION_";
+  postBuild = ''
+    make docs
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # For qhelpgenerator to find minimal plugin
+  env.QT_PLUGIN_PATH = "${lib.getBin qtbase}/${qtbase.qtPluginPrefix}";
+
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+    updateScript = gitUpdater {
+      rev-prefix = "VERSION_";
+    };
   };
 
   meta = {
-    description = "Qt library for accessing the online accounts database";
-    mainProgram = "accountstest";
-    homepage = "https://gitlab.com/accounts-sso/libaccounts-qt";
-    license = lib.licenses.lgpl21;
+    description = "Qt-based client library for the accounts database";
+    homepage = "https://accounts-sso.gitlab.io/";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.OPNA2608 ];
     platforms = lib.platforms.linux;
+    pkgConfigModules = [
+      "accounts-qt${lib.versions.major qtbase.version}"
+    ];
   };
 })


### PR DESCRIPTION
- Add OPNA2608 as maintainer
- Add outputs
- Run tests
- Fix doc graphics
- Add test for pkg-config modules
- Don't install test binary
- Set homepage to Accounts SSO website
- Clarify license

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
