### PR TITLE
linuxPackages.opensnitch-ebpf: fix build with kernel >= 6.19

### DIFF
--- a/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
+++ b/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
@@ -10,6 +10,7 @@
   bc,
   opensnitch,
   nixosTests,
+  fetchpatch2,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,6 +18,17 @@ stdenv.mkDerivation rec {
   version = "${opensnitch.version}-${kernel.version}";
 
   inherit (opensnitch) src;
+
+  patches = [
+    (fetchpatch2 {
+      # fixes build failures on kernel >= 6.19 (#490127)
+      # remove when added to a release
+      name = "fix-kernel-6.19-build.patch";
+      stripLen = 1;
+      url = "https://github.com/evilsocket/opensnitch/commit/614537c92ec82f54f76a45fb406ad2fb6e6fa618.patch?full_index=1";
+      hash = "sha256-FCJfDhgmnm1GXPDaxr+YpVWTRrwBvjVzvGdZSFB6SqQ=";
+    })
+  ];
 
   sourceRoot = "${src.name}/ebpf_prog";
 
@@ -35,6 +47,7 @@ stdenv.mkDerivation rec {
   # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=opensnitch-ebpf-module&id=984b952a784eb701f691dd9f2d45dfeb8d15053b
   env.NIX_CFLAGS_COMPILE = "-fno-stack-protector";
 
+  env.KERNEL_VER = kernel.modDirVersion;
   env.KERNEL_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source";
   env.KERNEL_HEADERS = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

fixes #490127

https://github.com/evilsocket/opensnitch/commit/0cb2adc89c1e7e5058a2c9c3eda9cf50520b4edd isn't part of a release yet

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test