### PR TITLE
libretro.dolphin: 0-unstable-2025-08-05 -> 0-unstable-2026-04-08

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/dolphin.nix
+++ b/pkgs/applications/emulators/libretro/cores/dolphin.nix
@@ -83,8 +83,6 @@ mkLibretroCore {
     (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
 
-  dontUseCmakeBuildDir = false;
-
   meta = {
     description = "Port of Dolphin to libretro";
     homepage = "https://github.com/libretro/dolphin";

--- a/pkgs/applications/emulators/libretro/cores/dolphin.nix
+++ b/pkgs/applications/emulators/libretro/cores/dolphin.nix
@@ -26,13 +26,14 @@
 }:
 mkLibretroCore {
   core = "dolphin";
-  version = "0-unstable-2025-08-05";
+  version = "0-unstable-2026-04-08";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "dolphin";
-    rev = "83438f9b1a2c832319876a1fda130a5e33d4ef87";
-    hash = "sha256-q4y+3uJ1tQ2OvlEvi/JNyIO/RfuWNIEKfVZ6xEWKFCg=";
+    rev = "0cd3bb89c29535db9b7552fc86871867ccf5b471";
+    hash = "sha256-cSiJO/EvspNvHopo/RLfuz8ONpbXk2NrrSDhkiAm7/s=";
+    fetchSubmodules = true;
   };
 
   extraNativeBuildInputs = [
@@ -82,7 +83,7 @@ mkLibretroCore {
     (cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ];
 
-  dontUseCmakeBuildDir = true;
+  dontUseCmakeBuildDir = false;
 
   meta = {
     description = "Port of Dolphin to libretro";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
