### PR TITLE
electron_41: allow Yarn 4.14 lockfile migration

### DIFF
--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -186,6 +186,9 @@ in
   + ''
     (
       cd electron
+      if YARN_IGNORE_PATH=1 yarn config get approvedGitRepositories >/dev/null 2>&1; then
+        printf '\napprovedGitRepositories: [ "**" ]\n' >> .yarnrc.yml
+      fi
       YARN_ENABLE_SCRIPTS=0 yarnBerryConfigHook
     )
     (


### PR DESCRIPTION
Yarn 4.14 introduces `approvedGitRepositories` during lockfile migration. `electron_41` still builds with nixpkgs Yarn 4.13 today, so gate the compatibility setting behind `yarn config get approvedGitRepositories` and append it only when the active Yarn supports it.

This was split out from #511735 because touching `electron_41` has a large Linux rebuild surface and should be reviewed independently from the Goose package changes.

Local validation:
- `nix fmt pkgs/development/tools/electron/common.nix`
- `nix build -L --keep-going -f . electron_41` reached and completed `yarnBerryConfigHook`, then entered native Electron compilation (`[3380/45167]` and later). I stopped the local build after proving the Yarn dependency/config phase passed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
