### PR TITLE
[Backport release-25.11] forgejo: 15.0.0 -> 15.0.1; forgejo-lts 11.0.12 -> 11.0.13

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -126,6 +126,7 @@ buildGoModule rec {
         "TestDNSUpdate" # requires network: release.forgejo.org
         "TestMigrateWhiteBlocklist" # requires network: gitlab.com (DNS)
         "TestURLAllowedSSH/Pushmirror_URL" # requires network git.gay (DNS)
+        "TestBleveDeleteIssue" # Known Flake-y https://github.com/NixOS/nixpkgs/issues/509878
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];

--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "11.0.12";
-  hash = "sha256-akPRq8quzdx8TU8NC/uxvngEl/fl/JjM1FcVhlHxcXo=";
-  npmDepsHash = "sha256-2COWPQM1iKpNG2TbPIv2zXXe28tsmuVc6IhkUeORBsU=";
-  vendorHash = "sha256-v1UZwhgZglJvIkEfO7662lKhdO3AxH+DGN70ziWfXG0=";
+  version = "11.0.13";
+  hash = "sha256-bXJ4ddUKTGKRWagL1G71sasMghr5FdiZPtHjrOTpxDY=";
+  npmDepsHash = "sha256-ZAcv/EnCx8dikjW9wgQBNln9WUQOkw0RCLVRoDPY8Gc=";
+  vendorHash = "sha256-0oh1zhMRz8B5TInAuuvYg63noxSAoupSQvQeerO3TFI=";
   lts = true;
   nixUpdateExtraArgs = [
     "--override-filename"

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "15.0.0";
-  hash = "sha256-KAGHascGFj4X6b4BpRqQ8yCedNh0nvHfQgbzJh9fxAc=";
-  npmDepsHash = "sha256-AWvLcAS7EEy796kAQfiQ8sFSh/s+6zNCJEqe4qzQL3s=";
-  vendorHash = "sha256-bP7cykWKwNQrWm9jJT4YYAHRV66HaTwGkvhBqSHgWAA=";
+  version = "15.0.1";
+  hash = "sha256-40hyQ6MPskyty/LsMVczuDpbu2q3Syoj3c00HUS+pVE=";
+  npmDepsHash = "sha256-xWbnSX11RkLjtJ62qG6rD+xQAOnUuI99r9uEHakkZPY=";
+  vendorHash = "sha256-JUBAcRYgflrvoAK0OvaU/Xr6/BakgaUtYwtvBF9vyk0=";
   lts = false;
   nixUpdateExtraArgs = [
     "--override-filename"


### PR DESCRIPTION
forgejo: 15.0.0 -> 15.0.1
changelog: https://codeberg.org/forgejo/forgejo/releases/tag/v15.0.1

forgejo: 11.0.12 -> 11.0.13
changelog: https://codeberg.org/forgejo/forgejo/releases/tag/v11.0.13

Backport of https://github.com/NixOS/nixpkgs/pull/514734 + 11.0.13 bump

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
