### PR TITLE
WIP: vlc: install makemkv bluray library

### DIFF
--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -7,7 +7,7 @@
   meson,
   ninja,
   withJava ? false,
-  jdk21_headless,
+  jdk21,
   jre21_minimal, # Newer JDK's depend on a release with a fix for https://code.videolan.org/videolan/libbluray/-/issues/46
   ant,
   stripJavaArchivesHook,
@@ -31,7 +31,7 @@ let
       "java.rmi"
       "java.xml"
     ];
-    jdk = jdk21_headless;
+    jdk = jdk21;
   };
 in
 stdenv.mkDerivation rec {
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ]
   ++ lib.optionals withJava [
-    jdk21_headless
+    jdk21
     ant
     stripJavaArchivesHook
   ];

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -63,6 +63,7 @@
   libxml2,
   live555,
   lua5,
+  makemkv,
   ncurses,
   nix-update-script,
   perl,
@@ -92,6 +93,7 @@
   skins2Support ? !onlyLibVLC,
   waylandSupport ? true,
   withQt5 ? true,
+  withLibmmbd ? true,
 }:
 
 # chromecastSupport requires TCP port 8010 to be open for it to work.
@@ -99,7 +101,7 @@
 #   networking.firewall.allowedTCPPorts = [ 8010 ];
 
 let
-  inherit (lib) optionalString optionals;
+  inherit (lib) getLib optionalString optionals;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "${optionalString onlyLibVLC "lib"}vlc";
@@ -219,7 +221,8 @@ stdenv.mkDerivation (finalAttrs: {
       qtx11extras
     ]
   )
-  ++ optionals (waylandSupport && withQt5) [ libsForQt5.qtwayland ];
+  ++ optionals (waylandSupport && withQt5) [ libsForQt5.qtwayland ]
+  ++ optionals withLibmmbd [ makemkv ];
   strictDeps = true;
 
   env = {
@@ -285,6 +288,9 @@ stdenv.mkDerivation (finalAttrs: {
   # Given in EXTRA_DIST, but not in install-data target
   postInstall = ''
     cp -R share/hrtfs $out/share/vlc
+  ''
+  + optionalString withLibmmbd ''
+    cp ${getLib makemkv}/lib/libmmbd* $out/lib/vlc/plugins/access/
   '';
 
   preFixup = ''


### PR DESCRIPTION
MakeMKV's libmmbd is capable of decoding blurays for VLC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
