### PR TITLE
python3Packages.viser: 1.0.20 -> 1.0.27 + clean

### DIFF
--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -49,7 +49,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "viser";
   version = "1.0.20";
   pyproject = true;
@@ -57,7 +57,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "viser-project";
     repo = "viser";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-usnvEvuBNPrqRXV7jh0qw1ppmZgAe1CUhAwd/M5CvC0=";
   };
 
@@ -81,7 +81,7 @@ buildPythonPackage rec {
   ];
 
   yarnOfflineCache = fetchYarnDeps {
-    yarnLock = src + "/src/viser/client/yarn.lock";
+    yarnLock = finalAttrs.src + "/src/viser/client/yarn.lock";
     hash = "sha256-4x+zJIqjVoKmEdOUPGpCuMmlRBfF++3oWtbNYAvd2ko=";
   };
 
@@ -145,10 +145,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/viser-project/viser/releases/tag/${src.tag}";
+    changelog = "https://github.com/viser-project/viser/releases/tag/${finalAttrs.src.tag}";
     description = "Web-based 3D visualization + Python";
     homepage = "https://github.com/nerfstudio-project/viser";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nim65s ];
   };
-}
+})

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -55,7 +55,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "nerfstudio-project";
+    owner = "viser-project";
     repo = "viser";
     tag = "v${version}";
     hash = "sha256-usnvEvuBNPrqRXV7jh0qw1ppmZgAe1CUhAwd/M5CvC0=";
@@ -145,7 +145,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/nerfstudio-project/viser/releases/tag/${src.tag}";
+    changelog = "https://github.com/viser-project/viser/releases/tag/${src.tag}";
     description = "Web-based 3D visualization + Python";
     homepage = "https://github.com/nerfstudio-project/viser";
     license = lib.licenses.asl20;

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -6,8 +6,8 @@
 
   # nativeBuildInputs
   nodejs,
-  fetchYarnDeps,
-  yarnConfigHook,
+  fetchNpmDeps,
+  npmHooks,
 
   # build-system
   hatchling,
@@ -15,79 +15,78 @@
   # dependencies
   imageio,
   msgspec,
-  nodeenv,
   numpy,
-  opencv-python,
-  plyfile,
-  psutil,
   requests,
   rich,
-  scikit-image,
-  scipy,
   tqdm,
   trimesh,
   typing-extensions,
   websockets,
   yourdfpy,
+  zstandard,
 
   # optional-dependencies
   hypothesis,
+  liblzfse,
+  nodeenv,
+  opencv-python,
+  playwright,
   pre-commit,
-  pandas,
+  psutil,
   pyright,
   pytest,
+  pytest-playwright,
+  pytest-xdist,
   ruff,
   gdown,
   matplotlib,
+  pandas,
   plotly,
-  # pyliblzfse,
+  plyfile,
   robot-descriptions,
   torch,
   tyro,
 
   # nativeCheckInputs
   pytestCheckHook,
+  playwright-driver,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "viser";
-  version = "1.0.20";
+  version = "1.0.26";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "viser-project";
     repo = "viser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-usnvEvuBNPrqRXV7jh0qw1ppmZgAe1CUhAwd/M5CvC0=";
+    hash = "sha256-qmHgjXBTJB0ka+QM+wmiUIXS+upeH3MxjAU9wHePWMY=";
   };
 
   postPatch = ''
-    # prepare yarn offline cache
+    # prepare npm offline cache
     mkdir -p node_modules
     cd src/viser/client
-    cp package.json yarn.lock ../../..
+    cp package.json package-lock.json ../../..
     ln -s ../../../node_modules
-
-    # fix: [vite-plugin-eslint] Failed to load config "react-app" to extend from.
-    substituteInPlace vite.config.mts --replace-fail \
-      "eslint({ failOnError: false, failOnWarning: false })," ""
-
     cd ../../..
   '';
 
   nativeBuildInputs = [
-    yarnConfigHook
+    npmHooks.npmConfigHook
     nodejs
   ];
 
-  yarnOfflineCache = fetchYarnDeps {
-    yarnLock = finalAttrs.src + "/src/viser/client/yarn.lock";
-    hash = "sha256-4x+zJIqjVoKmEdOUPGpCuMmlRBfF++3oWtbNYAvd2ko=";
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    src = finalAttrs.src + "/src/viser/client/";
+    hash = "sha256-pV8xc+dQA8Z2EpQoIxzUlH2cZJoGKB03cP6GglGdn58=";
   };
 
   preBuild = ''
     cd src/viser/client
-    yarn --offline build
+    npm --offline run build
     cd ../../..
   '';
 
@@ -98,37 +97,39 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     imageio
     msgspec
-    nodeenv
     numpy
-    opencv-python
-    plyfile
-    psutil
     requests
     rich
-    scikit-image
-    scipy
     tqdm
     trimesh
     typing-extensions
     websockets
     yourdfpy
