### PR TITLE
cudaPackages.nvbandwidth: init at 0.9

### DIFF
--- a/pkgs/development/cuda-modules/packages/nvbandwidth/package.nix
+++ b/pkgs/development/cuda-modules/packages/nvbandwidth/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  backendStdenv,
+  fetchFromGitHub,
+  flags,
+
+  # nativeBuildInputs
+  cmake,
+  cuda_nvcc,
+
+  # buildInputs
+  boost,
+  cuda_cudart,
+  cuda_nvml_dev,
+
+  # passthru
+  nvbandwidth,
+
+  config,
+  cudaSupport ? config.cudaSupport,
+}:
+backendStdenv.mkDerivation (finalAttrs: {
+  pname = "nvbandwidth";
+  version = "0.9";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "nvbandwidth";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j1bKWXHIkjsE/M+w5rRF0UGjkj1gLA2yi+5hc1sWl/A=";
+  };
+
+  patches = [
+    # Force a dynamic Boost build and link against the CUDA driver / NVML stubs via the CMake
+    # imported targets exposed by `find_package(CUDAToolkit)`.
+    ./use-cuda-imported-targets.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    cuda_nvcc
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" flags.cmakeCudaArchitecturesString)
+  ];
+
+  buildInputs = [
+    boost
+    cuda_cudart # cuda_runtime.h, libcuda stub
+    cuda_nvml_dev # libnvidia-ml
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 nvbandwidth -t $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.gpuCheck = nvbandwidth.overrideAttrs (_: {
+    requiredSystemFeatures = [ "cuda" ];
+    doInstallCheck = true;
+    postInstallCheck = ''
+      $out/bin/${nvbandwidth.meta.mainProgram}
+    '';
+
+    # Failing (probably a sandbox limitation):
+    #   hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.
+    meta.broken = true;
+  });
+
+  meta = {
+    description = "Tool for bandwidth measurements on NVIDIA GPUs";
+    homepage = "https://github.com/NVIDIA/nvbandwidth";
+    changelog = "https://github.com/NVIDIA/nvbandwidth/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "nvbandwidth";
+    platforms = lib.platforms.linux;
+    broken = !cudaSupport;
+  };
+})

--- a/pkgs/development/cuda-modules/packages/nvbandwidth/use-cuda-imported-targets.patch
+++ b/pkgs/development/cuda-modules/packages/nvbandwidth/use-cuda-imported-targets.patch
@@ -1,0 +1,47 @@
+Use CMake imported targets and disable the static Boost build.
+
+The upstream link command `target_link_libraries(... ${NVML_LIB_NAME} cuda)`
+expands to plain `-lnvidia-ml -lcuda`, which forces the linker to look up
+those names on its search path. The corresponding stubs live in non-standard
+`*/lib/stubs` directories that aren't on the Nix linker search path, so the
+build fails. Switching to the `CUDA::nvml` / `CUDA::cuda_driver` imported
+targets exposed by `find_package(CUDAToolkit)` makes CMake link against the
+absolute stub paths it discovers via `CUDAToolkit_ROOT` instead.
+
+The static-Boost branch is also dropped: it dispatches on `/etc/os-release`,
+which doesn't exist in the Nix sandbox, and we want a dynamic build anyway.
+---
+ CMakeLists.txt | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,16 +43,11 @@
+     set(CMAKE_BUILD_TYPE "Release")
+ endif()
+
+-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-    file(READ "/etc/os-release" OS_RELEASE_CONTENT)
+-    # Skip static libs on Fedora - https://github.com/NVIDIA/nvbandwidth/issues/4
+-    if(NOT OS_RELEASE_CONTENT MATCHES "ID=.*fedora|azurelinux")
+-        set(Boost_USE_STATIC_LIBS ON)
+-    endif()
+-else()
++if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+     set(Boost_USE_STATIC_LIBS ON)
+ endif()
+ find_package(Boost COMPONENTS program_options REQUIRED)
++find_package(CUDAToolkit REQUIRED)
+
+ set(src
+     environment.cpp
+@@ -85,7 +80,7 @@
+
+ add_executable(nvbandwidth ${src})
+ target_include_directories(nvbandwidth PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} .)
+-target_link_libraries(nvbandwidth Boost::program_options ${NVML_LIB_NAME} cuda)
++target_link_libraries(nvbandwidth Boost::program_options CUDA::nvml CUDA::cuda_driver)
+
+ if (MULTINODE)
+     find_package(MPI REQUIRED)


### PR DESCRIPTION
## Things done

Add [nvbandwidth](https://github.com/NVIDIA/nvbandwidth), a tool for bandwidth measurements on NVIDIA GPUs. 

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
