### PR TITLE
plover_5: 5.0.0.dev2 -> 5.3.0, fix darwin build

### DIFF
--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -30,6 +30,10 @@
   wrapQtAppsHook,
   hidapi,
   xkbcommon,
+  pyobjc-framework-Quartz,
+  pyobjc-framework-Cocoa,
+  appnope,
+  pyobjc-core,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -75,7 +79,6 @@ buildPythonPackage (finalAttrs: {
   ];
   dependencies = [
     appdirs
-    evdev
     hidapi
     packaging
     pkginfo
@@ -93,7 +96,14 @@ buildPythonPackage (finalAttrs: {
     xkbcommon
     xlib
   ]
-  ++ readme-renderer.optional-dependencies.md;
+  ++ readme-renderer.optional-dependencies.md
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ evdev ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    appnope
+    pyobjc-core
+    pyobjc-framework-Cocoa
+    pyobjc-framework-Quartz
+  ];
   nativeBuildInputs = [
     wrapQtAppsHook
   ];
@@ -134,6 +144,5 @@ buildPythonPackage (finalAttrs: {
     ];
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -28,20 +28,22 @@
   xlib,
   qtbase,
   wrapQtAppsHook,
+  hidapi,
+  xkbcommon,
 }:
 
 buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "plover";
-  version = "5.0.0.dev2";
+  version = "5.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openstenoproject";
     repo = "plover";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PZwxVrdQPhgbj+YmWZIUETngeJGs6IQty0hY43tLQO0=";
+    hash = "sha256-1NpZmUDq806geKANqswPYglHwInxum/c/Hxq7JhTpbc=";
   };
 
   # pythonRelaxDeps seemingly doesn't work here
@@ -49,6 +51,8 @@ buildPythonPackage (finalAttrs: {
     sed -i 's/,<77//g' pyproject.toml
     sed -i /PySide6-Essentials/d pyproject.toml
   '';
+
+  pythonRelaxDeps = [ "xkbcommon" ];
 
   build-system = [
     babel
@@ -72,6 +76,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     appdirs
     evdev
+    hidapi
     packaging
     pkginfo
     psutil
@@ -85,6 +90,7 @@ buildPythonPackage (finalAttrs: {
     rtf-tokenize
     setuptools
     wcwidth
+    xkbcommon
     xlib
   ]
   ++ readme-renderer.optional-dependencies.md;
@@ -103,8 +109,10 @@ buildPythonPackage (finalAttrs: {
     mock
   ];
 
-  # Segfaults?!
-  disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
+  disabledTestPaths = [
+    "test/gui_qt/test_dictionaries_widget.py" # segfaults
+    "test/gui_qt/test_i18n_files.py" # babel errors
+  ];
 
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

bumps version, fixes build on darwin

I also disabled the new test in https://github.com/opensteno/plover/blob/main/test/gui_qt/test_i18n_files.py as that's more of a test for the build process and it resulted in some import errors related to `babel` that don't relate to plover at runtime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
