### PR TITLE
stdenv.mkDerivation: more performance cleanups

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -14,7 +14,6 @@ let
   # Lib attributes are inherited to the lexical scope for performance reasons.
   inherit (lib)
     all
-    assertMsg
     attrNames
     concatLists
     concatMap
@@ -602,9 +601,8 @@ let
                 attrs.name + hostSuffix
               else
                 # we cannot coerce null to a string below
-                assert assertMsg (
-                  attrs ? version && attrs.version != null
-                ) "The `version` attribute cannot be null.";
+                assert
+                  (attrs ? version && attrs.version != null) || throw "The `version` attribute cannot be null.";
                 "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
             );
 
@@ -919,14 +917,17 @@ let
               }"
           ) overlappingNames;
         in
-        assert assertMsg (isAttrs env && !isDerivation env)
-          "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
-        assert assertMsg (overlappingNames == [ ])
-          "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
+        assert
+          (isAttrs env && !isDerivation env)
+          || throw "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
+        assert
+          (overlappingNames == [ ])
+          || throw "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
         mapAttrs (
           n: v:
-          assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
-            "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
+          assert
+            (isString v || isBool v || isInt v || isDerivation v)
+            || throw "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
           v
         ) env';
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -26,6 +26,7 @@ let
     getDev
     head
     foldl'
+    intersectAttrs
     isAttrs
     isBool
     isDerivation
@@ -909,13 +910,13 @@ let
 
       checkedEnv =
         let
-          overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
+          overlappingArgs = intersectAttrs env' derivationArg;
         in
         assert
           (isAttrs env && !isDerivation env)
           || throw "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
         assert
-          (overlappingNames == [ ])
+          (overlappingArgs == { })
           || throw (
             let
               errors = lib.concatMapStringsSep "\n" (
@@ -923,7 +924,7 @@ let
                 "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
                     lib.generators.toPretty { } derivationArg.${name}
                   }"
-              ) overlappingNames;
+              ) (attrNames overlappingArgs);
 
             in
             "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -24,9 +24,9 @@ let
     extendDerivation
     filter
     filterAttrs
+    foldl'
     getDev
     head
-    foldl'
     intersectAttrs
     isAttrs
     isBool
@@ -35,6 +35,7 @@ let
     isList
     isPath
     isString
+    listToAttrs
     mapAttrs
     mapNullable
     optional
@@ -47,7 +48,10 @@ let
     subtractLists
     toExtension
     toFunction
+    typeOf
     unique
+    unsafeDiscardStringContext
+    unsafeGetAttrPos
     warnIf
     zipAttrsWith
     ;
@@ -108,7 +112,7 @@ let
           let
             prev = rattrs final;
             thisOverlay = toExtension f0 final prev;
