### PR TITLE
[Don't merge yet] [Backport 25.11] python2Packages.buildPytonPackage: restructure with lib.extendMkDerivation

### DIFF
--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -269,14 +269,17 @@ let
 
         outputs = outputs ++ lib.optional withDistOutput "dist";
 
-        passthru.updateScript =
-          let
-            filename = builtins.head (lib.splitString ":" self.meta.position);
-          in
-          attrs.passthru.updateScript or [
-            update-python-libraries
-            filename
-          ];
+        passthru = {
+          updateScript =
+            let
+              filename = builtins.head (lib.splitString ":" self.meta.position);
+            in
+            [
+              update-python-libraries
+              filename
+            ];
+        }
+        // passthru;
 
         meta = {
           # default to python's platforms

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -301,7 +301,18 @@ let
       }
     )
   );
+
+  # Workaround to make the `lib.extendDerivation`-based disabled functionality
+  # respect `<pkg>.overrideAttrs`
+  # It doesn't cover `<pkg>.<output>.overrideAttrs`.
+  disablePythonPackage =
+    drv:
+    lib.extendDerivation (
+      drv.disabled
+      -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
+    ) { } drv
+    // {
+      overrideAttrs = fdrv: disablePythonPackage (drv.overrideAttrs fdrv);
+    };
 in
-lib.extendDerivation (
-  disabled -> throw "${name} not supported for interpreter ${python.executable}"
-) { } self
+disablePythonPackage self

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -187,7 +187,6 @@ let
         "catchConflicts"
         "format"
         "disabledTestPaths"
-        "outputs"
       ])
       // {
 

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -31,292 +31,291 @@ lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
 
   excludeDrvArgNames = [
-        "disabled"
-        "checkPhase"
-        "checkInputs"
-        "nativeCheckInputs"
-        "doCheck"
-        "doInstallCheck"
-        "dontWrapPythonPrograms"
-        "catchConflicts"
-        "format"
-        "disabledTestPaths"
+    "disabled"
+    "checkPhase"
+    "checkInputs"
+    "nativeCheckInputs"
+    "doCheck"
+    "doInstallCheck"
+    "dontWrapPythonPrograms"
+    "catchConflicts"
+    "format"
+    "disabledTestPaths"
   ];
 
   extendDrvArgs =
     finalAttrs:
