### PR TITLE
qt6Packages.accounts-qml-module: init at 0.7-unstable-2023-10-28

### DIFF
--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -14,6 +14,9 @@
   xvfb-run,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "accounts-qml-module";
   version = "0.7-unstable-2023-10-28";
@@ -27,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
+  ]
+  ++ lib.optionals (!withQt6) [
     "doc"
   ];
 
@@ -54,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     qmake
     qtdeclarative # qmlplugindump
+  ]
+  ++ lib.optionals (!withQt6) [
     qttools # qdoc
   ];
 
@@ -71,6 +78,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
+  qmakeFlags = lib.optionals (lib.strings.versionAtLeast qtbase.version "6") [
+    # No qdoc in Qt6 qttools?
+    "CONFIG+=no_docs"
+  ];
+
   postConfigure = ''
     make qmake_all
   '';
@@ -87,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString (!withQt6) ''
     moveToOutput share/accounts-qml-module/doc $doc
   '';
 

--- a/pkgs/development/libraries/accounts-qml-module/default.nix
+++ b/pkgs/development/libraries/accounts-qml-module/default.nix
@@ -14,6 +14,9 @@
   xvfb-run,
 }:
 
+let
+  withQt6 = lib.versions.major qtbase.version == "6";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "accounts-qml-module";
   version = "0.7-unstable-2023-10-28";
@@ -27,6 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
+  ]
+  ++ lib.optionals (!withQt6) [
     "doc"
   ];
 
@@ -54,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     qmake
     qtdeclarative # qmlplugindump
+  ]
+  ++ lib.optionals (!withQt6) [
     qttools # qdoc
   ];
 
@@ -71,6 +78,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
+  qmakeFlags = lib.optionals withQt6 [
+    # No qdoc in Qt6 qttools?
+    "CONFIG+=no_docs"
+  ];
+
   postConfigure = ''
     make qmake_all
   '';
@@ -87,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
   '';
 
-  postFixup = ''
+  postFixup = lib.optionalString (!withQt6) ''
     moveToOutput share/accounts-qml-module/doc $doc
   '';
 

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -42,6 +42,7 @@ makeScopeWithSplicing' {
     // {
 
       # LIBRARIES
+      accounts-qml-module = callPackage ../development/libraries/accounts-qml-module { };
       accounts-qt = callPackage ../development/libraries/accounts-qt { };
       appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
 


### PR DESCRIPTION
Still QMake. https://gitlab.com/accounts-sso/accounts-qml-module/-/merge_requests/12 would allow building with CMake, but maybe abit much to vendor considering that QMake still works for now…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
