### PR TITLE
d2: disable playwright/libgbm on platforms where libdrm is unsupported

### DIFF
--- a/pkgs/by-name/d2/d2/package.nix
+++ b/pkgs/by-name/d2/d2/package.nix
@@ -6,6 +6,7 @@
   git,
   testers,
   d2,
+  libdrm,
   libgbm,
   makeWrapper,
   playwright-driver,
@@ -37,7 +38,7 @@ buildGoModule (finalAttrs: {
     makeWrapper
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals libdrm.meta.available [
     libgbm
     playwright-driver.browsers
   ];
@@ -46,10 +47,11 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     installManPage ci/release/template/man/d2.1
-
-      # Wrap the d2 executable to set LD_LIBRARY_PATH for Playwright
-      wrapProgram $out/bin/d2 \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
+  ''
+  # Wrap the d2 executable to set LD_LIBRARY_PATH for Playwright
+  + lib.optionalString (finalAttrs.buildInputs != [ ]) ''
+    wrapProgram $out/bin/d2 \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
   '';
 
   preCheck = ''


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/pull/488723#issuecomment-4347819398

@isker, please test as i don't have a non-headless darwin to test on.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