-{
-  name ? "${attrs.pname}-${attrs.version}",
+    {
+      name ? "${attrs.pname}-${attrs.version}",
 
-  # Build-time dependencies for the package
-  nativeBuildInputs ? [ ],
+      # Build-time dependencies for the package
+      nativeBuildInputs ? [ ],
 
-  # Run-time dependencies for the package
-  buildInputs ? [ ],
+      # Run-time dependencies for the package
+      buildInputs ? [ ],
 
-  # Dependencies needed for running the checkPhase.
-  # These are added to buildInputs when doCheck = true.
-  checkInputs ? [ ],
-  nativeCheckInputs ? [ ],
+      # Dependencies needed for running the checkPhase.
+      # These are added to buildInputs when doCheck = true.
+      checkInputs ? [ ],
+      nativeCheckInputs ? [ ],
 
-  # propagate build dependencies so in case we have A -> B -> C,
-  # C can import package A propagated by B
-  propagatedBuildInputs ? [ ],
+      # propagate build dependencies so in case we have A -> B -> C,
+      # C can import package A propagated by B
+      propagatedBuildInputs ? [ ],
 
-  # DEPRECATED: use propagatedBuildInputs
-  pythonPath ? [ ],
+      # DEPRECATED: use propagatedBuildInputs
+      pythonPath ? [ ],
 
-  # Enabled to detect some (native)BuildInputs mistakes
-  strictDeps ? true,
+      # Enabled to detect some (native)BuildInputs mistakes
+      strictDeps ? true,
 
-  outputs ? [ "out" ],
+      outputs ? [ "out" ],
 
-  # used to disable derivation, useful for specific python versions
-  disabled ? false,
+      # used to disable derivation, useful for specific python versions
+      disabled ? false,
 
-  # Raise an error if two packages are installed with the same name
-  # TODO: For cross we probably need a different PYTHONPATH, or not
-  # add the runtime deps until after buildPhase.
-  catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
+      # Raise an error if two packages are installed with the same name
+      # TODO: For cross we probably need a different PYTHONPATH, or not
+      # add the runtime deps until after buildPhase.
+      catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
 
-  # Additional arguments to pass to the makeWrapper function, which wraps
-  # generated binaries.
-  makeWrapperArgs ? [ ],
+      # Additional arguments to pass to the makeWrapper function, which wraps
+      # generated binaries.
+      makeWrapperArgs ? [ ],
 
-  # Skip wrapping of python programs altogether
-  dontWrapPythonPrograms ? false,
+      # Skip wrapping of python programs altogether
+      dontWrapPythonPrograms ? false,
 
-  # Don't use Pip to install a wheel
-  # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
-  # It's included here to prevent an infinite recursion.
-  dontUsePipInstall ? false,
+      # Don't use Pip to install a wheel
+      # Note this is actually a variable for the pipInstallPhase in pip's setupHook.
+      # It's included here to prevent an infinite recursion.
+      dontUsePipInstall ? false,
 
-  # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
-  permitUserSite ? false,
+      # Skip setting the PYTHONNOUSERSITE environment variable in wrapped programs
+      permitUserSite ? false,
 
-  # Remove bytecode from bin folder.
-  # When a Python script has the extension `.py`, bytecode is generated
-  # Typically, executables in bin have no extension, so no bytecode is generated.
-  # However, some packages do provide executables with extensions, and thus bytecode is generated.
-  removeBinBytecode ? true,
+      # Remove bytecode from bin folder.
+      # When a Python script has the extension `.py`, bytecode is generated
+      # Typically, executables in bin have no extension, so no bytecode is generated.
+      # However, some packages do provide executables with extensions, and thus bytecode is generated.
+      removeBinBytecode ? true,
 
-  # Several package formats are supported.
-  # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
-  # "wheel" : Install from a pre-compiled wheel.
-  # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
-  # "egg": Install a package from an egg.
-  # "other" : Provide your own buildPhase and installPhase.
-  format ? "setuptools",
+      # Several package formats are supported.
+      # "setuptools" : Install a common setuptools/distutils based package. This builds a wheel.
+      # "wheel" : Install from a pre-compiled wheel.
+      # "pyproject": Install a package using a ``pyproject.toml`` file (PEP517). This builds a wheel.
+      # "egg": Install a package from an egg.
+      # "other" : Provide your own buildPhase and installPhase.
+      format ? "setuptools",
 
-  meta ? { },
+      meta ? { },
 
-  passthru ? { },
+      passthru ? { },
 
-  doCheck ? true,
+      doCheck ? true,
 
-  disabledTestPaths ? [ ],
+      disabledTestPaths ? [ ],
 
-  ...
-}@attrs:
+      ...
+    }@attrs:
 
-let
-  withDistOutput = lib.elem format [
-    "pyproject"
-    "setuptools"
-    "wheel"
-  ];
-
-  name_ = name;
-
-  validatePythonMatches =
-    attrName:
     let
-      isPythonModule =
-        drv:
-        # all pythonModules have the pythonModule attribute
-        (drv ? "pythonModule")
-        # Some pythonModules are turned in to a pythonApplication by setting the field to false
-        && (!builtins.isBool drv.pythonModule);
-      isMismatchedPython = drv: drv.pythonModule != python;
+      withDistOutput = lib.elem format [
+        "pyproject"
+        "setuptools"
+        "wheel"
+      ];
 
-      optionalLocation =
+      name_ = name;
+
+      validatePythonMatches =
+        attrName:
         let
