### PR TITLE
python3Packages.lupa: devendor lua and luajit

### DIFF
--- a/pkgs/development/python-modules/lupa/default.nix
+++ b/pkgs/development/python-modules/lupa/default.nix
@@ -2,12 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  srcOnly,
+  runCommand,
 
   # build-system
   cython,
   setuptools,
 
+  # devendor
+  lua5_1,
+  lua5_2,
+  lua5_3,
+  lua5_4,
+  lua5_5,
+  luajit_2_0,
+  luajit_2_1,
 }:
+
 buildPythonPackage (finalAttrs: {
   pname = "lupa";
   version = "2.8";
@@ -17,12 +28,30 @@ buildPythonPackage (finalAttrs: {
     owner = "scoder";
     repo = "lupa";
     tag = "lupa-${finalAttrs.version}";
-    # Lua sources are vendored as submodules under third-party/.
-    # They are needed so that setup.py builds properly named backend
-    # modules (e.g. lua51, lua54, luajit21) expected by consumers like fakeredis.
+    # we fetch the vendored lua sources for gracefull de-vendor degredation when a new lua is added
     fetchSubmodules = true;
     hash = "sha256-XLBUQ1TrzWWST9RJdMTnpsceldDNzidnL82bixLhSRA=";
   };
+
+  patches = [
+    # The updated lua52 src has a radically changed makefile, matching lua53
+    ./remove-lua52-special-case.patch
+  ];
+
+  # devendor/update the luas to newer patched versions
+  postPatch = ''
+    (
+      set -x
+      rm -rf third-party/lua51;    cp -r ${srcOnly lua5_1}     third-party/lua51
+      rm -rf third-party/lua52;    cp -r ${srcOnly lua5_2}/src third-party/lua52
+      rm -rf third-party/lua53;    cp -r ${srcOnly lua5_3}/src third-party/lua53
+      rm -rf third-party/lua54;    cp -r ${srcOnly lua5_4}/src third-party/lua54
+      rm -rf third-party/lua55;    cp -r ${srcOnly lua5_5}/src third-party/lua55
+      rm -rf third-party/luajit20; cp -r ${srcOnly luajit_2_0} third-party/luajit20
+      rm -rf third-party/luajit21; cp -r ${srcOnly luajit_2_1} third-party/luajit21
+      chmod -R +w third-party/*
+    )
+  '';
 
   build-system = [
     cython
@@ -30,6 +59,22 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "lupa" ];
+
+  # this helps us discover new lua versions when bumping, without blocking mass python-updates
+  passthru.tests.expected-third-party = runCommand "lupa-expected-third-party" { } ''
+    declare -a expected=( lua51 lua52 lua53 lua54 lua55 luajit20 luajit21 )
+
+    declare -a found_paths=( ${finalAttrs.src}/third-party/* )
+    declare -a found=("''${found_paths[@]##*/}")
+    if [[ "''${found[*]}" != "''${expected[*]}" ]]; then
+      echo >&2 "./third-party/ contains unexpected paths!"
+      echo >&2 "expected: ''${expected[*]}"
+      echo >&2 "found:    ''${found[*]}"
+      exit 1
+    else
+      touch $out
+    fi
+  '';
 
   meta = {
     description = "Lua in Python";

--- a/pkgs/development/python-modules/lupa/remove-lua52-special-case.patch
+++ b/pkgs/development/python-modules/lupa/remove-lua52-special-case.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 972277e..ec426a0 100644
+--- a/setup.py
++++ b/setup.py
+@@ -302,8 +302,6 @@ def use_bundled_lua(path, macros):
+         os.path.splitext(obj_file)[0] + '.c' if obj_file != 'lj_vm.o' else 'lj_vm.s'
+         for obj_file in obj_files
+     ]
+-    if libname == 'lua52':
+-        lua_sources.extend(['lbitlib.c', 'lcorolib.c', 'lctype.c'])
+     src_dir = os.path.dirname(makefile)
+     ext_libraries = [
+         [libname, {


### PR DESCRIPTION
continuing from https://github.com/NixOS/nixpkgs/pull/514692

This may be the best option, this way gets us any updates and patches applied in `pkgs/development/interpreters/lua-5/default.nix`, like the fixes for CVE-2014-5461 and CVE-2022-28805

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
