### PR TITLE
gcc: add enableHostPie option; use it for stdenv bootstrap-tools

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -21,6 +21,7 @@
   disableGdbPlugin ? !enablePlugin,
   enableShared,
   enableDefaultPie,
+  enableHostPie ? false,
   targetPrefix,
 
   langC,
@@ -285,6 +286,9 @@ let
     ]
     ++ lib.optionals enableDefaultPie [
       "--enable-default-pie"
+    ]
+    ++ lib.optionals enableHostPie [
+      "--enable-host-pie"
     ]
     ++ lib.optionals langJit [
       "--enable-host-shared"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -20,6 +20,7 @@
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
   enableDefaultPie ? stdenv.targetPlatform.hasSharedLibraries,
+  enableHostPie ? false,
   enableLTO ? stdenv.hostPlatform.hasSharedLibraries,
   texinfo ? null,
   perl ? null, # optional, for texi2pod (then pod2man)
@@ -141,6 +142,7 @@ let
       disableBootstrap
       disableGdbPlugin
       enableDefaultPie
+      enableHostPie
       enableLTO
       enableMultilib
       enablePlugin

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -50,6 +50,7 @@ rec {
   bootGCC = pkgs.gcc.cc.override {
     enableLTO = false;
     isl = null;
+    enableHostPie = pkgs.lib.versionAtLeast pkgs.gcc.cc.version "14";
   };
 
   bootBinutils = pkgs.binutils.bintools.override {


### PR DESCRIPTION
GCC's host binaries are linked as fixed-address `EXEC` ELFs with their lowest LOAD segment at `0x10000`. On systems where `vm.mmap_min_addr` is set higher than that (including the [RISE RISC-V Runners](https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/)) the kernel refuses the fixed mmap and the bootstrap `cc` segfaults on the very first `expand-response-params` compile.

GCC 14 added `--enable-host-pie`, which links the host `gcc` binaries as PIE so they can load anywhere. This wires that flag through as `enableHostPie` (default `false`) and turns it on when building `bootGCC` for stdenv bootstrap-tools, gated on gcc >= 14 since older versions don't know the flag.

Default off everywhere else, so existing arch tarballs aren't affected unless someone explicitly regenerates them.

The riscv64-linux bootstrap-files pin needs a separate follow-up PR once Hydra rebuilds `stdenvBootstrapTools.riscv64-linux.dist` with this change. Same dance as #498702.

Original diagnosis by @RossComputerGuy on a DC ROMA II laptop: https://tristanxr.com/post/dc-roma-ii-nix/.

cc @NixOS/risc-v @NixOS/stdenv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
