### PR TITLE
tooi: init at 0.24.0; textual-fspicker: init at 1.0.0

### DIFF
--- a/pkgs/by-name/to/tooi/package.nix
+++ b/pkgs/by-name/to/tooi/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromCodeberg,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "tooi";
+  version = "0.24.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "ihabunek";
+    repo = "tooi";
+    tag = finalAttrs.version;
+    hash = "sha256-+xNbOipfUVu4bqyCU+ECOBGZS5hsqQ/HmpNRZAjlJZg=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    aiodns
+    aiohttp
+    beautifulsoup4
+    certifi
+    click
+    html2text
+    markdown-it-py
+    platformdirs
+    pydantic
+    rich
+    textual
+    textual-fspicker
+    textual-image
+    tomlkit
+  ];
+
+  # has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Text-based user interface for Mastodon, Pleroma and friends";
+    mainProgram = "tooi";
+    homepage = "https://codeberg.org/ihabunek/tooi";
+    changelog = "https://codeberg.org/ihabunek/tooi/src/tag/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kybe236
+    ];
+  };
+})

--- a/pkgs/development/python-modules/textual-fspicker/default.nix
+++ b/pkgs/development/python-modules/textual-fspicker/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  uv-build,
+  textual,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "textual-fspicker";
+  version = "1.0.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) version;
+    pname = "textual_fspicker";
+    hash = "sha256-RiYI2+ahTt/2efxhFq3c8oj0p5+OT//SQPnOLKr55lU=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    textual
+  ];
+
+  pythonImportsCheck = [ "textual_fspicker" ];
+
+  meta = {
+    description = "A Textual widget library for picking things in the filesystem";
+    homepage = "https://github.com/davep/textual-fspicker";
+    changelog = "https://github.com/davep/textual-fspicker/blob/v${finalAttrs.version}/ChangeLog.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kybe236 ];
+  };
+})

--- a/pkgs/development/python-modules/textual-fspicker/default.nix
+++ b/pkgs/development/python-modules/textual-fspicker/default.nix
@@ -24,10 +24,13 @@ buildPythonPackage (finalAttrs: {
     textual
   ];
 
+  # has no tests
+  doCheck = false;
+
   pythonImportsCheck = [ "textual_fspicker" ];
 
   meta = {
-    description = "A Textual widget library for picking things in the filesystem";
+    description = "Textual widget library for picking things in the filesystem";
     homepage = "https://github.com/davep/textual-fspicker";
     changelog = "https://github.com/davep/textual-fspicker/blob/v${finalAttrs.version}/ChangeLog.md";
     license = lib.licenses.mit;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19315,6 +19315,8 @@ self: super: with self; {
 
   textual-fastdatatable = callPackage ../development/python-modules/textual-fastdatatable { };
 
+  textual-fspicker = callPackage ../development/python-modules/textual-fspicker { };
+
   textual-image = callPackage ../development/python-modules/textual-image { };
 
   textual-plotext = callPackage ../development/python-modules/textual-plotext { };


### PR DESCRIPTION
[`tooi`](https://codeberg.org/ihabunek/tooi) is a `text-based user interface for Mastodon, Pleroma and friends`.
It is recommended over [`toot tui`](https://github.com/ihabunek/toot/blob/3aeace1874a837fdbee0a677e51b878ca745012a/toot/cli/tui.py#L102) which is why I think it would be a valuable addition to Nixpkgs.
this also inits `textual-fspicker` because it's a dependency of `tooi`

I know very few about python so feedback is appreciated :-)

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
