### PR TITLE
toot: 0.51.1 -> 0.52.1

### DIFF
--- a/pkgs/by-name/to/toot/package.nix
+++ b/pkgs/by-name/to/toot/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "toot";
-  version = "0.51.1";
+  version = "0.52.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ihabunek";
     repo = "toot";
     tag = finalAttrs.version;
-    hash = "sha256-PZMh11MeJaKipt3E1reZQdL8+qz7gY/8bKleRPjshzI=";
+    hash = "sha256-lsX/34bdnAFWn/MNrQjrPIgkbgFusLvuK54Wc6N8bJU=";
   };
 
   nativeCheckInputs = with python3Packages; [ pytest ];
@@ -34,6 +34,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     click
     pillow
     term-image
+    pysocks
   ];
 
   checkPhase = ''


### PR DESCRIPTION
Diff: https://github.com/ihabunek/toot/compare/0.51.1...0.52.1
Changelogs:
> https://github.com/ihabunek/toot/releases/tag/0.52.1
> https://github.com/ihabunek/toot/releases/tag/0.52.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
