### PR TITLE
nixos/niri: add extraPackages

### DIFF
--- a/nixos/modules/programs/wayland/niri.nix
+++ b/nixos/modules/programs/wayland/niri.nix
@@ -16,14 +16,34 @@ in
     useNautilus = lib.mkEnableOption "Nautilus as file-chooser for xdg-desktop-portal-gnome" // {
       default = true;
     };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = with pkgs; [
+        alacritty
+        fuzzel
+        swaylock
+        brightnessctl
+
+        xwayland-satellite
+      ];
+      defaultText = lib.literalExpression ''
+        with pkgs; [ brightnessctl alacritty fuzzel swaylock ];
+      '';
+      example = lib.literalExpression ''
+        with pkgs; [ brightnessctl alacritty fuzzel swaylock ];
+      '';
+      description = ''
+        Extra packages to be installed system wide.
+        By default, they're the packages used in the base configuration, plus xwayland-satellite for running X11 apps.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        environment.systemPackages = [
-          cfg.package
-        ];
+        environment.systemPackages = lib.optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
 
         # Required for xdg-desktop-portal-gnome's FileChooser to work properly
         services.dbus.packages = lib.mkIf cfg.useNautilus [


### PR DESCRIPTION
The first-time experience with `niri` is pretty bad; I started out by enabling the nixos option, running `niri-session`, only to find out that I had no terminal and no application launcher (among other things)

The sway module in comparison includes all the packages used in the default config; so that's precisely what I did here, along with [xwayland-satellite](https://github.com/niri-wm/niri/wiki/Xwayland#using-xwayland-satellite) since some popular apps (eg steam) still rely on it unfortunately.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added `programs.niri.extraPackages` inspired by `programs.sway.extraPackages`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