-          pos = builtins.unsafeGetAttrPos (if attrs ? "pname" then "pname" else "name") attrs;
+          isPythonModule =
+            drv:
+            # all pythonModules have the pythonModule attribute
+            (drv ? "pythonModule")
+            # Some pythonModules are turned in to a pythonApplication by setting the field to false
+            && (!builtins.isBool drv.pythonModule);
+          isMismatchedPython = drv: drv.pythonModule != python;
+
+          optionalLocation =
+            let
+              pos = builtins.unsafeGetAttrPos (if attrs ? "pname" then "pname" else "name") attrs;
+            in
+            lib.optionalString (pos != null) " at ${pos.file}:${toString pos.line}:${toString pos.column}";
+
+          leftPadName =
+            name: against:
+            let
+              len = lib.max (lib.stringLength name) (lib.stringLength against);
+            in
+            lib.strings.fixedWidthString len " " name;
+
+          throwMismatch =
+            drv:
+            let
+              myName = "'${namePrefix}${name}'";
+              theirName = "'${drv.name}'";
+            in
+            throw ''
+              Python version mismatch in ${myName}:
+
+              The Python derivation ${myName} depends on a Python derivation
+              named ${theirName}, but the two derivations use different versions
+              of Python:
+
+                  ${leftPadName myName theirName} uses ${python}
+                  ${leftPadName theirName myName} uses ${toString drv.pythonModule}
+
+              Possible solutions:
+
+                * If ${theirName} is a Python library, change the reference to ${theirName}
+                  in the ${attrName} of ${myName} to use a ${theirName} built from the same
+                  version of Python
+
+                * If ${theirName} is used as a tool during the build, move the reference to
+                  ${theirName} in ${myName} from ${attrName} to nativeBuildInputs
+
+                * If ${theirName} provides executables that are called at run time, pass its
+                  bin path to makeWrapperArgs:
+
+                      makeWrapperArgs = [ "--prefix PATH : ''${lib.makeBinPath [ ${lib.getName drv} ] }" ];
+
+              ${optionalLocation}
+            '';
+
+          checkDrv = drv: if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch drv else drv;
+
         in
-        lib.optionalString (pos != null) " at ${pos.file}:${toString pos.line}:${toString pos.column}";
-
-      leftPadName =
-        name: against:
-        let
-          len = lib.max (lib.stringLength name) (lib.stringLength against);
-        in
-        lib.strings.fixedWidthString len " " name;
-
-      throwMismatch =
-        drv:
-        let
-          myName = "'${namePrefix}${name}'";
-          theirName = "'${drv.name}'";
-        in
-        throw ''
-          Python version mismatch in ${myName}:
-
-          The Python derivation ${myName} depends on a Python derivation
-          named ${theirName}, but the two derivations use different versions
-          of Python:
-
-              ${leftPadName myName theirName} uses ${python}
-              ${leftPadName theirName myName} uses ${toString drv.pythonModule}
-
-          Possible solutions:
-
-            * If ${theirName} is a Python library, change the reference to ${theirName}
-              in the ${attrName} of ${myName} to use a ${theirName} built from the same
-              version of Python
-
-            * If ${theirName} is used as a tool during the build, move the reference to
-              ${theirName} in ${myName} from ${attrName} to nativeBuildInputs
-
-            * If ${theirName} provides executables that are called at run time, pass its
-              bin path to makeWrapperArgs:
-
-                  makeWrapperArgs = [ "--prefix PATH : ''${lib.makeBinPath [ ${lib.getName drv} ] }" ];
-
-          ${optionalLocation}
-        '';
-
-      checkDrv = drv: if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch drv else drv;
+        inputs: map checkDrv inputs;
 
     in
-    inputs: map checkDrv inputs;
+    {
 
-in
-      {
+      name = namePrefix + name_;
 
-        name = namePrefix + name_;
+      nativeBuildInputs = [
+        python
+        wrapPython
+        ensureNewerSourcesForZipFilesHook # move to wheel installer (pip) or builder (setuptools, ...)?
+        pythonRemoveTestsDirHook
+      ]
+      ++ lib.optionals catchConflicts [
+        pythonCatchConflictsHook
+      ]
+      ++ lib.optionals removeBinBytecode [
+        pythonRemoveBinBytecodeHook
+      ]
+      ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
+        unzip
+      ]
+      ++ lib.optionals (format == "setuptools") [
+        setuptoolsBuildHook
+      ]
+      ++ lib.optionals (format == "pyproject") [
+        pipBuildHook
+      ]
+      ++ lib.optionals (format == "wheel") [
+        wheelUnpackHook
+      ]
+      ++ lib.optionals (format == "egg") [
+        eggUnpackHook
+        eggBuildHook
+        eggInstallHook
+      ]
+      ++ lib.optionals (format != "other") [
+        pipInstallHook
+      ]
+      ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+        # This is a test, however, it should be ran independent of the checkPhase and checkInputs
+        pythonImportsCheckHook
+      ]
+      ++ lib.optionals withDistOutput [
+        pythonOutputDistHook
+      ]
+      ++ nativeBuildInputs;
 
