### PR TITLE
python3Packages.mirakuru: increase darwin test timeout

### DIFF
--- a/pkgs/development/python-modules/mirakuru/default.nix
+++ b/pkgs/development/python-modules/mirakuru/default.nix
@@ -25,6 +25,11 @@ buildPythonPackage rec {
     hash = "sha256-3WyjvHxr+6kG+cLSCEZkHoA70mSoT66ubmp0W9g2yJM=";
   };
 
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace tests/executors/test_output_executor_regression_issue_98.py \
+      --replace-fail "timeout=15," "timeout=60,"
+  '';
+
   build-system = [ setuptools ];
 
   dependencies = [ psutil ];

--- a/pkgs/development/python-modules/mirakuru/default.nix
+++ b/pkgs/development/python-modules/mirakuru/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     hash = "sha256-3WyjvHxr+6kG+cLSCEZkHoA70mSoT66ubmp0W9g2yJM=";
   };
 
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+  postPatch = ''
     substituteInPlace tests/executors/test_output_executor_regression_issue_98.py \
       --replace-fail "timeout=15," "timeout=60,"
   '';


### PR DESCRIPTION
Fixes the Darwin build of `python313Packages.mirakuru`.

Timed out on Hydra, passes locally.

This PR keeps the test enabled and increases only that Darwin test timeout from 15 seconds to 60 seconds in `postPatch`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Built with:

```console
nix build -L .#python313Packages.mirakuru
```

Result:

```text
61 passed, 3 deselected in 90.31s
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
