### PR TITLE
perlPackages.Plack: 1.0050 -> 1.0053

### DIFF
--- a/pkgs/development/perl-modules/Plack-xsendfile-disable-by-default-CVE-2026-7381.patch
+++ b/pkgs/development/perl-modules/Plack-xsendfile-disable-by-default-CVE-2026-7381.patch
@@ -1,0 +1,31 @@
+diff --git a/lib/Plack/Middleware/XSendfile.pm b/lib/Plack/Middleware/XSendfile.pm
+index f2cd859..f96ccb5 100644
+--- a/lib/Plack/Middleware/XSendfile.pm
++++ b/lib/Plack/Middleware/XSendfile.pm
+@@ -10,7 +10,11 @@ use Plack::Util::Accessor qw( variation );
+ 
+ sub new {
+     my $class = shift;
+-    Carp::carp("Plack::Middleware::XSendfile is deprecated and will be removed in a future release");
++    unless (($ENV{PLACK_ENABLE_INSECURE_XSENDFILE} // '') eq '1') {
++        Carp::croak(
++          "CVE-2026-7381: Plack::Middleware::XSendfile is disabled by default. Set PLACK_ENABLE_INSECURE_XSENDFILE=1 to enable"
++        );
++    }
+     $class->SUPER::new(@_);
+ }
+ 
+diff --git a/t/Plack-Middleware/xsendfile.t b/t/Plack-Middleware/xsendfile.t
+index f1a02fa..248815e 100644
+--- a/t/Plack-Middleware/xsendfile.t
++++ b/t/Plack-Middleware/xsendfile.t
+@@ -6,6 +6,9 @@ use Plack::Builder;
+ use Plack::Test;
+ use Cwd;
+ 
++# CVE-2026-7381: Insecure feature disabled by default, but enable for tests
++$ENV{PLACK_ENABLE_INSECURE_XSENDFILE} = 1;
++
+ sub is_wo_case($$;$) {
+     is lc $_[0], lc $_[1], $_[2];
+ }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28193,10 +28193,10 @@ with self;
 
   Plack = buildPerlPackage {
     pname = "Plack";
-    version = "1.0050";
+    version = "1.0053";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-1.0050.tar.gz";
-      hash = "sha256-0mUa3oLrv/er4KOhifyTLa3Ed5GGzolGjlbQGJ6qbtQ=";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-1.0053.tar.gz";
+      hash = "sha256-QPxEA0wWTpr3DdCP++5AjCQwLsDbMQ0pAd9xdTuxZ9o=";
     };
     buildInputs = [
       AuthenSimplePasswd
@@ -28226,6 +28226,7 @@ with self;
       TryTiny
     ];
     patches = [
+      ../development/perl-modules/Plack-xsendfile-disable-by-default-CVE-2026-7381.patch
       ../development/perl-modules/Plack-test-replace-DES-hash-with-bcrypt.patch
     ];
     meta = {


### PR DESCRIPTION
Also disables Plack::Middleware::XSendfile due to CVE-2026-7381. The feature can be enabled by setting PLACK_ENABLE_INSECURE_XSENDFILE=1


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
