### PR TITLE
ocamlPackages.httpcats: fix darwin build

### DIFF
--- a/pkgs/development/ocaml-modules/httpcats/default.nix
+++ b/pkgs/development/ocaml-modules/httpcats/default.nix
@@ -1,10 +1,9 @@
 {
-  fetchpatch,
-  fetchFromGitHub,
+  fetchpatch2,
+  fetchzip,
   buildDunePackage,
   lib,
   logs,
-  miou,
   fmt,
   h2,
   h1,
@@ -22,17 +21,15 @@ buildDunePackage (finalAttrs: {
   pname = "httpcats";
   version = "0.2.1";
 
-  src = fetchFromGitHub {
-    owner = "robur-coop";
-    repo = "httpcats";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-I7u/n49WOnpc0EaagsjC4Ts/kz0Xj6YHZv6+QZKLrC4=";
+  src = fetchzip {
+    url = "https://github.com/robur-coop/httpcats/releases/download/v${finalAttrs.version}/httpcats-${finalAttrs.version}.tbz";
+    hash = "sha256-ehtwxQGHw8igzI0dy2Zzs+VOqvck/tAUuuJl+jSpVU8=";
   };
 
   patches = [
-    (fetchpatch {
+    (fetchpatch2 {
       url = "https://github.com/robur-coop/httpcats/commit/d8787555d4831e0488780d42bd2c65de662d1d38.patch";
-      hash = "sha256-Mqam6Sxd2kkkHDm459u9uerifuHbvZUVy2khQffvvCE=";
+      hash = "sha256-6zXPb+mvw2rcEMv28b0npcL8cKl3CASxDbl7FOAGsXs=";
     })
   ];
 
@@ -46,6 +43,8 @@ buildDunePackage (finalAttrs: {
     happy-eyeballs-miou-unix
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   doCheck = true;
   checkInputs = [
     logs
@@ -58,7 +57,7 @@ buildDunePackage (finalAttrs: {
   meta = {
     homepage = "https://github.com/robur-coop/httpcats/";
     description = "A simple HTTP client / server using h1, h2, and miou";
-    changelog = "https://github.com/robur-coop/httpcats/blob/${finalAttrs.src.tag}/CHANGES.md";
+    changelog = "https://github.com/robur-coop/httpcats/blob/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ rpqt ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

also switch fetchpatch2 and tbz from dune-release as there are template strings in src:

https://github.com/robur-coop/httpcats/blob/cb3e0f9456502a937a0f8fe6be6b640b659f905e/src/httpcats.ml#L109

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
