### PR TITLE
vespa-cli: init at 8.679.50

### DIFF
--- a/pkgs/by-name/ve/vespa-cli/package.nix
+++ b/pkgs/by-name/ve/vespa-cli/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "vespa-cli";
+  version = "8.679.50";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vespa-engine";
+    repo = "vespa";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4tABoAA96HoYghIno0qbieYbE4EJZRmFIFDnoOoMIaA=";
+  };
+
+  # case-insensitive conflicts which produce platform `vendorHash` checksumm
+  proxyVendor = true;
+
+  sourceRoot = "${finalAttrs.src.name}/client/go";
+
+  vendorHash = "sha256-qC/8pIhsVbt9uUyLDiAW18tCUWDw3Agvmcx/CIUsCKQ=";
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-X github.com/vespa-engine/vespa/client/go/internal/build.Version=${finalAttrs.version}"
+  ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # these tests try to call home
+        "TestAuthShow/auth_show"
+        "TestDeployCloud"
+        "TestDeployCloudFastWait"
+        "TestDeployCloudUnauthorized"
+        "TestDestroy"
+        "TestLogCloud"
+        "TestProdDeploy"
+        "TestProdDeployInvalidZip"
+        "TestProdDeployWarnsOnInstance"
+        "TestProdDeployWithJava"
+        "TestProdDeployWithWait"
+        "TestProdDeployWithoutCertificate"
+        "TestProdDeployWithoutTests"
+        "TestSingleTestWithCloudAndEndpoints"
+        "TestSingleTestWithCloudAndTokenAuth"
+        "TestStatusCloudDeployment"
+        # tries to call home for most recent version but we have our own test
+        "TestVersion"
+        "TestVersionCheckHomebrew"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line tool for Vespa.ai";
+    downloadPage = "https://github.com/vespa-engine/vespa/blob/v${finalAttrs.version}/client/go";
+    changelog = "https://github.com/vespa-engine/vespa/releases/tag/v${finalAttrs.version}";
+    homepage = "https://vespa.ai/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
+    mainProgram = "vespa";
+  };
+})


### PR DESCRIPTION
Homepage: https://github.com/vespa-engine/vespa/tree/v8.680.18/client/go
Download page: https://vespa.ai/
Description: vespa-cli is the command line interface for vespa.ai


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