+    zstandard
   ];
 
   optional-dependencies = {
     dev = [
       hypothesis
+      nodeenv
+      opencv-python
+      playwright
       pre-commit
+      psutil
       pyright
       pytest
+      pytest-playwright
+      pytest-xdist
       ruff
     ];
     examples = [
       gdown
+      liblzfse
       matplotlib
+      opencv-python
       pandas
       plotly
       plyfile
-      # pyliblzfse
       robot-descriptions
       torch
       tyro
@@ -137,7 +138,51 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     hypothesis
+    playwright-driver
     pytestCheckHook
+  ];
+
+  checkInputs = finalAttrs.passthru.optional-dependencies.dev;
+
+  env = {
+    PLAYWRIGHT_BROWSERS_PATH = playwright-driver.browsers;
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = true;
+    PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = true;
+  };
+
+  disabledTests = [
+    # AssertionError: Locator expected to be visible
+    "test_modal_renders_with_content[chromium]"
+    "test_rgb_color_picker_renders[chromium]"
+    "test_rgb_server_update[chromium]"
+    "test_rgba_color_picker_renders[chromium]"
+    "test_vector2_renders[chromium]"
+    "test_vector2_initial_values[chromium]"
+    "test_vector3_renders[chromium]"
+    "test_vector3_server_update[chromium]"
+    "test_slider_renders[chromium]"
+    "test_text_input_renders_with_value[chromium]"
+    "test_number_input_renders[chromium]"
+    "test_dropdown_renders[chromium]"
+    "test_dropdown_with_initial_value[chromium]"
+    "test_markdown_renders[chromium]"
+    "test_folder_renders_and_contains_children[chromium]"
+    "test_folder_collapse_toggle[chromium]"
+    "test_server_updates_text_value[chromium]"
+    "test_text_input_change_callback[chromium]"
+    "test_dropdown_selection_callback[chromium]"
+    "test_server_value_update_round_trip[chromium]"
+
+    # playwright._impl._errors.TimeoutError: Locator.wait_for: Timeout 5000ms exceeded.
+    # (same issue with 20s)
+    "test_long_underscore_label_wraps_within_container[chromium]"
+
+    # AssertionError: Locator expected to have Value 'initial'
+    "test_gui_state_sync_text[chromium]"
+
+    # assert 0 != 0
+    # (only when xdist)
+    "test_server_port_is_freed"
   ];
 
   pythonImportsCheck = [
@@ -146,8 +191,8 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     changelog = "https://github.com/viser-project/viser/releases/tag/${finalAttrs.src.tag}";
-    description = "Web-based 3D visualization + Python";
-    homepage = "https://github.com/nerfstudio-project/viser";
+    description = "Web-based 3D visualization in Python";
+    homepage = "https://github.com/viser-project/viser";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nim65s ];
   };

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -160,6 +160,10 @@ buildPythonPackage (finalAttrs: {
     # assert 0 != 0
     # (only when xdist)
     "test_server_port_is_freed"
+
+    # counts ffmpeg pids, can be confused when
+    # building multiple times this package in parallel
+    "test_process_termination"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -152,58 +152,15 @@ buildPythonPackage (finalAttrs: {
     PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = true;
   };
 
-  # flaky tests
+  disabledTestPaths = [
+    # too many flaky tests
+    "tests/e2e"
+  ];
   disabledTests = [
-    # AssertionError: Locator expected to be hidden
-    "test_fuzzy_search_filters_commands[chromium]"
-    "test_form_dirty_shows_on_sender[chromium]"
-
-    # AssertionError: Locator expected to be visible
-    "test_modal_renders_with_content[chromium]"
-    "test_rgb_color_picker_renders[chromium]"
-    "test_rgb_server_update[chromium]"
-    "test_rgba_color_picker_renders[chromium]"
-    "test_vector2_renders[chromium]"
-    "test_vector2_initial_values[chromium]"
-    "test_vector3_renders[chromium]"
-    "test_vector3_server_update[chromium]"
-    "test_slider_renders[chromium]"
-    "test_text_input_renders_with_value[chromium]"
-    "test_number_input_renders[chromium]"
-    "test_dropdown_renders[chromium]"
-    "test_dropdown_with_initial_value[chromium]"
-    "test_markdown_renders[chromium]"
-    "test_folder_renders_and_contains_children[chromium]"
-    "test_folder_collapse_toggle[chromium]"
-    "test_server_updates_text_value[chromium]"
-    "test_text_input_change_callback[chromium]"
-    "test_dropdown_selection_callback[chromium]"
-    "test_server_value_update_round_trip[chromium]"
-    "test_form_dirty_clears_on_submit_to_peer[chromium]"
-
-    # playwright._impl._errors.TimeoutError: Locator.wait_for: Timeout 5000ms exceeded.
-    "test_long_underscore_label_wraps_within_container[chromium]"
-    "test_command_description_update[chromium]"
-    "test_command_icon_update[chromium]"
-
-    # playwright._impl._errors.TargetClosedError: Browser.new_context: Target page, context or browser has been closed
-    "test_late_joining_client_sees_dirty_form[chromium]"
-    "test_per_client_form_dirty_is_isolated[chromium]"
-    "test_late_joining_client_sees_state[chromium]"
-    "test_scene_node_drag_callbacks[chromium]"
-    "test_scene_node_drag_filter_rejects_wrong_modifier[chromium]"
-    "test_form_dirty_syncs_to_peer[chromium]"
-
-    # AssertionError: Locator expected to have Value 'initial'
-    "test_gui_state_sync_text[chromium]"
-
     # assert 0 != 0
     # (only when xdist)
     "test_server_port_is_freed"
   ];
-
-  # 96 failed, 577 passed, 14 warnings on aarch64-linux
-  doInstallCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64;
 
   pythonImportsCheck = [
     "viser"

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -142,7 +142,8 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  checkInputs = finalAttrs.passthru.optional-dependencies.dev;
+  # adding pre-commit here break PYTHONPATH in 3.14
+  checkInputs = lib.filter (p: p.pname != "pre-commit") finalAttrs.passthru.optional-dependencies.dev;
 
   env = {
     PLAYWRIGHT_BROWSERS_PATH = playwright-driver.browsers;

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
 
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -200,6 +201,9 @@ buildPythonPackage (finalAttrs: {
     # (only when xdist)
     "test_server_port_is_freed"
   ];
+
+  # 96 failed, 577 passed, 14 warnings on aarch64-linux
+  doInstallCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64;
 
   pythonImportsCheck = [
     "viser"

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -181,8 +181,9 @@ buildPythonPackage (finalAttrs: {
     "test_form_dirty_clears_on_submit_to_peer[chromium]"
 
     # playwright._impl._errors.TimeoutError: Locator.wait_for: Timeout 5000ms exceeded.
-    # (same issue with 20s)
     "test_long_underscore_label_wraps_within_container[chromium]"
+    "test_command_description_update[chromium]"
+    "test_command_icon_update[chromium]"
 
     # playwright._impl._errors.TargetClosedError: Browser.new_context: Target page, context or browser has been closed
     "test_late_joining_client_sees_dirty_form[chromium]"

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -150,7 +150,12 @@ buildPythonPackage (finalAttrs: {
     PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = true;
   };
 
+  # flaky tests
   disabledTests = [
+    # AssertionError: Locator expected to be hidden
+    "test_fuzzy_search_filters_commands[chromium]"
+    "test_form_dirty_shows_on_sender[chromium]"
+
     # AssertionError: Locator expected to be visible
     "test_modal_renders_with_content[chromium]"
     "test_rgb_color_picker_renders[chromium]"
@@ -172,10 +177,19 @@ buildPythonPackage (finalAttrs: {
     "test_text_input_change_callback[chromium]"
     "test_dropdown_selection_callback[chromium]"
     "test_server_value_update_round_trip[chromium]"
+    "test_form_dirty_clears_on_submit_to_peer[chromium]"
 
     # playwright._impl._errors.TimeoutError: Locator.wait_for: Timeout 5000ms exceeded.
     # (same issue with 20s)
     "test_long_underscore_label_wraps_within_container[chromium]"
+
+    # playwright._impl._errors.TargetClosedError: Browser.new_context: Target page, context or browser has been closed
+    "test_late_joining_client_sees_dirty_form[chromium]"
+    "test_per_client_form_dirty_is_isolated[chromium]"
+    "test_late_joining_client_sees_state[chromium]"
+    "test_scene_node_drag_callbacks[chromium]"
+    "test_scene_node_drag_filter_rejects_wrong_modifier[chromium]"
+    "test_form_dirty_syncs_to_peer[chromium]"
 
     # AssertionError: Locator expected to have Value 'initial'
     "test_gui_state_sync_text[chromium]"

--- a/pkgs/development/python-modules/viser/default.nix
+++ b/pkgs/development/python-modules/viser/default.nix
@@ -54,14 +54,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "viser";
-  version = "1.0.26";
+  version = "1.0.27";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "viser-project";
     repo = "viser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qmHgjXBTJB0ka+QM+wmiUIXS+upeH3MxjAU9wHePWMY=";
+    hash = "sha256-qE9V6KjniKm3vBtf5ger6UHob4go0wTaJnmYtvYqvMc=";
   };
 
   postPatch = ''
@@ -81,7 +81,7 @@ buildPythonPackage (finalAttrs: {
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     src = finalAttrs.src + "/src/viser/client/";
-    hash = "sha256-pV8xc+dQA8Z2EpQoIxzUlH2cZJoGKB03cP6GglGdn58=";
+    hash = "sha256-fAFN/JCUVSvRDGfq39E3V+dhqp1i6vFG/j8wKmOva4c=";
   };
 
   preBuild = ''


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
