### PR TITLE
sonic-pi: pin ruby 3.3 and boost 1.86 and unmark as broken 

### DIFF
--- a/pkgs/by-name/so/sonic-pi/package.nix
+++ b/pkgs/by-name/so/sonic-pi/package.nix
@@ -14,11 +14,11 @@
   crossguid,
   reproc,
   platform-folders,
-  ruby,
+  ruby_3_3,
   beamPackages,
   alsa-lib,
   rtmidi,
-  boost,
+  boost186,
   aubio,
   jack2,
   jack-example-tools,
@@ -35,7 +35,7 @@
 }@args:
 
 let
-  ruby = args.ruby.withPackages (ps: [
+  ruby = args.ruby_3_3.withPackages (ps: [
     ps.prime
     ps.racc
     ps.rake
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     ruby
     alsa-lib
     rtmidi
-    boost
+    boost186
     aubio
   ]
   ++ lib.optionals withTauWidget [
@@ -274,6 +274,5 @@ stdenv.mkDerivation (finalAttrs: {
       sohalt
     ];
     platforms = lib.platforms.linux;
-    broken = true;
   };
 })


### PR DESCRIPTION
pin ruby to version 3.3 and boost to version 1.86 as ruby >= 3.4 removes the mutex header and boost 1.86 is used by supercollider to provide shared memory that is otherwise incompatible

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
