### PR TITLE
python312Packages.dlinfo: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/dlinfo/default.nix
+++ b/pkgs/development/python-modules/dlinfo/default.nix
@@ -23,6 +23,15 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # The glibc test asserts that resolved library paths exist as files on
+  # disk.  On macOS since Big Sur, system libraries live in a shared dyld
+  # cache and /usr/lib/lib*.dylib are no longer real files, causing the
+  # assertion to fail.  The macOS-specific mock test still runs and covers
+  # the Darwin codepath.
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    "tests/dlinfo_glibc_test.py"
+  ];
+
   pythonImportsCheck = [ "dlinfo" ];
 
   meta = {
@@ -31,6 +40,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/fphammerle/python-dlinfo";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
## Summary

- Skip `tests/dlinfo_glibc_test.py` on Darwin via `disabledTestPaths` instead of marking the package broken
- Remove `broken = stdenv.hostPlatform.isDarwin` from meta

## Problem

`dlinfo` is marked `broken` on Darwin because its glibc test asserts that resolved library paths exist as files on disk (`os.path.exists(dlinfo.path)`). On macOS since Big Sur, system libraries live in a shared dyld cache and `/usr/lib/lib*.dylib` are no longer real files, causing the assertion to fail.

This cascades downstream: `dlinfo` → `phonemizer` → `sentence-transformers` are all unbuildable on `aarch64-darwin`, preventing Hydra from caching any of them. Users who depend on `sentence-transformers` (e.g., for AI/ML tooling) face a multi-hour local `torch` rebuild.

## Fix

The test file `tests/dlinfo_glibc_test.py` tests Linux-specific behavior (libc's `dlinfo()` via `RTLD_DI_LINKMAP`). The package already ships a separate macOS test file (`tests/dlinfo_macosx_mock_test.py`) that validates the Darwin codepath via `dyld_find()` and correctly handles the shared-cache case where resolved paths don't exist as files.

Using `disabledTestPaths` to skip only the glibc test on Darwin.

## Testing

Built and tested on aarch64-darwin (macOS 15, Apple Silicon):

```
$ nix build .#python312Packages.dlinfo
# tests/dlinfo_macosx_mock_test.py: 2 passed, 2 xfailed in 0.11s
```

Also verified the library works at runtime:
```python
>>> from dlinfo import DLInfo
>>> import ctypes, ctypes.util
>>> lib = ctypes.cdll.LoadLibrary(ctypes.util.find_library("c"))
>>> DLInfo(lib).path
'/usr/lib/libc.dylib'
```

Confirmed `sentence-transformers` evaluates successfully with this fix applied.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)