-            pos = builtins.unsafeGetAttrPos "version" thisOverlay;
+            pos = unsafeGetAttrPos "version" thisOverlay;
           in
           warnIf
             (
@@ -312,7 +316,7 @@ let
   unsafeDerivationToUntrackedOutpath =
     drv:
     if isDerivation drv && (!drv.__contentAddressed or false) then
-      builtins.unsafeDiscardStringContext drv.outPath
+      unsafeDiscardStringContext drv.outPath
     else
       drv;
 
@@ -844,7 +848,7 @@ let
             then
               if separateDebugInfo' then debugCachedOutputChecks else cachedOutputChecks
             else
-              builtins.listToAttrs (
+              listToAttrs (
                 map (name: {
                   inherit name;
                   value =
@@ -899,11 +903,11 @@ let
       pos ? # position used in error messages and for meta.position
         (
           if attrs.meta.description or null != null then
-            builtins.unsafeGetAttrPos "description" attrs.meta
+            unsafeGetAttrPos "description" attrs.meta
           else if attrs.version or null != null then
-            builtins.unsafeGetAttrPos "version" attrs
+            unsafeGetAttrPos "version" attrs
           else
-            builtins.unsafeGetAttrPos "name" attrs
+            unsafeGetAttrPos "name" attrs
         ),
 
       # Experimental.  For simple packages mostly just works,
@@ -973,7 +977,7 @@ let
           n: v:
           assert
             (isString v || isBool v || isInt v || isDerivation v)
-            || throw "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
+            || throw "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${typeOf v}.";
           v
         ) env';
     in

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -187,6 +187,25 @@ let
     "allowedImpureDLLs"
   ];
 
+  attrsToRemoveLast = [
+    # Fixed-output derivations may not reference other paths, which means that
+    # for a fixed-output derivation, the corresponding inputDerivation should
+    # *not* be fixed-output. To achieve this we simply delete the attributes that
+    # would make it fixed-output.
+    "outputHashAlgo"
+    "outputHash"
+    "outputHashMode"
+
+    # inputDerivation produces the inputs; not the outputs, so any
+    # restrictions on what used to be the outputs don't serve a purpose
+    # anymore.
+    "allowedReferences"
+    "allowedRequisites"
+    "disallowedReferences"
+    "disallowedRequisites"
+    "outputChecks"
+  ];
+
   inherit (stdenv)
     hostPlatform
     buildPlatform
@@ -936,26 +955,6 @@ let
             || throw "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
           v
         ) env';
-
-      attrsToRemove = [
-        # Fixed-output derivations may not reference other paths, which means that
-        # for a fixed-output derivation, the corresponding inputDerivation should
-        # *not* be fixed-output. To achieve this we simply delete the attributes that
-        # would make it fixed-output.
-        "outputHashAlgo"
-        "outputHash"
-        "outputHashMode"
-
-        # inputDerivation produces the inputs; not the outputs, so any
-        # restrictions on what used to be the outputs don't serve a purpose
-        # anymore.
-        "allowedReferences"
-        "allowedRequisites"
-        "disallowedReferences"
-        "disallowedRequisites"
-        "outputChecks"
-      ];
-
     in
 
     extendDerivation validity.handled (
@@ -966,7 +965,7 @@ let
         # needed to enter a nix-shell with
         #   nix-build shell.nix -A inputDerivation
         inputDerivation = derivation (
-          removeAttrs derivationArg attrsToRemove
+          removeAttrs derivationArg attrsToRemoveLast
           // {
             # Add a name in case the original drv didn't have one
             name = "inputDerivation" + optionalString (derivationArg ? name) "-${derivationArg.name}";

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -400,7 +400,7 @@ let
           } requires __structuredAttrs if {dis,}allowedRequisites or {dis,}allowedReferences is set"
         else
           actualValue;
-      outputs' = outputs ++ optional separateDebugInfo' "debug";
+      outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
 
       noNonNativeDeps =
         (

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -164,6 +164,10 @@ let
     "zerocallusedregs"
   ];
 
+  concretizeFlagImplications =
+    flag: impliesFlags: list:
+    if elem flag list then (list ++ impliesFlags) else list;
+
   removedOrReplacedAttrNames = [
     "checkInputs"
     "installCheckInputs"
@@ -410,10 +414,6 @@ let
           ++ depsTargetTargetPropagated
         ) == [ ];
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
-
-      concretizeFlagImplications =
-        flag: impliesFlags: list:
-        if elem flag list then (list ++ impliesFlags) else list;
 
       hardeningDisable' = unique (
         pipe hardeningDisable [

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -165,6 +165,10 @@ let
     "zerocallusedregs"
   ];
 
+  concretizeFlagImplications =
+    flag: impliesFlags: list:
+    if elem flag list then (list ++ impliesFlags) else list;
+
   removedOrReplacedAttrNames = [
     "checkInputs"
     "installCheckInputs"
@@ -408,10 +412,6 @@ let
         else
           actualValue;
       outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
-
-      concretizeFlagImplications =
-        flag: impliesFlags: list:
-        if elem flag list then (list ++ impliesFlags) else list;
 
       hardeningDisable' = unique (
         pipe hardeningDisable [

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -13,7 +13,6 @@ stdenv:
 let
   # Lib attributes are inherited to the lexical scope for performance reasons.
   inherit (lib)
-    assertMsg
     attrNames
     concatLists
     concatMap
@@ -538,9 +537,8 @@ let
                 attrs.name + hostSuffix
               else
                 # we cannot coerce null to a string below
-                assert assertMsg (
-                  attrs ? version && attrs.version != null
-                ) "The `version` attribute cannot be null.";
+                assert
+                  (attrs ? version && attrs.version != null) || throw "The `version` attribute cannot be null.";
                 "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
             );
 
@@ -845,14 +843,17 @@ let
               }"
           ) overlappingNames;
         in
-        assert assertMsg (isAttrs env && !isDerivation env)
-          "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
-        assert assertMsg (overlappingNames == [ ])
-          "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
+        assert
+          (isAttrs env && !isDerivation env)
+          || throw "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
+        assert
+          (overlappingNames == [ ])
+          || throw "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
         mapAttrs (
           n: v:
-          assert assertMsg (isString v || isBool v || isInt v || isDerivation v)
-            "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
+          assert
+            (isString v || isBool v || isInt v || isDerivation v)
+            || throw "The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `${n}` attribute is of type ${builtins.typeOf v}.";
           v
         ) env';
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -194,6 +194,13 @@ let
     "disallowedRequisites"
   ];
 
+  argumentAttrsToRemove = [
+    "meta"
+    "passthru"
+    "pos"
+    "env"
+  ];
+
   attrsToRemoveLast = [
     # Fixed-output derivations may not reference other paths, which means that
     # for a fixed-output derivation, the corresponding inputDerivation should
@@ -917,12 +924,7 @@ let
         if attrs ? meta.mainProgram then env // { NIX_MAIN_PROGRAM = attrs.meta.mainProgram; } else env;
 
       derivationArg = makeDerivationArgument (
-        removeAttrs attrs [
-          "meta"
-          "passthru"
-          "pos"
-          "env"
-        ]
+        removeAttrs attrs argumentAttrsToRemove
         // {
           ${if __structuredAttrs then "env" else null} = checkedEnv;
           cmakeFlags = makeCMakeFlags attrs;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -25,6 +25,7 @@ let
     getDev
     head
     foldl'
+    intersectAttrs
     isAttrs
     isBool
     isDerivation
@@ -835,13 +836,13 @@ let
 
       checkedEnv =
         let
-          overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
+          overlappingArgs = intersectAttrs env' derivationArg;
         in
         assert
           (isAttrs env && !isDerivation env)
           || throw "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
         assert
-          (overlappingNames == [ ])
+          (overlappingArgs == { })
           || throw (
             let
               errors = lib.concatMapStringsSep "\n" (
@@ -849,7 +850,7 @@ let
                 "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
                     lib.generators.toPretty { } derivationArg.${name}
                   }"
-              ) overlappingNames;
+              ) (attrNames overlappingArgs);
 
             in
             "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -415,21 +415,20 @@ let
         ) == [ ];
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
 
-      hardeningDisable' = unique (
-        pipe hardeningDisable [
-          # disabling fortify implies fortify3 should also be disabled
-          (concretizeFlagImplications "fortify" [ "fortify3" ])
-          # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
-          (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
-          # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
-          (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
-        ]
-      );
       enabledHardeningOptions =
-        if elem "all" hardeningDisable' then
+        if elem "all" hardeningDisable then
           [ ]
         else
-          subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
+          subtractLists (unique (
+            pipe hardeningDisable [
+              # disabling fortify implies fortify3 should also be disabled
+              (concretizeFlagImplications "fortify" [ "fortify3" ])
+              # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
+              (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
+              # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
+              (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
+            ]
+          )) (defaultHardeningFlags ++ hardeningEnable);
       # hardeningDisable additionally supports "all".
       erroneousHardeningFlags = subtractLists knownHardeningFlags (
         hardeningEnable ++ remove "all" hardeningDisable

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -213,6 +213,12 @@ let
     "outputChecks"
   ];
 
+  defaultBuilderArgs = [
+    "-e"
+    ./source-stdenv.sh
+    ./default-builder.sh
+  ];
+
   inherit (stdenv)
     hostPlatform
     buildPlatform
@@ -635,11 +641,16 @@ let
 
           builder = attrs.realBuilder or stdenvShell;
           args =
-            attrs.args or [
-              "-e"
-              ./source-stdenv.sh
-              (attrs.builder or ./default-builder.sh)
-            ];
+            attrs.args or (
+              if attrs ? builder then
+                [
+                  "-e"
+                  ./source-stdenv.sh
+                  attrs.builder
+                ]
+              else
+                defaultBuilderArgs
+            );
           inherit stdenv;
 
           # The `system` attribute of a derivation has special meaning to Nix.

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -836,19 +836,24 @@ let
       checkedEnv =
         let
           overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
-          errors = lib.concatMapStringsSep "\n" (
-            name:
-            "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
-                lib.generators.toPretty { } derivationArg.${name}
-              }"
-          ) overlappingNames;
         in
         assert
           (isAttrs env && !isDerivation env)
           || throw "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
         assert
           (overlappingNames == [ ])
-          || throw "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
+          || throw (
+            let
+              errors = lib.concatMapStringsSep "\n" (
+                name:
+                "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
+                    lib.generators.toPretty { } derivationArg.${name}
+                  }"
+              ) overlappingNames;
+
+            in
+            "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}"
+          );
         mapAttrs (
           n: v:
           assert

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -187,6 +187,13 @@ let
     "allowedImpureDLLs"
   ];
 
+  referenceCheckingAttrsToRemove = [
+    "allowedReferences"
+    "allowedRequisites"
+    "disallowedReferences"
+    "disallowedRequisites"
+  ];
+
   attrsToRemoveLast = [
     # Fixed-output derivations may not reference other paths, which means that
     # for a fixed-output derivation, the corresponding inputDerivation should
@@ -828,12 +835,7 @@ let
                     # that's "normal". Notably it symlinks to the source.
                     # So disable reference checking for the debug output
                     if separateDebugInfo' && name == "debug" then
-                      removeAttrs raw [
-                        "allowedReferences"
-                        "allowedRequisites"
-                        "disallowedReferences"
-                        "disallowedRequisites"
-                      ]
+                      removeAttrs raw referenceCheckingAttrsToRemove
                     else
                       raw;
                 }) outputs

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -413,20 +413,6 @@ let
           actualValue;
       outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
 
-      enabledHardeningOptions =
-        if elem "all" hardeningDisable then
-          [ ]
-        else
-          subtractLists (unique (
-            pipe hardeningDisable [
-              # disabling fortify implies fortify3 should also be disabled
-              (concretizeFlagImplications "fortify" [ "fortify3" ])
-              # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
-              (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
-              # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
-              (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
-            ]
-          )) (defaultHardeningFlags ++ hardeningEnable);
       # hardeningDisable additionally supports "all".
       erroneousHardeningFlags = subtractLists knownHardeningFlags (
         hardeningEnable ++ remove "all" hardeningDisable
@@ -694,6 +680,22 @@ let
             else
               null
           } =
+            let
+              enabledHardeningOptions =
+                if elem "all" hardeningDisable then
+                  [ ]
+                else
+                  subtractLists (unique (
+                    pipe hardeningDisable [
+                      # disabling fortify implies fortify3 should also be disabled
+                      (concretizeFlagImplications "fortify" [ "fortify3" ])
+                      # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
+                      (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
+                      # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
+                      (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
+                    ]
+                  )) (defaultHardeningFlags ++ hardeningEnable);
+            in
             concatStringsSep " " enabledHardeningOptions;
 
           # TODO: remove platform condition

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -413,21 +413,20 @@ let
           actualValue;
       outputs' = if separateDebugInfo' then outputs ++ [ "debug" ] else outputs;
 
-      hardeningDisable' = unique (
-        pipe hardeningDisable [
-          # disabling fortify implies fortify3 should also be disabled
-          (concretizeFlagImplications "fortify" [ "fortify3" ])
-          # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
-          (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
-          # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
-          (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
-        ]
-      );
       enabledHardeningOptions =
-        if elem "all" hardeningDisable' then
+        if elem "all" hardeningDisable then
           [ ]
         else
-          subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
+          subtractLists (unique (
+            pipe hardeningDisable [
+              # disabling fortify implies fortify3 should also be disabled
+              (concretizeFlagImplications "fortify" [ "fortify3" ])
+              # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
+              (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
+              # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
+              (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
+            ]
+          )) (defaultHardeningFlags ++ hardeningEnable);
       # hardeningDisable additionally supports "all".
       erroneousHardeningFlags = subtractLists knownHardeningFlags (
         hardeningEnable ++ remove "all" hardeningDisable

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -910,19 +910,24 @@ let
       checkedEnv =
         let
           overlappingNames = attrNames (builtins.intersectAttrs env' derivationArg);
-          errors = lib.concatMapStringsSep "\n" (
-            name:
-            "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
-                lib.generators.toPretty { } derivationArg.${name}
-              }"
-          ) overlappingNames;
         in
         assert
           (isAttrs env && !isDerivation env)
           || throw "`env` must be an attribute set of environment variables. Set `env.env` or pick a more specific name.";
         assert
           (overlappingNames == [ ])
-          || throw "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}";
+          || throw (
+            let
+              errors = lib.concatMapStringsSep "\n" (
+                name:
+                "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
+                    lib.generators.toPretty { } derivationArg.${name}
+                  }"
+              ) overlappingNames;
+
+            in
+            "The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:\n${errors}"
+          );
         mapAttrs (
           n: v:
           assert

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -18,6 +18,7 @@ let
     concatLists
     concatMap
     concatMapStrings
+    concatMapStringsSep
     concatStringsSep
     elem
     extendDerivation
@@ -41,13 +42,18 @@ let
     optionals
     pipe
     remove
+    seq
     splitString
     subtractLists
+    toExtension
     toFunction
     unique
+    warnIf
     zipAttrsWith
-    seq
     ;
+
+  inherit (lib.generators) toPretty;
+  inherit (lib.strings) sanitizeDerivationName;
 
   inherit (import ../../build-support/lib/cmake.nix { inherit lib stdenv; }) makeCMakeFlags;
   inherit (import ../../build-support/lib/meson.nix { inherit lib stdenv; }) makeMesonFlags;
@@ -101,10 +107,10 @@ let
           final:
           let
             prev = rattrs final;
-            thisOverlay = lib.toExtension f0 final prev;
+            thisOverlay = toExtension f0 final prev;
             pos = builtins.unsafeGetAttrPos "version" thisOverlay;
           in
-          lib.warnIf
+          warnIf
             (
               prev ? src
               && thisOverlay ? version
@@ -482,7 +488,7 @@ let
     if erroneousHardeningFlags != [ ] then
       abort (
         "mkDerivation was called with unsupported hardening flags: "
-        + lib.generators.toPretty { } {
+        + toPretty { } {
           inherit
             erroneousHardeningFlags
             hardeningDisable
@@ -636,7 +642,7 @@ let
               # it again.
               staticMarker = stdenvStaticMarker;
             in
-            lib.strings.sanitizeDerivationName (
+            sanitizeDerivationName (
               if attrs ? name then
                 attrs.name + hostSuffix
               else
@@ -953,10 +959,10 @@ let
           (overlappingArgs == { })
           || throw (
             let
-              errors = lib.concatMapStringsSep "\n" (
+              errors = concatMapStringsSep "\n" (
                 name:
-                "  - ${name}: in `env`: ${lib.generators.toPretty { } env'.${name}}; in derivation arguments: ${
-                    lib.generators.toPretty { } derivationArg.${name}
+                "  - ${name}: in `env`: ${toPretty { } env'.${name}}; in derivation arguments: ${
+                    toPretty { } derivationArg.${name}
                   }"
               ) (attrNames overlappingArgs);
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -415,20 +415,6 @@ let
         ) == [ ];
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenvHasCC;
 
-      enabledHardeningOptions =
-        if elem "all" hardeningDisable then
-          [ ]
-        else
-          subtractLists (unique (
-            pipe hardeningDisable [
-              # disabling fortify implies fortify3 should also be disabled
-              (concretizeFlagImplications "fortify" [ "fortify3" ])
-              # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
-              (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
-              # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
-              (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
-            ]
-          )) (defaultHardeningFlags ++ hardeningEnable);
       # hardeningDisable additionally supports "all".
       erroneousHardeningFlags = subtractLists knownHardeningFlags (
         hardeningEnable ++ remove "all" hardeningDisable
@@ -630,6 +616,22 @@ let
             else
               null
           } =
+            let
+              enabledHardeningOptions =
+                if elem "all" hardeningDisable then
+                  [ ]
+                else
+                  subtractLists (unique (
+                    pipe hardeningDisable [
+                      # disabling fortify implies fortify3 should also be disabled
+                      (concretizeFlagImplications "fortify" [ "fortify3" ])
+                      # disabling strictflexarrays1 implies strictflexarrays3 should also be disabled
+                      (concretizeFlagImplications "strictflexarrays1" [ "strictflexarrays3" ])
+                      # disabling libcxxhardeningfast implies libcxxhardeningextensive should also be disabled
+                      (concretizeFlagImplications "libcxxhardeningfast" [ "libcxxhardeningextensive" ])
+                    ]
+                  )) (defaultHardeningFlags ++ hardeningEnable);
+            in
             concatStringsSep " " enabledHardeningOptions;
 
           # TODO: remove platform condition


### PR DESCRIPTION
I've already received some review on my mkDerivation PRs that are currently up, so I'm putting this up separately as to not invalidate those reviews. This should just be a minor savings for envs.bytes and thunks.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
