### PR TITLE
gamepad-mirror: init at 0.3-unstable-2025-10-18

### DIFF
--- a/pkgs/by-name/ga/gamepad-mirror/package.nix
+++ b/pkgs/by-name/ga/gamepad-mirror/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  appstream,
+  cmake,
+  desktop-file-utils,
+  gettext,
+  gjs,
+  glib,
+  gtk4,
+  graphene,
+  gobject-introspection,
+  pango,
+  harfbuzz,
+  gdk-pixbuf,
+  libadwaita,
+  libmanette,
+  libgudev,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gamepad-mirror";
+  version = "0.3-unstable-2025-10-18";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "vendillah";
+    repo = "GamepadMirror";
+    rev = "aa86d55f21b4d206eab61d0bf7cd9ccafc8aa607";
+    hash = "sha256-ZpBsJRQWRoAwp2G6CzVMtb+j71F0BbJuQ8vUnoZfEgc=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    meson
+    wrapGAppsHook4
+    pkg-config
+    cmake
+    ninja
+    gettext # msgfmt
+    appstream
+    gjs
+    desktop-file-utils # desktop-file-validate
+  ];
+
+  buildInputs = [
+    gjs
+    glib
+    gtk4
+  ];
+
+  passthru.giTypelibInputs = [
+    glib
+    gtk4
+    graphene
+    gobject-introspection
+    pango
+    harfbuzz
+    gdk-pixbuf
+    libadwaita
+    libmanette
+    libgudev
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GI_TYPELIB_PATH : ${
+        lib.makeSearchPathOutput "out" "lib/girepository-1.0" finalAttrs.passthru.giTypelibInputs
+      }
+    )
+  '';
+
+  # tries to look for .foobar-wrapped.{data,src}.gresource, switch to the hardcoded one
+  # TODO: why doesn't --inherit-argv0 work?
+  postFixup = ''
+    mv -v $out/share/gamepad-mirror/{page.codeberg.vendillah.GamepadMirror,gamepad-mirror}.data.gresource
+    mv -v $out/share/gamepad-mirror/{page.codeberg.vendillah.GamepadMirror,gamepad-mirror}.src.gresource
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    (
+      set -x
+      env -i $out/bin/${finalAttrs.meta.mainProgram} --help
+    )
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Small Adwaita application to show game pad inputs using libmanette";
+    homepage = "https://codeberg.org/vendillah/GamepadMirror";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "page.codeberg.vendillah.GamepadMirror";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
found this on https://arewelibadwaitayet.com/, looked neat

https://codeberg.org/vendillah/GamepadMirror
https://flathub.org/en/apps/page.codeberg.vendillah.GamepadMirror

man was this hard to debug and make hermetic, but `env -i` and `strace` did the trick

<img width="1804" height="1404" alt="image" src="https://github.com/user-attachments/assets/9fa6c537-5453-4bdb-822f-ed0e480992fe" />



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