-        nativeBuildInputs = [
+      buildInputs = validatePythonMatches "buildInputs" (buildInputs ++ pythonPath);
+
+      propagatedBuildInputs = validatePythonMatches "propagatedBuildInputs" (
+        propagatedBuildInputs
+        ++ [
+          # we propagate python even for packages transformed with 'toPythonApplication'
+          # this pollutes the PATH but avoids rebuilds
+          # see https://github.com/NixOS/nixpkgs/issues/170887 for more context
           python
-          wrapPython
-          ensureNewerSourcesForZipFilesHook # move to wheel installer (pip) or builder (setuptools, ...)?
-          pythonRemoveTestsDirHook
         ]
-        ++ lib.optionals catchConflicts [
-          pythonCatchConflictsHook
-        ]
-        ++ lib.optionals removeBinBytecode [
-          pythonRemoveBinBytecodeHook
-        ]
-        ++ lib.optionals (lib.hasSuffix "zip" (attrs.src.name or "")) [
-          unzip
-        ]
-        ++ lib.optionals (format == "setuptools") [
-          setuptoolsBuildHook
-        ]
-        ++ lib.optionals (format == "pyproject") [
-          pipBuildHook
-        ]
-        ++ lib.optionals (format == "wheel") [
-          wheelUnpackHook
-        ]
-        ++ lib.optionals (format == "egg") [
-          eggUnpackHook
-          eggBuildHook
-          eggInstallHook
-        ]
-        ++ lib.optionals (format != "other") [
-          pipInstallHook
-        ]
-        ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
-          # This is a test, however, it should be ran independent of the checkPhase and checkInputs
-          pythonImportsCheckHook
-        ]
-        ++ lib.optionals withDistOutput [
-          pythonOutputDistHook
-        ]
-        ++ nativeBuildInputs;
+      );
 
-        buildInputs = validatePythonMatches "buildInputs" (buildInputs ++ pythonPath);
+      inherit strictDeps;
 
-        propagatedBuildInputs = validatePythonMatches "propagatedBuildInputs" (
-          propagatedBuildInputs
-          ++ [
-            # we propagate python even for packages transformed with 'toPythonApplication'
-            # this pollutes the PATH but avoids rebuilds
-            # see https://github.com/NixOS/nixpkgs/issues/170887 for more context
-            python
-          ]
-        );
+      LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
 
-        inherit strictDeps;
+      # Python packages don't have a checkPhase, only an installCheckPhase
+      doCheck = false;
+      doInstallCheck = attrs.doCheck or true;
+      nativeInstallCheckInputs = nativeCheckInputs;
+      installCheckInputs = checkInputs;
 
-        LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
+      postFixup =
+        lib.optionalString (!dontWrapPythonPrograms) ''
+          wrapPythonPrograms
+        ''
+        + attrs.postFixup or "";
 
-        # Python packages don't have a checkPhase, only an installCheckPhase
-        doCheck = false;
-        doInstallCheck = attrs.doCheck or true;
-        nativeInstallCheckInputs = nativeCheckInputs;
-        installCheckInputs = checkInputs;
+      # Python packages built through cross-compilation are always for the host platform.
+      disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
+        python.pythonOnBuildForHost
+      ];
 
-        postFixup =
-          lib.optionalString (!dontWrapPythonPrograms) ''
-            wrapPythonPrograms
-          ''
-          + attrs.postFixup or "";
+      outputs = outputs ++ lib.optional withDistOutput "dist";
 
