### PR TITLE
samtools: 1.22.1 -> 1.23.1; htslib: 1.22 -> 1.23.1; bcftools: 1.22 -> 1.23.1

### DIFF
--- a/pkgs/by-name/bc/bcftools/package.nix
+++ b/pkgs/by-name/bc/bcftools/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bcftools";
-  version = "1.22";
+  version = "1.23.1";
 
   src = fetchFromGitHub {
     owner = "samtools";
     repo = "bcftools";
     tag = finalAttrs.version;
-    hash = "sha256-S+FuqjiOf38sAQKWYOixv/MlXGnuDmkx9z4Co/pk/eM=";
+    hash = "sha256-JImEnlfVMMXBvj24SGlF3Pvv58NjGW1FkItpZX/mwio=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ht/htslib/package.nix
+++ b/pkgs/by-name/ht/htslib/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   zlib,
   bzip2,
   xz,
@@ -13,22 +12,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "htslib";
-  version = "1.22";
+  version = "1.23.1";
 
   src = fetchurl {
     url = "https://github.com/samtools/htslib/releases/download/${finalAttrs.version}/htslib-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-YlDB3yl9tHdRbmCsjfRe11plLR8lsPN/EvWxcmnq/ek=";
+    hash = "sha256-+KPzbv/uw48EPFOrHy2e1FBk8UIFxe+OPIFXY7kIA8Q=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/samtools/htslib/commit/31006e1c8edd02eb6321ed9be76b84fca5d20cb6.patch";
-      hash = "sha256-sbnkVmXIbs/Cn/msUUrJpJZCI2DHX5kpGSka2cccZIQ=";
-    })
-  ];
-
-  # perl is only used during the check phase.
-  nativeBuildInputs = [ perl ];
 
   buildInputs = [
     zlib
@@ -37,6 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     libdeflate
   ];
+
+  nativeCheckInputs = [ perl ];
 
   configureFlags =
     if !stdenv.hostPlatform.isStatic then
@@ -58,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -d $out/lib
     install -d $out/include/htslib
     install -D libhts.a $out/lib
-    install  -m644 htslib/*h $out/include/htslib
+    install -m644 htslib/*h $out/include/htslib
     install -D bgzip htsfile tabix $out/bin
   '';
 
@@ -68,6 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
+  # Couldn't get two free ports
+  __darwinAllowLocalNetworking = true;
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/sa/samtools/package.nix
+++ b/pkgs/by-name/sa/samtools/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "samtools";
-  version = "1.22.1";
+  version = "1.23.1";
 
   src = fetchurl {
     url = "https://github.com/samtools/samtools/releases/download/${finalAttrs.version}/samtools-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-Aqpc0LpS4GwggAVOBZ19d6iF3+lxfDHNid/npAR+2g4=";
+    hash = "sha256-MiZhmKS8am3zldhSZojJaX2cjkcviIx0n93i4I6ojdI=";
   };
 
   # tests require `bgzip` from the htslib package


### PR DESCRIPTION
samtools: 1.22.1 -> 1.23.1

Diff: https://github.com/samtools/samtools/compare/1.22.1...1.23.1
Changelogs:
> https://github.com/samtools/samtools/releases/tag/1.23.1
> https://github.com/samtools/samtools/releases/tag/1.23
> https://github.com/samtools/samtools/releases/tag/1.22.2

bcftools: 1.22 -> 1.23.1

Diff: https://github.com/samtools/bcftools/compare/1.22...1.23.1
Changelogs:
> https://github.com/samtools/bcftools/releases/tag/1.23.1
> https://github.com/samtools/bcftools/releases/tag/1.23
> https://github.com/samtools/bcftools/releases/tag/1.22.1

htslib: 1.22 -> 1.23.1

Diff: https://github.com/samtools/htslib/compare/1.22...1.23.1
Changelogs:
> https://github.com/samtools/htslib/releases/tag/1.23.1
> https://github.com/samtools/htslib/releases/tag/1.23
> https://github.com/samtools/htslib/releases/tag/1.22.2
> https://github.com/samtools/htslib/releases/tag/1.22.1

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
