### PR TITLE
nixos/incus: gate bucket support since it requires insecure minio

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -54,8 +54,6 @@ let
       lvm2
       lz4
       lxcfs
-      minio
-      minio-client
       nftables
       qemu-utils
       qemu_kvm
@@ -99,6 +97,10 @@ let
     ]
     ++ lib.optionals nvidiaEnabled [
       libnvidia-container
+    ]
+    ++ lib.optionals cfg.bucketSupport [
+      minio
+      minio-client
     ];
 
   # https://github.com/lxc/incus/blob/cff35a29ee3d7a2af1f937cbb6cf23776941854b/internal/server/instance/drivers/driver_qemu.go#L123
@@ -209,6 +211,13 @@ in
         default = cfg.package.client;
         defaultText = lib.literalExpression "config.virtualisation.incus.package.client";
         description = "The incus client package to use. This package is added to PATH.";
+      };
+
+      bucketSupport = lib.mkOption {
+        type = lib.types.bool;
+        description = "Enable bucket support using minio, which is an insecure and unmaintained S3 provider.";
+        default = if lib.versionAtLeast config.system.stateVersion "26.11" then false else null;
+        defaultText = lib.literalExpression ''if lib.versionAtLeast config.system.stateVersion "26.11" then false else null;'';
       };
 
       softDaemonRestart = lib.mkOption {

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -51,6 +51,7 @@ in
       incus = {
         enable = true;
         package = cfg.package;
+        bucketSupport = false;
 
         preseed = {
           networks = [


### PR DESCRIPTION
If upstream replaces minio for v7, we can drop this, but minio is now insecure forcing us to act.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
