### PR TITLE
waterfox: init at 6.6.12

### DIFF
--- a/pkgs/by-name/wa/waterfox/package.nix
+++ b/pkgs/by-name/wa/waterfox/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  wrapGAppsHook3,
+  alsa-lib,
+  atk,
+  cairo,
+  dbus,
+  ffmpeg_6,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  gst_all_1,
+  libglvnd,
+  libpciaccess,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrandr,
+  libxrender,
+  nspr,
+  nss,
+  pango,
+  pciutils,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "waterfox";
+  version = "6.6.12";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://cdn.waterfox.com/waterfox/releases/${version}/Linux_x86_64/waterfox-${version}.tar.bz2";
+    hash = "sha256-4mEVeqGiNzO5au4LsOMc5i6UaQ/AxV9XH1ea7HAd+kU=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    alsa-lib
+    atk
+    cairo
+    dbus
+    ffmpeg_6
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    gst_all_1.gstreamer
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-ugly
+    libglvnd
+    libpciaccess
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    libxrender
+    nspr
+    nss
+    pango
+    pciutils
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/waterfox
+    cp -r ./* $out/lib/waterfox
+
+    chmod +x $out/lib/waterfox/waterfox
+
+    mkdir -p $out/bin
+
+    makeWrapper $out/lib/waterfox/waterfox $out/bin/waterfox \
+      --prefix LD_LIBRARY_PATH : "$out/lib/waterfox:${lib.makeLibraryPath buildInputs}" \
+      --set MOZ_SYSTEM_FFMPEG "1"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Privacy-focused browser based on Firefox";
+    homepage = "https://www.waterfox.net/";
+    license = licenses.mpl20;
+    platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "waterfox";
+  };
+}


### PR DESCRIPTION
Adds Waterfox, a privacy-focused browser based on Firefox.

This packages the official upstream Linux x86_64 binary release tarball.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
