### PR TITLE
various: fix incorrect changelogs

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
@@ -18,7 +18,7 @@ buildMozillaMach rec {
   };
 
   meta = {
-    changelog = "https://www.mozilla.org/en-US/firefox/${lib.versions.majorMinor version}beta/releasenotes/";
+    changelog = "https://www.firefox.com/en-US/firefox/150.0beta/releasenotes/?redirect_source=mozilla-org";
     description = "Web browser built from Firefox Beta Release source tree";
     homepage = "http://www.mozilla.com/en-US/firefox/";
     maintainers = with lib.maintainers; [ jopejoe1 ];

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -29,7 +29,7 @@ buildMozillaMach rec {
   '';
 
   meta = {
-    changelog = "https://www.mozilla.org/en-US/firefox/${lib.versions.majorMinor version}beta/releasenotes/";
+    changelog = "https://www.firefox.com/en-US/firefox/150.0beta/releasenotes/?redirect_source=mozilla-org";
     description = "Web browser built from Firefox Developer Edition source tree";
     homepage = "http://www.mozilla.com/en-US/firefox/";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/me/mercurial/package.nix
+++ b/pkgs/by-name/me/mercurial/package.nix
@@ -125,7 +125,7 @@ let
       description = "Fast, lightweight SCM system for very large distributed projects";
       homepage = "https://www.mercurial-scm.org";
       downloadPage = "https://www.mercurial-scm.org/release/";
-      changelog = "https://wiki.mercurial-scm.org/Release${lib.versions.majorMinor version}";
+      changelog = "https://mercurial-scm.org/relnotes/7.1";
       license = lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [
         lukegb

--- a/pkgs/by-name/oi/oils-for-unix/package.nix
+++ b/pkgs/by-name/oi/oils-for-unix/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
       mkg20001
       melkor333
     ];
-    changelog = "https://www.oils.pub/release/${finalAttrs.version}/changelog.html";
+    changelog = "https://oils.pub/release/${finalAttrs.version}/changelog.html";
   };
 
   passthru =

--- a/pkgs/by-name/sm/smartgit/package.nix
+++ b/pkgs/by-name/sm/smartgit/package.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
       Command line Git is required.
     '';
     homepage = "https://www.syntevo.com/smartgit/";
-    changelog = "https://www.syntevo.com/smartgit/changelog-${lib.versions.majorMinor finalAttrs.version}.txt";
+    changelog = "https://www.smartgit.dev/changelogs/changelog-24.1.txt";
     license = lib.licenses.unfree;
     mainProgram = "smartgit";
     platforms = lib.platforms.linux;

--- a/pkgs/development/ocaml-modules/integers/default.nix
+++ b/pkgs/development/ocaml-modules/integers/default.nix
@@ -22,7 +22,7 @@ buildDunePackage rec {
     description = "Various signed and unsigned integer types for OCaml";
     license = lib.licenses.mit;
     homepage = "https://github.com/ocamllabs/ocaml-integers";
-    changelog = "https://github.com/ocamllabs/ocaml-integers/raw/${version}/CHANGES.md";
+    changelog = "https://raw.githubusercontent.com/yallop/ocaml-integers/${version}/CHANGES.md";
     maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
- part of: https://github.com/NixOS/nixpkgs/issues/514132

Resolve all new URL for changelog that had a status 301 when fetched.

Excluding:
- #514568
- #514908
- repo name update

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
