### PR TITLE
various: update project website

### DIFF
--- a/pkgs/by-name/gr/graphite-cli/package.nix
+++ b/pkgs/by-name/gr/graphite-cli/package.nix
@@ -39,7 +39,7 @@ buildNpmPackage rec {
   passthru.updateScript = ./update.sh;
 
   meta = {
-    changelog = "https://graphite.dev/docs/cli-changelog";
+    changelog = "https://graphite.com/docs/cli-changelog";
     description = "CLI that makes creating stacked git changes fast & intuitive";
     downloadPage = "https://www.npmjs.com/package/@withgraphite/graphite-cli";
     homepage = "https://graphite.dev/docs/graphite-cli";

--- a/pkgs/by-name/lo/logmein-hamachi/package.nix
+++ b/pkgs/by-name/lo/logmein-hamachi/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Hosted VPN service that lets you securely extend LAN-like networks to distributed teams";
     homepage = "https://secure.logmein.com/products/hamachi/";
-    changelog = "https://support.logmeininc.com/central/help/whats-new-in-hamachi";
+    changelog = "https://support.logmein.com/central/help/whats-new-in-hamachi";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfreeRedistributable;
     maintainers = [ ];

--- a/pkgs/by-name/ls/lsr/package.nix
+++ b/pkgs/by-name/ls/lsr/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://tangled.sh/@rockorager.dev/lsr";
     description = "ls but with io_uring";
-    changelog = "https://tangled.sh/@rockorager.dev/lsr/tags";
+    changelog = "https://tangled.org/rockorager.dev/lsr/tags";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ddogfoodd ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/pa/palp/package.nix
+++ b/pkgs/by-name/pa/palp/package.nix
@@ -79,10 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
       algorithms work in any dimension and our key routine for vertex and
       facet enumeration compares well with existing packages.
     '';
-    homepage = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
+    homepage = "https://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
     # Not really a changelog, but a one-line summary of each update that should
     # be reviewed on update.
-    changelog = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
+    changelog = "https://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html";
     # Just a link on the website pointing to gpl -- now gplv3. When the last
     # version was released that pointed to gplv2 however, so thats probably
     # the right license.

--- a/pkgs/by-name/pi/pixi/package.nix
+++ b/pkgs/by-name/pi/pixi/package.nix
@@ -65,7 +65,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Package management made easy";
     homepage = "https://pixi.sh/";
-    changelog = "https://pixi.sh/latest/CHANGELOG";
+    changelog = "https://pixi.prefix.dev/latest/CHANGELOG/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       esteve

--- a/pkgs/development/python-modules/logfire/default.nix
+++ b/pkgs/development/python-modules/logfire/default.nix
@@ -187,7 +187,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   meta = {
-    changelog = "https://logfire.pydantic.dev/docs/release-notes";
+    changelog = "https://pydantic.dev/docs/logfire/resources/release-notes/";
     description = "Uncomplicated Observability for Python and beyond";
     downloadPage = "https://github.com/pydantic/logfire/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://logfire.pydantic.dev";

--- a/pkgs/development/python-modules/qiskit-finance/default.nix
+++ b/pkgs/development/python-modules/qiskit-finance/default.nix
@@ -80,7 +80,7 @@ buildPythonPackage rec {
     description = "Software for developing quantum computing programs";
     homepage = "https://qiskit.org";
     downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
-    changelog = "https://qiskit.org/documentation/release_notes.html";
+    changelog = "https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/qiskit-machine-learning/default.nix
+++ b/pkgs/development/python-modules/qiskit-machine-learning/default.nix
@@ -85,7 +85,7 @@ buildPythonPackage rec {
     description = "Software for developing quantum computing programs";
     homepage = "https://qiskit.org";
     downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
-    changelog = "https://qiskit.org/documentation/release_notes.html";
+    changelog = "https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/qiskit-nature/default.nix
+++ b/pkgs/development/python-modules/qiskit-nature/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
     description = "Software for developing quantum computing programs";
     homepage = "https://qiskit.org";
     downloadPage = "https://github.com/QISKit/qiskit-nature/releases";
-    changelog = "https://qiskit.org/documentation/release_notes.html";
+    changelog = "https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       binaryNativeCode # drivers/gaussiand/gauopen/*.so

--- a/pkgs/development/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/development/python-modules/qiskit-optimization/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     description = "Software for developing quantum computing programs";
     homepage = "https://qiskit.org";
     downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
-    changelog = "https://qiskit.org/documentation/release_notes.html";
+    changelog = "https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -101,7 +101,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://www.ibm.com/quantum/qiskit";
     downloadPage = "https://github.com/QISKit/qiskit/releases";
-    changelog = "https://docs.quantum.ibm.com/api/qiskit/release-notes";
+    changelog = "https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -308,7 +308,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Implementation of the SSH protocol${extraDesc}";
     homepage = "https://www.openssh.com/";
-    changelog = "https://www.openssh.com/releasenotes.html";
+    changelog = "https://www.openssh.org/releasenotes.html";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = extraMeta.maintainers or [ ];


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/514132
- extracted from #514568 (originally `treewide: update changelog`)

Trying to use `openssh.com` return a permanent redirect to `openssh.org`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
