### PR TITLE
nixos/i18n: fix eval for non-glibc systems (e.g. musl)

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -31,16 +31,23 @@ in
 
     i18n = {
       glibcLocales = lib.mkOption {
-        type = lib.types.path;
-        default = pkgs.glibcLocales.override {
-          allLocales = lib.elem "all" config.i18n.supportedLocales;
-          locales = config.i18n.supportedLocales;
-        };
+        type = lib.types.nullOr lib.types.path;
+        default =
+          if pkgs.glibcLocales != null then
+            pkgs.glibcLocales.override {
+              allLocales = lib.elem "all" config.i18n.supportedLocales;
+              locales = config.i18n.supportedLocales;
+            }
+          else
+            null;
         defaultText = lib.literalExpression ''
-          pkgs.glibcLocales.override {
-            allLocales = lib.elem "all" config.i18n.supportedLocales;
-            locales = config.i18n.supportedLocales;
-          }
+          if pkgs.glibcLocales != null then
+            pkgs.glibcLocales.override {
+              allLocales = lib.elem "all" config.i18n.supportedLocales;
+              locales = config.i18n.supportedLocales;
+            }
+          else
+            null
         '';
         example = lib.literalExpression "pkgs.glibcLocales";
         description = ''
@@ -171,7 +178,9 @@ in
 
     environment.systemPackages =
       # We increase the priority a little, so that plain glibc in systemPackages can't win.
-      lib.optional (config.i18n.supportedLocales != [ ]) (lib.setPrio (-1) config.i18n.glibcLocales);
+      lib.optional (config.i18n.glibcLocales != null && config.i18n.supportedLocales != [ ]) (
+        lib.setPrio (-1) config.i18n.glibcLocales
+      );
 
     environment.sessionVariables = {
       LANG = config.i18n.defaultLocale;
@@ -179,9 +188,11 @@ in
     }
     // config.i18n.extraLocaleSettings;
 
-    systemd.globalEnvironment = lib.mkIf (config.i18n.supportedLocales != [ ]) {
-      LOCALE_ARCHIVE = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
-    };
+    systemd.globalEnvironment =
+      lib.mkIf (config.i18n.glibcLocales != null && config.i18n.supportedLocales != [ ])
+        {
+          LOCALE_ARCHIVE = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
+        };
 
     # ‘/etc/locale.conf’ is used by systemd.
     environment.etc."locale.conf".source = pkgs.writeText "locale.conf" ''

--- a/nixos/modules/security/apparmor/includes.nix
+++ b/nixos/modules/security/apparmor/includes.nix
@@ -95,7 +95,9 @@ in
       include "${pkgs.apparmor-profiles}/etc/apparmor.d/abstractions/base"
       ${pkgs.stdenv.cc.libc}/share/locale/** r,
       ${pkgs.stdenv.cc.libc}/share/locale.alias r,
-      ${config.i18n.glibcLocales}/lib/locale/locale-archive r,
+      ${lib.optionalString (
+        config.i18n.glibcLocales != null
+      ) "${config.i18n.glibcLocales}/lib/locale/locale-archive r,"}
       ${etcRule "localtime"}
       ${pkgs.tzdata}/share/zoneinfo/** r,
       ${pkgs.stdenv.cc.libc}/share/i18n/** r,

--- a/nixos/modules/services/mail/public-inbox.nix
+++ b/nixos/modules/services/mail/public-inbox.nix
@@ -77,6 +77,8 @@ let
         BindReadOnlyPaths = [
           "/etc"
           "/run/systemd"
+        ]
+        ++ lib.optionals (config.i18n.glibcLocales != null) [
           "${config.i18n.glibcLocales}"
         ]
         ++ mapAttrsToList (name: inbox: inbox.description) cfg.inboxes

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -39,8 +39,12 @@ let
 
     # Ensure that clipboard works for non-ASCII characters
     sed -i -e '/.*SessionVariables.*/ a\
-    LANG=${config.i18n.defaultLocale}\
-    LOCALE_ARCHIVE=${config.i18n.glibcLocales}/lib/locale/locale-archive
+    LANG=${config.i18n.defaultLocale}${
+      lib.optionalString (config.i18n.glibcLocales != null) ''
+        \
+        LOCALE_ARCHIVE=${config.i18n.glibcLocales}/lib/locale/locale-archive
+      ''
+    }
     ' $out/sesman.ini
 
     ${cfg.extraConfDirCommands}

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -58,7 +58,11 @@
             --set DISTRO_ID ${lib.escapeShellArg config.system.nixos.distroId} \
             --set INSTALL_BOOTLOADER ${lib.escapeShellArg config.system.build.installBootLoader} \
             --set PRE_SWITCH_CHECK ${lib.escapeShellArg config.system.preSwitchChecksScript} \
-            --set LOCALE_ARCHIVE ${config.i18n.glibcLocales}/lib/locale/locale-archive \
+            ${
+              lib.optionalString (
+                config.i18n.glibcLocales != null
+              ) "--set LOCALE_ARCHIVE ${config.i18n.glibcLocales}/lib/locale/locale-archive"
+            } \
             --set SYSTEMD ${config.systemd.package}
         )
       '';

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -351,7 +351,6 @@ in
       # Legacy environment variables. These were used by the activation script,
       # but some other script might still depend on them, although unlikely.
       installBootLoader = config.system.build.installBootLoader;
-      localeArchive = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
       distroId = config.system.nixos.distroId;
       perl = pkgs.perl.withPackages (
         p: with p; [
@@ -373,6 +372,9 @@ in
       # to the system closure, which defeats the purpose of the `system.checks`
       # option, as opposed to `system.extraDependencies`.
       passedChecks = concatStringsSep " " config.system.checks;
+    }
+    // lib.optionalAttrs (config.i18n.glibcLocales != null) {
+      localeArchive = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
     }
     // lib.optionalAttrs (config.system.forbiddenDependenciesRegexes != [ ]) {
       closureInfo = pkgs.closureInfo {

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -1566,7 +1566,6 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
     let distro_id = required_env("DISTRO_ID")?;
     let pre_switch_check = required_env("PRE_SWITCH_CHECK")?;
     let install_bootloader = required_env("INSTALL_BOOTLOADER")?;
-    let locale_archive = required_env("LOCALE_ARCHIVE")?;
     let new_systemd = PathBuf::from(required_env("SYSTEMD")?);
     let log_level = if std::env::var("STC_DEBUG").is_ok() {
         LevelFilter::Debug
@@ -1580,11 +1579,6 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
     // The action that is to be performed (like switch, boot, test, dry-activate) Also exposed via
     // environment variable from now on
     std::env::set_var("NIXOS_ACTION", Into::<&'static str>::into(action));
-
-    // Expose the locale archive as an environment variable for systemctl and the activation script
-    if !locale_archive.is_empty() {
-        std::env::set_var("LOCALE_ARCHIVE", locale_archive);
-    }
 
     let os_release = parse_os_release().context("Failed to parse os-release")?;
 


### PR DESCRIPTION
`pkgs.glibcLocales` is null for musl systems, so
`options.i18n.glibcLocales` needs to also be nullable. otherwise, the `.override` and subsequence path interpolations fail for non-gnu systems.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
