### PR TITLE
docker-color-output: fix changelog URL

### DIFF
--- a/pkgs/by-name/do/docker-color-output/package.nix
+++ b/pkgs/by-name/do/docker-color-output/package.nix
@@ -12,6 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "devemio";
     repo = "docker-color-output";
+    # Warning: tag names are inconsistent: some have the 'v' prefix, some don't.
     tag = "v${finalAttrs.version}";
     hash = "sha256-Rpym9YckgJ583zgPpC/mQW1IGgQUppemFhAecgy3M8A=";
   };
@@ -31,7 +32,9 @@ buildGoModule (finalAttrs: {
     mainProgram = "docker-color-output";
     license = lib.licenses.mit;
     homepage = "https://github.com/devemio/docker-color-output";
-    changelog = "https://github.com/devemio/docker-color-output/releases/tag/${finalAttrs.version}";
+    # Note that due to inconsistent tag names (see above comment),
+    # we might want to check the URL before committing.
+    changelog = "https://github.com/devemio/docker-color-output/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ sguimmara ];
   };
 })


### PR DESCRIPTION
Due to inconsistent tag naming (some have the 'v' prefix, some don't), the URL to the newer releases was broken.

This was noticed by #514132


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