-        # Python packages built through cross-compilation are always for the host platform.
-        disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
-          python.pythonOnBuildForHost
-        ];
-
-        outputs = outputs ++ lib.optional withDistOutput "dist";
-
-        passthru = {
-          inherit
-            disabled
-            ;
-          updateScript =
-            let
-              filename = builtins.head (lib.splitString ":" finalAttrs.finalPackage.meta.position);
-            in
-            [
-              update-python-libraries
-              filename
-            ];
-        }
-        // passthru;
-
-        meta = {
-          # default to python's platforms
-          platforms = python.meta.platforms;
-          isBuildPythonPackage = python.meta.platforms;
-        }
-        // meta;
+      passthru = {
+        inherit
+          disabled
+          ;
+        updateScript =
+          let
+            filename = builtins.head (lib.splitString ":" finalAttrs.finalPackage.meta.position);
+          in
+          [
+            update-python-libraries
+            filename
+          ];
       }
-      // lib.optionalAttrs (attrs ? checkPhase) {
-        # If given use the specified checkPhase, otherwise use the setup hook.
-        # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-        installCheckPhase = attrs.checkPhase;
+      // passthru;
+
+      meta = {
+        # default to python's platforms
+        platforms = python.meta.platforms;
+        isBuildPythonPackage = python.meta.platforms;
       }
-      // lib.optionalAttrs (disabledTestPaths != [ ]) {
-        disabledTestPaths = lib.escapeShellArgs disabledTestPaths;
-      };
+      // meta;
+    }
+    // lib.optionalAttrs (attrs ? checkPhase) {
+      # If given use the specified checkPhase, otherwise use the setup hook.
+      # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
+      installCheckPhase = attrs.checkPhase;
+    }
+    // lib.optionalAttrs (disabledTestPaths != [ ]) {
+      disabledTestPaths = lib.escapeShellArgs disabledTestPaths;
+    };
 
   transformDrv =
     let
-  # Workaround to make the `lib.extendDerivation`-based disabled functionality
-  # respect `<pkg>.overrideAttrs`
-  # It doesn't cover `<pkg>.<output>.overrideAttrs`.
-  disablePythonPackage =
-    drv:
-    lib.extendDerivation (
-      drv.disabled
-      -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
-    ) { } drv
-    // {
-      overrideAttrs = fdrv: disablePythonPackage (drv.overrideAttrs fdrv);
-    };
+      # Workaround to make the `lib.extendDerivation`-based disabled functionality
+      # respect `<pkg>.overrideAttrs`
+      # It doesn't cover `<pkg>.<output>.overrideAttrs`.
+      disablePythonPackage =
+        drv:
+        lib.extendDerivation (
+          drv.disabled
+          -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
+        ) { } drv
+        // {
+          overrideAttrs = fdrv: disablePythonPackage (drv.overrideAttrs fdrv);
+        };
     in
-    drv:
-    disablePythonPackage (toPythonModule drv);
+    drv: disablePythonPackage (toPythonModule drv);
 }

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -269,6 +269,15 @@ let
 
         outputs = outputs ++ lib.optional withDistOutput "dist";
 
+        passthru.updateScript =
+          let
+            filename = builtins.head (lib.splitString ":" self.meta.position);
+          in
+          attrs.passthru.updateScript or [
+            update-python-libraries
+            filename
+          ];
+
         meta = {
           # default to python's platforms
           platforms = python.meta.platforms;
@@ -286,16 +295,7 @@ let
       }
     )
   );
-
-  passthru.updateScript =
-    let
-      filename = builtins.head (lib.splitString ":" self.meta.position);
-    in
-    attrs.passthru.updateScript or [
-      update-python-libraries
-      filename
-    ];
 in
 lib.extendDerivation (
   disabled -> throw "${name} not supported for interpreter ${python.executable}"
-) passthru self
+) { } self

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -270,6 +270,9 @@ let
         outputs = outputs ++ lib.optional withDistOutput "dist";
 
         passthru = {
+          inherit
+            disabled
+            ;
           updateScript =
             let
               filename = builtins.head (lib.splitString ":" self.meta.position);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
