### PR TITLE
python3Packages.googleapis-common-protos: fix homepage and changelog

### DIFF
--- a/pkgs/development/python-modules/googleapis-common-protos/default.nix
+++ b/pkgs/development/python-modules/googleapis-common-protos/default.nix
@@ -53,8 +53,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Common protobufs used in Google APIs";
-    homepage = "https://github.com/googleapis/python-api-common-protos";
-    changelog = "https://github.com/googleapis/python-api-common-protos/releases/tag/${src.tag}";
+    homepage = "https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos";
+    changelog = "https://github.com/googleapis/google-cloud-python/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sarahec ];
   };

--- a/pkgs/development/python-modules/googleapis-common-protos/default.nix
+++ b/pkgs/development/python-modules/googleapis-common-protos/default.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "googleapis-common-protos";
   version = "1.73.0";
   pyproject = true;
@@ -16,11 +16,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-python";
-    tag = "googleapis-common-protos-v${version}";
+    tag = "googleapis-common-protos-v${finalAttrs.version}";
     hash = "sha256-LrsmLySAOTsECwxa1NaFuyZAjar0Jbg9DHNi6uqYaxk=";
   };
 
-  sourceRoot = "${src.name}/packages/googleapis-common-protos";
+  sourceRoot = "${finalAttrs.src.name}/packages/googleapis-common-protos";
 
   build-system = [ setuptools ];
 
@@ -54,8 +54,8 @@ buildPythonPackage rec {
   meta = {
     description = "Common protobufs used in Google APIs";
     homepage = "https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos";
-    changelog = "https://github.com/googleapis/google-cloud-python/releases/tag/${src.tag}";
+    changelog = "https://github.com/googleapis/google-cloud-python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sarahec ];
   };
-}
+})


### PR DESCRIPTION
Tracking #514132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
