### PR TITLE
treewide: fix typo of updateScript as updateScripts

### DIFF
--- a/pkgs/by-name/ma/markitdown-mcp/package.nix
+++ b/pkgs/by-name/ma/markitdown-mcp/package.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "markitdown_mcp"
   ];
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "MCP server for the markitdown library";

--- a/pkgs/development/python-modules/cobble/default.nix
+++ b/pkgs/development/python-modules/cobble/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     "test_sub_sub_classes_are_included_in_abc"
   ];
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Create Python data objects";

--- a/pkgs/development/python-modules/funk/default.nix
+++ b/pkgs/development/python-modules/funk/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   # Disabling tests, they rely on Nose which is outdated and not supported
   doCheck = false;
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Mocking framework for Python, influenced by JMock";

--- a/pkgs/development/python-modules/mammoth/default.nix
+++ b/pkgs/development/python-modules/mammoth/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     export PATH=$out/bin:$PATH
   '';
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Convert Word documents (.docx files) to HTML";

--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -100,7 +100,7 @@ buildPythonPackage (finalAttrs: {
     "test_module_misc"
   ];
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Python tool for converting files and office documents to Markdown";

--- a/pkgs/development/python-modules/precisely/default.nix
+++ b/pkgs/development/python-modules/precisely/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   # Tests are outdated and based on Nose, which is not supported anymore.
   doCheck = false;
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Matcher library for Python";

--- a/pkgs/development/python-modules/tempman/default.nix
+++ b/pkgs/development/python-modules/tempman/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   # Disabling tests, they rely on dependencies that are outdated and not supported
   doCheck = false;
 
-  passthru.updateScripts = gitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Create and clean up temporary directories";


### PR DESCRIPTION
Every instance that `git grep updateScripts` found. Just done manually because it was so few.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
