### PR TITLE
bruno: remove reference to nodejs-source

### DIFF
--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -17,6 +17,8 @@
   npm-lockfile-fix,
   jq,
   moreutils,
+  srcOnly,
+  removeReferencesTo,
 }:
 
 buildNpmPackage rec {
@@ -41,6 +43,9 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [
     pkg-config
+
+    # remove references to nodejs-source
+    removeReferencesTo
   ]
   ++ lib.optional stdenv.isDarwin clang_20 # clang_21 breaks gyp builds
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
@@ -180,6 +185,9 @@ buildNpmPackage rec {
             size=${"$"}{s}x$s
             install -Dm644 $src/packages/bruno-electron/resources/icons/png/$size.png $out/share/icons/hicolor/$size/apps/bruno.png
           done
+
+          # remove dependency to nodejs-source
+          find "$out" -type f -exec remove-references-to -t "${srcOnly nodejs}" {} \;
         ''
     }
 


### PR DESCRIPTION
bruno has an unwanted runtime dependency to nodejs-source (with around 600MB). similar like https://github.com/NixOS/nixpkgs/issues/398794

```
130 root@0c14f2feb46e ..11p86bys57wnzkd4bwa2p0-bruno-cli-3.3.0 # rg nodejs-22.22.2-source .
./lib/node_modules/usebruno/node_modules/canvas/build/Makefile
346:cmd_regen_makefile = cd $(srcdir); /nix/store/0gznhjgyvvdk1i2vyqqrccg53nlqv4b8-nodejs-slim-22.22.2-npm/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py -fmake --ignore-environment "-Dlibrary=shared_library" "-Dvisibility=default" "-Dnode_root_dir=/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source" "-Dnode_gyp_dir=/nix/store/0gznhjgyvvdk1i2vyqqrccg53nlqv4b8-nodejs-slim-22.22.2-npm/lib/node_modules/npm/node_modules/node-gyp" "-Dnode_lib_file=/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/$(Configuration)/node.lib" "-Dmodule_root_dir=/build/source/node_modules/canvas" "-Dnode_engine=v8" "--depth=." "-Goutput_dir=." "--generator-output=build" -I/build/source/node_modules/canvas/build/config.gypi -I/nix/store/0gznhjgyvvdk1i2vyqqrccg53nlqv4b8-nodejs-slim-22.22.2-npm/lib/node_modules/npm/node_modules/node-gyp/addon.gypi -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/include/node/common.gypi "--toplevel-dir=." binding.gyp

./lib/node_modules/usebruno/node_modules/canvas/build/canvas.target.mk
40:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/include/node \
41:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/src \
42:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/openssl/config \
43:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/openssl/openssl/include \
44:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/uv/include \
45:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/zlib \
46:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/v8/include \
91:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/include/node \
92:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/src \
93:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/openssl/config \
94:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/openssl/openssl/include \
95:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/uv/include \
96:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/zlib \
97:     -I/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source/deps/v8/include \

./lib/node_modules/usebruno/node_modules/canvas/build/config.gypi
480:    "nodedir": "/nix/store/ync698l7ns2rai47ykx1c9h61l6c0jn9-nodejs-22.22.2-source",
root@0c14f2feb46e ..11p86bys57wnzkd4bwa2p0-bruno-cli-3.3.0 #

```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
